### PR TITLE
fix: strip port from Host header in is_allowed_host_header (#22095)

### DIFF
--- a/mlflow/server/security_utils.py
+++ b/mlflow/server/security_utils.py
@@ -140,6 +140,17 @@ def is_allowed_host_header(allowed_hosts: list[str], host: str) -> bool:
     if "*" in allowed_hosts:
         return True
 
+    # Strip port from host header before matching.
+    # Handles regular hosts (e.g. "myhost.com:5000" -> "myhost.com")
+    # and IPv6 addresses (e.g. "[::1]:5000" -> "[::1]")
+
+    if host.startswith("["):
+        # IPv6: strip port after closing bracket
+        host = host.split("]")[0] + "]"
+    elif ":" in host:
+        # Regular hostname: strip port
+        host = host.rsplit(":", 1)[0]
+
     return any(
         fnmatch.fnmatch(host, allowed) if "*" in allowed else host == allowed
         for allowed in allowed_hosts

--- a/tests/server/test_security.py
+++ b/tests/server/test_security.py
@@ -359,3 +359,42 @@ def test_fastapi_cors_allows_configured_origin(monkeypatch: pytest.MonkeyPatch):
         headers={"Host": "localhost", "Origin": "http://evil.com"},
     )
     assert response.headers.get("access-control-allow-origin") is None
+
+# -----------------------------------------------------------------------
+# Tests for is_allowed_host_header port-stripping fix (issue #22095)
+# -----------------------------------------------------------------------
+
+def test_host_with_port_matches_bare_hostname():
+    """Host header with port should match bare hostname in allowed list."""
+    from mlflow.server.security_utils import is_allowed_host_header
+
+    allowed = ["mlflow-service.namespace.svc.cluster.local"]
+    assert is_allowed_host_header(allowed, "mlflow-service.namespace.svc.cluster.local:5000") is True
+
+
+def test_host_without_port_still_matches():
+    """Existing behaviour: bare hostname still matches."""
+    from mlflow.server.security_utils import is_allowed_host_header
+
+    assert is_allowed_host_header(["myhost.com"], "myhost.com") is True
+
+
+def test_host_with_port_wrong_hostname_rejected():
+    """Different hostname with port should still be rejected."""
+    from mlflow.server.security_utils import is_allowed_host_header
+
+    assert is_allowed_host_header(["myhost.com"], "otherhost.com:5000") is False
+
+
+def test_wildcard_pattern_matches_host_with_port():
+    """Wildcard patterns should match even when host includes a port."""
+    from mlflow.server.security_utils import is_allowed_host_header
+
+    assert is_allowed_host_header(["*.internal.com"], "app.internal.com:8080") is True
+
+
+def test_ipv6_host_with_port_matches():
+    """IPv6 address with port should match bare IPv6 in allowed list."""
+    from mlflow.server.security_utils import is_allowed_host_header
+
+    assert is_allowed_host_header(["[::1]"], "[::1]:5000") is True


### PR DESCRIPTION
### Related Issues/PRs

Closes #22095

### What changes are proposed in this pull request?

Strip port from Host header in `is_allowed_host_header()` before matching.

- Regular hosts: `myhost.com:5000` → `myhost.com`
- IPv6 addresses: `[::1]:5000` → `[::1]`

Previously, requests with a port in the Host header were rejected with 403
even when the bare hostname was in the allowed-hosts list. This caused OTLP
traces to be silently rejected with 403 in Kubernetes deployments.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Host headers with ports (e.g. `myhost.com:5000`) now correctly match bare hostnames in the allowed-hosts list, fixing silent 403 rejections for OTLP and other clients that include ports in Host headers.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release