### PR TITLE
Add JSON OTLP encoding support for trace ingestion

### DIFF
--- a/mlflow/server/otel_api.py
+++ b/mlflow/server/otel_api.py
@@ -10,11 +10,14 @@ The actual span ingestion logic would need to properly convert incoming OTel for
 to MLflow spans, which requires more complex conversion logic.
 """
 
+import base64
 import json
 import logging
 
 from fastapi import APIRouter, Header, HTTPException, Request, Response, status
 from fastapi.responses import JSONResponse
+from google.protobuf.json_format import Error as ProtoJsonError
+from google.protobuf.json_format import Parse as ParseJsonProto
 from google.protobuf.message import DecodeError
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
     ExportTraceServiceRequest,
@@ -56,6 +59,34 @@ _KNOWN_SERVICE_NAMES = frozenset({
     "qwen-code",
 })
 
+# Span ID fields that need hex→base64 conversion in OTLP JSON payloads.
+# OTLP JSON uses lowercase hex for these fields, but protobuf's JSON mapping
+# (google.protobuf.json_format.Parse) expects base64 for `bytes` fields.
+_OTLP_HEX_ID_FIELDS = ("traceId", "spanId", "parentSpanId")
+
+
+def _convert_otlp_json_ids_to_base64(body: bytes) -> bytes:
+    """Convert hex-encoded trace/span IDs to base64 in an OTLP JSON payload.
+
+    The OTLP spec encodes trace_id and span_id as hex strings in JSON:
+        https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding
+
+    But protobuf's canonical JSON mapping uses base64 for ``bytes`` fields:
+        https://protobuf.dev/programming-guides/proto3/#json
+
+    ``google.protobuf.json_format.Parse`` follows the protobuf convention,
+    so we must convert the hex IDs to base64 before parsing.
+    """
+    data = json.loads(body)
+    for resource_span in data.get("resourceSpans", []):
+        for scope_span in resource_span.get("scopeSpans", []):
+            for span in scope_span.get("spans", []):
+                for field in _OTLP_HEX_ID_FIELDS:
+                    if hex_val := span.get(field):
+                        span[field] = base64.b64encode(bytes.fromhex(hex_val)).decode("ascii")
+    return json.dumps(data).encode("utf-8")
+
+
 # Create FastAPI router for OTel endpoints
 otel_router = APIRouter(prefix=OTLP_TRACES_PATH, tags=["OpenTelemetry"])
 
@@ -91,11 +122,14 @@ async def export_traces(
     Raises:
         HTTPException: If the request is invalid or span logging fails
     """
-    # Validate Content-Type header
-    if content_type != "application/x-protobuf":
+    # Validate Content-Type header. Normalize by stripping parameters like
+    # charset (e.g., "application/json; charset=utf-8" → "application/json").
+    media_type = content_type.split(";")[0].strip() if content_type else None
+    if media_type not in ("application/x-protobuf", "application/json"):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Invalid Content-Type: {content_type}. Expected: application/x-protobuf",
+            detail=f"Invalid Content-Type: {content_type}. "
+            "Expected: application/x-protobuf or application/json",
         )
 
     # Read & decompress request body
