### PR TITLE
Fix `MetaPromptOptimizer` failing on prompts with no template variables

### DIFF
--- a/mlflow/genai/optimize/optimizers/metaprompt_optimizer.py
+++ b/mlflow/genai/optimize/optimizers/metaprompt_optimizer.py
@@ -50,13 +50,15 @@ show intermediate steps
 
 CRITICAL REQUIREMENT - TEMPLATE VARIABLES:
 The following variables MUST be preserved EXACTLY as shown in the original prompts.
-DO NOT modify, remove, or change the formatting of these variables in any way:
+DO NOT modify, remove, add, or change the formatting of these variables in any way:
 {template_variables}
 
 IMPORTANT: Template variables use double curly braces like {{{{variable_name}}}}.
 You MUST copy them exactly as they appear in the original prompt into your improved
 prompt. If a variable appears as {{{{question}}}} in the original, it must appear as
 {{{{question}}}} in your improvement.
+If a prompt has NO template variables (marked as 'none' above), you MUST NOT introduce
+any new {{{{...}}}} patterns. Only improve the wording and phrasing of those prompts.
 
 {custom_guidelines}
 
@@ -412,20 +414,32 @@ class MetaPromptOptimizer(BasePromptOptimizer):
     def _validate_template_variables(
         self, original_prompts: dict[str, str], new_prompts: dict[str, str]
     ) -> bool:
-        """Validate that all template variables are preserved in new prompts."""
+        """Validate that all template variables are preserved in new prompts.
+
+        Extra variables introduced by the LLM are automatically stripped from the
+        generated prompt so that optimisation can succeed even when the model
+        erroneously adds new ``{{variable}}`` patterns.
+        """
         original_vars = self._extract_template_variables(original_prompts)
         new_vars = self._extract_template_variables(new_prompts)
 
         for name in original_prompts:
-            if original_vars[name] != new_vars[name]:
-                missing = original_vars[name] - new_vars[name]
-                extra = new_vars[name] - original_vars[name]
-                msg = f"Template variables mismatch in prompt '{name}'."
-                if missing:
-                    msg += f" Missing: {missing}."
-                if extra:
-                    msg += f" Extra: {extra}."
-                raise MlflowException(msg)
+            missing = original_vars[name] - new_vars[name]
+            extra = new_vars[name] - original_vars[name]
+
+            if missing:
+                raise MlflowException(
+                    f"Template variables mismatch in prompt '{name}'. Missing: {missing}."
+                )
+
+            if extra:
+                _logger.warning(
+                    f"Stripping extra template variables {extra} from prompt '{name}'."
+                )
+                text = new_prompts[name]
+                for var in extra:
+                    text = text.replace("{{" + var + "}}", "")
+                new_prompts[name] = text
 
         return True
 

--- a/mlflow/genai/optimize/optimizers/metaprompt_optimizer.py
+++ b/mlflow/genai/optimize/optimizers/metaprompt_optimizer.py
@@ -433,9 +433,7 @@ class MetaPromptOptimizer(BasePromptOptimizer):
                 )
 
             if extra:
-                _logger.warning(
-                    f"Stripping extra template variables {extra} from prompt '{name}'."
-                )
+                _logger.warning(f"Stripping extra template variables {extra} from prompt '{name}'.")
                 text = new_prompts[name]
                 for var in extra:
                     text = text.replace("{{" + var + "}}", "")

--- a/tests/genai/optimize/optimizers/test_metaprompt_optimizer.py
+++ b/tests/genai/optimize/optimizers/test_metaprompt_optimizer.py
@@ -130,13 +130,31 @@ def test_validate_template_variables_missing_var():
         optimizer._validate_template_variables(original, new)
 
 
-def test_validate_template_variables_extra_var():
+def test_validate_template_variables_extra_var_stripped():
     optimizer = MetaPromptOptimizer(reflection_model="openai:/gpt-4o")
     original = {"instruction": "Answer {{question}}"}
