### PR TITLE
[1/4] Add MLflow-native model catalog transform script

### DIFF
--- a/dev/convert_litellm_catalog.py
+++ b/dev/convert_litellm_catalog.py
@@ -1,0 +1,174 @@
+"""Convert LiteLLM model_prices_and_context_window.json to MLflow-native per-provider catalog.
+
+Usage:
+    uv run python dev/convert_litellm_catalog.py [--input PATH] [--output-dir PATH]
+
+Reads the LiteLLM JSON (default: mlflow/utils/model_prices_and_context_window.json),
+transforms it into the MLflow-native schema, and writes one JSON file per provider
+into the output directory (default: mlflow/utils/model_catalog/).
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+SCHEMA_VERSION = "1.0"
+
+# Modes that MLflow cares about for gateway / cost tracking
+_SUPPORTED_MODES = {"chat", "completion", "embedding"}
+
+# Providers that should be consolidated into a canonical name
+_PROVIDER_CONSOLIDATION = {
+    "vertex_ai-anthropic": "vertex_ai",
+    "vertex_ai-llama_models": "vertex_ai",
+    "vertex_ai-mistral": "vertex_ai",
+    "vertex_ai-chat-models": "vertex_ai",
+    "vertex_ai-text-models": "vertex_ai",
+    "vertex_ai-code-chat-models": "vertex_ai",
+    "vertex_ai-code-text-models": "vertex_ai",
+    "vertex_ai-embedding-models": "vertex_ai",
+    "vertex_ai-vision-models": "vertex_ai",
+}
+
+# Providers to exclude from the catalog entirely
+_EXCLUDED_PROVIDERS = {"bedrock_converse"}
+
+
+def _normalize_provider(provider: str) -> str:
+    if provider in _PROVIDER_CONSOLIDATION:
+        return _PROVIDER_CONSOLIDATION[provider]
+    if provider.startswith("vertex_ai-"):
+        return "vertex_ai"
+    return provider
+
+
+def _transform_entry(info: dict) -> dict | None:
+    """Transform a single LiteLLM model entry into MLflow-native schema."""
+    mode = info.get("mode")
+    if mode not in _SUPPORTED_MODES:
+        return None
+
+    pricing = {}
+    if (v := info.get("input_cost_per_token")) is not None:
+        pricing["input_per_token"] = v
+    if (v := info.get("output_cost_per_token")) is not None:
+        pricing["output_per_token"] = v
+    if (v := info.get("cache_read_input_token_cost")) is not None:
+        pricing["cache_read_per_token"] = v
+    if (v := info.get("cache_creation_input_token_cost")) is not None:
+        pricing["cache_write_per_token"] = v
+
+    capabilities = {
+        "function_calling": info.get("supports_function_calling", False),
+        "vision": info.get("supports_vision", False),
+        "reasoning": info.get("supports_reasoning", False),
+        "prompt_caching": info.get("supports_prompt_caching", False),
+        "response_schema": info.get("supports_response_schema", False),
+    }
+
+    context_window = {}
+    if (v := info.get("max_input_tokens")) is not None:
+        context_window["max_input"] = v
+    if (v := info.get("max_output_tokens")) is not None:
+        context_window["max_output"] = v
+
+    entry = {"mode": mode}
+    if context_window:
+        entry["context_window"] = context_window
+    if pricing:
+        entry["pricing"] = pricing
+    entry["capabilities"] = capabilities
+    if dep := info.get("deprecation_date"):
+        entry["deprecation_date"] = dep
+
+    return entry
+
+
+def convert(input_path: Path, output_dir: Path) -> dict[str, int]:
+    """Convert LiteLLM JSON to per-provider MLflow catalog files.
+
+    Returns a dict mapping provider names to model counts.
+    """
+    with input_path.open(encoding="utf-8") as f:
+        raw = json.load(f)
+
+    # Group by provider
+    providers: dict[str, dict[str, dict]] = {}
+    seen: set[tuple[str, str]] = set()
+
+    for key, info in raw.items():
+        if key == "sample_spec":
+            continue
+
+        provider = info.get("litellm_provider")
+        if not provider:
+            continue
+        if provider in _EXCLUDED_PROVIDERS:
+            continue
+
+        provider = _normalize_provider(provider)
+        model_name = key.split("/", 1)[-1]
+
+        # Skip fine-tuned variants
+        if model_name.startswith("ft:"):
+            continue
+
+        # Dedupe by (provider, model_name)
+        dedup_key = (provider, model_name)
+        if dedup_key in seen:
+            continue
+        seen.add(dedup_key)
+
+        entry = _transform_entry(info)
+        if entry is None:
+            continue
+
+        providers.setdefault(provider, {})[model_name] = entry
+
+    # Write per-provider files
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Remove stale provider files
+    existing_files = {p.stem for p in output_dir.glob("*.json")}
+    new_files = set(providers.keys())
+    for stale in existing_files - new_files:
+        (output_dir / f"{stale}.json").unlink()
+
+    stats = {}
+    for provider, models in sorted(providers.items()):
+        catalog = {
+            "schema_version": SCHEMA_VERSION,
+            "models": dict(sorted(models.items())),
+        }
+        out_path = output_dir / f"{provider}.json"
+        out_path.write_text(json.dumps(catalog, indent=2) + "\n", encoding="utf-8")
+        stats[provider] = len(models)
+
+    return stats
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input",
+        type=Path,
+        default=Path("mlflow/utils/model_prices_and_context_window.json"),
+        help="Path to LiteLLM model prices JSON",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("mlflow/utils/model_catalog"),
+        help="Output directory for per-provider JSON files",
+    )
+    args = parser.parse_args()
+
+    stats = convert(args.input, args.output_dir)
+    total = sum(stats.values())
+    print(f"Converted {total} models across {len(stats)} providers:")
+    for provider, count in sorted(stats.items(), key=lambda x: -x[1]):
+        print(f"  {provider}: {count}")
+
+
+if __name__ == "__main__":
+    main()

--- a/mlflow/utils/model_catalog/ai21.json
+++ b/mlflow/utils/model_catalog/ai21.json
@@ -1,0 +1,221 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "j2-light": {
+      "mode": "completion",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 3e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "j2-mid": {
+      "mode": "completion",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1e-05,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "j2-ultra": {
+      "mode": "completion",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "jamba-1.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "jamba-1.5-large": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 8e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "jamba-1.5-large@001": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 8e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "jamba-1.5-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "jamba-1.5-mini@001": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "jamba-large-1.6": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 8e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "jamba-large-1.7": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 8e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "jamba-mini-1.6": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "jamba-mini-1.7": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/aleph_alpha.json
+++ b/mlflow/utils/model_catalog/aleph_alpha.json
@@ -1,0 +1,89 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "luminous-base": {
+      "mode": "completion",
+      "pricing": {
+        "input_per_token": 3e-05,
+        "output_per_token": 3.3e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "luminous-base-control": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 3.75e-05,
+        "output_per_token": 4.125e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "luminous-extended": {
+      "mode": "completion",
+      "pricing": {
+        "input_per_token": 4.5e-05,
+        "output_per_token": 4.95e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "luminous-extended-control": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 5.625e-05,
+        "output_per_token": 6.1875e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "luminous-supreme": {
+      "mode": "completion",
+      "pricing": {
+        "input_per_token": 0.000175,
+        "output_per_token": 0.0001925
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "luminous-supreme-control": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 0.00021875,
+        "output_per_token": 0.000240625
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/amazon_nova.json
+++ b/mlflow/utils/model_catalog/amazon_nova.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "nova-lite-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 300000,
+        "max_output": 10000
+      },
+      "pricing": {
+        "input_per_token": 6e-08,
+        "output_per_token": 2.4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "nova-micro-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 10000
+      },
+      "pricing": {
+        "input_per_token": 3.5e-08,
+        "output_per_token": 1.4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "nova-premier-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 10000
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1.25e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "nova-pro-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 300000,
+        "max_output": 10000
+      },
+      "pricing": {
+        "input_per_token": 8e-07,
+        "output_per_token": 3.2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/anthropic.json
+++ b/mlflow/utils/model_catalog/anthropic.json
@@ -1,0 +1,370 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "claude-3-7-sonnet-20250219": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-02-19"
+    },
+    "claude-3-haiku-20240307": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 1.25e-06,
+        "cache_read_per_token": 3e-08,
+        "cache_write_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "claude-3-opus-20240229": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 7.5e-05,
+        "cache_read_per_token": 1.5e-06,
+        "cache_write_per_token": 1.875e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-05-01"
+    },
+    "claude-4-opus-20250514": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 7.5e-05,
+        "cache_read_per_token": 1.5e-06,
+        "cache_write_per_token": 1.875e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "claude-4-sonnet-20250514": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "claude-haiku-4-5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 5e-06,
+        "cache_read_per_token": 1e-07,
+        "cache_write_per_token": 1.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "claude-haiku-4-5-20251001": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 5e-06,
+        "cache_read_per_token": 1e-07,
+        "cache_write_per_token": 1.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "claude-opus-4-1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 7.5e-05,
+        "cache_read_per_token": 1.5e-06,
+        "cache_write_per_token": 1.875e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "claude-opus-4-1-20250805": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 7.5e-05,
+        "cache_read_per_token": 1.5e-06,
+        "cache_write_per_token": 1.875e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-08-05"
+    },
+    "claude-opus-4-20250514": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 7.5e-05,
+        "cache_read_per_token": 1.5e-06,
+        "cache_write_per_token": 1.875e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-05-14"
+    },
+    "claude-opus-4-5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 5e-06,
+        "output_per_token": 2.5e-05,
+        "cache_read_per_token": 5e-07,
+        "cache_write_per_token": 6.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "claude-opus-4-5-20251101": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 5e-06,
+        "output_per_token": 2.5e-05,
+        "cache_read_per_token": 5e-07,
+        "cache_write_per_token": 6.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "claude-opus-4-6": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 5e-06,
+        "output_per_token": 2.5e-05,
+        "cache_read_per_token": 5e-07,
+        "cache_write_per_token": 6.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "claude-opus-4-6-20260205": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 5e-06,
+        "output_per_token": 2.5e-05,
+        "cache_read_per_token": 5e-07,
+        "cache_write_per_token": 6.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "claude-sonnet-4-20250514": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-05-14"
+    },
+    "claude-sonnet-4-5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "claude-sonnet-4-5-20250929": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "claude-sonnet-4-6": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/anyscale.json
+++ b/mlflow/utils/model_catalog/anyscale.json
@@ -1,0 +1,221 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "HuggingFaceH4/zephyr-7b-beta": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "codellama/CodeLlama-34b-Instruct-hf": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 1e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "codellama/CodeLlama-70b-Instruct-hf": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 1e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "google/gemma-7b-it": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Llama-2-13b-chat-hf": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 2.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Llama-2-70b-chat-hf": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 1e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Llama-2-7b-chat-hf": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Meta-Llama-3-70B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 1e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Meta-Llama-3-8B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistralai/Mistral-7B-Instruct-v0.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistralai/Mixtral-8x22B-Instruct-v0.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 65536,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistralai/Mixtral-8x7B-Instruct-v0.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/azure.json
+++ b/mlflow/utils/model_catalog/azure.json
@@ -1,0 +1,2337 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "ada": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 8191
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "command-r-plus": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "computer-use-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 1024
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.2e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "container": {
+      "mode": "chat",
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu/gpt-4o-2024-08-06": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.75e-06,
+        "output_per_token": 1.1e-05,
+        "cache_read_per_token": 1.375e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-02-27"
+    },
+    "eu/gpt-4o-2024-11-20": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.75e-06,
+        "output_per_token": 1.1e-05,
+        "cache_write_per_token": 1.38e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-03-01"
+    },
+    "eu/gpt-4o-mini-2024-07-18": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1.65e-07,
+        "output_per_token": 6.6e-07,
+        "cache_read_per_token": 8.3e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "eu/gpt-4o-mini-realtime-preview-2024-12-17": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 6.6e-07,
+        "output_per_token": 2.64e-06,
+        "cache_read_per_token": 3.3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu/gpt-4o-realtime-preview-2024-10-01": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 5.5e-06,
+        "output_per_token": 2.2e-05,
+        "cache_read_per_token": 2.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu/gpt-4o-realtime-preview-2024-12-17": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 5.5e-06,
+        "output_per_token": 2.2e-05,
+        "cache_read_per_token": 2.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu/gpt-5-2025-08-07": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.375e-06,
+        "output_per_token": 1.1e-05,
+        "cache_read_per_token": 1.375e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "eu/gpt-5-mini-2025-08-07": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2.75e-07,
+        "output_per_token": 2.2e-06,
+        "cache_read_per_token": 2.75e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "eu/gpt-5-nano-2025-08-07": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 5.5e-08,
+        "output_per_token": 4.4e-07,
+        "cache_read_per_token": 5.5e-09
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "eu/gpt-5.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.38e-06,
+        "output_per_token": 1.1e-05,
+        "cache_read_per_token": 1.4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "eu/gpt-5.1-chat": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.38e-06,
+        "output_per_token": 1.1e-05,
+        "cache_read_per_token": 1.4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "eu/o1-2024-12-17": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 100000
+      },
+      "pricing": {
+        "input_per_token": 1.65e-05,
+        "output_per_token": 6.6e-05,
+        "cache_read_per_token": 8.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "eu/o1-mini-2024-09-12": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 1.21e-06,
+        "output_per_token": 4.84e-06,
+        "cache_read_per_token": 6.05e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "eu/o1-preview-2024-09-12": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1.65e-05,
+        "output_per_token": 6.6e-05,
+        "cache_read_per_token": 8.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "eu/o3-mini-2025-01-31": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 100000
+      },
+      "pricing": {
+        "input_per_token": 1.21e-06,
+        "output_per_token": 4.84e-06,
+        "cache_read_per_token": 6.05e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "global-standard/gpt-4o-2024-08-06": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-02-27"
+    },
+    "global-standard/gpt-4o-2024-11-20": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-03-01"
+    },
+    "global-standard/gpt-4o-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "global/gpt-4o-2024-08-06": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-02-27"
+    },
+    "global/gpt-4o-2024-11-20": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-03-01"
+    },
+    "global/gpt-5.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "global/gpt-5.1-chat": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-3.5-turbo": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4097,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 1.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-3.5-turbo-0125": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 1.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      },
+      "deprecation_date": "2025-03-31"
+    },
+    "gpt-35-turbo": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4097,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 1.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-35-turbo-0125": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 1.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      },
+      "deprecation_date": "2025-05-31"
+    },
+    "gpt-35-turbo-1106": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      },
+      "deprecation_date": "2025-03-31"
+    },
+    "gpt-35-turbo-16k": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16385,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 4e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-35-turbo-16k-0613": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16385,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 4e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 3e-05,
+        "output_per_token": 6e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4-0125-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-05,
+        "output_per_token": 3e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4-0613": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 3e-05,
+        "output_per_token": 6e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4-1106-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-05,
+        "output_per_token": 3e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4-32k": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 6e-05,
+        "output_per_token": 0.00012
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4-32k-0613": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 6e-05,
+        "output_per_token": 0.00012
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4-turbo": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-05,
+        "output_per_token": 3e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4-turbo-2024-04-09": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-05,
+        "output_per_token": 3e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4-turbo-vision-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-05,
+        "output_per_token": 3e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1047576,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 8e-06,
+        "cache_read_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-4.1-2025-04-14": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1047576,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 8e-06,
+        "cache_read_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-11-04"
+    },
+    "gpt-4.1-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1047576,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 1.6e-06,
+        "cache_read_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-4.1-mini-2025-04-14": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1047576,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 1.6e-06,
+        "cache_read_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-11-04"
+    },
+    "gpt-4.1-nano": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1047576,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 4e-07,
+        "cache_read_per_token": 2.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-4.1-nano-2025-04-14": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1047576,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 4e-07,
+        "cache_read_per_token": 2.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-11-04"
+    },
+    "gpt-4.5-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 7.5e-05,
+        "output_per_token": 0.00015,
+        "cache_read_per_token": 3.75e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-4o": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-4o-2024-05-13": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 5e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "gpt-4o-2024-08-06": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-02-27"
+    },
+    "gpt-4o-2024-11-20": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.75e-06,
+        "output_per_token": 1.1e-05,
+        "cache_read_per_token": 1.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-03-01"
+    },
+    "gpt-4o-audio-preview-2024-12-17": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4o-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1.65e-07,
+        "output_per_token": 6.6e-07,
+        "cache_read_per_token": 7.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-4o-mini-2024-07-18": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1.65e-07,
+        "output_per_token": 6.6e-07,
+        "cache_read_per_token": 7.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-4o-mini-audio-preview-2024-12-17": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4o-mini-realtime-preview-2024-12-17": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.4e-06,
+        "cache_read_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4o-realtime-preview-2024-10-01": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 5e-06,
+        "output_per_token": 2e-05,
+        "cache_read_per_token": 2.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4o-realtime-preview-2024-12-17": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 5e-06,
+        "output_per_token": 2e-05,
+        "cache_read_per_token": 2.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5-2025-08-07": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5-chat": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5-chat-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 2e-06,
+        "cache_read_per_token": 2.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5-mini-2025-08-07": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 2e-06,
+        "cache_read_per_token": 2.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5-nano": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 5e-08,
+        "output_per_token": 4e-07,
+        "cache_read_per_token": 5e-09
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5-nano-2025-08-07": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 5e-08,
+        "output_per_token": 4e-07,
+        "cache_read_per_token": 5e-09
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5.1-2025-11-13": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5.1-chat": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5.1-chat-2025-11-13": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5.2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.75e-06,
+        "output_per_token": 1.4e-05,
+        "cache_read_per_token": 1.75e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5.2-2025-12-11": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.75e-06,
+        "output_per_token": 1.4e-05,
+        "cache_read_per_token": 1.75e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5.2-chat": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1.75e-06,
+        "output_per_token": 1.4e-05,
+        "cache_read_per_token": 1.75e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5.2-chat-2025-12-11": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1.75e-06,
+        "output_per_token": 1.4e-05,
+        "cache_read_per_token": 1.75e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5.3-chat": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1.75e-06,
+        "output_per_token": 1.4e-05,
+        "cache_read_per_token": 1.75e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5.4": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1050000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 2.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5.4-2026-03-05": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1050000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 2.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5.4-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1050000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 7.5e-07,
+        "output_per_token": 4.5e-06,
+        "cache_read_per_token": 7.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5.4-nano": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1050000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 1.25e-06,
+        "cache_read_per_token": 2e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-audio-1.5-2026-02-23": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-audio-2025-08-28": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-audio-mini-2025-10-06": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.4e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-realtime-1.5-2026-02-23": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 4e-06,
+        "output_per_token": 1.6e-05,
+        "cache_read_per_token": 4e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-realtime-2025-08-28": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 4e-06,
+        "output_per_token": 1.6e-05,
+        "cache_read_per_token": 4e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-realtime-mini-2025-10-06": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.4e-06,
+        "cache_read_per_token": 6e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral-large-2402": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000
+      },
+      "pricing": {
+        "input_per_token": 8e-06,
+        "output_per_token": 2.4e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral-large-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000
+      },
+      "pricing": {
+        "input_per_token": 8e-06,
+        "output_per_token": 2.4e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "o1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 100000
+      },
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 6e-05,
+        "cache_read_per_token": 7.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "o1-2024-12-17": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 100000
+      },
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 6e-05,
+        "cache_read_per_token": 7.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "o1-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 1.21e-06,
+        "output_per_token": 4.84e-06,
+        "cache_read_per_token": 6.05e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "o1-mini-2024-09-12": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 1.1e-06,
+        "output_per_token": 4.4e-06,
+        "cache_read_per_token": 5.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "o1-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 6e-05,
+        "cache_read_per_token": 7.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "o1-preview-2024-09-12": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 6e-05,
+        "cache_read_per_token": 7.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "o3": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 100000
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 8e-06,
+        "cache_read_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "o3-2025-04-16": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 100000
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 8e-06,
+        "cache_read_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-04-16"
+    },
+    "o3-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 100000
+      },
+      "pricing": {
+        "input_per_token": 1.1e-06,
+        "output_per_token": 4.4e-06,
+        "cache_read_per_token": 5.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "o3-mini-2025-01-31": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 100000
+      },
+      "pricing": {
+        "input_per_token": 1.1e-06,
+        "output_per_token": 4.4e-06,
+        "cache_read_per_token": 5.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "o4-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 100000
+      },
+      "pricing": {
+        "input_per_token": 1.1e-06,
+        "output_per_token": 4.4e-06,
+        "cache_read_per_token": 2.75e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "o4-mini-2025-04-16": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 100000
+      },
+      "pricing": {
+        "input_per_token": 1.1e-06,
+        "output_per_token": 4.4e-06,
+        "cache_read_per_token": 2.75e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "text-embedding-3-large": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 8191
+      },
+      "pricing": {
+        "input_per_token": 1.3e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "text-embedding-3-small": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 8191
+      },
+      "pricing": {
+        "input_per_token": 2e-08,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      },
+      "deprecation_date": "2026-04-30"
+    },
+    "text-embedding-ada-002": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 8191
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us/gpt-4.1-2025-04-14": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1047576,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2.2e-06,
+        "output_per_token": 8.8e-06,
+        "cache_read_per_token": 5.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-11-04"
+    },
+    "us/gpt-4.1-mini-2025-04-14": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1047576,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 4.4e-07,
+        "output_per_token": 1.76e-06,
+        "cache_read_per_token": 1.1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-11-04"
+    },
+    "us/gpt-4.1-nano-2025-04-14": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1047576,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1.1e-07,
+        "output_per_token": 4.4e-07,
+        "cache_read_per_token": 2.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-11-04"
+    },
+    "us/gpt-4o-2024-08-06": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.75e-06,
+        "output_per_token": 1.1e-05,
+        "cache_read_per_token": 1.375e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-02-27"
+    },
+    "us/gpt-4o-2024-11-20": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.75e-06,
+        "output_per_token": 1.1e-05,
+        "cache_write_per_token": 1.38e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-03-01"
+    },
+    "us/gpt-4o-mini-2024-07-18": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1.65e-07,
+        "output_per_token": 6.6e-07,
+        "cache_read_per_token": 8.3e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "us/gpt-4o-mini-realtime-preview-2024-12-17": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 6.6e-07,
+        "output_per_token": 2.64e-06,
+        "cache_read_per_token": 3.3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us/gpt-4o-realtime-preview-2024-10-01": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 5.5e-06,
+        "output_per_token": 2.2e-05,
+        "cache_read_per_token": 2.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us/gpt-4o-realtime-preview-2024-12-17": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 5.5e-06,
+        "output_per_token": 2.2e-05,
+        "cache_read_per_token": 2.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us/gpt-5-2025-08-07": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.375e-06,
+        "output_per_token": 1.1e-05,
+        "cache_read_per_token": 1.375e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "us/gpt-5-mini-2025-08-07": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2.75e-07,
+        "output_per_token": 2.2e-06,
+        "cache_read_per_token": 2.75e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "us/gpt-5-nano-2025-08-07": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 5.5e-08,
+        "output_per_token": 4.4e-07,
+        "cache_read_per_token": 5.5e-09
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "us/gpt-5.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.38e-06,
+        "output_per_token": 1.1e-05,
+        "cache_read_per_token": 1.4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "us/gpt-5.1-chat": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.38e-06,
+        "output_per_token": 1.1e-05,
+        "cache_read_per_token": 1.4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "us/o1-2024-12-17": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 100000
+      },
+      "pricing": {
+        "input_per_token": 1.65e-05,
+        "output_per_token": 6.6e-05,
+        "cache_read_per_token": 8.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "us/o1-mini-2024-09-12": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 1.21e-06,
+        "output_per_token": 4.84e-06,
+        "cache_read_per_token": 6.05e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "us/o1-preview-2024-09-12": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1.65e-05,
+        "output_per_token": 6.6e-05,
+        "cache_read_per_token": 8.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "us/o3-2025-04-16": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 100000
+      },
+      "pricing": {
+        "input_per_token": 2.2e-06,
+        "output_per_token": 8.8e-06,
+        "cache_read_per_token": 5.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-04-16"
+    },
+    "us/o3-mini-2025-01-31": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 100000
+      },
+      "pricing": {
+        "input_per_token": 1.21e-06,
+        "output_per_token": 4.84e-06,
+        "cache_read_per_token": 6.05e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "us/o4-mini-2025-04-16": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 100000
+      },
+      "pricing": {
+        "input_per_token": 1.21e-06,
+        "output_per_token": 4.84e-06,
+        "cache_read_per_token": 3.1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/azure_ai.json
+++ b/mlflow/utils/model_catalog/azure_ai.json
@@ -1,0 +1,1126 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "Cohere-embed-v3-english": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 512
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Cohere-embed-v3-multilingual": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 512
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Llama-3.2-11B-Vision-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 2048
+      },
+      "pricing": {
+        "input_per_token": 3.7e-07,
+        "output_per_token": 3.7e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Llama-3.2-90B-Vision-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 2048
+      },
+      "pricing": {
+        "input_per_token": 2.04e-06,
+        "output_per_token": 2.04e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Llama-3.3-70B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 2048
+      },
+      "pricing": {
+        "input_per_token": 7.1e-07,
+        "output_per_token": 7.1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Llama-4-Maverick-17B-128E-Instruct-FP8": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1.41e-06,
+        "output_per_token": 3.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Llama-4-Scout-17B-16E-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 10000000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 7.8e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "MAI-DS-R1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1.35e-06,
+        "output_per_token": 5.4e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Meta-Llama-3-70B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 2048
+      },
+      "pricing": {
+        "input_per_token": 1.1e-06,
+        "output_per_token": 3.7e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Meta-Llama-3.1-405B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 2048
+      },
+      "pricing": {
+        "input_per_token": 5.33e-06,
+        "output_per_token": 1.6e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Meta-Llama-3.1-70B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 2048
+      },
+      "pricing": {
+        "input_per_token": 2.68e-06,
+        "output_per_token": 3.54e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Meta-Llama-3.1-8B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 2048
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 6.1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Phi-3-medium-128k-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.7e-07,
+        "output_per_token": 6.8e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Phi-3-medium-4k-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.7e-07,
+        "output_per_token": 6.8e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Phi-3-mini-128k-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.3e-07,
+        "output_per_token": 5.2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Phi-3-mini-4k-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.3e-07,
+        "output_per_token": 5.2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Phi-3-small-128k-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Phi-3-small-8k-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Phi-3.5-MoE-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.6e-07,
+        "output_per_token": 6.4e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Phi-3.5-mini-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.3e-07,
+        "output_per_token": 5.2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Phi-3.5-vision-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.3e-07,
+        "output_per_token": 5.2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Phi-4": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1.25e-07,
+        "output_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Phi-4-mini-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 7.5e-08,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Phi-4-mini-reasoning": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 8e-08,
+        "output_per_token": 3.2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Phi-4-multimodal-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 8e-08,
+        "output_per_token": 3.2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Phi-4-reasoning": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.25e-07,
+        "output_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "claude-haiku-4-5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 5e-06,
+        "cache_read_per_token": 1e-07,
+        "cache_write_per_token": 1.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "claude-opus-4-1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 7.5e-05,
+        "cache_read_per_token": 1.5e-06,
+        "cache_write_per_token": 1.875e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "claude-opus-4-5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 5e-06,
+        "output_per_token": 2.5e-05,
+        "cache_read_per_token": 5e-07,
+        "cache_write_per_token": 6.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "claude-opus-4-6": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 5e-06,
+        "output_per_token": 2.5e-05,
+        "cache_read_per_token": 5e-07,
+        "cache_write_per_token": 6.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "claude-sonnet-4-5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "claude-sonnet-4-6": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "deepseek-r1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1.35e-06,
+        "output_per_token": 5.4e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-v3": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1.14e-06,
+        "output_per_token": 4.56e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-v3-0324": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1.14e-06,
+        "output_per_token": 4.56e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-v3.2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 163840
+      },
+      "pricing": {
+        "input_per_token": 5.8e-07,
+        "output_per_token": 1.68e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "deepseek-v3.2-speciale": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 163840
+      },
+      "pricing": {
+        "input_per_token": 5.8e-07,
+        "output_per_token": 1.68e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "embed-v-4-0": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.2e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "global/grok-3": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "global/grok-3-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 1.27e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-oss-120b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "grok-3": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "grok-3-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 1.27e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "grok-4": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "grok-4-1-fast-non-reasoning": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "grok-4-1-fast-reasoning": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "grok-4-fast-non-reasoning": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "grok-4-fast-reasoning": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "grok-code-fast-1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 1.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "jais-30b-chat": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 0.0032,
+        "output_per_token": 0.00971
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "jamba-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 70000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 7e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "kimi-k2.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 3e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ministral-3b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 4e-08,
+        "output_per_token": 4e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral-large": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 4e-06,
+        "output_per_token": 1.2e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral-large-2407": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 6e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral-large-3": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 1.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral-large-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 6e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral-medium-2505": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral-nemo": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral-small": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 3e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral-small-2503": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "model_router": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 1.4e-07,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/azure_text.json
+++ b/mlflow/utils/model_catalog/azure_text.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "gpt-3.5-turbo-instruct-0914": {
+      "mode": "completion",
+      "context_window": {
+        "max_input": 4097
+      },
+      "pricing": {
+        "input_per_token": 1.5e-06,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-35-turbo-instruct": {
+      "mode": "completion",
+      "context_window": {
+        "max_input": 4097
+      },
+      "pricing": {
+        "input_per_token": 1.5e-06,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-35-turbo-instruct-0914": {
+      "mode": "completion",
+      "context_window": {
+        "max_input": 4097
+      },
+      "pricing": {
+        "input_per_token": 1.5e-06,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/bedrock.json
+++ b/mlflow/utils/model_catalog/bedrock.json
@@ -1,0 +1,3746 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "*/1-month-commitment/cohere.command-light-text-v14": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "*/1-month-commitment/cohere.command-text-v14": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "*/6-month-commitment/cohere.command-light-text-v14": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "*/6-month-commitment/cohere.command-text-v14": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ai21.j2-mid-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8191,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 1.25e-05,
+        "output_per_token": 1.25e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ai21.j2-ultra-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8191,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 1.88e-05,
+        "output_per_token": 1.88e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ai21.jamba-1-5-large-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 8e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ai21.jamba-1-5-mini-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ai21.jamba-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 70000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 7e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "amazon.nova-2-multimodal-embeddings-v1:0": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 8172
+      },
+      "pricing": {
+        "input_per_token": 1.35e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "amazon.titan-embed-image-v1": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 128
+      },
+      "pricing": {
+        "input_per_token": 8e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "amazon.titan-embed-text-v1": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 8192
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "amazon.titan-embed-text-v2:0": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 8192
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "amazon.titan-text-express-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 42000,
+        "max_output": 8000
+      },
+      "pricing": {
+        "input_per_token": 1.3e-06,
+        "output_per_token": 1.7e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "amazon.titan-text-lite-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 42000,
+        "max_output": 4000
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "amazon.titan-text-premier-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 42000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 1.5e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "anthropic.claude-3-5-haiku-20241022-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 8e-07,
+        "output_per_token": 4e-06,
+        "cache_read_per_token": 8e-08,
+        "cache_write_per_token": 1e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "anthropic.claude-3-5-sonnet-20240620-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "anthropic.claude-3-5-sonnet-20241022-v2:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "anthropic.claude-3-7-sonnet-20240620-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3.6e-06,
+        "output_per_token": 1.8e-05,
+        "cache_read_per_token": 3.6e-07,
+        "cache_write_per_token": 4.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "anthropic.claude-3-haiku-20240307-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 1.25e-06,
+        "cache_read_per_token": 2.5e-08,
+        "cache_write_per_token": 3.125e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "anthropic.claude-3-opus-20240229-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 7.5e-05,
+        "cache_read_per_token": 1.5e-06,
+        "cache_write_per_token": 1.875e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "anthropic.claude-3-sonnet-20240229-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "anthropic.claude-instant-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 8e-07,
+        "output_per_token": 2.4e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "anthropic.claude-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 8e-06,
+        "output_per_token": 2.4e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "anthropic.claude-v2:1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 8e-06,
+        "output_per_token": 2.4e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ap-northeast-1/1-month-commitment/anthropic.claude-instant-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ap-northeast-1/1-month-commitment/anthropic.claude-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ap-northeast-1/1-month-commitment/anthropic.claude-v2:1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ap-northeast-1/6-month-commitment/anthropic.claude-instant-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ap-northeast-1/6-month-commitment/anthropic.claude-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ap-northeast-1/6-month-commitment/anthropic.claude-v2:1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ap-northeast-1/anthropic.claude-instant-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 2.23e-06,
+        "output_per_token": 7.55e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ap-northeast-1/anthropic.claude-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 8e-06,
+        "output_per_token": 2.4e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ap-northeast-1/anthropic.claude-v2:1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 8e-06,
+        "output_per_token": 2.4e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ap-northeast-1/deepseek.v3.2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 163840
+      },
+      "pricing": {
+        "input_per_token": 7.4e-07,
+        "output_per_token": 2.22e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ap-northeast-1/minimax.minimax-m2.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 196000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3.6e-07,
+        "output_per_token": 1.44e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ap-northeast-1/moonshotai.kimi-k2-thinking": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 7.3e-07,
+        "output_per_token": 3.03e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ap-northeast-1/moonshotai.kimi-k2.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 7.2e-07,
+        "output_per_token": 3.6e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ap-northeast-1/qwen.qwen3-coder-next": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 1.44e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ap-south-1/deepseek.v3.2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 163840
+      },
+      "pricing": {
+        "input_per_token": 7.4e-07,
+        "output_per_token": 2.22e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ap-south-1/meta.llama3-70b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3.18e-06,
+        "output_per_token": 4.2e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ap-south-1/meta.llama3-8b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3.6e-07,
+        "output_per_token": 7.2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ap-south-1/minimax.minimax-m2.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 196000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3.6e-07,
+        "output_per_token": 1.44e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ap-south-1/moonshotai.kimi-k2-thinking": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 7.1e-07,
+        "output_per_token": 2.94e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ap-south-1/moonshotai.kimi-k2.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 7.2e-07,
+        "output_per_token": 3.6e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ap-south-1/qwen.qwen3-coder-next": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 1.44e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ap-southeast-3/deepseek.v3.2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 163840
+      },
+      "pricing": {
+        "input_per_token": 7.4e-07,
+        "output_per_token": 2.22e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ap-southeast-3/minimax.minimax-m2.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 196000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3.6e-07,
+        "output_per_token": 1.44e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ap-southeast-3/moonshotai.kimi-k2.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 7.2e-07,
+        "output_per_token": 3.6e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ap-southeast-3/qwen.qwen3-coder-next": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 1.44e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "apac.anthropic.claude-3-5-sonnet-20240620-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "apac.anthropic.claude-3-5-sonnet-20241022-v2:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "apac.anthropic.claude-3-haiku-20240307-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 1.25e-06,
+        "cache_read_per_token": 2.5e-08,
+        "cache_write_per_token": 3.125e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "apac.anthropic.claude-3-sonnet-20240229-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "ca-central-1/meta.llama3-70b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3.05e-06,
+        "output_per_token": 4.03e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ca-central-1/meta.llama3-8b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3.5e-07,
+        "output_per_token": 6.9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "claude-sonnet-4-5-20250929-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "cohere.command-light-text-v14": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "cohere.command-r-plus-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "cohere.command-r-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 1.5e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "cohere.command-text-v14": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.5e-06,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "cohere.embed-english-v3": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 512
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "cohere.embed-multilingual-v3": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 512
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "cohere.embed-v4:0": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.2e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu-central-1/1-month-commitment/anthropic.claude-instant-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu-central-1/1-month-commitment/anthropic.claude-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu-central-1/1-month-commitment/anthropic.claude-v2:1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu-central-1/6-month-commitment/anthropic.claude-instant-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu-central-1/6-month-commitment/anthropic.claude-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu-central-1/6-month-commitment/anthropic.claude-v2:1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu-central-1/anthropic.claude-instant-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 2.48e-06,
+        "output_per_token": 8.38e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu-central-1/anthropic.claude-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 8e-06,
+        "output_per_token": 2.4e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu-central-1/anthropic.claude-v2:1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 8e-06,
+        "output_per_token": 2.4e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu-central-1/minimax.minimax-m2.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 196000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3.6e-07,
+        "output_per_token": 1.44e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu-central-1/qwen.qwen3-coder-next": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 1.44e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu-north-1/deepseek.v3.2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 163840
+      },
+      "pricing": {
+        "input_per_token": 7.4e-07,
+        "output_per_token": 2.22e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu-north-1/minimax.minimax-m2.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 196000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3.6e-07,
+        "output_per_token": 1.44e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu-north-1/moonshotai.kimi-k2.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 7.2e-07,
+        "output_per_token": 3.6e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu-south-1/minimax.minimax-m2.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 196000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3.6e-07,
+        "output_per_token": 1.44e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu-south-1/qwen.qwen3-coder-next": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 1.44e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu-west-1/meta.llama3-70b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 2.86e-06,
+        "output_per_token": 3.78e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu-west-1/meta.llama3-8b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3.2e-07,
+        "output_per_token": 6.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu-west-1/minimax.minimax-m2.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 196000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3.6e-07,
+        "output_per_token": 1.44e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu-west-1/qwen.qwen3-coder-next": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 1.44e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu-west-2/meta.llama3-70b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3.45e-06,
+        "output_per_token": 4.55e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu-west-2/meta.llama3-8b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3.9e-07,
+        "output_per_token": 7.8e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu-west-2/minimax.minimax-m2.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 196000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 4.7e-07,
+        "output_per_token": 1.86e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu-west-2/qwen.qwen3-coder-next": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 7.8e-07,
+        "output_per_token": 1.86e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu-west-3/mistral.mistral-7b-instruct-v0:2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2.6e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu-west-3/mistral.mistral-large-2402-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 1.04e-05,
+        "output_per_token": 3.12e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu-west-3/mistral.mixtral-8x7b-instruct-v0:1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 5.9e-07,
+        "output_per_token": 9.1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu.anthropic.claude-3-5-haiku-20241022-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 1.25e-06,
+        "cache_read_per_token": 2.5e-08,
+        "cache_write_per_token": 3.125e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "eu.anthropic.claude-3-5-sonnet-20240620-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "eu.anthropic.claude-3-5-sonnet-20241022-v2:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "eu.anthropic.claude-3-7-sonnet-20250219-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "eu.anthropic.claude-3-haiku-20240307-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 1.25e-06,
+        "cache_read_per_token": 2.5e-08,
+        "cache_write_per_token": 3.125e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "eu.anthropic.claude-3-opus-20240229-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 7.5e-05,
+        "cache_read_per_token": 1.5e-06,
+        "cache_write_per_token": 1.875e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "eu.anthropic.claude-3-sonnet-20240229-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "eu.meta.llama3-2-1b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.3e-07,
+        "output_per_token": 1.3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu.meta.llama3-2-3b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.9e-07,
+        "output_per_token": 1.9e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu.twelvelabs.marengo-embed-2-7-v1:0": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 77
+      },
+      "pricing": {
+        "input_per_token": 7e-05,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "eu.twelvelabs.pegasus-1-2-v1:0": {
+      "mode": "chat",
+      "pricing": {
+        "output_per_token": 7.5e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "invoke/anthropic.claude-3-5-sonnet-20240620-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "meta.llama2-13b-chat-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 7.5e-07,
+        "output_per_token": 1e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta.llama2-70b-chat-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.95e-06,
+        "output_per_token": 2.56e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta.llama3-1-405b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 5.32e-06,
+        "output_per_token": 1.6e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta.llama3-1-70b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 2048
+      },
+      "pricing": {
+        "input_per_token": 9.9e-07,
+        "output_per_token": 9.9e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta.llama3-1-8b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 2048
+      },
+      "pricing": {
+        "input_per_token": 2.2e-07,
+        "output_per_token": 2.2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta.llama3-2-11b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 3.5e-07,
+        "output_per_token": 3.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta.llama3-2-1b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta.llama3-2-3b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta.llama3-2-90b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta.llama3-70b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 2.65e-06,
+        "output_per_token": 3.5e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta.llama3-8b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral.mistral-7b-instruct-v0:2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral.mistral-large-2402-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 8e-06,
+        "output_per_token": 2.4e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral.mistral-large-2407-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 9e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral.mistral-small-2402-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 3e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral.mixtral-8x7b-instruct-v0:1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 4.5e-07,
+        "output_per_token": 7e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "moonshotai.kimi-k2-thinking": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 7.3e-07,
+        "output_per_token": 3.03e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "moonshotai.kimi-k2.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 3.03e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "sa-east-1/deepseek.v3.2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 163840
+      },
+      "pricing": {
+        "input_per_token": 7.4e-07,
+        "output_per_token": 2.22e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "sa-east-1/meta.llama3-70b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 4.45e-06,
+        "output_per_token": 5.88e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "sa-east-1/meta.llama3-8b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 1.01e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "sa-east-1/minimax.minimax-m2.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 196000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3.6e-07,
+        "output_per_token": 1.44e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "sa-east-1/moonshotai.kimi-k2-thinking": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 7.3e-07,
+        "output_per_token": 3.03e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "sa-east-1/moonshotai.kimi-k2.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 7.2e-07,
+        "output_per_token": 3.6e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "sa-east-1/qwen.qwen3-coder-next": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 1.44e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "twelvelabs.marengo-embed-2-7-v1:0": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 77
+      },
+      "pricing": {
+        "input_per_token": 7e-05,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "twelvelabs.pegasus-1-2-v1:0": {
+      "mode": "chat",
+      "pricing": {
+        "output_per_token": 7.5e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-east-1/1-month-commitment/anthropic.claude-instant-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-east-1/1-month-commitment/anthropic.claude-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-east-1/1-month-commitment/anthropic.claude-v2:1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-east-1/6-month-commitment/anthropic.claude-instant-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-east-1/6-month-commitment/anthropic.claude-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-east-1/6-month-commitment/anthropic.claude-v2:1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-east-1/anthropic.claude-instant-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 8e-07,
+        "output_per_token": 2.4e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-east-1/anthropic.claude-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 8e-06,
+        "output_per_token": 2.4e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-east-1/anthropic.claude-v2:1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 8e-06,
+        "output_per_token": 2.4e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-east-1/deepseek.v3.2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 163840
+      },
+      "pricing": {
+        "input_per_token": 6.2e-07,
+        "output_per_token": 1.85e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-east-1/meta.llama3-70b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 2.65e-06,
+        "output_per_token": 3.5e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-east-1/meta.llama3-8b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-east-1/minimax.minimax-m2.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 196000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-east-1/mistral.mistral-7b-instruct-v0:2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-east-1/mistral.mistral-large-2402-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 8e-06,
+        "output_per_token": 2.4e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-east-1/mistral.mixtral-8x7b-instruct-v0:1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 4.5e-07,
+        "output_per_token": 7e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-east-1/moonshotai.kimi-k2-thinking": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-east-1/moonshotai.kimi-k2.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 3e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-east-1/qwen.qwen3-coder-next": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-east-2/deepseek.v3.2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 163840
+      },
+      "pricing": {
+        "input_per_token": 6.2e-07,
+        "output_per_token": 1.85e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-east-2/minimax.minimax-m2.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 196000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-east-2/moonshotai.kimi-k2-thinking": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-east-2/moonshotai.kimi-k2.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 3e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-east-2/qwen.qwen3-coder-next": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-gov-east-1/amazon.nova-pro-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 300000,
+        "max_output": 10000
+      },
+      "pricing": {
+        "input_per_token": 9.6e-07,
+        "output_per_token": 3.84e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "us-gov-east-1/amazon.titan-embed-text-v1": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 8192
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-gov-east-1/amazon.titan-embed-text-v2:0": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 8192
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-gov-east-1/amazon.titan-text-express-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 42000,
+        "max_output": 8000
+      },
+      "pricing": {
+        "input_per_token": 1.3e-06,
+        "output_per_token": 1.7e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-gov-east-1/amazon.titan-text-lite-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 42000,
+        "max_output": 4000
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-gov-east-1/amazon.titan-text-premier-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 42000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 1.5e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-gov-east-1/anthropic.claude-3-5-sonnet-20240620-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3.6e-06,
+        "output_per_token": 1.8e-05,
+        "cache_read_per_token": 3.6e-07,
+        "cache_write_per_token": 4.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "us-gov-east-1/anthropic.claude-3-haiku-20240307-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 1.5e-06,
+        "cache_read_per_token": 3e-08,
+        "cache_write_per_token": 3.75e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "us-gov-east-1/claude-sonnet-4-5-20250929-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 3.3e-06,
+        "output_per_token": 1.65e-05,
+        "cache_read_per_token": 3.3e-07,
+        "cache_write_per_token": 4.125e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "us-gov-east-1/meta.llama3-70b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8000,
+        "max_output": 2048
+      },
+      "pricing": {
+        "input_per_token": 2.65e-06,
+        "output_per_token": 3.5e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-gov-east-1/meta.llama3-8b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8000,
+        "max_output": 2048
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 2.65e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-gov-west-1/amazon.nova-pro-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 300000,
+        "max_output": 10000
+      },
+      "pricing": {
+        "input_per_token": 9.6e-07,
+        "output_per_token": 3.84e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "us-gov-west-1/amazon.titan-embed-text-v1": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 8192
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-gov-west-1/amazon.titan-embed-text-v2:0": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 8192
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-gov-west-1/amazon.titan-text-express-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 42000,
+        "max_output": 8000
+      },
+      "pricing": {
+        "input_per_token": 1.3e-06,
+        "output_per_token": 1.7e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-gov-west-1/amazon.titan-text-lite-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 42000,
+        "max_output": 4000
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-gov-west-1/amazon.titan-text-premier-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 42000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 1.5e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-gov-west-1/anthropic.claude-3-5-sonnet-20240620-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3.6e-06,
+        "output_per_token": 1.8e-05,
+        "cache_read_per_token": 3.6e-07,
+        "cache_write_per_token": 4.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "us-gov-west-1/anthropic.claude-3-7-sonnet-20250219-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3.6e-06,
+        "output_per_token": 1.8e-05,
+        "cache_read_per_token": 3.6e-07,
+        "cache_write_per_token": 4.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "us-gov-west-1/anthropic.claude-3-haiku-20240307-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 1.5e-06,
+        "cache_read_per_token": 3e-08,
+        "cache_write_per_token": 3.75e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "us-gov-west-1/claude-sonnet-4-5-20250929-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 3.3e-06,
+        "output_per_token": 1.65e-05,
+        "cache_read_per_token": 3.3e-07,
+        "cache_write_per_token": 4.125e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "us-gov-west-1/meta.llama3-70b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8000,
+        "max_output": 2048
+      },
+      "pricing": {
+        "input_per_token": 2.65e-06,
+        "output_per_token": 3.5e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-gov-west-1/meta.llama3-8b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8000,
+        "max_output": 2048
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 2.65e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-west-1/meta.llama3-70b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 2.65e-06,
+        "output_per_token": 3.5e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-west-1/meta.llama3-8b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-west-2/1-month-commitment/anthropic.claude-instant-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-west-2/1-month-commitment/anthropic.claude-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-west-2/1-month-commitment/anthropic.claude-v2:1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-west-2/6-month-commitment/anthropic.claude-instant-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-west-2/6-month-commitment/anthropic.claude-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-west-2/6-month-commitment/anthropic.claude-v2:1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-west-2/anthropic.claude-instant-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 8e-07,
+        "output_per_token": 2.4e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-west-2/anthropic.claude-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 8e-06,
+        "output_per_token": 2.4e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-west-2/anthropic.claude-v2:1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 8e-06,
+        "output_per_token": 2.4e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-west-2/deepseek.v3.2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 163840
+      },
+      "pricing": {
+        "input_per_token": 6.2e-07,
+        "output_per_token": 1.85e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-west-2/minimax.minimax-m2.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 196000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-west-2/mistral.mistral-7b-instruct-v0:2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-west-2/mistral.mistral-large-2402-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 8e-06,
+        "output_per_token": 2.4e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-west-2/mistral.mixtral-8x7b-instruct-v0:1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 4.5e-07,
+        "output_per_token": 7e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-west-2/moonshotai.kimi-k2-thinking": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-west-2/moonshotai.kimi-k2.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 3e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us-west-2/qwen.qwen3-coder-next": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us.anthropic.claude-3-5-haiku-20241022-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 8e-07,
+        "output_per_token": 4e-06,
+        "cache_read_per_token": 8e-08,
+        "cache_write_per_token": 1e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "us.anthropic.claude-3-5-sonnet-20240620-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "us.anthropic.claude-3-5-sonnet-20241022-v2:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "us.anthropic.claude-3-haiku-20240307-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 1.25e-06,
+        "cache_read_per_token": 2.5e-08,
+        "cache_write_per_token": 3.125e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "us.anthropic.claude-3-opus-20240229-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 7.5e-05,
+        "cache_read_per_token": 1.5e-06,
+        "cache_write_per_token": 1.875e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "us.anthropic.claude-3-sonnet-20240229-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "us.meta.llama3-1-405b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 5.32e-06,
+        "output_per_token": 1.6e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us.meta.llama3-1-70b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 2048
+      },
+      "pricing": {
+        "input_per_token": 9.9e-07,
+        "output_per_token": 9.9e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us.meta.llama3-1-8b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 2048
+      },
+      "pricing": {
+        "input_per_token": 2.2e-07,
+        "output_per_token": 2.2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us.meta.llama3-2-11b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 3.5e-07,
+        "output_per_token": 3.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us.meta.llama3-2-1b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us.meta.llama3-2-3b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us.meta.llama3-2-90b-instruct-v1:0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us.twelvelabs.marengo-embed-2-7-v1:0": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 77
+      },
+      "pricing": {
+        "input_per_token": 7e-05,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "us.twelvelabs.pegasus-1-2-v1:0": {
+      "mode": "chat",
+      "pricing": {
+        "output_per_token": 7.5e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/bedrock_mantle.json
+++ b/mlflow/utils/model_catalog/bedrock_mantle.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "openai.gpt-oss-120b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "openai.gpt-oss-20b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 7.5e-08,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "openai.gpt-oss-safeguard-120b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "openai.gpt-oss-safeguard-20b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 7.5e-08,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/cerebras.json
+++ b/mlflow/utils/model_catalog/cerebras.json
@@ -1,0 +1,132 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "gpt-oss-120b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 3.5e-07,
+        "output_per_token": 7.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "llama-3.3-70b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 8.5e-07,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama3.1-70b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama3.1-8b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen-3-32b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 8e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "zai-glm-4.6": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2.25e-06,
+        "output_per_token": 2.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      },
+      "deprecation_date": "2026-01-20"
+    },
+    "zai-glm-4.7": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2.25e-06,
+        "output_per_token": 2.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/cloudflare.json
+++ b/mlflow/utils/model_catalog/cloudflare.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "@cf/meta/llama-2-7b-chat-fp16": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 3072,
+        "max_output": 3072
+      },
+      "pricing": {
+        "input_per_token": 1.923e-06,
+        "output_per_token": 1.923e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "@cf/meta/llama-2-7b-chat-int8": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 2048,
+        "max_output": 2048
+      },
+      "pricing": {
+        "input_per_token": 1.923e-06,
+        "output_per_token": 1.923e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "@cf/mistral/mistral-7b-instruct-v0.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1.923e-06,
+        "output_per_token": 1.923e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "@hf/thebloke/codellama-7b-instruct-awq": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.923e-06,
+        "output_per_token": 1.923e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/codestral.json
+++ b/mlflow/utils/model_catalog/codestral.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "codestral-2405": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "codestral-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/cohere.json
+++ b/mlflow/utils/model_catalog/cohere.json
@@ -1,0 +1,177 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "command": {
+      "mode": "completion",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "command-nightly": {
+      "mode": "completion",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "embed-english-light-v2.0": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 1024
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "embed-english-light-v3.0": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 1024
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "embed-english-v2.0": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "embed-english-v3.0": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 1024
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "embed-multilingual-light-v3.0": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 1024
+      },
+      "pricing": {
+        "input_per_token": 0.0001,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "embed-multilingual-v2.0": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 768
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "embed-multilingual-v3.0": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 1024
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "embed-v4.0": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.2e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/cohere_chat.json
+++ b/mlflow/utils/model_catalog/cohere_chat.json
@@ -1,0 +1,131 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "command-a-03-2025": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 8000
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "command-light": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "command-r": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "command-r-08-2024": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "command-r-plus": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "command-r-plus-08-2024": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "command-r7b-12-2024": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 3.75e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/dashscope.json
+++ b/mlflow/utils/model_catalog/dashscope.json
@@ -1,0 +1,521 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "qwen-coder": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 1.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen-flash": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 997952,
+        "max_output": 32768
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen-flash-2025-07-28": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 997952,
+        "max_output": 32768
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen-max": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 30720,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1.6e-06,
+        "output_per_token": 6.4e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen-plus": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 129024,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen-plus-2025-01-25": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 129024,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen-plus-2025-04-28": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 129024,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen-plus-2025-07-14": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 129024,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen-plus-2025-07-28": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 997952,
+        "max_output": 32768
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen-plus-2025-09-11": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 997952,
+        "max_output": 32768
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen-plus-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 997952,
+        "max_output": 32768
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen-turbo": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 129024,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 5e-08,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen-turbo-2024-11-01": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 5e-08,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen-turbo-2025-04-28": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 5e-08,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen-turbo-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 5e-08,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen3-30b-a3b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 129024,
+        "max_output": 16384
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen3-coder-flash": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 997952,
+        "max_output": 65536
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen3-coder-flash-2025-07-28": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 997952,
+        "max_output": 65536
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen3-coder-plus": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 997952,
+        "max_output": 65536
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen3-coder-plus-2025-07-22": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 997952,
+        "max_output": 65536
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen3-max": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 258048,
+        "max_output": 65536
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen3-max-2026-01-23": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 258048,
+        "max_output": 65536
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen3-max-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 258048,
+        "max_output": 65536
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen3-next-80b-a3b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen3-next-80b-a3b-thinking": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen3-vl-235b-a22b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 1.6e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen3-vl-235b-a22b-thinking": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 4e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen3-vl-32b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1.6e-07,
+        "output_per_token": 6.4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen3-vl-32b-thinking": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1.6e-07,
+        "output_per_token": 2.87e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen3-vl-plus": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 260096,
+        "max_output": 32768
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen3.5-plus": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 991808,
+        "max_output": 65536
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwq-plus": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 98304,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 8e-07,
+        "output_per_token": 2.4e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/databricks.json
+++ b/mlflow/utils/model_catalog/databricks.json
@@ -1,0 +1,507 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "databricks-bge-large-en": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 512
+      },
+      "pricing": {
+        "input_per_token": 1.0003e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "databricks-claude-3-7-sonnet": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2.9999900000000002e-06,
+        "output_per_token": 1.5000020000000002e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "databricks-claude-haiku-4-5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 1.00002e-06,
+        "output_per_token": 5.00003e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "databricks-claude-opus-4": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 1.5000020000000002e-05,
+        "output_per_token": 7.500003000000001e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "databricks-claude-opus-4-1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 1.5000020000000002e-05,
+        "output_per_token": 7.500003000000001e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "databricks-claude-opus-4-5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 5.00003e-06,
+        "output_per_token": 2.5000010000000002e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "databricks-claude-sonnet-4": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 2.9999900000000002e-06,
+        "output_per_token": 1.5000020000000002e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "databricks-claude-sonnet-4-1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 2.9999900000000002e-06,
+        "output_per_token": 1.5000020000000002e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "databricks-claude-sonnet-4-5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 2.9999900000000002e-06,
+        "output_per_token": 1.5000020000000002e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "databricks-gemini-2-5-flash": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65535
+      },
+      "pricing": {
+        "input_per_token": 3.0001999999999996e-07,
+        "output_per_token": 2.49998e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "databricks-gemini-2-5-pro": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 1.24999e-06,
+        "output_per_token": 9.999990000000002e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "databricks-gemma-3-12b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 1.5000999999999998e-07,
+        "output_per_token": 5.0001e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "databricks-gpt-5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.24999e-06,
+        "output_per_token": 9.999990000000002e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "databricks-gpt-5-1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.24999e-06,
+        "output_per_token": 9.999990000000002e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "databricks-gpt-5-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2.4997000000000006e-07,
+        "output_per_token": 1.9999700000000004e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "databricks-gpt-5-nano": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 4.998e-08,
+        "output_per_token": 3.9998000000000007e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "databricks-gpt-oss-120b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1.5000999999999998e-07,
+        "output_per_token": 5.9997e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "databricks-gpt-oss-20b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 7e-08,
+        "output_per_token": 3.0001999999999996e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "databricks-gte-large-en": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 8192
+      },
+      "pricing": {
+        "input_per_token": 1.2999000000000001e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "databricks-llama-2-70b-chat": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 5.0001e-07,
+        "output_per_token": 1.5000300000000002e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "databricks-llama-4-maverick": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 5.0001e-07,
+        "output_per_token": 1.5000300000000002e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "databricks-meta-llama-3-1-405b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 5.00003e-06,
+        "output_per_token": 1.5000020000000002e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "databricks-meta-llama-3-1-8b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.5000999999999998e-07,
+        "output_per_token": 4.5003000000000007e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "databricks-meta-llama-3-3-70b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 5.0001e-07,
+        "output_per_token": 1.5000300000000002e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "databricks-meta-llama-3-70b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.00002e-06,
+        "output_per_token": 2.9999900000000002e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "databricks-mixtral-8x7b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 5.0001e-07,
+        "output_per_token": 1.00002e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "databricks-mpt-30b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1.00002e-06,
+        "output_per_token": 1.00002e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "databricks-mpt-7b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 5.0001e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/deepinfra.json
+++ b/mlflow/utils/model_catalog/deepinfra.json
@@ -1,0 +1,1217 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "Gryphe/MythoMax-L2-13b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 8e-08,
+        "output_per_token": 9e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "NousResearch/Hermes-3-Llama-3.1-405B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 1e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "NousResearch/Hermes-3-Llama-3.1-70B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/QwQ-32B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen2.5-72B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1.2e-07,
+        "output_per_token": 3.9e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen2.5-7B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 4e-08,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen2.5-VL-32B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen3-14B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 40960,
+        "max_output": 40960
+      },
+      "pricing": {
+        "input_per_token": 6e-08,
+        "output_per_token": 2.4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen3-235B-A22B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 40960,
+        "max_output": 40960
+      },
+      "pricing": {
+        "input_per_token": 1.8e-07,
+        "output_per_token": 5.4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen3-235B-A22B-Instruct-2507": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 9e-08,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen3-235B-A22B-Thinking-2507": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 2.9e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen3-30B-A3B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 40960,
+        "max_output": 40960
+      },
+      "pricing": {
+        "input_per_token": 8e-08,
+        "output_per_token": 2.9e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen3-32B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 40960,
+        "max_output": 40960
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 2.8e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen3-Coder-480B-A35B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 1.6e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 2.9e-07,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen3-Next-80B-A3B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 1.4e-07,
+        "output_per_token": 1.4e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen3-Next-80B-A3B-Thinking": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 1.4e-07,
+        "output_per_token": 1.4e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Sao10K/L3-8B-Lunaris-v1-Turbo": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 4e-08,
+        "output_per_token": 5e-08
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Sao10K/L3.1-70B-Euryale-v2.2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 6.5e-07,
+        "output_per_token": 7.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Sao10K/L3.3-70B-Euryale-v2.3": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 6.5e-07,
+        "output_per_token": 7.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "allenai/olmOCR-7B-0725-FP8": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.7e-07,
+        "output_per_token": 1.5e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "anthropic/claude-3-7-sonnet-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 200000
+      },
+      "pricing": {
+        "input_per_token": 3.3e-06,
+        "output_per_token": 1.65e-05,
+        "cache_read_per_token": 3.3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "anthropic/claude-4-opus": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 200000
+      },
+      "pricing": {
+        "input_per_token": 1.65e-05,
+        "output_per_token": 8.25e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "anthropic/claude-4-sonnet": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 200000
+      },
+      "pricing": {
+        "input_per_token": 3.3e-06,
+        "output_per_token": 1.65e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/DeepSeek-R1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 163840
+      },
+      "pricing": {
+        "input_per_token": 7e-07,
+        "output_per_token": 2.4e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/DeepSeek-R1-0528": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 163840
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 2.15e-06,
+        "cache_read_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/DeepSeek-R1-0528-Turbo": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 3e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/DeepSeek-R1-Distill-Llama-70B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2.7e-07,
+        "output_per_token": 2.7e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/DeepSeek-R1-Turbo": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 40960,
+        "max_output": 40960
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 3e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/DeepSeek-V3": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 163840
+      },
+      "pricing": {
+        "input_per_token": 3.8e-07,
+        "output_per_token": 8.9e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/DeepSeek-V3-0324": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 163840
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 8.8e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/DeepSeek-V3.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 163840
+      },
+      "pricing": {
+        "input_per_token": 2.7e-07,
+        "output_per_token": 1e-06,
+        "cache_read_per_token": 2.16e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/DeepSeek-V3.1-Terminus": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 163840
+      },
+      "pricing": {
+        "input_per_token": 2.7e-07,
+        "output_per_token": 1e-06,
+        "cache_read_per_token": 2.16e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "google/gemini-2.0-flash-001": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 1000000
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      },
+      "deprecation_date": "2026-06-01"
+    },
+    "google/gemini-2.5-flash": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 1000000
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 2.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "google/gemini-2.5-pro": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 1000000
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "google/gemma-3-12b-it": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 5e-08,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "google/gemma-3-27b-it": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 9e-08,
+        "output_per_token": 1.6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "google/gemma-3-4b-it": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 4e-08,
+        "output_per_token": 8e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Llama-3.2-11B-Vision-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 4.9e-08,
+        "output_per_token": 4.9e-08
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Llama-3.2-3B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-08,
+        "output_per_token": 2e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Llama-3.3-70B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2.3e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Llama-3.3-70B-Instruct-Turbo": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1.3e-07,
+        "output_per_token": 3.9e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 1048576
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Llama-4-Scout-17B-16E-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 327680,
+        "max_output": 327680
+      },
+      "pricing": {
+        "input_per_token": 8e-08,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Llama-Guard-3-8B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 5.5e-08,
+        "output_per_token": 5.5e-08
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Llama-Guard-4-12B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 163840
+      },
+      "pricing": {
+        "input_per_token": 1.8e-07,
+        "output_per_token": 1.8e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Meta-Llama-3-8B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3e-08,
+        "output_per_token": 6e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Meta-Llama-3.1-70B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 2.8e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Meta-Llama-3.1-8B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 3e-08,
+        "output_per_token": 5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-08,
+        "output_per_token": 3e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "microsoft/WizardLM-2-8x22B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 65536,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 4.8e-07,
+        "output_per_token": 4.8e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "microsoft/phi-4": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 7e-08,
+        "output_per_token": 1.4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistralai/Mistral-Nemo-Instruct-2407": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-08,
+        "output_per_token": 4e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistralai/Mistral-Small-24B-Instruct-2501": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 5e-08,
+        "output_per_token": 8e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistralai/Mistral-Small-3.2-24B-Instruct-2506": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 7.5e-08,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistralai/Mixtral-8x7B-Instruct-v0.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "moonshotai/Kimi-K2-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "moonshotai/Kimi-K2-Instruct-0905": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 2e-06,
+        "cache_read_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "nvidia/Llama-3.1-Nemotron-70B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "nvidia/Llama-3.3-Nemotron-Super-49B-v1.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "nvidia/NVIDIA-Nemotron-Nano-9B-v2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 4e-08,
+        "output_per_token": 1.6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-oss-120b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 5e-08,
+        "output_per_token": 4.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-oss-20b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 4e-08,
+        "output_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "zai-org/GLM-4.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 1.6e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/deepseek.json
+++ b/mlflow/utils/model_catalog/deepseek.json
@@ -1,0 +1,117 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "deepseek-chat": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 2.8e-07,
+        "output_per_token": 4.2e-07,
+        "cache_read_per_token": 2.8e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "deepseek-coder": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.4e-07,
+        "output_per_token": 2.8e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "deepseek-r1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 65536,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 5.5e-07,
+        "output_per_token": 2.19e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "deepseek-reasoner": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 2.8e-07,
+        "output_per_token": 4.2e-07,
+        "cache_read_per_token": 2.8e-08
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "deepseek-v3": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 65536,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 2.7e-07,
+        "output_per_token": 1.1e-06,
+        "cache_read_per_token": 7e-08,
+        "cache_write_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "deepseek-v3.2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 163840
+      },
+      "pricing": {
+        "input_per_token": 2.8e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/featherless_ai.json
+++ b/mlflow/utils/model_catalog/featherless_ai.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "featherless-ai/Qwerky-72B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 4096
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "featherless-ai/Qwerky-QwQ-32B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 4096
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/fireworks_ai-embedding-models.json
+++ b/mlflow/utils/model_catalog/fireworks_ai-embedding-models.json
@@ -1,0 +1,90 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "WhereIsAI/UAE-Large-V1": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 512
+      },
+      "pricing": {
+        "input_per_token": 1.6e-08,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "nomic-ai/nomic-embed-text-v1": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 8192
+      },
+      "pricing": {
+        "input_per_token": 8e-09,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "nomic-ai/nomic-embed-text-v1.5": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 8192
+      },
+      "pricing": {
+        "input_per_token": 8e-09,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "thenlper/gte-base": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 512
+      },
+      "pricing": {
+        "input_per_token": 8e-09,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "thenlper/gte-large": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 512
+      },
+      "pricing": {
+        "input_per_token": 1.6e-08,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/fireworks_ai.json
+++ b/mlflow/utils/model_catalog/fireworks_ai.json
@@ -1,0 +1,4457 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "accounts/fireworks/models/": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 40960,
+        "max_output": 40960
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/chronos-hermes-13b-v2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/code-llama-13b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/code-llama-13b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/code-llama-13b-python": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/code-llama-34b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/code-llama-34b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/code-llama-34b-python": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/code-llama-70b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/code-llama-70b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/code-llama-70b-python": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/code-llama-7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/code-llama-7b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/code-llama-7b-python": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/code-qwen-1p5-7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 65536,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/codegemma-2b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/codegemma-7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/cogito-671b-v2-p1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 163840
+      },
+      "pricing": {
+        "input_per_token": 1.2e-06,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/cogito-v1-preview-llama-3b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/cogito-v1-preview-llama-70b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/cogito-v1-preview-llama-8b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/cogito-v1-preview-qwen-14b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/cogito-v1-preview-qwen-32b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/dbrx-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1.2e-06,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/deepseek-coder-1b-base": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/deepseek-coder-33b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/deepseek-coder-7b-base": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/deepseek-coder-7b-base-v1p5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/deepseek-coder-7b-instruct-v1p5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/deepseek-coder-v2-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 65536,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 1.2e-06,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "accounts/fireworks/models/deepseek-coder-v2-lite-base": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 163840
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/deepseek-coder-v2-lite-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 163840
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/deepseek-prover-v2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 163840
+      },
+      "pricing": {
+        "input_per_token": 1.2e-06,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/deepseek-r1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 20480
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 8e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "accounts/fireworks/models/deepseek-r1-0528": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 160000,
+        "max_output": 160000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 8e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "accounts/fireworks/models/deepseek-r1-0528-distill-qwen3-8b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/deepseek-r1-basic": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 20480
+      },
+      "pricing": {
+        "input_per_token": 5.5e-07,
+        "output_per_token": 2.19e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "accounts/fireworks/models/deepseek-r1-distill-llama-70b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/deepseek-r1-distill-llama-8b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/deepseek-r1-distill-qwen-14b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/deepseek-r1-distill-qwen-1p5b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/deepseek-r1-distill-qwen-32b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/deepseek-r1-distill-qwen-7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/deepseek-v2-lite-chat": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 163840
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/deepseek-v2p5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1.2e-06,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/deepseek-v3": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "accounts/fireworks/models/deepseek-v3-0324": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 163840
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "accounts/fireworks/models/deepseek-v3p1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 5.6e-07,
+        "output_per_token": 1.68e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "accounts/fireworks/models/deepseek-v3p1-terminus": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 5.6e-07,
+        "output_per_token": 1.68e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "accounts/fireworks/models/deepseek-v3p2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 163840
+      },
+      "pricing": {
+        "input_per_token": 5.6e-07,
+        "output_per_token": 1.68e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "accounts/fireworks/models/devstral-small-2505": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/dobby-mini-unhinged-plus-llama-3-1-8b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/dobby-unhinged-llama-3-3-70b-new": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/dolphin-2-9-2-qwen2-72b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/dolphin-2p6-mixtral-8x7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/ernie-4p5-21b-a3b-pt": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/ernie-4p5-300b-a47b-pt": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/fare-20b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/firefunction-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/firefunction-v2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "accounts/fireworks/models/firellava-13b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/firesearch-ocr-v6": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/flux-1-dev": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/flux-1-dev-controlnet-union": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-09,
+        "output_per_token": 1e-09
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/flux-1-schnell": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/gemma-2b-it": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/gemma-3-27b-it": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/gemma-7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/gemma-7b-it": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/gemma2-9b-it": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/glm-4p5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 96000
+      },
+      "pricing": {
+        "input_per_token": 5.5e-07,
+        "output_per_token": 2.19e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "accounts/fireworks/models/glm-4p5-air": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 96000
+      },
+      "pricing": {
+        "input_per_token": 2.2e-07,
+        "output_per_token": 8.8e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "accounts/fireworks/models/glm-4p5v": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1.2e-06,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/glm-4p6": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 202800,
+        "max_output": 202800
+      },
+      "pricing": {
+        "input_per_token": 5.5e-07,
+        "output_per_token": 2.19e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "accounts/fireworks/models/glm-4p7": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 202800,
+        "max_output": 202800
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.2e-06,
+        "cache_read_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "accounts/fireworks/models/gpt-oss-120b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "accounts/fireworks/models/gpt-oss-20b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 5e-08,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "accounts/fireworks/models/gpt-oss-safeguard-120b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1.2e-06,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/gpt-oss-safeguard-20b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/hermes-2-pro-mistral-7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/internvl3-38b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/internvl3-78b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/internvl3-8b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/kat-coder": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/kat-dev-32b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/kat-dev-72b-exp": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/kimi-k2-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "accounts/fireworks/models/kimi-k2-instruct-0905": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "accounts/fireworks/models/kimi-k2-thinking": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "accounts/fireworks/models/kimi-k2p5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 3e-06,
+        "cache_read_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "accounts/fireworks/models/llama-guard-2-8b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/llama-guard-3-1b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/llama-guard-3-8b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/llama-v2-13b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/llama-v2-13b-chat": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/llama-v2-70b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/llama-v2-70b-chat": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 2048,
+        "max_output": 2048
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/llama-v2-7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/llama-v2-7b-chat": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/llama-v3-70b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/llama-v3-70b-instruct-hf": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/llama-v3-8b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/llama-v3-8b-instruct-hf": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/llama-v3p1-405b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 3e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "accounts/fireworks/models/llama-v3p1-405b-instruct-long": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/llama-v3p1-70b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/llama-v3p1-70b-instruct-1b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/llama-v3p1-8b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "accounts/fireworks/models/llama-v3p1-nemotron-70b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/llama-v3p2-11b-vision-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "accounts/fireworks/models/llama-v3p2-1b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/llama-v3p2-1b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "accounts/fireworks/models/llama-v3p2-3b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/llama-v3p2-3b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "accounts/fireworks/models/llama-v3p2-90b-vision-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "accounts/fireworks/models/llama-v3p3-70b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/llama4-maverick-instruct-basic": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2.2e-07,
+        "output_per_token": 8.8e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "accounts/fireworks/models/llama4-scout-instruct-basic": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "accounts/fireworks/models/llamaguard-7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/llava-yi-34b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/minimax-m1-80k": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/minimax-m2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/minimax-m2p1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 204800,
+        "max_output": 204800
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 1.2e-06,
+        "cache_read_per_token": 3e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "accounts/fireworks/models/ministral-3-14b-instruct-2512": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/ministral-3-3b-instruct-2512": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/ministral-3-8b-instruct-2512": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/mistral-7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/mistral-7b-instruct-4k": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/mistral-7b-instruct-v0p2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/mistral-7b-instruct-v3": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/mistral-7b-v0p2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/mistral-large-3-fp8": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 1.2e-06,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/mistral-nemo-base-2407": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/mistral-nemo-instruct-2407": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/mistral-small-24b-instruct-2501": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/mixtral-8x22b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 65536,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 1.2e-06,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/mixtral-8x22b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 65536,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 1.2e-06,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/mixtral-8x22b-instruct-hf": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 65536,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 1.2e-06,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "accounts/fireworks/models/mixtral-8x7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/mixtral-8x7b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/mixtral-8x7b-instruct-hf": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/mythomax-l2-13b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/nemotron-nano-v2-12b-vl": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/nous-capybara-7b-v1p9": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/nous-hermes-2-mixtral-8x7b-dpo": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/nous-hermes-2-yi-34b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/nous-hermes-llama2-13b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/nous-hermes-llama2-70b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/nous-hermes-llama2-7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/nvidia-nemotron-nano-12b-v2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/nvidia-nemotron-nano-9b-v2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/openchat-3p5-0106-7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/openhermes-2-mistral-7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/openhermes-2p5-mistral-7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/openorca-7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/phi-2-3b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 2048,
+        "max_output": 2048
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/phi-3-mini-128k-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/phi-3-vision-128k-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32064,
+        "max_output": 32064
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/phind-code-llama-34b-python-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/phind-code-llama-34b-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/phind-code-llama-34b-v2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/pythia-12b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 2048,
+        "max_output": 2048
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen-qwq-32b-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen-v2p5-14b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen-v2p5-7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen1p5-72b-chat": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen2-72b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "accounts/fireworks/models/qwen2-7b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen2-vl-2b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen2-vl-72b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen2-vl-7b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen2p5-0p5b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen2p5-14b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen2p5-1p5b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen2p5-32b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen2p5-32b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen2p5-72b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen2p5-72b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen2p5-7b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen2p5-coder-0p5b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen2p5-coder-0p5b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen2p5-coder-14b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen2p5-coder-14b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen2p5-coder-1p5b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen2p5-coder-1p5b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen2p5-coder-32b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen2p5-coder-32b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "accounts/fireworks/models/qwen2p5-coder-32b-instruct-128k": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen2p5-coder-32b-instruct-32k-rope": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen2p5-coder-32b-instruct-64k": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 65536,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen2p5-coder-3b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen2p5-coder-3b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen2p5-coder-7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen2p5-coder-7b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen2p5-math-72b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen2p5-vl-32b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen2p5-vl-3b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen2p5-vl-72b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen2p5-vl-7b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen3-0p6b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 40960,
+        "max_output": 40960
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen3-14b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 40960,
+        "max_output": 40960
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen3-1p7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen3-1p7b-fp8-draft": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen3-1p7b-fp8-draft-131072": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen3-1p7b-fp8-draft-40960": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 40960,
+        "max_output": 40960
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen3-235b-a22b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2.2e-07,
+        "output_per_token": 8.8e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen3-235b-a22b-instruct-2507": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 2.2e-07,
+        "output_per_token": 8.8e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen3-235b-a22b-thinking-2507": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 2.2e-07,
+        "output_per_token": 8.8e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen3-30b-a3b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen3-30b-a3b-instruct-2507": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen3-30b-a3b-thinking-2507": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen3-32b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen3-4b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 40960,
+        "max_output": 40960
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen3-4b-instruct-2507": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen3-8b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 40960,
+        "max_output": 40960
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen3-coder-30b-a3b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen3-coder-480b-a35b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 4.5e-07,
+        "output_per_token": 1.8e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen3-coder-480b-instruct-bf16": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen3-embedding-0p6b": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen3-embedding-4b": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 40960,
+        "max_output": 40960
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen3-next-80b-a3b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen3-next-80b-a3b-thinking": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen3-vl-235b-a22b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 2.2e-07,
+        "output_per_token": 8.8e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen3-vl-235b-a22b-thinking": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 2.2e-07,
+        "output_per_token": 8.8e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen3-vl-30b-a3b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen3-vl-30b-a3b-thinking": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen3-vl-32b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwen3-vl-8b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/qwq-32b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/rolm-ocr": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/snorkel-mistral-7b-pairrm-dpo": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/stablecode-3b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/starcoder-16b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/starcoder-7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/starcoder2-15b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/starcoder2-3b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/starcoder2-7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/toppy-m-7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/yi-34b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/yi-34b-200k-capybara": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 200000
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/yi-34b-chat": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/yi-6b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "accounts/fireworks/models/yi-large": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 3e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "accounts/fireworks/models/zephyr-7b-beta": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "glm-4p7": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 202800,
+        "max_output": 202800
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.2e-06,
+        "cache_read_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "kimi-k2p5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 3e-06,
+        "cache_read_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "minimax-m2p1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 204800,
+        "max_output": 204800
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 1.2e-06,
+        "cache_read_per_token": 3e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/friendliai.json
+++ b/mlflow/utils/model_catalog/friendliai.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "meta-llama-3.1-70b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "meta-llama-3.1-8b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/gemini.json
+++ b/mlflow/utils/model_catalog/gemini.json
@@ -1,0 +1,675 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "gemini-1.5-flash": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 8192
+      },
+      "pricing": {
+        "input_per_token": 7.5e-08,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      },
+      "deprecation_date": "2025-09-29"
+    },
+    "gemini-2.0-flash": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 4e-07,
+        "cache_read_per_token": 2.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-06-01"
+    },
+    "gemini-2.0-flash-001": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 4e-07,
+        "cache_read_per_token": 2.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-06-01"
+    },
+    "gemini-2.0-flash-lite": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 7.5e-08,
+        "output_per_token": 3e-07,
+        "cache_read_per_token": 1.875e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-06-01"
+    },
+    "gemini-2.0-flash-lite-001": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 7.5e-08,
+        "output_per_token": 3e-07,
+        "cache_read_per_token": 1.875e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-06-01"
+    },
+    "gemini-2.5-computer-use-preview-10-2025": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gemini-2.5-flash": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65535
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 2.5e-06,
+        "cache_read_per_token": 3e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gemini-2.5-flash-lite": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65535
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 4e-07,
+        "cache_read_per_token": 1e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gemini-2.5-flash-lite-preview-06-17": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65535
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 4e-07,
+        "cache_read_per_token": 2.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "deprecation_date": "2025-11-18"
+    },
+    "gemini-2.5-flash-lite-preview-09-2025": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65535
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 4e-07,
+        "cache_read_per_token": 1e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gemini-2.5-flash-native-audio-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 2.5e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gemini-2.5-flash-native-audio-preview-09-2025": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 2.5e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gemini-2.5-flash-native-audio-preview-12-2025": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 2.5e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gemini-2.5-flash-preview-09-2025": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65535
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 2.5e-06,
+        "cache_read_per_token": 7.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gemini-2.5-pro": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65535
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gemini-2.5-pro-preview-tts": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65535
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gemini-3-flash-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65535
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 3e-06,
+        "cache_read_per_token": 5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gemini-3-pro-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65535
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 1.2e-05,
+        "cache_read_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-03-09"
+    },
+    "gemini-3.1-flash-lite-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 1.5e-06,
+        "cache_read_per_token": 2.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gemini-3.1-flash-live-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 7.5e-07,
+        "output_per_token": 4.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gemini-3.1-pro-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 1.2e-05,
+        "cache_read_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gemini-3.1-pro-preview-customtools": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 1.2e-05,
+        "cache_read_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gemini-embedding-001": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 2048
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gemini-embedding-2-preview": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 8192
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gemini-exp-1114": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 0,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "gemini-exp-1206": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 2097152,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 0,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "gemini-flash-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65535
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 2.5e-06,
+        "cache_read_per_token": 7.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gemini-flash-lite-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65535
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 4e-07,
+        "cache_read_per_token": 2.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gemini-gemma-2-27b-it": {
+      "mode": "chat",
+      "context_window": {
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3.5e-07,
+        "output_per_token": 1.05e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gemini-gemma-2-9b-it": {
+      "mode": "chat",
+      "context_window": {
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3.5e-07,
+        "output_per_token": 1.05e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gemini-pro-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65535
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gemini-robotics-er-1.5-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65535
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 2.5e-06,
+        "cache_read_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "gemma-3-27b-it": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 0,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "learnlm-1.5-pro-experimental": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32767,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 0,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "lyria-3-clip-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 0,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "lyria-3-pro-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 0,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/gigachat.json
+++ b/mlflow/utils/model_catalog/gigachat.json
@@ -1,0 +1,110 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "Embeddings": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 512
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Embeddings-2": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 512
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "EmbeddingsGigaR": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 4096
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "GigaChat-2-Lite": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "GigaChat-2-Max": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "GigaChat-2-Pro": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/github_copilot.json
+++ b/mlflow/utils/model_catalog/github_copilot.json
@@ -1,0 +1,404 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "claude-haiku-4.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16000
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "claude-opus-4.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16000
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "claude-opus-4.6-fast": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16000
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "claude-opus-41": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 80000,
+        "max_output": 16000
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "claude-sonnet-4": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16000
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "claude-sonnet-4.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16000
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gemini-2.5-pro": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 64000
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gemini-3-pro-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 64000
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-3.5-turbo": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 4096
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-3.5-turbo-0613": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 4096
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 4096
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4-0613": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 4096
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4-o-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 64000,
+        "max_output": 4096
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "gpt-4.1-2025-04-14": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "gpt-41-copilot": {
+      "mode": "completion",
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4o": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 64000,
+        "max_output": 4096
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4o-2024-05-13": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 64000,
+        "max_output": 4096
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4o-2024-08-06": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 64000,
+        "max_output": 16384
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4o-2024-11-20": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 64000,
+        "max_output": 16384
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4o-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 64000,
+        "max_output": 4096
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4o-mini-2024-07-18": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 64000,
+        "max_output": 4096
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "gpt-5-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 64000
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "gpt-5.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 64000
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "gpt-5.2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 64000
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "text-embedding-3-small": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 8191
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "text-embedding-3-small-inference": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 8191
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "text-embedding-ada-002": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 8191
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/gmi.json
+++ b/mlflow/utils/model_catalog/gmi.json
@@ -1,0 +1,311 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "MiniMaxAI/MiniMax-M2.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 196608,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen3-VL-235B-A22B-Instruct-FP8": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 1.4e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "anthropic/claude-opus-4": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 409600,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 7.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "anthropic/claude-opus-4.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 409600,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 5e-06,
+        "output_per_token": 2.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "anthropic/claude-sonnet-4": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 409600,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "anthropic/claude-sonnet-4.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 409600,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/DeepSeek-V3-0324": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.8e-07,
+        "output_per_token": 8.8e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/DeepSeek-V3.2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.8e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "google/gemini-3-flash-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 3e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "google/gemini-3-pro-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 1.2e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "moonshotai/Kimi-K2-Thinking": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 8e-07,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-4o": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-4o-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 409600,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-5.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 409600,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-5.2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 409600,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 1.75e-06,
+        "output_per_token": 1.4e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "zai-org/GLM-4.7-FP8": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 202752,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/gradient_ai.json
+++ b/mlflow/utils/model_catalog/gradient_ai.json
@@ -1,0 +1,175 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "alibaba-qwen3-32b": {
+      "mode": "chat",
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "anthropic-claude-3-opus": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 7.5e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "anthropic-claude-3.5-haiku": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 8e-07,
+        "output_per_token": 4e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "anthropic-claude-3.5-sonnet": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "anthropic-claude-3.7-sonnet": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-r1-distill-llama-70b": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 9.9e-07,
+        "output_per_token": 9.9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama3-8b-instruct": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama3.3-70b-instruct": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 6.5e-07,
+        "output_per_token": 6.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral-nemo-instruct-2407": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai-gpt-4o": {
+      "mode": "chat",
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai-gpt-4o-mini": {
+      "mode": "chat",
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai-o3": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 8e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai-o3-mini": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 1.1e-06,
+        "output_per_token": 4.4e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/groq.json
+++ b/mlflow/utils/model_catalog/groq.json
@@ -1,0 +1,207 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "gemma-7b-it": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 5e-08,
+        "output_per_token": 8e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama-3.1-8b-instant": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 5e-08,
+        "output_per_token": 8e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama-3.3-70b-versatile": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 5.9e-07,
+        "output_per_token": 7.9e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/llama-4-maverick-17b-128e-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "meta-llama/llama-4-scout-17b-16e-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1.1e-07,
+        "output_per_token": 3.4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "meta-llama/llama-guard-4-12b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "moonshotai/kimi-k2-instruct-0905": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 3e-06,
+        "cache_read_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "openai/gpt-oss-120b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 32766
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 6e-07,
+        "cache_read_per_token": 7.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "openai/gpt-oss-20b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 7.5e-08,
+        "output_per_token": 3e-07,
+        "cache_read_per_token": 3.75e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "openai/gpt-oss-safeguard-20b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 7.5e-08,
+        "output_per_token": 3e-07,
+        "cache_read_per_token": 3.7e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "qwen/qwen3-32b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131000,
+        "max_output": 131000
+      },
+      "pricing": {
+        "input_per_token": 2.9e-07,
+        "output_per_token": 5.9e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/heroku.json
+++ b/mlflow/utils/model_catalog/heroku.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "claude-3-5-haiku": {
+      "mode": "chat",
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "claude-3-5-sonnet-latest": {
+      "mode": "chat",
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "claude-3-7-sonnet": {
+      "mode": "chat",
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "claude-4-sonnet": {
+      "mode": "chat",
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/hyperbolic.json
+++ b/mlflow/utils/model_catalog/hyperbolic.json
@@ -1,0 +1,293 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "NousResearch/Hermes-3-Llama-3.1-70B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1.2e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/QwQ-32B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen2.5-72B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1.2e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen2.5-Coder-32B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1.2e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen3-235B-A22B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/DeepSeek-R1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/DeepSeek-R1-0528": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 2.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/DeepSeek-V3": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/DeepSeek-V3-0324": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Llama-3.2-3B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1.2e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Llama-3.3-70B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1.2e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Meta-Llama-3-70B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1.2e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Meta-Llama-3.1-405B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1.2e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Meta-Llama-3.1-70B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1.2e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Meta-Llama-3.1-8B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1.2e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "moonshotai/Kimi-K2-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/lambda_ai.json
+++ b/mlflow/utils/model_catalog/lambda_ai.json
@@ -1,0 +1,365 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "deepseek-llama3.3-70b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-r1-0528": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-r1-671b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 8e-07,
+        "output_per_token": 8e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-v3-0324": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "hermes3-405b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 8e-07,
+        "output_per_token": 8e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "hermes3-70b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1.2e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "hermes3-8b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2.5e-08,
+        "output_per_token": 4e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "lfm-40b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "lfm-7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2.5e-08,
+        "output_per_token": 4e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama-4-maverick-17b-128e-instruct-fp8": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 5e-08,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama-4-scout-17b-16e-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 5e-08,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama3.1-405b-instruct-fp8": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 8e-07,
+        "output_per_token": 8e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama3.1-70b-instruct-fp8": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1.2e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama3.1-8b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2.5e-08,
+        "output_per_token": 4e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama3.1-nemotron-70b-instruct-fp8": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1.2e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama3.2-11b-vision-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1.5e-08,
+        "output_per_token": 2.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama3.2-3b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1.5e-08,
+        "output_per_token": 2.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama3.3-70b-instruct-fp8": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1.2e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen25-coder-32b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 5e-08,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen3-32b-fp8": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 5e-08,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/lemonade.json
+++ b/mlflow/utils/model_catalog/lemonade.json
@@ -1,0 +1,95 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "Gemma-3-4b-it-GGUF": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 0,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "Qwen3-4B-Instruct-2507-GGUF": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 0,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "Qwen3-Coder-30B-A3B-Instruct-GGUF": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 0,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "gpt-oss-120b-mxfp-GGUF": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 0,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "gpt-oss-20b-mxfp4-GGUF": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 0,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/llamagate.json
+++ b/mlflow/utils/model_catalog/llamagate.json
@@ -1,0 +1,291 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "codellama-7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 6e-08,
+        "output_per_token": 1.2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "deepseek-coder-6.7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 6e-08,
+        "output_per_token": 1.2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "deepseek-r1-7b-qwen": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 8e-08,
+        "output_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "deepseek-r1-8b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 65536,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "dolphin3-8b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 8e-08,
+        "output_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "gemma3-4b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3e-08,
+        "output_per_token": 8e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "llama-3.1-8b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3e-08,
+        "output_per_token": 5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "llama-3.2-3b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 4e-08,
+        "output_per_token": 8e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "llava-7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 2048
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "mistral-7b-v0.3": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "nomic-embed-text": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 8192
+      },
+      "pricing": {
+        "input_per_token": 2e-08,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openthinker-7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 8e-08,
+        "output_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "qwen2.5-coder-7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 6e-08,
+        "output_per_token": 1.2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "qwen3-8b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 4e-08,
+        "output_per_token": 1.4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "qwen3-embedding-8b": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 40960
+      },
+      "pricing": {
+        "input_per_token": 2e-08,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen3-vl-8b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 5.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/meta_llama.json
+++ b/mlflow/utils/model_catalog/meta_llama.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "Llama-3.3-70B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4028
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Llama-3.3-8B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4028
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Llama-4-Maverick-17B-128E-Instruct-FP8": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 4028
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Llama-4-Scout-17B-16E-Instruct-FP8": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 10000000,
+        "max_output": 4028
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/minimax.json
+++ b/mlflow/utils/model_catalog/minimax.json
@@ -1,0 +1,105 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "MiniMax-M2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 1.2e-06,
+        "cache_read_per_token": 3e-08,
+        "cache_write_per_token": 3.75e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "MiniMax-M2.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 1.2e-06,
+        "cache_read_per_token": 3e-08,
+        "cache_write_per_token": 3.75e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "MiniMax-M2.1-lightning": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 2.4e-06,
+        "cache_read_per_token": 3e-08,
+        "cache_write_per_token": 3.75e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "MiniMax-M2.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 1.2e-06,
+        "cache_read_per_token": 3e-08,
+        "cache_write_per_token": 3.75e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "MiniMax-M2.5-lightning": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 2.4e-06,
+        "cache_read_per_token": 3e-08,
+        "cache_write_per_token": 3.75e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/mistral.json
+++ b/mlflow/utils/model_catalog/mistral.json
@@ -1,0 +1,881 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "codestral-2405": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 3e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "codestral-2508": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "codestral-embed": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 8192
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "codestral-embed-2505": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 8192
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "codestral-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 3e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "codestral-mamba-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 2.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "devstral-2512": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "devstral-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "devstral-medium-2507": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "devstral-medium-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "devstral-small-2505": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "devstral-small-2507": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "devstral-small-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "labs-devstral-small-2512": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "magistral-medium-1-2-2509": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 40000,
+        "max_output": 40000
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "magistral-medium-2506": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 40000,
+        "max_output": 40000
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "magistral-medium-2509": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 40000,
+        "max_output": 40000
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "magistral-medium-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 40000,
+        "max_output": 40000
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "magistral-small-1-2-2509": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 40000,
+        "max_output": 40000
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 1.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "magistral-small-2506": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 40000,
+        "max_output": 40000
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 1.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "magistral-small-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 40000,
+        "max_output": 40000
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 1.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "ministral-3-14b-2512": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "ministral-3-3b-2512": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "ministral-3-8b-2512": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "mistral-embed": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 8192
+      },
+      "pricing": {
+        "input_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral-large-2402": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 4e-06,
+        "output_per_token": 1.2e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "mistral-large-2407": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 9e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "mistral-large-2411": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 6e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "mistral-large-2512": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 1.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "mistral-large-3": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 1.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "mistral-large-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 1.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "mistral-medium": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 2.7e-06,
+        "output_per_token": 8.1e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "mistral-medium-2312": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 2.7e-06,
+        "output_per_token": 8.1e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "mistral-medium-2505": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "mistral-medium-3-1-2508": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "mistral-medium-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "mistral-small": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "mistral-small-3-2-2506": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 6e-08,
+        "output_per_token": 1.8e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "mistral-small-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 6e-08,
+        "output_per_token": 1.8e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "mistral-tiny": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 2.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "open-codestral-mamba": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 2.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "open-mistral-7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 2.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "open-mistral-nemo": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "open-mistral-nemo-2407": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "open-mixtral-8x22b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 65336,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 6e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "open-mixtral-8x7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 7e-07,
+        "output_per_token": 7e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "pixtral-12b-2409": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "pixtral-large-2411": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 6e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "pixtral-large-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 6e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/moonshot.json
+++ b/mlflow/utils/model_catalog/moonshot.json
@@ -1,0 +1,394 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "kimi-k2-0711-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.5e-06,
+        "cache_read_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "kimi-k2-0905-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.5e-06,
+        "cache_read_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "kimi-k2-thinking": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.5e-06,
+        "cache_read_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "kimi-k2-thinking-turbo": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 1.15e-06,
+        "output_per_token": 8e-06,
+        "cache_read_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "kimi-k2-turbo-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 1.15e-06,
+        "output_per_token": 8e-06,
+        "cache_read_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "kimi-k2.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 3e-06,
+        "cache_read_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "kimi-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 5e-06,
+        "cache_read_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "kimi-latest-128k": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 5e-06,
+        "cache_read_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "kimi-latest-32k": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 3e-06,
+        "cache_read_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "kimi-latest-8k": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-06,
+        "cache_read_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "kimi-thinking-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.5e-06,
+        "cache_read_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "moonshot-v1-128k": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "moonshot-v1-128k-0430": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "moonshot-v1-128k-vision-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "moonshot-v1-32k": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 3e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "moonshot-v1-32k-0430": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 3e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "moonshot-v1-32k-vision-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 3e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "moonshot-v1-8k": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "moonshot-v1-8k-0430": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "moonshot-v1-8k-vision-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "moonshot-v1-auto": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/morph.json
+++ b/mlflow/utils/model_catalog/morph.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "morph-v3-fast": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16000,
+        "max_output": 16000
+      },
+      "pricing": {
+        "input_per_token": 8e-07,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "morph-v3-large": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16000,
+        "max_output": 16000
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 1.9e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/nebius.json
+++ b/mlflow/utils/model_catalog/nebius.json
@@ -1,0 +1,542 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "BAAI/bge-en-icl": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 32768
+      },
+      "pricing": {
+        "input_per_token": 1e-08,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "BAAI/bge-multilingual-gemma2": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 8192
+      },
+      "pricing": {
+        "input_per_token": 1e-08,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "NousResearch/Hermes-3-Llama-3.1-405B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 3e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/QwQ-32B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 4.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen2-VL-72B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1.3e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen2-VL-7B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-08,
+        "output_per_token": 6e-08
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen2.5-32B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 6e-08,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen2.5-72B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.3e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen2.5-Coder-7B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1e-08,
+        "output_per_token": 3e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen2.5-VL-72B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1.3e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen3-14B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 8e-08,
+        "output_per_token": 2.4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen3-235B-A22B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen3-30B-A3B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen3-32B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen3-4B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 8e-08,
+        "output_per_token": 2.4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/DeepSeek-R1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 8e-07,
+        "output_per_token": 2.4e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/DeepSeek-R1-0528": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 164000,
+        "max_output": 164000
+      },
+      "pricing": {
+        "input_per_token": 8e-07,
+        "output_per_token": 2.4e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/DeepSeek-R1-Distill-Llama-70B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 7.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/DeepSeek-V3": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 1.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/DeepSeek-V3-0324": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 1.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "google/gemma-3-27b-it": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 6e-08,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "intfloat/e5-mistral-7b-instruct": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 32768
+      },
+      "pricing": {
+        "input_per_token": 1e-08,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Llama-3.3-70B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.3e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Llama-Guard-3-8B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2e-08,
+        "output_per_token": 6e-08
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Meta-Llama-3.1-405B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 3e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Meta-Llama-3.1-70B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.3e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Meta-Llama-3.1-8B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2e-08,
+        "output_per_token": 6e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistralai/Mistral-Nemo-Instruct-2407": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 4e-08,
+        "output_per_token": 1.2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "nvidia/Llama-3.1-Nemotron-Ultra-253B-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 1.8e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "nvidia/Llama-3.3-Nemotron-Super-49B-v1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/nlp_cloud.json
+++ b/mlflow/utils/model_catalog/nlp_cloud.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "chatdolphin": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "dolphin": {
+      "mode": "completion",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/novita.json
+++ b/mlflow/utils/model_catalog/novita.json
@@ -1,0 +1,1513 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "Sao10K/L3-8B-Stheno-v3.2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 5e-08,
+        "output_per_token": 5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "baai/bge-m3": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 96000
+      },
+      "pricing": {
+        "input_per_token": 1e-08,
+        "output_per_token": 1e-08
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "baichuan/baichuan-m2-32b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 7e-08,
+        "output_per_token": 7e-08
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "baidu/ernie-4.5-21B-a3b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 120000,
+        "max_output": 8000
+      },
+      "pricing": {
+        "input_per_token": 7e-08,
+        "output_per_token": 2.8e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "baidu/ernie-4.5-21B-a3b-thinking": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 7e-08,
+        "output_per_token": 2.8e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "baidu/ernie-4.5-300b-a47b-paddle": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 123000,
+        "max_output": 12000
+      },
+      "pricing": {
+        "input_per_token": 2.8e-07,
+        "output_per_token": 1.1e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "baidu/ernie-4.5-vl-28b-a3b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 30000,
+        "max_output": 8000
+      },
+      "pricing": {
+        "input_per_token": 1.4e-07,
+        "output_per_token": 5.6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "baidu/ernie-4.5-vl-28b-a3b-thinking": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 3.9e-07,
+        "output_per_token": 3.9e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "baidu/ernie-4.5-vl-424b-a47b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 123000,
+        "max_output": 16000
+      },
+      "pricing": {
+        "input_per_token": 4.2e-07,
+        "output_per_token": 1.25e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek/deepseek-ocr": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3e-08,
+        "output_per_token": 3e-08
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "deepseek/deepseek-prover-v2-671b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 160000,
+        "max_output": 160000
+      },
+      "pricing": {
+        "input_per_token": 7e-07,
+        "output_per_token": 2.5e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek/deepseek-r1-0528": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 7e-07,
+        "output_per_token": 2.5e-06,
+        "cache_read_per_token": 3.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "deepseek/deepseek-r1-0528-qwen3-8b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 6e-08,
+        "output_per_token": 9e-08
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek/deepseek-r1-distill-llama-70b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 8e-07,
+        "output_per_token": 8e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "deepseek/deepseek-r1-distill-qwen-14b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "deepseek/deepseek-r1-distill-qwen-32b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 64000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "deepseek/deepseek-r1-turbo": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 64000,
+        "max_output": 16000
+      },
+      "pricing": {
+        "input_per_token": 7e-07,
+        "output_per_token": 2.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek/deepseek-v3-0324": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 163840
+      },
+      "pricing": {
+        "input_per_token": 2.7e-07,
+        "output_per_token": 1.12e-06,
+        "cache_read_per_token": 1.35e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "deepseek/deepseek-v3-turbo": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 64000,
+        "max_output": 16000
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 1.3e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek/deepseek-v3.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2.7e-07,
+        "output_per_token": 1e-06,
+        "cache_read_per_token": 1.35e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "deepseek/deepseek-v3.1-terminus": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2.7e-07,
+        "output_per_token": 1e-06,
+        "cache_read_per_token": 1.35e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "deepseek/deepseek-v3.2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 2.69e-07,
+        "output_per_token": 4e-07,
+        "cache_read_per_token": 1.345e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "deepseek/deepseek-v3.2-exp": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 2.7e-07,
+        "output_per_token": 4.1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "google/gemma-3-12b-it": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 5e-08,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "google/gemma-3-27b-it": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 98304,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1.19e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gryphe/mythomax-l2-13b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 3200
+      },
+      "pricing": {
+        "input_per_token": 9e-08,
+        "output_per_token": 9e-08
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "kwaipilot/kat-coder-pro": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 1.2e-06,
+        "cache_read_per_token": 6e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "meta-llama/llama-3-70b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8000
+      },
+      "pricing": {
+        "input_per_token": 5.1e-07,
+        "output_per_token": 7.4e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "meta-llama/llama-3-8b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 4e-08,
+        "output_per_token": 4e-08
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/llama-3.1-8b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2e-08,
+        "output_per_token": 5e-08
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/llama-3.2-3b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 3e-08,
+        "output_per_token": 5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/llama-3.3-70b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 120000
+      },
+      "pricing": {
+        "input_per_token": 1.35e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/llama-4-maverick-17b-128e-instruct-fp8": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 2.7e-07,
+        "output_per_token": 8.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/llama-4-scout-17b-16e-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1.8e-07,
+        "output_per_token": 5.9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "microsoft/wizardlm-2-8x22b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 65535,
+        "max_output": 8000
+      },
+      "pricing": {
+        "input_per_token": 6.2e-07,
+        "output_per_token": 6.2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "minimax/minimax-m2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 204800,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 1.2e-06,
+        "cache_read_per_token": 3e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "minimax/minimax-m2.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 204800,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 1.2e-06,
+        "cache_read_per_token": 3e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "minimaxai/minimax-m1-80k": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 40000
+      },
+      "pricing": {
+        "input_per_token": 5.5e-07,
+        "output_per_token": 2.2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistralai/mistral-nemo": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 60288,
+        "max_output": 16000
+      },
+      "pricing": {
+        "input_per_token": 4e-08,
+        "output_per_token": 1.7e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "moonshotai/kimi-k2-0905": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "moonshotai/kimi-k2-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 5.7e-07,
+        "output_per_token": 2.3e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "moonshotai/kimi-k2-thinking": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "nousresearch/hermes-2-pro-llama-3-8b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1.4e-07,
+        "output_per_token": 1.4e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "openai/gpt-oss-120b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 5e-08,
+        "output_per_token": 2.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "openai/gpt-oss-20b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 4e-08,
+        "output_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "paddlepaddle/paddleocr-vl": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2e-08,
+        "output_per_token": 2e-08
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen/qwen-2.5-72b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3.8e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "qwen/qwen-mt-plus": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 7.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen/qwen2.5-7b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 7e-08,
+        "output_per_token": 7e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "qwen/qwen2.5-vl-72b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 8e-07,
+        "output_per_token": 8e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen/qwen3-235b-a22b-fp8": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 40960,
+        "max_output": 20000
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 8e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen/qwen3-235b-a22b-instruct-2507": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 9e-08,
+        "output_per_token": 5.8e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "qwen/qwen3-235b-a22b-thinking-2507": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 3e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen/qwen3-30b-a3b-fp8": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 40960,
+        "max_output": 20000
+      },
+      "pricing": {
+        "input_per_token": 9e-08,
+        "output_per_token": 4.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen/qwen3-32b-fp8": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 40960,
+        "max_output": 20000
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 4.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen/qwen3-4b-fp8": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 20000
+      },
+      "pricing": {
+        "input_per_token": 3e-08,
+        "output_per_token": 3e-08
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen/qwen3-8b-fp8": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 20000
+      },
+      "pricing": {
+        "input_per_token": 3.5e-08,
+        "output_per_token": 1.38e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen/qwen3-coder-30b-a3b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 160000,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 7e-08,
+        "output_per_token": 2.7e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "qwen/qwen3-coder-480b-a35b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 1.3e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "qwen/qwen3-embedding-0.6b": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 7e-08,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen/qwen3-embedding-8b": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 7e-08,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen/qwen3-max": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 2.11e-06,
+        "output_per_token": 8.45e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "qwen/qwen3-next-80b-a3b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 1.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "qwen/qwen3-next-80b-a3b-thinking": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 1.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "qwen/qwen3-omni-30b-a3b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 65536,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 9.7e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "qwen/qwen3-omni-30b-a3b-thinking": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 65536,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 9.7e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "qwen/qwen3-vl-235b-a22b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 1.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "qwen/qwen3-vl-235b-a22b-thinking": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 9.8e-07,
+        "output_per_token": 3.95e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen/qwen3-vl-30b-a3b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 7e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "qwen/qwen3-vl-30b-a3b-thinking": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 1e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "qwen/qwen3-vl-8b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 8e-08,
+        "output_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "sao10k/l3-70b-euryale-v2.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1.48e-06,
+        "output_per_token": 1.48e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "sao10k/l3-8b-lunaris": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 5e-08,
+        "output_per_token": 5e-08
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "sao10k/l31-70b-euryale-v2.2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1.48e-06,
+        "output_per_token": 1.48e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "skywork/r1v4-lite": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "xiaomimimo/mimo-v2-flash": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 3e-07,
+        "cache_read_per_token": 2e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "zai-org/autoglm-phone-9b-multilingual": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 65536,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 3.5e-08,
+        "output_per_token": 1.38e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "zai-org/glm-4.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 98304
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.2e-06,
+        "cache_read_per_token": 1.1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "zai-org/glm-4.5-air": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 98304
+      },
+      "pricing": {
+        "input_per_token": 1.3e-07,
+        "output_per_token": 8.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "zai-org/glm-4.5v": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 65536,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 1.8e-06,
+        "cache_read_per_token": 1.1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "zai-org/glm-4.6": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 204800,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 5.5e-07,
+        "output_per_token": 2.2e-06,
+        "cache_read_per_token": 1.1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "zai-org/glm-4.6v": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 9e-07,
+        "cache_read_per_token": 5.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "zai-org/glm-4.7": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 204800,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.2e-06,
+        "cache_read_per_token": 1.1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/nscale.json
+++ b/mlflow/utils/model_catalog/nscale.json
@@ -1,0 +1,201 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "Qwen/QwQ-32B": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 1.8e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen2.5-Coder-32B-Instruct": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 6e-08,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen2.5-Coder-3B-Instruct": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 1e-08,
+        "output_per_token": 3e-08
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen2.5-Coder-7B-Instruct": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 1e-08,
+        "output_per_token": 3e-08
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/DeepSeek-R1-Distill-Llama-70B": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 3.75e-07,
+        "output_per_token": 3.75e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/DeepSeek-R1-Distill-Llama-8B": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 2.5e-08,
+        "output_per_token": 2.5e-08
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 9e-08,
+        "output_per_token": 9e-08
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 7e-08,
+        "output_per_token": 7e-08
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Llama-3.1-8B-Instruct": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 3e-08,
+        "output_per_token": 3e-08
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Llama-3.3-70B-Instruct": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Llama-4-Scout-17B-16E-Instruct": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 9e-08,
+        "output_per_token": 2.9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistralai/mixtral-8x22b-instruct-v0.1": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/oci.json
+++ b/mlflow/utils/model_catalog/oci.json
@@ -1,0 +1,239 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "cohere.command-a-03-2025": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 4000
+      },
+      "pricing": {
+        "input_per_token": 1.56e-06,
+        "output_per_token": 1.56e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "cohere.command-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4000
+      },
+      "pricing": {
+        "input_per_token": 1.56e-06,
+        "output_per_token": 1.56e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "cohere.command-plus-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4000
+      },
+      "pricing": {
+        "input_per_token": 1.56e-06,
+        "output_per_token": 1.56e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta.llama-3.1-405b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4000
+      },
+      "pricing": {
+        "input_per_token": 1.068e-05,
+        "output_per_token": 1.068e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta.llama-3.2-90b-vision-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4000
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta.llama-3.3-70b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4000
+      },
+      "pricing": {
+        "input_per_token": 7.2e-07,
+        "output_per_token": 7.2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta.llama-4-maverick-17b-128e-instruct-fp8": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 512000,
+        "max_output": 4000
+      },
+      "pricing": {
+        "input_per_token": 7.2e-07,
+        "output_per_token": 7.2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta.llama-4-scout-17b-16e-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 192000,
+        "max_output": 4000
+      },
+      "pricing": {
+        "input_per_token": 7.2e-07,
+        "output_per_token": 7.2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "xai.grok-3": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "xai.grok-3-fast": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 5e-06,
+        "output_per_token": 2.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "xai.grok-3-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "xai.grok-3-mini-fast": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 4e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "xai.grok-4": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/ollama.json
+++ b/mlflow/utils/model_catalog/ollama.json
@@ -1,0 +1,527 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "codegeex4": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "codegemma": {
+      "mode": "completion",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "codellama": {
+      "mode": "completion",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-coder-v2-base": {
+      "mode": "completion",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-coder-v2-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-coder-v2-lite-base": {
+      "mode": "completion",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-coder-v2-lite-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-v3.1:671b-cloud": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 163840
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-oss:120b-cloud": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-oss:20b-cloud": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "internlm2_5-20b-chat": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama2-uncensored": {
+      "mode": "completion",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama2:13b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama2:70b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama2:7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama3": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama3.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama3:70b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama3:8b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral": {
+      "mode": "completion",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral-7B-Instruct-v0.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral-7B-Instruct-v0.2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral-large-instruct-2407": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 65536,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mixtral-8x22B-Instruct-v0.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 65536,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mixtral-8x7B-Instruct-v0.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "orca-mini": {
+      "mode": "completion",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen3-coder:480b-cloud": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "vicuna": {
+      "mode": "completion",
+      "context_window": {
+        "max_input": 2048,
+        "max_output": 2048
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/openai.json
+++ b/mlflow/utils/model_catalog/openai.json
@@ -1,0 +1,1582 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "chatgpt-4o-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 5e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "container": {
+      "mode": "chat",
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-3.5-turbo": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16385,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 1.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "gpt-3.5-turbo-0125": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16385,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 1.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "gpt-3.5-turbo-1106": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16385,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": false
+      },
+      "deprecation_date": "2026-09-28"
+    },
+    "gpt-3.5-turbo-16k": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16385,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 4e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "gpt-4": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 3e-05,
+        "output_per_token": 6e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "gpt-4-0125-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-05,
+        "output_per_token": 3e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": false
+      },
+      "deprecation_date": "2026-03-26"
+    },
+    "gpt-4-0314": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 3e-05,
+        "output_per_token": 6e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      },
+      "deprecation_date": "2026-03-26"
+    },
+    "gpt-4-0613": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 3e-05,
+        "output_per_token": 6e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": false
+      },
+      "deprecation_date": "2025-06-06"
+    },
+    "gpt-4-1106-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-05,
+        "output_per_token": 3e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": false
+      },
+      "deprecation_date": "2026-03-26"
+    },
+    "gpt-4-turbo": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-05,
+        "output_per_token": 3e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "gpt-4-turbo-2024-04-09": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-05,
+        "output_per_token": 3e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "gpt-4-turbo-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-05,
+        "output_per_token": 3e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "gpt-4.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1047576,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 8e-06,
+        "cache_read_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-4.1-2025-04-14": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1047576,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 8e-06,
+        "cache_read_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-4.1-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1047576,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 1.6e-06,
+        "cache_read_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-4.1-mini-2025-04-14": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1047576,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 1.6e-06,
+        "cache_read_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-4.1-nano": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1047576,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 4e-07,
+        "cache_read_per_token": 2.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-4.1-nano-2025-04-14": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1047576,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 4e-07,
+        "cache_read_per_token": 2.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-4o": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-4o-2024-05-13": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 5e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "gpt-4o-2024-08-06": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-4o-2024-11-20": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-4o-audio-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4o-audio-preview-2024-12-17": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4o-audio-preview-2025-06-03": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4o-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 6e-07,
+        "cache_read_per_token": 7.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-4o-mini-2024-07-18": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 6e-07,
+        "cache_read_per_token": 7.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-4o-mini-audio-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4o-mini-audio-preview-2024-12-17": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4o-mini-realtime-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.4e-06,
+        "cache_read_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4o-mini-realtime-preview-2024-12-17": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.4e-06,
+        "cache_read_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4o-mini-search-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 6e-07,
+        "cache_read_per_token": 7.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-4o-mini-search-preview-2025-03-11": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 6e-07,
+        "cache_read_per_token": 7.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-4o-realtime-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 5e-06,
+        "output_per_token": 2e-05,
+        "cache_read_per_token": 2.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4o-realtime-preview-2024-12-17": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 5e-06,
+        "output_per_token": 2e-05,
+        "cache_read_per_token": 2.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4o-realtime-preview-2025-06-03": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 5e-06,
+        "output_per_token": 2e-05,
+        "cache_read_per_token": 2.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-4o-search-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-4o-search-preview-2025-03-11": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5-2025-08-07": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5-chat": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5-chat-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 2e-06,
+        "cache_read_per_token": 2.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5-mini-2025-08-07": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 2e-06,
+        "cache_read_per_token": 2.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5-nano": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 5e-08,
+        "output_per_token": 4e-07,
+        "cache_read_per_token": 5e-09
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5-nano-2025-08-07": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 5e-08,
+        "output_per_token": 4e-07,
+        "cache_read_per_token": 5e-09
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5-search-api": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5-search-api-2025-10-14": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5.1-2025-11-13": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5.1-chat-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5.2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.75e-06,
+        "output_per_token": 1.4e-05,
+        "cache_read_per_token": 1.75e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5.2-2025-12-11": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.75e-06,
+        "output_per_token": 1.4e-05,
+        "cache_read_per_token": 1.75e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5.2-chat-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1.75e-06,
+        "output_per_token": 1.4e-05,
+        "cache_read_per_token": 1.75e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5.3-chat-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1.75e-06,
+        "output_per_token": 1.4e-05,
+        "cache_read_per_token": 1.75e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5.4": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1050000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 2.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5.4-2026-03-05": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1050000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 2.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5.4-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 7.5e-07,
+        "output_per_token": 4.5e-06,
+        "cache_read_per_token": 7.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-5.4-nano": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 1.25e-06,
+        "cache_read_per_token": 2e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gpt-audio": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-audio-1.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-audio-2025-08-28": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-audio-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.4e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-audio-mini-2025-10-06": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.4e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-audio-mini-2025-12-15": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.4e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-realtime": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 4e-06,
+        "output_per_token": 1.6e-05,
+        "cache_read_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-realtime-1.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 4e-06,
+        "output_per_token": 1.6e-05,
+        "cache_read_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-realtime-2025-08-28": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 4e-06,
+        "output_per_token": 1.6e-05,
+        "cache_read_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-realtime-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.4e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-realtime-mini-2025-10-06": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.4e-06,
+        "cache_read_per_token": 6e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-realtime-mini-2025-12-15": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.4e-06,
+        "cache_read_per_token": 6e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "o1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 100000
+      },
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 6e-05,
+        "cache_read_per_token": 7.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "o1-2024-12-17": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 100000
+      },
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 6e-05,
+        "cache_read_per_token": 7.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "o3": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 100000
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 8e-06,
+        "cache_read_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "o3-2025-04-16": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 100000
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 8e-06,
+        "cache_read_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "o3-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 100000
+      },
+      "pricing": {
+        "input_per_token": 1.1e-06,
+        "output_per_token": 4.4e-06,
+        "cache_read_per_token": 5.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "o3-mini-2025-01-31": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 100000
+      },
+      "pricing": {
+        "input_per_token": 1.1e-06,
+        "output_per_token": 4.4e-06,
+        "cache_read_per_token": 5.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "o4-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 100000
+      },
+      "pricing": {
+        "input_per_token": 1.1e-06,
+        "output_per_token": 4.4e-06,
+        "cache_read_per_token": 2.75e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "o4-mini-2025-04-16": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 100000
+      },
+      "pricing": {
+        "input_per_token": 1.1e-06,
+        "output_per_token": 4.4e-06,
+        "cache_read_per_token": 2.75e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "text-embedding-3-large": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 8191
+      },
+      "pricing": {
+        "input_per_token": 1.3e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "text-embedding-3-small": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 8191
+      },
+      "pricing": {
+        "input_per_token": 2e-08,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "text-embedding-ada-002": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 8191
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "text-embedding-ada-002-v2": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 8191
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/openrouter.json
+++ b/mlflow/utils/model_catalog/openrouter.json
@@ -1,0 +1,1595 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "anthropic/claude-3-haiku": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 1.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "anthropic/claude-3.5-sonnet": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "anthropic/claude-3.7-sonnet": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "anthropic/claude-haiku-4.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 200000
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 5e-06,
+        "cache_read_per_token": 1e-07,
+        "cache_write_per_token": 1.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "anthropic/claude-opus-4": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 7.5e-05,
+        "cache_read_per_token": 1.5e-06,
+        "cache_write_per_token": 1.875e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "anthropic/claude-opus-4.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 7.5e-05,
+        "cache_read_per_token": 1.5e-06,
+        "cache_write_per_token": 1.875e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "anthropic/claude-opus-4.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 5e-06,
+        "output_per_token": 2.5e-05,
+        "cache_read_per_token": 5e-07,
+        "cache_write_per_token": 6.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "anthropic/claude-opus-4.6": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 5e-06,
+        "output_per_token": 2.5e-05,
+        "cache_read_per_token": 5e-07,
+        "cache_write_per_token": 6.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "anthropic/claude-sonnet-4": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "anthropic/claude-sonnet-4.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 1000000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "anthropic/claude-sonnet-4.6": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "bytedance/ui-tars-1.5-7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 2048
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek/deepseek-chat": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 65536,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1.4e-07,
+        "output_per_token": 2.8e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "deepseek/deepseek-chat-v3-0324": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 65536,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1.4e-07,
+        "output_per_token": 2.8e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "deepseek/deepseek-chat-v3.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 163840
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 8e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "deepseek/deepseek-r1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 65336,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 5.5e-07,
+        "output_per_token": 2.19e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "deepseek/deepseek-r1-0528": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 65336,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 2.15e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "deepseek/deepseek-v3.2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 163840
+      },
+      "pricing": {
+        "input_per_token": 2.8e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "deepseek/deepseek-v3.2-exp": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 163840
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "google/gemini-2.0-flash-001": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-06-01"
+    },
+    "google/gemini-2.5-flash": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 2.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "google/gemini-2.5-pro": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "google/gemini-3-flash-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65535
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 3e-06,
+        "cache_read_per_token": 5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "google/gemini-3-pro-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65535
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 1.2e-05,
+        "cache_read_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "google/gemini-3.1-pro-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 1.2e-05,
+        "cache_read_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gryphe/mythomax-l2-13b": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 1.875e-06,
+        "output_per_token": 1.875e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mancer/weaver": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 5.625e-06,
+        "output_per_token": 5.625e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/llama-3-70b-instruct": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 5.9e-07,
+        "output_per_token": 7.9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "minimax/minimax-m2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 204800,
+        "max_output": 204800
+      },
+      "pricing": {
+        "input_per_token": 2.55e-07,
+        "output_per_token": 1.02e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "minimax/minimax-m2.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 204000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 2.7e-07,
+        "output_per_token": 1.2e-06,
+        "cache_read_per_token": 0.0,
+        "cache_write_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "minimax/minimax-m2.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 196608,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 1.1e-06,
+        "cache_read_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "mistralai/devstral-2512": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistralai/ministral-14b-2512": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistralai/ministral-3b-2512": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistralai/ministral-8b-2512": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistralai/mistral-7b-instruct": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 1.3e-07,
+        "output_per_token": 1.3e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistralai/mistral-large": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 8e-06,
+        "output_per_token": 2.4e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistralai/mistral-large-2512": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 1.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistralai/mistral-small-3.1-24b-instruct": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistralai/mistral-small-3.2-24b-instruct": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistralai/mixtral-8x22b-instruct": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 6.5e-07,
+        "output_per_token": 6.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "moonshotai/kimi-k2.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 3e-06,
+        "cache_read_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-3.5-turbo": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 1.5e-06,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-3.5-turbo-16k": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 4e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-4": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 3e-05,
+        "output_per_token": 6e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-4.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1047576,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 8e-06,
+        "cache_read_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "openai/gpt-4.1-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1047576,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 1.6e-06,
+        "cache_read_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "openai/gpt-4.1-nano": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1047576,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 4e-07,
+        "cache_read_per_token": 2.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "openai/gpt-4o": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-4o-2024-05-13": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 5e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-5-chat": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-5-codex": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-5-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 2e-06,
+        "cache_read_per_token": 2.5e-08
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-5-nano": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 5e-08,
+        "output_per_token": 4e-07,
+        "cache_read_per_token": 5e-09
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-5.1-codex-max": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 400000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-5.2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.75e-06,
+        "output_per_token": 1.4e-05,
+        "cache_read_per_token": 1.75e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-5.2-chat": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1.75e-06,
+        "output_per_token": 1.4e-05,
+        "cache_read_per_token": 1.75e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-5.2-codex": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.75e-06,
+        "output_per_token": 1.4e-05,
+        "cache_read_per_token": 1.75e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-5.2-pro": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 272000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2.1e-05,
+        "output_per_token": 0.000168
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-oss-120b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1.8e-07,
+        "output_per_token": 8e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "openai/gpt-oss-20b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-08,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "openai/o1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 100000
+      },
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 6e-05,
+        "cache_read_per_token": 7.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "openai/o3-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 1.1e-06,
+        "output_per_token": 4.4e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/o3-mini-high": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 1.1e-06,
+        "output_per_token": 4.4e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openrouter/auto": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 2000000
+      },
+      "pricing": {
+        "input_per_token": 0,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "openrouter/bodybuilder": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000
+      },
+      "pricing": {
+        "input_per_token": 0,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openrouter/free": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000
+      },
+      "pricing": {
+        "input_per_token": 0,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "qwen/qwen-2.5-coder-32b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 33792,
+        "max_output": 33792
+      },
+      "pricing": {
+        "input_per_token": 1.8e-07,
+        "output_per_token": 1.8e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen/qwen-vl-plus": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 2048
+      },
+      "pricing": {
+        "input_per_token": 2.1e-07,
+        "output_per_token": 6.3e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen/qwen3-235b-a22b-2507": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 7.1e-08,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen/qwen3-235b-a22b-thinking-2507": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 1.1e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen/qwen3-coder": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262100,
+        "max_output": 262100
+      },
+      "pricing": {
+        "input_per_token": 2.2e-07,
+        "output_per_token": 9.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen/qwen3-coder-plus": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 997952,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen/qwen3.5-122b-a10b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen/qwen3.5-27b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 2.4e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen/qwen3.5-35b-a3b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen/qwen3.5-397b-a17b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 3.6e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen/qwen3.5-flash-02-23": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen/qwen3.5-plus-02-15": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 2.4e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "switchpoint/router": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 8.5e-07,
+        "output_per_token": 3.4e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "undi95/remm-slerp-l2-13b": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 1.875e-06,
+        "output_per_token": 1.875e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "x-ai/grok-4": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "xiaomi/mimo-v2-flash": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 9e-08,
+        "output_per_token": 2.9e-07,
+        "cache_read_per_token": 0.0,
+        "cache_write_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "z-ai/glm-4.6": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 202800,
+        "max_output": 131000
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 1.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "z-ai/glm-4.6:exacto": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 202800,
+        "max_output": 131000
+      },
+      "pricing": {
+        "input_per_token": 4.5e-07,
+        "output_per_token": 1.9e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "z-ai/glm-4.7": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 202752,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 1.5e-06,
+        "cache_read_per_token": 0.0,
+        "cache_write_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "z-ai/glm-4.7-flash": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 7e-08,
+        "output_per_token": 4e-07,
+        "cache_read_per_token": 0.0,
+        "cache_write_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "z-ai/glm-5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 202752,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 8e-07,
+        "output_per_token": 2.56e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/ovhcloud.json
+++ b/mlflow/utils/model_catalog/ovhcloud.json
@@ -1,0 +1,275 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "DeepSeek-R1-Distill-Llama-70B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131000,
+        "max_output": 131000
+      },
+      "pricing": {
+        "input_per_token": 6.7e-07,
+        "output_per_token": 6.7e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "Llama-3.1-8B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131000,
+        "max_output": 131000
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "Meta-Llama-3_1-70B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131000,
+        "max_output": 131000
+      },
+      "pricing": {
+        "input_per_token": 6.7e-07,
+        "output_per_token": 6.7e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Meta-Llama-3_3-70B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131000,
+        "max_output": 131000
+      },
+      "pricing": {
+        "input_per_token": 6.7e-07,
+        "output_per_token": 6.7e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "Mistral-7B-Instruct-v0.3": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 127000,
+        "max_output": 127000
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "Mistral-Nemo-Instruct-2407": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 118000,
+        "max_output": 118000
+      },
+      "pricing": {
+        "input_per_token": 1.3e-07,
+        "output_per_token": 1.3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "Mistral-Small-3.2-24B-Instruct-2506": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 9e-08,
+        "output_per_token": 2.8e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "Mixtral-8x7B-Instruct-v0.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 6.3e-07,
+        "output_per_token": 6.3e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "Qwen2.5-Coder-32B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 8.7e-07,
+        "output_per_token": 8.7e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "Qwen2.5-VL-72B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 9.1e-07,
+        "output_per_token": 9.1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "Qwen3-32B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 8e-08,
+        "output_per_token": 2.3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "gpt-oss-120b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131000,
+        "max_output": 131000
+      },
+      "pricing": {
+        "input_per_token": 8e-08,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "gpt-oss-20b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131000,
+        "max_output": 131000
+      },
+      "pricing": {
+        "input_per_token": 4e-08,
+        "output_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "llava-v1.6-mistral-7b-hf": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 2.9e-07,
+        "output_per_token": 2.9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "mamba-codestral-7B-v0.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 1.9e-07,
+        "output_per_token": 1.9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/palm.json
+++ b/mlflow/utils/model_catalog/palm.json
@@ -1,0 +1,113 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "chat-bison": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.25e-07,
+        "output_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "chat-bison-001": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.25e-07,
+        "output_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "text-bison": {
+      "mode": "completion",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 1024
+      },
+      "pricing": {
+        "input_per_token": 1.25e-07,
+        "output_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "text-bison-001": {
+      "mode": "completion",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 1024
+      },
+      "pricing": {
+        "input_per_token": 1.25e-07,
+        "output_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "text-bison-safety-off": {
+      "mode": "completion",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 1024
+      },
+      "pricing": {
+        "input_per_token": 1.25e-07,
+        "output_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "text-bison-safety-recitation-off": {
+      "mode": "completion",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 1024
+      },
+      "pricing": {
+        "input_per_token": 1.25e-07,
+        "output_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/perplexity.json
+++ b/mlflow/utils/model_catalog/perplexity.json
@@ -1,0 +1,395 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "codellama-34b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 3.5e-07,
+        "output_per_token": 1.4e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "codellama-70b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 7e-07,
+        "output_per_token": 2.8e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama-2-70b-chat": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 7e-07,
+        "output_per_token": 2.8e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama-3.1-70b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 1e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama-3.1-8b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral-7b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 7e-08,
+        "output_per_token": 2.8e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mixtral-8x7b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 7e-08,
+        "output_per_token": 2.8e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "pplx-70b-chat": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 7e-07,
+        "output_per_token": 2.8e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "pplx-70b-online": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 2.8e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "pplx-7b-chat": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 7e-08,
+        "output_per_token": 2.8e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "pplx-7b-online": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 2.8e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "pplx-embed-v1-0.6b": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 32768
+      },
+      "pricing": {
+        "input_per_token": 4e-09,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "pplx-embed-v1-4b": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 32768
+      },
+      "pricing": {
+        "input_per_token": 3e-08,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "sonar": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 1e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "sonar-deep-research": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 8e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "sonar-medium-chat": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 1.8e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "sonar-medium-online": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 12000,
+        "max_output": 12000
+      },
+      "pricing": {
+        "input_per_token": 0,
+        "output_per_token": 1.8e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "sonar-pro": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 8000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "sonar-reasoning": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 5e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "sonar-reasoning-pro": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 8e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "sonar-small-chat": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 7e-08,
+        "output_per_token": 2.8e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "sonar-small-online": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 12000,
+        "max_output": 12000
+      },
+      "pricing": {
+        "input_per_token": 0,
+        "output_per_token": 2.8e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/publicai.json
+++ b/mlflow/utils/model_catalog/publicai.json
@@ -1,0 +1,167 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "BSC-LT/ALIA-40b-instruct_Q8_0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "BSC-LT/salamandra-7b-instruct-tools-16k": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "aisingapore/Gemma-SEA-LION-v4-27B-IT": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "aisingapore/Qwen-SEA-LION-v4-32B-IT": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "allenai/Olmo-3-32B-Think": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "allenai/Olmo-3-7B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "allenai/Olmo-3-7B-Think": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "swiss-ai/apertus-70b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "swiss-ai/apertus-8b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/replicate.json
+++ b/mlflow/utils/model_catalog/replicate.json
@@ -1,0 +1,629 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "anthropic/claude-3.5-haiku": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "anthropic/claude-3.5-sonnet": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 3.75e-06,
+        "output_per_token": 1.875e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "anthropic/claude-3.7-sonnet": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "anthropic/claude-4-sonnet": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "anthropic/claude-4.5-haiku": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "anthropic/claude-4.5-sonnet": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "deepseek-ai/deepseek-r1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 65536,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3.75e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/deepseek-v3": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 65536,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1.45e-06,
+        "output_per_token": 1.45e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/deepseek-v3.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 163840
+      },
+      "pricing": {
+        "input_per_token": 6.72e-07,
+        "output_per_token": 2.016e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "google/gemini-2.5-flash": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 2.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "google/gemini-3-pro": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 1.2e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "gpt-oss-20b": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 9e-08,
+        "output_per_token": 3.6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ibm-granite/granite-3.3-8b-instruct": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 3e-08,
+        "output_per_token": 2.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta/llama-2-13b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta/llama-2-13b-chat": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta/llama-2-70b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 6.5e-07,
+        "output_per_token": 2.75e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta/llama-2-70b-chat": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 6.5e-07,
+        "output_per_token": 2.75e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta/llama-2-7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 5e-08,
+        "output_per_token": 2.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta/llama-2-7b-chat": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 5e-08,
+        "output_per_token": 2.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta/llama-3-70b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 6.5e-07,
+        "output_per_token": 2.75e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta/llama-3-70b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 6.5e-07,
+        "output_per_token": 2.75e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta/llama-3-8b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8086,
+        "max_output": 8086
+      },
+      "pricing": {
+        "input_per_token": 5e-08,
+        "output_per_token": 2.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta/llama-3-8b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8086,
+        "max_output": 8086
+      },
+      "pricing": {
+        "input_per_token": 5e-08,
+        "output_per_token": 2.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistralai/mistral-7b-instruct-v0.2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 5e-08,
+        "output_per_token": 2.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistralai/mistral-7b-v0.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 5e-08,
+        "output_per_token": 2.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistralai/mixtral-8x7b-instruct-v0.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 1e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-4.1": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 8e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "openai/gpt-4.1-mini": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 1.6e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "openai/gpt-4.1-nano": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-4o": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "openai/gpt-4o-mini": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "openai/gpt-5": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "openai/gpt-5-mini": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "openai/gpt-5-nano": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 5e-08,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-oss-120b": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 1.8e-07,
+        "output_per_token": 7.2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/o1": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 6e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/o1-mini": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 1.1e-06,
+        "output_per_token": 4.4e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/o4-mini": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 4e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen/qwen3-235b-a22b-instruct-2507": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 2.64e-07,
+        "output_per_token": 1.06e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "xai/grok-4": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 7.2e-06,
+        "output_per_token": 3.6e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/sagemaker.json
+++ b/mlflow/utils/model_catalog/sagemaker.json
@@ -1,0 +1,113 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "meta-textgeneration-llama-2-13b": {
+      "mode": "completion",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-textgeneration-llama-2-13b-f": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-textgeneration-llama-2-70b": {
+      "mode": "completion",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-textgeneration-llama-2-70b-b-f": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-textgeneration-llama-2-7b": {
+      "mode": "completion",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-textgeneration-llama-2-7b-f": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/sambanova.json
+++ b/mlflow/utils/model_catalog/sambanova.json
@@ -1,0 +1,293 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "DeepSeek-R1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 5e-06,
+        "output_per_token": 7e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "DeepSeek-R1-Distill-Llama-70B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 7e-07,
+        "output_per_token": 1.4e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "DeepSeek-V3-0324": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 4.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "DeepSeek-V3.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 4.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Llama-4-Maverick-17B-128E-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 6.3e-07,
+        "output_per_token": 1.8e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "Llama-4-Scout-17B-16E-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 7e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "Meta-Llama-3.1-405B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 5e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "Meta-Llama-3.1-8B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "Meta-Llama-3.2-1B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 4e-08,
+        "output_per_token": 8e-08
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Meta-Llama-3.2-3B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 8e-08,
+        "output_per_token": 1.6e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Meta-Llama-3.3-70B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "Meta-Llama-Guard-3-8B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "QwQ-32B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 1e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen2-Audio-7B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 0.0001
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen3-32B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 8e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-oss-120b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 4.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/sarvam.json
+++ b/mlflow/utils/model_catalog/sarvam.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "sarvam-m": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 0,
+        "output_per_token": 0,
+        "cache_read_per_token": 0,
+        "cache_write_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/snowflake.json
+++ b/mlflow/utils/model_catalog/snowflake.json
@@ -1,0 +1,341 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "claude-3-5-sonnet": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 18000,
+        "max_output": 8192
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-r1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 8192
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gemma-7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8000,
+        "max_output": 8192
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "jamba-1.5-large": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 8192
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "jamba-1.5-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 8192
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "jamba-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 8192
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama2-70b-chat": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 8192
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama3-70b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8000,
+        "max_output": 8192
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama3-8b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8000,
+        "max_output": 8192
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama3.1-405b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8192
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama3.1-70b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8192
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama3.1-8b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8192
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama3.2-1b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8192
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama3.2-3b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8192
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "llama3.3-70b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8192
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral-7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8192
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral-large": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8192
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral-large2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8192
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mixtral-8x7b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8192
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "reka-core": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8192
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "reka-flash": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 100000,
+        "max_output": 8192
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "snowflake-arctic": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 4096,
+        "max_output": 8192
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "snowflake-llama-3.1-405b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8000,
+        "max_output": 8192
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "snowflake-llama-3.3-70b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8000,
+        "max_output": 8192
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/text-completion-codestral.json
+++ b/mlflow/utils/model_catalog/text-completion-codestral.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "codestral-2405": {
+      "mode": "completion",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "codestral-latest": {
+      "mode": "completion",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/text-completion-openai.json
+++ b/mlflow/utils/model_catalog/text-completion-openai.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "babbage-002": {
+      "mode": "completion",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "davinci-002": {
+      "mode": "completion",
+      "context_window": {
+        "max_input": 16384,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-3.5-turbo-instruct": {
+      "mode": "completion",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.5e-06,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gpt-3.5-turbo-instruct-0914": {
+      "mode": "completion",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 4097
+      },
+      "pricing": {
+        "input_per_token": 1.5e-06,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/together_ai.json
+++ b/mlflow/utils/model_catalog/together_ai.json
@@ -1,0 +1,645 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "BAAI/bge-base-en-v1.5": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 512
+      },
+      "pricing": {
+        "input_per_token": 8e-09,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen2.5-72B-Instruct-Turbo": {
+      "mode": "chat",
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "Qwen/Qwen2.5-7B-Instruct-Turbo": {
+      "mode": "chat",
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "Qwen/Qwen3-235B-A22B-Instruct-2507-tput": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262000
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 6e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "Qwen/Qwen3-235B-A22B-Thinking-2507": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000
+      },
+      "pricing": {
+        "input_per_token": 6.5e-07,
+        "output_per_token": 3e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "Qwen/Qwen3-235B-A22B-fp8-tput": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 40000
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "Qwen/Qwen3-Next-80B-A3B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 1.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "Qwen/Qwen3-Next-80B-A3B-Thinking": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 1.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "Qwen/Qwen3.5-397B-A17B": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 3.6e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "baai/bge-base-en-v1.5": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 512
+      },
+      "pricing": {
+        "input_per_token": 8e-09,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/DeepSeek-R1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 20480
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 7e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "deepseek-ai/DeepSeek-R1-0528-tput": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000
+      },
+      "pricing": {
+        "input_per_token": 5.5e-07,
+        "output_per_token": 2.19e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "deepseek-ai/DeepSeek-V3": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 65536,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "deepseek-ai/DeepSeek-V3.1": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 1.7e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Llama-3.2-3B-Instruct-Turbo": {
+      "mode": "chat",
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "meta-llama/Llama-3.3-70B-Instruct-Turbo": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 8.8e-07,
+        "output_per_token": 8.8e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "meta-llama/Llama-3.3-70B-Instruct-Turbo-Free": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 0,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 2.7e-07,
+        "output_per_token": 8.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "meta-llama/Llama-4-Scout-17B-16E-Instruct": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 1.8e-07,
+        "output_per_token": 5.9e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 3.5e-06,
+        "output_per_token": 3.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 8.8e-07,
+        "output_per_token": 8.8e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 1.8e-07,
+        "output_per_token": 1.8e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "mistralai/Mistral-7B-Instruct-v0.1": {
+      "mode": "chat",
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "mistralai/Mistral-Small-24B-Instruct-2501": {
+      "mode": "chat",
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistralai/Mixtral-8x7B-Instruct-v0.1": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "moonshotai/Kimi-K2-Instruct": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 3e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "moonshotai/Kimi-K2-Instruct-0905": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 3e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "moonshotai/Kimi-K2.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 2.8e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-oss-120b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "openai/gpt-oss-20b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000
+      },
+      "pricing": {
+        "input_per_token": 5e-08,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "together-ai-21.1b-41b": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 8e-07,
+        "output_per_token": 8e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "together-ai-4.1b-8b": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "together-ai-41.1b-80b": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "together-ai-8.1b-21b": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "together-ai-81.1b-110b": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 1.8e-06,
+        "output_per_token": 1.8e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "together-ai-embedding-151m-to-350m": {
+      "mode": "embedding",
+      "pricing": {
+        "input_per_token": 1.6e-08,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "together-ai-embedding-up-to-150m": {
+      "mode": "embedding",
+      "pricing": {
+        "input_per_token": 8e-09,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "together-ai-up-to-4b": {
+      "mode": "chat",
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "togethercomputer/CodeLlama-34b-Instruct": {
+      "mode": "chat",
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "zai-org/GLM-4.5-Air-FP8": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 1.1e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "zai-org/GLM-4.6": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 200000
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "zai-org/GLM-4.7": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 200000
+      },
+      "pricing": {
+        "input_per_token": 4.5e-07,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/v0.json
+++ b/mlflow/utils/model_catalog/v0.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "v0-1.0-md": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "v0-1.5-lg": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 512000,
+        "max_output": 512000
+      },
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 7.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "v0-1.5-md": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/vercel_ai_gateway.json
+++ b/mlflow/utils/model_catalog/vercel_ai_gateway.json
@@ -1,0 +1,1878 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "alibaba/qwen-3-14b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 40960,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 8e-08,
+        "output_per_token": 2.4e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "alibaba/qwen-3-235b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 40960,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "alibaba/qwen-3-30b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 40960,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "alibaba/qwen-3-32b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 40960,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "alibaba/qwen3-coder": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 66536
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 1.6e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "amazon/nova-lite": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 300000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 6e-08,
+        "output_per_token": 2.4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "amazon/nova-micro": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3.5e-08,
+        "output_per_token": 1.4e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "amazon/nova-pro": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 300000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 8e-07,
+        "output_per_token": 3.2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "amazon/titan-embed-text-v2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 0,
+        "max_output": 0
+      },
+      "pricing": {
+        "input_per_token": 2e-08,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "anthropic/claude-3-5-sonnet": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "anthropic/claude-3-5-sonnet-20241022": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "anthropic/claude-3-7-sonnet": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "anthropic/claude-3-haiku": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 1.25e-06,
+        "cache_read_per_token": 3e-08,
+        "cache_write_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "anthropic/claude-3-opus": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 7.5e-05,
+        "cache_read_per_token": 1.5e-06,
+        "cache_write_per_token": 1.875e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "anthropic/claude-3.5-haiku": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 8e-07,
+        "output_per_token": 4e-06,
+        "cache_read_per_token": 8e-08,
+        "cache_write_per_token": 1e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "anthropic/claude-3.5-sonnet": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "anthropic/claude-3.7-sonnet": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "anthropic/claude-4-opus": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 7.5e-05,
+        "cache_read_per_token": 1.5e-06,
+        "cache_write_per_token": 1.875e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "anthropic/claude-4-sonnet": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "anthropic/claude-haiku-4.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 5e-06,
+        "cache_read_per_token": 1e-07,
+        "cache_write_per_token": 1.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "anthropic/claude-opus-4": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 7.5e-05,
+        "cache_read_per_token": 1.5e-06,
+        "cache_write_per_token": 1.875e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "anthropic/claude-opus-4.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 7.5e-05,
+        "cache_read_per_token": 1.5e-06,
+        "cache_write_per_token": 1.875e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "anthropic/claude-opus-4.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 5e-06,
+        "output_per_token": 2.5e-05,
+        "cache_read_per_token": 5e-07,
+        "cache_write_per_token": 6.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "anthropic/claude-opus-4.6": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 5e-06,
+        "output_per_token": 2.5e-05,
+        "cache_read_per_token": 5e-07,
+        "cache_write_per_token": 6.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "anthropic/claude-sonnet-4": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "anthropic/claude-sonnet-4.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "cohere/command-a": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 8000
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "cohere/command-r": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "cohere/command-r-plus": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "cohere/embed-v4.0": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 0,
+        "max_output": 0
+      },
+      "pricing": {
+        "input_per_token": 1.2e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek/deepseek-r1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 5.5e-07,
+        "output_per_token": 2.19e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek/deepseek-r1-distill-llama-70b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 7.5e-07,
+        "output_per_token": 9.9e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "deepseek/deepseek-v3": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "google/gemini-2.0-flash": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-06-01"
+    },
+    "google/gemini-2.0-flash-lite": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 7.5e-08,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-06-01"
+    },
+    "google/gemini-2.5-flash": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 2.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "google/gemini-2.5-pro": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "google/gemini-embedding-001": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 0,
+        "max_output": 0
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "google/gemma-2-9b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "google/text-embedding-005": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 0,
+        "max_output": 0
+      },
+      "pricing": {
+        "input_per_token": 2.5e-08,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "google/text-multilingual-embedding-002": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 0,
+        "max_output": 0
+      },
+      "pricing": {
+        "input_per_token": 2.5e-08,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "inception/mercury-coder-small": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 1e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta/llama-3-70b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 5.9e-07,
+        "output_per_token": 7.9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta/llama-3-8b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 5e-08,
+        "output_per_token": 8e-08
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta/llama-3.1-70b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 7.2e-07,
+        "output_per_token": 7.2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta/llama-3.1-8b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131000,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 5e-08,
+        "output_per_token": 8e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "meta/llama-3.2-11b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1.6e-07,
+        "output_per_token": 1.6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta/llama-3.2-1b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta/llama-3.2-3b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "meta/llama-3.2-90b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 7.2e-07,
+        "output_per_token": 7.2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta/llama-3.3-70b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 7.2e-07,
+        "output_per_token": 7.2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta/llama-4-maverick": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta/llama-4-scout": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral/codestral": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 4000
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral/codestral-embed": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 0,
+        "max_output": 0
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral/devstral-small": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 7e-08,
+        "output_per_token": 2.8e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "mistral/magistral-medium": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "mistral/magistral-small": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 1.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral/ministral-3b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4000
+      },
+      "pricing": {
+        "input_per_token": 4e-08,
+        "output_per_token": 4e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral/ministral-8b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4000
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral/mistral-embed": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 0,
+        "max_output": 0
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral/mistral-large": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 4000
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 6e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral/mistral-saba-24b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 7.9e-07,
+        "output_per_token": 7.9e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral/mistral-small": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 4000
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "mistral/mixtral-8x22b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 65536,
+        "max_output": 2048
+      },
+      "pricing": {
+        "input_per_token": 1.2e-06,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral/pixtral-12b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4000
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "mistral/pixtral-large": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4000
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 6e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "moonshotai/kimi-k2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 5.5e-07,
+        "output_per_token": 2.2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "morph/morph-v3-fast": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 8e-07,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "morph/morph-v3-large": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 9e-07,
+        "output_per_token": 1.9e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-3.5-turbo": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 16385,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 1.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-3.5-turbo-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.5e-06,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-4-turbo": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-05,
+        "output_per_token": 3e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-4.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1047576,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 8e-06,
+        "cache_read_per_token": 5e-07,
+        "cache_write_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "openai/gpt-4.1-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1047576,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 1.6e-06,
+        "cache_read_per_token": 1e-07,
+        "cache_write_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "openai/gpt-4.1-nano": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1047576,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 4e-07,
+        "cache_read_per_token": 2.5e-08,
+        "cache_write_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "openai/gpt-4o": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.5e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-06,
+        "cache_write_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "openai/gpt-4o-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 6e-07,
+        "cache_read_per_token": 7.5e-08,
+        "cache_write_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "openai/o1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 100000
+      },
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 6e-05,
+        "cache_read_per_token": 7.5e-06,
+        "cache_write_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "openai/o3": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 100000
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 8e-06,
+        "cache_read_per_token": 5e-07,
+        "cache_write_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "openai/o3-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 100000
+      },
+      "pricing": {
+        "input_per_token": 1.1e-06,
+        "output_per_token": 4.4e-06,
+        "cache_read_per_token": 5.5e-07,
+        "cache_write_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "openai/o4-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 100000
+      },
+      "pricing": {
+        "input_per_token": 1.1e-06,
+        "output_per_token": 4.4e-06,
+        "cache_read_per_token": 2.75e-07,
+        "cache_write_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "openai/text-embedding-3-large": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 0,
+        "max_output": 0
+      },
+      "pricing": {
+        "input_per_token": 1.3e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/text-embedding-3-small": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 0,
+        "max_output": 0
+      },
+      "pricing": {
+        "input_per_token": 2e-08,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/text-embedding-ada-002": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 0,
+        "max_output": 0
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "perplexity/sonar": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 127000,
+        "max_output": 8000
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 1e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "perplexity/sonar-pro": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 8000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "perplexity/sonar-reasoning": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 127000,
+        "max_output": 8000
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 5e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "perplexity/sonar-reasoning-pro": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 127000,
+        "max_output": 8000
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 8e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "vercel/v0-1.0-md": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "vercel/v0-1.5-md": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "xai/grok-2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 4000
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "xai/grok-2-vision": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "xai/grok-3": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "xai/grok-3-fast": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 5e-06,
+        "output_per_token": 2.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "xai/grok-3-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "xai/grok-3-mini-fast": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 4e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "xai/grok-4": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "zai/glm-4.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "zai/glm-4.5-air": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 96000
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 1.1e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "zai/glm-4.6": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 200000
+      },
+      "pricing": {
+        "input_per_token": 4.5e-07,
+        "output_per_token": 1.8e-06,
+        "cache_read_per_token": 1.1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/vertex_ai.json
+++ b/mlflow/utils/model_catalog/vertex_ai.json
@@ -1,0 +1,1954 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "claude-3-5-haiku": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "claude-3-5-haiku@20241022": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "claude-3-5-sonnet": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "claude-3-5-sonnet@20240620": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "claude-3-7-sonnet@20250219": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-05-11"
+    },
+    "claude-3-haiku": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 1.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "claude-3-haiku@20240307": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 1.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "claude-3-opus": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 7.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "claude-3-opus@20240229": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 7.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "claude-3-sonnet": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "claude-3-sonnet@20240229": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 4096
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "claude-haiku-4-5@20251001": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 5e-06,
+        "cache_read_per_token": 1e-07,
+        "cache_write_per_token": 1.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "claude-opus-4": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 7.5e-05,
+        "cache_read_per_token": 1.5e-06,
+        "cache_write_per_token": 1.875e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "claude-opus-4-1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 7.5e-05,
+        "cache_read_per_token": 1.5e-06,
+        "cache_write_per_token": 1.875e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "claude-opus-4-1@20250805": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 7.5e-05,
+        "cache_read_per_token": 1.5e-06,
+        "cache_write_per_token": 1.875e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "claude-opus-4-5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 5e-06,
+        "output_per_token": 2.5e-05,
+        "cache_read_per_token": 5e-07,
+        "cache_write_per_token": 6.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "claude-opus-4-5@20251101": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 5e-06,
+        "output_per_token": 2.5e-05,
+        "cache_read_per_token": 5e-07,
+        "cache_write_per_token": 6.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "claude-opus-4-6": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 5e-06,
+        "output_per_token": 2.5e-05,
+        "cache_read_per_token": 5e-07,
+        "cache_write_per_token": 6.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "claude-opus-4-6@default": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 5e-06,
+        "output_per_token": 2.5e-05,
+        "cache_read_per_token": 5e-07,
+        "cache_write_per_token": 6.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "claude-opus-4@20250514": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 1.5e-05,
+        "output_per_token": 7.5e-05,
+        "cache_read_per_token": 1.5e-06,
+        "cache_write_per_token": 1.875e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "claude-sonnet-4": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "claude-sonnet-4-5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "claude-sonnet-4-5@20250929": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "claude-sonnet-4-6": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "claude-sonnet-4-6@default": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "claude-sonnet-4@20250514": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 3.75e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "codestral-2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "codestral-2501": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "codestral-2@001": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "codestral@2405": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "codestral@latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/deepseek-r1-0528-maas": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 65336,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1.35e-06,
+        "output_per_token": 5.4e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/deepseek-v3.1-maas": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1.35e-06,
+        "output_per_token": 5.4e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/deepseek-v3.2-maas": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 163840,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 5.6e-07,
+        "output_per_token": 1.68e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "gemini-2.0-flash": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 4e-07,
+        "cache_read_per_token": 2.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-06-01"
+    },
+    "gemini-2.0-flash-001": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 6e-07,
+        "cache_read_per_token": 3.75e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-06-01"
+    },
+    "gemini-2.0-flash-lite": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 7.5e-08,
+        "output_per_token": 3e-07,
+        "cache_read_per_token": 1.875e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-06-01"
+    },
+    "gemini-2.0-flash-lite-001": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 7.5e-08,
+        "output_per_token": 3e-07,
+        "cache_read_per_token": 1.875e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-06-01"
+    },
+    "gemini-2.5-computer-use-preview-10-2025": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gemini-2.5-flash": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65535
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 2.5e-06,
+        "cache_read_per_token": 3e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gemini-2.5-flash-lite": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65535
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 4e-07,
+        "cache_read_per_token": 1e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gemini-2.5-flash-lite-preview-06-17": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65535
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 4e-07,
+        "cache_read_per_token": 2.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "deprecation_date": "2025-11-18"
+    },
+    "gemini-2.5-flash-lite-preview-09-2025": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65535
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 4e-07,
+        "cache_read_per_token": 1e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gemini-2.5-flash-preview-09-2025": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65535
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 2.5e-06,
+        "cache_read_per_token": 7.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gemini-2.5-pro": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65535
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gemini-2.5-pro-preview-tts": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65535
+      },
+      "pricing": {
+        "input_per_token": 1.25e-06,
+        "output_per_token": 1e-05,
+        "cache_read_per_token": 1.25e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gemini-3-flash-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65535
+      },
+      "pricing": {
+        "input_per_token": 5e-07,
+        "output_per_token": 3e-06,
+        "cache_read_per_token": 5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gemini-3-pro-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65535
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 1.2e-05,
+        "cache_read_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "deprecation_date": "2026-03-26"
+    },
+    "gemini-3.1-flash-lite-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 1.5e-06,
+        "cache_read_per_token": 2.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gemini-3.1-pro-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 1.2e-05,
+        "cache_read_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gemini-3.1-pro-preview-customtools": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65536
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 1.2e-05,
+        "cache_read_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "gemini-embedding-001": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 2048
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gemini-embedding-2-preview": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 8192
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gemini-flash-experimental": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 0,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "gemini-robotics-er-1.5-preview": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65535
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 2.5e-06,
+        "cache_read_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "jamba-1.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "jamba-1.5-large": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 8e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "jamba-1.5-large@001": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 8e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "jamba-1.5-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "jamba-1.5-mini@001": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 4e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "medlm-large": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 1024
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "medlm-medium": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 8192
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta/llama-3.1-405b-instruct-maas": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 2048
+      },
+      "pricing": {
+        "input_per_token": 5e-06,
+        "output_per_token": 1.6e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta/llama-3.1-70b-instruct-maas": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 2048
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta/llama-3.1-8b-instruct-maas": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 2048
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta/llama-3.2-90b-vision-instruct-maas": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 2048
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta/llama-4-maverick-17b-128e-instruct-maas": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 1000000
+      },
+      "pricing": {
+        "input_per_token": 3.5e-07,
+        "output_per_token": 1.15e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta/llama-4-maverick-17b-16e-instruct-maas": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 1000000
+      },
+      "pricing": {
+        "input_per_token": 3.5e-07,
+        "output_per_token": 1.15e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta/llama-4-scout-17b-128e-instruct-maas": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 10000000,
+        "max_output": 10000000
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 7e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta/llama-4-scout-17b-16e-instruct-maas": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 10000000,
+        "max_output": 10000000
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 7e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta/llama3-405b-instruct-maas": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta/llama3-70b-instruct-maas": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta/llama3-8b-instruct-maas": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "minimaxai/minimax-m2-maas": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 196608,
+        "max_output": 196608
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral-large-2411": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 6e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral-large@2407": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 6e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral-large@2411-001": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 6e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral-large@latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 6e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral-medium-3": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral-medium-3@001": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral-nemo@2407": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 3e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral-nemo@latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral-small-2503": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 3e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistral-small-2503@001": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 3e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistralai/codestral-2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistralai/codestral-2@001": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 9e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistralai/mistral-medium-3": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistralai/mistral-medium-3@001": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 8191
+      },
+      "pricing": {
+        "input_per_token": 4e-07,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "moonshotai/kimi-k2-thinking-maas": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "multimodalembedding": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 2048
+      },
+      "pricing": {
+        "input_per_token": 8e-07,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "multimodalembedding@001": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 2048
+      },
+      "pricing": {
+        "input_per_token": 8e-07,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-oss-120b-maas": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-oss-20b-maas": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 7.5e-08,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen/qwen3-235b-a22b-instruct-2507-maas": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 2.5e-07,
+        "output_per_token": 1e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen/qwen3-coder-480b-a35b-instruct-maas": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 4e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen/qwen3-next-80b-a3b-instruct-maas": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "qwen/qwen3-next-80b-a3b-thinking-maas": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 1.2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "text-embedding-004": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 2048
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      },
+      "deprecation_date": "2026-01-14"
+    },
+    "text-embedding-005": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 2048
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "text-embedding-large-exp-03-07": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 8192
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "text-embedding-preview-0409": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 3072
+      },
+      "pricing": {
+        "input_per_token": 6.25e-09,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "text-multilingual-embedding-002": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 2048
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "text-unicorn": {
+      "mode": "completion",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 1024
+      },
+      "pricing": {
+        "input_per_token": 1e-05,
+        "output_per_token": 2.8e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "text-unicorn@001": {
+      "mode": "completion",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 1024
+      },
+      "pricing": {
+        "input_per_token": 1e-05,
+        "output_per_token": 2.8e-05
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "zai-org/glm-4.7-maas": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "zai-org/glm-5-maas": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 3.2e-06,
+        "cache_read_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/volcengine.json
+++ b/mlflow/utils/model_catalog/volcengine.json
@@ -1,0 +1,200 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "deepseek-v3-2-251201": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 98304,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "doubao-embedding": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 4096
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "doubao-embedding-large": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 4096
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "doubao-embedding-large-text-240915": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 4096
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "doubao-embedding-large-text-250515": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 4096
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "doubao-embedding-text-240715": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 4096
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "doubao-seed-2-0-code-preview-260215": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 128000
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "doubao-seed-2-0-lite-260215": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 128000
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "doubao-seed-2-0-mini-260215": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 128000
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "doubao-seed-2-0-pro-260215": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 128000
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "glm-4-7-251222": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 204800,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "kimi-k2-thinking-251104": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 229376,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 0.0,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/voyage.json
+++ b/mlflow/utils/model_catalog/voyage.json
@@ -1,0 +1,260 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "voyage-2": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 4000
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "voyage-3": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 32000
+      },
+      "pricing": {
+        "input_per_token": 6e-08,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "voyage-3-large": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 32000
+      },
+      "pricing": {
+        "input_per_token": 1.8e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "voyage-3-lite": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 32000
+      },
+      "pricing": {
+        "input_per_token": 2e-08,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "voyage-3.5": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 32000
+      },
+      "pricing": {
+        "input_per_token": 6e-08,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "voyage-3.5-lite": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 32000
+      },
+      "pricing": {
+        "input_per_token": 2e-08,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "voyage-code-2": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 16000
+      },
+      "pricing": {
+        "input_per_token": 1.2e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "voyage-code-3": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 32000
+      },
+      "pricing": {
+        "input_per_token": 1.8e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "voyage-context-3": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 120000
+      },
+      "pricing": {
+        "input_per_token": 1.8e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "voyage-finance-2": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 32000
+      },
+      "pricing": {
+        "input_per_token": 1.2e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "voyage-large-2": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 16000
+      },
+      "pricing": {
+        "input_per_token": 1.2e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "voyage-law-2": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 16000
+      },
+      "pricing": {
+        "input_per_token": 1.2e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "voyage-lite-01": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 4096
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "voyage-lite-02-instruct": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 4000
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "voyage-multimodal-3": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 32000
+      },
+      "pricing": {
+        "input_per_token": 1.2e-07,
+        "output_per_token": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/wandb.json
+++ b/mlflow/utils/model_catalog/wandb.json
@@ -1,0 +1,257 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "Qwen/Qwen3-235B-A22B-Instruct-2507": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 0.01,
+        "output_per_token": 0.01
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen3-235B-A22B-Thinking-2507": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 0.01,
+        "output_per_token": 0.01
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "Qwen/Qwen3-Coder-480B-A35B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144
+      },
+      "pricing": {
+        "input_per_token": 0.1,
+        "output_per_token": 0.15
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/DeepSeek-R1-0528": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 161000,
+        "max_output": 161000
+      },
+      "pricing": {
+        "input_per_token": 0.135,
+        "output_per_token": 0.54
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/DeepSeek-V3-0324": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 161000,
+        "max_output": 161000
+      },
+      "pricing": {
+        "input_per_token": 0.114,
+        "output_per_token": 0.275
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "deepseek-ai/DeepSeek-V3.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 0.055,
+        "output_per_token": 0.165
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Llama-3.1-8B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 0.022,
+        "output_per_token": 0.022
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Llama-3.3-70B-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 0.071,
+        "output_per_token": 0.071
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/Llama-4-Scout-17B-16E-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 64000,
+        "max_output": 64000
+      },
+      "pricing": {
+        "input_per_token": 0.017,
+        "output_per_token": 0.066
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "microsoft/Phi-4-mini-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 0.008,
+        "output_per_token": 0.035
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "moonshotai/Kimi-K2-Instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.5e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-oss-120b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 0.015,
+        "output_per_token": 0.06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-oss-20b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 0.005,
+        "output_per_token": 0.02
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "zai-org/GLM-4.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 0.055,
+        "output_per_token": 0.2
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/watsonx.json
+++ b/mlflow/utils/model_catalog/watsonx.json
@@ -1,0 +1,509 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "bigscience/mt0-xxl-13b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 0.0005,
+        "output_per_token": 0.002
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "core42/jais-13b-chat": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 0.0005,
+        "output_per_token": 0.002
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "google/flan-t5-xl-3b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ibm/granite-13b-chat-v2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ibm/granite-13b-instruct-v2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ibm/granite-3-3-8b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ibm/granite-3-8b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 1024
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "ibm/granite-4-h-small": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 20480,
+        "max_output": 20480
+      },
+      "pricing": {
+        "input_per_token": 6e-08,
+        "output_per_token": 2.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ibm/granite-guardian-3-2-2b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ibm/granite-guardian-3-3-8b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ibm/granite-ttm-1024-96-r2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 512,
+        "max_output": 512
+      },
+      "pricing": {
+        "input_per_token": 3.8e-07,
+        "output_per_token": 3.8e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ibm/granite-ttm-1536-96-r2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 512,
+        "max_output": 512
+      },
+      "pricing": {
+        "input_per_token": 3.8e-07,
+        "output_per_token": 3.8e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ibm/granite-ttm-512-96-r2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 512,
+        "max_output": 512
+      },
+      "pricing": {
+        "input_per_token": 3.8e-07,
+        "output_per_token": 3.8e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "ibm/granite-vision-3-2-2b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/llama-3-2-11b-vision-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 3.5e-07,
+        "output_per_token": 3.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/llama-3-2-1b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/llama-3-2-3b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/llama-3-2-90b-vision-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/llama-3-3-70b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 7.1e-07,
+        "output_per_token": 7.1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/llama-4-maverick-17b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 3.5e-07,
+        "output_per_token": 1.4e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "meta-llama/llama-guard-3-11b-vision": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 3.5e-07,
+        "output_per_token": 3.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistralai/mistral-large": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 16384
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      }
+    },
+    "mistralai/mistral-medium-2505": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistralai/mistral-small-2503": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistralai/mistral-small-3-1-24b-instruct-2503": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 3e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "mistralai/pixtral-12b-2409": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 3.5e-07,
+        "output_per_token": 3.5e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "openai/gpt-oss-120b": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1.5e-07,
+        "output_per_token": 6e-07
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "sdaia/allam-1-13b-instruct": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 1.8e-06,
+        "output_per_token": 1.8e-06
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/xai.json
+++ b/mlflow/utils/model_catalog/xai.json
@@ -1,0 +1,662 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "grok-2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "grok-2-1212": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "grok-2-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "grok-2-vision": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "grok-2-vision-1212": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      },
+      "deprecation_date": "2026-02-28"
+    },
+    "grok-2-vision-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 32768,
+        "max_output": 32768
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 1e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "grok-3": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 7.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "grok-3-beta": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 7.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "grok-3-fast-beta": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 5e-06,
+        "output_per_token": 2.5e-05,
+        "cache_read_per_token": 1.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "grok-3-fast-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 5e-06,
+        "output_per_token": 2.5e-05,
+        "cache_read_per_token": 1.25e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "grok-3-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05,
+        "cache_read_per_token": 7.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "grok-3-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 5e-07,
+        "cache_read_per_token": 7.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      },
+      "deprecation_date": "2026-02-28"
+    },
+    "grok-3-mini-beta": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 5e-07,
+        "cache_read_per_token": 7.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      },
+      "deprecation_date": "2026-02-28"
+    },
+    "grok-3-mini-fast": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 4e-06,
+        "cache_read_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "grok-3-mini-fast-beta": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 4e-06,
+        "cache_read_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "grok-3-mini-fast-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 4e-06,
+        "cache_read_per_token": 1.5e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "grok-3-mini-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 3e-07,
+        "output_per_token": 5e-07,
+        "cache_read_per_token": 7.5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "grok-4": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "grok-4-0709": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "grok-4-1-fast": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 2000000.0,
+        "max_output": 2000000.0
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 5e-07,
+        "cache_read_per_token": 5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "grok-4-1-fast-non-reasoning": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 2000000.0,
+        "max_output": 2000000.0
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 5e-07,
+        "cache_read_per_token": 5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "grok-4-1-fast-non-reasoning-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 2000000.0,
+        "max_output": 2000000.0
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 5e-07,
+        "cache_read_per_token": 5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "grok-4-1-fast-reasoning": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 2000000.0,
+        "max_output": 2000000.0
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 5e-07,
+        "cache_read_per_token": 5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "grok-4-1-fast-reasoning-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 2000000.0,
+        "max_output": 2000000.0
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 5e-07,
+        "cache_read_per_token": 5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "grok-4-fast-non-reasoning": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 2000000.0,
+        "max_output": 2000000.0
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 5e-07,
+        "cache_read_per_token": 5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "grok-4-fast-reasoning": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 2000000.0,
+        "max_output": 2000000.0
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 5e-07,
+        "cache_read_per_token": 5e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "grok-4-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 3e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "grok-4.20-beta-0309-non-reasoning": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 2000000,
+        "max_output": 2000000
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 6e-06,
+        "cache_read_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "grok-4.20-beta-0309-reasoning": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 2000000,
+        "max_output": 2000000
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 6e-06,
+        "cache_read_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "grok-4.20-multi-agent-beta-0309": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 2000000,
+        "max_output": 2000000
+      },
+      "pricing": {
+        "input_per_token": 2e-06,
+        "output_per_token": 6e-06,
+        "cache_read_per_token": 2e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "grok-beta": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 131072,
+        "max_output": 131072
+      },
+      "pricing": {
+        "input_per_token": 5e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "grok-code-fast": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 1.5e-06,
+        "cache_read_per_token": 2e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "grok-code-fast-1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 1.5e-06,
+        "cache_read_per_token": 2e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "grok-code-fast-1-0825": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 1.5e-06,
+        "cache_read_per_token": 2e-08
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "grok-vision-beta": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 8192,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_token": 5e-06,
+        "output_per_token": 1.5e-05
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/zai.json
+++ b/mlflow/utils/model_catalog/zai.json
@@ -1,0 +1,211 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "glm-4-32b-0414-128k": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 1e-07,
+        "output_per_token": 1e-07
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "glm-4.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.2e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "glm-4.5-air": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 2e-07,
+        "output_per_token": 1.1e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "glm-4.5-airx": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 1.1e-06,
+        "output_per_token": 4.5e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "glm-4.5-flash": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 0,
+        "output_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "glm-4.5-x": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 2.2e-06,
+        "output_per_token": 8.9e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "glm-4.5v": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 32000
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 1.8e-06
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      }
+    },
+    "glm-4.6": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.2e-06,
+        "cache_read_per_token": 1.1e-07,
+        "cache_write_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "glm-4.7": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 6e-07,
+        "output_per_token": 2.2e-06,
+        "cache_read_per_token": 1.1e-07,
+        "cache_write_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "glm-5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1e-06,
+        "output_per_token": 3.2e-06,
+        "cache_read_per_token": 2e-07,
+        "cache_write_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    },
+    "glm-5-code": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_token": 1.2e-06,
+        "output_per_token": 5e-06,
+        "cache_read_per_token": 3e-07,
+        "cache_write_per_token": 0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      }
+    }
+  }
+}

--- a/tests/dev/test_convert_litellm_catalog.py
+++ b/tests/dev/test_convert_litellm_catalog.py
@@ -1,0 +1,156 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "dev"))
+
+from convert_litellm_catalog import _normalize_provider, _transform_entry, convert
+
+
+@pytest.mark.parametrize(
+    ("provider", "expected"),
+    [
+        ("openai", "openai"),
+        ("anthropic", "anthropic"),
+        ("vertex_ai", "vertex_ai"),
+        ("vertex_ai-anthropic", "vertex_ai"),
+        ("vertex_ai-llama_models", "vertex_ai"),
+        ("vertex_ai-chat-models", "vertex_ai"),
+        ("bedrock", "bedrock"),
+    ],
+)
+def test_normalize_provider(provider, expected):
+    assert _normalize_provider(provider) == expected
+
+
+def test_transform_entry_chat_model():
+    info = {
+        "mode": "chat",
+        "input_cost_per_token": 3e-6,
+        "output_cost_per_token": 1.5e-5,
+        "cache_read_input_token_cost": 3e-7,
+        "cache_creation_input_token_cost": 3.75e-6,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "supports_function_calling": True,
+        "supports_vision": True,
+        "supports_reasoning": True,
+        "supports_prompt_caching": True,
+        "supports_response_schema": True,
+    }
+    result = _transform_entry(info)
+    assert result == {
+        "mode": "chat",
+        "context_window": {"max_input": 200000, "max_output": 64000},
+        "pricing": {
+            "input_per_token": 3e-6,
+            "output_per_token": 1.5e-5,
+            "cache_read_per_token": 3e-7,
+            "cache_write_per_token": 3.75e-6,
+        },
+        "capabilities": {
+            "function_calling": True,
+            "vision": True,
+            "reasoning": True,
+            "prompt_caching": True,
+            "response_schema": True,
+        },
+    }
+
+
+def test_transform_entry_skips_image_generation():
+    info = {"mode": "image_generation", "input_cost_per_token": 1e-6}
+    assert _transform_entry(info) is None
+
+
+def test_transform_entry_includes_deprecation_date():
+    info = {
+        "mode": "chat",
+        "deprecation_date": "2026-01-01",
+    }
+    result = _transform_entry(info)
+    assert result["deprecation_date"] == "2026-01-01"
+
+
+def test_convert_end_to_end(tmp_path):
+    input_data = {
+        "sample_spec": {"mode": "chat"},
+        "gpt-4o": {
+            "litellm_provider": "openai",
+            "mode": "chat",
+            "input_cost_per_token": 2.5e-6,
+            "output_cost_per_token": 1e-5,
+            "max_input_tokens": 128000,
+            "max_output_tokens": 16384,
+            "supports_function_calling": True,
+            "supports_vision": True,
+        },
+        "openai/gpt-4o-mini": {
+            "litellm_provider": "openai",
+            "mode": "chat",
+            "input_cost_per_token": 1.5e-7,
+            "output_cost_per_token": 6e-7,
+            "max_input_tokens": 128000,
+            "max_output_tokens": 16384,
+        },
+        "claude-3-5-sonnet": {
+            "litellm_provider": "anthropic",
+            "mode": "chat",
+            "input_cost_per_token": 3e-6,
+            "output_cost_per_token": 1.5e-5,
+        },
+        "dall-e-3": {
+            "litellm_provider": "openai",
+            "mode": "image_generation",
+        },
+        "ft:gpt-4o:org::id": {
+            "litellm_provider": "openai",
+            "mode": "chat",
+        },
+        "bedrock_converse/model": {
+            "litellm_provider": "bedrock_converse",
+            "mode": "chat",
+        },
+    }
+
+    input_path = tmp_path / "input.json"
+    input_path.write_text(json.dumps(input_data))
+    output_dir = tmp_path / "output"
+
+    stats = convert(input_path, output_dir)
+
+    assert stats == {"anthropic": 1, "openai": 2}
+    assert (output_dir / "openai.json").exists()
+    assert (output_dir / "anthropic.json").exists()
+    assert not (output_dir / "bedrock_converse.json").exists()
+
+    openai_catalog = json.loads((output_dir / "openai.json").read_text())
+    assert openai_catalog["schema_version"] == "1.0"
+    assert "gpt-4o" in openai_catalog["models"]
+    assert "gpt-4o-mini" in openai_catalog["models"]
+    # Fine-tuned and image_generation should be excluded
+    assert "ft:gpt-4o:org::id" not in openai_catalog["models"]
+    assert "dall-e-3" not in openai_catalog["models"]
+
+
+def test_convert_removes_stale_files(tmp_path):
+    input_data = {
+        "gpt-4o": {
+            "litellm_provider": "openai",
+            "mode": "chat",
+        },
+    }
+    input_path = tmp_path / "input.json"
+    input_path.write_text(json.dumps(input_data))
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    # Create a stale file
+    (output_dir / "stale_provider.json").write_text("{}")
+
+    convert(input_path, output_dir)
+
+    assert not (output_dir / "stale_provider.json").exists()
+    assert (output_dir / "openai.json").exists()


### PR DESCRIPTION
## Summary
- Adds `dev/convert_litellm_catalog.py` that converts LiteLLM's monolithic JSON into per-provider MLflow-native catalog files
- Generates ~2K curated models (vs. 31K raw entries) across 68 providers in `mlflow/utils/model_catalog/`
- MLflow-native schema with explicit versioning, nested pricing/capabilities/context_window fields

**Stack:** 1/4 — this is the base PR

## Test plan
- [x] Unit tests in `tests/dev/test_convert_litellm_catalog.py` (12 tests)
- [x] Verified transform produces correct output for all providers

This pull request was AI-assisted by Isaac.