### PR TITLE
[UI] Show header and breadcrumb on gateway usage page when no endpoints exist

### DIFF
--- a/mlflow/server/js/src/gateway/pages/GatewayUsagePage.test.tsx
+++ b/mlflow/server/js/src/gateway/pages/GatewayUsagePage.test.tsx
@@ -1,26 +1,29 @@
-import { describe, test, expect, jest, beforeEach } from '@jest/globals';
 import userEvent from '@testing-library/user-event';
 import { renderWithDesignSystem, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
 import { GatewayUsagePage } from './GatewayUsagePage';
 import { MemoryRouter } from '../../common/utils/RoutingUtils';
 
-// Mock GatewayChartsPanel
-jest.mock('../components/GatewayChartsPanel', () => ({
-  GatewayChartsPanel: ({ additionalControls }: { additionalControls?: React.ReactNode }) => (
-    <div data-testid="gateway-charts-panel">
-      {additionalControls}
-      <div data-testid="time-unit-selector">Time Unit Selector</div>
-      <div data-testid="date-selector">Date Selector</div>
-      <div data-testid="trace-requests-chart">Requests Chart</div>
-      <div data-testid="trace-latency-chart">Latency Chart</div>
-      <div data-testid="trace-errors-chart">Errors Chart</div>
-      <div data-testid="trace-token-usage-chart">Token Usage Chart</div>
-      <div data-testid="trace-token-stats-chart">Token Stats Chart</div>
-      <div data-testid="trace-cost-breakdown-chart">Cost Breakdown Chart</div>
-      <div data-testid="trace-cost-over-time-chart">Cost Over Time Chart</div>
-    </div>
-  ),
-}));
+// Mock GatewayChartsPanel - use createElement to avoid JSX transpilation issues in mock factories
+jest.mock('../components/GatewayChartsPanel', () => {
+  const React = require('react');
+  return {
+    GatewayChartsPanel: ({ additionalControls }) =>
+      React.createElement(
+        'div',
+        { 'data-testid': 'gateway-charts-panel' },
+        additionalControls,
+        React.createElement('div', { 'data-testid': 'time-unit-selector' }, 'Time Unit Selector'),
+        React.createElement('div', { 'data-testid': 'date-selector' }, 'Date Selector'),
+        React.createElement('div', { 'data-testid': 'trace-requests-chart' }, 'Requests Chart'),
+        React.createElement('div', { 'data-testid': 'trace-latency-chart' }, 'Latency Chart'),
+        React.createElement('div', { 'data-testid': 'trace-errors-chart' }, 'Errors Chart'),
+        React.createElement('div', { 'data-testid': 'trace-token-usage-chart' }, 'Token Usage Chart'),
+        React.createElement('div', { 'data-testid': 'trace-token-stats-chart' }, 'Token Stats Chart'),
+        React.createElement('div', { 'data-testid': 'trace-cost-breakdown-chart' }, 'Cost Breakdown Chart'),
+        React.createElement('div', { 'data-testid': 'trace-cost-over-time-chart' }, 'Cost Over Time Chart'),
+      ),
+  };
+});
 
 // Mock useEndpointsQuery
 const mockUseEndpointsQuery = jest.fn();
@@ -172,12 +175,20 @@ describe('GatewayUsagePage', () => {
       });
     });
 
