### PR TITLE
Add `GeminiCliTranslator` for Gemini CLI OTLP span type mapping

### DIFF
--- a/mlflow/server/otel_api.py
+++ b/mlflow/server/otel_api.py
@@ -10,11 +10,14 @@ The actual span ingestion logic would need to properly convert incoming OTel for
 to MLflow spans, which requires more complex conversion logic.
 """
 
+import base64
 import json
 import logging
 
 from fastapi import APIRouter, Header, HTTPException, Request, Response, status
 from fastapi.responses import JSONResponse
+from google.protobuf.json_format import Error as ProtoJsonError
+from google.protobuf.json_format import Parse as ParseJsonProto
 from google.protobuf.message import DecodeError
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
     ExportTraceServiceRequest,
@@ -56,6 +59,34 @@ _KNOWN_SERVICE_NAMES = frozenset({
     "qwen-code",
 })
 
+# Span ID fields that need hex→base64 conversion in OTLP JSON payloads.
+# OTLP JSON uses lowercase hex for these fields, but protobuf's JSON mapping
+# (google.protobuf.json_format.Parse) expects base64 for `bytes` fields.
+_OTLP_HEX_ID_FIELDS = ("traceId", "spanId", "parentSpanId")
+
+
+def _convert_otlp_json_ids_to_base64(body: bytes) -> bytes:
+    """Convert hex-encoded trace/span IDs to base64 in an OTLP JSON payload.
+
+    The OTLP spec encodes trace_id and span_id as hex strings in JSON:
+        https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding
+
+    But protobuf's canonical JSON mapping uses base64 for ``bytes`` fields:
+        https://protobuf.dev/programming-guides/proto3/#json
+
+    ``google.protobuf.json_format.Parse`` follows the protobuf convention,
+    so we must convert the hex IDs to base64 before parsing.
+    """
+    data = json.loads(body)
+    for resource_span in data.get("resourceSpans", []):
+        for scope_span in resource_span.get("scopeSpans", []):
+            for span in scope_span.get("spans", []):
+                for field in _OTLP_HEX_ID_FIELDS:
+                    if hex_val := span.get(field):
+                        span[field] = base64.b64encode(bytes.fromhex(hex_val)).decode("ascii")
+    return json.dumps(data).encode("utf-8")
+
+
 # Create FastAPI router for OTel endpoints
 otel_router = APIRouter(prefix=OTLP_TRACES_PATH, tags=["OpenTelemetry"])
 
@@ -91,11 +122,14 @@ async def export_traces(
     Raises:
         HTTPException: If the request is invalid or span logging fails
     """
-    # Validate Content-Type header
-    if content_type != "application/x-protobuf":
+    # Validate Content-Type header. Normalize by stripping parameters like
+    # charset (e.g., "application/json; charset=utf-8" → "application/json").
+    media_type = content_type.split(";")[0].strip() if content_type else None
+    if media_type not in ("application/x-protobuf", "application/json"):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Invalid Content-Type: {content_type}. Expected: application/x-protobuf",
+            detail=f"Invalid Content-Type: {content_type}. "
+            "Expected: application/x-protobuf or application/json",
         )
 
     # Read & decompress request body
@@ -103,26 +137,33 @@ async def export_traces(
     if content_encoding:
         body = decompress_otlp_body(body, content_encoding.lower())
 
-    # Parse protobuf payload
+    # Parse payload — supports both protobuf and JSON encoding per the OTLP spec:
+    # https://opentelemetry.io/docs/specs/otlp/#otlphttp
     parsed_request = ExportTraceServiceRequest()
 
     try:
-        # In Python protobuf library 5.x, ParseFromString may not raise DecodeError on invalid data
-        parsed_request.ParseFromString(body)
+        if media_type == "application/json":
+            # OTLP JSON encodes trace_id/span_id as hex strings, but protobuf's
+            # JSON mapping expects base64 for `bytes` fields (per proto3 spec).
+            # We must convert hex→base64 before calling Parse(), otherwise the
+            # IDs are decoded incorrectly and overflow downstream int conversions.
+            body = _convert_otlp_json_ids_to_base64(body)
+            ParseJsonProto(body, parsed_request, ignore_unknown_fields=True)
+        else:
+            # In Python protobuf library 5.x, ParseFromString may not raise
+            # DecodeError on invalid data
+            parsed_request.ParseFromString(body)
 
-        # Check if we actually parsed any data
-        # If no resource_spans were parsed, the data was likely invalid
         if not parsed_request.resource_spans:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Invalid OpenTelemetry protobuf format - no spans found",
+                detail="Invalid OpenTelemetry format - no spans found",
             )
 
