### PR TITLE
feat: add MiniMax provider support

### DIFF
--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -64,6 +64,7 @@ class Provider(str, Enum):
     OPENROUTER = "openrouter"
     OLLAMA = "ollama"
     VERTEX_AI = "vertex_ai"
+    MINIMAX = "minimax"
 
     @classmethod
     def values(cls):

--- a/mlflow/gateway/provider_registry.py
+++ b/mlflow/gateway/provider_registry.py
@@ -35,6 +35,7 @@ def _register_default_providers(registry: ProviderRegistry):
     from mlflow.gateway.providers.groq import GroqProvider
     from mlflow.gateway.providers.huggingface import HFTextGenerationInferenceServerProvider
     from mlflow.gateway.providers.litellm import LiteLLMProvider
+    from mlflow.gateway.providers.minimax import MiniMaxProvider
     from mlflow.gateway.providers.mistral import MistralProvider
     from mlflow.gateway.providers.mlflow import MlflowModelServingProvider
     from mlflow.gateway.providers.mosaicml import MosaicMLProvider
@@ -61,6 +62,7 @@ def _register_default_providers(registry: ProviderRegistry):
         Provider.HUGGINGFACE_TEXT_GENERATION_INFERENCE, HFTextGenerationInferenceServerProvider
     )
     registry.register(Provider.LITELLM, LiteLLMProvider)
+    registry.register(Provider.MINIMAX, MiniMaxProvider)
     registry.register(Provider.MISTRAL, MistralProvider)
     registry.register(Provider.MLFLOW_MODEL_SERVING, MlflowModelServingProvider)
     registry.register(Provider.MOSAICML, MosaicMLProvider)

--- a/mlflow/gateway/providers/minimax.py
+++ b/mlflow/gateway/providers/minimax.py
@@ -1,0 +1,8 @@
+from mlflow.gateway.config import _OpenAICompatibleConfig
+from mlflow.gateway.providers.openai_compatible import OpenAICompatibleProvider
+
+
+class MiniMaxProvider(OpenAICompatibleProvider):
+    DISPLAY_NAME = "MiniMax"
+    CONFIG_TYPE = _OpenAICompatibleConfig
+    DEFAULT_API_BASE = "https://api.minimax.io/v1"

--- a/tests/gateway/providers/test_minimax.py
+++ b/tests/gateway/providers/test_minimax.py
@@ -1,0 +1,77 @@
+from unittest import mock
+
+import pytest
+from fastapi.encoders import jsonable_encoder
+
+from mlflow.gateway.config import EndpointConfig
+from mlflow.gateway.providers.minimax import MiniMaxProvider
+from mlflow.gateway.schemas import chat
+
+from tests.gateway.tools import MockAsyncResponse, mock_http_client
+
+
+def _make_provider() -> MiniMaxProvider:
+    endpoint_config = EndpointConfig(
+        name="minimax-endpoint",
+        endpoint_type="llm/v1/chat",
+        model={
+            "provider": "minimax",
+            "name": "MiniMax-M2.7",
+            "config": {"api_key": "sk-minimax-test-key"},
+        },
+    )
+    return MiniMaxProvider(endpoint_config)
+
+
+def _chat_response():
+    return {
+        "id": "chatcmpl-minimax-123",
+        "object": "chat.completion",
+        "created": 1700000000,
+        "model": "MiniMax-M2.7",
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 20,
+            "total_tokens": 30,
+        },
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": "Hello from MiniMax!"},
+                "finish_reason": "stop",
+                "index": 0,
+            }
+        ],
+        "headers": {"Content-Type": "application/json"},
+    }
+
+
+def test_default_api_base():
+    provider = _make_provider()
+    assert provider._api_base == "https://api.minimax.io/v1"
+
+
+def test_headers():
+    provider = _make_provider()
+    assert provider.headers == {"Authorization": "Bearer sk-minimax-test-key"}
+
+
+def test_name():
+    provider = _make_provider()
+    assert provider.DISPLAY_NAME == "MiniMax"
+    assert provider.get_provider_name() == "minimax"
+
+
+@pytest.mark.asyncio
+async def test_chat():
+    provider = _make_provider()
+    mock_client = mock_http_client(MockAsyncResponse(_chat_response()))
+
+    with mock.patch("aiohttp.ClientSession", return_value=mock_client):
+        payload = chat.RequestPayload(
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+        response = await provider.chat(payload)
+
+    result = jsonable_encoder(response)
+    assert result["id"] == "chatcmpl-minimax-123"
+    assert result["choices"][0]["message"]["content"] == "Hello from MiniMax!"


### PR DESCRIPTION
## Summary

- Add MiniMax as a new LLM provider in the MLflow AI Gateway
- Implements the OpenAI-compatible API interface via `OpenAICompatibleProvider`
- Registers `MiniMax` in the `Provider` enum and the provider registry
- Default base URL: `https://api.minimax.io/v1`
- Supported models: `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`

## Configuration

To use the MiniMax provider, configure a gateway endpoint with:

```yaml
routes:
  - name: chat
    route_type: llm/v1/chat
    model:
      provider: minimax
      name: MiniMax-M2.7
      config:
        api_key: $MINIMAX_API_KEY
```

## API Documentation

- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api

## Test plan

- [x] Unit tests added in `tests/gateway/providers/test_minimax.py`
- [x] `test_default_api_base` — verifies correct base URL
- [x] `test_headers` — verifies Authorization header
- [x] `test_name` — verifies display name and provider name
- [x] `test_chat` — verifies chat completion response parsing
- [x] Integration test with real MiniMax API confirmed working