-    test('renders empty state', () => {
+    test('renders page header and breadcrumb', () => {
+      renderComponent();
+
+      expect(screen.getAllByText('Usage').length).toBeGreaterThanOrEqual(1);
+    });
+
+    test('renders empty state with correct message', () => {
       renderComponent();
 
       expect(screen.getByText('No usage data available')).toBeInTheDocument();
       expect(
-        screen.getByText('Enable usage tracking on your endpoints to see usage metrics here.'),
+        screen.getByText(
+          'Once you have endpoints with usage tracking enabled, usage metrics will appear here.',
+        ),
       ).toBeInTheDocument();
     });
 
@@ -185,6 +196,13 @@ describe('GatewayUsagePage', () => {
       renderComponent();
 
       expect(screen.getByText('Go to Endpoints')).toBeInTheDocument();
+    });
+
+    test('does not render endpoint or user filters', () => {
+      renderComponent();
+
+      expect(screen.queryByText('Endpoint:')).not.toBeInTheDocument();
+      expect(screen.queryByText('User:')).not.toBeInTheDocument();
     });
 
     test('does not render charts', () => {
@@ -203,18 +221,16 @@ describe('GatewayUsagePage', () => {
       });
     });
 
-    test('shows loading spinner', () => {
+    test('does not show empty state while loading', () => {
       renderComponent();
 
-      // The spinner should be in the controls section
-      expect(screen.getByText('Endpoint:')).toBeInTheDocument();
+      expect(screen.queryByText('No usage data available')).not.toBeInTheDocument();
     });
 
-    test('disables endpoint selector while loading', () => {
+    test('renders charts panel while loading', () => {
       renderComponent();
 
-      const selectors = screen.getAllByRole('combobox');
-      expect(selectors[0]).toBeDisabled();
+      expect(screen.getByTestId('gateway-charts-panel')).toBeInTheDocument();
     });
   });
 
@@ -226,10 +242,18 @@ describe('GatewayUsagePage', () => {
       });
     });
 
-    test('renders empty state', () => {
+    test('renders page header with empty state', () => {
       renderComponent();
 
+      expect(screen.getAllByText('Usage').length).toBeGreaterThanOrEqual(1);
       expect(screen.getByText('No usage data available')).toBeInTheDocument();
+    });
+
+    test('does not render endpoint or user filters', () => {
+      renderComponent();
+
+      expect(screen.queryByText('Endpoint:')).not.toBeInTheDocument();
+      expect(screen.queryByText('User:')).not.toBeInTheDocument();
     });
   });
 });