-    except DecodeError:
-        # This will catch errors in Python protobuf library 3.x
+    except (DecodeError, ProtoJsonError, json.JSONDecodeError, ValueError):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid OpenTelemetry protobuf format",
+            detail="Invalid OpenTelemetry format",
         )
 
     all_spans = []

--- a/mlflow/tracing/otel/translation/__init__.py
+++ b/mlflow/tracing/otel/translation/__init__.py
@@ -14,6 +14,7 @@ from typing import Any
 from mlflow.entities.span import Span, SpanType
 from mlflow.tracing.constant import CostKey, SpanAttributeKey, TokenUsageKey
 from mlflow.tracing.otel.translation.base import OtelSchemaTranslator
+from mlflow.tracing.otel.translation.gemini_cli import GeminiCliTranslator
 from mlflow.tracing.otel.translation.genai_semconv import GenAiTranslator
 from mlflow.tracing.otel.translation.google_adk import GoogleADKTranslator
 from mlflow.tracing.otel.translation.laminar import LaminarTranslator
@@ -34,6 +35,7 @@ _logger = logging.getLogger(__name__)
 
 _TRANSLATORS: list[OtelSchemaTranslator] = [
     OpenInferenceTranslator(),
+    GeminiCliTranslator(),
     GenAiTranslator(),
     SpringAiTranslator(),
     TraceloopTranslator(),

--- a/mlflow/tracing/otel/translation/gemini_cli.py
+++ b/mlflow/tracing/otel/translation/gemini_cli.py
@@ -88,11 +88,15 @@ class GeminiCliTranslator(GenAiTranslator):
 
         The MLflow UI Gemini renderer (gemini.ts normalizeGeminiChatInput)
         expects {contents: [GeminiContent, ...]} or {contents: "string"}.
+
+        For system_prompt spans, we rewrite role "user" → "system" so the
+        Chat UI renders them with the correct role badge.
         """
         if not self._is_gemini_cli(attributes):
             return None
         if value := super().get_input_value(attributes):
-            return self._try_wrap_input(value)
+            operation = attributes.get(self.SPAN_KIND_ATTRIBUTE_KEY)
+            return self._try_wrap_input(value, operation=operation)
         return None
 
     def get_output_value(self, attributes: dict[str, Any]) -> Any:
@@ -111,11 +115,21 @@ class GeminiCliTranslator(GenAiTranslator):
         return None
 
     @staticmethod
-    def _try_wrap_input(value: Any) -> Any:
+    def _try_wrap_input(value: Any, operation: str | None = None) -> Any:
         decoded = try_json_loads(value)
         # Already wrapped
         if isinstance(decoded, dict) and "contents" in decoded:
             return value
+        # For system_prompt spans, Gemini CLI sets role="user" on the content
+        # but the Chat UI should render it as "system". Rewrite the role so
+        # the system prompt gets the correct role badge.
+        if operation == "system_prompt" and isinstance(decoded, list):
+            decoded = [
+                {**item, "role": "system"}
+                if isinstance(item, dict) and item.get("role") == "user"
+                else item
+                for item in decoded
+            ]
         # List of GeminiContent or a plain string → wrap
         if isinstance(decoded, (list, str)):
             return json.dumps({"contents": decoded})

--- a/mlflow/tracing/otel/translation/gemini_cli.py
+++ b/mlflow/tracing/otel/translation/gemini_cli.py
@@ -1,0 +1,142 @@
+"""
+Translator for Gemini CLI OTEL spans.
+
+Gemini CLI (google-gemini/gemini-cli) emits OTLP traces using `gen_ai.operation.name`
+for span kind (same key as the GenAI semantic conventions), but with its own operation
+names that don't match the standard GenAI values.  This translator maps those
+Gemini-specific names to MLflow span types.
+
+Gemini CLI operation names:
+- ``llm_call``            → LLM span
+- ``tool_call``           → TOOL span
+- ``agent_call``          → AGENT span
+- ``user_prompt``         → (no MLflow equivalent, left as UNKNOWN)
+- ``system_prompt``       → (no MLflow equivalent, left as UNKNOWN)
+- ``schedule_tool_calls`` → (no MLflow equivalent, left as UNKNOWN)
+
+Additionally, this translator wraps ``gen_ai.input.messages`` and
+``gen_ai.output.messages`` into the Gemini SDK format so the MLflow UI's
+existing Gemini chat renderer can display them correctly:
+- inputs  → ``{"contents": [...]}``
+- outputs → ``{"candidates": [{"content": ...}]}``
+
+References:
+- Gemini CLI telemetry: github.com/google-gemini/gemini-cli/blob/main/docs/cli/telemetry.md
+- Gemini CLI OTLP source: github.com/google-gemini/gemini-cli packages/core/src/telemetry/sdk.ts
+"""
+
+import json
+from typing import Any
+
+from mlflow.entities.span import SpanType
+from mlflow.tracing.otel.translation.genai_semconv import GenAiTranslator
+from mlflow.tracing.utils import try_json_loads
+
+_GEMINI_CLI_AGENT_NAME = "gemini-cli"
+_AGENT_NAME_ATTRIBUTE_KEY = "gen_ai.agent.name"
+
+_GEMINI_OPERATION_NAME_TO_MLFLOW_TYPE: dict[str, str] = {
+    "llm_call": SpanType.LLM,
+    "tool_call": SpanType.TOOL,
+    "agent_call": SpanType.AGENT,
+}
+
+# Message format identifier that tells the MLflow UI to use the Gemini
+# chat renderer (mlflow/server/js chat-utils/gemini.ts).
+_MESSAGE_FORMAT = "gemini"
+
+
+class GeminiCliTranslator(GenAiTranslator):
+    """
+    Translator for Gemini CLI OTEL spans.
+
+    Extends GenAiTranslator to reuse token-usage and model-name handling,
+    but scopes span-type translation to Gemini CLI spans only (identified by
+    ``gen_ai.agent.name == "gemini-cli"``) and maps Gemini-specific operation names.
+
+    Also sets ``message_format = "gemini"`` and wraps input/output messages into
+    the Gemini SDK format so the UI renders them with the Gemini chat view.
+    """
+
+    SPAN_KIND_TO_MLFLOW_TYPE = _GEMINI_OPERATION_NAME_TO_MLFLOW_TYPE
+
+    def _is_gemini_cli(self, attributes: dict[str, Any]) -> bool:
+        agent_name = attributes.get(_AGENT_NAME_ATTRIBUTE_KEY)
+        if isinstance(agent_name, str):
+            try:
+                agent_name = json.loads(agent_name)
+            except (json.JSONDecodeError, TypeError):
+                pass
+        return agent_name == _GEMINI_CLI_AGENT_NAME
+
+    def translate_span_type(self, attributes: dict[str, Any]) -> str | None:
+        if not self._is_gemini_cli(attributes):
+            return None
+        return super().translate_span_type(attributes)
+
+    def get_message_format(self, attributes: dict[str, Any]) -> str | None:
+        if self._is_gemini_cli(attributes):
+            return _MESSAGE_FORMAT
+        return None
+
+    def get_input_value(self, attributes: dict[str, Any]) -> Any:
+        """Wrap gen_ai.input.messages in Gemini SDK format {contents: [...]}.
+
+        Gemini CLI sets gen_ai.input.messages as either:
+        - A list of GeminiContent objects: [{role, parts}, ...]
+        - A plain string (for simple user prompts)
+
+        The MLflow UI Gemini renderer (gemini.ts normalizeGeminiChatInput)
+        expects {contents: [GeminiContent, ...]} or {contents: "string"}.
+        """
+        if not self._is_gemini_cli(attributes):
+            return None
+        if value := super().get_input_value(attributes):
+            return self._try_wrap_input(value)
+        return None
+
+    def get_output_value(self, attributes: dict[str, Any]) -> Any:
+        """Wrap gen_ai.output.messages in Gemini SDK format {candidates: [{content: ...}]}.
+
+        Gemini CLI sets gen_ai.output.messages as a list of GeminiContent
+        objects: [{role: "model", parts: [...]}, ...]
+
+        The MLflow UI Gemini renderer (gemini.ts normalizeGeminiChatOutput)
+        expects {candidates: [{content: {role, parts}}, ...]}.
+        """
+        if not self._is_gemini_cli(attributes):
+            return None
+        if value := super().get_output_value(attributes):
+            return self._try_wrap_output(value)
+        return None
+
+    @staticmethod
+    def _try_wrap_input(value: Any) -> Any:
+        decoded = try_json_loads(value)
+        # Already wrapped
+        if isinstance(decoded, dict) and "contents" in decoded:
+            return value
+        # List of GeminiContent or a plain string → wrap
+        if isinstance(decoded, (list, str)):
+            return json.dumps({"contents": decoded})
+        return value
+
+    @staticmethod
+    def _try_wrap_output(value: Any) -> Any:
+        decoded = try_json_loads(value)
+        # Already wrapped
+        if isinstance(decoded, dict) and "candidates" in decoded:
+            return value
+        # List of GeminiContent objects → merge all parts into a single candidate.
+        # Gemini CLI emits one content object per streaming chunk/step, but the
+        # UI expects a single candidate with all parts combined.
+        if isinstance(decoded, list):
+            all_parts = []
+            for item in decoded:
+                if isinstance(item, dict) and isinstance(item.get("parts"), list):
+                    all_parts.extend(item["parts"])
+            if all_parts:
+                return json.dumps({
+                    "candidates": [{"content": {"role": "model", "parts": all_parts}}]
+                })
+        return value

--- a/tests/server/test_otel_api.py
+++ b/tests/server/test_otel_api.py
@@ -163,7 +163,7 @@ def test_otlp_invalid_content_type(monkeypatch):
 
     client = _make_test_client()
 
-    # Test with unsupported content type (application/json is now valid)
+    # Test with unsupported content type
     response = client.post(
         OTLP_TRACES_PATH,
         data=_build_otlp_payload(),

--- a/tests/server/test_otel_api.py
+++ b/tests/server/test_otel_api.py
@@ -163,12 +163,12 @@ def test_otlp_invalid_content_type(monkeypatch):
 
     client = _make_test_client()
 
-    # Test with wrong content type
+    # Test with unsupported content type (application/json is now valid)
     response = client.post(
         OTLP_TRACES_PATH,
         data=_build_otlp_payload(),
         headers={
-            "Content-Type": "application/json",
+            "Content-Type": "text/plain",
             "X-MLflow-Experiment-Id": "42",
         },
     )
@@ -207,7 +207,7 @@ def test_otlp_invalid_protobuf_data(monkeypatch):
         },
     )
     assert response.status_code == 400
-    assert "Invalid OpenTelemetry protobuf format" in response.json()["detail"]
+    assert "Invalid OpenTelemetry format" in response.json()["detail"]
 
 
 def test_otlp_empty_resource_spans(monkeypatch):

--- a/tests/tracing/otel/test_span_translation.py
+++ b/tests/tracing/otel/test_span_translation.py
@@ -14,6 +14,7 @@ from mlflow.tracing.otel.translation import (
     update_token_usage,
 )
 from mlflow.tracing.otel.translation.base import OtelSchemaTranslator
+from mlflow.tracing.otel.translation.gemini_cli import GeminiCliTranslator
 from mlflow.tracing.otel.translation.genai_semconv import GenAiTranslator
 from mlflow.tracing.otel.translation.google_adk import GoogleADKTranslator
 from mlflow.tracing.otel.translation.laminar import LaminarTranslator
@@ -69,6 +70,68 @@ def test_translate_span_type_from_otel(
     attributes = {translator.SPAN_KIND_ATTRIBUTE_KEY: otel_kind}
     result = translate_span_type_from_otel(attributes)
     assert result == expected_type
+
+
+@pytest.mark.parametrize(
+    ("operation_name", "expected_type"),
+    [
+        ("llm_call", SpanType.LLM),
+        ("tool_call", SpanType.TOOL),
+        ("agent_call", SpanType.AGENT),
+    ],
+)
+def test_gemini_cli_translator_maps_operation_names(operation_name, expected_type):
+    attributes = {
+        "gen_ai.agent.name": "gemini-cli",
+        "gen_ai.operation.name": operation_name,
+    }
+    result = translate_span_type_from_otel(attributes)
+    assert result == expected_type
+
+
+@pytest.mark.parametrize(
+    "attributes",
+    [
+        # Missing gen_ai.agent.name → should not match GeminiCliTranslator
+        {"gen_ai.operation.name": "llm_call"},
+        # Wrong agent name
+        {"gen_ai.agent.name": "other-agent", "gen_ai.operation.name": "llm_call"},
+        # Unmapped Gemini operation names
+        {"gen_ai.agent.name": "gemini-cli", "gen_ai.operation.name": "user_prompt"},
+        {"gen_ai.agent.name": "gemini-cli", "gen_ai.operation.name": "system_prompt"},
+        {"gen_ai.agent.name": "gemini-cli", "gen_ai.operation.name": "schedule_tool_calls"},
+    ],
+)
+def test_gemini_cli_translator_does_not_map(attributes):
+    translator = GeminiCliTranslator()
+    assert translator.translate_span_type(attributes) is None
+
+
+def test_gemini_cli_translator_message_format():
+    translator = GeminiCliTranslator()
+    attrs = {"gen_ai.agent.name": "gemini-cli", "gen_ai.operation.name": "llm_call"}
+    assert translator.get_message_format(attrs) == "gemini"
+    assert translator.get_message_format({"gen_ai.agent.name": "other"}) is None
+
+
+def test_gemini_cli_translator_wraps_input():
+    translator = GeminiCliTranslator()
+    attrs = {
+        "gen_ai.agent.name": "gemini-cli",
+        "gen_ai.input.messages": '[{"role": "user", "parts": [{"text": "hello"}]}]',
+    }
+    result = translator.get_input_value(attrs)
+    assert '"contents"' in result
+
+
+def test_gemini_cli_translator_wraps_output():
+    translator = GeminiCliTranslator()
+    attrs = {
+        "gen_ai.agent.name": "gemini-cli",
+        "gen_ai.output.messages": '[{"role": "model", "parts": [{"text": "hi"}]}]',
+    }
+    result = translator.get_output_value(attrs)
+    assert '"candidates"' in result
 
 
 @pytest.mark.parametrize(

--- a/tests/tracing/otel/test_span_translation.py
+++ b/tests/tracing/otel/test_span_translation.py
@@ -124,6 +124,19 @@ def test_gemini_cli_translator_wraps_input():
     assert '"contents"' in result
 
 
+def test_gemini_cli_translator_rewrites_system_prompt_role():
+    translator = GeminiCliTranslator()
+    messages = json.dumps([{"role": "user", "parts": [{"text": "You are helpful"}]}])
+    attrs = {
+        "gen_ai.agent.name": "gemini-cli",
+        "gen_ai.operation.name": "system_prompt",
+        "gen_ai.input.messages": messages,
+    }
+    result = translator.get_input_value(attrs)
+    parsed = json.loads(result)
+    assert parsed["contents"][0]["role"] == "system"
+
+
 def test_gemini_cli_translator_wraps_output():
     translator = GeminiCliTranslator()
     attrs = {

--- a/tests/tracing/test_otel_logging.py
+++ b/tests/tracing/test_otel_logging.py
@@ -301,7 +301,7 @@ def test_invalid_content_type_returns_400(mlflow_server: str):
     request = ExportTraceServiceRequest()
     request.resource_spans.append(resource_spans)
 
-    # Send request with unsupported Content-Type (application/json is now valid)
+    # Send request with unsupported Content-Type
     response = requests.post(
         f"{mlflow_server}/v1/traces",
         data=request.SerializeToString(),

--- a/tests/tracing/test_otel_logging.py
+++ b/tests/tracing/test_otel_logging.py
@@ -301,12 +301,12 @@ def test_invalid_content_type_returns_400(mlflow_server: str):
     request = ExportTraceServiceRequest()
     request.resource_spans.append(resource_spans)
 
-    # Send request with incorrect Content-Type
+    # Send request with unsupported Content-Type (application/json is now valid)
     response = requests.post(
         f"{mlflow_server}/v1/traces",
         data=request.SerializeToString(),
         headers={
-            "Content-Type": "application/json",  # Wrong content type
+            "Content-Type": "text/plain",
             MLFLOW_EXPERIMENT_ID_HEADER: "test-experiment",
         },
         timeout=10,
@@ -878,6 +878,65 @@ def test_service_name_propagated_to_root_span(mlflow_server: str):
     # service.name should be on the root span only
     assert root_span.get_attribute("service.name") == "gemini-cli"
     assert child_span.get_attribute("service.name") is None
+
+
+def test_otlp_json_encoding(mlflow_server: str):
+    mlflow.set_tracking_uri(mlflow_server)
+    experiment = mlflow.set_experiment("otel-json-encoding-test")
+    experiment_id = experiment.experiment_id
+
+    trace_id_hex = "61181d5c16b3b25d966891c3fc595af9"
+    span_id_hex = "508755a859b294e3"
+
+    payload = {
+        "resourceSpans": [
+            {
+                "resource": {
+                    "attributes": [
+                        {"key": "service.name", "value": {"stringValue": "gemini-cli"}},
+                    ]
+                },
+                "scopeSpans": [
+                    {
+                        "scope": {"name": "gemini-cli"},
+                        "spans": [
+                            {
+                                "traceId": trace_id_hex,
+                                "spanId": span_id_hex,
+                                "name": "user_prompt",
+                                "startTimeUnixNano": str(int(time.time() * 1e9)),
+                                "endTimeUnixNano": str(int(time.time() * 1e9) + 1000000000),
+                                "attributes": [
+                                    {
+                                        "key": "gen_ai.operation.name",
+                                        "value": {"stringValue": "user_prompt"},
+                                    },
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+
+    response = requests.post(
+        f"{mlflow_server}/v1/traces",
+        json=payload,
+        headers={
+            "Content-Type": "application/json",
+            MLFLOW_EXPERIMENT_ID_HEADER: experiment_id,
+        },
+        timeout=10,
+    )
+    assert response.status_code == 200
+
+    traces = mlflow.search_traces(locations=[experiment_id], include_spans=True, return_type="list")
+    assert len(traces) == 1
+
+    root_span = traces[0].data.spans[0]
+    assert root_span.name == "user_prompt"
+    assert root_span.get_attribute("service.name") == "gemini-cli"
 
 
 def test_response_is_protobuf_format(mlflow_server: str):


### PR DESCRIPTION
## 🥞 Stacked PR
- [stack/agent-tracing/1-service-name](https://github.com/mlflow/mlflow/pull/22407)
  - [stack/agent-tracing/2-json-otlp](https://github.com/mlflow/mlflow/pull/22408)
    - [**stack/agent-tracing/3-gemini-translator**](https://github.com/mlflow/mlflow/pull/22409)
      - [stack/agent-tracing/4-codex-ts](https://github.com/mlflow/mlflow/pull/22410)
        - [stack/agent-tracing/5-qwen-ts](https://github.com/mlflow/mlflow/pull/22411)
          - [stack/agent-tracing/6-docs](https://github.com/mlflow/mlflow/pull/22412)

---------
### Related Issues/PRs

Depends on #22408

### What changes are proposed in this pull request?

Adds `GeminiCliTranslator` to map Gemini CLI's OTLP span operation names to MLflow span types and enable Chat UI rendering.

Gemini CLI emits OTLP traces using `gen_ai.operation.name` (same key as the OpenTelemetry GenAI semantic conventions) but with its own operation names that don't match the standard values already handled by `GenAiTranslator`:

| Gemini CLI `gen_ai.operation.name` | MLflow span type |
|---|---|
| `llm_call` | LLM |
| `tool_call` | TOOL |
| `agent_call` | AGENT |

The translator is scoped to Gemini CLI spans via `gen_ai.agent.name == "gemini-cli"`. It extends `GenAiTranslator` to reuse existing token-usage and model-name attribute handling.

Additionally, it:
- Sets `message_format: "gemini"` so the MLflow UI Chat tab uses the existing Gemini renderer
- Wraps `gen_ai.input.messages` as `{contents: [...]}` and `gen_ai.output.messages` as `{candidates: [{content: ...}]}` for proper UI rendering
- Merges streaming content objects into a single candidate to avoid duplicate assistant blocks

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Parametrized tests for the 3 mapped operation names and 5 negative cases. E2E tested with real Gemini CLI sending OTLP traces.

<img width="1508" height="547" alt="Screenshot 2026-04-07 at 7 51 42 PM" src="https://github.com/user-attachments/assets/329ef912-015e-40e2-8436-5f88a34b9e9c" />

<img width="1375" height="849" alt="Screenshot 2026-04-07 at 7 50 40 PM" src="https://github.com/user-attachments/assets/3cb56cb1-2f23-4401-be6b-440438bb0fcd" />



### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [x] Instructions

Updated in stack 6 (#22412).

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [] Yes. Give a description of this change to be included in the release notes for MLflow users.
- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release