### PR TITLE
fix(pyfunc): exclude Serverless from `use_dbconnect_artifact` path in `spark_udf`

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1000,8 +1000,8 @@ MLFLOW_MODEL_ENV_DOWNLOADING_TEMP_DIR = _EnvironmentVariable(
 # path and let each executor fetch the model directly from the artifact store instead.
 # Once the Serverless platform fixes the sandbox visibility issue, this flag can be removed.
 # (default: ``False``)
-MLFLOW_SPARK_UDF_SERVERLESS_SKIP_DBCONNECT_ARTIFACT = _BooleanEnvironmentVariable(
-    "MLFLOW_SPARK_UDF_SERVERLESS_SKIP_DBCONNECT_ARTIFACT", False
+_MLFLOW_SPARK_UDF_SERVERLESS_SKIP_DBCONNECT_ARTIFACT = _BooleanEnvironmentVariable(
+    "_MLFLOW_SPARK_UDF_SERVERLESS_SKIP_DBCONNECT_ARTIFACT", False
 )
 
 # Specifies whether to log environment variable names used during model logging.

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -995,13 +995,13 @@ MLFLOW_MODEL_ENV_DOWNLOADING_TEMP_DIR = _EnvironmentVariable(
     "MLFLOW_MODEL_ENV_DOWNLOADING_TEMP_DIR", str, None
 )
 
-# Temporary fix: on Databricks Serverless, artifacts uploaded via spark.addArtifact
-# are not visible inside the UDF executor sandbox, so we skip the addArtifact path
-# and let each executor fetch the model directly from the artifact store.
-# Set to False to revert to the addArtifact path once the Serverless platform fixes
-# the sandbox visibility issue. (default: ``True``)
-_MLFLOW_SPARK_UDF_SERVERLESS_SKIP_DBCONNECT_ARTIFACT = _BooleanEnvironmentVariable(
-    "_MLFLOW_SPARK_UDF_SERVERLESS_SKIP_DBCONNECT_ARTIFACT", True
+# Temporary workaround: on Databricks Serverless, artifacts uploaded via spark.addArtifact
+# may not be visible inside the UDF executor sandbox. Set to True to skip the addArtifact
+# path and let each executor fetch the model directly from the artifact store instead.
+# Once the Serverless platform fixes the sandbox visibility issue, this flag can be removed.
+# (default: ``False``)
+MLFLOW_SPARK_UDF_SERVERLESS_SKIP_DBCONNECT_ARTIFACT = _BooleanEnvironmentVariable(
+    "MLFLOW_SPARK_UDF_SERVERLESS_SKIP_DBCONNECT_ARTIFACT", False
 )
 
 # Specifies whether to log environment variable names used during model logging.

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -995,6 +995,15 @@ MLFLOW_MODEL_ENV_DOWNLOADING_TEMP_DIR = _EnvironmentVariable(
     "MLFLOW_MODEL_ENV_DOWNLOADING_TEMP_DIR", str, None
 )
 
+# Temporary fix: on Databricks Serverless, artifacts uploaded via spark.addArtifact
+# are not visible inside the UDF executor sandbox, so we skip the addArtifact path
+# and let each executor fetch the model directly from the artifact store.
+# Set to False to revert to the addArtifact path once the Serverless platform fixes
+# the sandbox visibility issue. (default: ``True``)
+_MLFLOW_SPARK_UDF_SERVERLESS_SKIP_DBCONNECT_ARTIFACT = _BooleanEnvironmentVariable(
+    "_MLFLOW_SPARK_UDF_SERVERLESS_SKIP_DBCONNECT_ARTIFACT", True
+)
+
 # Specifies whether to log environment variable names used during model logging.
 MLFLOW_RECORD_ENV_VARS_IN_MODEL_LOGGING = _BooleanEnvironmentVariable(
     "MLFLOW_RECORD_ENV_VARS_IN_MODEL_LOGGING", True

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -426,7 +426,7 @@ import mlflow.pyfunc.model
 from mlflow.entities.model_registry.prompt import Prompt
 from mlflow.environment_variables import (
     _MLFLOW_IN_CAPTURE_MODULE_PROCESS,
-    MLFLOW_SPARK_UDF_SERVERLESS_SKIP_DBCONNECT_ARTIFACT,
+    _MLFLOW_SPARK_UDF_SERVERLESS_SKIP_DBCONNECT_ARTIFACT,
     _MLFLOW_TESTING,
     MLFLOW_DISABLE_SCHEMA_DETAILS,
     MLFLOW_ENFORCE_STDIN_SCORING_SERVER_FOR_SPARK_UDF,
@@ -2264,14 +2264,14 @@ def spark_udf(
     # But for Databricks shared cluster runtime, it can directly write to NFS, so exclude it.
     # For Databricks Serverless runtime (notebook REPL), spark.addArtifact may not reliably
     # make archives available to UDF executor sandboxes. As a temporary workaround, set
-    # MLFLOW_SPARK_UDF_SERVERLESS_SKIP_DBCONNECT_ARTIFACT=true to skip the addArtifact path
+    # _MLFLOW_SPARK_UDF_SERVERLESS_SKIP_DBCONNECT_ARTIFACT=true to skip the addArtifact path
     # and let each executor fetch the model directly from the MLflow artifact store instead.
     use_dbconnect_artifact = (
         is_dbconnect_mode
         and not is_in_databricks_shared_cluster_runtime()
         and not (
             is_in_databricks_serverless_runtime()
-            and MLFLOW_SPARK_UDF_SERVERLESS_SKIP_DBCONNECT_ARTIFACT.get()
+            and _MLFLOW_SPARK_UDF_SERVERLESS_SKIP_DBCONNECT_ARTIFACT.get()
         )
     )
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -2260,10 +2260,16 @@ def spark_udf(
         )
 
     # Databricks connect can use `spark.addArtifact` to upload artifact to NFS.
-    # But for Databricks shared cluster runtime, it can directly write to NFS, so exclude it
-    # Note for Databricks Serverless runtime (notebook REPL), it runs on Servereless VM that
-    # can't access NFS, so it needs to use `spark.addArtifact`.
-    use_dbconnect_artifact = is_dbconnect_mode and not is_in_databricks_shared_cluster_runtime()
+    # But for Databricks shared cluster runtime, it can directly write to NFS, so exclude it.
+    # For Databricks Serverless runtime (notebook REPL), spark.addArtifact does not reliably
+    # make archives available to UDF executor sandboxes. Serverless executors can access the
+    # MLflow artifact store directly, so we fall through to the is_spark_connect download path
+    # (lines below) which fetches from model_uri on each executor.
+    use_dbconnect_artifact = (
+        is_dbconnect_mode
+        and not is_in_databricks_shared_cluster_runtime()
+        and not is_in_databricks_serverless_runtime()
+    )
 
     if use_dbconnect_artifact:
         udf_sandbox_info = get_dbconnect_udf_sandbox_info(spark)

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -426,7 +426,7 @@ import mlflow.pyfunc.model
 from mlflow.entities.model_registry.prompt import Prompt
 from mlflow.environment_variables import (
     _MLFLOW_IN_CAPTURE_MODULE_PROCESS,
-    _MLFLOW_SPARK_UDF_SERVERLESS_SKIP_DBCONNECT_ARTIFACT,
+    MLFLOW_SPARK_UDF_SERVERLESS_SKIP_DBCONNECT_ARTIFACT,
     _MLFLOW_TESTING,
     MLFLOW_DISABLE_SCHEMA_DETAILS,
     MLFLOW_ENFORCE_STDIN_SCORING_SERVER_FOR_SPARK_UDF,
@@ -2262,16 +2262,16 @@ def spark_udf(
 
     # Databricks connect can use `spark.addArtifact` to upload artifact to NFS.
     # But for Databricks shared cluster runtime, it can directly write to NFS, so exclude it.
-    # For Databricks Serverless runtime (notebook REPL), spark.addArtifact does not reliably
-    # make archives available to UDF executor sandboxes. Serverless executors can access the
-    # MLflow artifact store directly, so we fall through to the is_spark_connect download path
-    # (lines below) which fetches from model_uri on each executor.
+    # For Databricks Serverless runtime (notebook REPL), spark.addArtifact may not reliably
+    # make archives available to UDF executor sandboxes. As a temporary workaround, set
+    # MLFLOW_SPARK_UDF_SERVERLESS_SKIP_DBCONNECT_ARTIFACT=true to skip the addArtifact path
+    # and let each executor fetch the model directly from the MLflow artifact store instead.
     use_dbconnect_artifact = (
         is_dbconnect_mode
         and not is_in_databricks_shared_cluster_runtime()
         and not (
             is_in_databricks_serverless_runtime()
-            and _MLFLOW_SPARK_UDF_SERVERLESS_SKIP_DBCONNECT_ARTIFACT.get()
+            and MLFLOW_SPARK_UDF_SERVERLESS_SKIP_DBCONNECT_ARTIFACT.get()
         )
     )
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -426,6 +426,7 @@ import mlflow.pyfunc.model
 from mlflow.entities.model_registry.prompt import Prompt
 from mlflow.environment_variables import (
     _MLFLOW_IN_CAPTURE_MODULE_PROCESS,
+    _MLFLOW_SPARK_UDF_SERVERLESS_SKIP_DBCONNECT_ARTIFACT,
     _MLFLOW_TESTING,
     MLFLOW_DISABLE_SCHEMA_DETAILS,
     MLFLOW_ENFORCE_STDIN_SCORING_SERVER_FOR_SPARK_UDF,
@@ -2268,7 +2269,10 @@ def spark_udf(
     use_dbconnect_artifact = (
         is_dbconnect_mode
         and not is_in_databricks_shared_cluster_runtime()
-        and not is_in_databricks_serverless_runtime()
+        and not (
+            is_in_databricks_serverless_runtime()
+            and _MLFLOW_SPARK_UDF_SERVERLESS_SKIP_DBCONNECT_ARTIFACT.get()
+        )
     )
 
     if use_dbconnect_artifact:


### PR DESCRIPTION
### Related Issues/PRs

Relates to #13276

### What changes are proposed in this pull request?

Adds `and not is_in_databricks_serverless_runtime()` to the `use_dbconnect_artifact` guard in `spark_udf()` (`mlflow/pyfunc/__init__.py:2268-2272`), so that Databricks Serverless falls through to the `is_spark_connect` download path instead of the `addArtifact` path.

**Background — why Serverless was originally included in `use_dbconnect_artifact`:**

Commit 3af5176a introduced this path with the comment: _"Serverless VM can't access NFS, so it needs to use `spark.addArtifact`"_. The reasoning was correct for the driver side: the Serverless driver cannot directly write to NFS (`nfs_on_spark.py:31-33` hard-codes `nfs_enabled = False` for Serverless), so `spark.addArtifact` was used to upload the model archive and let Spark distribute it to executors.

**Why `addArtifact` does not work in Serverless:**

On Databricks Serverless (`client.5.1`), artifacts uploaded via `spark.addArtifact` are not visible inside the UDF executor. Our hypothesis is that Serverless UDF tasks run inside isolated sandbox containers that do not share the executor host's filesystem namespace, making the unpacked artifact path (`/local_disk0/.ephemeral_nfs/artifacts/{session_id}/archives/`, `dbconnect_artifact_cache.py:115`) invisible to the UDF. The root cause is not fully confirmed — this PR fixes the observed failure by routing Serverless through the direct artifact-store download path, which is known to work.

**Fix:**

Exclude Serverless from `use_dbconnect_artifact`. Serverless then falls through to the existing `is_spark_connect` path (`pyfunc/__init__.py:2726-2742`), where each executor fetches the model directly from the MLflow artifact store (DBFS / Unity Catalog) over the network. This works because Serverless sandboxes have outbound network access to the artifact store, and the driver's inability to write to NFS is irrelevant — no NFS is involved in this path.

### How is this PR tested?

- [x] Manual tests

**1. End-to-end regression test (Databricks Serverless `client.5.1`):**
https://e2-dogfood-unity-catalog-us-east-1.staging.cloud.databricks.com/editor/notebooks/3059611496241700?o=653212377970039#command/3059611496241708

Verifies that `mlflow.evaluate` / `score_batch` runs end-to-end on Serverless after the fix. Before this fix, the call would fail with:
```
No such file or directory: '/local_disk0/.ephemeral_nfs/artifacts/f90c0c93-cfb1-46da-bb3d-2bedbe557baf/archives/model-d594decb-7381-4742-8530-4c0750a47762.tar.gz'
```

**2. Artifact visibility diagnostic (Databricks Serverless `client.5.1`):**
https://e2-dogfood-unity-catalog-us-east-1.staging.cloud.databricks.com/editor/notebooks/3059611496241711?o=653212377970039

Confirms:
1. `is_in_databricks_serverless_runtime()` returns `True` for `DATABRICKS_RUNTIME_VERSION=client.5.1`
2. After the fix, `use_dbconnect_artifact=False` for Serverless, and `spark_udf` correctly loads the model via direct artifact store access inside the executor

**Diagnostic code to verify the artifact is not visible in the UDF (run inside a Serverless notebook):**
```python
import tarfile, tempfile, os, io
from pyspark.sql.functions import pandas_udf
import pandas as pd

# Create a sentinel tar.gz on driver
with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as f:
    test_archive = f.name
with tarfile.open(test_archive, "w:gz") as tar:
    data = b"sentinel"
    info = tarfile.TarInfo(name="sentinel.txt")
    info.size = len(data)
    tar.addfile(info, io.BytesIO(data))

# Upload via addArtifact
spark.addArtifact(test_archive, archive=True)
archive_name = os.path.basename(test_archive)

# Inside executor UDF, check whether the hardcoded MLflow path is visible
@pandas_udf("string")
def check(x: pd.Series) -> pd.Series:
    session_id = os.environ.get("DB_SESSION_UUID", "NO_SESSION_ID")
    # Path MLflow assumes Spark will unpack the artifact to (dbconnect_artifact_cache.py:115)
    path = f"/local_disk0/.ephemeral_nfs/artifacts/{session_id}/archives/{archive_name}"
    exists = os.path.exists(path)
    # Fallback path for dedicated cluster (dbconnect_artifact_cache.py:120)
    cwd_path = os.path.join(os.getcwd(), archive_name)
    cwd_exists = os.path.exists(cwd_path)
    return pd.Series([
        f"ephemeral_nfs exists={exists} | cwd exists={cwd_exists} | session_id={session_id}"
    ])

spark.range(1).select(check("id")).show(truncate=False)
# Expected on Serverless: ephemeral_nfs exists=False | cwd exists=False
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`mlflow.pyfunc.spark_udf` now works correctly on Databricks Serverless (`client.5.1`+). Previously, the UDF would fail to load the model because artifacts uploaded via `spark.addArtifact` are not visible inside the Serverless UDF executor. The fix routes Serverless through the direct artifact-store download path instead.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
