### PR TITLE
Show Save/Cancel buttons only when endpoint has unsaved changes

### DIFF
--- a/mlflow/server/js/src/gateway/components/edit-endpoint/EditEndpointFormRenderer.tsx
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/EditEndpointFormRenderer.tsx
@@ -469,7 +469,7 @@ export const EditEndpointFormRenderer = ({
         </div>
       </Tabs.Root>
 
-      {activeTab === 'overview' && (
+      {hasChanges && activeTab === 'overview' && (
         <div
           css={{
             display: 'flex',
@@ -496,12 +496,7 @@ export const EditEndpointFormRenderer = ({
                       defaultMessage: 'Please configure at least one model in traffic split',
                       description: 'Tooltip shown when save button is disabled due to incomplete form',
                     })
-                  : !hasChanges
-                    ? intl.formatMessage({
-                        defaultMessage: 'No changes to save',
-                        description: 'Tooltip shown when save button is disabled due to no changes',
-                      })
-                    : undefined
+                  : undefined
             }
           >
             <Button
@@ -509,7 +504,7 @@ export const EditEndpointFormRenderer = ({
               type="primary"
               onClick={form.handleSubmit(onSubmit)}
               loading={isSubmitting}
-              disabled={!isFormComplete || !hasChanges}
+              disabled={!isFormComplete}
             >
               <FormattedMessage defaultMessage="Save changes" description="Save changes button" />
             </Button>

--- a/mlflow/server/js/src/gateway/hooks/useEditEndpointForm.ts
+++ b/mlflow/server/js/src/gateway/hooks/useEditEndpointForm.ts
@@ -272,8 +272,8 @@ export function useEditEndpointForm(endpointId: string): UseEditEndpointFormResu
   );
 
   const handleCancel = useCallback(() => {
-    navigate(GatewayRoutes.gatewayPageRoute);
-  }, [navigate]);
+    form.reset();
+  }, [form]);
 
   const handleNameUpdate = useCallback(
     async (newName: string) => {


### PR DESCRIPTION
### Related Issues/PRs



### What changes are proposed in this pull request?

The endpoint detail page previously showed greyed-out "Save changes" and "Cancel" buttons at all times, even when no changes had been made. This is confusing UX since it suggests users are in an edit flow when they may just be viewing the endpoint.

This PR:
- Only shows the Save/Cancel footer bar when there are unsaved changes (`hasChanges` is true)
- Changes Cancel to reset the form to its original state (via `form.reset()`) instead of navigating away to the gateway list page
- Cleans up dead code: removes the "No changes to save" tooltip branch and the `!hasChanges` disabled condition, since the footer is only visible when there are changes

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Verified manually:
1. Open endpoint detail page: no Save/Cancel buttons visible
2. Adjust traffic split weight: footer appears with Cancel and Save changes
3. Click Cancel: form resets, footer disappears
4. Type-check, lint, and prettier all pass


https://github.com/user-attachments/assets/2e430dda-330f-46f0-b86d-f275d578e362



### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The endpoint detail page no longer shows greyed-out Save/Cancel buttons when there are no changes. The buttons now only appear after editing, and Cancel resets the form instead of navigating away.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release