### PR TITLE
Add run page support for pagination

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTab.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTab.tsx
@@ -71,6 +71,8 @@ import { useIntl } from 'react-intl';
 import { ExportTracesToDatasetModal } from '../../pages/experiment-evaluation-datasets/components/ExportTracesToDatasetModal';
 import { useSearchRunsQuery } from '../run-page/hooks/useSearchRunsQuery';
 import { AssistantAwareDrawer } from '@mlflow/mlflow/src/common/components/AssistantAwareDrawer';
+import { useCountInfo } from '../experiment-page/components/traces-v3/hooks/useCountInfo';
+import { useAssessmentCountMetrics } from '../experiment-page/components/traces-v3/hooks/useAssessmentCountMetrics';
 
 const ContextProviders = ({
   children,
@@ -182,6 +184,9 @@ const RunViewEvaluationsTabInner = ({
     isFetching: traceInfosFetching,
     error: traceInfosError,
     refetchMlflowTraces,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
   } = useSearchMlflowTraces({
     locations: traceLocations,
     currentRunDisplayName: runDisplayName,
@@ -220,14 +225,22 @@ const RunViewEvaluationsTabInner = ({
     }
   }, [traceInfos]);
 
-  const countInfo = useMemo(() => {
-    return {
-      currentCount: traceInfos?.length,
-      logCountLoading: traceInfosLoading,
-      totalCount: totalCount,
-      maxAllowedCount: getEvalTabTotalTracesLimit(),
-    };
-  }, [traceInfos, traceInfosLoading, totalCount]);
+  const experimentIds = useMemo(() => [experimentId], [experimentId]);
+
+  const countInfo = useCountInfo({
+    experimentIds,
+    runUuid,
+    traceInfosCount: traceInfos?.length,
+    traceInfosLoading,
+    metadataTotalCount: totalCount,
+    disabled: isQueryDisabled,
+  });
+
+  const assessmentCountMetrics = useAssessmentCountMetrics({
+    experimentIds,
+    runUuid,
+    disabled: isQueryDisabled,
+  });
 
   // TODO: We should update this to use web-shared/unified-tagging components for the
   // tag editor and react-query mutations for the apis.
@@ -385,6 +398,10 @@ const RunViewEvaluationsTabInner = ({
                     onTraceTagsEdit={showEditTagsModalForTrace}
                     isTableLoading={isTableLoading}
                     isGroupedBySession={isGroupedBySession}
+                    fetchNextPage={fetchNextPage}
+                    hasNextPage={hasNextPage}
+                    isFetchingNextPage={isFetchingNextPage}
+                    assessmentCountMetrics={assessmentCountMetrics}
                   />
                 </ContextProviders>
               )


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/22272/files) to review incremental changes.
- [**stack/pagination-part-5**](https://github.com/mlflow/mlflow/pull/22272) [[Files changed](https://github.com/mlflow/mlflow/pull/22272/files)]
  - [stack/pagination-part-6](https://github.com/mlflow/mlflow/pull/22273) [[Files changed](https://github.com/mlflow/mlflow/pull/22273/files/69cf76e225283711be0b816479e04c36f1cd6ddb..4c73da8fda090d66bc0157b1fd759cd1e7e0b285)]
    - [stack/pagination-part-7](https://github.com/mlflow/mlflow/pull/22441) [[Files changed](https://github.com/mlflow/mlflow/pull/22441/files/4c73da8fda090d66bc0157b1fd759cd1e7e0b285..7128b4c1e9768d89fa1a1eae8696d7523b0b1c08)]
      - [stack/pagination-part-8](https://github.com/mlflow/mlflow/pull/22447) [[Files changed](https://github.com/mlflow/mlflow/pull/22447/files/7128b4c1e9768d89fa1a1eae8696d7523b0b1c08..213fa26176d5d24b700e89f4c5f4eb8b6aa7b1d7)]
        - [stack/pagination-part-9](https://github.com/mlflow/mlflow/pull/22482) [[Files changed](https://github.com/mlflow/mlflow/pull/22482/files/213fa26176d5d24b700e89f4c5f4eb8b6aa7b1d7..15734b4e991650bb07c99e13fc01ede8fd4e9fe6)]

---------
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

Previous PRs only dealt with the Traces + Sessions tab (`<TracesV3Logs>` component). This PR adds support for the run page. Luckily it is fairly simple, just use the same shared hooks that we defined previously.


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<img width="1919" height="1009" alt="Screenshot 2026-04-07 at 5 16 42 PM" src="https://github.com/user-attachments/assets/0fc55b82-f1cc-412c-a77e-a13efbcbc94c" />


### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
