### PR TITLE
Support `tool_reference` content blocks in Anthropic Chat UI parser

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/anthropic.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/anthropic.test.ts
@@ -145,4 +145,41 @@ describe('normalizeConversation', () => {
       expect(result?.[0]).not.toHaveProperty('reasoning');
     });
   });
+
+  describe('tool_reference content blocks', () => {
+    it('handles tool_result with tool_reference content', () => {
+      const input = {
+        messages: [
+          { role: 'user', content: 'search the web' },
+          {
+            role: 'assistant',
+            content: [
+              { type: 'tool_use', id: 'toolu_1', name: 'ToolSearch', input: { query: 'WebSearch' } },
+            ],
+          },
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: 'toolu_1',
+                content: [{ type: 'tool_reference', tool_name: 'WebSearch' }],
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = normalizeConversation(input, 'anthropic');
+      expect(result).not.toBeNull();
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            role: 'tool',
+            content: expect.stringContaining('WebSearch'),
+          }),
+        ]),
+      );
+    });
+  });
 });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/anthropic.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/anthropic.test.ts
@@ -153,9 +153,7 @@ describe('normalizeConversation', () => {
           { role: 'user', content: 'search the web' },
           {
             role: 'assistant',
-            content: [
-              { type: 'tool_use', id: 'toolu_1', name: 'ToolSearch', input: { query: 'WebSearch' } },
-            ],
+            content: [{ type: 'tool_use', id: 'toolu_1', name: 'ToolSearch', input: { query: 'WebSearch' } }],
           },
           {
             role: 'user',
@@ -188,9 +186,7 @@ describe('normalizeConversation', () => {
           { role: 'user', content: 'search for tools' },
           {
             role: 'assistant',
-            content: [
-              { type: 'tool_use', id: 'srvtoolu_01ABC', name: 'ToolSearch', input: { query: 'weather' } },
-            ],
+            content: [{ type: 'tool_use', id: 'srvtoolu_01ABC', name: 'ToolSearch', input: { query: 'weather' } }],
           },
           {
             role: 'user',

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/anthropic.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/anthropic.test.ts
@@ -181,5 +181,46 @@ describe('normalizeConversation', () => {
         ]),
       );
     });
+
+    it('handles tool_search_tool_result content block', () => {
+      const input = {
+        messages: [
+          { role: 'user', content: 'search for tools' },
+          {
+            role: 'assistant',
+            content: [
+              { type: 'tool_use', id: 'srvtoolu_01ABC', name: 'ToolSearch', input: { query: 'weather' } },
+            ],
+          },
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_search_tool_result',
+                tool_use_id: 'srvtoolu_01ABC',
+                content: {
+                  type: 'tool_search_tool_search_result',
+                  tool_references: [
+                    { type: 'tool_reference', tool_name: 'get_weather' },
+                    { type: 'tool_reference', tool_name: 'get_forecast' },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = normalizeConversation(input, 'anthropic');
+      expect(result).not.toBeNull();
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            role: 'tool',
+            content: expect.stringContaining('get_weather'),
+          }),
+        ]),
+      );
+    });
   });
 });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/anthropic.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/anthropic.ts
@@ -85,7 +85,15 @@ type AnthropicToolUseBlock = {
 };
 
 // Content blocks that can appear inside a tool_result
