### PR TITLE
Add deltalake-backed pandas and polars options to mlflow.data.load_delta

### DIFF
--- a/mlflow/data/spark_dataset.py
+++ b/mlflow/data/spark_dataset.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from functools import cached_property
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from packaging.version import Version
 
@@ -230,7 +230,8 @@ def load_delta(
     targets: str | None = None,
     name: str | None = None,
     digest: str | None = None,
-) -> SparkDataset:
+    dataset_type: Literal["spark", "pandas", "polars"] = "spark",
+) -> SparkDataset | "PandasDataset" | "PolarsDataset":
     """
     Loads a :py:class:`SparkDataset <mlflow.data.spark_dataset.SparkDataset>` from a Delta table
     for use with MLflow Tracking.
@@ -246,14 +247,23 @@ def load_delta(
             automatically generated.
         digest: The digest (hash, fingerprint) of the dataset. If unspecified, a digest
             is automatically computed.
+        dataset_type: The dataset type to load. ``spark`` uses Spark to return a
+            :py:class:`SparkDataset <mlflow.data.spark_dataset.SparkDataset>`. ``pandas`` and
+            ``polars`` use the optional ``deltalake`` package to return
+            :py:class:`PandasDataset <mlflow.data.pandas_dataset.PandasDataset>` and
+            :py:class:`PolarsDataset <mlflow.data.polars_dataset.PolarsDataset>`, respectively.
+            ``pandas`` and ``polars`` require ``path`` to be specified.
 
     Returns:
-        An instance of :py:class:`SparkDataset <mlflow.data.spark_dataset.SparkDataset>`.
+        An instance of :py:class:`SparkDataset <mlflow.data.spark_dataset.SparkDataset>`,
+        :py:class:`PandasDataset <mlflow.data.pandas_dataset.PandasDataset>`, or
+        :py:class:`PolarsDataset <mlflow.data.polars_dataset.PolarsDataset>`.
     """
