### PR TITLE
Pin Node 22 to 22.22.1 in typescript CI workflow

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -36,7 +36,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20, 22, 24]
+        # 22.22.2 has a regression where `npm install -g` fails
+        # See: https://github.com/nodejs/node/issues/62425
+        node-version: [20, 22.22.1, 24]
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/nodejs/node/issues/62425

### What changes are proposed in this pull request?

Pin Node 22 to 22.22.1 in the typescript CI workflow. Node 22.22.2 has a [known regression](https://github.com/nodejs/node/issues/62425) where `npm install -g` fails with `Cannot find module 'promise-retry'`, which causes the [typescript-sdk (22) job to fail](https://github.com/mlflow/mlflow/actions/runs/23892487071/job/69668981237).

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)