-    new = {"instruction": "Answer {{question}} about {{topic}}"}  # Extra {{topic}}
+    new = {"instruction": "Answer {{question}} about {{topic}}"}
 
-    with pytest.raises(MlflowException, match="Extra.*topic"):
-        optimizer._validate_template_variables(original, new)
+    assert optimizer._validate_template_variables(original, new) is True
+    assert new["instruction"] == "Answer {{question}} about "
+
+
+def test_validate_template_variables_extra_var_no_original_vars():
+    optimizer = MetaPromptOptimizer(reflection_model="openai:/gpt-4o")
+    original = {"system": "You are a helpful assistant."}
+    new = {"system": "You are {{role}}, a helpful assistant."}
+
+    assert optimizer._validate_template_variables(original, new) is True
+    assert new["system"] == "You are , a helpful assistant."
+
+
+def test_validate_template_variables_multiple_extra_vars_stripped():
+    optimizer = MetaPromptOptimizer(reflection_model="openai:/gpt-4o")
+    original = {"instruction": "Answer {{question}}"}
+    new = {"instruction": "As a {{role}}, answer {{question}} about {{topic}}"}
+
+    assert optimizer._validate_template_variables(original, new) is True
+    assert new["instruction"] == "As a , answer {{question}} about "
 
 
 def test_validate_prompt_names_missing():
@@ -366,6 +384,34 @@ def test_optimize_few_shot_with_baseline_eval(sample_train_data, sample_target_p
         assert result.initial_eval_score is not None
         assert result.final_eval_score is not None
         assert "Better" in result.optimized_prompts["instruction"]
+
+
+def test_optimize_strips_extra_vars_from_no_variable_prompt(sample_train_data):
+    mock_response = Mock()
+    mock_response.choices = [Mock()]
+    mock_response.choices[0].message = Mock()
+    mock_response.choices[0].message.content = json.dumps({
+        "system": "You are an expert {{topic}} assistant.",
+        "instruction": "Please answer: {{question}}",
+    })
+
+    prompts = {
+        "system": "You are a helpful assistant.",
+        "instruction": "Answer {{question}}",
+    }
+
+    with patch("litellm.completion", return_value=mock_response):
+        optimizer = MetaPromptOptimizer(reflection_model="openai:/gpt-4o")
+
+        result = optimizer.optimize(
+            eval_fn=mock_eval_fn,
+            train_data=sample_train_data,
+            target_prompts=prompts,
+            enable_tracking=False,
+        )
+
+        assert result.optimized_prompts["system"] == "You are an expert  assistant."
+        assert result.optimized_prompts["instruction"] == "Please answer: {{question}}"
 
 
 def test_optimize_preserves_template_variables(sample_train_data):


### PR DESCRIPTION
### Related Issues/PRs

Relates to `optimize_prompts()` usability with plain system prompts.

### What changes are proposed in this pull request?

When using `optimize_prompts()` with a plain system prompt that has no `{{ }}` template variables, the LLM frequently introduces new variables like `{{question}}` in its optimized output. This caused `_validate_template_variables` to raise an exception, falling back to the original unmodified prompt — silently defeating the optimization.

**Changes:**
1. The meta-prompt now explicitly instructs the LLM not to introduce new `{{ }}` patterns when the original prompt has no template variables.
2. `_validate_template_variables` now **strips** extra variables (with a warning log) instead of raising an exception. Missing variables still raise. This makes optimization resilient to LLM non-compliance while preserving safety for variable removal.

### How is this PR tested?

- [x] Manual tests

Tested end-to-end with `optimize_prompts()` on a plain system prompt (no template variables). Before the fix, optimization silently failed every time. After the fix, optimization succeeds and produces improved prompts.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. `optimize_prompts()` now works correctly with plain system prompts that have no template variables, instead of silently falling back to the original prompt.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request was AI-assisted by Isaac.