### PR TITLE
Fix dark mode CSS not consistently applied in compare runs page

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunView.css
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunView.css
@@ -33,18 +33,18 @@
 }
 
 .mlflow-compare-table .diff-row .data-value {
-  background-color: rgba(249, 237, 190, 0.5);
-  color: #555;
+  background-color: var(--mlflow-compare-diff-bg, rgba(249, 237, 190, 0.5));
+  color: var(--mlflow-compare-diff-color, #555);
 }
 
 .mlflow-compare-table .diff-row .head-value {
-  background-color: rgba(249, 237, 190, 1);
-  color: #555;
+  background-color: var(--mlflow-compare-diff-bg, rgba(249, 237, 190, 1));
+  color: var(--mlflow-compare-diff-color, #555);
 }
 
 .mlflow-compare-table .diff-row:hover {
-  background-color: rgba(249, 237, 190, 1);
-  color: #555;
+  background-color: var(--mlflow-compare-diff-bg, rgba(249, 237, 190, 1));
+  color: var(--mlflow-compare-diff-color, #555);
 }
 
 /* Overrides to make it look more like antd */
@@ -56,14 +56,14 @@
 .mlflow-compare-table th,
 .mlflow-compare-table td {
   padding: 12px 8px;
-  border-bottom: 1px solid #e8e8e8;
+  border-bottom: 1px solid var(--mlflow-compare-border-color, #e8e8e8);
 }
 .mlflow-compare-table th {
-  color: rgba(0, 0, 0, 0.85);
+  color: var(--mlflow-compare-header-color, rgba(0, 0, 0, 0.85));
   font-weight: 500;
-  background-color: rgb(250, 250, 250);
+  background-color: var(--mlflow-compare-header-bg, rgb(250, 250, 250));
   text-align: left;
 }
 .mlflow-compare-table > tbody > tr:hover:not(.diff-row) > td:not(.highlight-data) {
-  background-color: rgb(250, 250, 250);
+  background-color: var(--mlflow-compare-hover-bg, rgb(250, 250, 250));
 }

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunView.tsx
@@ -8,7 +8,15 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { injectIntl, FormattedMessage, type IntlShape } from 'react-intl';
-import { Spacer, Switch, LegacyTabs, LegacyTooltip, Tooltip, Typography } from '@databricks/design-system';
+import {
+  Spacer,
+  Switch,
+  LegacyTabs,
+  LegacyTooltip,
+  Tooltip,
+  Typography,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
 
 import { getExperiment, getParams, getRunInfo, getRunTags } from '../reducers/Reducers';
 import './CompareRunView.css';
@@ -263,13 +271,13 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
       );
     }
     return (
-      <table
+      <CompareRunTable
         className="table mlflow-compare-table mlflow-compare-run-table"
         css={{ maxHeight: '500px' }}
         onScroll={this.onCompareRunTableScrollHandler}
       >
         <tbody>{dataRows}</tbody>
-      </table>
+      </CompareRunTable>
     );
   }
 
@@ -329,13 +337,13 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
       );
     }
     return (
-      <table
+      <CompareRunTable
         className="table mlflow-compare-table mlflow-compare-run-table"
         css={{ maxHeight: '500px' }}
         onScroll={this.onCompareRunTableScrollHandler}
       >
         <tbody>{dataRows}</tbody>
-      </table>
+      </CompareRunTable>
     );
   }
 
@@ -514,7 +522,7 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
             description: 'Compare table title on the compare runs page',
           })}
         >
-          <table
+          <CompareRunTable
             className="table mlflow-compare-table mlflow-compare-run-table"
             ref={this.runDetailsTableRef}
             onScroll={this.onCompareRunTableScrollHandler}
@@ -586,7 +594,7 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
                 </tr>
               )}
             </tbody>
-          </table>
+          </CompareRunTable>
         </CollapsibleSection>
         <CollapsibleSection title={paramsLabel}>
           <Switch
@@ -763,5 +771,28 @@ const parsePythonDictString = (value: string) => {
     return null;
   }
 };
+
+const CompareRunTable = React.forwardRef<HTMLTableElement, React.ComponentPropsWithoutRef<'table'>>(
+  function CompareRunTable({ style, ...props }, ref) {
+    const { theme } = useDesignSystemTheme();
+    return (
+      <table
+        ref={ref}
+        style={
+          {
+            '--mlflow-compare-border-color': theme.colors.border,
+            '--mlflow-compare-header-color': theme.colors.textPrimary,
+            '--mlflow-compare-header-bg': theme.colors.backgroundSecondary,
+            '--mlflow-compare-diff-bg': theme.colors.backgroundWarning,
+            '--mlflow-compare-diff-color': theme.colors.textSecondary,
+            '--mlflow-compare-hover-bg': theme.colors.backgroundSecondary,
+            ...style,
+          } as React.CSSProperties
+        }
+        {...props}
+      />
+    );
+  },
+);
 
 export default connect(mapStateToProps)(injectIntl(CompareRunView));

--- a/mlflow/server/js/src/experiment-tracking/components/LazyPlot.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/LazyPlot.tsx
@@ -5,16 +5,43 @@
  * annotations are already looking good, please remove this comment.
  */
 
-import React from 'react';
-import { LegacySkeleton } from '@databricks/design-system';
+import React, { useMemo } from 'react';
+import { LegacySkeleton, useDesignSystemTheme } from '@databricks/design-system';
 import { SectionErrorBoundary } from '../../common/components/error-boundaries/SectionErrorBoundary';
 
 const Plot = React.lazy(() => import('react-plotly.js'));
 
