### PR TITLE
Add remote model catalog fetch with bundled fallback

### DIFF
--- a/dev/publish_model_catalog.sh
+++ b/dev/publish_model_catalog.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Publish model catalog JSON files as GitHub Release assets.
+#
+# Usage:
+#   bash dev/publish_model_catalog.sh [--repo OWNER/REPO] [--tag TAG] [--catalog-dir DIR]
+#
+# Defaults:
+#   --repo       mlflow/mlflow
+#   --tag        model-catalog/latest
+#   --catalog-dir mlflow/utils/model_catalog
+#
+# The script creates the release if it doesn't exist, then uploads
+# every *.json file in the catalog directory as a release asset,
+# overwriting any existing asset with the same name.
+
+set -euo pipefail
+
+REPO="mlflow/mlflow"
+TAG="model-catalog/latest"
+CATALOG_DIR="mlflow/utils/model_catalog"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) REPO="$2"; shift 2 ;;
+    --tag) TAG="$2"; shift 2 ;;
+    --catalog-dir) CATALOG_DIR="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+echo "Repo:        $REPO"
+echo "Tag:         $TAG"
+echo "Catalog dir: $CATALOG_DIR"
+
+# Count JSON files
+file_count=$(find "$CATALOG_DIR" -maxdepth 1 -name '*.json' | wc -l | tr -d ' ')
+if [[ "$file_count" -eq 0 ]]; then
+  echo "Error: no JSON files found in $CATALOG_DIR" >&2
+  exit 1
+fi
+echo "Files:       $file_count"
+
+# Create release if it doesn't exist
+if ! gh release view "$TAG" --repo "$REPO" &>/dev/null; then
+  echo "Creating release $TAG ..."
+  gh release create "$TAG" \
+    --repo "$REPO" \
+    --title "Model Catalog" \
+    --notes "Per-provider model catalog files. Updated weekly by CI." \
+    --latest=false
+fi
+
+# Upload all JSON files as release assets.
+# --clobber overwrites existing assets (delete + re-upload per file).
+# There is a brief window where each asset is missing during the overwrite,
+# but clients fall back to the bundled catalog so this is safe.
+echo "Uploading $file_count files to release $TAG ..."
+gh release upload "$TAG" \
+  --repo "$REPO" \
+  --clobber \
+  "$CATALOG_DIR"/*.json
+
+echo "Done. Assets available at:"
+echo "  https://github.com/$REPO/releases/tag/$(echo "$TAG" | sed 's|/|%2F|g')"

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1437,6 +1437,22 @@ _MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN = _EnvironmentVariable(
 )
 
 
+#: URL to fetch the latest model catalog from. Set to an empty string to disable remote fetch.
+#: (default: ``https://raw.githubusercontent.com/mlflow/mlflow/master/mlflow/utils/model_catalog``)
+MLFLOW_MODEL_CATALOG_URL = _EnvironmentVariable(
+    "MLFLOW_MODEL_CATALOG_URL",
+    str,
+    "https://raw.githubusercontent.com/mlflow/mlflow/master/mlflow/utils/model_catalog",
+)
+
+
+#: TTL in seconds for the local model catalog cache. Set to 0 to disable caching.
+#: (default: ``86400`` — 24 hours)
+MLFLOW_MODEL_CATALOG_CACHE_TTL = _EnvironmentVariable(
+    "MLFLOW_MODEL_CATALOG_CACHE_TTL", int, 86400
+)
+
+
 #: Specifies whether to enable automatic UV project detection during model logging.
 #: When enabled, MLflow will look for uv.lock and pyproject.toml in the current working
 #: directory and use ``uv export`` for dependency inference instead of capturing imported packages.

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1437,20 +1437,20 @@ _MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN = _EnvironmentVariable(
 )
 
 
-#: URL to fetch the latest model catalog from. Set to an empty string to disable remote fetch.
-#: (default: ``https://raw.githubusercontent.com/mlflow/mlflow/master/mlflow/utils/model_catalog``)
-MLFLOW_MODEL_CATALOG_URL = _EnvironmentVariable(
-    "MLFLOW_MODEL_CATALOG_URL",
+#: Base URI to fetch the latest model catalog from. Each provider file is fetched
+#: as ``{uri}/{provider}.json``. Supports http(s):// and file:// schemes.
+#: Set to an empty string to disable remote fetch.
+#: (default: ``https://github.com/mlflow/mlflow/releases/download/model-catalog%2Flatest``)
+MLFLOW_MODEL_CATALOG_URI = _EnvironmentVariable(
+    "MLFLOW_MODEL_CATALOG_URI",
     str,
-    "https://raw.githubusercontent.com/mlflow/mlflow/master/mlflow/utils/model_catalog",
+    "https://github.com/mlflow/mlflow/releases/download/model-catalog%2Flatest",
 )
 
 
 #: TTL in seconds for the local model catalog cache. Set to 0 to disable caching.
 #: (default: ``86400`` — 24 hours)
-MLFLOW_MODEL_CATALOG_CACHE_TTL = _EnvironmentVariable(
-    "MLFLOW_MODEL_CATALOG_CACHE_TTL", int, 86400
-)
+MLFLOW_MODEL_CATALOG_CACHE_TTL = _EnvironmentVariable("MLFLOW_MODEL_CATALOG_CACHE_TTL", int, 86400)
 
 
 #: Specifies whether to enable automatic UV project detection during model logging.

--- a/mlflow/utils/providers.py
+++ b/mlflow/utils/providers.py
@@ -240,9 +240,7 @@ def _fetch_remote_provider(provider: str) -> dict[str, ModelInfo] | None:
 
     match parsed.scheme:
         case "file":
-            result = _fetch_local_provider(
-                provider, Path(urllib.request.url2pathname(parsed.path))
-            )
+            result = _fetch_local_provider(provider, Path(urllib.request.url2pathname(parsed.path)))
         case "http" | "https":
             result = _fetch_http_provider(provider, url)
         case _:

--- a/mlflow/utils/providers.py
+++ b/mlflow/utils/providers.py
@@ -2,15 +2,24 @@ import functools
 import importlib.resources
 import json
 import logging
+import threading
+import time
+import urllib.request
 from collections.abc import Iterator
 from pathlib import Path
 from typing import TypedDict
 
 from typing_extensions import NotRequired
 
+from mlflow.environment_variables import MLFLOW_MODEL_CATALOG_CACHE_TTL, MLFLOW_MODEL_CATALOG_URL
+
 _logger = logging.getLogger(__name__)
 
 _SUPPORTED_MODEL_MODES = ("chat", "completion", "embedding", None)
+
+# Per-provider remote cache: {provider: (models, timestamp)}
+_remote_provider_cache: dict[str, tuple[dict[str, "ModelInfo"], float]] = {}
+_remote_provider_lock = threading.Lock()
 
 
 class FieldDict(TypedDict):
@@ -189,18 +198,55 @@ def _list_provider_names() -> list[str]:
         return []
 
 
+def _parse_catalog_models(catalog: CatalogFile) -> dict[str, ModelInfo]:
+    return {
+        name: _flatten_catalog_entry(entry) for name, entry in catalog.get("models", {}).items()
+    }
+
+
+def _fetch_remote_provider(provider: str) -> dict[str, ModelInfo] | None:
+    """Try to fetch a single provider's catalog from the remote URL with TTL caching."""
+    base_url = MLFLOW_MODEL_CATALOG_URL.get()
+    if not base_url:
+        return None
+
+    ttl = MLFLOW_MODEL_CATALOG_CACHE_TTL.get()
+
+    with _remote_provider_lock:
+        if cached := _remote_provider_cache.get(provider):
+            if (time.time() - cached[1]) < ttl:
+                return cached[0]
+
+    try:
+        url = f"{base_url.rstrip('/')}/{provider}.json"
+        with urllib.request.urlopen(url, timeout=5) as resp:
+            catalog: CatalogFile = json.loads(resp.read().decode("utf-8"))
+        result = _parse_catalog_models(catalog)
+        with _remote_provider_lock:
+            _remote_provider_cache[provider] = (result, time.time())
+        return result
+    except Exception:
+        _logger.debug("Failed to fetch remote catalog for %s", provider, exc_info=True)
+        return None
+
+
 @functools.lru_cache(maxsize=128)
-def _load_provider(provider: str) -> dict[str, ModelInfo]:
-    """Load a single provider's catalog file, returning ``{model_name: ModelInfo}``."""
+def _load_bundled_provider(provider: str) -> dict[str, ModelInfo]:
+    """Load a single provider's catalog from the bundled package resources."""
     resource = _catalog_pkg().joinpath(f"{provider}.json")
     try:
         with importlib.resources.as_file(resource) as path, path.open(encoding="utf-8") as f:
             catalog: CatalogFile = json.load(f)
+            return _parse_catalog_models(catalog)
     except (FileNotFoundError, TypeError):
         return {}
-    return {
-        name: _flatten_catalog_entry(entry) for name, entry in catalog.get("models", {}).items()
-    }
+
+
+def _load_provider(provider: str) -> dict[str, ModelInfo]:
+    """Load a provider's model catalog, trying remote first then bundled fallback."""
+    if remote := _fetch_remote_provider(provider):
+        return remote
+    return _load_bundled_provider(provider)
 
 
 def _lookup_model_info(model: str, custom_llm_provider: str | None = None) -> ModelInfo | None:

--- a/mlflow/utils/providers.py
+++ b/mlflow/utils/providers.py
@@ -2,24 +2,33 @@ import functools
 import importlib.resources
 import json
 import logging
-import threading
-import time
+import urllib.parse
 import urllib.request
 from collections.abc import Iterator
 from pathlib import Path
 from typing import TypedDict
 
+import cachetools
 from typing_extensions import NotRequired
 
-from mlflow.environment_variables import MLFLOW_MODEL_CATALOG_CACHE_TTL, MLFLOW_MODEL_CATALOG_URL
+from mlflow.environment_variables import MLFLOW_MODEL_CATALOG_CACHE_TTL, MLFLOW_MODEL_CATALOG_URI
+from mlflow.utils.request_utils import cloud_storage_http_request
 
 _logger = logging.getLogger(__name__)
 
 _SUPPORTED_MODEL_MODES = ("chat", "completion", "embedding", None)
 
-# Per-provider remote cache: {provider: (models, timestamp)}
-_remote_provider_cache: dict[str, tuple[dict[str, "ModelInfo"], float]] = {}
-_remote_provider_lock = threading.Lock()
+_REMOTE_FETCH_MAX_RETRIES = 3
+_REMOTE_FETCH_TIMEOUT = 5
+
+# Retry codes for catalog fetches. Extends the standard transient codes with 404
+# because GitHub Releases assets can briefly return 404 during the --clobber
+# re-upload window or CDN propagation delay.
+_CATALOG_RETRY_CODES = frozenset([404, 408, 429, 500, 502, 503, 504])
+
+# Per-provider TTL cache for remote catalog fetches.
+# Initialized lazily in _get_remote_cache() so the TTL reads the env var at first use.
+_remote_cache: cachetools.TTLCache | None = None
 
 
 class FieldDict(TypedDict):
@@ -204,27 +213,71 @@ def _parse_catalog_models(catalog: CatalogFile) -> dict[str, ModelInfo]:
     }
 
 
+def _get_remote_cache() -> cachetools.TTLCache:
+    global _remote_cache
+    if _remote_cache is None:
+        _remote_cache = cachetools.TTLCache(maxsize=256, ttl=MLFLOW_MODEL_CATALOG_CACHE_TTL.get())
+    return _remote_cache
+
+
 def _fetch_remote_provider(provider: str) -> dict[str, ModelInfo] | None:
-    """Try to fetch a single provider's catalog from the remote URL with TTL caching."""
-    base_url = MLFLOW_MODEL_CATALOG_URL.get()
+    """Try to fetch a single provider's catalog from the configured URL with TTL caching.
+
+    Supports ``http(s)://`` URLs (GitHub Releases, CDNs) and ``file://`` paths
+    (for air-gapped / mirrored environments). Set ``MLFLOW_MODEL_CATALOG_URI``
+    to an empty string to disable remote fetch entirely.
+    """
+    base_url = MLFLOW_MODEL_CATALOG_URI.get()
     if not base_url:
         return None
 
-    ttl = MLFLOW_MODEL_CATALOG_CACHE_TTL.get()
+    cache = _get_remote_cache()
+    if provider in cache:
+        return cache[provider] or None
 
-    with _remote_provider_lock:
-        if cached := _remote_provider_cache.get(provider):
-            if (time.time() - cached[1]) < ttl:
-                return cached[0]
+    url = f"{base_url.rstrip('/')}/{provider}.json"
+    parsed = urllib.parse.urlparse(url)
 
+    match parsed.scheme:
+        case "file":
+            result = _fetch_local_provider(
+                provider, Path(urllib.request.url2pathname(parsed.path))
+            )
+        case "http" | "https":
+            result = _fetch_http_provider(provider, url)
+        case _:
+            raise ValueError(
+                f"Unsupported MLFLOW_MODEL_CATALOG_URI scheme: {parsed.scheme!r}. "
+                f"Expected 'http', 'https', or 'file'. Got URI: {base_url}"
+            )
+
+    # Cache failures as empty dict so we don't retry on every call within the TTL
+    cache[provider] = result or {}
+    return result
+
+
+def _fetch_local_provider(provider: str, path: Path) -> dict[str, ModelInfo] | None:
     try:
-        url = f"{base_url.rstrip('/')}/{provider}.json"
-        with urllib.request.urlopen(url, timeout=5) as resp:
-            catalog: CatalogFile = json.loads(resp.read().decode("utf-8"))
-        result = _parse_catalog_models(catalog)
-        with _remote_provider_lock:
-            _remote_provider_cache[provider] = (result, time.time())
-        return result
+        catalog: CatalogFile = json.loads(path.read_text("utf-8"))
+        return _parse_catalog_models(catalog)
+    except Exception:
+        _logger.debug("Failed to read local catalog for %s", provider, exc_info=True)
+        return None
+
+
+def _fetch_http_provider(provider: str, url: str) -> dict[str, ModelInfo] | None:
+    try:
+        resp = cloud_storage_http_request(
+            "GET",
+            url,
+            max_retries=_REMOTE_FETCH_MAX_RETRIES,
+            backoff_factor=1,
+            retry_codes=_CATALOG_RETRY_CODES,
+            timeout=_REMOTE_FETCH_TIMEOUT,
+        )
+        resp.raise_for_status()
+        catalog: CatalogFile = resp.json()
+        return _parse_catalog_models(catalog)
     except Exception:
         _logger.debug("Failed to fetch remote catalog for %s", provider, exc_info=True)
         return None

--- a/tests/utils/test_providers.py
+++ b/tests/utils/test_providers.py
@@ -1,3 +1,4 @@
+import json
 from unittest import mock
 
 import pytest
@@ -5,6 +6,7 @@ import pytest
 from mlflow.utils.providers import (
     _fetch_remote_provider,
     _flatten_catalog_entry,
+    _get_remote_cache,
     _list_provider_names,
     _load_bundled_provider,
     _load_provider,
@@ -48,8 +50,9 @@ def test_list_provider_names_excludes_non_json():
         assert not p.endswith(".py")
 
 
-def test_load_provider_returns_models():
-    _load_provider.cache_clear()
+def test_load_provider_returns_models(monkeypatch):
+    monkeypatch.setenv("MLFLOW_MODEL_CATALOG_URI", "")
+    _load_bundled_provider.cache_clear()
     models = _load_provider("openai")
     assert len(models) > 0
     assert "gpt-4o" in models
@@ -59,13 +62,15 @@ def test_load_provider_returns_models():
     assert info["input_cost_per_token"] > 0
 
 
-def test_load_provider_returns_empty_for_unknown():
-    _load_provider.cache_clear()
+def test_load_provider_returns_empty_for_unknown(monkeypatch):
+    monkeypatch.setenv("MLFLOW_MODEL_CATALOG_URI", "")
+    _load_bundled_provider.cache_clear()
     assert _load_provider("nonexistent_provider_xyz") == {}
 
 
-def test_load_provider_flattens_pricing():
-    _load_provider.cache_clear()
+def test_load_provider_flattens_pricing(monkeypatch):
+    monkeypatch.setenv("MLFLOW_MODEL_CATALOG_URI", "")
+    _load_bundled_provider.cache_clear()
     models = _load_provider("anthropic")
     model = next(iter(models.values()))
     # Should have flat ModelInfo keys, not nested pricing/capabilities
@@ -409,6 +414,19 @@ def test_load_provider_falls_back_to_bundled_when_remote_fails():
         assert "gpt-4o" in result
 
 
-def test_fetch_remote_provider_disabled_when_url_empty():
-    with mock.patch("mlflow.environment_variables.MLFLOW_MODEL_CATALOG_URL.get", return_value=""):
-        assert _fetch_remote_provider("openai") is None
+def test_fetch_remote_provider_disabled_when_url_empty(monkeypatch):
+    monkeypatch.setenv("MLFLOW_MODEL_CATALOG_URI", "")
+    assert _fetch_remote_provider("openai") is None
+
+
+def test_fetch_remote_provider_supports_file_url(tmp_path, monkeypatch):
+    catalog = {
+        "schema_version": "1.0",
+        "models": {"test-model": {"mode": "chat", "pricing": {"input_per_million_tokens": 1.0}}},
+    }
+    (tmp_path / "test_provider.json").write_text(json.dumps(catalog))
+    monkeypatch.setenv("MLFLOW_MODEL_CATALOG_URI", tmp_path.as_uri())
+    _get_remote_cache().clear()
+    result = _fetch_remote_provider("test_provider")
+    assert result is not None
+    assert "test-model" in result

--- a/tests/utils/test_providers.py
+++ b/tests/utils/test_providers.py
@@ -3,7 +3,10 @@ from unittest import mock
 import pytest
 
 from mlflow.utils.providers import (
+    _fetch_remote_provider,
+    _flatten_catalog_entry,
     _list_provider_names,
+    _load_bundled_provider,
     _load_provider,
     _normalize_provider,
     cost_per_token,
@@ -341,3 +344,71 @@ def test_cost_per_token_no_cache_cost_falls_back_to_input_rate():
         # cache_read: 200 * 1e-6 = 0.0002 (same rate as regular)
         assert input_cost == pytest.approx(0.001)
         assert output_cost == pytest.approx(0.001)
+
+
+def test_flatten_catalog_entry():
+    entry = {
+        "mode": "chat",
+        "context_window": {"max_input": 128000, "max_output": 16384},
+        "pricing": {
+            "input_per_million_tokens": 2.5,
+            "output_per_million_tokens": 10.0,
+            "cache_read_per_million_tokens": 1.25,
+            "cache_write_per_million_tokens": 5.0,
+        },
+        "capabilities": {
+            "function_calling": True,
+            "vision": True,
+            "reasoning": False,
+            "prompt_caching": True,
+            "response_schema": True,
+        },
+        "deprecation_date": "2026-01-01",
+    }
+    info = _flatten_catalog_entry(entry)
+    assert info["mode"] == "chat"
+    assert info["max_input_tokens"] == 128000
+    assert info["max_output_tokens"] == 16384
+    assert info["input_cost_per_token"] == pytest.approx(2.5e-6)
+    assert info["output_cost_per_token"] == pytest.approx(1e-5)
+    assert info["cache_read_input_token_cost"] == pytest.approx(1.25e-6)
+    assert info["cache_creation_input_token_cost"] == pytest.approx(5e-6)
+    assert info["supports_function_calling"] is True
+    assert info["supports_vision"] is True
+    assert info["supports_reasoning"] is False
+    assert info["deprecation_date"] == "2026-01-01"
+
+
+def test_load_bundled_provider_returns_data():
+    _load_bundled_provider.cache_clear()
+    result = _load_bundled_provider("openai")
+    assert len(result) > 0
+    assert "gpt-4o" in result
+    info = result["gpt-4o"]
+    assert info["mode"] == "chat"
+    assert "input_cost_per_token" in info
+
+
+def test_load_provider_uses_remote_when_available():
+    remote_data = {"test-model": {"mode": "chat", "input_cost_per_token": 1e-6}}
+    with mock.patch(
+        "mlflow.utils.providers._fetch_remote_provider", return_value=remote_data
+    ) as mock_remote:
+        result = _load_provider("openai")
+        mock_remote.assert_called_once_with("openai")
+        assert result is remote_data
+
+
+def test_load_provider_falls_back_to_bundled_when_remote_fails():
+    with mock.patch(
+        "mlflow.utils.providers._fetch_remote_provider", return_value=None
+    ) as mock_remote:
+        result = _load_provider("openai")
+        mock_remote.assert_called_once_with("openai")
+        assert len(result) > 0
+        assert "gpt-4o" in result
+
+
+def test_fetch_remote_provider_disabled_when_url_empty():
+    with mock.patch("mlflow.environment_variables.MLFLOW_MODEL_CATALOG_URL.get", return_value=""):
+        assert _fetch_remote_provider("openai") is None


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/22260/files) to review incremental changes.
- [**stack/model-catalog/3-remote-fetch**](https://github.com/mlflow/mlflow/pull/22260) [[Files changed](https://github.com/mlflow/mlflow/pull/22260/files)]

---------
### Related Issues/PRs

Depends on #22259

### What changes are proposed in this pull request?

Adds remote catalog fetching so MLflow clients can get the latest model pricing/capabilities without upgrading the package.

- Per-provider TTL caching via `cachetools.TTLCache` — failures cached as empty dict to avoid repeated failing requests
- Supports `http(s)://` (GitHub Releases, CDNs) and `file://` (air-gapped/mirrored environments)
- Adds `dev/publish_model_catalog.sh` script to upload per-provider JSON files as GitHub Release assets

New environment variables:
- `MLFLOW_MODEL_CATALOG_URI`: base URI for remote catalog (default: GitHub Releases; empty string to disable)
- `MLFLOW_MODEL_CATALOG_CACHE_TTL`: cache TTL in seconds (default: 86400 / 24 hours)

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Tests cover: remote disabled, file:// URL support, remote/bundled fallback, TTL caching. Manually verified against GitHub Release assets on TomeHirata/mlflow fork.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
