### PR TITLE
Replace `LegacyTooltip` with `Tooltip` in experiment tracking components

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/ArtifactView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ArtifactView.tsx
@@ -31,7 +31,6 @@ import {
   Empty,
   InfoTooltip,
   LayerIcon,
-  LegacyTooltip,
   Tooltip,
   Typography,
   WithDesignSystemThemeHoc,

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunMetricTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunMetricTable.tsx
@@ -5,7 +5,7 @@ import { AutoSizer, Grid } from 'react-virtualized';
 import { Link } from '@mlflow/mlflow/src/common/utils/RoutingUtils';
 import Routes from '@mlflow/mlflow/src/experiment-tracking/routes';
 import Utils from '@mlflow/mlflow/src/common/utils/Utils';
-import { LegacyTooltip, useDesignSystemTheme } from '@databricks/design-system';
+import { Tooltip, useDesignSystemTheme } from '@databricks/design-system';
 
 export type CompareRunMetricTableRef = {
   setScrollLeft: (scrollLeft: number) => void;
@@ -288,17 +288,15 @@ function CompareRunMetricTableBodyCell({
             : undefined,
       }}
     >
-      <LegacyTooltip
-        title={formattedMetric}
-        // @ts-expect-error TS(2322): Type '{ children: any; title: any; color: string; ... Remove this comment to see the full error message
-        color="gray"
-        placement="topLeft"
-        overlayStyle={{ maxWidth: '400px' }}
-        // mouseEnterDelay prop is not available in DuBois design system (yet)
-        dangerouslySetAntdProps={{ mouseEnterDelay: 1 }}
+      <Tooltip
+        componentId="mlflow.compare_runs.metric_table.cell"
+        content={formattedMetric}
+        side="top"
+        align="start"
+        maxWidth={400}
       >
-        {formattedMetric}
-      </LegacyTooltip>
+        <span>{formattedMetric}</span>
+      </Tooltip>
     </div>
   );
 }

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunView.tsx
@@ -8,15 +8,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { injectIntl, FormattedMessage, type IntlShape } from 'react-intl';
-import {
-  Spacer,
-  Switch,
-  LegacyTabs,
-  LegacyTooltip,
-  Tooltip,
-  Typography,
-  useDesignSystemTheme,
-} from '@databricks/design-system';
+import { Spacer, Switch, LegacyTabs, Tooltip, Typography, useDesignSystemTheme } from '@databricks/design-system';
 
 import { getExperiment, getParams, getRunInfo, getRunTags } from '../reducers/Reducers';
 import './CompareRunView.css';
@@ -698,16 +690,15 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
             const cellText = value === undefined ? '' : formatter(value);
             return (
               <td className="data-value" key={this.props.runInfos[i].runUuid} css={colWidthStyle}>
-                <LegacyTooltip
-                  title={cellText}
-                  // @ts-expect-error TS(2322): Type '{ children: Element; title: any; color: stri... Remove this comment to see the full error message
-                  color="gray"
-                  placement="topLeft"
-                  overlayStyle={{ maxWidth: '400px' }}
-                  mouseEnterDelay={1.0}
+                <Tooltip
+                  componentId="mlflow.compare_runs.data_cell"
+                  content={cellText}
+                  side="top"
+                  align="start"
+                  maxWidth={400}
                 >
                   <span className="truncate-text single-line">{cellText}</span>
-                </LegacyTooltip>
+                </Tooltip>
               </td>
             );
           })}

--- a/mlflow/server/js/src/experiment-tracking/components/EntitySearchAutoComplete.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/EntitySearchAutoComplete.tsx
@@ -6,7 +6,6 @@ import {
   InfoPopover,
   InfoSmallIcon,
   Input,
-  LegacyTooltip,
   SearchIcon,
   Tooltip,
   useDesignSystemTheme,

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeaderRegisterModelButton.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeaderRegisterModelButton.tsx
@@ -4,7 +4,6 @@ import {
   DropdownMenu,
   NewWindowIcon,
   Tag,
-  LegacyTooltip,
   useDesignSystemTheme,
   Tooltip,
 } from '@databricks/design-system';

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsTooltipBody.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsTooltipBody.tsx
@@ -1,14 +1,5 @@
 import { isNil } from 'lodash';
-import {
-  Button,
-  CloseIcon,
-  PinIcon,
-  PinFillIcon,
-  LegacyTooltip,
-  VisibleIcon,
-  Typography,
-  Tooltip,
-} from '@databricks/design-system';
+import { Button, CloseIcon, PinIcon, PinFillIcon, VisibleIcon, Typography, Tooltip } from '@databricks/design-system';
 import type { Theme } from '@emotion/react';
 import { FormattedMessage } from 'react-intl';
 import { Link } from '../../../../common/utils/RoutingUtils';

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/config/RunsChartsConfigureDifferenceChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/config/RunsChartsConfigureDifferenceChart.tsx
@@ -3,7 +3,6 @@ import {
   Input,
   Switch,
   useDesignSystemTheme,
-  LegacyTooltip,
   InfoSmallIcon,
   LegacyInfoTooltip,
 } from '@databricks/design-system';

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/config/RunsChartsConfigureLineChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/config/RunsChartsConfigureLineChart.tsx
@@ -3,7 +3,6 @@ import {
   Radio,
   LegacySelect,
   Switch,
-  LegacyTooltip,
   QuestionMarkIcon,
   useDesignSystemTheme,
   SegmentedControlGroup,


### PR DESCRIPTION
### Related Issues/PRs

Relates to design system migration effort

### What changes are proposed in this pull request?

Migrate all remaining `LegacyTooltip` usages to the new `Tooltip` component from `@databricks/design-system` in experiment tracking components:

- **`CompareRunMetricTable.tsx`** — Replaced `LegacyTooltip` JSX with `Tooltip` using `content`, `side`, `align`, and `maxWidth` props
- **`CompareRunView.tsx`** — Same migration in the `renderDataRows` method for parameter/tag table cells
- **6 files** — Removed unused `LegacyTooltip` imports (`ArtifactView`, `EntitySearchAutoComplete`, `RunViewHeaderRegisterModelButton`, `RunsChartsConfigureLineChart`, `RunsChartsConfigureDifferenceChart`, `RunsChartsTooltipBody`)

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

New tooltips look fine

https://github.com/user-attachments/assets/ecf51e21-46ea-476c-9b27-6b3dfc90dfa1

`rg "LegacyTooltip" .` no results


### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release