-    from mlflow.data.spark_delta_utils import (
-        _try_get_delta_table_latest_version_from_path,
-        _try_get_delta_table_latest_version_from_table_name,
-    )
+    if dataset_type not in {"spark", "pandas", "polars"}:
+        raise MlflowException(
+            "`dataset_type` must be one of 'spark', 'pandas', or 'polars'.",
+            INVALID_PARAMETER_VALUE,
+        )
 
     if (path, table_name).count(None) != 1:
         raise MlflowException(
@@ -261,7 +271,12 @@ def load_delta(
             INVALID_PARAMETER_VALUE,
         )
 
-    if version is None:
+    if version is None and dataset_type == "spark":
+        from mlflow.data.spark_delta_utils import (
+            _try_get_delta_table_latest_version_from_path,
+            _try_get_delta_table_latest_version_from_table_name,
+        )
+
         if path is not None:
             version = _try_get_delta_table_latest_version_from_path(path)
         else:
@@ -270,7 +285,58 @@ def load_delta(
     if name is None and table_name is not None:
         name = table_name + (f"@v{version}" if version is not None else "")
 
-    source = DeltaDatasetSource(path=path, delta_table_name=table_name, delta_table_version=version)
+    source = DeltaDatasetSource(
+        path=path,
+        delta_table_name=table_name,
+        delta_table_version=version,
+    )
+
+    if dataset_type != "spark":
+        if path is None:
+            raise MlflowException(
+                "`dataset_type='pandas'` and `dataset_type='polars'` require `path`.",
+                INVALID_PARAMETER_VALUE,
+            )
+
+        try:
+            from deltalake import DeltaTable
+        except ImportError as e:
+            raise MlflowException(
+                "The `deltalake` package is required when `dataset_type` is 'pandas' or"
+                " 'polars'. Install it with `pip install deltalake`.",
+                INVALID_PARAMETER_VALUE,
+            ) from e
+
+        delta_table = DeltaTable(path, version=version)
+        if source.delta_table_version is None:
+            source = DeltaDatasetSource(
+                path=path,
+                delta_table_name=table_name,
+                delta_table_version=delta_table.version(),
+            )
+
+        if dataset_type == "pandas":
+            from mlflow.data.pandas_dataset import from_pandas
+
+            return from_pandas(
+                df=delta_table.to_pandas(),
+                source=source,
+                targets=targets,
+                name=name,
+                digest=digest,
+            )
+
+        from mlflow.data.polars_dataset import from_polars
+        import polars as pl
+
+        return from_polars(
+            df=pl.from_arrow(delta_table.to_pyarrow_table()),
+            source=source,
+            targets=targets,
+            name=name,
+            digest=digest,
+        )
+
     df = source.load()
 
     return SparkDataset(

--- a/tests/data/test_load_delta_dataset_types.py
+++ b/tests/data/test_load_delta_dataset_types.py
@@ -1,0 +1,63 @@
+import sys
+from types import SimpleNamespace
+from unittest import mock
+
+import pandas as pd
+import pytest
+
+import mlflow.data
+from mlflow.data.delta_dataset_source import DeltaDatasetSource
+from mlflow.exceptions import MlflowException
+
+
+def test_load_delta_invalid_dataset_type_raises():
+    with pytest.raises(
+        MlflowException,
+        match="`dataset_type` must be one of 'spark', 'pandas', or 'polars'",
+    ):
+        mlflow.data.load_delta(path="/tmp/delta", dataset_type="duckdb")
+
+
+def test_load_delta_non_spark_requires_path():
+    with pytest.raises(
+        MlflowException,
+        match="`dataset_type='pandas'` and `dataset_type='polars'` require `path`",
+    ):
+        mlflow.data.load_delta(table_name="my_table", dataset_type="pandas")
+
+
+def test_load_delta_pandas_uses_deltalake(monkeypatch):
+    class FakeDeltaTable:
+        def __init__(self, path, version=None):
+            self.path = path
+            self._version = version
+
+        def version(self):
+            return 5
+
+        def to_pandas(self):
+            return pd.DataFrame({"feature": [1], "target": [0]})
+
+    monkeypatch.setitem(sys.modules, "deltalake", SimpleNamespace(DeltaTable=FakeDeltaTable))
+
+    expected_dataset = object()
+    with mock.patch(
+        "mlflow.data.pandas_dataset.from_pandas", return_value=expected_dataset
+    ) as from_pandas:
+        result = mlflow.data.load_delta(
+            path="/tmp/delta",
+            dataset_type="pandas",
+            targets="target",
+            name="my-delta-dataset",
+            digest="123",
+        )
+
+    assert result is expected_dataset
+    from_pandas.assert_called_once()
+    call_kwargs = from_pandas.call_args.kwargs
+    assert isinstance(call_kwargs["source"], DeltaDatasetSource)
+    assert call_kwargs["source"].path == "/tmp/delta"
+    assert call_kwargs["source"].delta_table_version == 5
+    assert call_kwargs["targets"] == "target"
+    assert call_kwargs["name"] == "my-delta-dataset"
+    assert call_kwargs["digest"] == "123"


### PR DESCRIPTION
### Related Issues/PRs

Closes #11960

### What changes are proposed in this pull request?

This PR extends mlflow.data.load_delta with a dataset_type option so Delta tables can be loaded without Spark when using the optional deltalake package.

- add dataset_type (spark default, plus pandas and polars) to mlflow.data.load_delta
- preserve existing Spark behavior for default usage
- for pandas / polars, load with deltalake.DeltaTable and return PandasDataset / PolarsDataset
- validate non-Spark usage (path required) and return clear dependency error when deltalake is missing
- add tests for dataset type validation and deltalake-backed pandas loading

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Attempted locally:

- python3 -m py_compile mlflow/data/spark_dataset.py tests/data/test_load_delta_dataset_types.py
- uv run pytest tests/data/test_load_delta_dataset_types.py (blocked: uv unavailable in current environment)
- python3 -m pytest tests/data/test_load_delta_dataset_types.py (blocked: pytest unavailable in current environment)

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the MLflow Skills repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

mlflow.data.load_delta now supports optional non-Spark loading paths via dataset_type=pandas and dataset_type=polars when deltalake is installed.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] area/tracking
- [ ] area/models
- [ ] area/model-registry
- [ ] area/scoring
- [ ] area/evaluation
- [ ] area/gateway
- [ ] area/prompts
- [ ] area/tracing
- [ ] area/projects
- [ ] area/uiux
- [ ] area/build
- [ ] area/docs

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] rn/none
- [ ] rn/breaking-change
- [x] rn/feature
- [ ] rn/bug-fix
- [ ] rn/documentation

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release