### PR TITLE
Fix `_lookup_model_info` all-provider scan causing network latency

### DIFF
--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -325,18 +325,10 @@ def calculate_cost_by_model_and_token_usage(
             # MLflow's logger is set to DEBUG level.
             litellm.suppress_debug_info = not _logger.isEnabledFor(logging.DEBUG)
 
-        result = cost_per_token(
-            model=model_name,
-            prompt_tokens=prompt_tokens,
-            completion_tokens=completion_tokens,
-            **cache_kwargs,
-        )
-    except Exception:
+        # When provider is known, try it first — this is a fast single-provider lookup
+        # and avoids the slower all-provider scan.
         result = None
         if model_provider:
-            # pass model_provider only in exception case to avoid invalid model_provider
-            # being used when model_name itself is enough to calculate cost, since model_provider
-            # field can be with any value and litellm may not support it.
             try:
                 result = cost_per_token(
                     model=model_name,
@@ -347,20 +339,22 @@ def calculate_cost_by_model_and_token_usage(
                 )
             except Exception:
                 pass
+
+        # Fallback: try without provider (for litellm this may match by model name alone,
+        # for builtin this scans bundled providers).
+        if result is None:
+            try:
+                result = cost_per_token(
+                    model=model_name,
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=completion_tokens,
+                    **cache_kwargs,
+                )
+            except Exception:
+                pass
     finally:
         if litellm is not None:
             litellm.suppress_debug_info = original_suppress
-
-    if result is None:
-        # Try with provider as a last resort (builtin path only, litellm already tried above)
-        if litellm is None and model_provider:
-            result = cost_per_token(
-                model=model_name,
-                prompt_tokens=prompt_tokens,
-                completion_tokens=completion_tokens,
-                custom_llm_provider=model_provider.lower(),
-                **cache_kwargs,
-            )
 
     if result is None:
         _logger.debug(f"Failed to calculate cost for model {model_name}")

--- a/mlflow/utils/providers.py
+++ b/mlflow/utils/providers.py
@@ -301,19 +301,17 @@ def _load_provider(provider: str) -> dict[str, ModelInfo]:
 
 
 def _lookup_model_info(model: str, custom_llm_provider: str | None = None) -> ModelInfo | None:
-    """Look up model cost info, loading only the relevant provider file when possible."""
+    """Look up model cost info, loading only the relevant provider file."""
     bare_model = model.split("/", 1)[-1]
 
     if custom_llm_provider:
-        # Fast path: load only the one provider file we need
-        if info := _load_provider(custom_llm_provider).get(bare_model):
-            return info
+        return _load_provider(custom_llm_provider).get(bare_model)
 
-    # Fallback: scan all providers for bare model name.
-    # Prefer entries that have pricing data over empty/stub entries.
+    # No provider given — scan bundled providers only (no remote fetch)
+    # to avoid O(N) network requests across all providers.
     fallback = None
     for provider in _list_provider_names():
-        if info := _load_provider(provider).get(bare_model):
+        if info := _load_bundled_provider(provider).get(bare_model):
             if info.get("input_cost_per_token"):
                 return info
             if fallback is None:

--- a/tests/utils/test_providers.py
+++ b/tests/utils/test_providers.py
@@ -233,6 +233,9 @@ def mock_model_cost():
             "mlflow.utils.providers._load_provider", side_effect=_mock_load_provider
         ) as m_load,
         mock.patch(
+            "mlflow.utils.providers._load_bundled_provider", side_effect=_mock_load_provider
+        ),
+        mock.patch(
             "mlflow.utils.providers._list_provider_names",
             return_value=list(_MOCK_PROVIDER_DATA.keys()),
         ),
@@ -331,6 +334,10 @@ def test_cost_per_token_no_cache_cost_falls_back_to_input_rate():
     with (
         mock.patch(
             "mlflow.utils.providers._load_provider",
+            side_effect=lambda p: no_cache_data.get(p, {}),
+        ),
+        mock.patch(
+            "mlflow.utils.providers._load_bundled_provider",
             side_effect=lambda p: no_cache_data.get(p, {}),
         ),
         mock.patch(


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22259

### What changes are proposed in this pull request?

When `_lookup_model_info` is called without a provider, it previously scanned all 68 providers via `_load_provider()`, which triggers remote fetches (with retries + timeouts) for each. For unknown models, this caused O(N) network latency (potentially ~1000s worst case).

Now:
- **With provider**: uses `_load_provider()` (remote fetch + bundled fallback) — single provider, fast
- **Without provider**: uses `_load_bundled_provider()` (local files only, no network) — safe to scan all providers

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

All 29 provider tests pass. Verified `test_invoke_agentic_scorer` no longer times out.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release