### PR TITLE
Fix grammar error in tracking server documentation

### DIFF
--- a/docs/docs/classic-ml/tracking/index.mdx
+++ b/docs/docs/classic-ml/tracking/index.mdx
@@ -314,7 +314,7 @@ see [MLflow Model Registry](/ml/model-registry) for details.
 #### [MLflow Tracking Server](/self-hosting/architecture/tracking-server) (Optional) \{#tracking_server}
 
 MLflow Tracking Server is a stand-alone HTTP server that provides REST APIs for accessing backend and/or artifact store.
-Tracking server also offers flexibility to configure what data to server, govern access control, versioning, and etc. Read
+Tracking server also offers flexibility to configure what data to serve, govern access control, versioning, and etc. Read
 [MLflow Tracking Server documentation](/self-hosting) for more details.
 
 ### Common Setups \{#tracking_setup}


### PR DESCRIPTION
### Related Issues/PRs

### What changes are proposed in this pull request?

Fixed a minor grammatical error (`server` -> `serve`) in the Tracking Server documentation to ensure proper verb usage.

### How is this PR tested?

- [x] Manual tests

Verified the formatting visually in the PR diff.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release