### PR TITLE
Add `sqlstate`/`error_class` to `MlflowException` for error classification

### DIFF
--- a/mlflow/exceptions.py
+++ b/mlflow/exceptions.py
@@ -72,7 +72,9 @@ class MlflowException(Exception):
     instead.
     """
 
-    def __init__(self, message, error_code=INTERNAL_ERROR, **kwargs):
+    def __init__(
+        self, message, error_code=INTERNAL_ERROR, sqlstate=None, error_class=None, **kwargs
+    ):
         """
         Args:
             message: The message or exception describing the error that occurred. This will be
@@ -80,6 +82,9 @@ class MlflowException(Exception):
             error_code: An appropriate error code for the error that occurred; it will be
                 included in the exception's serialized JSON representation. This should
                 be one of the codes listed in the `mlflow.protos.databricks_pb2` proto.
+            sqlstate: A 5-character SQLSTATE code for error classification. Used by
+                Databricks reliability dashboards to categorize errors.
+            error_class: A descriptive error class name (e.g., "SCHEMA_ENFORCEMENT_FAILED").
             kwargs: Additional key-value pairs to include in the serialized JSON representation
                 of the MlflowException.
         """
@@ -89,11 +94,17 @@ class MlflowException(Exception):
             self.error_code = ErrorCode.Name(INTERNAL_ERROR)
         message = str(message)
         self.message = message
+        self.sqlstate = sqlstate
+        self.error_class = error_class
         self.json_kwargs = kwargs
         super().__init__(message)
 
     def serialize_as_json(self):
         exception_dict = {"error_code": self.error_code, "message": self.message}
+        if self.sqlstate is not None:
+            exception_dict["sqlstate"] = self.sqlstate
+        if self.error_class is not None:
+            exception_dict["error_class"] = self.error_class
         exception_dict.update(self.json_kwargs)
         return json.dumps(exception_dict)
 
@@ -101,16 +112,47 @@ class MlflowException(Exception):
         return ERROR_CODE_TO_HTTP_STATUS.get(self.error_code, 500)
 
     @classmethod
-    def invalid_parameter_value(cls, message, **kwargs):
+    def invalid_parameter_value(cls, message, sqlstate=None, error_class=None, **kwargs):
         """Constructs an `MlflowException` object with the `INVALID_PARAMETER_VALUE` error code.
 
         Args:
             message: The message describing the error that occurred. This will be included in the
                 exception's serialized JSON representation.
+            sqlstate: A 5-character SQLSTATE code for error classification.
+            error_class: A descriptive error class name.
             kwargs: Additional key-value pairs to include in the serialized JSON representation
                 of the MlflowException.
         """
-        return cls(message, error_code=INVALID_PARAMETER_VALUE, **kwargs)
+        return cls(
+            message,
+            error_code=INVALID_PARAMETER_VALUE,
+            sqlstate=sqlstate,
+            error_class=error_class,
+            **kwargs,
+        )
+
+
+_CP_ERROR_CODE_TO_SQLSTATE = {
+    "PERMISSION_DENIED": "KAMC1",
+    "CUSTOMER_UNAUTHORIZED": "KAMC1",
+    "UNAUTHENTICATED": "KAMC1",
+    "RESOURCE_DOES_NOT_EXIST": "KAMC2",
+    "ENDPOINT_NOT_FOUND": "KAMC2",
+    "NOT_FOUND": "KAMC2",
+    "REQUEST_LIMIT_EXCEEDED": "KAMC3",
+    "RESOURCE_EXHAUSTED": "KAMC3",
+    "INVALID_PARAMETER_VALUE": "KAMC4",
+    "BAD_REQUEST": "KAMC4",
+    "RESOURCE_ALREADY_EXISTS": "KAMC5",
+    "RESOURCE_CONFLICT": "KAMC5",
+    "INTERNAL_ERROR": "XXMC0",
+    "TEMPORARILY_UNAVAILABLE": "XXMC1",
+    "INVALID_STATE": "XXMC2",
+}
+
+
+def _get_cp_sqlstate(error_code):
+    return _CP_ERROR_CODE_TO_SQLSTATE.get(error_code)
 
 
 class RestException(MlflowException):
@@ -140,6 +182,15 @@ class RestException(MlflowException):
                     "e.g., within a proxy server or authentication / authorization service."
                 )
                 super().__init__(message)
+
+        # Preserve sqlstate/error_class from CP response if present, otherwise
+        # map from error_code to provide default classification for CP errors.
+        if "sqlstate" in json:
+            self.sqlstate = json["sqlstate"]
+        elif self.sqlstate is None:
+            self.sqlstate = _get_cp_sqlstate(self.error_code)
+        if "error_class" in json:
+            self.error_class = json["error_class"]
 
     def __reduce__(self):
         """

