### PR TITLE
fix: handle AsyncAPIResponse in OpenAI agent streaming trace

### DIFF
--- a/mlflow/openai/autolog.py
+++ b/mlflow/openai/autolog.py
@@ -359,6 +359,19 @@ def _end_span_on_success(
             _process_last_chunk(span, chunk, inputs, output, is_responses_api)
 
         result._iterator = _stream_output_logging_hook(result._iterator)
+    elif _is_async_api_response(result):
+        # When OpenAI Agent SDK uses streaming via `with_streaming_response`, the result
+        # is an AsyncAPIResponse. Its `parse()` method returns the actual stream object
+        # (e.g. AsyncStream). We wrap `parse()` so that once the parsed result is available,
+        # it is properly traced like any other stream or response.
+        original_parse = result.parse
+
+        async def _wrapped_parse(*args, **kwargs):
+            parsed = await original_parse(*args, **kwargs)
+            _end_span_on_success(span, inputs, parsed, is_responses_api)
+            return parsed
+
+        result.parse = _wrapped_parse
     else:
         try:
             set_span_chat_attributes(span, inputs, result)
@@ -490,6 +503,22 @@ def _is_response_output_item_done_event(chunk: Any) -> bool:
         from openai.types.responses import ResponseOutputItemDoneEvent
 
         return isinstance(chunk, ResponseOutputItemDoneEvent)
+    except ImportError:
+        return False
+
+
+def _is_async_api_response(result: Any) -> bool:
+    """Check if the result is an AsyncAPIResponse from the OpenAI SDK.
+
+    When the OpenAI Agent SDK fetches streaming responses, it uses
+    ``with_streaming_response`` which returns an ``AsyncAPIResponse`` instead of
+    the parsed stream directly.  We need to detect this so we can defer tracing
+    until ``parse()`` is called and the actual stream is available.
+    """
+    try:
+        from openai._response import AsyncAPIResponse
+
+        return isinstance(result, AsyncAPIResponse)
     except ImportError:
         return False
 


### PR DESCRIPTION
## Summary

Fixes #22244

When using the OpenAI Agent SDK with streaming (`Runner.run_streamed`), the SDK internally calls `AsyncResponses.create` via `with_streaming_response`, which returns an `AsyncAPIResponse` object rather than the parsed stream. MLflow's autolog patches `AsyncResponses.create`, so it receives this `AsyncAPIResponse` as the result. Because there was no handling for this type, it fell through to the generic `else` branch and logged the raw `AsyncAPIResponse` string representation instead of properly tracing the streamed response.

## Changes

- Added an `AsyncAPIResponse` detection branch in `_end_span_on_success` that wraps the response's `parse()` method. When `parse()` is called (which the Agent SDK does internally to obtain the `AsyncStream`), the wrapper delegates back to `_end_span_on_success` with the resolved stream, enabling proper span event recording and output logging.
- Added a helper function `_is_async_api_response` that safely checks for `AsyncAPIResponse` with an import guard, consistent with the existing pattern used elsewhere in the module.

## Test plan

- Verified that the fix correctly traces streaming responses when using `Runner.run_streamed` with OpenAI Agent SDK, matching the behavior described in the issue
- Existing autolog tests for non-streaming and sync streaming paths remain unaffected since the new branch only activates for `AsyncAPIResponse` instances
- The fix is minimal and follows the same deferred-tracing pattern already used for `Stream` and `AsyncStream` handling