### PR TITLE
Remove silent pip fallback when uv sync fails during model restore

### DIFF
--- a/mlflow/utils/virtualenv.py
+++ b/mlflow/utils/virtualenv.py
@@ -281,19 +281,23 @@ def _create_virtualenv(
             extra_env=env_creation_extra_env,
         )
 
-        # Try UV sync if model has uv.lock artifact and using UV env manager
-        uv_sync_succeeded = False
+        # Use UV sync if model has uv.lock artifact and using UV env manager
         if env_manager == em.UV and has_uv_lock_artifact(local_model_path):
-            _logger.info("Found uv.lock artifact, attempting UV sync for environment restoration")
-            if setup_uv_sync_environment(env_dir, local_model_path, python_env.python):
-                uv_sync_succeeded = run_uv_sync(env_dir, capture_output=capture_output)
-                if uv_sync_succeeded:
-                    _logger.info("UV sync completed successfully")
-                else:
-                    _logger.warning("UV sync failed, falling back to pip-based installation")
-
-        # Fall back to pip-based installation if UV sync was not used or failed
-        if not uv_sync_succeeded:
+            _logger.info("Found uv.lock artifact, restoring environment with uv sync")
+            if not setup_uv_sync_environment(env_dir, local_model_path, python_env.python):
+                raise MlflowException(
+                    "Failed to set up uv sync environment. Ensure the model's uv.lock "
+                    "and pyproject.toml artifacts are valid."
+                )
+            if not run_uv_sync(env_dir, capture_output=capture_output):
+                raise MlflowException(
+                    "Failed to restore model environment using uv sync. Ensure that uv is "
+                    "installed and the model's uv.lock artifact is valid. To install "
+                    "dependencies with pip instead, set the env_manager parameter to "
+                    "'virtualenv' instead of 'uv'."
+                )
+            _logger.info("UV sync completed successfully")
+        else:
             _logger.info("Installing dependencies")
             for deps in filter(None, [python_env.build_dependencies, python_env.dependencies]):
                 with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
### What changes are proposed in this pull request?

When a model is logged with the new uv-based dependency inference and `uv sync `fails at loat time, current MLflow fallback to pip-based installation. It does not use the locked dependency versions, so silently installs unpinned version, causing unexpected behavior or exposing the deployment to supply chain risks.

(This is not breaking change as the feature is to be released in 3.11)

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
