### PR TITLE
Fix performance degradation for single-tenant installation

### DIFF
--- a/mlflow/store/db_migrations/versions/7d34483879f0_add_model_version_tags_workspace_index.py
+++ b/mlflow/store/db_migrations/versions/7d34483879f0_add_model_version_tags_workspace_index.py
@@ -1,0 +1,35 @@
+"""Add index on model_version_tags (workspace, name, version)
+
+The workspace migration (1b5f0d9ad7c1) changed the primary key of
+model_version_tags to (workspace, key, name, version).  SQLAlchemy's
+relationship loader joins on (workspace, name, version) to fetch tags
+for a batch of model versions, but the PK has ``key`` between
+``workspace`` and ``name``, so the join can only use the first PK
+column.  This index provides an efficient lookup path for that join.
+
+Create Date: 2026-04-08 00:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "7d34483879f0"
+down_revision = "ae8bbe7743c9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(
+        "idx_model_version_tags_workspace_name_version",
+        "model_version_tags",
+        ["workspace", "name", "version"],
+    )
+
+
+def downgrade():
+    op.drop_index(
+        "idx_model_version_tags_workspace_name_version",
+        table_name="model_version_tags",
+    )

--- a/mlflow/store/db_migrations/versions/7d34483879f0_add_model_version_tags_workspace_index.py
+++ b/mlflow/store/db_migrations/versions/7d34483879f0_add_model_version_tags_workspace_index.py
@@ -1,11 +1,11 @@
-"""Add index on model_version_tags (workspace, name, version)
+"""Add indexes for relationship loading after workspace PK migration
 
-The workspace migration (1b5f0d9ad7c1) changed the primary key of
-model_version_tags to (workspace, key, name, version).  SQLAlchemy's
-relationship loader joins on (workspace, name, version) to fetch tags
-for a batch of model versions, but the PK has ``key`` between
-``workspace`` and ``name``, so the join can only use the first PK
-column.  This index provides an efficient lookup path for that join.
+The workspace migration (1b5f0d9ad7c1) changed primary keys to include
+``workspace`` as the leading column.  SQLAlchemy's relationship loader
+joins on (workspace, name, version) for model_version_tags and
+(workspace, name) for registered_model_tags, but the PKs have ``key``
+between ``workspace`` and ``name``, so the join can only use the first
+PK column.  These indexes provide efficient lookup paths for those joins.
 
 Create Date: 2026-04-08 00:00:00.000000
 
@@ -26,9 +26,18 @@ def upgrade():
         "model_version_tags",
         ["workspace", "name", "version"],
     )
+    op.create_index(
+        "idx_registered_model_tags_workspace_name",
+        "registered_model_tags",
+        ["workspace", "name"],
+    )
 
 
 def downgrade():
+    op.drop_index(
+        "idx_registered_model_tags_workspace_name",
+        table_name="registered_model_tags",
+    )
     op.drop_index(
         "idx_model_version_tags_workspace_name_version",
         table_name="model_version_tags",

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -71,6 +71,17 @@ from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
 
 _logger = logging.getLogger(__name__)
 
+# Models that carry a ``workspace`` column and must be filtered
+# by the active workspace in every query.
+_WORKSPACE_MODELS = (
+    SqlRegisteredModel,
+    SqlModelVersion,
+    SqlWebhook,
+    SqlRegisteredModelTag,
+    SqlModelVersionTag,
+    SqlRegisteredModelAlias,
+)
+
 # For each database table, fetch its columns and define an appropriate attribute for each column
 # on the table's associated object representation (Mapper). This is necessary to ensure that
 # columns defined via backreference are available as Mapper instance attributes (e.g.,
@@ -155,13 +166,10 @@ class SqlAlchemyStore(AbstractStore):
     def _get_query(self, session, model):
         """
         Return a query for ``model``.
-        Workspace-aware subclasses override this to enforce scoping.
-
-        In single-tenant mode we still filter on the default workspace so that
-        the database can use the (workspace, ...) primary-key index efficiently.
+        Always filter on workspace for relevant models, to benefit from DB index.
         """
         query = session.query(model)
-        if hasattr(model, "workspace"):
+        if model in _WORKSPACE_MODELS:
             query = query.filter(model.workspace == self._get_active_workspace())
         return query
 
@@ -283,7 +291,11 @@ class SqlAlchemyStore(AbstractStore):
             sqlalchemy.func
             .row_number()
             .over(
-                partition_by=[SqlModelVersion.name, SqlModelVersion.current_stage],
+                partition_by=[
+                    SqlModelVersion.workspace,
+                    SqlModelVersion.name,
+                    SqlModelVersion.current_stage,
+                ],
                 order_by=SqlModelVersion.version.desc(),
             )
             .label("rn")
@@ -338,13 +350,9 @@ class SqlAlchemyStore(AbstractStore):
     def _get_workspace_clauses(self, model):
         """
         Return workspace filter clauses for the model.
