### PR TITLE
Document X-MLflow-Gateway response headers in query-endpoints.mdx

### DIFF
--- a/docs/docs/genai/governance/ai-gateway/endpoints/query-endpoints.mdx
+++ b/docs/docs/genai/governance/ai-gateway/endpoints/query-endpoints.mdx
@@ -465,9 +465,38 @@ The workspace header applies to all gateway API endpoints, including:
 
 For more details on workspace configuration and management, see the [Workspaces documentation](/self-hosting/workspaces/getting-started).
 
+## Response Headers
+
+Every gateway response includes diagnostic headers that let you measure how much latency the gateway itself adds on top of the underlying provider call.
+
+| Header | Description |
+|--------|-------------|
+| `X-MLflow-Gateway-Duration-Ms` | Total time in milliseconds from when the gateway received the request to when it returned a response. For streaming endpoints this reflects time-to-first-stream (gateway setup time), not the total streaming duration. |
+| `X-MLflow-Gateway-Overhead-Duration-Ms` | Gateway-only processing time in milliseconds — the difference between total duration and the provider HTTP round-trip. Omitted when provider timing is unavailable (e.g. streaming responses). |
+
+```python
+import requests
+
+response = requests.post(
+    "http://localhost:5000/gateway/my-endpoint/mlflow/invocations",
+    json={"messages": [{"role": "user", "content": "Hello!"}]},
+)
+
+total_ms = response.headers.get("X-MLflow-Gateway-Duration-Ms")
+overhead_ms = response.headers.get("X-MLflow-Gateway-Overhead-Duration-Ms")
+
+print(f"Total: {total_ms}ms")
+if overhead_ms:
+    print(f"Gateway overhead: {overhead_ms}ms, Provider: {int(total_ms) - int(overhead_ms)}ms")
+```
+
 ## Using Gateway Endpoints with MLflow Judges
 
 AI Gateway endpoints can be used as the backing LLM for MLflow's [LLM Judges](/genai/eval-monitor/scorers/#llms-as-judges). This allows you to run judge evaluations through the gateway, benefiting from centralized API key management and cost tracking.
+
+:::note
+When MLflow Judges call the gateway, they automatically include the `X-MLflow-Gateway-Caller: judge` request header. The gateway records this in telemetry to distinguish judge traffic from regular endpoint traffic. You do not need to set this header manually.
+:::
 
 To use a gateway endpoint as a judge model, use the `gateway:/` prefix followed by your endpoint name:
 

--- a/docs/docs/genai/governance/ai-gateway/endpoints/query-endpoints.mdx
+++ b/docs/docs/genai/governance/ai-gateway/endpoints/query-endpoints.mdx
@@ -467,12 +467,12 @@ For more details on workspace configuration and management, see the [Workspaces 
 
 ## Response Headers
 
-Every gateway response includes diagnostic headers that let you measure how much latency the gateway itself adds on top of the underlying provider call.
+Gateway responses include diagnostic headers that let you measure how much latency the gateway itself adds on top of the underlying provider call.
 
-| Header | Description |
-|--------|-------------|
-| `X-MLflow-Gateway-Duration-Ms` | Total time in milliseconds from when the gateway received the request to when it returned a response. For streaming endpoints this reflects time-to-first-stream (gateway setup time), not the total streaming duration. |
-| `X-MLflow-Gateway-Overhead-Duration-Ms` | Gateway-only processing time in milliseconds — the difference between total duration and the provider HTTP round-trip. Omitted when provider timing is unavailable (e.g. streaming responses). |
+| Header                                  | Description                                                                                                                                                                                                                                                                                                            |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `X-MLflow-Gateway-Duration-Ms`          | Total time in milliseconds from when the gateway received the request to when it returned a response. For streaming endpoints, this reflects gateway setup/handling time before streaming begins (until the `StreamingResponse` is returned), not the total streaming duration or time until the first bytes are sent. |
+| `X-MLflow-Gateway-Overhead-Duration-Ms` | Gateway-only processing time in milliseconds — the difference between total duration and the provider HTTP round-trip. This header is omitted when provider timing is unavailable, including for streaming responses.                                                                                                  |
 
 ```python
 import requests
@@ -485,9 +485,14 @@ response = requests.post(
 total_ms = response.headers.get("X-MLflow-Gateway-Duration-Ms")
 overhead_ms = response.headers.get("X-MLflow-Gateway-Overhead-Duration-Ms")
 
-print(f"Total: {total_ms}ms")
-if overhead_ms:
-    print(f"Gateway overhead: {overhead_ms}ms, Provider: {int(total_ms) - int(overhead_ms)}ms")
+if total_ms is not None:
+    total_ms_value = float(total_ms)
+    print(f"Total: {total_ms_value:.0f}ms")
+
+    if overhead_ms is not None:
+        overhead_ms_value = float(overhead_ms)
+        provider_ms_value = total_ms_value - overhead_ms_value
+        print(f"Gateway overhead: {overhead_ms_value:.0f}ms, Provider: {provider_ms_value:.0f}ms")
 ```
 
 ## Using Gateway Endpoints with MLflow Judges


### PR DESCRIPTION
### Related Issues/PRs

<!-- Resolve --> #22229

### What changes are proposed in this pull request?

Adds a **Response Headers** section to `docs/docs/genai/governance/ai-gateway/endpoints/query-endpoints.mdx` documenting the three MLflow Gateway headers introduced/used in #22229:

- `X-MLflow-Gateway-Duration-Ms` — total gateway request duration in ms
- `X-MLflow-Gateway-Overhead-Duration-Ms` — gateway-only overhead (total minus provider HTTP time); omitted for streaming responses where provider time is unavailable
- `X-MLflow-Gateway-Caller` — request header automatically set by MLflow Judges to identify judge traffic in telemetry

Also adds a Python code example showing how to read and interpret the timing headers.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Docs change only — verified rendering locally.

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Documents the `X-MLflow-Gateway-Duration-Ms` and `X-MLflow-Gateway-Overhead-Duration-Ms` response headers added to all AI Gateway endpoints, which allow users to measure gateway latency overhead on top of provider call time.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/docs`: MLflow documentation pages
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none`
- [ ] `rn/breaking-change`
- [ ] `rn/feature`
- [ ] `rn/bug-fix`
- [x] `rn/documentation`

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)