-export const LazyPlot = ({ fallback, ...props }: any) => (
-  <SectionErrorBoundary>
-    <React.Suspense fallback={fallback ?? <LegacySkeleton active />}>
-      <Plot {...props} />
-    </React.Suspense>
-  </SectionErrorBoundary>
-);
+export const LazyPlot = ({ fallback, layout, ...props }: any) => {
+  const { theme } = useDesignSystemTheme();
+
+  const themedLayout = useMemo(() => {
+    const { xaxis, yaxis, font, ...rest } = layout || {};
+    return {
+      paper_bgcolor: 'transparent',
+      plot_bgcolor: 'transparent',
+      font: {
+        color: theme.colors.textPrimary,
+        ...font,
+      },
+      xaxis: {
+        gridcolor: theme.colors.border,
+        zerolinecolor: theme.colors.border,
+        ...xaxis,
+      },
+      yaxis: {
+        gridcolor: theme.colors.border,
+        zerolinecolor: theme.colors.border,
+        ...yaxis,
+      },
+      ...rest,
+    };
+  }, [layout, theme]);
+
+  return (
+    <SectionErrorBoundary>
+      <React.Suspense fallback={fallback ?? <LegacySkeleton active />}>
+        <Plot layout={themedLayout} {...props} />
+      </React.Suspense>
+    </SectionErrorBoundary>
+  );
+};

--- a/mlflow/server/js/src/model-registry/components/CompareModelVersionsView.tsx
+++ b/mlflow/server/js/src/model-registry/components/CompareModelVersionsView.tsx
@@ -43,7 +43,7 @@ function CenteredText(props: any) {
   );
 }
 
-function CompareTable(props: any) {
+function CompareTable({ style, ...props }: any) {
   const { theme } = useDesignSystemTheme();
   return (
     <table
@@ -57,6 +57,17 @@ function CompareTable(props: any) {
           backgroundColor: theme.colors.backgroundValidationWarning,
         },
       }}
+      style={
+        {
+          '--mlflow-compare-border-color': theme.colors.border,
+          '--mlflow-compare-header-color': theme.colors.textPrimary,
+          '--mlflow-compare-header-bg': theme.colors.backgroundSecondary,
+          '--mlflow-compare-diff-bg': theme.colors.backgroundWarning,
+          '--mlflow-compare-diff-color': theme.colors.textSecondary,
+          '--mlflow-compare-hover-bg': theme.colors.backgroundSecondary,
+          ...style,
+        } as React.CSSProperties
+      }
       {...props}
     />
   );


### PR DESCRIPTION
### Related Issues/PRs

Closes #22210

### What changes are proposed in this pull request?

Dark mode theme colors were not applied to compare run tables and Plotly charts on the compare runs page. Table headers, borders, diff-row highlights, and hover states used hardcoded light-mode colors in `CompareRunView.css`, while Plotly charts rendered with a default white background.

**Tables fix** (`CompareRunView.css`, `CompareRunView.tsx`, `CompareModelVersionsView.tsx`):
- Replace hardcoded colors in `CompareRunView.css` with CSS custom properties (`var(--mlflow-compare-*, <fallback>)`) that retain the original light-mode values as fallbacks.
- Add a `CompareRunTable` functional component in `CompareRunView.tsx` (with `forwardRef`) that uses `useDesignSystemTheme()` to set the CSS custom properties via the `style` prop — matching the existing `CompareTable` pattern in `CompareModelVersionsView.tsx`.
- Set the same CSS custom properties on the existing `CompareTable` component in `CompareModelVersionsView.tsx`, which imports and shares `CompareRunView.css`.

**Charts fix** (`LazyPlot.tsx`):
- Make `LazyPlot` theme-aware by injecting `paper_bgcolor: 'transparent'`, `plot_bgcolor: 'transparent'`, `font.color`, `gridcolor`, and `zerolinecolor` from theme tokens into the Plotly layout. This fixes all four chart types (Parallel Coordinates, Scatter, Box, Contour) at once.

<img width="1511" height="765" alt="Screenshot 2026-04-01 at 12 01 32 PM" src="https://github.com/user-attachments/assets/3f08ac97-3f90-4838-bf8a-ce7e3e5befbc" />
<img width="1511" height="765" alt="Screenshot 2026-04-01 at 12 01 54 PM" src="https://github.com/user-attachments/assets/43759fe4-62c5-43b0-926e-f1e606745a0c" />
<img width="1511" height="765" alt="Screenshot 2026-04-01 at 12 02 07 PM" src="https://github.com/user-attachments/assets/a8a1b37b-3a4c-4bf1-ae12-97caff9a669f" />
<img width="1511" height="765" alt="Screenshot 2026-04-01 at 12 02 21 PM" src="https://github.com/user-attachments/assets/46e63491-bb73-4215-8980-983b323aba7d" />

https://github.com/user-attachments/assets/ca019374-babb-4712-850c-37db7b6d02ae

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Verified in the MLflow dev server with dark mode enabled that:
- Compare runs table headers, borders, diff highlights, and hover states use dark-mode-appropriate colors
- Plotly charts (Parallel Coordinates, Scatter, Box, Contour) render with transparent backgrounds and readable text/gridlines in dark mode
- Light mode appearance is unchanged (CSS custom properties fall back to original values)

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fix dark mode CSS not being consistently applied on the compare runs page — table headers, borders, diff-row highlights, and Plotly chart backgrounds now respect dark mode.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release

Made with [Cursor](https://cursor.com)