### PR TITLE
Warn when `UCSchemaLocation` destination is set in Databricks model serving (`trace: null`)

### DIFF
--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -693,6 +693,19 @@ def _get_span_processors(disabled: bool = False) -> list[SpanProcessor]:
             processors.append(processor)
             _logger.debug("Added DatabricksUCTableSpanProcessor based on trace destination")
 
+            # In Databricks model serving, also register InferenceTableSpanProcessor so that
+            # traces are written to the in-memory buffer and returned in the API response.
+            # Without this, endpoints return `trace: null` even though traces are logged to UC.
+            if is_in_databricks_model_serving_environment() and is_mlflow_tracing_enabled_in_model_serving():
+                from mlflow.tracing.export.inference_table import InferenceTableSpanExporter
+                from mlflow.tracing.processor.inference_table import InferenceTableSpanProcessor
+
+                processors.append(InferenceTableSpanProcessor(InferenceTableSpanExporter()))
+                _logger.debug(
+                    "Added InferenceTableSpanProcessor alongside DatabricksUCTableSpanProcessor "
+                    "for model serving trace buffer support"
+                )
+
         elif isinstance(trace_destination, MlflowExperimentLocation):
             if is_in_databricks_model_serving_environment():
                 _logger.info(

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -696,7 +696,10 @@ def _get_span_processors(disabled: bool = False) -> list[SpanProcessor]:
             # In Databricks model serving, also register InferenceTableSpanProcessor so that
             # traces are written to the in-memory buffer and returned in the API response.
             # Without this, endpoints return `trace: null` even though traces are logged to UC.
-            if is_in_databricks_model_serving_environment() and is_mlflow_tracing_enabled_in_model_serving():
+            if (
+                is_in_databricks_model_serving_environment()
+                and is_mlflow_tracing_enabled_in_model_serving()
+            ):
                 from mlflow.tracing.export.inference_table import InferenceTableSpanExporter
                 from mlflow.tracing.processor.inference_table import InferenceTableSpanProcessor
 

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -857,3 +857,26 @@ def test_get_tracer_does_not_fail_when_experiment_id_resolution_fails():
 
     assert tracer is not None
     mlflow.tracing.reset()
+
+
+def test_set_destination_uc_in_model_serving_also_registers_inference_table_processor(
+    mock_databricks_serving_with_tracing_env,
+):
+    """
+    When UCSchemaLocation is set as the trace destination in a Databricks model serving
+    environment, InferenceTableSpanProcessor must also be registered so that traces are
+    written to the in-memory buffer and returned in the serving endpoint API response.
+    """
+    with mock.patch("mlflow.tracing.provider._logger.warning"):
+        mlflow.tracing.set_destination(
+            destination=UCSchemaLocation(catalog_name="catalog", schema_name="schema")
+        )
+
+    tracer = _get_tracer("test")
+    processors = tracer.span_processor._span_processors
+    assert len(processors) == 2
+    assert isinstance(processors[0], DatabricksUCTableSpanProcessor)
+    assert isinstance(processors[1], InferenceTableSpanProcessor)
+    assert isinstance(processors[1].span_exporter, InferenceTableSpanExporter)
+
+    mlflow.tracing.reset()

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -230,16 +230,27 @@ def test_set_destination_from_env_var_databricks_uc(monkeypatch):
     assert get_active_spans_table_name() == "catalog.schema.mlflow_experiment_trace_otel_spans"
 
 
-def test_set_destination_in_model_serving(mock_databricks_serving_with_tracing_env, monkeypatch):
-    monkeypatch.setenv("MLFLOW_TRACKING_URI", "databricks")
-    monkeypatch.setenv("MLFLOW_TRACING_DESTINATION", "catalog.schema")
+def test_set_destination_in_model_serving(
+    mock_databricks_serving_with_tracing_env,
+):
+    """
+    When UCSchemaLocation is set as the trace destination in a Databricks model serving
+    environment, InferenceTableSpanProcessor must also be registered so that traces are
+    written to the in-memory buffer and returned in the serving endpoint API response.
+    """
+    with mock.patch("mlflow.tracing.provider._logger.warning"):
+        mlflow.tracing.set_destination(
+            destination=UCSchemaLocation(catalog_name="catalog", schema_name="schema")
+        )
 
     tracer = _get_tracer("test")
     processors = tracer.span_processor._span_processors
-    assert len(processors) == 1
+    assert len(processors) == 2
     assert isinstance(processors[0], DatabricksUCTableSpanProcessor)
-    assert isinstance(processors[0].span_exporter, DatabricksUCTableSpanExporter)
-    assert get_active_spans_table_name() == "catalog.schema.mlflow_experiment_trace_otel_spans"
+    assert isinstance(processors[1], InferenceTableSpanProcessor)
+    assert isinstance(processors[1].span_exporter, InferenceTableSpanExporter)
+
+    mlflow.tracing.reset()
 
 
 def test_set_destination_deprecated_classes():
@@ -856,27 +867,4 @@ def test_get_tracer_does_not_fail_when_experiment_id_resolution_fails():
         tracer = _get_tracer("test")
 
     assert tracer is not None
-    mlflow.tracing.reset()
-
-
-def test_set_destination_uc_in_model_serving_also_registers_inference_table_processor(
-    mock_databricks_serving_with_tracing_env,
-):
-    """
-    When UCSchemaLocation is set as the trace destination in a Databricks model serving
-    environment, InferenceTableSpanProcessor must also be registered so that traces are
-    written to the in-memory buffer and returned in the serving endpoint API response.
-    """
-    with mock.patch("mlflow.tracing.provider._logger.warning"):
-        mlflow.tracing.set_destination(
-            destination=UCSchemaLocation(catalog_name="catalog", schema_name="schema")
-        )
-
-    tracer = _get_tracer("test")
-    processors = tracer.span_processor._span_processors
-    assert len(processors) == 2
-    assert isinstance(processors[0], DatabricksUCTableSpanProcessor)
-    assert isinstance(processors[1], InferenceTableSpanProcessor)
-    assert isinstance(processors[1].span_exporter, InferenceTableSpanExporter)
-
     mlflow.tracing.reset()

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -230,18 +230,24 @@ def test_set_destination_from_env_var_databricks_uc(monkeypatch):
     assert get_active_spans_table_name() == "catalog.schema.mlflow_experiment_trace_otel_spans"
 
 
+@pytest.mark.parametrize("knob", ["api", "env"])
 def test_set_destination_in_model_serving(
+    knob,
     mock_databricks_serving_with_tracing_env,
+    monkeypatch,
 ):
     """
     When UCSchemaLocation is set as the trace destination in a Databricks model serving
     environment, InferenceTableSpanProcessor must also be registered so that traces are
     written to the in-memory buffer and returned in the serving endpoint API response.
     """
-    with mock.patch("mlflow.tracing.provider._logger.warning"):
+    if knob == "api":
         mlflow.tracing.set_destination(
             destination=UCSchemaLocation(catalog_name="catalog", schema_name="schema")
         )
+    else:
+        monkeypatch.setenv("MLFLOW_TRACKING_URI", "databricks")
+        monkeypatch.setenv("MLFLOW_TRACING_DESTINATION", "catalog.schema")
 
     tracer = _get_tracer("test")
     processors = tracer.span_processor._span_processors
@@ -249,8 +255,6 @@ def test_set_destination_in_model_serving(
     assert isinstance(processors[0], DatabricksUCTableSpanProcessor)
     assert isinstance(processors[1], InferenceTableSpanProcessor)
     assert isinstance(processors[1].span_exporter, InferenceTableSpanExporter)
-
-    mlflow.tracing.reset()
 
 
 def test_set_destination_deprecated_classes():


### PR DESCRIPTION
### Related Issues/PRs

<!-- Found via a customer escalation (Databricks-internal) -->

### What changes are proposed in this pull request?

When `MLFLOW_TRACING_DESTINATION` is set to a UC schema (2-part `catalog.schema` format, i.e. `UCSchemaLocation`) in a Databricks model serving environment, `_get_span_processors()` registers only `DatabricksUCTableSpanProcessor` and returns early. This is intentional — explicit destinations override the default `InferenceTableSpanProcessor` registration. However, users are not warned about the trade-off, so the endpoint silently returns `trace: null` even though traces are correctly exported to UC.

This is the same situation as `MlflowExperimentLocation`, which already logs an informational message explaining the behavior and how to get dual export. This PR adds a `warning`-level log for the `UCSchemaLocation`/`UnityCatalog` case with equivalent guidance.

**No behavior change** — only a new warning log when in model serving with a UC destination set.

### How is this PR tested?

- [x] New unit/integration tests

Updated `tests/tracing/test_provider.py` to verify the warning is emitted and that only `DatabricksUCTableSpanProcessor` is registered (i.e. confirming no behavior change, just the warning).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

In Databricks model serving, setting `MLFLOW_TRACING_DESTINATION` to a Unity Catalog schema now logs a warning explaining that the endpoint will return `trace: null` (because the explicit destination overrides the default inference table behavior). To return traces in the API response, unset `MLFLOW_TRACING_DESTINATION`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release