### PR TITLE
Fix cross-workspace `copy_model_version` failure caused by `get_logged_model` call

### DIFF
--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -322,9 +322,7 @@ def get_model_version_dependencies(model_dir):
         _DATABRICKS_CHAT_ENDPOINT_NAME_KEY = "databricks_chat_endpoint_name"
         _DB_DEPENDENCY_KEY = "databricks_dependency"
 
-        databricks_dependencies = model.flavors.get("langchain", {}).get(
-            _DB_DEPENDENCY_KEY, {}
-        )
+        databricks_dependencies = model.flavors.get("langchain", {}).get(_DB_DEPENDENCY_KEY, {})
 
         index_names = _fetch_langchain_dependency_from_model_info(
             databricks_dependencies, _DATABRICKS_VECTOR_SEARCH_INDEX_NAME_KEY

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -248,9 +248,8 @@ def get_feature_dependencies(model_dir):
     Databricks. In OSS mlflow, the dependencies are always empty ("").
     """
     model = _load_model(model_dir)
-    model_info = model.get_model_info()
     if (
-        model_info.flavors.get("python_function", {}).get("loader_module")
+        model.flavors.get("python_function", {}).get("loader_module")
         == mlflow.models.model._DATABRICKS_FS_LOADER_MODULE
     ):
         raise MlflowException(
@@ -268,7 +267,6 @@ def get_model_version_dependencies(model_dir):
     from mlflow.models.resources import ResourceType
 
     model = _load_model(model_dir)
-    model_info = model.get_model_info()
     dependencies = []
 
     # Try to get model.auth_policy.system_auth_policy.resources. If that is not found or empty,
@@ -324,7 +322,7 @@ def get_model_version_dependencies(model_dir):
         _DATABRICKS_CHAT_ENDPOINT_NAME_KEY = "databricks_chat_endpoint_name"
         _DB_DEPENDENCY_KEY = "databricks_dependency"
 
-        databricks_dependencies = model_info.flavors.get("langchain", {}).get(
+        databricks_dependencies = model.flavors.get("langchain", {}).get(
             _DB_DEPENDENCY_KEY, {}
         )
 

--- a/tests/store/artifact/test_unity_catalog_models_artifact_repo.py
+++ b/tests/store/artifact/test_unity_catalog_models_artifact_repo.py
@@ -2,6 +2,7 @@ import json
 from unittest import mock
 from unittest.mock import ANY
 
+import mlflow
 import pytest
 from google.cloud.storage import Client
 from requests import Response
@@ -317,8 +318,6 @@ def test_uc_models_artifact_repo_list_artifacts_uses_temporary_creds(monkeypatch
 
 
 def test_get_feature_dependencies_doesnt_throw():
-    import mlflow
-
     class MyModel(mlflow.pyfunc.PythonModel):
         def predict(self, context, model_input):
             return model_input
@@ -332,6 +331,45 @@ def test_get_feature_dependencies_doesnt_throw():
         )
         == ""
     )
+
+
+def test_get_feature_dependencies_works_when_experiment_not_found():
+    class MyModel(mlflow.pyfunc.PythonModel):
+        def predict(self, context, model_input):
+            return model_input
+
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(name="model", python_model=MyModel())
+
+    # Simulate cross-workspace scenario: get_logged_model would fail
+    with mock.patch(
+        "mlflow.get_logged_model",
+        side_effect=MlflowException("RESOURCE_DOES_NOT_EXIST"),
+    ) as mock_get_logged_model:
+        result = mlflow.store._unity_catalog.registry.rest_store.get_feature_dependencies(
+            model_info.model_uri
+        )
+        assert result == ""
+        mock_get_logged_model.assert_not_called()
+
+
+def test_get_model_version_dependencies_works_when_experiment_not_found():
+    class MyModel(mlflow.pyfunc.PythonModel):
+        def predict(self, context, model_input):
+            return model_input
+
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(name="model", python_model=MyModel())
+
+    with mock.patch(
+        "mlflow.get_logged_model",
+        side_effect=MlflowException("RESOURCE_DOES_NOT_EXIST"),
+    ) as mock_get_logged_model:
+        result = mlflow.store._unity_catalog.registry.rest_store.get_model_version_dependencies(
+            model_info.model_uri
+        )
+        assert result == []
+        mock_get_logged_model.assert_not_called()
 
 
 def test_store_use_presigned_url_store_when_disabled(monkeypatch):

--- a/tests/store/artifact/test_unity_catalog_models_artifact_repo.py
+++ b/tests/store/artifact/test_unity_catalog_models_artifact_repo.py
@@ -2,11 +2,11 @@ import json
 from unittest import mock
 from unittest.mock import ANY
 
-import mlflow
 import pytest
 from google.cloud.storage import Client
 from requests import Response
 
+import mlflow
 from mlflow import MlflowClient
 from mlflow.entities.file_info import FileInfo
 from mlflow.exceptions import MlflowException


### PR DESCRIPTION
### Related Issues/PRs

### What changes are proposed in this pull request?

`copy_model_version` fails with `RESOURCE_DOES_NOT_EXIST` when copying a model across workspaces. This is a regression introduced when `model_id` was added to MLflow models.

**Root cause:** `get_feature_dependencies` and `get_model_version_dependencies` in the UC registry rest store called `model.get_model_info()`, which (since `model_id` was introduced) triggers a `get_logged_model()` call against the current tracking URI. During cross-workspace model copy, the source experiment doesn't exist on the destination workspace, causing the failure.

**Fix:** Both functions only need `model.flavors` to check for Feature Store loader modules or langchain dependencies. This is available directly on the `Model` object without requiring a tracking server round-trip. The unnecessary `get_model_info()` calls are removed.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fix `copy_model_version` failing with `RESOURCE_DOES_NOT_EXIST` when copying models across Databricks workspaces. This regression was caused by an unnecessary `get_logged_model` call during model version creation.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release