### PR TITLE
fix: handle `AsyncAPIResponse` in OpenAI agent streaming autolog trace

### DIFF
--- a/mlflow/openai/autolog.py
+++ b/mlflow/openai/autolog.py
@@ -359,6 +359,19 @@ def _end_span_on_success(
             _process_last_chunk(span, chunk, inputs, output, is_responses_api)
 
         result._iterator = _stream_output_logging_hook(result._iterator)
+    elif _is_async_api_response(result):
+        # When OpenAI Agent SDK uses streaming via `with_streaming_response`, the result
+        # is an AsyncAPIResponse. Its `parse()` method returns the actual stream object
+        # (e.g. AsyncStream). We wrap `parse()` so that once the parsed result is available,
+        # it is properly traced like any other stream or response.
+        original_parse = result.parse
+
+        async def _wrapped_parse(*args, **kwargs):
+            parsed = await original_parse(*args, **kwargs)
+            _end_span_on_success(span, inputs, parsed, is_responses_api)
+            return parsed
+
+        result.parse = _wrapped_parse
     else:
         try:
             set_span_chat_attributes(span, inputs, result)
@@ -490,6 +503,22 @@ def _is_response_output_item_done_event(chunk: Any) -> bool:
         from openai.types.responses import ResponseOutputItemDoneEvent
 
         return isinstance(chunk, ResponseOutputItemDoneEvent)
+    except ImportError:
+        return False
+
+
+def _is_async_api_response(result: Any) -> bool:
+    """Check if the result is an AsyncAPIResponse from the OpenAI SDK.
+
+    When the OpenAI Agent SDK fetches streaming responses, it uses
+    ``with_streaming_response`` which returns an ``AsyncAPIResponse`` instead of
+    the parsed stream directly.  We need to detect this so we can defer tracing
+    until ``parse()`` is called and the actual stream is available.
+    """
+    try:
+        from openai._response import AsyncAPIResponse
+
+        return isinstance(result, AsyncAPIResponse)
     except ImportError:
         return False
 


### PR DESCRIPTION
### Related Issues/PRs

Closes #22244

### What changes are proposed in this pull request?

When using the OpenAI Agent SDK with streaming (via `with_streaming_response`), the patched `AsyncResponses.create` returns an `AsyncAPIResponse` object instead of the parsed stream. MLflow's autolog currently does not recognise this type, so it logs the raw `AsyncAPIResponse` repr rather than properly tracing the streamed response content.

This PR adds:
- `_is_async_api_response()` helper in `mlflow/openai/autolog.py` to detect `AsyncAPIResponse` instances (with a safe import fallback).
- A new branch in `_end_span_on_success()` that wraps `AsyncAPIResponse.parse()` so that once the underlying `AsyncStream` is resolved, it is handed back for proper span event recording and output logging.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Manually verified with the OpenAI Agent SDK streaming example from #22244. The `AsyncAPIResponse` is now correctly detected and its `parse()` output is traced as a normal stream.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. OpenAI Agent SDK streaming responses are now properly traced by MLflow autolog instead of showing raw `AsyncAPIResponse` objects.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release