### PR TITLE
Revert "Register `InferenceTableSpanProcessor` alongside `DatabricksUCTableSpanProcessor` in model serving (#22332)"

### DIFF
--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -693,22 +693,6 @@ def _get_span_processors(disabled: bool = False) -> list[SpanProcessor]:
             processors.append(processor)
             _logger.debug("Added DatabricksUCTableSpanProcessor based on trace destination")
 
-            # In Databricks model serving, also register InferenceTableSpanProcessor so that
-            # traces are written to the in-memory buffer and returned in the API response.
-            # Without this, endpoints return `trace: null` even though traces are logged to UC.
-            if (
-                is_in_databricks_model_serving_environment()
-                and is_mlflow_tracing_enabled_in_model_serving()
-            ):
-                from mlflow.tracing.export.inference_table import InferenceTableSpanExporter
-                from mlflow.tracing.processor.inference_table import InferenceTableSpanProcessor
-
-                processors.append(InferenceTableSpanProcessor(InferenceTableSpanExporter()))
-                _logger.debug(
-                    "Added InferenceTableSpanProcessor alongside DatabricksUCTableSpanProcessor "
-                    "for model serving trace buffer support"
-                )
-
         elif isinstance(trace_destination, MlflowExperimentLocation):
             if is_in_databricks_model_serving_environment():
                 _logger.info(

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -230,31 +230,16 @@ def test_set_destination_from_env_var_databricks_uc(monkeypatch):
     assert get_active_spans_table_name() == "catalog.schema.mlflow_experiment_trace_otel_spans"
 
 
-@pytest.mark.parametrize("knob", ["api", "env"])
-def test_set_destination_in_model_serving(
-    knob,
-    mock_databricks_serving_with_tracing_env,
-    monkeypatch,
-):
-    """
-    When UCSchemaLocation is set as the trace destination in a Databricks model serving
-    environment, InferenceTableSpanProcessor must also be registered so that traces are
-    written to the in-memory buffer and returned in the serving endpoint API response.
-    """
-    if knob == "api":
-        mlflow.tracing.set_destination(
-            destination=UCSchemaLocation(catalog_name="catalog", schema_name="schema")
-        )
-    else:
-        monkeypatch.setenv("MLFLOW_TRACKING_URI", "databricks")
-        monkeypatch.setenv("MLFLOW_TRACING_DESTINATION", "catalog.schema")
+def test_set_destination_in_model_serving(mock_databricks_serving_with_tracing_env, monkeypatch):
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", "databricks")
+    monkeypatch.setenv("MLFLOW_TRACING_DESTINATION", "catalog.schema")
 
     tracer = _get_tracer("test")
     processors = tracer.span_processor._span_processors
-    assert len(processors) == 2
+    assert len(processors) == 1
     assert isinstance(processors[0], DatabricksUCTableSpanProcessor)
-    assert isinstance(processors[1], InferenceTableSpanProcessor)
-    assert isinstance(processors[1].span_exporter, InferenceTableSpanExporter)
+    assert isinstance(processors[0].span_exporter, DatabricksUCTableSpanExporter)
+    assert get_active_spans_table_name() == "catalog.schema.mlflow_experiment_trace_otel_spans"
 
 
 def test_set_destination_deprecated_classes():


### PR DESCRIPTION
### Related Issues/PRs

Reverts #22332. Superseded by #22353.

### What changes are proposed in this pull request?

\#22332 registered `InferenceTableSpanProcessor` alongside `DatabricksUCTableSpanProcessor` in model serving when a UC trace destination is set, so that `_TRACE_BUFFER` is populated and endpoints can return traces in API responses.

However, it introduced a duplicate-write bug: when `MLFLOW_EXPERIMENT_ID` is also set (which `agents.deploy()` does automatically), both `DatabricksUCTableSpanExporter` (via `MlflowV3SpanExporter`) and `InferenceTableSpanExporter` call `start_trace` on the MLflow backend — writing the same trace twice.

\#22353 fixes this properly by making `InferenceTableSpanExporter` skip the MLflow backend write when a UC destination is active (deferring to `DatabricksUCTableSpanProcessor`). This revert exists as a safety option if #22353 needs more review time but the duplicate-write regression needs to be addressed urgently.

**If #22353 merges first, this PR can be closed.**

### How is this PR tested?

- [x] Existing unit/integration tests (restores pre-#22332 behavior)

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Reverts the behavior introduced in #22332 (registering `InferenceTableSpanProcessor` alongside `DatabricksUCTableSpanProcessor` in model serving). Superseded by #22353 which fixes the same issue correctly without the duplicate MLflow backend write.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release