### PR TITLE
[UI] Fix endpoint details to display all API keys for multi-model endpoints

### DIFF
--- a/mlflow/server/js/src/gateway/components/edit-endpoint/EditEndpointFormRenderer.tsx
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/EditEndpointFormRenderer.tsx
@@ -144,6 +144,13 @@ export const EditEndpointFormRenderer = ({
   const totalWeight = trafficSplitModels.reduce((sum, m) => sum + m.weight, 0);
   const isValidTotal = Math.abs(totalWeight - 100) < 0.01;
 
+  const uniqueSecretNames = useMemo(
+    () => [
+      ...new Set(endpoint?.model_mappings.map((m) => m.model_definition?.secret_name).filter(Boolean) as string[]),
+    ],
+    [endpoint?.model_mappings],
+  );
+
   if (isLoadingEndpoint) {
     return (
       <div css={{ overflow: 'hidden', display: 'flex', flexDirection: 'column', flex: 1 }}>
@@ -404,23 +411,33 @@ export const EditEndpointFormRenderer = ({
                     </Typography.Text>
                   </div>
 
-                  {endpoint.model_mappings[0]?.model_definition?.secret_name && (
+                  {uniqueSecretNames.length > 0 && (
                     <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
                       <Typography.Text bold color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
-                        <FormattedMessage defaultMessage="API key" description="Label for endpoint API key" />
+                        {uniqueSecretNames.length === 1 ? (
+                          <FormattedMessage defaultMessage="API key" description="Label for endpoint API key" />
+                        ) : (
+                          <FormattedMessage
+                            defaultMessage="API keys"
+                            description="Label for endpoint API keys (plural)"
+                          />
+                        )}
                       </Typography.Text>
-                      <Link
-                        componentId="mlflow.gateway.edit-endpoint.api-key-link"
-                        to={GatewayRoutes.apiKeysPageRoute}
-                        css={{
-                          fontSize: theme.typography.fontSizeSm,
-                          color: theme.colors.actionPrimaryBackgroundDefault,
-                          textDecoration: 'none',
-                          '&:hover': { textDecoration: 'underline' },
-                        }}
-                      >
-                        {endpoint.model_mappings[0].model_definition.secret_name}
-                      </Link>
+                      {uniqueSecretNames.map((secretName) => (
+                        <Link
+                          key={secretName}
+                          componentId="mlflow.gateway.edit-endpoint.api-key-link"
+                          to={GatewayRoutes.apiKeysPageRoute}
+                          css={{
+                            fontSize: theme.typography.fontSizeSm,
+                            color: theme.colors.actionPrimaryBackgroundDefault,
+                            textDecoration: 'none',
+                            '&:hover': { textDecoration: 'underline' },
+                          }}
+                        >
+                          {secretName}
+                        </Link>
+                      ))}
                     </div>
                   )}
 

--- a/mlflow/server/js/src/gateway/components/edit-endpoint/EditEndpointFormRenderer.tsx
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/EditEndpointFormRenderer.tsx
@@ -414,14 +414,11 @@ export const EditEndpointFormRenderer = ({
                   {uniqueSecretNames.length > 0 && (
                     <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
                       <Typography.Text bold color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
-                        {uniqueSecretNames.length === 1 ? (
-                          <FormattedMessage defaultMessage="API key" description="Label for endpoint API key" />
-                        ) : (
-                          <FormattedMessage
-                            defaultMessage="API keys"
-                            description="Label for endpoint API keys (plural)"
-                          />
-                        )}
+                        <FormattedMessage
+                          defaultMessage="{count, plural, =1 {API key} other {API keys}}"
+                          description="Label for endpoint API key(s)"
+                          values={{ count: uniqueSecretNames.length }}
+                        />
                       </Typography.Text>
                       {uniqueSecretNames.map((secretName) => (
                         <Link

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -2682,6 +2682,10 @@
     "defaultMessage": "Endpoint Name",
     "description": "Label for endpoint name input"
   },
+  "FRsU9y": {
+    "defaultMessage": "API keys",
+    "description": "Label for endpoint API keys (plural)"
+  },
   "FTx+Hi": {
     "defaultMessage": "(baseline)",
     "description": "A label displayed next to baseline version in the prompt versions comparison view"

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -2682,10 +2682,6 @@
     "defaultMessage": "Endpoint Name",
     "description": "Label for endpoint name input"
   },
-  "FRsU9y": {
-    "defaultMessage": "API keys",
-    "description": "Label for endpoint API keys (plural)"
-  },
   "FTx+Hi": {
     "defaultMessage": "(baseline)",
     "description": "A label displayed next to baseline version in the prompt versions comparison view"
@@ -4077,6 +4073,10 @@
   "On3g1B": {
     "defaultMessage": "Running",
     "description": "Run page > Overview > Run status cell > Value for running state"
+  },
+  "OnZkIA": {
+    "defaultMessage": "{count, plural, =1 {API key} other {API keys}}",
+    "description": "Label for endpoint API key(s)"
   },
   "OneX+E": {
     "defaultMessage": "Add expectation",
@@ -8478,10 +8478,6 @@
   "qKGnLV": {
     "defaultMessage": "Model Config:",
     "description": "Label for model configuration in the prompt details page"
-  },
-  "qKHKw4": {
-    "defaultMessage": "API key",
-    "description": "Label for endpoint API key"
   },
   "qMwRy3": {
     "defaultMessage": "Registered Models",


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22284

### What changes are proposed in this pull request?

Fixes a bug introduced in #22284 where the endpoint details right panel only displayed the API key from the first model mapping (`model_mappings[0]`). When an endpoint has multiple models (traffic split or fallback), each model may use a different API key, but only the first one was shown.

**Changes:**
- Extract all unique `secret_name` values from every model mapping instead of hardcoding index `[0]`
- Display "API key" (singular) or "API keys" (plural) label based on count
- Render a clickable link for each unique API key

### How is this PR tested?
<img width="355" height="364" alt="image" src="https://github.com/user-attachments/assets/e9f0ea9b-9b46-4b23-8ed2-aa6ca4a3ebea" />


- [x] Manual tests

Verified on endpoint details page with single-model and multi-model endpoints.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fix endpoint details page to display all API keys when an endpoint has multiple models with different keys.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release