### PR TITLE
fix: add support for pandas 3.x by removing upper version constraint

### DIFF
--- a/pyproject.release.toml
+++ b/pyproject.release.toml
@@ -39,7 +39,7 @@ dependencies = [
   "huey<3,>=2.5.4",
   "matplotlib<4",
   "numpy<3",
-  "pandas<3",
+  "pandas>=1.3.0",
   "pyarrow<24,>=4.0.0",
   "scikit-learn<2",
   "scipy<2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
   "opentelemetry-proto<3,>=1.9.0",
   "opentelemetry-sdk<3,>=1.9.0",
   "packaging<27",
-  "pandas<3",
+  "pandas>=1.3.0",
   "protobuf<8,>=3.12.0",
   "pyarrow<24,>=4.0.0",
   "pydantic<3,>=2.0.0",


### PR DESCRIPTION
Closes #22349

Removes the pandas<3 upper version constraint from pyproject.toml,
pyproject.release.toml, and dev/build.py to allow compatibility
with pandas 3.x releases.