--- a/mlflow/server/js/src/gateway/pages/GatewayUsagePage.test.tsx
+++ b/mlflow/server/js/src/gateway/pages/GatewayUsagePage.test.tsx
@@ -1,29 +1,26 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals';
 import userEvent from '@testing-library/user-event';
 import { renderWithDesignSystem, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
 import { GatewayUsagePage } from './GatewayUsagePage';
 import { MemoryRouter } from '../../common/utils/RoutingUtils';
 
-// Mock GatewayChartsPanel - use createElement to avoid JSX transpilation issues in mock factories
-jest.mock('../components/GatewayChartsPanel', () => {
-  const React = require('react');
-  return {
-    GatewayChartsPanel: ({ additionalControls }) =>
-      React.createElement(
-        'div',
-        { 'data-testid': 'gateway-charts-panel' },
-        additionalControls,
-        React.createElement('div', { 'data-testid': 'time-unit-selector' }, 'Time Unit Selector'),
-        React.createElement('div', { 'data-testid': 'date-selector' }, 'Date Selector'),
-        React.createElement('div', { 'data-testid': 'trace-requests-chart' }, 'Requests Chart'),
-        React.createElement('div', { 'data-testid': 'trace-latency-chart' }, 'Latency Chart'),
-        React.createElement('div', { 'data-testid': 'trace-errors-chart' }, 'Errors Chart'),
-        React.createElement('div', { 'data-testid': 'trace-token-usage-chart' }, 'Token Usage Chart'),
-        React.createElement('div', { 'data-testid': 'trace-token-stats-chart' }, 'Token Stats Chart'),
-        React.createElement('div', { 'data-testid': 'trace-cost-breakdown-chart' }, 'Cost Breakdown Chart'),
-        React.createElement('div', { 'data-testid': 'trace-cost-over-time-chart' }, 'Cost Over Time Chart'),
-      ),
-  };
-});
+// Mock GatewayChartsPanel
+jest.mock('../components/GatewayChartsPanel', () => ({
+  GatewayChartsPanel: ({ additionalControls }: { additionalControls?: React.ReactNode }) => (
+    <div data-testid="gateway-charts-panel">
+      {additionalControls}
+      <div data-testid="time-unit-selector">Time Unit Selector</div>
+      <div data-testid="date-selector">Date Selector</div>
+      <div data-testid="trace-requests-chart">Requests Chart</div>
+      <div data-testid="trace-latency-chart">Latency Chart</div>
+      <div data-testid="trace-errors-chart">Errors Chart</div>
+      <div data-testid="trace-token-usage-chart">Token Usage Chart</div>
+      <div data-testid="trace-token-stats-chart">Token Stats Chart</div>
+      <div data-testid="trace-cost-breakdown-chart">Cost Breakdown Chart</div>
+      <div data-testid="trace-cost-over-time-chart">Cost Over Time Chart</div>
+    </div>
+  ),
+}));
 
 // Mock useEndpointsQuery
 const mockUseEndpointsQuery = jest.fn();

--- a/mlflow/server/js/src/gateway/pages/GatewayUsagePage.test.tsx
+++ b/mlflow/server/js/src/gateway/pages/GatewayUsagePage.test.tsx
@@ -183,9 +183,7 @@ describe('GatewayUsagePage', () => {
 
       expect(screen.getByText('No usage data available')).toBeInTheDocument();
       expect(
-        screen.getByText(
-          'Once you have endpoints with usage tracking enabled, usage metrics will appear here.',
-        ),
+        screen.getByText('Once you have endpoints with usage tracking enabled, usage metrics will appear here.'),
       ).toBeInTheDocument();
     });
 

--- a/mlflow/server/js/src/gateway/pages/GatewayUsagePage.tsx
+++ b/mlflow/server/js/src/gateway/pages/GatewayUsagePage.tsx
@@ -61,6 +61,40 @@ const GatewayLogsContent = ({
   );
 };
 
+const UsageEmptyState = ({
+  title,
+  description,
+  componentId,
+}: {
+  title: React.ReactNode;
+  description: React.ReactNode;
+  componentId: string;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  return (
+    <div
+      css={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: 300,
+        textAlign: 'center',
+        padding: theme.spacing.lg,
+      }}
+    >
+      <ChartLineIcon css={{ fontSize: 48, color: theme.colors.textSecondary, marginBottom: theme.spacing.md }} />
+      <Typography.Title level={3}>{title}</Typography.Title>
+      <Typography.Text color="secondary" css={{ marginBottom: theme.spacing.md }}>
+        {description}
+      </Typography.Text>
+      <Link componentId={componentId} to={GatewayRoutes.gatewayPageRoute}>
+        <FormattedMessage defaultMessage="Go to Endpoints" description="Link to endpoints page" />
+      </Link>
+    </div>
+  );
+};
+
 export const GatewayUsagePage = () => {
   const { theme } = useDesignSystemTheme();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -120,43 +154,7 @@ export const GatewayUsagePage = () => {
     return [{ column: 'user', operator: FilterOperator.EQUALS, value: selectedUserId }];
   }, [selectedUserId]);
 
-  if (!isLoadingEndpoints && endpointsWithExperiments.length === 0) {
-    return (
-      <div
-        css={{
-          flex: 1,
-          overflow: 'auto',
-          padding: theme.spacing.md,
-        }}
-      >
-        <div
-          css={{
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            justifyContent: 'center',
-            minHeight: 300,
-            textAlign: 'center',
-            padding: theme.spacing.lg,
-          }}
-        >
-          <ChartLineIcon css={{ fontSize: 48, color: theme.colors.textSecondary, marginBottom: theme.spacing.md }} />
-          <Typography.Title level={3}>
-            <FormattedMessage defaultMessage="No usage data available" description="Empty state title" />
-          </Typography.Title>
-          <Typography.Text color="secondary" css={{ marginBottom: theme.spacing.md }}>
-            <FormattedMessage
-              defaultMessage="Enable usage tracking on your endpoints to see usage metrics here."
-              description="Empty state description"
-            />
-          </Typography.Text>
-          <Link componentId="mlflow.gateway.usage.go_to_endpoints_link" to={GatewayRoutes.gatewayPageRoute}>
-            <FormattedMessage defaultMessage="Go to Endpoints" description="Link to endpoints page" />
-          </Link>
-        </div>
-      </div>
-    );
-  }
+  const hasEndpoints = endpointsWithExperiments.length > 0;
 
   const endpointAndUserControls = (
     <>
@@ -227,7 +225,7 @@ export const GatewayUsagePage = () => {
           paddingBottom: 0,
         }}
       >
-        <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+        <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs, marginBottom: theme.spacing.md }}>
           <Breadcrumb includeTrailingCaret>
             <Breadcrumb.Item>
               <Link componentId="mlflow.gateway.usage.breadcrumb_gateway_link" to={GatewayRoutes.gatewayPageRoute}>
@@ -252,17 +250,19 @@ export const GatewayUsagePage = () => {
           </div>
         </div>
 
-        {/* Filters */}
-        <div
-          css={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: theme.spacing.md,
-            marginBottom: theme.spacing.sm,
-          }}
-        >
-          {endpointAndUserControls}
-        </div>
+        {/* Filters - only shown when endpoints with usage tracking exist */}
+        {hasEndpoints && (
+          <div
+            css={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: theme.spacing.md,
+              marginBottom: theme.spacing.sm,
+            }}
+          >
+            {endpointAndUserControls}
+          </div>
+        )}
       </div>
 
       {/* Tabs */}
@@ -300,7 +300,18 @@ export const GatewayUsagePage = () => {
             padding: theme.spacing.md,
           }}
         >
