### PR TITLE
Auto-fetch next page when client-side filtering reduces visible rows

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTab.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTab.tsx
@@ -196,6 +196,8 @@ const RunViewEvaluationsTabInner = ({
     tableSort,
     disabled: isQueryDisabled,
     filterByAssessmentSourceRun: true,
+    // Disable pagination in comparison mode — both runs need complete data to join on inputs
+    enablePagination: isNil(compareToRunUuid),
   });
 
   const {
@@ -535,6 +537,7 @@ const useGetCompareToData = (params: {
     runUuid: compareToRunUuid,
     disabled: isNil(compareToRunUuid) || isQueryDisabled,
     filterByAssessmentSourceRun: true,
+    enablePagination: false,
   });
 
   const { data: runData, loading: runDetailsLoading } = useSearchRunsQuery({

--- a/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTab.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTab.tsx
@@ -204,9 +204,6 @@ const RunViewEvaluationsTabInner = ({
     data: compareToRunData,
     displayName: compareToRunDisplayName,
     loading: compareToRunLoading,
-    fetchNextPage: compareFetchNextPage,
-    hasNextPage: compareHasNextPage,
-    isFetchingNextPage: compareIsFetchingNextPage,
   } = useGetCompareToData({
     experimentId,
     traceLocations,
@@ -276,16 +273,6 @@ const RunViewEvaluationsTabInner = ({
   }, [deleteTracesAction, showEditTagsModalForTrace, EditTagsModal]);
 
   const isTableLoading = traceInfosLoading || compareToRunLoading;
-
-  // When scrolling, fetch the next page for both the current and comparison runs together.
-  const combinedFetchNextPage = useCallback(() => {
-    if (fetchNextPage) fetchNextPage();
-    if (compareFetchNextPage) compareFetchNextPage();
-  }, [fetchNextPage, compareFetchNextPage]);
-
-  const combinedHasNextPage = (hasNextPage ?? false) || (compareHasNextPage ?? false);
-
-  const combinedIsFetchingNextPage = (isFetchingNextPage ?? false) || (compareIsFetchingNextPage ?? false);
 
   const selectedRunColor = getRunColor(runUuid);
   const compareToRunColor = compareToRunUuid ? getRunColor(compareToRunUuid) : undefined;
@@ -419,9 +406,9 @@ const RunViewEvaluationsTabInner = ({
                     onTraceTagsEdit={showEditTagsModalForTrace}
                     isTableLoading={isTableLoading}
                     isGroupedBySession={isGroupedBySession}
-                    fetchNextPage={combinedFetchNextPage}
-                    hasNextPage={combinedHasNextPage}
-                    isFetchingNextPage={combinedIsFetchingNextPage}
+                    fetchNextPage={fetchNextPage}
+                    hasNextPage={hasNextPage}
+                    isFetchingNextPage={isFetchingNextPage}
                     assessmentCountMetrics={assessmentCountMetrics}
                     compareAssessmentCountMetrics={compareAssessmentCountMetrics}
                   />
@@ -520,18 +507,9 @@ const useGetCompareToData = (params: {
   data: ModelTraceInfoV3[] | undefined;
   displayName: string;
   loading: boolean;
-  fetchNextPage?: () => void;
-  hasNextPage?: boolean;
-  isFetchingNextPage?: boolean;
 } => {
   const { compareToRunUuid, experimentId, traceLocations, isQueryDisabled } = params;
-  const {
-    data: traceInfos,
-    isLoading: traceInfosLoading,
-    fetchNextPage,
-    hasNextPage,
-    isFetchingNextPage,
-  } = useSearchMlflowTraces({
+  const { data: traceInfos, isLoading: traceInfosLoading } = useSearchMlflowTraces({
     locations: traceLocations,
     currentRunDisplayName: undefined,
     runUuid: compareToRunUuid,
@@ -550,8 +528,5 @@ const useGetCompareToData = (params: {
     data: traceInfos,
     displayName: Utils.getRunDisplayName(runData?.info, compareToRunUuid),
     loading: traceInfosLoading || runDetailsLoading,
-    fetchNextPage,
-    hasNextPage,
-    isFetchingNextPage,
   };
 };

--- a/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTab.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTab.tsx
@@ -245,6 +245,12 @@ const RunViewEvaluationsTabInner = ({
     disabled: isQueryDisabled,
   });
 
+  const compareAssessmentCountMetrics = useAssessmentCountMetrics({
+    experimentIds,
+    runUuid: compareToRunUuid,
+    disabled: isQueryDisabled || isNil(compareToRunUuid),
+  });
+
   // TODO: We should update this to use web-shared/unified-tagging components for the
   // tag editor and react-query mutations for the apis.
   const { showEditTagsModalForTrace, EditTagsModal } = useEditExperimentTraceTags({
@@ -415,6 +421,7 @@ const RunViewEvaluationsTabInner = ({
                     hasNextPage={combinedHasNextPage}
                     isFetchingNextPage={combinedIsFetchingNextPage}
                     assessmentCountMetrics={assessmentCountMetrics}
+                    compareAssessmentCountMetrics={compareAssessmentCountMetrics}
                   />
                 </ContextProviders>
               )

--- a/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTab.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTab.tsx
@@ -202,6 +202,9 @@ const RunViewEvaluationsTabInner = ({
     data: compareToRunData,
     displayName: compareToRunDisplayName,
     loading: compareToRunLoading,
+    fetchNextPage: compareFetchNextPage,
+    hasNextPage: compareHasNextPage,
+    isFetchingNextPage: compareIsFetchingNextPage,
   } = useGetCompareToData({
     experimentId,
     traceLocations,
@@ -265,6 +268,16 @@ const RunViewEvaluationsTabInner = ({
   }, [deleteTracesAction, showEditTagsModalForTrace, EditTagsModal]);
 
   const isTableLoading = traceInfosLoading || compareToRunLoading;
+
+  // When scrolling, fetch the next page for both the current and comparison runs together.
+  const combinedFetchNextPage = useCallback(() => {
+    if (fetchNextPage) fetchNextPage();
+    if (compareFetchNextPage) compareFetchNextPage();
+  }, [fetchNextPage, compareFetchNextPage]);
+
+  const combinedHasNextPage = (hasNextPage ?? false) || (compareHasNextPage ?? false);
+
+  const combinedIsFetchingNextPage = (isFetchingNextPage ?? false) || (compareIsFetchingNextPage ?? false);
 
   const selectedRunColor = getRunColor(runUuid);
   const compareToRunColor = compareToRunUuid ? getRunColor(compareToRunUuid) : undefined;
@@ -398,9 +411,9 @@ const RunViewEvaluationsTabInner = ({
                     onTraceTagsEdit={showEditTagsModalForTrace}
                     isTableLoading={isTableLoading}
                     isGroupedBySession={isGroupedBySession}
-                    fetchNextPage={fetchNextPage}
-                    hasNextPage={hasNextPage}
-                    isFetchingNextPage={isFetchingNextPage}
+                    fetchNextPage={combinedFetchNextPage}
+                    hasNextPage={combinedHasNextPage}
+                    isFetchingNextPage={combinedIsFetchingNextPage}
                     assessmentCountMetrics={assessmentCountMetrics}
                   />
                 </ContextProviders>
@@ -498,9 +511,18 @@ const useGetCompareToData = (params: {
   data: ModelTraceInfoV3[] | undefined;
   displayName: string;
   loading: boolean;
+  fetchNextPage?: () => void;
+  hasNextPage?: boolean;
+  isFetchingNextPage?: boolean;
 } => {
   const { compareToRunUuid, experimentId, traceLocations, isQueryDisabled } = params;
-  const { data: traceInfos, isLoading: traceInfosLoading } = useSearchMlflowTraces({
+  const {
+    data: traceInfos,
+    isLoading: traceInfosLoading,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useSearchMlflowTraces({
     locations: traceLocations,
     currentRunDisplayName: undefined,
     runUuid: compareToRunUuid,
@@ -518,5 +540,8 @@ const useGetCompareToData = (params: {
     data: traceInfos,
     displayName: Utils.getRunDisplayName(runData?.info, compareToRunUuid),
     loading: traceInfosLoading || runDetailsLoading,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
   };
 };

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableBodyContainer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableBodyContainer.tsx
@@ -75,6 +75,7 @@ interface GenAITracesTableBodyContainerProps {
 
   // Server-side assessment count data (active when shouldUseInfinitePaginatedTraces is true)
   assessmentCountMetrics?: AssessmentCountMetrics;
+  compareAssessmentCountMetrics?: AssessmentCountMetrics;
 }
 
 const GenAITracesTableBodyContainerImpl: React.FC<React.PropsWithChildren<GenAITracesTableBodyContainerProps>> =
@@ -105,6 +106,7 @@ const GenAITracesTableBodyContainerImpl: React.FC<React.PropsWithChildren<GenAIT
       hasNextPage,
       isFetchingNextPage,
       assessmentCountMetrics,
+      compareAssessmentCountMetrics,
     } = props;
     const { theme } = useDesignSystemTheme();
 
@@ -277,6 +279,7 @@ const GenAITracesTableBodyContainerImpl: React.FC<React.PropsWithChildren<GenAIT
                 hasNextPage={hasNextPage}
                 isFetchingNextPage={isFetchingNextPage}
                 assessmentCountMetrics={assessmentCountMetrics}
+                compareAssessmentCountMetrics={compareAssessmentCountMetrics}
               />
             </AssessmentSchemaContextProvider>
           </div>

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
@@ -585,13 +585,16 @@ export const GenAiTracesTableBody = React.memo(
     // Auto-fetch next page when client-side filtering reduces rows below the scroll threshold
     // (e.g. filtering by error assessments may leave only a few visible rows, making the
     // container non-scrollable so the scroll handler never fires).
+    // We depend on evaluations.length (pre-filter count) rather than rows.length because
+    // a new page may contain zero rows that pass the filter, so rows.length wouldn't change
+    // and the effect wouldn't re-fire.
     useEffect(() => {
       const container = tableContainerRef.current;
       if (!container || !fetchNextPage || !hasNextPage || isFetchingNextPage) return;
       if (container.scrollHeight <= container.clientHeight) {
         fetchNextPage();
       }
-    }, [fetchNextPage, hasNextPage, isFetchingNextPage, rows.length]);
+    }, [fetchNextPage, hasNextPage, isFetchingNextPage, evaluations.length]);
 
     return (
       <>

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
@@ -84,6 +84,7 @@ export const GenAiTracesTableBody = React.memo(
     hasNextPage,
     isFetchingNextPage,
     assessmentCountMetrics,
+    compareAssessmentCountMetrics,
   }: {
     experimentId?: string;
     selectedColumns: TracesTableColumn[];
@@ -127,6 +128,7 @@ export const GenAiTracesTableBody = React.memo(
     isFetchingNextPage?: boolean;
     // Server-side assessment count data (active when shouldUseInfinitePaginatedTraces is true)
     assessmentCountMetrics?: AssessmentCountMetrics;
+    compareAssessmentCountMetrics?: AssessmentCountMetrics;
   }) => {
     const intl = useIntl();
     const { theme } = useDesignSystemTheme();
@@ -505,20 +507,22 @@ export const GenAiTracesTableBody = React.memo(
     // use them for categorical assessments to get accurate counts across all traces.
     const assessmentNameToAggregates = useMemo(() => {
       const result: Record<string, AssessmentAggregates> = {};
-      const useServerCounts = assessmentCountMetrics && !assessmentCountMetrics.isLoading;
+      const currentData = !assessmentCountMetrics?.isLoading ? assessmentCountMetrics?.data : undefined;
+      const otherData = !compareAssessmentCountMetrics?.isLoading ? compareAssessmentCountMetrics?.data : undefined;
       for (const assessmentInfo of selectedAssessmentInfos) {
-        if (useServerCounts && assessmentInfo.dtype !== 'unknown') {
+        if (currentData && assessmentInfo.dtype !== 'unknown') {
           result[assessmentInfo.name] = buildAggregatesFromCountMetrics(
             assessmentInfo,
-            assessmentCountMetrics.data,
+            currentData,
             assessmentFilters,
+            otherData,
           );
         } else {
           result[assessmentInfo.name] = getAssessmentAggregates(assessmentInfo, evaluations, assessmentFilters);
         }
       }
       return result;
-    }, [selectedAssessmentInfos, evaluations, assessmentFilters, assessmentCountMetrics]);
+    }, [selectedAssessmentInfos, evaluations, assessmentFilters, assessmentCountMetrics, compareAssessmentCountMetrics]);
 
     const evalEntryMatchesEvaluationId = useCallback((evaluationId: string, entry?: RunEvaluationTracesDataEntry) => {
       if (isV4TraceId(evaluationId) && entry?.fullTraceId === evaluationId) {

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
@@ -522,7 +522,13 @@ export const GenAiTracesTableBody = React.memo(
         }
       }
       return result;
-    }, [selectedAssessmentInfos, evaluations, assessmentFilters, assessmentCountMetrics, compareAssessmentCountMetrics]);
+    }, [
+      selectedAssessmentInfos,
+      evaluations,
+      assessmentFilters,
+      assessmentCountMetrics,
+      compareAssessmentCountMetrics,
+    ]);
 
     const evalEntryMatchesEvaluationId = useCallback((evaluationId: string, entry?: RunEvaluationTracesDataEntry) => {
       if (isV4TraceId(evaluationId) && entry?.fullTraceId === evaluationId) {

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
@@ -582,6 +582,17 @@ export const GenAiTracesTableBody = React.memo(
       [fetchNextPage, hasNextPage, isFetchingNextPage],
     );
 
+    // Auto-fetch next page when client-side filtering reduces rows below the scroll threshold
+    // (e.g. filtering by error assessments may leave only a few visible rows, making the
+    // container non-scrollable so the scroll handler never fires).
+    useEffect(() => {
+      const container = tableContainerRef.current;
+      if (!container || !fetchNextPage || !hasNextPage || isFetchingNextPage) return;
+      if (container.scrollHeight <= container.clientHeight) {
+        fetchNextPage();
+      }
+    }, [fetchNextPage, hasNextPage, isFetchingNextPage, rows.length]);
+
     return (
       <>
         <div

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/hooks/useMlflowTraces.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/hooks/useMlflowTraces.tsx
@@ -313,6 +313,7 @@ export const useSearchMlflowTraces = ({
   loggedModelId,
   sqlWarehouseId,
   filterByAssessmentSourceRun = false,
+  enablePagination = true,
 }: {
   locations: (ModelTraceLocationMlflowExperiment | ModelTraceLocationUcSchema)[];
   runUuid?: string | null;
@@ -344,6 +345,12 @@ export const useSearchMlflowTraces = ({
    * Defaults to false for other tabs (traces, labeling, etc.).
    */
   filterByAssessmentSourceRun?: boolean;
+  /**
+   * When false, forces the eager-fetch path even when infinite pagination is globally enabled.
+   * Used to disable pagination in run comparison mode where both runs need complete data
+   * to join on inputs.
+   */
+  enablePagination?: boolean;
 }): {
   data: ModelTraceInfoV3[] | undefined;
   isLoading: boolean;
@@ -389,6 +396,7 @@ export const useSearchMlflowTraces = ({
     orderBy,
     loggedModelId,
     sqlWarehouseId,
+    enablePagination,
   });
 
   // TODO: Remove this once mlflow apis support filtering
@@ -553,6 +561,7 @@ interface UseSearchMlflowTracesInnerParams {
   loggedModelId?: string;
   sqlWarehouseId?: string;
   enabled?: boolean;
+  enablePagination?: boolean;
 }
 
 interface UseSearchMlflowTracesInnerResult {
@@ -676,10 +685,11 @@ const useSearchMlflowTracesInner = ({
   loggedModelId,
   sqlWarehouseId,
   enabled = true,
+  enablePagination = true,
 }: UseSearchMlflowTracesInnerParams): UseSearchMlflowTracesInnerResult => {
   const usingV4APIs = locations?.some((location) => location.type === 'UC_SCHEMA') && shouldUseTracesV4API();
   const usingLongRunningAPI = usingV4APIs && shouldUseLongRunningTracesAPI();
-  const usingInfinitePagination = !usingV4APIs && shouldUseInfinitePaginatedTraces();
+  const usingInfinitePagination = !usingV4APIs && shouldUseInfinitePaginatedTraces() && enablePagination;
 
   const queryCacheConfig = useMemo(() => getSearchMlflowTracesQueryCacheConfig(Boolean(usingV4APIs)), [usingV4APIs]);
 

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/AggregationUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/AggregationUtils.ts
@@ -788,6 +788,29 @@ export function getUniqueValueCountsBySourceId(
   return valueCounts;
 }
 
+function buildCountsFromMetrics(
+  assessmentInfo: AssessmentInfo,
+  metricsData: AssessmentCountMetrics['data'],
+): { counts: AssessmentRunCounts; numericValues: number[] } {
+  const relevant = metricsData.filter((m) => m.assessmentName === assessmentInfo.name);
+  const counts: AssessmentRunCounts = new Map();
+  const numericValues: number[] = [];
+
+  for (const metric of relevant) {
+    const typedValue = parseMetricAssessmentValue(metric.assessmentValue);
+    if (assessmentInfo.dtype === 'numeric' && typeof typedValue === 'number') {
+      counts.set(typedValue, metric.count);
+      for (let i = 0; i < metric.count; i++) {
+        numericValues.push(typedValue);
+      }
+    } else {
+      counts.set(typedValue, metric.count);
+    }
+  }
+
+  return { counts, numericValues };
+}
+
 /**
  * Converts a raw string value from the metrics API into a typed AssessmentValueType.
  * The API JSON-encodes assessment values, so "\"yes\"" → "yes",
@@ -810,47 +833,34 @@ function parseMetricAssessmentValue(rawValue: string): AssessmentValueType {
  * Builds AssessmentAggregates from server-side count metrics.
  * Used when infinite pagination is enabled to get accurate counts across all traces.
  * Handles both categorical (pass-fail, boolean, string) and numeric assessments.
+ * Optionally accepts comparison run metrics data for `otherCounts`.
  */
 export function buildAggregatesFromCountMetrics(
   assessmentInfo: AssessmentInfo,
   metricsData: AssessmentCountMetrics['data'],
   allAssessmentFilters: AssessmentFilter[],
+  otherMetricsData?: AssessmentCountMetrics['data'],
 ): AssessmentAggregates {
-  const relevantMetrics = metricsData.filter((m) => m.assessmentName === assessmentInfo.name);
+  const current = buildCountsFromMetrics(assessmentInfo, metricsData);
+  const other = otherMetricsData ? buildCountsFromMetrics(assessmentInfo, otherMetricsData) : undefined;
   const assessmentFilters = allAssessmentFilters.filter((f) => f.assessmentName === assessmentInfo.name);
 
   if (assessmentInfo.dtype === 'numeric') {
-    // For numeric assessments, expand (value, count) pairs into a values array
-    // and build the histogram using the existing bucketing logic.
-    const numericValues: number[] = [];
-    for (const metric of relevantMetrics) {
-      const value = parseFloat(metric.assessmentValue);
-      if (!isNaN(value)) {
-        for (let i = 0; i < metric.count; i++) {
-          numericValues.push(value);
-        }
-      }
-    }
     return {
       assessmentInfo,
-      currentNumericValues: numericValues,
-      currentNumericAggregate: getNumericAggregate(numericValues),
+      currentNumericValues: current.numericValues,
+      otherNumericValues: other?.numericValues,
+      currentNumericAggregate: getNumericAggregate(current.numericValues),
       currentNumRootCause: 0,
       otherNumRootCause: 0,
       assessmentFilters,
     };
   }
 
-  // For categorical assessments, build the value → count map directly.
-  const currentCounts: AssessmentRunCounts = new Map();
-  for (const metric of relevantMetrics) {
-    const typedValue = parseMetricAssessmentValue(metric.assessmentValue);
-    currentCounts.set(typedValue, metric.count);
-  }
-
   return {
     assessmentInfo,
-    currentCounts,
+    currentCounts: current.counts,
+    otherCounts: other?.counts,
     currentNumRootCause: 0,
     otherNumRootCause: 0,
     assessmentFilters,

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/FeatureUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/FeatureUtils.ts
@@ -50,5 +50,5 @@ export const shouldEnableSessionGrouping = () => {
  * instead of eagerly fetching all pages in a single query.
  */
 export const shouldUseInfinitePaginatedTraces = () => {
-  return false;
+  return true;
 };

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/FeatureUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/FeatureUtils.ts
@@ -50,5 +50,5 @@ export const shouldEnableSessionGrouping = () => {
  * instead of eagerly fetching all pages in a single query.
  */
 export const shouldUseInfinitePaginatedTraces = () => {
-  return true;
+  return false;
 };


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/22441/files/bb5b0b4ce7b7bedccd0798d44fccb724202a4daf..a860127c2dd9022b210ce368f7b6026e697a42a5) to review incremental changes.
- [stack/pagination-part-6](https://github.com/mlflow/mlflow/pull/22273) [[Files changed](https://github.com/mlflow/mlflow/pull/22273/files)]
  - [**stack/pagination-part-7**](https://github.com/mlflow/mlflow/pull/22441) [[Files changed](https://github.com/mlflow/mlflow/pull/22441/files/bb5b0b4ce7b7bedccd0798d44fccb724202a4daf..a860127c2dd9022b210ce368f7b6026e697a42a5)]
    - [stack/pagination-part-9](https://github.com/mlflow/mlflow/pull/22482) [[Files changed](https://github.com/mlflow/mlflow/pull/22482/files/a860127c2dd9022b210ce368f7b6026e697a42a5..6b5906af9f1d1bb4c81a49caefd82064168248b4)]
      - [stack/pagination-part-8](https://github.com/mlflow/mlflow/pull/22447) [[Files changed](https://github.com/mlflow/mlflow/pull/22447/files/6b5906af9f1d1bb4c81a49caefd82064168248b4..1b32ecddde7150301d2c310d9dbd6b98ce83ec96)]

---------
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

Currently the next page fetch handler only fires on table scroll. This mostly works, but there is an issue when client side filters are applied (notably for error assessment filtering).

This PR makes it call fetch as long as the height of the table is less than the scrollheight. After that, the user can scroll to fetch more

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Before, no way to fetch all errors:


https://github.com/user-attachments/assets/1d18d434-f40d-4b57-bf8a-121bcbfa9ab5




After, pages are fetched to fill the table, and then user can scroll to fetch even more:


https://github.com/user-attachments/assets/84fe899e-99ae-48ab-8b8e-bfa6b9d4b83a




### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
