### PR TITLE
Fix: adding a tag with a key but empty value in the Experiments table silently failed with no user feedback

### DIFF
--- a/mlflow/server/js/src/common/hooks/useEditKeyValueTagsModal.test.tsx
+++ b/mlflow/server/js/src/common/hooks/useEditKeyValueTagsModal.test.tsx
@@ -20,12 +20,14 @@ describe('useEditKeyValueTagsModal', () => {
     allAvailableTags: string[],
     saveTagsHandler = jest.fn<Parameters<typeof useEditKeyValueTagsModal>[0]['saveTagsHandler']>(),
     onSuccess = jest.fn(),
+    valueRequired = false,
   ) {
     function TestComponent() {
       const { showEditTagsModal, EditTagsModal } = useEditKeyValueTagsModal({
         allAvailableTags,
         saveTagsHandler,
         onSuccess,
+        valueRequired,
       });
       return (
         <>
@@ -159,6 +161,33 @@ describe('useEditKeyValueTagsModal', () => {
       { key: 'tag1', value: 'tagvalue1' },
       { key: 'newtag', value: 'newvalue' },
     ]);
+  });
+
+  test('it should show a validation error when value is required but empty', async () => {
+    const saveHandlerFn = jest
+      .fn<Parameters<typeof useEditKeyValueTagsModal>[0]['saveTagsHandler']>()
+      .mockResolvedValue({});
+
+    renderTestComponent(existingTaggedEntity, ['tag1', 'tag2'], saveHandlerFn, jest.fn(), true);
+
+    // When click on trigger button to open modal
+    await userEvent.click(screen.getByRole('button', { name: 'trigger button' }));
+    expect(screen.getByRole('dialog', { name: /Add\/Edit tags/ })).toBeInTheDocument();
+
+    // Select a key but leave value empty
+    await userEvent.click(within(screen.getByRole('dialog')).getByRole('combobox'));
+    await userEvent.paste('newtag', {
+      clipboardData: { getData: jest.fn() },
+    } as any);
+    await userEvent.click(screen.getByText(/Add tag "newtag"/));
+    await userEvent.click(screen.getByLabelText('Add tag'));
+
+    // Then a validation error should be shown
+    expect(screen.getByText('A tag value is required')).toBeInTheDocument();
+    // And the tag should not have been added
+    expect(screen.queryByRole('status', { name: 'newtag' })).not.toBeInTheDocument();
+    // And the save handler should not have been called
+    expect(saveHandlerFn).not.toHaveBeenCalled();
   });
 
   test('it should properly display error when saving tags', async () => {

--- a/mlflow/server/js/src/common/hooks/useEditKeyValueTagsModal.tsx
+++ b/mlflow/server/js/src/common/hooks/useEditKeyValueTagsModal.tsx
@@ -125,6 +125,13 @@ export const useEditKeyValueTagsModal = <T extends { tags?: KeyValueEntity[] }>(
   const onSubmit = () => {
     // Do not accept form if no value provided while it's required
     if (valueRequired && !formValues.value.trim()) {
+      form.setError('value', {
+        type: 'required',
+        message: intl.formatMessage({
+          defaultMessage: 'A tag value is required',
+          description: 'Key-value tag editor modal > Value required error message',
+        }),
+      });
       return;
     }
 
@@ -248,7 +255,11 @@ export const useEditKeyValueTagsModal = <T extends { tags?: KeyValueEntity[] }>(
                 defaultMessage: 'Type a value',
                 description: 'Key-value tag editor modal > Value input placeholder',
               })}
+              validationState={form.formState.errors.value ? 'error' : undefined}
             />
+            {form.formState.errors.value && (
+              <FormUI.Message type="error" message={form.formState.errors.value.message} />
+            )}
           </div>
         </div>
         <Tooltip

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -6115,6 +6115,10 @@
     "defaultMessage": "Outputs",
     "description": "Table section name for schema outputs in the model comparison page"
   },
+  "buuQsF": {
+    "defaultMessage": "A tag value is required",
+    "description": "Key-value tag editor modal > Value required error message"
+  },
   "by+x8N": {
     "defaultMessage": "Type",
     "description": "Run page > Overview > Experiment ID section label"


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #22292

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
  Root cause:                                                                                                                                                       
                                                                                                                                                                   
  In useEditKeyValueTagsModal, the onSubmit handler silently returned when valueRequired was true and the value field was empty, giving the user no indication of what went wrong.                                                                                                                                                 
                                                                                                                                                                   
  Fix:                                                                                                                                                            
                                                                                                                                                                   
  - Call form.setError('value', ...) instead of silently returning, so react-hook-form tracks the validation failure.                                              
  - Add validationState="error" on the value input (red border) and a FormUI.Message below it to display the error text — consistent with the pattern used in      
  WebhookFormModal and other forms.                                                                                                                                
  - Add a unit test covering the scenario: key entered, value empty, valueRequired=true → error message shown, tag not added, save handler not called.             
    
### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
<img width="1962" height="1014" alt="image" src="https://github.com/user-attachments/assets/d861d618-c55c-421b-b4a0-1d833d99bef5" />

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
