### PR TITLE
fix: add support for pandas 3.x by removing upper version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
   "opentelemetry-proto<3,>=1.9.0",
   "opentelemetry-sdk<3,>=1.9.0",
   "packaging<27",
-  "pandas<3",
+  "pandas>=1.3.0",
   "protobuf<8,>=3.12.0",
   "pyarrow<24,>=4.0.0",
   "pydantic<3,>=2.0.0",


### PR DESCRIPTION
## Related Issues/PRs
Closes #22349

## What changes are proposed in this pull request?
Removes the `pandas<3` upper version constraint in `pyproject.toml`
to allow compatibility with pandas 3.x releases.

## How is this PR tested?
- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

## Does this PR require documentation update?
- [x] No.

## Does this PR require updating the MLflow Skills repository?
- [x] No.

## Is this a user-facing change?
- [x] No.

## What component(s) does this PR affect?
- [x] `area/build` : Build and test infrastructure for MLflow

## How should the PR be classified in the release notes?
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

## Is this PR a critical bugfix or security fix?
No.