@@ -103,26 +137,33 @@ async def export_traces(
     if content_encoding:
         body = decompress_otlp_body(body, content_encoding.lower())
 
-    # Parse protobuf payload
+    # Parse payload — supports both protobuf and JSON encoding per the OTLP spec:
+    # https://opentelemetry.io/docs/specs/otlp/#otlphttp
     parsed_request = ExportTraceServiceRequest()
 
     try:
-        # In Python protobuf library 5.x, ParseFromString may not raise DecodeError on invalid data
-        parsed_request.ParseFromString(body)
+        if media_type == "application/json":
+            # OTLP JSON encodes trace_id/span_id as hex strings, but protobuf's
+            # JSON mapping expects base64 for `bytes` fields (per proto3 spec).
+            # We must convert hex→base64 before calling Parse(), otherwise the
+            # IDs are decoded incorrectly and overflow downstream int conversions.
+            body = _convert_otlp_json_ids_to_base64(body)
+            ParseJsonProto(body, parsed_request, ignore_unknown_fields=True)
+        else:
+            # In Python protobuf library 5.x, ParseFromString may not raise
+            # DecodeError on invalid data
+            parsed_request.ParseFromString(body)
 
-        # Check if we actually parsed any data
-        # If no resource_spans were parsed, the data was likely invalid
         if not parsed_request.resource_spans:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Invalid OpenTelemetry protobuf format - no spans found",
+                detail="Invalid OpenTelemetry format - no spans found",
             )
 
-    except DecodeError:
-        # This will catch errors in Python protobuf library 3.x
+    except (DecodeError, ProtoJsonError, json.JSONDecodeError, ValueError):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid OpenTelemetry protobuf format",
+            detail="Invalid OpenTelemetry format",
         )
 
     all_spans = []

--- a/tests/server/test_otel_api.py
+++ b/tests/server/test_otel_api.py
@@ -163,7 +163,7 @@ def test_otlp_invalid_content_type(monkeypatch):
 
     client = _make_test_client()
 
-    # Test with unsupported content type (application/json is now valid)
+    # Test with unsupported content type
     response = client.post(
         OTLP_TRACES_PATH,
         data=_build_otlp_payload(),

--- a/tests/server/test_otel_api.py
+++ b/tests/server/test_otel_api.py
@@ -163,12 +163,12 @@ def test_otlp_invalid_content_type(monkeypatch):
 
     client = _make_test_client()
 
-    # Test with wrong content type
+    # Test with unsupported content type (application/json is now valid)
     response = client.post(
         OTLP_TRACES_PATH,
         data=_build_otlp_payload(),
         headers={
-            "Content-Type": "application/json",
+            "Content-Type": "text/plain",
             "X-MLflow-Experiment-Id": "42",
         },
     )
@@ -207,7 +207,7 @@ def test_otlp_invalid_protobuf_data(monkeypatch):
         },
     )
     assert response.status_code == 400
-    assert "Invalid OpenTelemetry protobuf format" in response.json()["detail"]
+    assert "Invalid OpenTelemetry format" in response.json()["detail"]
 
 
 def test_otlp_empty_resource_spans(monkeypatch):

--- a/tests/tracing/test_otel_logging.py
+++ b/tests/tracing/test_otel_logging.py
@@ -301,7 +301,7 @@ def test_invalid_content_type_returns_400(mlflow_server: str):
     request = ExportTraceServiceRequest()
     request.resource_spans.append(resource_spans)
 