-        Used for select() queries that can't use _get_query().
-        Workspace-aware subclasses override to return actual filters.
-
-        In single-tenant mode we still filter on the default workspace so that
-        the database can use the (workspace, ...) primary-key index efficiently.
+        Always filter on workspace for relevant models, to benefit from DB index.
         """
-        if hasattr(model, "workspace"):
+        if model in _WORKSPACE_MODELS:
             return [model.workspace == self._get_active_workspace()]
         return []
 

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -156,8 +156,14 @@ class SqlAlchemyStore(AbstractStore):
         """
         Return a query for ``model``.
         Workspace-aware subclasses override this to enforce scoping.
+
+        In single-tenant mode we still filter on the default workspace so that
+        the database can use the (workspace, ...) primary-key index efficiently.
         """
-        return session.query(model)
+        query = session.query(model)
+        if hasattr(model, "workspace"):
+            query = query.filter(model.workspace == self._get_active_workspace())
+        return query
 
     def _with_workspace_field(self, instance):
         """
@@ -330,7 +336,12 @@ class SqlAlchemyStore(AbstractStore):
         Return workspace filter clauses for the model.
         Used for select() queries that can't use _get_query().
         Workspace-aware subclasses override to return actual filters.
+
+        In single-tenant mode we still filter on the default workspace so that
+        the database can use the (workspace, ...) primary-key index efficiently.
         """
+        if hasattr(model, "workspace"):
+            return [model.workspace == self._get_active_workspace()]
         return []
 
     def create_registered_model(self, name, tags=None, description=None, deployment_job_id=None):
@@ -601,15 +612,19 @@ class SqlAlchemyStore(AbstractStore):
         if tag_filters:
             sql_tag_filters = (sqlalchemy.and_(*x) for x in tag_filters.values())
             tag_filter_query = (
-                select(SqlRegisteredModelTag.name)
+                select(SqlRegisteredModelTag.workspace, SqlRegisteredModelTag.name)
                 .filter(sqlalchemy.or_(*sql_tag_filters))
-                .group_by(SqlRegisteredModelTag.name)
+                .group_by(SqlRegisteredModelTag.workspace, SqlRegisteredModelTag.name)
                 .having(sqlalchemy.func.count(sqlalchemy.literal(1)) == len(tag_filters))
                 .subquery()
             )
 
             return rm_query.join(
-                tag_filter_query, SqlRegisteredModel.name == tag_filter_query.c.name
+                tag_filter_query,
+                sqlalchemy.and_(
+                    SqlRegisteredModel.workspace == tag_filter_query.c.workspace,
+                    SqlRegisteredModel.name == tag_filter_query.c.name,
+                ),
             )
         else:
             return rm_query
@@ -700,15 +715,24 @@ class SqlAlchemyStore(AbstractStore):
         if tag_filters:
             sql_tag_filters = (sqlalchemy.and_(*x) for x in tag_filters.values())
             tag_filter_query = (
-                select(SqlModelVersionTag.name, SqlModelVersionTag.version)
+                select(
+                    SqlModelVersionTag.workspace,
+                    SqlModelVersionTag.name,
+                    SqlModelVersionTag.version,
+                )
                 .filter(sqlalchemy.or_(*sql_tag_filters))
-                .group_by(SqlModelVersionTag.name, SqlModelVersionTag.version)
+                .group_by(
+                    SqlModelVersionTag.workspace,
+                    SqlModelVersionTag.name,
+                    SqlModelVersionTag.version,
+                )
                 .having(sqlalchemy.func.count(sqlalchemy.literal(1)) == len(tag_filters))
                 .subquery()
             )
             return mv_query.join(
                 tag_filter_query,
                 sqlalchemy.and_(
+                    SqlModelVersion.workspace == tag_filter_query.c.workspace,
                     SqlModelVersion.name == tag_filter_query.c.name,
                     SqlModelVersion.version == tag_filter_query.c.version,
                 ),
@@ -743,17 +767,22 @@ class SqlAlchemyStore(AbstractStore):
         # Filter to get all prompt rows
         equal = SearchUtils.get_sql_comparison_func("=", dialect)
         prompts_subquery = (
-            select(tag_db_model.name)
+            select(tag_db_model.workspace, tag_db_model.name)
             .filter(
                 equal(tag_db_model.key, IS_PROMPT_TAG_KEY),
                 equal(tag_db_model.value, "true"),
                 *self._get_workspace_clauses(tag_db_model),
             )
-            .group_by(tag_db_model.name)
+            .group_by(tag_db_model.workspace, tag_db_model.name)
             .subquery()
         )
         return query.join(
-            prompts_subquery, main_db_model.name == prompts_subquery.c.name, isouter=True
+            prompts_subquery,
+            sqlalchemy.and_(
+                main_db_model.workspace == prompts_subquery.c.workspace,
+                main_db_model.name == prompts_subquery.c.name,
+            ),
+            isouter=True,
         ).filter(prompts_subquery.c.name.is_(None))
 
     @classmethod

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -265,9 +265,8 @@ class SqlAlchemyStore(AbstractStore):
             sqlalchemy.orm.subqueryload(SqlRegisteredModel.registered_model_aliases),
         ]
 
-    @classmethod
     def _get_latest_versions_for_models(
-        cls, session, model_names: list[str]
+        self, session, model_names: list[str]
     ) -> dict[str, list[SqlModelVersion]]:
         """
         Batch-fetch the latest model version per stage for multiple registered models.
