### PR TITLE
Fix download_artifacts and list_artifacts returning wrong status for missing artifacts

### DIFF
--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -22,8 +22,10 @@ from mlflow.exceptions import (
     MlflowTraceDataNotFound,
 )
 from mlflow.protos.databricks_pb2 import (
+    INTERNAL_ERROR,
     INVALID_PARAMETER_VALUE,
     RESOURCE_DOES_NOT_EXIST,
+    ErrorCode,
 )
 from mlflow.tracing.utils.artifact_utils import TRACE_DATA_FILE_NAME
 from mlflow.utils.annotations import developer_stable
@@ -337,11 +339,20 @@ class ArtifactRepository:
                 template.format(path=path, error=error, traceback=tracebacks[path])
                 for path, error in failed_downloads.items()
             )
+            error_codes = {
+                e.error_code
+                for e in failed_downloads.values()
+                if isinstance(e, MlflowException) and e.error_code != "INTERNAL_ERROR"
+            }
+            error_code = (
+                ErrorCode.Value(error_codes.pop()) if len(error_codes) == 1 else INTERNAL_ERROR
+            )
             raise MlflowException(
                 message=(
                     "The following failures occurred while downloading one or more"
                     f" artifacts from {self.artifact_uri}:\n{_truncate_error(failures)}"
-                )
+                ),
+                error_code=error_code,
             )
 
         return os.path.join(dst_path, artifact_path)

--- a/mlflow/store/artifact/local_artifact_repo.py
+++ b/mlflow/store/artifact/local_artifact_repo.py
@@ -112,11 +112,6 @@ class LocalArtifactRepository(ArtifactRepository):
                 for f in artifact_files
             ]
             return sorted(infos, key=lambda f: f.path)
-        elif path and not os.path.exists(list_dir):
-            raise MlflowException(
-                f"No such artifact: '{path}'",
-                error_code=RESOURCE_DOES_NOT_EXIST,
-            )
         else:
             return []
 

--- a/mlflow/store/artifact/local_artifact_repo.py
+++ b/mlflow/store/artifact/local_artifact_repo.py
@@ -2,6 +2,8 @@ import os
 import shutil
 from typing import Any
 
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
 from mlflow.store.artifact.artifact_repo import (
     ArtifactRepository,
     try_read_trace_data,
@@ -90,7 +92,10 @@ class LocalArtifactRepository(ArtifactRepository):
         local_artifact_path = os.path.join(self.artifact_dir, os.path.normpath(artifact_path))
         validate_path_within_directory(self.artifact_dir, local_artifact_path)
         if not os.path.exists(local_artifact_path):
-            raise OSError(f"No such file or directory: '{local_artifact_path}'")
+            raise MlflowException(
+                f"No such artifact: '{artifact_path}'",
+                error_code=RESOURCE_DOES_NOT_EXIST,
+            )
         return os.path.abspath(local_artifact_path)
 
     def list_artifacts(self, path=None):
@@ -107,6 +112,11 @@ class LocalArtifactRepository(ArtifactRepository):
                 for f in artifact_files
             ]
             return sorted(infos, key=lambda f: f.path)
+        elif path and not os.path.exists(list_dir):
+            raise MlflowException(
+                f"No such artifact: '{path}'",
+                error_code=RESOURCE_DOES_NOT_EXIST,
+            )
         else:
             return []
 
@@ -114,6 +124,11 @@ class LocalArtifactRepository(ArtifactRepository):
         remote_file_path = validate_path_is_safe(remote_file_path)
         remote_file_path = os.path.join(self.artifact_dir, os.path.normpath(remote_file_path))
         validate_path_within_directory(self.artifact_dir, remote_file_path)
+        if not os.path.exists(remote_file_path):
+            raise MlflowException(
+                f"No such artifact: '{os.path.relpath(remote_file_path, self.artifact_dir)}'",
+                error_code=RESOURCE_DOES_NOT_EXIST,
+            )
         shutil.copy2(remote_file_path, local_path)
 
     def delete_artifacts(self, artifact_path=None):

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -438,12 +438,12 @@ def test_model_load_input_example_failures():
         loaded_example = loaded_model.load_input_example(local_path)
         assert loaded_example is not None
 