-    # Send request with unsupported Content-Type (application/json is now valid)
+    # Send request with unsupported Content-Type
     response = requests.post(
         f"{mlflow_server}/v1/traces",
         data=request.SerializeToString(),

--- a/tests/tracing/test_otel_logging.py
+++ b/tests/tracing/test_otel_logging.py
@@ -301,12 +301,12 @@ def test_invalid_content_type_returns_400(mlflow_server: str):
     request = ExportTraceServiceRequest()
     request.resource_spans.append(resource_spans)
 
-    # Send request with incorrect Content-Type
+    # Send request with unsupported Content-Type (application/json is now valid)
     response = requests.post(
         f"{mlflow_server}/v1/traces",
         data=request.SerializeToString(),
         headers={
-            "Content-Type": "application/json",  # Wrong content type
+            "Content-Type": "text/plain",
             MLFLOW_EXPERIMENT_ID_HEADER: "test-experiment",
         },
         timeout=10,
@@ -878,6 +878,65 @@ def test_service_name_propagated_to_root_span(mlflow_server: str):
     # service.name should be on the root span only
     assert root_span.get_attribute("service.name") == "gemini-cli"
     assert child_span.get_attribute("service.name") is None
+
+
+def test_otlp_json_encoding(mlflow_server: str):
+    mlflow.set_tracking_uri(mlflow_server)
+    experiment = mlflow.set_experiment("otel-json-encoding-test")
+    experiment_id = experiment.experiment_id
+
+    trace_id_hex = "61181d5c16b3b25d966891c3fc595af9"
+    span_id_hex = "508755a859b294e3"
+
+    payload = {
+        "resourceSpans": [
+            {
+                "resource": {
+                    "attributes": [
+                        {"key": "service.name", "value": {"stringValue": "gemini-cli"}},
+                    ]
+                },
+                "scopeSpans": [
+                    {
+                        "scope": {"name": "gemini-cli"},
+                        "spans": [
+                            {
+                                "traceId": trace_id_hex,
+                                "spanId": span_id_hex,
+                                "name": "user_prompt",
+                                "startTimeUnixNano": str(int(time.time() * 1e9)),
+                                "endTimeUnixNano": str(int(time.time() * 1e9) + 1000000000),
+                                "attributes": [
+                                    {
+                                        "key": "gen_ai.operation.name",
+                                        "value": {"stringValue": "user_prompt"},
+                                    },
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+
+    response = requests.post(
+        f"{mlflow_server}/v1/traces",
+        json=payload,
+        headers={
+            "Content-Type": "application/json",
+            MLFLOW_EXPERIMENT_ID_HEADER: experiment_id,
+        },
+        timeout=10,
+    )
+    assert response.status_code == 200
+
+    traces = mlflow.search_traces(locations=[experiment_id], include_spans=True, return_type="list")
+    assert len(traces) == 1
+
+    root_span = traces[0].data.spans[0]
+    assert root_span.name == "user_prompt"
+    assert root_span.get_attribute("service.name") == "gemini-cli"
 
 
 def test_response_is_protobuf_format(mlflow_server: str):


### PR DESCRIPTION
## 🥞 Stacked PR
- [stack/agent-tracing/1-service-name](https://github.com/mlflow/mlflow/pull/22407)
  - [**stack/agent-tracing/2-json-otlp**](https://github.com/mlflow/mlflow/pull/22408)
    - [stack/agent-tracing/3-gemini-translator](https://github.com/mlflow/mlflow/pull/22409)
      - [stack/agent-tracing/4-codex-ts](https://github.com/mlflow/mlflow/pull/22410)
        - [stack/agent-tracing/5-qwen-ts](https://github.com/mlflow/mlflow/pull/22411)
          - [stack/agent-tracing/6-docs](https://github.com/mlflow/mlflow/pull/22412)

---------
### Related Issues/PRs

Depends on #22287. Split out per review feedback from @B-Step62.

### What changes are proposed in this pull request?

Adds `Content-Type: application/json` support to the OTLP trace ingestion endpoint (`/v1/traces`), alongside the existing `application/x-protobuf` path.

Some OTEL clients (notably Gemini CLI) send JSON by default. The key challenge is that OTLP JSON encodes trace/span IDs as hex strings, but protobuf's JSON mapping (`google.protobuf.json_format.Parse`) expects base64 for `bytes` fields. This PR bridges the mismatch with a `_convert_otlp_json_ids_to_base64` conversion step.

Also:
- Normalizes Content-Type by stripping charset parameters (e.g., `application/json; charset=utf-8`)
- Uses `ignore_unknown_fields=True` for forward compatibility
- Catches `ProtoJsonError` for proper 400 responses on malformed JSON

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

- Integration test sending JSON OTLP payload with hex trace/span IDs
- Existing content-type validation tests updated (`application/json` is now valid, uses `text/plain` for invalid type test)
- E2E tested with real Gemini CLI sending JSON OTLP traces

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [x] Instructions

Gemini CLI setup docs in stack 5 (#22326) reference this capability.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release