@@ -277,6 +276,8 @@ class SqlAlchemyStore(AbstractStore):
         """
         if not model_names:
             return {}
+
+        workspace_clauses = self._get_workspace_clauses(SqlModelVersion)
 
         row_num = (
             sqlalchemy.func
@@ -291,6 +292,7 @@ class SqlAlchemyStore(AbstractStore):
         subquery = (
             select(SqlModelVersion, row_num)
             .where(
+                *workspace_clauses,
                 SqlModelVersion.name.in_(model_names),
                 SqlModelVersion.current_stage != STAGE_DELETED_INTERNAL,
             )
@@ -299,15 +301,17 @@ class SqlAlchemyStore(AbstractStore):
 
         query = (
             select(SqlModelVersion)
+            .where(*workspace_clauses)
             .join(
                 subquery,
                 sqlalchemy.and_(
+                    SqlModelVersion.workspace == subquery.c.workspace,
                     SqlModelVersion.name == subquery.c.name,
                     SqlModelVersion.version == subquery.c.version,
                 ),
             )
             .where(subquery.c.rn == 1)
-            .options(*cls._get_eager_model_version_query_options())
+            .options(*self._get_eager_model_version_query_options())
         )
 
         latest_versions = session.execute(query).scalars().all()

--- a/mlflow/store/model_registry/sqlalchemy_workspace_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_workspace_store.py
@@ -6,51 +6,23 @@ from __future__ import annotations
 
 import logging
 
-from mlflow.store.model_registry.dbmodels.models import (
-    SqlModelVersion,
-    SqlModelVersionTag,
-    SqlRegisteredModel,
-    SqlRegisteredModelAlias,
-    SqlRegisteredModelTag,
-    SqlWebhook,
-)
 from mlflow.store.model_registry.sqlalchemy_store import SqlAlchemyStore
 from mlflow.store.workspace_aware_mixin import WorkspaceAwareMixin
 
 _logger = logging.getLogger(__name__)
-
-_WORKSPACE_ISOLATED_MODELS = (
-    SqlRegisteredModel,
-    SqlModelVersion,
-    SqlWebhook,
-    SqlRegisteredModelTag,
-    SqlModelVersionTag,
-    SqlRegisteredModelAlias,
-)
 
 
 class WorkspaceAwareSqlAlchemyStore(WorkspaceAwareMixin, SqlAlchemyStore):
     """
     Workspace-aware variant of the model registry SQLAlchemy store.
 
-    This store adds workspace filtering to all queries, ensuring data isolation
-    between workspaces.
+    Workspace filtering is handled by the base ``SqlAlchemyStore`` via
+    ``_get_active_workspace()``, which ``WorkspaceAwareMixin`` overrides
+    to return the workspace from the current request context.
     """
 
     def __init__(self, db_uri):
         super().__init__(db_uri)
-
-    def _get_query(self, session, model):
-        """
-        Return a query for ``model`` filtered by the active workspace.
-        """
-        query = super()._get_query(session, model)
-        workspace = self._get_active_workspace()
-
-        if model in _WORKSPACE_ISOLATED_MODELS:
-            return query.filter(model.workspace == workspace)
-
-        return query
 
     def _initialize_store_state(self):
         """
