### PR TITLE
fix: strip port from Host header in is_allowed_host_header

### DIFF
--- a/mlflow/server/security_utils.py
+++ b/mlflow/server/security_utils.py
@@ -140,6 +140,17 @@ def is_allowed_host_header(allowed_hosts: list[str], host: str) -> bool:
     if "*" in allowed_hosts:
         return True
 
+    # Strip port from host header before matching.
+    # Handles regular hosts (e.g. "myhost.com:5000" -> "myhost.com")
+    # and IPv6 addresses (e.g. "[::1]:5000" -> "[::1]")
+
+    if host.startswith("["):
+        # IPv6: strip port after closing bracket
+        host = host.split("]")[0] + "]"
+    elif ":" in host:
+        # Regular hostname: strip port
+        host = host.rsplit(":", 1)[0]
+
     return any(
         fnmatch.fnmatch(host, allowed) if "*" in allowed else host == allowed
         for allowed in allowed_hosts

--- a/tests/server/test_security.py
+++ b/tests/server/test_security.py
@@ -359,3 +359,42 @@ def test_fastapi_cors_allows_configured_origin(monkeypatch: pytest.MonkeyPatch):
         headers={"Host": "localhost", "Origin": "http://evil.com"},
     )
     assert response.headers.get("access-control-allow-origin") is None
+
+# -----------------------------------------------------------------------
+# Tests for is_allowed_host_header port-stripping fix (issue #22095)
+# -----------------------------------------------------------------------
+
+def test_host_with_port_matches_bare_hostname():
+    """Host header with port should match bare hostname in allowed list."""
+    from mlflow.server.security_utils import is_allowed_host_header
+
+    allowed = ["mlflow-service.namespace.svc.cluster.local"]
+    assert is_allowed_host_header(allowed, "mlflow-service.namespace.svc.cluster.local:5000") is True
+
+
+def test_host_without_port_still_matches():
+    """Existing behaviour: bare hostname still matches."""
+    from mlflow.server.security_utils import is_allowed_host_header
+
+    assert is_allowed_host_header(["myhost.com"], "myhost.com") is True
+
+
+def test_host_with_port_wrong_hostname_rejected():
+    """Different hostname with port should still be rejected."""
+    from mlflow.server.security_utils import is_allowed_host_header
+
+    assert is_allowed_host_header(["myhost.com"], "otherhost.com:5000") is False
+
+
+def test_wildcard_pattern_matches_host_with_port():
+    """Wildcard patterns should match even when host includes a port."""
+    from mlflow.server.security_utils import is_allowed_host_header
+
+    assert is_allowed_host_header(["*.internal.com"], "app.internal.com:8080") is True
+
+
+def test_ipv6_host_with_port_matches():
+    """IPv6 address with port should match bare IPv6 in allowed list."""
+    from mlflow.server.security_utils import is_allowed_host_header
+
+    assert is_allowed_host_header(["[::1]"], "[::1]:5000") is True


### PR DESCRIPTION
## Changes
- Strip port from Host header in `is_allowed_host_header()` before matching to fix #22095
- Add 5 new test cases in `tests/server/test_security.py`

## Why are these changes needed?
`is_allowed_host_header()` rejected valid requests when the Host header included a port (e.g. `hostname:5000`) but the allowed-hosts list only contained the bare hostname. This caused OTLP traces to be silently rejected with 403.

## Does this PR introduce _any_ user-facing change?
Yes. Host headers with ports (e.g. `myhost.com:5000`) are now correctly matched against bare hostnames in the allowed-hosts list.

## How is this PR tested?
5 new unit tests added to `tests/server/test_security.py`:
- `test_host_with_port_matches_bare_hostname`
- `test_host_without_port_still_matches`
- `test_host_with_port_wrong_hostname_rejected`
- `test_wildcard_pattern_matches_host_with_port`
- `test_ipv6_host_with_port_matches`