### PR TITLE
Add OTLP helpers for archived trace payloads

### DIFF
--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -9,13 +9,14 @@ from abc import ABC, ABCMeta, abstractmethod
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from mlflow.entities.file_info import FileInfo
 from mlflow.entities.multipart_upload import (
     CreateMultipartUploadResponse,
     MultipartUploadPart,
 )
+from mlflow.entities.trace_data import TraceData
 from mlflow.exceptions import (
     MlflowException,
     MlflowTraceDataCorrupted,
@@ -25,6 +26,7 @@ from mlflow.protos.databricks_pb2 import (
     INVALID_PARAMETER_VALUE,
     RESOURCE_DOES_NOT_EXIST,
 )
+from mlflow.tracing.constant import SpansLocation
 from mlflow.tracing.utils.artifact_utils import TRACE_DATA_FILE_NAME
 from mlflow.utils.annotations import developer_stable
 from mlflow.utils.async_logging.async_artifacts_logging_queue import (
@@ -32,6 +34,9 @@ from mlflow.utils.async_logging.async_artifacts_logging_queue import (
 )
 from mlflow.utils.file_utils import ArtifactProgressBar, create_tmp_dir
 from mlflow.utils.validation import bad_path_message, path_not_unique
+
+if TYPE_CHECKING:
+    from mlflow.entities.span import Span
 
 # Constants used to determine max level of parallelism to use while uploading/downloading artifacts.
 # Max threads to use for parallelism.
@@ -395,6 +400,51 @@ class ArtifactRepository:
                 raise MlflowTraceDataNotFound(artifact_path=TRACE_DATA_FILE_NAME) from e
             return try_read_trace_data(temp_file)
 
+    def _download_trace_data_pb(self) -> list["Span"]:
+        """
+        Download archived trace span data from ``artifacts/traces.pb``.
+
+        Returns:
+            The archived spans as MLflow ``Span`` entities.
+        """
+        from mlflow.tracing.otel.otel_archival import (
+            TRACE_ARCHIVAL_ARTIFACT_PATH,
+            TRACE_ARCHIVAL_FILENAME,
+        )
+
+        trace_pb_path = f"{TRACE_ARCHIVAL_ARTIFACT_PATH}/{TRACE_ARCHIVAL_FILENAME}"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_file = Path(temp_dir, TRACE_ARCHIVAL_FILENAME)
+            try:
+                self._download_file(trace_pb_path, temp_file)
+            except Exception as e:
+                raise MlflowTraceDataNotFound(artifact_path=trace_pb_path) from e
+            return _try_read_trace_data_pb(temp_file)
+
+    def download_trace_payload(
+        self, spans_location: SpansLocation = SpansLocation.ARTIFACT_REPO
+    ) -> TraceData:
+        """
+        Download trace payload data without exposing the underlying storage format.
+
+        Args:
+            spans_location: ``ARTIFACT_REPO`` for the legacy JSON trace-data payload or
+                ``ARCHIVE_REPO`` for the OTLP protobuf archive payload.
+
+        Returns:
+            The trace payload as a ``TraceData`` object.
+        """
+        if spans_location == SpansLocation.ARTIFACT_REPO:
+            return TraceData.from_dict(self.download_trace_data())
+        if spans_location == SpansLocation.ARCHIVE_REPO:
+            return TraceData(spans=self._download_trace_data_pb())
+
+        raise MlflowException.invalid_parameter_value(
+            "Artifact repositories only support trace payloads stored in "
+            f"{SpansLocation.ARTIFACT_REPO.value} or {SpansLocation.ARCHIVE_REPO.value}; "
+            f"got {spans_location!r}."
+        )
+
     def download_trace_attachment(self, path: str) -> bytes:
         _validate_attachment_path(path)
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -412,6 +462,50 @@ class ArtifactRepository:
         with write_local_temp_trace_data_file(trace_data) as temp_file:
             self.log_artifact(temp_file)
 
+    def _upload_trace_data_pb(self, spans: list["Span"]) -> None:
+        """
+        Upload archived trace span data as OTLP protobuf to ``artifacts/traces.pb``.
+        """
+        from mlflow.tracing.otel.otel_archival import (
+            TRACE_ARCHIVAL_ARTIFACT_PATH,
+            spans_to_traces_data_pb,
+        )
+
+        data = spans_to_traces_data_pb(spans)
+        with _write_local_temp_trace_data_pb_file(data) as temp_file:
+            self.log_artifact(temp_file, artifact_path=TRACE_ARCHIVAL_ARTIFACT_PATH)
+
+    def upload_trace_payload(
+        self,
+        trace_data: TraceData,
+        spans_location: SpansLocation = SpansLocation.ARTIFACT_REPO,
+    ) -> None:
+        """
+        Upload trace payload data without exposing the underlying storage format.
+
+        Args:
+            trace_data: The trace payload to upload.
+            spans_location: ``ARTIFACT_REPO`` for the legacy JSON trace-data payload or
+                ``ARCHIVE_REPO`` for the OTLP protobuf archive payload.
+        """
+        if spans_location == SpansLocation.ARTIFACT_REPO:
+            from mlflow.tracing.utils import TraceJSONEncoder
+
+            trace_data_json = json.dumps(
+                trace_data.to_dict(), cls=TraceJSONEncoder, ensure_ascii=False
+            )
+            self.upload_trace_data(trace_data_json)
+            return
+        if spans_location == SpansLocation.ARCHIVE_REPO:
+            self._upload_trace_data_pb(trace_data.spans)
+            return
+
+        raise MlflowException.invalid_parameter_value(
+            "Artifact repositories only support trace payloads stored in "
+            f"{SpansLocation.ARTIFACT_REPO.value} or {SpansLocation.ARCHIVE_REPO.value}; "
+            f"got {spans_location!r}."
+        )
+
     def upload_attachment(self, attachment_id: str, content_bytes: bytes) -> None:
         _validate_attachment_path(attachment_id)
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -428,6 +522,16 @@ def write_local_temp_trace_data_file(trace_data: str):
         yield temp_file
 
 
+@contextmanager
+def _write_local_temp_trace_data_pb_file(data: bytes):
+    from mlflow.tracing.otel.otel_archival import TRACE_ARCHIVAL_FILENAME
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_file = Path(temp_dir, TRACE_ARCHIVAL_FILENAME)
+        temp_file.write_bytes(data)
+        yield temp_file
+
+
 def try_read_trace_data(trace_data_path):
     if not os.path.exists(trace_data_path):
         raise MlflowTraceDataNotFound(artifact_path=trace_data_path)
@@ -438,6 +542,20 @@ def try_read_trace_data(trace_data_path):
     try:
         return json.loads(data)
     except json.decoder.JSONDecodeError as e:
+        raise MlflowTraceDataCorrupted(artifact_path=trace_data_path) from e
+
+
+def _try_read_trace_data_pb(trace_data_path) -> list["Span"]:
+    from mlflow.tracing.otel.otel_archival import traces_data_pb_to_spans
+
+    if not os.path.exists(trace_data_path):
+        raise MlflowTraceDataNotFound(artifact_path=trace_data_path)
+    data = Path(trace_data_path).read_bytes()
+    if not data:
+        raise MlflowTraceDataCorrupted(artifact_path=trace_data_path)
+    try:
+        return traces_data_pb_to_spans(data)
+    except Exception as e:
         raise MlflowTraceDataCorrupted(artifact_path=trace_data_path) from e
 
 

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -192,6 +192,7 @@ GET_TRACE_V4_RETRY_TIMEOUT_SECONDS = 15
 class SpansLocation(str, Enum):
     TRACKING_STORE = "TRACKING_STORE"
     ARTIFACT_REPO = "ARTIFACT_REPO"
+    ARCHIVE_REPO = "ARCHIVE_REPO"
 
 
 # Path to the notebook trace renderer directory

--- a/mlflow/tracing/otel/otel_archival.py
+++ b/mlflow/tracing/otel/otel_archival.py
@@ -1,0 +1,59 @@
+"""
+Helpers for serializing archived trace spans as OTLP ``TracesData`` protobuf.
+"""
+
+from __future__ import annotations
+
+from opentelemetry.proto.trace.v1.trace_pb2 import TracesData
+
+from mlflow.entities.span import Span
+from mlflow.exceptions import MlflowException
+from mlflow.tracing.utils.otlp import resource_to_otel_proto
+
+TRACE_ARCHIVAL_ARTIFACT_PATH = "artifacts"
+TRACE_ARCHIVAL_FILENAME = "traces.pb"
+
+
+def spans_to_traces_data_pb(spans: list[Span]) -> bytes:
+    """
+    Serialize MLflow spans to OTLP ``TracesData`` protobuf bytes.
+
+    Archived trace payloads must be non-empty and all spans must belong to the
+    same underlying OTLP trace.
+    """
+    if not spans:
+        raise MlflowException.invalid_parameter_value(
+            "Archived trace payload must include at least one span."
+        )
+
+    otlp_trace_ids = {span._trace_id for span in spans}
+    if len(otlp_trace_ids) > 1:
+        raise MlflowException.invalid_parameter_value(
+            "Archived spans must belong to a single OTLP trace, but got distinct trace IDs: "
+            f"{sorted(otlp_trace_ids)}"
+        )
+
+    traces_data = TracesData()
+    resource_spans = traces_data.resource_spans.add()
+    resource = getattr(spans[0]._span, "resource", None)
+    resource_spans.resource.CopyFrom(resource_to_otel_proto(resource))
+    scope_spans = resource_spans.scope_spans.add()
+    scope_spans.spans.extend(span.to_otel_proto() for span in spans)
+    return traces_data.SerializeToString()
+
+
+def traces_data_pb_to_spans(data: bytes) -> list[Span]:
+    """Deserialize OTLP ``TracesData`` protobuf bytes into MLflow spans."""
+    if not data:
+        raise MlflowException.invalid_parameter_value(
+            "Archived trace payload must be a non-empty OTLP TracesData protobuf."
+        )
+
+    traces_data = TracesData()
+    traces_data.ParseFromString(data)
+    return [
+        Span.from_otel_proto(otel_span)
+        for resource_spans in traces_data.resource_spans
+        for scope_spans in resource_spans.scope_spans
+        for otel_span in scope_spans.spans
+    ]

--- a/tests/store/artifact/test_local_artifact_repo.py
+++ b/tests/store/artifact/test_local_artifact_repo.py
@@ -4,9 +4,15 @@ import pathlib
 import posixpath
 
 import pytest
+from opentelemetry.sdk.trace import ReadableSpan as OTelReadableSpan
 
+from mlflow.entities.span import Span, SpanAttributeKey
+from mlflow.entities.trace_data import TraceData
 from mlflow.exceptions import MlflowException, MlflowTraceDataCorrupted, MlflowTraceDataNotFound
 from mlflow.store.artifact.local_artifact_repo import LocalArtifactRepository
+from mlflow.tracing.constant import SpansLocation
+from mlflow.tracing.otel.otel_archival import TRACE_ARCHIVAL_ARTIFACT_PATH, TRACE_ARCHIVAL_FILENAME
+from mlflow.tracing.utils import build_otel_context
 from mlflow.utils.file_utils import TempDir
 
 
@@ -243,6 +249,75 @@ def test_trace_data(local_artifact_repo):
     mock_trace_data = {"spans": [], "request": {"test": 1}, "response": {"test": 2}}
     local_artifact_repo.upload_trace_data(json.dumps(mock_trace_data))
     assert local_artifact_repo.download_trace_data() == mock_trace_data
+
+
+def _make_span() -> Span:
+    otel_span = OTelReadableSpan(
+        name="test-span",
+        context=build_otel_context(1, 10),
+        start_time=1_000_000,
+        end_time=2_000_000,
+        attributes={
+            SpanAttributeKey.REQUEST_ID: "tr-abc123",
+            SpanAttributeKey.INPUTS: json.dumps({"q": "hello"}),
+            SpanAttributeKey.OUTPUTS: json.dumps({"a": "world"}),
+            SpanAttributeKey.SPAN_TYPE: json.dumps("UNKNOWN"),
+        },
+    )
+    return Span(otel_span)
+
+
+def test_trace_payload_archive_repo_errors(local_artifact_repo):
+    with pytest.raises(MlflowTraceDataNotFound, match=r"Trace data not found for path="):
+        local_artifact_repo.download_trace_payload(spans_location=SpansLocation.ARCHIVE_REPO)
+
+    artifact_path = pathlib.Path(local_artifact_repo.artifact_dir, TRACE_ARCHIVAL_ARTIFACT_PATH)
+    artifact_path.mkdir(parents=True, exist_ok=True)
+    trace_pb_path = artifact_path / TRACE_ARCHIVAL_FILENAME
+    trace_pb_path.write_bytes(b"")
+    with pytest.raises(MlflowTraceDataCorrupted, match=r"Trace data is corrupted for path="):
+        local_artifact_repo.download_trace_payload(spans_location=SpansLocation.ARCHIVE_REPO)
+
+
+def test_trace_payload_archive_repo_rejects_empty_spans(local_artifact_repo):
+    with pytest.raises(MlflowException, match="at least one span"):
+        local_artifact_repo.upload_trace_payload(
+            TraceData(spans=[]), spans_location=SpansLocation.ARCHIVE_REPO
+        )
+
+
+def test_trace_payload_artifact_repo(local_artifact_repo):
+    local_artifact_repo.upload_trace_payload(
+        TraceData(spans=[_make_span()]), spans_location=SpansLocation.ARTIFACT_REPO
+    )
+
+    trace_data = local_artifact_repo.download_trace_payload(
+        spans_location=SpansLocation.ARTIFACT_REPO
+    )
+    assert len(trace_data.spans) == 1
+    assert trace_data.spans[0].name == "test-span"
+
+
+def test_trace_payload_archive_repo(local_artifact_repo):
+    local_artifact_repo.upload_trace_payload(
+        TraceData(spans=[_make_span()]), spans_location=SpansLocation.ARCHIVE_REPO
+    )
+
+    trace_data = local_artifact_repo.download_trace_payload(
+        spans_location=SpansLocation.ARCHIVE_REPO
+    )
+    assert len(trace_data.spans) == 1
+    assert trace_data.spans[0].name == "test-span"
+
+
+def test_trace_payload_rejects_tracking_store(local_artifact_repo):
+    with pytest.raises(MlflowException, match="TRACKING_STORE"):
+        local_artifact_repo.download_trace_payload(spans_location=SpansLocation.TRACKING_STORE)
+
+    with pytest.raises(MlflowException, match="TRACKING_STORE"):
+        local_artifact_repo.upload_trace_payload(
+            TraceData(spans=[_make_span()]), spans_location=SpansLocation.TRACKING_STORE
+        )
 
 
 @pytest.fixture

--- a/tests/tracing/otel/test_otel_archival.py
+++ b/tests/tracing/otel/test_otel_archival.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from opentelemetry.sdk.resources import Resource as OTelResource
+from opentelemetry.sdk.trace import Event as OTelEvent
+from opentelemetry.sdk.trace import ReadableSpan as OTelReadableSpan
+from opentelemetry.proto.trace.v1.trace_pb2 import TracesData
+from opentelemetry.trace import Status as OTelStatus
+from opentelemetry.trace import StatusCode as OTelStatusCode
+
+from mlflow.entities.span import Span
+from mlflow.exceptions import MlflowException
+from mlflow.tracing.constant import SpanAttributeKey
+from mlflow.tracing.otel.otel_archival import (
+    TRACE_ARCHIVAL_ARTIFACT_PATH,
+    TRACE_ARCHIVAL_FILENAME,
+    spans_to_traces_data_pb,
+    traces_data_pb_to_spans,
+)
+from mlflow.tracing.utils import build_otel_context
+from mlflow.tracing.utils.otlp import _decode_otel_proto_anyvalue
+
+
+def _make_span(
+    trace_id: int,
+    span_id: int,
+    request_id: str = "tr-abc123",
+    *,
+    name: str = "test_span",
+    parent_span_id: int | None = None,
+    resource: OTelResource | None = None,
+) -> Span:
+    otel_span = OTelReadableSpan(
+        name=name,
+        context=build_otel_context(trace_id, span_id),
+        parent=build_otel_context(trace_id, parent_span_id) if parent_span_id is not None else None,
+        start_time=1_000_000,
+        end_time=2_000_000,
+        attributes={
+            SpanAttributeKey.REQUEST_ID: json.dumps(request_id),
+            SpanAttributeKey.INPUTS: json.dumps({"q": "hello"}),
+            SpanAttributeKey.OUTPUTS: json.dumps({"a": "world"}),
+            SpanAttributeKey.SPAN_TYPE: json.dumps("UNKNOWN"),
+        },
+        events=[
+            OTelEvent(
+                name="test_event",
+                timestamp=1_500_000,
+                attributes={"event.attr": "value"},
+            )
+        ],
+        status=OTelStatus(OTelStatusCode.ERROR, "test failure"),
+        resource=resource,
+    )
+    return Span(otel_span)
+
+
+def test_rejects_empty_span_list():
+    with pytest.raises(MlflowException, match="at least one span"):
+        spans_to_traces_data_pb([])
+
+
+def test_round_trip_single_span():
+    original = [_make_span(trace_id=1, span_id=10)]
+    restored = traces_data_pb_to_spans(spans_to_traces_data_pb(original))
+    assert [span.to_dict() for span in restored] == [span.to_dict() for span in original]
+
+
+def test_round_trip_multiple_spans_same_trace():
+    originals = [
+        _make_span(trace_id=1, span_id=10, name="root_span"),
+        _make_span(trace_id=1, span_id=20, name="child_span", parent_span_id=10),
+    ]
+    restored = traces_data_pb_to_spans(spans_to_traces_data_pb(originals))
+    assert [span.to_dict() for span in restored] == [span.to_dict() for span in originals]
+
+
+def test_serialized_traces_data_preserves_resource_attributes():
+    resource = OTelResource.create({
+        "service.name": "test-service",
+        "service.version": "1.0.0",
+        "deployment.environment.name": "test",
+    })
+
+    traces_data = TracesData()
+    traces_data.ParseFromString(
+        spans_to_traces_data_pb([_make_span(trace_id=1, span_id=10, resource=resource)])
+    )
+
+    attrs = {
+        attr.key: _decode_otel_proto_anyvalue(attr.value)
+        for attr in traces_data.resource_spans[0].resource.attributes
+    }
+
+    assert attrs["service.name"] == "test-service"
+    assert attrs["service.version"] == "1.0.0"
+    assert attrs["deployment.environment.name"] == "test"
+
+
+def test_rejects_multiple_otlp_trace_ids_even_with_same_request_id():
+    spans = [
+        _make_span(trace_id=1, span_id=10, request_id="tr-shared"),
+        _make_span(trace_id=2, span_id=20, request_id="tr-shared"),
+    ]
+    with pytest.raises(MlflowException, match="distinct trace IDs"):
+        spans_to_traces_data_pb(spans)
+
+
+def test_rejects_empty_bytes():
+    with pytest.raises(MlflowException, match="non-empty OTLP TracesData protobuf"):
+        traces_data_pb_to_spans(TracesData().SerializeToString())
+
+
+def test_artifact_path_constant():
+    assert TRACE_ARCHIVAL_ARTIFACT_PATH == "artifacts"
+
+
+def test_filename_constant():
+    assert TRACE_ARCHIVAL_FILENAME == "traces.pb"


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/mlflow/rfcs/blob/main/rfcs/0001-trace-archival/0001-trace-archival.md


### What changes are proposed in this pull request?
Add reusable OTLP protobuf serialization helpers and artifact repository APIs for reading and writing archived trace span payloads as traces.pb. This keeps the archival storage format work separate from the higher-level archival orchestration that will land later.


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests


### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.



### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