-          {isLoadingEndpoints || experimentIds.length > 0 ? (
+          {!isLoadingEndpoints && !hasEndpoints ? (
+            <UsageEmptyState
+              title={<FormattedMessage defaultMessage="No usage data available" description="Empty state title" />}
+              description={
+                <FormattedMessage
+                  defaultMessage="Once you have endpoints with usage tracking enabled, usage metrics will appear here."
+                  description="Empty state description for usage tab"
+                />
+              }
+              componentId="mlflow.gateway.usage.go_to_endpoints_link"
+            />
+          ) : isLoadingEndpoints || experimentIds.length > 0 ? (
             <GatewayChartsPanel
               experimentIds={experimentIds}
               showTokenStats
@@ -343,7 +354,20 @@ export const GatewayUsagePage = () => {
             padding: theme.spacing.md,
           }}
         >
-          {experimentIds.length > 0 ? (
+          {!isLoadingEndpoints && !hasEndpoints ? (
+            <UsageEmptyState
+              title={
+                <FormattedMessage defaultMessage="No logs available" description="Empty state title for logs tab" />
+              }
+              description={
+                <FormattedMessage
+                  defaultMessage="Once you have endpoints with usage tracking enabled, logs will appear here."
+                  description="Empty state description for logs tab"
+                />
+              }
+              componentId="mlflow.gateway.usage.go_to_endpoints_link_logs"
+            />
+          ) : experimentIds.length > 0 ? (
             <MonitoringConfigProvider>
               <GatewayLogsContent experimentIds={experimentIds} additionalFilters={tableFilters} />
             </MonitoringConfigProvider>

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -1050,6 +1050,10 @@
     "defaultMessage": "Date created",
     "description": "Label for endpoint creation date"
   },
+  "54bvuq": {
+    "defaultMessage": "Once you have endpoints with usage tracking enabled, usage metrics will appear here.",
+    "description": "Empty state description for usage tab"
+  },
   "58/xE7": {
     "defaultMessage": "Output /1M",
     "description": "Table header for output cost"
@@ -5212,10 +5216,6 @@
     "defaultMessage": "Register model",
     "description": "Run page > Header > Register model dropdown > Button label when some models are not registered"
   },
-  "WGU215": {
-    "defaultMessage": "Enable usage tracking on your endpoints to see usage metrics here.",
-    "description": "Empty state description"
-  },
   "WHf+VX": {
     "defaultMessage": "Please enter a name",
     "description": "Error message for empty assessment name in a creation form"
@@ -8227,6 +8227,10 @@
     "defaultMessage": "Showing all runs",
     "description": "Experiment page > compare runs > parallel chart > header > indicator for all runs shown"
   },
+  "oZ4C/F": {
+    "defaultMessage": "Once you have endpoints with usage tracking enabled, logs will appear here.",
+    "description": "Empty state description for logs tab"
+  },
   "oZReP2": {
     "defaultMessage": "Copied from",
     "description": "Label name for source model version metadata in model version page"
@@ -8450,6 +8454,10 @@
   "qB4ZRq": {
     "defaultMessage": "Conversational guidelines",
     "description": "LLM template option"
+  },
+  "qBGVKG": {
+    "defaultMessage": "No logs available",
+    "description": "Empty state title for logs tab"
   },
   "qDiJI2": {
     "defaultMessage": "Forecasting",


### PR DESCRIPTION
### Related Issues/PRs

### What changes are proposed in this pull request?

When the gateway usage page has zero endpoints with usage tracking enabled, it previously returned early with just an empty state card — no breadcrumb, page header, or tabs were rendered. This was inconsistent with sibling pages (API Keys, Budgets) which always render the full page chrome.

This PR moves the empty state inside the tab content area so the page always renders:
- Breadcrumb navigation back to Gateway
- "Usage" page title with icon
- Usage / Logs tabs

The endpoint/user filter dropdowns are hidden when there are no endpoints since they'd be non-functional. Each tab shows its own contextual empty state with a "Go to Endpoints" link.

<img width="1216" height="454" alt="image" src="https://github.com/user-attachments/assets/dbe16b4d-a675-485d-8024-fc2aaf73a4d2" />
<img width="1384" height="510" alt="image" src="https://github.com/user-attachments/assets/880f03f0-5f89-4987-8f95-930181be9e7f" />


### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The gateway usage page now shows the full page layout (breadcrumb, header, tabs) even when no endpoints have usage tracking enabled, instead of showing a bare empty state.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release