### PR TITLE
Extract `service.name` from OTLP resource attributes for usage telemetry

### DIFF
--- a/mlflow/server/otel_api.py
+++ b/mlflow/server/otel_api.py
@@ -40,6 +40,22 @@ from mlflow.tracking.request_header.default_request_header_provider import (
 
 _logger = logging.getLogger(__name__)
 
+# Allowlist of known OTEL client service names.
+# Only service names on this list are stored and propagated to root spans.
+# This prevents storing arbitrary free-form text from untrusted clients.
+_KNOWN_SERVICE_NAMES = frozenset({
+    # Claude Code
+    "claude-code",
+    # Codex CLI (Rust)
+    "codex_cli_rs",
+    # Codex VS Code extension
+    "codex_vscode",
+    # Gemini CLI
+    "gemini-cli",
+    # Qwen Code
+    "qwen-code",
+})
+
 # Create FastAPI router for OTel endpoints
 otel_router = APIRouter(prefix=OTLP_TRACES_PATH, tags=["OpenTelemetry"])
 
@@ -118,7 +134,7 @@ async def export_traces(
         for attr in resource_span.resource.attributes:
             if attr.key == "service.name":
                 value = _decode_otel_proto_anyvalue(attr.value)
-                if value is not None:
+                if value is not None and str(value) in _KNOWN_SERVICE_NAMES:
                     resource_service_name = str(value)
                     service_names.add(resource_service_name)
                 break

--- a/mlflow/server/otel_api.py
+++ b/mlflow/server/otel_api.py
@@ -26,9 +26,11 @@ from mlflow.exceptions import MlflowException
 from mlflow.server.handlers import _get_tracking_store
 from mlflow.telemetry.events import TraceSource, TracesReceivedByServerEvent
 from mlflow.telemetry.track import _record_event
+from mlflow.tracing.utils import dump_span_attribute_value
 from mlflow.tracing.utils.otlp import (
     MLFLOW_EXPERIMENT_ID_HEADER,
     OTLP_TRACES_PATH,
+    _decode_otel_proto_anyvalue,
     decompress_otlp_body,
 )
 from mlflow.tracking.request_header.default_request_header_provider import (
@@ -109,14 +111,35 @@ async def export_traces(
 
     all_spans = []
     completed_trace_ids = set()
+    service_names = set()
     for resource_span in parsed_request.resource_spans:
+        # Extract service.name from resource attributes for telemetry and root span propagation
+        resource_service_name = None
+        for attr in resource_span.resource.attributes:
+            if attr.key == "service.name":
+                value = _decode_otel_proto_anyvalue(attr.value)
+                if value is not None:
+                    resource_service_name = str(value)
+                    service_names.add(resource_service_name)
+                break
+
         for scope_span in resource_span.scope_spans:
             for otel_proto_span in scope_span.spans:
                 try:
                     mlflow_span = Span.from_otel_proto(otel_proto_span)
-                    all_spans.append(mlflow_span)
+
+                    # Propagate service.name onto root spans so it's visible
+                    # in the UI. Per the OTel resource spec, resource attrs
+                    # describe the entity producing telemetry:
+                    # https://opentelemetry.io/docs/specs/otel/resource/sdk/
                     if mlflow_span.parent_id is None:
                         completed_trace_ids.add(mlflow_span.trace_id)
+                        if resource_service_name:
+                            mlflow_span._span._attributes["service.name"] = (
+                                dump_span_attribute_value(resource_service_name)
+                            )
+
+                    all_spans.append(mlflow_span)
                 except Exception:
                     raise HTTPException(
                         status_code=422,
@@ -148,19 +171,21 @@ async def export_traces(
             )
 
         if completed_trace_ids:
-            trace_source = (
-                TraceSource.MLFLOW_PYTHON_CLIENT
-                if user_agent and user_agent.startswith(_MLFLOW_PYTHON_CLIENT_USER_AGENT_PREFIX)
-                else TraceSource.UNKNOWN
-            )
+            if user_agent and user_agent.startswith(_MLFLOW_PYTHON_CLIENT_USER_AGENT_PREFIX):
+                trace_source = TraceSource.MLFLOW_PYTHON_CLIENT
+            elif service_names:
+                trace_source = TraceSource.EXTERNAL_OTEL_CLIENT
+            else:
+                trace_source = TraceSource.UNKNOWN
 
-            _record_event(
-                TracesReceivedByServerEvent,
-                {
-                    "source": trace_source,
-                    "count": len(completed_trace_ids),
-                },
-            )
+            event_params: dict[str, object] = {
+                "source": trace_source,
+                "count": len(completed_trace_ids),
+            }
+            if service_names:
+                event_params["service_names"] = sorted(service_names)
+
+            _record_event(TracesReceivedByServerEvent, event_params)
 
     # Return protobuf response as per OTLP specification
     response_message = ExportTraceServiceResponse()

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -659,6 +659,7 @@ class TraceSource(str, Enum):
     """Source of a trace received by the MLflow server."""
 
     MLFLOW_PYTHON_CLIENT = "MLFLOW_PYTHON_CLIENT"
+    EXTERNAL_OTEL_CLIENT = "EXTERNAL_OTEL_CLIENT"
     UNKNOWN = "UNKNOWN"
 
 

--- a/tests/tracing/test_otel_logging.py
+++ b/tests/tracing/test_otel_logging.py
@@ -741,16 +741,20 @@ def test_otel_trace_received_telemetry_from_external_client(mlflow_server: str):
 
 
 @pytest.mark.parametrize(
-    ("service_name", "expected_service_names"),
+    ("service_name", "expected_source", "expected_service_names"),
     [
-        ("codex_cli_rs", ["codex_cli_rs"]),
-        ("gemini-cli", ["gemini-cli"]),
-        ("qwen-code", ["qwen-code"]),
-        ("my-custom-app", ["my-custom-app"]),
+        ("codex_cli_rs", TraceSource.EXTERNAL_OTEL_CLIENT, ["codex_cli_rs"]),
+        ("gemini-cli", TraceSource.EXTERNAL_OTEL_CLIENT, ["gemini-cli"]),
+        ("qwen-code", TraceSource.EXTERNAL_OTEL_CLIENT, ["qwen-code"]),
+        # Unknown service names are not on the allowlist — source falls back to UNKNOWN
+        ("my-custom-app", TraceSource.UNKNOWN, None),
     ],
 )
 def test_otel_trace_received_telemetry_from_external_otel_client_with_service_name(
-    mlflow_server: str, service_name: str, expected_service_names: list[str]
+    mlflow_server: str,
+    service_name: str,
+    expected_source: TraceSource,
+    expected_service_names: list[str] | None,
 ):
     mlflow.set_tracking_uri(mlflow_server)
     experiment = mlflow.set_experiment("otel-telemetry-service-name-test")
@@ -804,9 +808,12 @@ def test_otel_trace_received_telemetry_from_external_otel_client_with_service_na
         record = mock_client.add_record.call_args[0][0]
 
         assert record.event_name == TracesReceivedByServerEvent.name
-        assert record.params["source"] == TraceSource.EXTERNAL_OTEL_CLIENT.value
+        assert record.params["source"] == expected_source.value
         assert record.params["count"] == 1
-        assert record.params["service_names"] == expected_service_names
+        if expected_service_names is not None:
+            assert record.params["service_names"] == expected_service_names
+        else:
+            assert "service_names" not in record.params
 
 
 def test_service_name_propagated_to_root_span(mlflow_server: str):

--- a/tests/tracing/test_otel_logging.py
+++ b/tests/tracing/test_otel_logging.py
@@ -20,7 +20,7 @@ from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
     ExportTraceServiceRequest,
     ExportTraceServiceResponse,
 )
-from opentelemetry.proto.common.v1.common_pb2 import InstrumentationScope
+from opentelemetry.proto.common.v1.common_pb2 import AnyValue, InstrumentationScope, KeyValue
 from opentelemetry.proto.resource.v1.resource_pb2 import Resource
 from opentelemetry.proto.trace.v1.trace_pb2 import ResourceSpans, ScopeSpans
 from opentelemetry.proto.trace.v1.trace_pb2 import Span as OTelProtoSpan
@@ -738,6 +738,139 @@ def test_otel_trace_received_telemetry_from_external_client(mlflow_server: str):
         assert record.status.value == "success"
         assert record.params["source"] == TraceSource.UNKNOWN.value
         assert record.params["count"] == 2
+
+
+@pytest.mark.parametrize(
+    ("service_name", "expected_service_names"),
+    [
+        ("codex_cli_rs", ["codex_cli_rs"]),
+        ("gemini-cli", ["gemini-cli"]),
+        ("qwen-code", ["qwen-code"]),
+        ("my-custom-app", ["my-custom-app"]),
+    ],
+)
+def test_otel_trace_received_telemetry_from_external_otel_client_with_service_name(
+    mlflow_server: str, service_name: str, expected_service_names: list[str]
+):
+    mlflow.set_tracking_uri(mlflow_server)
+    experiment = mlflow.set_experiment("otel-telemetry-service-name-test")
+    experiment_id = experiment.experiment_id
+
+    trace_id = bytes.fromhex("0000000000000500" + "0" * 16)
+
+    request = ExportTraceServiceRequest()
+    request.resource_spans.append(
+        ResourceSpans(
+            resource=Resource(
+                attributes=[
+                    KeyValue(key="service.name", value=AnyValue(string_value=service_name)),
+                ]
+            ),
+            scope_spans=[
+                ScopeSpans(
+                    scope=InstrumentationScope(name="test-scope"),
+                    spans=[
+                        OTelProtoSpan(
+                            trace_id=trace_id,
+                            span_id=bytes.fromhex("00000005" + "0" * 8),
+                            name="root-span",
+                            start_time_unix_nano=1000000000,
+                            end_time_unix_nano=2000000000,
+                        ),
+                    ],
+                )
+            ],
+        )
+    )
+
+    with mock.patch("mlflow.telemetry.track.get_telemetry_client") as mock_get_client:
+        mock_client = mock.MagicMock(spec=TelemetryClient)
+        mock_client.config = None
+        mock_get_client.return_value = mock_client
+
+        response = requests.post(
+            f"{mlflow_server}/v1/traces",
+            data=request.SerializeToString(),
+            headers={
+                "Content-Type": "application/x-protobuf",
+                MLFLOW_EXPERIMENT_ID_HEADER: experiment_id,
+            },
+            timeout=10,
+        )
+
+        assert response.status_code == 200
+
+        mock_client.add_record.assert_called_once()
+        record = mock_client.add_record.call_args[0][0]
+
+        assert record.event_name == TracesReceivedByServerEvent.name
+        assert record.params["source"] == TraceSource.EXTERNAL_OTEL_CLIENT.value
+        assert record.params["count"] == 1
+        assert record.params["service_names"] == expected_service_names
+
+
+def test_service_name_propagated_to_root_span(mlflow_server: str):
+    mlflow.set_tracking_uri(mlflow_server)
+    experiment = mlflow.set_experiment("otel-service-name-on-span-test")
+    experiment_id = experiment.experiment_id
+
+    trace_id = bytes.fromhex("0000000000000600" + "0" * 16)
+    root_span_id = bytes.fromhex("00000006" + "0" * 8)
+    child_span_id = bytes.fromhex("00000007" + "0" * 8)
+
+    request = ExportTraceServiceRequest()
+    request.resource_spans.append(
+        ResourceSpans(
+            resource=Resource(
+                attributes=[
+                    KeyValue(key="service.name", value=AnyValue(string_value="gemini-cli")),
+                ]
+            ),
+            scope_spans=[
+                ScopeSpans(
+                    scope=InstrumentationScope(name="test-scope"),
+                    spans=[
+                        OTelProtoSpan(
+                            trace_id=trace_id,
+                            span_id=root_span_id,
+                            name="root-span",
+                            start_time_unix_nano=1000000000,
+                            end_time_unix_nano=2000000000,
+                        ),
+                        OTelProtoSpan(
+                            trace_id=trace_id,
+                            span_id=child_span_id,
+                            parent_span_id=root_span_id,
+                            name="child-span",
+                            start_time_unix_nano=1100000000,
+                            end_time_unix_nano=1500000000,
+                        ),
+                    ],
+                )
+            ],
+        )
+    )
+
+    response = requests.post(
+        f"{mlflow_server}/v1/traces",
+        data=request.SerializeToString(),
+        headers={
+            "Content-Type": "application/x-protobuf",
+            MLFLOW_EXPERIMENT_ID_HEADER: experiment_id,
+        },
+        timeout=10,
+    )
+    assert response.status_code == 200
+
+    traces = mlflow.search_traces(locations=[experiment_id], include_spans=True, return_type="list")
+    assert len(traces) == 1
+
+    root_span = next(s for s in traces[0].data.spans if s.parent_id is None)
+    child_span = next(s for s in traces[0].data.spans if s.parent_id is not None)
+
+    # service.name should be on the root span only
+    assert root_span.get_attribute("service.name") == "gemini-cli"
+    assert child_span.get_attribute("service.name") is None
 
 
 def test_response_is_protobuf_format(mlflow_server: str):


### PR DESCRIPTION
## 🥞 Stacked PR
- [**stack/agent-tracing/1-service-name**](https://github.com/mlflow/mlflow/pull/22407)
  - [stack/agent-tracing/2-json-otlp](https://github.com/mlflow/mlflow/pull/22408)
    - [stack/agent-tracing/3-gemini-translator](https://github.com/mlflow/mlflow/pull/22409)
      - [stack/agent-tracing/4-codex-ts](https://github.com/mlflow/mlflow/pull/22410)
        - [stack/agent-tracing/5-qwen-ts](https://github.com/mlflow/mlflow/pull/22411)
          - [stack/agent-tracing/6-docs](https://github.com/mlflow/mlflow/pull/22412)

---------
### Related Issues/PRs

Relates to coding agent tracing project (Codex CLI, Gemini CLI, Qwen Code support)

### What changes are proposed in this pull request?

Three enhancements to the OTLP trace ingestion endpoint (`/v1/traces`):

1. **Usage telemetry**: Extracts `service.name` from OTLP resource attributes. Adds `EXTERNAL_OTEL_CLIENT` to the `TraceSource` enum and reports `service_names` in the `TracesReceivedByServerEvent`.

2. **Root span visibility**: Propagates `service.name` as an attribute on root spans so it's visible in the MLflow UI (follows OTel convention of associating resource attributes with the producing entity).

3. **JSON OTLP encoding**: Adds `Content-Type: application/json` support alongside existing `application/x-protobuf`. Some OTEL clients (notably Gemini CLI) send JSON by default. Handles the hex→base64 conversion needed for trace/span IDs because OTLP JSON uses hex strings while protobuf's JSON mapping expects base64 for `bytes` fields.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests
- [ ] Manual tests

Tested end-to-end with real Gemini CLI sending JSON OTLP traces to a local MLflow server. Also parametrized integration tests for service.name telemetry, root span propagation, and JSON encoding.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

Documentation for Gemini CLI setup (env vars) will be added in a follow-up.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release