@@ -61,14 +33,3 @@ class WorkspaceAwareSqlAlchemyStore(WorkspaceAwareMixin, SqlAlchemyStore):
         """
         # No validation needed in workspace-aware mode - entries in different
         # workspaces are expected and correct behavior
-
-    def _get_workspace_clauses(self, model):
-        """
-        Return workspace filter clauses for the model.
-        """
-        workspace = self._get_active_workspace()
-
-        if model in _WORKSPACE_ISOLATED_MODELS:
-            return [model.workspace == workspace]
-
-        return []

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -1122,6 +1122,56 @@ def test_search_model_versions_by_tag(store):
     assert search_versions("tag.t2 like 'x%' and tag.t2 != 'xyz'") == [2]
 
 
+def test_search_queries_include_workspace_predicate(store):
+    from sqlalchemy import event
+
+    name = "test_ws_predicate"
+    _rm_maker(store, name)
+    _mv_maker(
+        store,
+        name=name,
+        source="A/B",
+        tags=[ModelVersionTag("t1", "abc")],
+    )
+
+    search_cases = [
+        f"name = '{name}'",
+        "tag.t1 = 'abc'",
+        f"name = '{name}' AND tag.t1 = 'abc'",
+    ]
+
+    for filter_string in search_cases:
+        captured_sql: list[str] = []
+
+        def _capture(conn, cursor, statement, parameters, context, executemany):
+            captured_sql.append(statement)
+
+        event.listen(store.engine, "before_cursor_execute", _capture)
+        try:
+            store.search_model_versions(filter_string)
+        finally:
+            event.remove(store.engine, "before_cursor_execute", _capture)
+
+        # The main search query is the one with ORDER BY + LIMIT — the actual
+        # search result query.  Tag-loading subqueries don't have ORDER BY.
+        main_queries = [
+            s
+            for s in captured_sql
+            if "ORDER BY" in s
+            and "model_versions" in s
+            and "LIMIT" in s
+        ]
+        assert main_queries, f"No main search query found for filter: {filter_string}"
+
+        for sql in main_queries:
+            where_clause = sql.split("WHERE", 1)[-1] if "WHERE" in sql else ""
+            assert "workspace" in where_clause.lower(), (
+                f"search_model_versions('{filter_string}') missing workspace "
+                f"predicate in WHERE — causes full table scan on "
+                f"(workspace, ...) PK:\n{sql}"
+            )
+
+
 def _search_registered_models(store, filter_string, max_results=10, order_by=None, page_token=None):
     result = store.search_registered_models(
         filter_string=filter_string,

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -1135,7 +1135,6 @@ def _assert_workspace_in_main_queries(captured_sql, table_name, context_label):
 
 
 def test_search_model_versions_includes_workspace_predicate(store):
-    """search_model_versions queries must filter on workspace to use the PK index."""
     from sqlalchemy import event
 
     name = "test_ws_predicate_mv"
@@ -1164,7 +1163,6 @@ def test_search_model_versions_includes_workspace_predicate(store):
 
 
 def test_search_registered_models_includes_workspace_predicate(store):
-    """search_registered_models queries must filter on workspace to use the PK index."""
     from sqlalchemy import event
 
     name = "test_ws_predicate_rm"

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -1122,25 +1122,31 @@ def test_search_model_versions_by_tag(store):
     assert search_versions("tag.t2 like 'x%' and tag.t2 != 'xyz'") == [2]
 
 
-def test_search_queries_include_workspace_predicate(store):
+def _assert_workspace_in_main_queries(captured_sql, table_name, context_label):
+    """Assert that every main search query (ORDER BY + LIMIT) includes workspace in WHERE."""
+    main_queries = [s for s in captured_sql if "ORDER BY" in s and table_name in s and "LIMIT" in s]
+    assert main_queries, f"No main search query found for {context_label}"
+    for sql in main_queries:
+        where_clause = sql.split("WHERE", 1)[-1] if "WHERE" in sql else ""
+        assert "workspace" in where_clause.lower(), (
+            f"{context_label} missing workspace predicate in WHERE — "
+            f"causes full table scan on (workspace, ...) PK:\n{sql}"
+        )
+
+
+def test_search_model_versions_includes_workspace_predicate(store):
+    """search_model_versions queries must filter on workspace to use the PK index."""
     from sqlalchemy import event
 
-    name = "test_ws_predicate"
+    name = "test_ws_predicate_mv"
     _rm_maker(store, name)
-    _mv_maker(
-        store,
-        name=name,
-        source="A/B",
-        tags=[ModelVersionTag("t1", "abc")],
-    )
+    _mv_maker(store, name=name, source="A/B", tags=[ModelVersionTag("t1", "abc")])
 
-    search_cases = [
+    for filter_string in [
         f"name = '{name}'",
         "tag.t1 = 'abc'",
         f"name = '{name}' AND tag.t1 = 'abc'",
-    ]
-
-    for filter_string in search_cases:
+    ]:
         captured_sql: list[str] = []
 
         def _capture(conn, cursor, statement, parameters, context, executemany):
@@ -1152,20 +1158,39 @@ def test_search_queries_include_workspace_predicate(store):
         finally:
             event.remove(store.engine, "before_cursor_execute", _capture)
 
-        # The main search query is the one with ORDER BY + LIMIT — the actual
-        # search result query.  Tag-loading subqueries don't have ORDER BY.
-        main_queries = [
-            s for s in captured_sql if "ORDER BY" in s and "model_versions" in s and "LIMIT" in s
-        ]
-        assert main_queries, f"No main search query found for filter: {filter_string}"
+        _assert_workspace_in_main_queries(
+            captured_sql, "model_versions", f"search_model_versions('{filter_string}')"
+        )
 
-        for sql in main_queries:
-            where_clause = sql.split("WHERE", 1)[-1] if "WHERE" in sql else ""
-            assert "workspace" in where_clause.lower(), (
-                f"search_model_versions('{filter_string}') missing workspace "
-                f"predicate in WHERE — causes full table scan on "
-                f"(workspace, ...) PK:\n{sql}"
-            )
+
+def test_search_registered_models_includes_workspace_predicate(store):
+    """search_registered_models queries must filter on workspace to use the PK index."""
+    from sqlalchemy import event
+
+    name = "test_ws_predicate_rm"
+    _rm_maker(store, name, tags=[RegisteredModelTag("t1", "abc")])
+
+    for filter_string in [
+        f"name = '{name}'",
+        "tag.t1 = 'abc'",
+        f"name = '{name}' AND tag.t1 = 'abc'",
+    ]:
+        captured_sql: list[str] = []
+
+        def _capture(conn, cursor, statement, parameters, context, executemany):
+            captured_sql.append(statement)
+
+        event.listen(store.engine, "before_cursor_execute", _capture)
+        try:
+            store.search_registered_models(filter_string)
+        finally:
+            event.remove(store.engine, "before_cursor_execute", _capture)
+
+        _assert_workspace_in_main_queries(
+            captured_sql,
+            "registered_models",
+            f"search_registered_models('{filter_string}')",
+        )
 
 
 def _search_registered_models(store, filter_string, max_results=10, order_by=None, page_token=None):

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -1155,11 +1155,7 @@ def test_search_queries_include_workspace_predicate(store):
         # The main search query is the one with ORDER BY + LIMIT — the actual
         # search result query.  Tag-loading subqueries don't have ORDER BY.
         main_queries = [
-            s
-            for s in captured_sql
-            if "ORDER BY" in s
-            and "model_versions" in s
-            and "LIMIT" in s
+            s for s in captured_sql if "ORDER BY" in s and "model_versions" in s and "LIMIT" in s
         ]
         assert main_queries, f"No main search query found for filter: {filter_string}"
 

--- a/tests/store/test_workspace_model_coverage.py
+++ b/tests/store/test_workspace_model_coverage.py
@@ -20,10 +20,10 @@ from mlflow.store.db.base_sql_model import Base
 # store paths resolve correctly regardless of the pytest working directory.
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
-# Every workspace store that provides a ``_get_query`` override.
+# Every store that provides a ``_get_query`` with workspace filtering.
 WORKSPACE_STORE_PATHS = [
     "mlflow/store/tracking/sqlalchemy_workspace_store.py",
-    "mlflow/store/model_registry/sqlalchemy_workspace_store.py",
+    "mlflow/store/model_registry/sqlalchemy_store.py",
     "mlflow/store/jobs/sqlalchemy_workspace_store.py",
 ]
 


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #22397

### What changes are proposed in this pull request?

Make sure workspace is always added in search queries, even when workspaces are not enabled.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
