### PR TITLE
Hide provider-specific starter code tab for multi-provider endpoints

### DIFF
--- a/mlflow/server/js/src/gateway/components/edit-endpoint/EditEndpointFormRenderer.tsx
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/EditEndpointFormRenderer.tsx
@@ -24,11 +24,29 @@ import { FallbackModelsConfigurator } from './FallbackModelsConfigurator';
 import { StarterCodeCard } from './StarterCodeCard';
 import { EditableEndpointName } from './EditableEndpointName';
 import { GatewayUsageSection } from './GatewayUsageSection';
-import type { Endpoint } from '../../types';
+import type { Endpoint, EndpointModelMapping } from '../../types';
 import { TracesV3Logs } from '../../../experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs';
 import { MonitoringConfigProvider } from '../../../experiment-tracking/hooks/useMonitoringConfig';
 import { useMonitoringFiltersTimeRange } from '../../../experiment-tracking/hooks/useMonitoringFilters';
 import { TracesV3DateSelector } from '../../../experiment-tracking/components/experiment-page/components/traces-v3/TracesV3DateSelector';
+
+/**
+ * Returns the provider string to pass to StarterCodeCard.
+ * If all models share the same passthrough API (treating openai and azure as equivalent),
+ * returns the first model's provider so the passthrough tab is shown.
+ * Otherwise returns undefined so only the MLflow Chat Completions tab is shown.
+ */
+export const getStarterCodeProvider = (
+  modelMappings: EndpointModelMapping[],
+): string | undefined => {
+  const normalized = new Set(
+    modelMappings.map((m) => {
+      const p = m.model_definition?.provider;
+      return p === 'azure' ? 'openai' : p;
+    }),
+  );
+  return normalized.size <= 1 ? modelMappings[0]?.model_definition?.provider : undefined;
+};
 
 const LogsTabContent = ({ experimentId }: { experimentId: string }) => {
   const { theme } = useDesignSystemTheme();
@@ -273,7 +291,7 @@ export const EditEndpointFormRenderer = ({
                 {endpoint && (
                   <StarterCodeCard
                     endpointName={endpoint.name}
-                    provider={endpoint.model_mappings[0]?.model_definition?.provider}
+                    provider={getStarterCodeProvider(endpoint.model_mappings)}
                   />
                 )}
 

--- a/mlflow/server/js/src/gateway/components/edit-endpoint/EditEndpointFormRenderer.tsx
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/EditEndpointFormRenderer.tsx
@@ -36,9 +36,7 @@ import { TracesV3DateSelector } from '../../../experiment-tracking/components/ex
  * returns the first model's provider so the passthrough tab is shown.
  * Otherwise returns undefined so only the MLflow Chat Completions tab is shown.
  */
-export const getStarterCodeProvider = (
-  modelMappings: EndpointModelMapping[],
-): string | undefined => {
+export const getStarterCodeProvider = (modelMappings: EndpointModelMapping[]): string | undefined => {
   const normalized = new Set(
     modelMappings.map((m) => {
       const p = m.model_definition?.provider;

--- a/mlflow/server/js/src/gateway/components/edit-endpoint/getStarterCodeProvider.test.ts
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/getStarterCodeProvider.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from '@jest/globals';
+import { getStarterCodeProvider } from './EditEndpointFormRenderer';
+import type { EndpointModelMapping } from '../../types';
+
+const mapping = (provider: string): EndpointModelMapping =>
+  ({
+    mapping_id: '1',
+    endpoint_id: '1',
+    model_definition_id: '1',
+    model_definition: { provider },
+    weight: 100,
+    created_at: 0,
+  }) as EndpointModelMapping;
+
+describe('getStarterCodeProvider', () => {
+  it('returns the provider when all models share the same provider', () => {
+    expect(getStarterCodeProvider([mapping('openai'), mapping('openai')])).toBe('openai');
+  });
+
+  it('returns the first provider when openai and azure are mixed', () => {
+    expect(getStarterCodeProvider([mapping('openai'), mapping('azure')])).toBe('openai');
+    expect(getStarterCodeProvider([mapping('azure'), mapping('openai')])).toBe('azure');
+  });
+
+  it('returns undefined when providers differ', () => {
+    expect(getStarterCodeProvider([mapping('openai'), mapping('anthropic')])).toBeUndefined();
+  });
+
+  it('returns the provider for a single model', () => {
+    expect(getStarterCodeProvider([mapping('anthropic')])).toBe('anthropic');
+  });
+
+  it('returns undefined for empty mappings', () => {
+    expect(getStarterCodeProvider([])).toBeUndefined();
+  });
+
+  it('returns undefined when no model_definition exists', () => {
+    const m = { mapping_id: '1', endpoint_id: '1', model_definition_id: '1', weight: 100, created_at: 0 };
+    expect(getStarterCodeProvider([m as EndpointModelMapping])).toBeUndefined();
+  });
+});


### PR DESCRIPTION
### Related Issues/PRs



### What changes are proposed in this pull request?

When an endpoint has models from multiple distinct providers (e.g., OpenAI + Anthropic), the provider-specific passthrough tab in `StarterCodeCard` is misleading since it only reflects one provider's API. This PR:

- Extracts a `getStarterCodeProvider` helper that checks whether all model mappings share the same provider
- If they do, passes that provider so the passthrough tab (e.g., OpenAI Responses) is shown as before
- If they differ, passes `undefined` so only the MLflow Chat Completions tab is shown
- Treats OpenAI and Azure as equivalent since they share the same passthrough API

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests


<img width="540" height="571" alt="image" src="https://github.com/user-attachments/assets/e6bacc94-27d4-45ea-89da-717cb2e5dbf1" />
<img width="542" height="661" alt="image" src="https://github.com/user-attachments/assets/e6449701-c0be-4aec-bd21-4684470721a7" />

Added `getStarterCodeProvider.test.ts` with 6 test cases covering: single provider, openai+azure equivalence, mixed providers, single model, empty mappings, and missing model definition.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release