### PR TITLE
Fix `ina a` typo in tracking artifact store docs

### DIFF
--- a/docs/docs/classic-ml/tracking/index.mdx
+++ b/docs/docs/classic-ml/tracking/index.mdx
@@ -300,7 +300,7 @@ REST-based backend store that is externally managed and not directly accessible.
 #### [Artifact Store](/self-hosting/architecture/artifact-store) \{#artifact-stores}
 
 Artifact store persists (typically large) artifacts for each run, such as model weights (e.g. a pickled scikit-learn model),
-images (e.g. PNGs), model and data files (e.g. [Parquet](https://parquet.apache.org) file). MLflow stores artifacts ina a
+images (e.g. PNGs), model and data files (e.g. [Parquet](https://parquet.apache.org) file). MLflow stores artifacts in a
 local file (`mlruns`) by default, but also supports different storage options such as Amazon S3 and Azure Blob Storage.
 
 For models which are logged as MLflow artifacts, you can refer the model through a model URI of format: `models:/<model_id>`,


### PR DESCRIPTION
### Related Issues/PRs

### What changes are proposed in this pull request?

Fixed a minor typographical error (`ina a` -> `in a`) in the Artifact Store tracking documentation.

### How is this PR tested?

- [x] Manual tests

Verified the formatting visually in the PR diff.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release