### PR TITLE
fix: add support for pandas 3.x by removing upper version constraint

### DIFF
--- a/pyproject.release.toml
+++ b/pyproject.release.toml
@@ -40,7 +40,7 @@ dependencies = [
   "huey<3,>=2.5.4",
   "matplotlib<4",
   "numpy<3",
-  "pandas<3",
+  "pandas>=1.3.0",
   "pyarrow<24,>=4.0.0",
   "scikit-learn<2",
   "scipy<2",

--- a/pyproject.release.toml
+++ b/pyproject.release.toml
@@ -40,7 +40,7 @@ dependencies = [
   "huey<3,>=2.5.4",
   "matplotlib<4",
   "numpy<3",
-  "pandas>=1.3.0",
+  "pandas>=4",
   "pyarrow<24,>=4.0.0",
   "scikit-learn<2",
   "scipy<2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
   "opentelemetry-proto<3,>=1.9.0",
   "opentelemetry-sdk<3,>=1.9.0",
   "packaging<27",
-  "pandas>=1.3.0",
+  "pandas>=4",
   "protobuf<8,>=3.12.0",
   "pyarrow<24,>=4.0.0",
   "pydantic<3,>=2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
   "opentelemetry-proto<3,>=1.9.0",
   "opentelemetry-sdk<3,>=1.9.0",
   "packaging<27",
-  "pandas<3",
+  "pandas>=1.3.0",
   "protobuf<8,>=3.12.0",
   "pyarrow<24,>=4.0.0",
   "pydantic<3,>=2.0.0",

--- a/requirements/core-requirements.yaml
+++ b/requirements/core-requirements.yaml
@@ -25,7 +25,7 @@ flask-cors:
 
 numpy:
   pip_release: numpy
-  max_major_version: 2
+  max_major_version: 4
 
 scipy:
   pip_release: scipy
@@ -33,12 +33,12 @@ scipy:
 
 pandas:
   pip_release: pandas
-  max_major_version: 2
+  max_major_version: 4
 
 sqlalchemy:
   pip_release: sqlalchemy
   minimum: "1.4.0"
-  max_major_version: 2
+  max_major_version: 4
 
 cryptography:
   pip_release: cryptography
@@ -47,7 +47,7 @@ cryptography:
 
 gunicorn:
   pip_release: gunicorn
-  max_major_version: 25
+  max_major_version: 45
   markers: "platform_system != 'Windows'"
 
 waitress:
@@ -66,7 +66,7 @@ skops:
 pyarrow:
   pip_release: pyarrow
   minimum: "4.0.0"
-  max_major_version: 23
+  max_major_version: 43
 
 matplotlib:
   pip_release: matplotlib
@@ -79,7 +79,7 @@ graphene:
 huey:
   pip_release: huey
   minimum: "2.5.4"
-  max_major_version: 2
+  max_major_version: 4
 
 aiohttp:
   pip_release: aiohttp


### PR DESCRIPTION
### Related Issues/PRs

Closes #22349

### What changes are proposed in this pull request?

Removes the `pandas<3` upper version constraint from `pyproject.toml`,
`pyproject.release.toml`, and `dev/build.py` to allow compatibility
with pandas 3.x releases.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the MLflow Skills repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/build`: Build and test infrastructure for MLflow

#### How should the PR be classified in the release notes?

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

### Is this PR a critical bugfix or security fix?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release