### PR TITLE
Add server side check for registering custom scorer

### DIFF
--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -14,6 +14,9 @@ from mlflow.entities import Assessment, Feedback
 from mlflow.entities.assessment import DEFAULT_FEEDBACK_NAME
 from mlflow.entities.trace import Trace
 from mlflow.exceptions import MlflowException
+from mlflow.genai.scorers.scorer_utils import (
+    DECORATOR_SCORER_REGISTRATION_NOT_SUPPORTED_ERROR,
+)
 from mlflow.telemetry.events import ScorerCallEvent
 from mlflow.telemetry.track import record_usage_event
 from mlflow.tracking._tracking_service.utils import get_tracking_uri
@@ -441,14 +444,7 @@ class Scorer(BaseModel):
                 code_snippet += f"    {line}\n"
 
             raise MlflowException.invalid_parameter_value(
-                f"Loading custom scorer '{serialized.name}' is not supported outside of "
-                "Databricks environments due to security concerns. Custom scorers "
-                "require arbitrary code execution during deserialization.\n\n"
-                "To use this scorer, please:\n"
-                "1. Configure MLflow to use a Databricks tracking URI, or\n"
-                "2. Copy the code below and save it in your source code repository\n"
-                "3. Import and use it directly in your code, or\n"
-                "4. Use built-in scorers or make_judge() scorers instead\n\n"
+                f"{DECORATOR_SCORER_REGISTRATION_NOT_SUPPORTED_ERROR}\n"
                 f"Registered scorer code:\n{code_snippet}"
             )
 
@@ -952,14 +948,7 @@ class Scorer(BaseModel):
         # to ensure loaded scorers can only be executed in controlled environments.
         if self.kind == ScorerKind.DECORATOR and not is_databricks_uri(get_tracking_uri()):
             raise MlflowException.invalid_parameter_value(
-                "Custom scorer registration (using @scorer decorator) is not supported "
-                "outside of Databricks tracking environments due to security concerns. "
-                "Custom scorers require arbitrary code execution during deserialization.\n\n"
-                "To use custom scorers:\n"
-                "1. Configure MLflow to use a Databricks tracking URI, or\n"
-                "2. Manage your custom scorer code in a source code repository "
-                "(e.g., GitHub) and import it directly, or\n"
-                "3. Use built-in scorers or make_judge() scorers instead"
+                DECORATOR_SCORER_REGISTRATION_NOT_SUPPORTED_ERROR
             )
 
         store = _get_scorer_store()

--- a/mlflow/genai/scorers/scorer_utils.py
+++ b/mlflow/genai/scorers/scorer_utils.py
@@ -19,6 +19,20 @@ GATEWAY_PROVIDER = "gateway"
 INSTRUCTIONS_JUDGE_PYDANTIC_DATA = "instructions_judge_pydantic_data"
 BUILTIN_SCORER_PYDANTIC_DATA = "builtin_scorer_pydantic_data"
 
+# Error message used by both the Python client (Scorer._check_can_be_registered) and the
+# server handler (_register_scorer) to consistently reject decorator scorer registration
+# outside of Databricks environments.
+DECORATOR_SCORER_REGISTRATION_NOT_SUPPORTED_ERROR = (
+    "Custom scorer registration (using @scorer decorator) is not supported "
+    "outside of Databricks tracking environments due to security concerns. "
+    "Custom scorers require arbitrary code execution during deserialization.\n\n"
+    "To use custom scorers:\n"
+    "1. Configure MLflow to use a Databricks tracking URI, or\n"
+    "2. Manage your custom scorer code in a source code repository "
+    "(e.g., GitHub) and import it directly, or\n"
+    "3. Use built-in scorers or make_judge() scorers instead."
+)
+
 
 # FunctionBodyExtractor class is forked from https://github.com/unitycatalog/unitycatalog/blob/20dd3820be332ac04deec4e063099fb863eb3392/ai/core/src/unitycatalog/ai/core/utils/callable_utils.py
 class FunctionBodyExtractor(ast.NodeVisitor):

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -4651,6 +4651,20 @@ def _register_scorer():
             "serialized_scorer": [_assert_required, _assert_string],
         },
     )
