### PR TITLE
feat: Add numeric comparators for feedback/expectation filters in search_traces

### DIFF
--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -1735,7 +1735,19 @@ class SearchTraceUtils(SearchUtils):
     VALID_STRING_ATTRIBUTE_COMPARATORS = {"!=", "=", "IN", "NOT IN", "LIKE", "ILIKE", "RLIKE"}
     VALID_SPAN_ATTRIBUTE_COMPARATORS = {"!=", "=", "IN", "NOT IN", "LIKE", "ILIKE", "RLIKE"}
     VALID_METADATA_COMPARATORS = {"!=", "=", "LIKE", "ILIKE", "RLIKE", "IS NULL", "IS NOT NULL"}
-    VALID_ASSESSMENT_COMPARATORS = {"!=", "=", "LIKE", "ILIKE", "RLIKE", "IS NULL", "IS NOT NULL"}
+    VALID_ASSESSMENT_COMPARATORS = {
+        "!=",
+        "=",
+        ">",
+        "<",
+        ">=",
+        "<=",
+        "LIKE",
+        "ILIKE",
+        "RLIKE",
+        "IS NULL",
+        "IS NOT NULL",
+    }
 
     _REQUEST_METADATA_IDENTIFIER = "request_metadata"
     _TAG_IDENTIFIER = "tag"
@@ -2036,6 +2048,24 @@ class SearchTraceUtils(SearchUtils):
                 clause = sa.not_(clause)
             return clause
 
+        _NUMERIC_COMPARATORS = {">", "<", ">=", "<="}
+
+        if comparator in _NUMERIC_COMPARATORS:
+
+            def numeric_json_comparison(column: "ColumnElement", value: str) -> "ClauseElement":
+                try:
+                    numeric_value = float(value)
+                except (ValueError, TypeError):
+                    raise MlflowException(
+                        f"Invalid numeric value '{value}' for comparator '{comparator}'. "
+                        "Numeric comparators (>, <, >=, <=) require numeric values.",
+                        error_code=INVALID_PARAMETER_VALUE,
+                    )
+                casted_column = sa.cast(column, sa.Float)
+                return SearchUtils.get_comparison_func(comparator)(casted_column, numeric_value)
+
+            return numeric_json_comparison
+
         if comparator not in ("=", "!="):
             return SearchTraceUtils.get_sql_comparison_func(comparator, dialect)
         elif dialect == MYSQL:
@@ -2144,14 +2174,14 @@ class SearchTraceUtils(SearchUtils):
             cls._EXPECTATION_IDENTIFIER,
             cls._ISSUE_IDENTIFIER,
         ):
-            # Feedback and expectation values are stored as JSON, so we expect string values
             if token.ttype in cls.STRING_VALUE_TYPES or isinstance(token, Identifier):
                 return cls._strip_quotes(token.value, expect_quoted_value=True)