--- a/mlflow/genai/utils/data_validation.py
+++ b/mlflow/genai/utils/data_validation.py
@@ -58,7 +58,9 @@ def _validate_function_and_input_compatibility(
     # For other errors, show a generic error message
     raise MlflowException.invalid_parameter_value(
         "Failed to run the prediction function specified in the `predict_fn` "
-        f"parameter. Input: {sample_input}. Error: {e}\n\n"
+        f"parameter. Input: {sample_input}. Error: {e}\n\n",
+        sqlstate="KAM02",
+        error_class="PREDICTION_FUNCTION_FAILED",
     ) from e
 
 

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -1349,7 +1349,10 @@ def _enforce_datatype(data: Any, dtype: DataType, required=True):
         pd_series = _enforce_mlflow_datatype("", pd_series, dtype)
     except MlflowException:
         raise MlflowException(
-            f"Failed to enforce schema of data `{data}` with dtype `{dtype.name}`"
+            f"Failed to enforce schema of data `{data}` with dtype `{dtype.name}`",
+            error_code=INVALID_PARAMETER_VALUE,
+            sqlstate="KAM01",
+            error_class="SCHEMA_ENFORCEMENT_FAILED",
         )
     return pd_series[0]
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -739,7 +739,9 @@ def _validate_prediction_input(data: PyFuncInput, params, input_schema, params_s
                     f"with schema '{input_schema}'. "
                     f"Error: {e}"
                 )
-            raise MlflowException.invalid_parameter_value(message)
+            raise MlflowException.invalid_parameter_value(
+                message, sqlstate="KAM01", error_class="SCHEMA_ENFORCEMENT_FAILED"
+            )
     params = _enforce_params_schema(params, params_schema)
     if HAS_PYSPARK and isinstance(data, SparkDataFrame):
         _logger.warning(

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -1104,7 +1104,10 @@ def _save_model_with_class_artifacts_params(
             raise MlflowException(
                 "Failed to serialize Python model. Please save the model into a python file "
                 "and use code-based logging method instead. See"
-                "https://mlflow.org/docs/latest/models.html#models-from-code for more information."
+                "https://mlflow.org/docs/latest/models.html#models-from-code for more information.",
+                error_code=INVALID_PARAMETER_VALUE,
+                sqlstate="KAM03",
+                error_class="MODEL_SERIALIZATION_FAILED",
             ) from e
 
         custom_model_config_kwargs[CONFIG_KEY_PYTHON_MODEL] = saved_python_model_subpath

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -30,6 +30,7 @@ from mlflow.exceptions import (
     InvalidUrlException,
     MlflowException,
     RestException,
+    _get_cp_sqlstate,
     get_error_code,
 )
 from mlflow.protos import databricks_pb2
@@ -365,9 +366,11 @@ def verify_rest_response(
                 f"failed with error code {response.status_code} "
                 f"!= {expected_status}"
             )
+            error_code = get_error_code(response.status_code)
             raise MlflowException(
                 f"{base_msg}. Response body: '{response.text}'",
-                error_code=get_error_code(response.status_code),
+                error_code=error_code,
+                sqlstate=_get_cp_sqlstate(ErrorCode.Name(error_code)),
             )
 
     if response.status_code == 204:

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,6 +1,8 @@
 import json
 import pickle
 
+import pytest
+
 from mlflow.exceptions import MlflowException, RestException
 from mlflow.protos.databricks_pb2 import (
     ENDPOINT_NOT_FOUND,
@@ -84,3 +86,93 @@ def test_rest_exception_with_missing_error_code():
     exception = RestException({"message": "test message"})
     assert exception.error_code == "INTERNAL_ERROR"
     assert "test message" in str(exception)
+
+
+# --- sqlstate / error_class tests ---
+
+
+def test_sqlstate_default_none():
+    exc = MlflowException("test")
+    assert exc.sqlstate is None
+    assert exc.error_class is None
+
+
+def test_sqlstate_set_on_construction():
+    exc = MlflowException(
+        "test",
+        error_code=INVALID_PARAMETER_VALUE,
+        sqlstate="KAM01",
+        error_class="SCHEMA_ENFORCEMENT_FAILED",
+    )
+    assert exc.sqlstate == "KAM01"
+    assert exc.error_class == "SCHEMA_ENFORCEMENT_FAILED"
+
+
+def test_sqlstate_serialize_as_json_present():
+    exc = MlflowException("test", sqlstate="KAM01", error_class="SCHEMA_ENFORCEMENT_FAILED")
+    deserialized = json.loads(exc.serialize_as_json())
+    assert deserialized["sqlstate"] == "KAM01"
+    assert deserialized["error_class"] == "SCHEMA_ENFORCEMENT_FAILED"
+
+
+def test_sqlstate_serialize_as_json_absent_when_none():
+    exc = MlflowException("test")
+    deserialized = json.loads(exc.serialize_as_json())
+    assert "sqlstate" not in deserialized
+    assert "error_class" not in deserialized
+
+
+def test_invalid_parameter_value_with_sqlstate():
+    exc = MlflowException.invalid_parameter_value(
+        "bad input", sqlstate="KAM02", error_class="PREDICTION_FUNCTION_FAILED"
+    )
+    assert exc.error_code == "INVALID_PARAMETER_VALUE"
+    assert exc.sqlstate == "KAM02"
+    assert exc.error_class == "PREDICTION_FUNCTION_FAILED"
+
+
+def test_rest_exception_maps_cp_sqlstate():
+    exc = RestException({"error_code": "PERMISSION_DENIED", "message": "no access"})
+    assert exc.sqlstate == "KAMC1"
+
+
+@pytest.mark.parametrize(
+    ("error_code", "expected_sqlstate"),
+    [
+        ("PERMISSION_DENIED", "KAMC1"),
+        ("RESOURCE_DOES_NOT_EXIST", "KAMC2"),
+        ("REQUEST_LIMIT_EXCEEDED", "KAMC3"),
+        ("INVALID_PARAMETER_VALUE", "KAMC4"),
+        ("INTERNAL_ERROR", "XXMC0"),
+        ("TEMPORARILY_UNAVAILABLE", "XXMC1"),
+        ("INVALID_STATE", "XXMC2"),
+    ],
+)
+def test_rest_exception_cp_sqlstate_mapping(error_code, expected_sqlstate):
+    exc = RestException({"error_code": error_code, "message": "test"})
+    assert exc.sqlstate == expected_sqlstate
+
+
+def test_rest_exception_preserves_sqlstate_from_json():
+    exc = RestException({
+        "error_code": "PERMISSION_DENIED",
+        "message": "no access",
+        "sqlstate": "CUSTOM",
+        "error_class": "CUSTOM_CLASS",
+    })
+    assert exc.sqlstate == "CUSTOM"
+    assert exc.error_class == "CUSTOM_CLASS"
+
+
+def test_rest_exception_pickle_with_sqlstate():
+    e1 = RestException({"error_code": "PERMISSION_DENIED", "message": "no access"})
+    e2 = pickle.loads(pickle.dumps(e1))
+    assert e1.error_code == e2.error_code
+    assert e1.message == e2.message
+    assert e1.sqlstate == e2.sqlstate
+
+
+def test_rest_exception_unrecognized_error_code_no_sqlstate():
+    exc = RestException({"error_code": "weird error", "messages": "something"})
+    # Unrecognized error codes fall back to INTERNAL_ERROR, which maps to XXMC0
+    assert exc.sqlstate == "XXMC0"


### PR DESCRIPTION
### Related Issues/PRs

Relates to internal Jira: Classify errors originating from the mlflow python package

### What changes are proposed in this pull request?

Add `sqlstate` and `error_class` parameters to `MlflowException` for error classification, enabling Databricks reliability dashboards to categorize MLflow errors.

**Infrastructure changes (`mlflow/exceptions.py`):**
- Add `sqlstate` and `error_class` params to `MlflowException.__init__()` (default `None`, backward compatible)
- Update `serialize_as_json()` to include these fields when present
- Update `invalid_parameter_value()` classmethod to pass through `sqlstate`/`error_class`
- Add `_CP_ERROR_CODE_TO_SQLSTATE` mapping for `RestException` to auto-classify control plane errors (permission denied, resource not found, rate limiting, etc.)

**Client-side error classification (top patterns from production logs):**
- Schema enforcement failures → `KAM01` / `SCHEMA_ENFORCEMENT_FAILED`
- Prediction function failures → `KAM02` / `PREDICTION_FUNCTION_FAILED`
- Model serialization failures → `KAM03` / `MODEL_SERIALIZATION_FAILED`

Also fixes two raise sites that incorrectly defaulted to `INTERNAL_ERROR` when they should use `INVALID_PARAMETER_VALUE` (`mlflow/models/utils.py:1351`, `mlflow/pyfunc/model.py:1104`).

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

16 new tests in `tests/test_exceptions.py` covering sqlstate/error_class construction, JSON serialization, `RestException` CP mapping, pickle round-trip, and backward compatibility.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release