-type AnthropicToolResultContentBlock = AnthropicTextBlockParam | AnthropicImageBlockParam;
+type AnthropicToolReferenceBlockParam = {
+  tool_name: string;
+  type: 'tool_reference';
+};
+
+type AnthropicToolResultContentBlock =
+  | AnthropicTextBlockParam
+  | AnthropicImageBlockParam
+  | AnthropicToolReferenceBlockParam;
 
 type AnthropicToolResultBlockParam = {
   content: string | AnthropicToolResultContentBlock[];
@@ -93,12 +101,15 @@ type AnthropicToolResultBlockParam = {
   type: 'tool_result';
 };
 
-// Helper to validate content blocks inside tool_result (text or image)
+// Helper to validate content blocks inside tool_result (text, image, or tool_reference)
 const isAnthropicToolResultContentBlock = (obj: unknown): obj is AnthropicToolResultContentBlock => {
   if (isNil(obj) || !isObject(obj) || !has(obj, 'type')) {
     return false;
   }
   if (obj.type === 'text' && has(obj, 'text') && isString(obj.text)) {
+    return true;
+  }
+  if (obj.type === 'tool_reference' && has(obj, 'tool_name') && isString(obj.tool_name)) {
     return true;
   }
   if (obj.type === 'image' && has(obj, 'source') && has(obj.source, 'type')) {
@@ -233,7 +244,11 @@ const processAnthropicMessageContent = (
       // to convert to the final ModelTraceChatMessage format (with string content)
       const normalizedContent = isString(item.content)
         ? item.content
-        : item.content.map((block) => normalizeAnthropicContentBlockParam(block));
+        : item.content.map((block) =>
+            block.type === 'tool_reference'
+              ? { type: 'text' as const, text: `[Tool: ${block.tool_name}]` }
+              : normalizeAnthropicContentBlockParam(block),
+          );
       const toolMessage = prettyPrintChatMessage({
         type: 'message',
         role: 'tool',

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/anthropic.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/anthropic.ts
@@ -38,6 +38,7 @@ type AnthropicContentBlockParam =
   | AnthropicImageBlockParam
   | AnthropicToolUseBlockParam
   | AnthropicToolResultBlockParam
+  | AnthropicToolSearchToolResultBlockParam
   | AnthropicThinkingBlock;
 // | DocumentBlockParam
 // | RedactedThinkingBlockParam
@@ -99,6 +100,15 @@ type AnthropicToolResultBlockParam = {
   content: string | AnthropicToolResultContentBlock[];
   tool_use_id: string;
   type: 'tool_result';
+};
+
+type AnthropicToolSearchToolResultBlockParam = {
+  tool_use_id: string;
+  type: 'tool_search_tool_result';
+  content: {
+    type: 'tool_search_tool_search_result';
+    tool_references: AnthropicToolReferenceBlockParam[];
+  };
 };
 
 // Helper to validate content blocks inside tool_result (text, image, or tool_reference)
@@ -168,6 +178,10 @@ const isAnthropicContentBlockParam = (obj: unknown): obj is AnthropicContentBloc
       return isString(obj.tool_use_id) && contentValid;
     }
 
+    if (obj.type === 'tool_search_tool_result' && has(obj, 'tool_use_id') && has(obj, 'content')) {
+      return true;
+    }
+
     if (obj.type === 'thinking' && has(obj, 'thinking') && isString(obj.thinking)) {
       return true;
     }
@@ -188,7 +202,9 @@ const isAnthropicMessageParam = (obj: unknown): obj is AnthropicMessageParam => 
   return hasRole && hasContent;
 };
 
-const normalizeAnthropicContentBlockParam = (item: AnthropicContentBlockParam): ModelTraceContentParts => {
+const normalizeAnthropicContentBlockParam = (
+  item: AnthropicContentBlockParam | AnthropicToolReferenceBlockParam,
+): ModelTraceContentParts => {
   switch (item.type) {
     case 'text': {
       return { type: 'text', text: item.text };
@@ -209,6 +225,10 @@ const normalizeAnthropicContentBlockParam = (item: AnthropicContentBlockParam): 
           return { type: 'image_url', image_url: { url: item.source.url } };
         }
       }
+      break;
+    }
+    case 'tool_reference': {
+      return { type: 'text', text: `[Tool: ${item.tool_name}]` };
     }
   }
   throw new Error(`Unsupported content block type: ${(item as any).type}`);
@@ -244,11 +264,18 @@ const processAnthropicMessageContent = (
       // to convert to the final ModelTraceChatMessage format (with string content)
       const normalizedContent = isString(item.content)
         ? item.content
-        : item.content.map((block) =>
-            block.type === 'tool_reference'
-              ? { type: 'text' as const, text: `[Tool: ${block.tool_name}]` }
-              : normalizeAnthropicContentBlockParam(block),
-          );
+        : item.content.map(normalizeAnthropicContentBlockParam);
+      const toolMessage = prettyPrintChatMessage({
+        type: 'message',
+        role: 'tool',
+        tool_call_id: item.tool_use_id,
+        content: normalizedContent,
+      });
+      if (toolMessage) {
+        messages.push(toolMessage);
+      }
+    } else if (item.type === 'tool_search_tool_result') {
+      const normalizedContent = item.content.tool_references.map(normalizeAnthropicContentBlockParam);
       const toolMessage = prettyPrintChatMessage({
         type: 'message',
         role: 'tool',


### PR DESCRIPTION
### Related Issues/PRs

Relates to Claude Code tracing integration

### What changes are proposed in this pull request?

The Anthropic message parser in the Chat UI strictly validates content block types inside `tool_result` blocks. When a `tool_result` contains a `tool_reference` content block (used by Claude Code to reference dynamically loaded tools), the entire message validation fails and the Chat tab renders nothing.

This PR adds `tool_reference` as a valid content block type inside `tool_result`:
- Adds `AnthropicToolReferenceBlockParam` type (`{ type: 'tool_reference', tool_name: string }`)
- Validates `tool_reference` blocks in `isAnthropicToolResultContentBlock`
- Normalizes `tool_reference` blocks to text (`[Tool: {tool_name}]`) during rendering

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New test case: `handles tool_result with tool_reference content` verifies that messages containing `tool_reference` blocks inside `tool_result` are parsed and rendered correctly.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fix Chat UI not rendering for LLM spans whose input messages contain `tool_reference` content blocks inside `tool_result` (e.g., from Claude Code tracing).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release