### PR TITLE
Skip cost calculation for `gateway:/` and `endpoints:/` model URIs

### DIFF
--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -290,10 +290,18 @@ def calculate_span_cost(span: LiveSpan) -> dict[str, float] | None:
     return calculate_cost_by_model_and_token_usage(model_name, usage, model_provider)
 
 
+# Model URI prefixes that are internal routing identifiers (not real model names).
+# Cost lookup would never find them in the catalog and just wastes time.
+_SKIP_COST_PREFIXES = ("gateway:/", "endpoints:/")
+
+
 def calculate_cost_by_model_and_token_usage(
     model_name: str | None, usage: dict[str, int] | None, model_provider: str | None = None
 ) -> dict[str, float] | None:
     if not model_name or not usage:
+        return None
+
+    if model_name.startswith(_SKIP_COST_PREFIXES):
         return None
 
     prompt_tokens = usage.get(TokenUsageKey.INPUT_TOKENS, 0)

--- a/tests/tracing/utils/test_utils.py
+++ b/tests/tracing/utils/test_utils.py
@@ -691,6 +691,14 @@ def test_builtin_cost_fallback_with_provider_case_insensitive(model_provider):
     assert result["total_cost"] == pytest.approx(0.0075)
 
 
+@pytest.mark.parametrize("model_name", ["gateway:/my-endpoint", "endpoints:/my-endpoint"])
+def test_cost_skipped_for_internal_routing_uris(model_name):
+    result = calculate_cost_by_model_and_token_usage(
+        model_name, {"input_tokens": 1000, "output_tokens": 500}
+    )
+    assert result is None
+
+
 def test_litellm_provider_list_not_printed_during_cost_calculation(capsys):
     litellm.suppress_debug_info = False
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22369

### What changes are proposed in this pull request?

Adds an early return in `calculate_cost_by_model_and_token_usage` for model names starting with `gateway:/` or `endpoints:/`. These are internal MLflow routing identifiers, not real model names — looking them up in the pricing catalog always fails and wastes time (especially with remote fetch retries).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added parametrized test for both `gateway:/` and `endpoints:/` prefixes.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release