### PR TITLE
Unify Gateway capability tags via shared `getModelCapabilities` utility

### DIFF
--- a/mlflow/server/js/src/gateway/components/create-endpoint/ModelSelect.tsx
+++ b/mlflow/server/js/src/gateway/components/create-endpoint/ModelSelect.tsx
@@ -4,6 +4,7 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import { ModelSelectorModal } from '../model-selector/ModelSelectorModal';
 import { useModelsQuery } from '../../hooks/useModelsQuery';
 import type { ProviderModel } from '../../types';
+import { getModelCapabilities } from '../../utils/getModelCapabilities';
 
 interface ModelSelectProps {
   provider: string;
@@ -103,13 +104,7 @@ export const ModelSelect = ({
 const ModelCapabilities = memo(function ModelCapabilities({ model }: { model: ProviderModel }) {
   const { theme } = useDesignSystemTheme();
 
-  const capabilities = useMemo(() => {
-    const caps: string[] = [];
-    if (model.supports_function_calling) caps.push('Tools');
-    if (model.supports_reasoning) caps.push('Reasoning');
-    if (model.supports_prompt_caching) caps.push('Caching');
-    return caps;
-  }, [model.supports_function_calling, model.supports_reasoning, model.supports_prompt_caching]);
+  const capabilities = getModelCapabilities(model);
 
   if (capabilities.length === 0) {
     return null;

--- a/mlflow/server/js/src/gateway/components/endpoint-form/EndpointFormRenderer.tsx
+++ b/mlflow/server/js/src/gateway/components/endpoint-form/EndpointFormRenderer.tsx
@@ -14,6 +14,7 @@ import { LongFormSection } from '../../../common/components/long-form/LongFormSe
 import { LongFormSummary } from '../../../common/components/long-form/LongFormSummary';
 import type { ProviderModel, SecretInfo } from '../../types';
 import { formatTokens, formatCost } from '../../utils/formatters';
+import { getModelCapabilities } from '../../utils/getModelCapabilities';
 import type { CreateEndpointFormData } from '../../hooks/useCreateEndpointForm';
 
 const LONG_FORM_TITLE_WIDTH = 200;
@@ -403,9 +404,7 @@ const ModelSummary = ({ model, modelName }: { model: ProviderModel | undefined; 
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
 
-  const capabilities: string[] = [];
-  if (model?.supports_function_calling) capabilities.push('Tools');
-  if (model?.supports_reasoning) capabilities.push('Reasoning');
+  const capabilities = getModelCapabilities(model);
 
   const contextWindow = formatTokens(model?.max_input_tokens);
   const inputCost = formatCost(model?.input_cost_per_token);

--- a/mlflow/server/js/src/gateway/components/model-selector/ModelRow.tsx
+++ b/mlflow/server/js/src/gateway/components/model-selector/ModelRow.tsx
@@ -3,6 +3,7 @@ import { Radio, Tooltip, Typography, useDesignSystemTheme, WarningFillIcon } fro
 import { CostIndicator } from './CostIndicator';
 import { formatTokens } from '../../utils/formatters';
 import type { ProviderModel } from '../../types';
+import { getModelCapabilities } from '../../utils/getModelCapabilities';
 
 interface ModelRowProps {
   model: ProviderModel;
@@ -64,14 +65,7 @@ export const ModelRow = ({ model, isSelected, onSelect }: ModelRowProps) => {
           )}
         </div>
         <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm, display: 'block' }}>
-          {[
-            model.supports_function_calling && 'Tools',
-            model.supports_reasoning && 'Reasoning',
-            model.supports_prompt_caching && 'Caching',
-            model.supports_response_schema && 'Structured',
-          ]
-            .filter(Boolean)
-            .join(', ') || '\u00A0'}
+          {getModelCapabilities(model).join(', ') || '\u00A0'}
         </Typography.Text>
       </div>
       <div css={{ textAlign: 'right' }}>

--- a/mlflow/server/js/src/gateway/utils/getModelCapabilities.test.ts
+++ b/mlflow/server/js/src/gateway/utils/getModelCapabilities.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from '@jest/globals';
+import { getModelCapabilities } from './getModelCapabilities';
+import type { ProviderModel } from '../types';
+
+const baseModel: ProviderModel = {
+  model: 'test-model',
+  provider: 'test-provider',
+  supports_function_calling: false,
+};
+
+describe('getModelCapabilities', () => {
+  it('returns empty array for undefined', () => {
+    expect(getModelCapabilities(undefined)).toEqual([]);
+  });
+
+  it('returns empty array when no capabilities are supported', () => {
+    expect(getModelCapabilities(baseModel)).toEqual([]);
+  });
+
+  it('returns all four capabilities when all are supported', () => {
+    expect(
+      getModelCapabilities({
+        ...baseModel,
+        supports_function_calling: true,
+        supports_reasoning: true,
+        supports_prompt_caching: true,
+        supports_response_schema: true,
+      }),
+    ).toEqual(['Tools', 'Reasoning', 'Caching', 'Structured']);
+  });
+
+  it('returns only the supported capabilities', () => {
+    expect(
+      getModelCapabilities({
+        ...baseModel,
+        supports_function_calling: true,
+        supports_response_schema: true,
+      }),
+    ).toEqual(['Tools', 'Structured']);
+  });
+
+  it('preserves order regardless of which capabilities are set', () => {
+    expect(
+      getModelCapabilities({
+        ...baseModel,
+        supports_prompt_caching: true,
+        supports_reasoning: true,
+      }),
+    ).toEqual(['Reasoning', 'Caching']);
+  });
+});

--- a/mlflow/server/js/src/gateway/utils/getModelCapabilities.ts
+++ b/mlflow/server/js/src/gateway/utils/getModelCapabilities.ts
@@ -1,0 +1,11 @@
+import type { ProviderModel } from '../types';
+
+export function getModelCapabilities(model: ProviderModel | undefined): string[] {
+  if (!model) return [];
+  const caps: string[] = [];
+  if (model.supports_function_calling) caps.push('Tools');
+  if (model.supports_reasoning) caps.push('Reasoning');
+  if (model.supports_prompt_caching) caps.push('Caching');
+  if (model.supports_response_schema) caps.push('Structured');
+  return caps;
+}


### PR DESCRIPTION
### Related Issues/PRs

Relates to Gateway endpoint creation flow consistency.

### What changes are proposed in this pull request?

The AI Gateway endpoint creation flow displays model capability tags (Tools, Reasoning, Caching, Structured) in three locations, but each was checking a different subset of `ProviderModel` boolean fields:

| Location | Before | After |
|---|---|---|
| Model selector dropdown (`ModelRow.tsx`) | Tools, Reasoning, Caching, Structured | All 4 via shared utility |
| Under model selector (`ModelSelect.tsx`) | Tools, Reasoning, Caching (missing Structured) | All 4 via shared utility |
| Right panel summary (`EndpointFormRenderer.tsx`) | Tools, Reasoning (missing Caching, Structured) | All 4 via shared utility |

Extracted a shared `getModelCapabilities()` utility and replaced all three inline implementations with it.

### How is this PR tested?

<img width="915" height="801" alt="image" src="https://github.com/user-attachments/assets/db06c7a8-6eaf-4b0d-8132-50cbb95fe246" />
<img width="969" height="415" alt="image" src="https://github.com/user-attachments/assets/2beb5f0c-359c-4226-89a3-083ffa914c12" />

- [x] New unit/integration tests
- [x] Manual tests

New test file `getModelCapabilities.test.ts` covers: undefined input, no capabilities, all capabilities, partial capabilities, and ordering. Manually verified all three locations show consistent tags in the UI.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release