-        with pytest.raises(MlflowException, match="No such file or directory"):
+        with pytest.raises(MlflowException, match="No such artifact"):
             loaded_model.load_input_example(os.path.join(local_path, "folder_which_does_not_exist"))
 
         path = os.path.join(local_path, loaded_model.saved_input_example_info["artifact_path"])
         os.remove(path)
-        with pytest.raises(MlflowException, match="No such file or directory"):
+        with pytest.raises(MlflowException, match="No such artifact"):
             loaded_model.load_input_example(local_path)
 
 

--- a/tests/store/artifact/test_local_artifact_repo.py
+++ b/tests/store/artifact/test_local_artifact_repo.py
@@ -328,3 +328,26 @@ def test_symlink_within_artifact_dir_allowed(
         artifacts = local_artifact_repo.list_artifacts("link_to_subdir")
         assert len(artifacts) == 1
         assert artifacts[0].path == "link_to_subdir/file.txt"
+
+
+def test_list_artifacts_nonexistent_path_raises(local_artifact_repo):
+    with pytest.raises(MlflowException) as exc_info:
+        local_artifact_repo.list_artifacts("nonexistent")
+    assert exc_info.value.error_code == "RESOURCE_DOES_NOT_EXIST"
+
+
+def test_list_artifacts_on_file_returns_empty(local_artifact_repo, local_artifact_root):
+    artifact_path = os.path.join(local_artifact_root, "file.txt")
+    with open(artifact_path, "w") as f:
+        f.write("data")
+    assert local_artifact_repo.list_artifacts("file.txt") == []
+
+
+@pytest.mark.parametrize("dst_path_provided", [True, False])
+def test_download_artifacts_nonexistent_raises_resource_does_not_exist(
+    local_artifact_repo, tmp_path, dst_path_provided
+):
+    dst = str(tmp_path) if dst_path_provided else None
+    with pytest.raises(MlflowException) as exc_info:
+        local_artifact_repo.download_artifacts("nonexistent.txt", dst_path=dst)
+    assert exc_info.value.error_code == "RESOURCE_DOES_NOT_EXIST"

--- a/tests/store/artifact/test_local_artifact_repo.py
+++ b/tests/store/artifact/test_local_artifact_repo.py
@@ -342,6 +342,6 @@ def test_download_artifacts_nonexistent_raises_resource_does_not_exist(
     local_artifact_repo, tmp_path, dst_path_provided
 ):
     dst = str(tmp_path) if dst_path_provided else None
-    with pytest.raises(MlflowException) as exc_info:
+    with pytest.raises(MlflowException, match="No such artifact") as exc_info:
         local_artifact_repo.download_artifacts("nonexistent.txt", dst_path=dst)
     assert exc_info.value.error_code == "RESOURCE_DOES_NOT_EXIST"

--- a/tests/store/artifact/test_local_artifact_repo.py
+++ b/tests/store/artifact/test_local_artifact_repo.py
@@ -330,12 +330,6 @@ def test_symlink_within_artifact_dir_allowed(
         assert artifacts[0].path == "link_to_subdir/file.txt"
 
 
-def test_list_artifacts_nonexistent_path_raises(local_artifact_repo):
-    with pytest.raises(MlflowException) as exc_info:
-        local_artifact_repo.list_artifacts("nonexistent")
-    assert exc_info.value.error_code == "RESOURCE_DOES_NOT_EXIST"
-
-
 def test_list_artifacts_on_file_returns_empty(local_artifact_repo, local_artifact_root):
     artifact_path = os.path.join(local_artifact_root, "file.txt")
     with open(artifact_path, "w") as f:


### PR DESCRIPTION

<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #22294 

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

- mlflow.artifacts.download_artifacts now send 404 errors when artifacts don't exist (instead of timing out)
<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
