### PR TITLE
[UI] Cache gateway provider/model queries to eliminate redundant fetches

### DIFF
--- a/mlflow/server/js/src/gateway/hooks/useModelsQuery.ts
+++ b/mlflow/server/js/src/gateway/hooks/useModelsQuery.ts
@@ -16,6 +16,8 @@ export const useModelsQuery = ({ provider }: { provider?: string } = {}) => {
     {
       queryFn,
       retry: false,
+      staleTime: Infinity,
+      refetchOnWindowFocus: false,
       enabled: provider !== undefined,
     },
   );

--- a/mlflow/server/js/src/gateway/hooks/useProviderConfigQuery.ts
+++ b/mlflow/server/js/src/gateway/hooks/useProviderConfigQuery.ts
@@ -16,6 +16,8 @@ export const useProviderConfigQuery = ({ provider }: { provider: string }) => {
     {
       queryFn,
       retry: false,
+      staleTime: Infinity,
+      refetchOnWindowFocus: false,
       enabled: Boolean(provider),
     },
   );

--- a/mlflow/server/js/src/gateway/hooks/useProvidersQuery.ts
+++ b/mlflow/server/js/src/gateway/hooks/useProvidersQuery.ts
@@ -13,6 +13,8 @@ export const useProvidersQuery = () => {
   const queryResult = useQuery<ProvidersResponse, Error, ProvidersResponse, ProvidersQueryKey>(['gateway_providers'], {
     queryFn,
     retry: false,
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
   });
 
   return {


### PR DESCRIPTION
### Related Issues/PRs

### What changes are proposed in this pull request?

The gateway provider, model, and provider config React Query hooks (`useProvidersQuery`, `useModelsQuery`, `useProviderConfigQuery`) had no `staleTime` configured, defaulting to `0`. This caused React Query to refetch on every component mount, showing a loading spinner each time the user opened the endpoint create/edit form.

Since this data is derived from static bundled JSON catalogs (`model_catalog/*.json`) that never change during a session, this PR sets `staleTime: Infinity` and `refetchOnWindowFocus: false` on all three hooks. After the initial fetch, cached data is served instantly with no spinner.

This matches the existing pattern used by `useServerInfo` for other session-scoped static data.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Verified that provider/model dropdowns load instantly on subsequent opens of the endpoint create/edit form after the first fetch.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. AI Gateway provider and model dropdowns now load instantly after first fetch, eliminating repeated loading spinners when creating or editing endpoints.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release