+            elif token.ttype in cls.NUMERIC_VALUE_TYPES:
+                return token.value
             else:
                 raise MlflowException(
-                    "Expected a quoted string value for "
-                    f"{identifier_type} (e.g. 'my-value'). Got value "
-                    f"{token.value}",
+                    "Expected a quoted string value or numeric value for "
+                    f"{identifier_type}. Got value {token.value}",
                     error_code=INVALID_PARAMETER_VALUE,
                 )
         else:

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -6147,6 +6147,85 @@ def test_search_traces_with_feedback_and_expectation_filters(store: SqlAlchemySt
     assert len(traces) == 0
 
 
+def test_search_traces_with_numeric_feedback_comparators(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("test_numeric_feedback_search")
+
+    trace1_id = "trace1"
+    trace2_id = "trace2"
+    trace3_id = "trace3"
+    trace4_id = "trace4"
+
+    _create_trace(store, trace1_id, exp_id)
+    _create_trace(store, trace2_id, exp_id)
+    _create_trace(store, trace3_id, exp_id)
+    _create_trace(store, trace4_id, exp_id)
+
+    source = AssessmentSource(source_type="HUMAN", source_id="user@example.com")
+
+    # Create feedback with numeric values
+    store.create_assessment(
+        Feedback(trace_id=trace1_id, name="score", value=25.0, source=source)
+    )
+    store.create_assessment(
+        Feedback(trace_id=trace2_id, name="score", value=50.0, source=source)
+    )
+    store.create_assessment(
+        Feedback(trace_id=trace3_id, name="score", value=75.0, source=source)
+    )
+    store.create_assessment(
+        Feedback(trace_id=trace4_id, name="score", value=100.0, source=source)
+    )
+
+    # Create expectations with numeric values
+    store.create_assessment(
+        Expectation(trace_id=trace1_id, name="latency", value=100, source=source)
+    )
+    store.create_assessment(
+        Expectation(trace_id=trace2_id, name="latency", value=200, source=source)
+    )
+
+    # Test: greater than
+    traces, _ = store.search_traces([exp_id], filter_string="feedback.score > 50")
+    assert sorted(t.request_id for t in traces) == ["trace3", "trace4"]
+
+    # Test: greater than or equal
+    traces, _ = store.search_traces([exp_id], filter_string="feedback.score >= 50")
+    assert sorted(t.request_id for t in traces) == ["trace2", "trace3", "trace4"]
+
+    # Test: less than
+    traces, _ = store.search_traces([exp_id], filter_string="feedback.score < 50")
+    assert len(traces) == 1
+    assert traces[0].request_id == trace1_id
+
+    # Test: less than or equal
+    traces, _ = store.search_traces([exp_id], filter_string="feedback.score <= 50")
+    assert sorted(t.request_id for t in traces) == ["trace1", "trace2"]
+
+    # Test: combined range query
+    traces, _ = store.search_traces(
+        [exp_id],
+        filter_string="feedback.score > 25 AND feedback.score < 100",
+    )
+    assert sorted(t.request_id for t in traces) == ["trace2", "trace3"]
+
+    # Test: numeric comparators on expectations
+    traces, _ = store.search_traces([exp_id], filter_string="expectation.latency > 150")
+    assert len(traces) == 1
+    assert traces[0].request_id == trace2_id
+
+    traces, _ = store.search_traces([exp_id], filter_string="expectation.latency <= 100")
+    assert len(traces) == 1
+    assert traces[0].request_id == trace1_id
+
+    # Test: float comparison values
+    traces, _ = store.search_traces([exp_id], filter_string="feedback.score >= 75.0")
+    assert sorted(t.request_id for t in traces) == ["trace3", "trace4"]
+
+    # Test: no matches
+    traces, _ = store.search_traces([exp_id], filter_string="feedback.score > 100")
+    assert len(traces) == 0
+
+
 def test_search_traces_with_run_id(store: SqlAlchemyStore):
     exp_id = store.create_experiment("test_run_id")
     run1_id = "run1"

--- a/tests/utils/test_search_utils.py
+++ b/tests/utils/test_search_utils.py
@@ -826,3 +826,34 @@ def test_search_trace_utils_filter_metadata_is_null():
 
     result = SearchTraceUtils.filter(traces, "metadata.session IS NOT NULL")
     assert {t.trace_id for t in result} == {"t1"}
+
+
+@pytest.mark.parametrize(
+    ("filter_string", "expected_comparator", "expected_value"),
+    [
+        ("feedback.score > 50", ">", "50"),
+        ("feedback.score < 0.5", "<", "0.5"),
+        ("feedback.score >= 75", ">=", "75"),
+        ("feedback.score <= 100.0", "<=", "100.0"),
+        ("expectation.latency > 200", ">", "200"),
+        ("expectation.latency < 1000", "<", "1000"),
+    ],
+)
+def test_search_trace_utils_parse_numeric_assessment_comparators(
+    filter_string, expected_comparator, expected_value
+):
+    parsed = SearchTraceUtils.parse_search_filter_for_search_traces(filter_string)
+    assert len(parsed) == 1
+    assert parsed[0]["comparator"] == expected_comparator
+    assert parsed[0]["value"] == expected_value
+
+
+def test_search_trace_utils_parse_numeric_assessment_combined_filter():
+    parsed = SearchTraceUtils.parse_search_filter_for_search_traces(
+        "feedback.score > 0 AND feedback.score <= 50"
+    )
+    assert len(parsed) == 2
+    assert parsed[0]["comparator"] == ">"
+    assert parsed[0]["value"] == "0"
+    assert parsed[1]["comparator"] == "<="
+    assert parsed[1]["value"] == "50"


### PR DESCRIPTION
### Related Issues/PRs

Closes #21774

### What changes are proposed in this pull request?

Adds numeric comparators (`>`, `<`, `>=`, `<=`) for `feedback.*` and `expectation.*` filters in `search_traces`. Previously, only string comparators (`=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`, `IS NULL`, `IS NOT NULL`) were supported, making range queries on numeric feedback values impossible.

Changes:
- Added `>`, `<`, `>=`, `<=` to `VALID_ASSESSMENT_COMPARATORS` in `search_utils.py`
- Added numeric JSON comparison handler in `_get_sql_json_comparison_func` that casts the `SqlAssessments.value` column to `Float` for numeric comparisons
- Updated `_get_value` to accept unquoted numeric literals for feedback/expectation filters

Users can now write queries like:
```python
mlflow.search_traces(filter_string="feedback.score >= 0.9")
mlflow.search_traces(filter_string="feedback.score > 50 AND feedback.score <= 100")
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

New tests added:
- `test_search_traces_with_numeric_feedback_comparators` in `tests/store/tracking/test_sqlalchemy_store.py` — integration tests covering `>`, `>=`, `<`, `<=`, combined range queries, float values, and expectations
- `test_search_trace_utils_parse_numeric_assessment_comparators` and `test_search_trace_utils_parse_numeric_assessment_combined_filter` in `tests/utils/test_search_utils.py` — parsing tests for all numeric comparators on both feedback and expectation

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. `search_traces` now supports numeric comparators (`>`, `<`, `>=`, `<=`) for `feedback.*` and `expectation.*` filters, enabling range queries on numeric feedback values.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release