+    # Decorator scorers contain a `call_source` field that is executed via exec() during
+    # deserialization. The Python client blocks this via `_check_can_be_registered()`, but
+    # that check is client-side only and can be bypassed by calling the REST API directly.
+    # Enforce the same restriction here in the server handler so it applies regardless of
+    # how the request arrives.
+    serialized_data = json.loads(request_message.serialized_scorer)
+    if serialized_data.get("call_source") is not None:
+        from mlflow.genai.scorers.scorer_utils import (
+            DECORATOR_SCORER_REGISTRATION_NOT_SUPPORTED_ERROR,
+        )
+
+        raise MlflowException.invalid_parameter_value(
+            DECORATOR_SCORER_REGISTRATION_NOT_SUPPORTED_ERROR
+        )
     scorer_version = _get_tracking_store().register_scorer(
         request_message.experiment_id,
         request_message.name,

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -4659,9 +4659,7 @@ def _register_scorer():
     try:
         serialized_data = json.loads(request_message.serialized_scorer)
     except json.JSONDecodeError as e:
-        raise MlflowException.invalid_parameter_value(
-            "serialized_scorer must be valid JSON"
-        ) from e
+        raise MlflowException.invalid_parameter_value("serialized_scorer must be valid JSON") from e
     if serialized_data.get("call_source") is not None:
         from mlflow.genai.scorers.scorer_utils import (
             DECORATOR_SCORER_REGISTRATION_NOT_SUPPORTED_ERROR,

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -82,6 +82,7 @@ from mlflow.exceptions import (
 )
 from mlflow.gateway.budget_tracker import get_budget_tracker
 from mlflow.gateway.utils import is_valid_endpoint_name
+from mlflow.genai.scorers.scorer_utils import DECORATOR_SCORER_REGISTRATION_NOT_SUPPORTED_ERROR
 from mlflow.models import Model
 from mlflow.prompt.constants import PROMPT_TEXT_TAG_KEY, PROMPT_TYPE_TAG_KEY
 from mlflow.protos import databricks_pb2
@@ -4661,10 +4662,6 @@ def _register_scorer():
     except json.JSONDecodeError as e:
         raise MlflowException.invalid_parameter_value("serialized_scorer must be valid JSON") from e
     if serialized_data.get("call_source") is not None:
-        from mlflow.genai.scorers.scorer_utils import (
-            DECORATOR_SCORER_REGISTRATION_NOT_SUPPORTED_ERROR,
-        )
-
         raise MlflowException.invalid_parameter_value(
             DECORATOR_SCORER_REGISTRATION_NOT_SUPPORTED_ERROR
         )

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -4656,7 +4656,12 @@ def _register_scorer():
     # that check is client-side only and can be bypassed by calling the REST API directly.
     # Enforce the same restriction here in the server handler so it applies regardless of
     # how the request arrives.
-    serialized_data = json.loads(request_message.serialized_scorer)
+    try:
+        serialized_data = json.loads(request_message.serialized_scorer)
+    except json.JSONDecodeError as e:
+        raise MlflowException.invalid_parameter_value(
+            "serialized_scorer must be valid JSON"
+        ) from e
     if serialized_data.get("call_source") is not None:
         from mlflow.genai.scorers.scorer_utils import (
             DECORATOR_SCORER_REGISTRATION_NOT_SUPPORTED_ERROR,

--- a/tests/genai/scorers/test_scorer.py
+++ b/tests/genai/scorers/test_scorer.py
@@ -360,7 +360,7 @@ def test_custom_scorer_loading_blocked_for_non_databricks_uri():
     )
 
     with pytest.raises(
-        mlflow.exceptions.MlflowException, match="Loading custom scorer.*not supported"
+        mlflow.exceptions.MlflowException, match="Custom scorer registration.*not supported"
     ):
         Scorer._reconstruct_decorator_scorer(serialized)
 

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -1674,6 +1674,19 @@ def test_register_scorer(mock_get_request_message, mock_tracking_store):
     }
 
 
+def test_register_scorer_rejects_decorator_scorer(mock_get_request_message, mock_tracking_store):
+    from mlflow.genai.scorers.scorer_utils import DECORATOR_SCORER_REGISTRATION_NOT_SUPPORTED_ERROR
+
+    serialized_scorer = json.dumps({"name": "my_scorer", "call_source": "    return 1.0\n"})
+    mock_get_request_message.return_value = RegisterScorer(
+        experiment_id="123", name="my_scorer", serialized_scorer=serialized_scorer
+    )
+    resp = _register_scorer()
+    assert resp.status_code == 400
+    assert DECORATOR_SCORER_REGISTRATION_NOT_SUPPORTED_ERROR in resp.get_json()["message"]
+    mock_tracking_store.register_scorer.assert_not_called()
+
+
 def test_list_scorers(mock_get_request_message, mock_tracking_store):
     experiment_id = "123"
 

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -1641,7 +1641,7 @@ def test_get_dataset_records_pagination(mock_tracking_store):
 def test_register_scorer(mock_get_request_message, mock_tracking_store):
     experiment_id = "123"
     name = "accuracy_scorer"
-    serialized_scorer = "serialized_scorer_data"
+    serialized_scorer = '{"name": "accuracy_scorer"}'
 
     mock_get_request_message.return_value = RegisterScorer(
         experiment_id=experiment_id, name=name, serialized_scorer=serialized_scorer

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -3992,7 +3992,7 @@ def test_scorer_CRUD(mlflow_client, store_type):
     store = mlflow_client._tracking_client.store
 
     # Test register scorer
-    scorer_data = {"name": "test_scorer", "call_source": "test", "original_func_name": "test_func"}
+    scorer_data = {"name": "test_scorer", "original_func_name": "test_func"}
     serialized_scorer = json.dumps(scorer_data)
 
     version = store.register_scorer(experiment_id, "test_scorer", serialized_scorer)
@@ -4023,7 +4023,6 @@ def test_scorer_CRUD(mlflow_client, store_type):
     # Test register second version
     scorer_data_v2 = {
         "name": "test_scorer_v2",
-        "call_source": "test",
         "original_func_name": "test_func_v2",
     }
     serialized_scorer_v2 = json.dumps(scorer_data_v2)


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #22265

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Add server side check for registering custom scorer.

Currently, custom scorer is designed to only support Databricks backend (because of the remote code execution risk, and Databricks backend provides user authentication to de-risk it),

MLflow server should add check to forbid custom scorer registration, otherwise attacker can load it through REST API and then triggers server side remote code execution vulnerability  (bypassing [the python client SDK check](https://github.com/mlflow/mlflow/blob/d1a798f0f029014c769973d5640ebf1b4148f4a9/mlflow/genai/scorers/base.py#L435) )


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
