### PR TITLE
Extract `service.name` from OTLP resource attributes for usage telemetry

### DIFF
--- a/mlflow/server/otel_api.py
+++ b/mlflow/server/otel_api.py
@@ -108,7 +108,7 @@ async def export_traces(
     """
     # Validate Content-Type header. Normalize by stripping parameters like
     # charset (e.g., "application/json; charset=utf-8" → "application/json").
-    media_type = (content_type or "").split(";")[0].strip()
+    media_type = content_type.split(";")[0].strip() if content_type else None
     if media_type not in ("application/x-protobuf", "application/json"):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/mlflow/server/otel_api.py
+++ b/mlflow/server/otel_api.py
@@ -10,14 +10,11 @@ The actual span ingestion logic would need to properly convert incoming OTel for
 to MLflow spans, which requires more complex conversion logic.
 """
 
-import base64
 import json
 import logging
 
 from fastapi import APIRouter, Header, HTTPException, Request, Response, status
 from fastapi.responses import JSONResponse
-from google.protobuf.json_format import Error as ProtoJsonError
-from google.protobuf.json_format import Parse as ParseJsonProto
 from google.protobuf.message import DecodeError
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
     ExportTraceServiceRequest,
@@ -42,34 +39,6 @@ from mlflow.tracking.request_header.default_request_header_provider import (
 )
 
 _logger = logging.getLogger(__name__)
-
-# Span ID fields that need hex→base64 conversion in OTLP JSON payloads.
-# OTLP JSON uses lowercase hex for these fields, but protobuf's JSON mapping
-# (google.protobuf.json_format.Parse) expects base64 for `bytes` fields.
-_OTLP_HEX_ID_FIELDS = ("traceId", "spanId", "parentSpanId")
-
-
-def _convert_otlp_json_ids_to_base64(body: bytes) -> bytes:
-    """Convert hex-encoded trace/span IDs to base64 in an OTLP JSON payload.
-
-    The OTLP spec encodes trace_id and span_id as hex strings in JSON:
-        https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding
-
-    But protobuf's canonical JSON mapping uses base64 for ``bytes`` fields:
-        https://protobuf.dev/programming-guides/proto3/#json
-
-    ``google.protobuf.json_format.Parse`` follows the protobuf convention,
-    so we must convert the hex IDs to base64 before parsing.
-    """
-    data = json.loads(body)
-    for resource_span in data.get("resourceSpans", []):
-        for scope_span in resource_span.get("scopeSpans", []):
-            for span in scope_span.get("spans", []):
-                for field in _OTLP_HEX_ID_FIELDS:
-                    if hex_val := span.get(field):
-                        span[field] = base64.b64encode(bytes.fromhex(hex_val)).decode("ascii")
-    return json.dumps(data).encode("utf-8")
-
 
 # Create FastAPI router for OTel endpoints
 otel_router = APIRouter(prefix=OTLP_TRACES_PATH, tags=["OpenTelemetry"])
@@ -106,14 +75,11 @@ async def export_traces(
     Raises:
         HTTPException: If the request is invalid or span logging fails
     """
-    # Validate Content-Type header. Normalize by stripping parameters like
-    # charset (e.g., "application/json; charset=utf-8" → "application/json").
-    media_type = content_type.split(";")[0].strip() if content_type else None
-    if media_type not in ("application/x-protobuf", "application/json"):
+    # Validate Content-Type header
+    if content_type != "application/x-protobuf":
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Invalid Content-Type: {content_type}. "
-            "Expected: application/x-protobuf or application/json",
+            detail=f"Invalid Content-Type: {content_type}. Expected: application/x-protobuf",
         )
 
     # Read & decompress request body
@@ -121,33 +87,26 @@ async def export_traces(
     if content_encoding:
         body = decompress_otlp_body(body, content_encoding.lower())
 
-    # Parse payload — supports both protobuf and JSON encoding per the OTLP spec:
-    # https://opentelemetry.io/docs/specs/otlp/#otlphttp
+    # Parse protobuf payload
     parsed_request = ExportTraceServiceRequest()
 
     try:
-        if media_type == "application/json":
-            # OTLP JSON encodes trace_id/span_id as hex strings, but protobuf's
-            # JSON mapping expects base64 for `bytes` fields (per proto3 spec).
-            # We must convert hex→base64 before calling Parse(), otherwise the
-            # IDs are decoded incorrectly and overflow downstream int conversions.
-            body = _convert_otlp_json_ids_to_base64(body)
-            ParseJsonProto(body, parsed_request, ignore_unknown_fields=True)
-        else:
-            # In Python protobuf library 5.x, ParseFromString may not raise
-            # DecodeError on invalid data
-            parsed_request.ParseFromString(body)
+        # In Python protobuf library 5.x, ParseFromString may not raise DecodeError on invalid data
+        parsed_request.ParseFromString(body)
 
+        # Check if we actually parsed any data
+        # If no resource_spans were parsed, the data was likely invalid
         if not parsed_request.resource_spans:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Invalid OpenTelemetry format - no spans found",
+                detail="Invalid OpenTelemetry protobuf format - no spans found",
             )
 
-    except (DecodeError, ProtoJsonError, json.JSONDecodeError, ValueError):
+    except DecodeError:
+        # This will catch errors in Python protobuf library 3.x
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid OpenTelemetry format",
+            detail="Invalid OpenTelemetry protobuf format",
         )
 
     all_spans = []
@@ -171,8 +130,9 @@ async def export_traces(
                     mlflow_span = Span.from_otel_proto(otel_proto_span)
 
                     # Propagate resource attributes onto root spans so they're
-                    # visible in the UI (following the OTel convention of
-                    # associating resource attrs with the producing entity).
+                    # visible in the UI. Per the OTel resource spec, resource
+                    # attributes describe the entity producing telemetry:
+                    # https://opentelemetry.io/docs/specs/otel/resource/sdk/
                     if mlflow_span.parent_id is None:
                         completed_trace_ids.add(mlflow_span.trace_id)
                         if resource_service_name:

--- a/mlflow/server/otel_api.py
+++ b/mlflow/server/otel_api.py
@@ -10,11 +10,13 @@ The actual span ingestion logic would need to properly convert incoming OTel for
 to MLflow spans, which requires more complex conversion logic.
 """
 
+import base64
 import json
 import logging
 
 from fastapi import APIRouter, Header, HTTPException, Request, Response, status
 from fastapi.responses import JSONResponse
+from google.protobuf.json_format import Parse as ParseJsonProto
 from google.protobuf.message import DecodeError
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
     ExportTraceServiceRequest,
@@ -39,6 +41,34 @@ from mlflow.tracking.request_header.default_request_header_provider import (
 )
 
 _logger = logging.getLogger(__name__)
+
+# Span ID fields that need hex→base64 conversion in OTLP JSON payloads.
+# OTLP JSON uses lowercase hex for these fields, but protobuf's JSON mapping
+# (google.protobuf.json_format.Parse) expects base64 for `bytes` fields.
+_OTLP_HEX_ID_FIELDS = ("traceId", "spanId", "parentSpanId")
+
+
+def _convert_otlp_json_ids_to_base64(body: bytes) -> bytes:
+    """Convert hex-encoded trace/span IDs to base64 in an OTLP JSON payload.
+
+    The OTLP spec encodes trace_id and span_id as hex strings in JSON:
+        https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding
+
+    But protobuf's canonical JSON mapping uses base64 for ``bytes`` fields:
+        https://protobuf.dev/programming-guides/proto3/#json
+
+    ``google.protobuf.json_format.Parse`` follows the protobuf convention,
+    so we must convert the hex IDs to base64 before parsing.
+    """
+    data = json.loads(body)
+    for resource_span in data.get("resourceSpans", []):
+        for scope_span in resource_span.get("scopeSpans", []):
+            for span in scope_span.get("spans", []):
+                for field in _OTLP_HEX_ID_FIELDS:
+                    if hex_val := span.get(field):
+                        span[field] = base64.b64encode(bytes.fromhex(hex_val)).decode("ascii")
+    return json.dumps(data).encode("utf-8")
+
 
 # Create FastAPI router for OTel endpoints
 otel_router = APIRouter(prefix=OTLP_TRACES_PATH, tags=["OpenTelemetry"])
@@ -76,10 +106,11 @@ async def export_traces(
         HTTPException: If the request is invalid or span logging fails
     """
     # Validate Content-Type header
-    if content_type != "application/x-protobuf":
+    if content_type not in ("application/x-protobuf", "application/json"):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Invalid Content-Type: {content_type}. Expected: application/x-protobuf",
+            detail=f"Invalid Content-Type: {content_type}. "
+            "Expected: application/x-protobuf or application/json",
         )
 
     # Read & decompress request body
@@ -87,26 +118,33 @@ async def export_traces(
     if content_encoding:
         body = decompress_otlp_body(body, content_encoding.lower())
 
-    # Parse protobuf payload
+    # Parse payload — supports both protobuf and JSON encoding per the OTLP spec:
+    # https://opentelemetry.io/docs/specs/otlp/#otlphttp
     parsed_request = ExportTraceServiceRequest()
 
     try:
-        # In Python protobuf library 5.x, ParseFromString may not raise DecodeError on invalid data
-        parsed_request.ParseFromString(body)
+        if content_type == "application/json":
+            # OTLP JSON encodes trace_id/span_id as hex strings, but protobuf's
+            # JSON mapping expects base64 for `bytes` fields (per proto3 spec).
+            # We must convert hex→base64 before calling Parse(), otherwise the
+            # IDs are decoded incorrectly and overflow downstream int conversions.
+            body = _convert_otlp_json_ids_to_base64(body)
+            ParseJsonProto(body, parsed_request)
+        else:
+            # In Python protobuf library 5.x, ParseFromString may not raise
+            # DecodeError on invalid data
+            parsed_request.ParseFromString(body)
 
-        # Check if we actually parsed any data
-        # If no resource_spans were parsed, the data was likely invalid
         if not parsed_request.resource_spans:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Invalid OpenTelemetry protobuf format - no spans found",
+                detail="Invalid OpenTelemetry format - no spans found",
             )
 
-    except DecodeError:
-        # This will catch errors in Python protobuf library 3.x
+    except (DecodeError, json.JSONDecodeError, ValueError):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid OpenTelemetry protobuf format",
+            detail="Invalid OpenTelemetry format",
         )
 
     all_spans = []

--- a/mlflow/server/otel_api.py
+++ b/mlflow/server/otel_api.py
@@ -16,6 +16,7 @@ import logging
 
 from fastapi import APIRouter, Header, HTTPException, Request, Response, status
 from fastapi.responses import JSONResponse
+from google.protobuf.json_format import Error as ProtoJsonError
 from google.protobuf.json_format import Parse as ParseJsonProto
 from google.protobuf.message import DecodeError
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
@@ -105,8 +106,10 @@ async def export_traces(
     Raises:
         HTTPException: If the request is invalid or span logging fails
     """
-    # Validate Content-Type header
-    if content_type not in ("application/x-protobuf", "application/json"):
+    # Validate Content-Type header. Normalize by stripping parameters like
+    # charset (e.g., "application/json; charset=utf-8" → "application/json").
+    media_type = (content_type or "").split(";")[0].strip()
+    if media_type not in ("application/x-protobuf", "application/json"):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Invalid Content-Type: {content_type}. "
@@ -123,7 +126,7 @@ async def export_traces(
     parsed_request = ExportTraceServiceRequest()
 
     try:
-        if content_type == "application/json":
+        if media_type == "application/json":
             # OTLP JSON encodes trace_id/span_id as hex strings, but protobuf's
             # JSON mapping expects base64 for `bytes` fields (per proto3 spec).
             # We must convert hex→base64 before calling Parse(), otherwise the
@@ -141,7 +144,7 @@ async def export_traces(
                 detail="Invalid OpenTelemetry format - no spans found",
             )
 
-    except (DecodeError, json.JSONDecodeError, ValueError):
+    except (DecodeError, ProtoJsonError, json.JSONDecodeError, ValueError):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid OpenTelemetry format",

--- a/mlflow/server/otel_api.py
+++ b/mlflow/server/otel_api.py
@@ -129,7 +129,7 @@ async def export_traces(
             # We must convert hex→base64 before calling Parse(), otherwise the
             # IDs are decoded incorrectly and overflow downstream int conversions.
             body = _convert_otlp_json_ids_to_base64(body)
-            ParseJsonProto(body, parsed_request)
+            ParseJsonProto(body, parsed_request, ignore_unknown_fields=True)
         else:
             # In Python protobuf library 5.x, ParseFromString may not raise
             # DecodeError on invalid data

--- a/mlflow/server/otel_api.py
+++ b/mlflow/server/otel_api.py
@@ -26,6 +26,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.server.handlers import _get_tracking_store
 from mlflow.telemetry.events import TraceSource, TracesReceivedByServerEvent
 from mlflow.telemetry.track import _record_event
+from mlflow.tracing.utils import dump_span_attribute_value
 from mlflow.tracing.utils.otlp import (
     MLFLOW_EXPERIMENT_ID_HEADER,
     OTLP_TRACES_PATH,
@@ -112,20 +113,33 @@ async def export_traces(
     completed_trace_ids = set()
     service_names = set()
     for resource_span in parsed_request.resource_spans:
-        if sn_attr := next(
-            (attr for attr in resource_span.resource.attributes if attr.key == "service.name"),
-            None,
-        ):
-            if value := _decode_otel_proto_anyvalue(sn_attr.value):
-                service_names.add(str(value))
+        # Extract resource-level attributes to propagate onto root spans
+        resource_service_name = None
+        resource_attrs: dict[str, str] = {}
+        for attr in resource_span.resource.attributes:
+            if value := _decode_otel_proto_anyvalue(attr.value):
+                resource_attrs[attr.key] = str(value)
+
+        if sn := resource_attrs.get("service.name"):
+            resource_service_name = sn
+            service_names.add(sn)
 
         for scope_span in resource_span.scope_spans:
             for otel_proto_span in scope_span.spans:
                 try:
                     mlflow_span = Span.from_otel_proto(otel_proto_span)
-                    all_spans.append(mlflow_span)
+
+                    # Propagate resource attributes onto root spans so they're
+                    # visible in the UI (following the OTel convention of
+                    # associating resource attrs with the producing entity).
                     if mlflow_span.parent_id is None:
                         completed_trace_ids.add(mlflow_span.trace_id)
+                        if resource_service_name:
+                            mlflow_span._span._attributes["service.name"] = (
+                                dump_span_attribute_value(resource_service_name)
+                            )
+
+                    all_spans.append(mlflow_span)
                 except Exception:
                     raise HTTPException(
                         status_code=422,

--- a/mlflow/server/otel_api.py
+++ b/mlflow/server/otel_api.py
@@ -29,6 +29,7 @@ from mlflow.telemetry.track import _record_event
 from mlflow.tracing.utils.otlp import (
     MLFLOW_EXPERIMENT_ID_HEADER,
     OTLP_TRACES_PATH,
+    _decode_otel_proto_anyvalue,
     decompress_otlp_body,
 )
 from mlflow.tracking.request_header.default_request_header_provider import (
@@ -109,7 +110,15 @@ async def export_traces(
 
     all_spans = []
     completed_trace_ids = set()
+    service_names = set()
     for resource_span in parsed_request.resource_spans:
+        if sn_attr := next(
+            (attr for attr in resource_span.resource.attributes if attr.key == "service.name"),
+            None,
+        ):
+            if value := _decode_otel_proto_anyvalue(sn_attr.value):
+                service_names.add(str(value))
+
         for scope_span in resource_span.scope_spans:
             for otel_proto_span in scope_span.spans:
                 try:
@@ -148,19 +157,21 @@ async def export_traces(
             )
 
         if completed_trace_ids:
-            trace_source = (
-                TraceSource.MLFLOW_PYTHON_CLIENT
-                if user_agent and user_agent.startswith(_MLFLOW_PYTHON_CLIENT_USER_AGENT_PREFIX)
-                else TraceSource.UNKNOWN
-            )
+            if user_agent and user_agent.startswith(_MLFLOW_PYTHON_CLIENT_USER_AGENT_PREFIX):
+                trace_source = TraceSource.MLFLOW_PYTHON_CLIENT
+            elif service_names:
+                trace_source = TraceSource.EXTERNAL_OTEL_CLIENT
+            else:
+                trace_source = TraceSource.UNKNOWN
 
-            _record_event(
-                TracesReceivedByServerEvent,
-                {
-                    "source": trace_source,
-                    "count": len(completed_trace_ids),
-                },
-            )
+            event_params: dict[str, object] = {
+                "source": trace_source,
+                "count": len(completed_trace_ids),
+            }
+            if service_names:
+                event_params["service_names"] = sorted(service_names)
+
+            _record_event(TracesReceivedByServerEvent, event_params)
 
     # Return protobuf response as per OTLP specification
     response_message = ExportTraceServiceResponse()

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -609,6 +609,7 @@ class TraceSource(str, Enum):
     """Source of a trace received by the MLflow server."""
 
     MLFLOW_PYTHON_CLIENT = "MLFLOW_PYTHON_CLIENT"
+    EXTERNAL_OTEL_CLIENT = "EXTERNAL_OTEL_CLIENT"
     UNKNOWN = "UNKNOWN"
 
 

--- a/tests/server/test_otel_api.py
+++ b/tests/server/test_otel_api.py
@@ -163,12 +163,12 @@ def test_otlp_invalid_content_type(monkeypatch):
 
     client = _make_test_client()
 
-    # Test with wrong content type
+    # Test with unsupported content type (application/json is now valid)
     response = client.post(
         OTLP_TRACES_PATH,
         data=_build_otlp_payload(),
         headers={
-            "Content-Type": "application/json",
+            "Content-Type": "text/plain",
             "X-MLflow-Experiment-Id": "42",
         },
     )

--- a/tests/server/test_otel_api.py
+++ b/tests/server/test_otel_api.py
@@ -207,7 +207,7 @@ def test_otlp_invalid_protobuf_data(monkeypatch):
         },
     )
     assert response.status_code == 400
-    assert "Invalid OpenTelemetry protobuf format" in response.json()["detail"]
+    assert "Invalid OpenTelemetry format" in response.json()["detail"]
 
 
 def test_otlp_empty_resource_spans(monkeypatch):

--- a/tests/server/test_otel_api.py
+++ b/tests/server/test_otel_api.py
@@ -163,12 +163,12 @@ def test_otlp_invalid_content_type(monkeypatch):
 
     client = _make_test_client()
 
-    # Test with unsupported content type (application/json is now valid)
+    # Test with wrong content type
     response = client.post(
         OTLP_TRACES_PATH,
         data=_build_otlp_payload(),
         headers={
-            "Content-Type": "text/plain",
+            "Content-Type": "application/json",
             "X-MLflow-Experiment-Id": "42",
         },
     )
@@ -207,7 +207,7 @@ def test_otlp_invalid_protobuf_data(monkeypatch):
         },
     )
     assert response.status_code == 400
-    assert "Invalid OpenTelemetry format" in response.json()["detail"]
+    assert "Invalid OpenTelemetry protobuf format" in response.json()["detail"]
 
 
 def test_otlp_empty_resource_spans(monkeypatch):

--- a/tests/tracing/test_otel_logging.py
+++ b/tests/tracing/test_otel_logging.py
@@ -804,6 +804,70 @@ def test_otel_trace_received_telemetry_from_external_otel_client_with_service_na
         assert record.params["service_names"] == expected_service_names
 
 
+def test_service_name_propagated_to_root_span(mlflow_server: str):
+    mlflow.set_tracking_uri(mlflow_server)
+    experiment = mlflow.set_experiment("otel-service-name-on-span-test")
+    experiment_id = experiment.experiment_id
+
+    trace_id = bytes.fromhex("0000000000000600" + "0" * 16)
+    root_span_id = bytes.fromhex("00000006" + "0" * 8)
+    child_span_id = bytes.fromhex("00000007" + "0" * 8)
+
+    request = ExportTraceServiceRequest()
+    request.resource_spans.append(
+        ResourceSpans(
+            resource=Resource(
+                attributes=[
+                    KeyValue(key="service.name", value=AnyValue(string_value="gemini-cli")),
+                ]
+            ),
+            scope_spans=[
+                ScopeSpans(
+                    scope=InstrumentationScope(name="test-scope"),
+                    spans=[
+                        OTelProtoSpan(
+                            trace_id=trace_id,
+                            span_id=root_span_id,
+                            name="root-span",
+                            start_time_unix_nano=1000000000,
+                            end_time_unix_nano=2000000000,
+                        ),
+                        OTelProtoSpan(
+                            trace_id=trace_id,
+                            span_id=child_span_id,
+                            parent_span_id=root_span_id,
+                            name="child-span",
+                            start_time_unix_nano=1100000000,
+                            end_time_unix_nano=1500000000,
+                        ),
+                    ],
+                )
+            ],
+        )
+    )
+
+    response = requests.post(
+        f"{mlflow_server}/v1/traces",
+        data=request.SerializeToString(),
+        headers={
+            "Content-Type": "application/x-protobuf",
+            MLFLOW_EXPERIMENT_ID_HEADER: experiment_id,
+        },
+        timeout=10,
+    )
+    assert response.status_code == 200
+
+    traces = mlflow.search_traces(locations=[experiment_id], include_spans=True, return_type="list")
+    assert len(traces) == 1
+
+    root_span = next(s for s in traces[0].data.spans if s.parent_id is None)
+    child_span = next(s for s in traces[0].data.spans if s.parent_id is not None)
+
+    # service.name should be on the root span only
+    assert root_span.get_attribute("service.name") == "gemini-cli"
+    assert child_span.get_attribute("service.name") is None
+
+
 def test_response_is_protobuf_format(mlflow_server: str):
     mlflow.set_tracking_uri(mlflow_server)
     experiment = mlflow.set_experiment("otel-protobuf-response-test")

--- a/tests/tracing/test_otel_logging.py
+++ b/tests/tracing/test_otel_logging.py
@@ -296,12 +296,12 @@ def test_invalid_content_type_returns_400(mlflow_server: str):
     request = ExportTraceServiceRequest()
     request.resource_spans.append(resource_spans)
 
-    # Send request with unsupported Content-Type (application/json is now valid)
+    # Send request with incorrect Content-Type
     response = requests.post(
         f"{mlflow_server}/v1/traces",
         data=request.SerializeToString(),
         headers={
-            "Content-Type": "text/plain",
+            "Content-Type": "application/json",  # Wrong content type
             MLFLOW_EXPERIMENT_ID_HEADER: "test-experiment",
         },
         timeout=10,
@@ -866,69 +866,6 @@ def test_service_name_propagated_to_root_span(mlflow_server: str):
     # service.name should be on the root span only
     assert root_span.get_attribute("service.name") == "gemini-cli"
     assert child_span.get_attribute("service.name") is None
-
-
-def test_otlp_json_encoding(mlflow_server: str):
-    """OTLP JSON encoding uses hex for trace/span IDs per the OTLP spec.
-
-    Ref: https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding
-    """
-    mlflow.set_tracking_uri(mlflow_server)
-    experiment = mlflow.set_experiment("otel-json-encoding-test")
-    experiment_id = experiment.experiment_id
-
-    trace_id_hex = "61181d5c16b3b25d966891c3fc595af9"
-    span_id_hex = "508755a859b294e3"
-
-    payload = {
-        "resourceSpans": [
-            {
-                "resource": {
-                    "attributes": [
-                        {"key": "service.name", "value": {"stringValue": "gemini-cli"}},
-                    ]
-                },
-                "scopeSpans": [
-                    {
-                        "scope": {"name": "gemini-cli"},
-                        "spans": [
-                            {
-                                "traceId": trace_id_hex,
-                                "spanId": span_id_hex,
-                                "name": "user_prompt",
-                                "startTimeUnixNano": str(int(time.time() * 1e9)),
-                                "endTimeUnixNano": str(int(time.time() * 1e9) + 1000000000),
-                                "attributes": [
-                                    {
-                                        "key": "gen_ai.operation.name",
-                                        "value": {"stringValue": "user_prompt"},
-                                    },
-                                ],
-                            }
-                        ],
-                    }
-                ],
-            }
-        ]
-    }
-
-    response = requests.post(
-        f"{mlflow_server}/v1/traces",
-        json=payload,
-        headers={
-            "Content-Type": "application/json",
-            MLFLOW_EXPERIMENT_ID_HEADER: experiment_id,
-        },
-        timeout=10,
-    )
-    assert response.status_code == 200
-
-    traces = mlflow.search_traces(locations=[experiment_id], include_spans=True, return_type="list")
-    assert len(traces) == 1
-
-    root_span = traces[0].data.spans[0]
-    assert root_span.name == "user_prompt"
-    assert root_span.get_attribute("service.name") == "gemini-cli"
 
 
 def test_response_is_protobuf_format(mlflow_server: str):

--- a/tests/tracing/test_otel_logging.py
+++ b/tests/tracing/test_otel_logging.py
@@ -296,12 +296,12 @@ def test_invalid_content_type_returns_400(mlflow_server: str):
     request = ExportTraceServiceRequest()
     request.resource_spans.append(resource_spans)
 
-    # Send request with incorrect Content-Type
+    # Send request with unsupported Content-Type (application/json is now valid)
     response = requests.post(
         f"{mlflow_server}/v1/traces",
         data=request.SerializeToString(),
         headers={
-            "Content-Type": "application/json",  # Wrong content type
+            "Content-Type": "text/plain",
             MLFLOW_EXPERIMENT_ID_HEADER: "test-experiment",
         },
         timeout=10,

--- a/tests/tracing/test_otel_logging.py
+++ b/tests/tracing/test_otel_logging.py
@@ -868,6 +868,69 @@ def test_service_name_propagated_to_root_span(mlflow_server: str):
     assert child_span.get_attribute("service.name") is None
 
 
+def test_otlp_json_encoding(mlflow_server: str):
+    """OTLP JSON encoding uses hex for trace/span IDs per the OTLP spec.
+
+    Ref: https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding
+    """
+    mlflow.set_tracking_uri(mlflow_server)
+    experiment = mlflow.set_experiment("otel-json-encoding-test")
+    experiment_id = experiment.experiment_id
+
+    trace_id_hex = "61181d5c16b3b25d966891c3fc595af9"
+    span_id_hex = "508755a859b294e3"
+
+    payload = {
+        "resourceSpans": [
+            {
+                "resource": {
+                    "attributes": [
+                        {"key": "service.name", "value": {"stringValue": "gemini-cli"}},
+                    ]
+                },
+                "scopeSpans": [
+                    {
+                        "scope": {"name": "gemini-cli"},
+                        "spans": [
+                            {
+                                "traceId": trace_id_hex,
+                                "spanId": span_id_hex,
+                                "name": "user_prompt",
+                                "startTimeUnixNano": str(int(time.time() * 1e9)),
+                                "endTimeUnixNano": str(int(time.time() * 1e9) + 1000000000),
+                                "attributes": [
+                                    {
+                                        "key": "gen_ai.operation.name",
+                                        "value": {"stringValue": "user_prompt"},
+                                    },
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+
+    response = requests.post(
+        f"{mlflow_server}/v1/traces",
+        json=payload,
+        headers={
+            "Content-Type": "application/json",
+            MLFLOW_EXPERIMENT_ID_HEADER: experiment_id,
+        },
+        timeout=10,
+    )
+    assert response.status_code == 200
+
+    traces = mlflow.search_traces(locations=[experiment_id], include_spans=True, return_type="list")
+    assert len(traces) == 1
+
+    root_span = traces[0].data.spans[0]
+    assert root_span.name == "user_prompt"
+    assert root_span.get_attribute("service.name") == "gemini-cli"
+
+
 def test_response_is_protobuf_format(mlflow_server: str):
     mlflow.set_tracking_uri(mlflow_server)
     experiment = mlflow.set_experiment("otel-protobuf-response-test")

--- a/tests/tracing/test_otel_logging.py
+++ b/tests/tracing/test_otel_logging.py
@@ -20,7 +20,7 @@ from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
     ExportTraceServiceRequest,
     ExportTraceServiceResponse,
 )
-from opentelemetry.proto.common.v1.common_pb2 import InstrumentationScope
+from opentelemetry.proto.common.v1.common_pb2 import AnyValue, InstrumentationScope, KeyValue
 from opentelemetry.proto.resource.v1.resource_pb2 import Resource
 from opentelemetry.proto.trace.v1.trace_pb2 import ResourceSpans, ScopeSpans
 from opentelemetry.proto.trace.v1.trace_pb2 import Span as OTelProtoSpan
@@ -733,6 +733,75 @@ def test_otel_trace_received_telemetry_from_external_client(mlflow_server: str):
         assert record.status.value == "success"
         assert record.params["source"] == TraceSource.UNKNOWN.value
         assert record.params["count"] == 2
+
+
+@pytest.mark.parametrize(
+    ("service_name", "expected_service_names"),
+    [
+        ("codex_cli_rs", ["codex_cli_rs"]),
+        ("gemini-cli", ["gemini-cli"]),
+        ("qwen-code", ["qwen-code"]),
+        ("my-custom-app", ["my-custom-app"]),
+    ],
+)
+def test_otel_trace_received_telemetry_from_external_otel_client_with_service_name(
+    mlflow_server: str, service_name: str, expected_service_names: list[str]
+):
+    mlflow.set_tracking_uri(mlflow_server)
+    experiment = mlflow.set_experiment("otel-telemetry-service-name-test")
+    experiment_id = experiment.experiment_id
+
+    trace_id = bytes.fromhex("0000000000000500" + "0" * 16)
+
+    request = ExportTraceServiceRequest()
+    request.resource_spans.append(
+        ResourceSpans(
+            resource=Resource(
+                attributes=[
+                    KeyValue(key="service.name", value=AnyValue(string_value=service_name)),
+                ]
+            ),
+            scope_spans=[
+                ScopeSpans(
+                    scope=InstrumentationScope(name="test-scope"),
+                    spans=[
+                        OTelProtoSpan(
+                            trace_id=trace_id,
+                            span_id=bytes.fromhex("00000005" + "0" * 8),
+                            name="root-span",
+                            start_time_unix_nano=1000000000,
+                            end_time_unix_nano=2000000000,
+                        ),
+                    ],
+                )
+            ],
+        )
+    )
+
+    with mock.patch("mlflow.telemetry.track.get_telemetry_client") as mock_get_client:
+        mock_client = mock.MagicMock(spec=TelemetryClient)
+        mock_client.config = None
+        mock_get_client.return_value = mock_client
+
+        response = requests.post(
+            f"{mlflow_server}/v1/traces",
+            data=request.SerializeToString(),
+            headers={
+                "Content-Type": "application/x-protobuf",
+                MLFLOW_EXPERIMENT_ID_HEADER: experiment_id,
+            },
+            timeout=10,
+        )
+
+        assert response.status_code == 200
+
+        mock_client.add_record.assert_called_once()
+        record = mock_client.add_record.call_args[0][0]
+
+        assert record.event_name == TracesReceivedByServerEvent.name
+        assert record.params["source"] == TraceSource.EXTERNAL_OTEL_CLIENT.value
+        assert record.params["count"] == 1
+        assert record.params["service_names"] == expected_service_names
 
 
 def test_response_is_protobuf_format(mlflow_server: str):


### PR DESCRIPTION
## 🥞 Stacked PR
- [**stack/coding-agent-tracing/1-usage-telemetry**](https://github.com/mlflow/mlflow/pull/22287)
  - [stack/coding-agent-tracing/1b-json-otlp](https://github.com/mlflow/mlflow/pull/22402)
    - [stack/coding-agent-tracing/2-gemini-otlp](https://github.com/mlflow/mlflow/pull/22288)
      - [stack/coding-agent-tracing/3-codex-hooks](https://github.com/mlflow/mlflow/pull/22289)
        - [stack/coding-agent-tracing/4-qwen-hooks](https://github.com/mlflow/mlflow/pull/22290)
          - [stack/coding-agent-tracing/5-docs](https://github.com/mlflow/mlflow/pull/22326)

---------
### Related Issues/PRs

Relates to coding agent tracing project (Codex CLI, Gemini CLI, Qwen Code support)

### What changes are proposed in this pull request?

Three enhancements to the OTLP trace ingestion endpoint (`/v1/traces`):

1. **Usage telemetry**: Extracts `service.name` from OTLP resource attributes. Adds `EXTERNAL_OTEL_CLIENT` to the `TraceSource` enum and reports `service_names` in the `TracesReceivedByServerEvent`.

2. **Root span visibility**: Propagates `service.name` as an attribute on root spans so it's visible in the MLflow UI (follows OTel convention of associating resource attributes with the producing entity).

3. **JSON OTLP encoding**: Adds `Content-Type: application/json` support alongside existing `application/x-protobuf`. Some OTEL clients (notably Gemini CLI) send JSON by default. Handles the hex→base64 conversion needed for trace/span IDs because OTLP JSON uses hex strings while protobuf's JSON mapping expects base64 for `bytes` fields.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests
- [ ] Manual tests

Tested end-to-end with real Gemini CLI sending JSON OTLP traces to a local MLflow server. Also parametrized integration tests for service.name telemetry, root span propagation, and JSON encoding.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

Documentation for Gemini CLI setup (env vars) will be added in a follow-up.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The OTLP trace ingestion endpoint now accepts JSON-encoded payloads (`Content-Type: application/json`) in addition to protobuf, and propagates `service.name` from OTLP resource attributes onto root spans.

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release