### PR TITLE
[DRAFT] Fix multimodal tracing rendering and extraction bugs

### DIFF
--- a/mlflow/demo/data.py
+++ b/mlflow/demo/data.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import base64
+import math
+import struct
+import zlib
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -844,6 +848,214 @@ SESSION_TRACES: list[DemoTrace] = [
         turn_index=2,
     ),
 ]
+
+# =============================================================================
+# Multimodal Traces (4 traces)
+# =============================================================================
+
+
+def _generate_synthetic_png() -> str:
+    """Generate an 8x8 red square PNG as base64. ~100 chars."""
+    width, height = 8, 8
+    raw = b""
+    for _y in range(height):
+        raw += b"\x00"
+        for _x in range(width):
+            raw += b"\xff\x00\x00"
+
+    def _chunk(chunk_type: bytes, data: bytes) -> bytes:
+        c = chunk_type + data
+        return struct.pack(">I", len(data)) + c + struct.pack(">I", zlib.crc32(c) & 0xFFFFFFFF)
+
+    png = b"\x89PNG\r\n\x1a\n"
+    png += _chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0))
+    png += _chunk(b"IDAT", zlib.compress(raw))
+    png += _chunk(b"IEND", b"")
+    return base64.b64encode(png).decode()
+
+
+def _generate_synthetic_wav() -> str:
+    """Generate a 0.25s 440Hz beep as WAV base64. ~5.4KB."""
+    sample_rate = 8000
+    duration = 0.25
+    frequency = 440
+    num_samples = int(sample_rate * duration)
+
+    samples = b"".join(
+        struct.pack("<h", int(16000 * math.sin(2 * math.pi * frequency * i / sample_rate)))
+        for i in range(num_samples)
+    )
+
+    header = struct.pack("<4sI4s", b"RIFF", 36 + len(samples), b"WAVE")
+    header += struct.pack("<4sIHHIIHH", b"fmt ", 16, 1, 1, sample_rate, sample_rate * 2, 2, 16)
+    header += struct.pack("<4sI", b"data", len(samples))
+    return base64.b64encode(header + samples).decode()
+
+
+@dataclass
+class MultimodalDemoTrace:
+    """Demo trace definition for multimodal content.
+
+    Each trace has pre-built input/output dicts in OpenAI message format
+    so the generator can set them directly on spans.
+    """
+
+    name: str
+    description: str
+    span_type: str
+    inputs: dict[str, Any]
+    outputs: dict[str, Any]
+    v1_response_text: str
+    v2_response_text: str
+
+
+def _build_multimodal_traces() -> list[MultimodalDemoTrace]:
+    png_b64 = _generate_synthetic_png()
+    wav_b64 = _generate_synthetic_wav()
+
+    return [
+        # 1. Vision input: image + text → text response
+        MultimodalDemoTrace(
+            name="vision_analysis",
+            description="Analyze an uploaded image",
+            span_type="CHAT_MODEL",
+            inputs={
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "What do you see in this image?"},
+                            {
+                                "type": "image_url",
+                                "image_url": {
+                                    "url": f"data:image/png;base64,{png_b64}",
+                                },
+                            },
+                        ],
+                    }
+                ]
+            },
+            outputs={
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                        },
+                        "finish_reason": "stop",
+                    }
+                ]
+            },
+            v1_response_text=(
+                "The image appears to be a small red square. It could be a test image "
+                "or a placeholder graphic of some kind."
+            ),
+            v2_response_text=(
+                "The image shows a solid red 8×8 pixel square, likely a synthetic test "
+                "image used for validating image processing pipelines."
+            ),
+        ),
+        # 2. Image generation: text → image output (DALL-E style)
+        MultimodalDemoTrace(
+            name="image_generation",
+            description="Generate an image from a text prompt",
+            span_type="CHAT_MODEL",
+            inputs={
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "Generate a simple logo: a red square on a white background.",
+                    }
+                ]
+            },
+            outputs={
+                "data": [
+                    {
+                        "b64_json": png_b64,
+                        "revised_prompt": (
+                            "A minimalist logo featuring a solid red square "
+                            "centered on a clean white background."
+                        ),
+                    }
+                ]
+            },
+            v1_response_text="Here is the generated image.",
+            v2_response_text="Here is the generated image.",
+        ),
+        # 3. Audio input: audio + text → text response
+        MultimodalDemoTrace(
+            name="audio_transcription",
+            description="Transcribe and summarize audio input",
+            span_type="CHAT_MODEL",
+            inputs={
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "Summarize what is being said in this audio."},
+                            {
+                                "type": "input_audio",
+                                "input_audio": {
+                                    "data": wav_b64,
+                                    "format": "wav",
+                                },
+                            },
+                        ],
+                    }
+                ]
+            },
+            outputs={
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                        },
+                        "finish_reason": "stop",
+                    }
+                ]
+            },
+            v1_response_text="The audio contains a short beep tone. It sounds like a test signal.",
+            v2_response_text=(
+                "The audio contains a brief 440Hz sine tone (concert A), commonly used "
+                "as a calibration or test signal in audio systems."
+            ),
+        ),
+        # 4. Audio output: text → audio response
+        MultimodalDemoTrace(
+            name="text_to_speech",
+            description="Convert text to spoken audio",
+            span_type="CHAT_MODEL",
+            inputs={
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "Read this aloud: Welcome to MLflow Tracing.",
+                    }
+                ]
+            },
+            outputs={
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "audio": {
+                                "data": wav_b64,
+                                "transcript": "Welcome to MLflow Tracing.",
+                            },
+                        },
+                        "finish_reason": "stop",
+                    }
+                ]
+            },
+            v1_response_text="Welcome to MLflow Tracing.",
+            v2_response_text="Welcome to MLflow Tracing.",
+        ),
+    ]
+
+
+MULTIMODAL_TRACES: list[MultimodalDemoTrace] = _build_multimodal_traces()
 
 # =============================================================================
 # Combined Trace Data

--- a/mlflow/demo/generators/traces.py
+++ b/mlflow/demo/generators/traces.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import hashlib
 import logging
 import random
@@ -18,10 +19,12 @@ from mlflow.demo.base import (
 )
 from mlflow.demo.data import (
     AGENT_TRACES,
+    MULTIMODAL_TRACES,
     PROMPT_TRACES,
     RAG_TRACES,
     SESSION_TRACES,
     DemoTrace,
+    MultimodalDemoTrace,
 )
 from mlflow.entities import SpanType
 from mlflow.tracing.constant import SpanAttributeKey, TraceMetadataKey
@@ -34,7 +37,7 @@ DEMO_TRACE_TYPE_TAG = "mlflow.demo.trace_type"
 DEMO_START_TIME_TAG = "mlflow.demo.start_time_ms"
 DEMO_END_TIME_TAG = "mlflow.demo.end_time_ms"
 
-_TOTAL_TRACES_PER_VERSION = 17
+_TOTAL_TRACES_PER_VERSION = 21
 
 
 @dataclass(frozen=True)
@@ -203,6 +206,14 @@ class TracesDemoGenerator(BaseDemoGenerator):
             if trace_id := self._create_prompt_trace(
                 trace_def, version, start_ns, end_ns, prompt_version_num
             ):
+                trace_ids.append(trace_id)
+            trace_index += 1
+
+        for trace_def in MULTIMODAL_TRACES:
+            start_ns, end_ns = _get_trace_timestamps(trace_index, version)
+            min_start_ns = min(min_start_ns, start_ns)
+            max_end_ns = max(max_end_ns, end_ns)
+            if trace_id := self._create_multimodal_trace(trace_def, version, start_ns, end_ns):
                 trace_ids.append(trace_id)
             trace_index += 1
 
@@ -523,6 +534,54 @@ class TracesDemoGenerator(BaseDemoGenerator):
         self._link_prompt_to_trace(trace_def.prompt_template.prompt_name, trace_id, prompt_version)
 
         return trace_id
+
+    def _create_multimodal_trace(
+        self,
+        trace_def: MultimodalDemoTrace,
+        version: Literal["v1", "v2"],
+        start_ns: int,
+        end_ns: int,
+    ) -> str | None:
+        """Create a multimodal trace with pre-built inputs/outputs."""
+        response_text = (
+            trace_def.v1_response_text if version == "v1" else trace_def.v2_response_text
+        )
+        prompt_tokens = 200
+        completion_tokens = _estimate_tokens(response_text)
+
+        model = GPT_5_2
+
+        # Deep copy to avoid mutating shared trace definition data
+        outputs = copy.deepcopy(trace_def.outputs)
+        # Inject version-specific response text into outputs
+        if "choices" in outputs:
+            for choice in outputs["choices"]:
+                msg = choice.get("message", {})
+                if msg.get("content") is None and "audio" not in msg:
+                    msg["content"] = response_text
+
+        root = mlflow.start_span_no_context(
+            name=trace_def.name,
+            span_type=trace_def.span_type,
+            inputs=trace_def.inputs,
+            attributes={
+                SpanAttributeKey.MESSAGE_FORMAT: "openai",
+                SpanAttributeKey.CHAT_USAGE: {
+                    "input_tokens": prompt_tokens,
+                    "output_tokens": completion_tokens,
+                    "total_tokens": prompt_tokens + completion_tokens,
+                },
+                SpanAttributeKey.MODEL: model.name,
+                SpanAttributeKey.MODEL_PROVIDER: model.provider,
+                SpanAttributeKey.LLM_COST: _compute_cost(model, prompt_tokens, completion_tokens),
+            },
+            metadata={DEMO_VERSION_TAG: version, DEMO_TRACE_TYPE_TAG: "multimodal"},
+            start_time_ns=start_ns,
+        )
+        root.set_outputs(outputs)
+        root.end(end_time_ns=end_ns)
+
+        return root.trace_id
 
     def _link_prompt_to_trace(
         self, short_prompt_name: str, trace_id: str, prompt_version: str = "1"

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -751,6 +751,23 @@ class LiveSpan(Span):
                     "inline_data": {**inline, "data": ref},
                 }
 
+        # OpenAI Responses API image generation:
+        # {"type": "image_generation_call", "result": "<base64>", "output_format": "png"}
+        if value.get("type") == "image_generation_call":
+            data = value.get("result")
+            fmt = value.get("output_format", "png")
+            if isinstance(data, str) and data and not data.startswith("mlflow-attachment://"):
+                if not isinstance(fmt, str) or not fmt:
+                    fmt = "png"
+                try:
+                    content_bytes = base64.b64decode(data, validate=True)
+                except Exception:
+                    return None
+                ref = self._store_attachment(
+                    Attachment(content_type=f"image/{fmt}", content_bytes=content_bytes)
+                )
+                return {**value, "result": ref}
+
         return None
 
     def set_attributes(self, attributes: dict[str, Any]):

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -1,3 +1,4 @@
+import ast
 import base64
 import json
 import logging
@@ -733,16 +734,27 @@ class LiveSpan(Span):
                     }
 
         # Google Gemini: {"inline_data": {"mime_type": "image/png", "data": "<base64>"}}
+        # The Gemini SDK (Pydantic) may serialize bytes as a Python repr string
+        # (e.g., "b'\\x89PNG...'") instead of base64, so we handle both formats.
         if isinstance(inline := value.get("inline_data"), dict):
             data = inline.get("data")
             mime_type = inline.get("mime_type", "application/octet-stream")
             if isinstance(data, str) and data and not data.startswith("mlflow-attachment://"):
                 if not isinstance(mime_type, str) or not mime_type:
                     mime_type = "application/octet-stream"
-                try:
-                    content_bytes = base64.b64decode(data, validate=True)
-                except Exception:
-                    return None
+                content_bytes = None
+                if data.startswith(("b'", 'b"')):
+                    try:
+                        parsed = ast.literal_eval(data)
+                        if isinstance(parsed, bytes):
+                            content_bytes = parsed
+                    except Exception:
+                        pass
+                if content_bytes is None:
+                    try:
+                        content_bytes = base64.b64decode(data, validate=True)
+                    except Exception:
+                        return None
                 ref = self._store_attachment(
                     Attachment(content_type=mime_type, content_bytes=content_bytes)
                 )

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactImageView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactImageView.tsx
@@ -6,13 +6,14 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { LegacySkeleton } from '@databricks/design-system';
+import { LegacySkeleton, Typography } from '@databricks/design-system';
 import {
   getArtifactBytesContent,
   getArtifactLocationUrl,
   getLoggedModelArtifactLocationUrl,
 } from '../../../common/utils/ArtifactUtils';
 import { ImagePreviewGroup, Image } from '../../../shared/building_blocks/Image';
+import { exceedsRenderSizeLimit, formatFileSize } from '../../../shared/web-shared/media-rendering-utils';
 import type { LoggedModelArtifactViewerProps } from './ArtifactViewComponents.types';
 import { fetchArtifactUnified } from './utils/fetchArtifactUnified';
 
@@ -34,6 +35,9 @@ const ShowArtifactImageView = ({
   const [isLoading, setIsLoading] = useState(true);
   const [previewVisible, setPreviewVisible] = useState(false);
   const [imageUrl, setImageUrl] = useState(null);
+  const [contentLength, setContentLength] = useState(0);
+
+  const contentType = path.toLowerCase().endsWith('.svg') ? 'image/svg+xml' : 'image/png';
 
   useEffect(() => {
     setIsLoading(true);
@@ -52,11 +56,25 @@ const ShowArtifactImageView = ({
       getArtifact,
     ).then((result: any) => {
       const options = path.toLowerCase().endsWith('.svg') ? { type: 'image/svg+xml' } : undefined;
+      const blob = new Blob([new Uint8Array(result)], options);
+      setContentLength(blob.size);
       // @ts-expect-error TS(2345): Argument of type 'string' is not assignable to par... Remove this comment to see the full error message
-      setImageUrl(URL.createObjectURL(new Blob([new Uint8Array(result)], options)));
+      setImageUrl(URL.createObjectURL(blob));
       setIsLoading(false);
     });
   }, [runUuid, path, getArtifact, isLoggedModelsMode, loggedModelId, experimentId, entityTags]);
+
+  if (exceedsRenderSizeLimit(contentType, contentLength) && imageUrl) {
+    return (
+      <div css={{ padding: '10px' }}>
+        <Typography.Text>
+          <a href={imageUrl} download={path.split('/').pop()}>
+            {`Download image (${formatFileSize(contentLength)})`}
+          </a>
+        </Typography.Text>
+      </div>
+    );
+  }
 
   return (
     imageUrl && (

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactVideoView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactVideoView.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from 'react';
-import { LegacySkeleton } from '@databricks/design-system';
+import { LegacySkeleton, Typography } from '@databricks/design-system';
 import {
   getArtifactBlob,
   getArtifactLocationUrl,
   getLoggedModelArtifactLocationUrl,
 } from '../../../common/utils/ArtifactUtils';
+import { exceedsRenderSizeLimit, formatFileSize } from '../../../shared/web-shared/media-rendering-utils';
 import type { LoggedModelArtifactViewerProps } from './ArtifactViewComponents.types';
 
 type Props = {
@@ -21,6 +22,7 @@ const ShowArtifactVideoView = ({
   loggedModelId,
 }: Props) => {
   const [videoUrl, setVideoUrl] = useState<string>();
+  const [contentLength, setContentLength] = useState(0);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -33,6 +35,7 @@ const ShowArtifactVideoView = ({
 
     getArtifact(artifactUrl).then((blob: Blob) => {
       objUrl = URL.createObjectURL(blob);
+      setContentLength(blob.size);
       setVideoUrl(objUrl);
       setLoading(false);
     });
@@ -57,6 +60,18 @@ const ShowArtifactVideoView = ({
       display: 'block',
     },
   };
+
+  if (exceedsRenderSizeLimit('video/mp4', contentLength) && videoUrl) {
+    return (
+      <div css={{ padding: 10 }}>
+        <Typography.Text>
+          <a href={videoUrl} download={path.split('/').pop()}>
+            {`Download video (${formatFileSize(contentLength)})`}
+          </a>
+        </Typography.Text>
+      </div>
+    );
+  }
 
   return (
     <div css={{ flex: 1 }}>

--- a/mlflow/server/js/src/shared/web-shared/media-rendering-utils.ts
+++ b/mlflow/server/js/src/shared/web-shared/media-rendering-utils.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared utilities for deciding whether to auto-render media content inline
+ * or show a download link instead. Used by both trace attachment rendering
+ * and artifact viewing.
+ */
+
+// Auto-render size thresholds (bytes). Files exceeding these show a download link.
+const MAX_IMAGE_RENDER_BYTES = 10 * 1024 * 1024; // 10 MB
+const MAX_AUDIO_RENDER_BYTES = 50 * 1024 * 1024; // 50 MB
+const MAX_PDF_RENDER_BYTES = 20 * 1024 * 1024; // 20 MB
+const MAX_VIDEO_RENDER_BYTES = 50 * 1024 * 1024; // 50 MB
+
+/**
+ * Returns the maximum file size (in bytes) that should be auto-rendered
+ * inline for a given content type. Files exceeding this should show a
+ * download link instead to prevent browser performance issues.
+ *
+ * Returns 0 for unknown content types (always show download link).
+ */
+export function getMaxRenderSize(contentType: string): number {
+  if (contentType.startsWith('image/')) return MAX_IMAGE_RENDER_BYTES;
+  if (contentType.startsWith('audio/')) return MAX_AUDIO_RENDER_BYTES;
+  if (contentType.startsWith('video/')) return MAX_VIDEO_RENDER_BYTES;
+  if (contentType === 'application/pdf') return MAX_PDF_RENDER_BYTES;
+  return 0;
+}
+
+/**
+ * Returns true if the content exceeds the auto-render size limit for its type.
+ */
+export function exceedsRenderSizeLimit(contentType: string, contentLength: number): boolean {
+  return contentLength > getMaxRenderSize(contentType);
+}
+
+/**
+ * Formats a byte count as a human-readable string (e.g., "1.5 MB").
+ */
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
@@ -1087,10 +1087,15 @@ export const normalizeConversation = (input: any, messageFormat?: string): Model
     }
 
     switch (messageFormat) {
-      case 'langchain':
-        const langchainMessages = normalizeLangchainChatInput(input) ?? normalizeLangchainChatResult(input);
+      case 'langchain': {
+        const langchainMessages =
+          normalizeLangchainChatInput(input) ??
+          normalizeLangchainChatResult(input) ??
+          // LangChain autolog may serialize messages in OpenAI format
+          normalizeOpenAIFormats(input);
         if (langchainMessages) return langchainMessages;
         break;
+      }
       case 'llamaindex':
         const llamaIndexMessages = normalizeLlamaIndexChatInput(input) ?? normalizeLlamaIndexChatResponse(input);
         if (llamaIndexMessages) return llamaIndexMessages;

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/attachment-utils.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/attachment-utils.ts
@@ -94,6 +94,10 @@ export function isAttachmentUri(value: string): boolean {
   return value.startsWith('mlflow-attachment://');
 }
 
+export function containsAttachmentUri(value: string): boolean {
+  return value.includes('mlflow-attachment://');
+}
+
 /**
  * URL transform for react-markdown that preserves mlflow-attachment:// URIs.
  * Without this, the default transform strips non-standard protocols.

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/attachment-utils.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/attachment-utils.ts
@@ -36,15 +36,23 @@ export function parseAttachmentUri(uri: string): { attachmentId: string; traceId
  * Hook that fetches an attachment by URI and returns a blob URL for rendering.
  * Handles cleanup of blob URLs on unmount or when the URI changes.
  */
-export function useAttachmentUrl(uri: string | null): { url: string | null; loading: boolean; error: boolean } {
+export function useAttachmentUrl(uri: string | null): {
+  url: string | null;
+  contentLength: number;
+  contentType: string | null;
+  loading: boolean;
+  error: boolean;
+} {
   const parsed = uri ? parseAttachmentUri(uri) : null;
   const [url, setUrl] = useState<string | null>(null);
+  const [contentLength, setContentLength] = useState(0);
   const [loading, setLoading] = useState(!!parsed);
   const [error, setError] = useState(false);
 
   useEffect(() => {
     if (!parsed) {
       setUrl(null);
+      setContentLength(0);
       setLoading(false);
       setError(false);
       return;
@@ -62,9 +70,11 @@ export function useAttachmentUrl(uri: string | null): { url: string | null; load
           return;
         }
         if (data) {
-          const blobUrl = URL.createObjectURL(new Blob([data], { type: parsed.contentType }));
+          const blob = new Blob([data], { type: parsed.contentType });
+          const blobUrl = URL.createObjectURL(blob);
           localUrl = blobUrl;
           setUrl(blobUrl);
+          setContentLength(blob.size);
         } else {
           setError(true);
         }
@@ -87,7 +97,7 @@ export function useAttachmentUrl(uri: string | null): { url: string | null; load
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [uri]);
 
-  return { url, loading, error };
+  return { url, loading, error, contentLength, contentType: parsed?.contentType ?? null };
 }
 
 export function isAttachmentUri(value: string): boolean {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/gemini.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/gemini.ts
@@ -356,6 +356,18 @@ export const normalizeGeminiChatInput = (obj: unknown): ModelTraceChatMessage[] 
         return messages.length > 0 ? messages : null;
       }
     }
+
+    // Handle single content object (e.g., {"role": "user", "parts": [...]})
+    if (isGeminiContent(obj.contents)) {
+      const messages = normalizeGeminiContentToMessages(obj.contents);
+      return messages.length > 0 ? messages : null;
+    }
+
+    // Handle single part dict (e.g., {"text": "Say hello"})
+    if (isGeminiContentPart(obj.contents)) {
+      const messages = normalizeGeminiContentToMessages({ role: 'user', parts: [obj.contents] });
+      return messages.length > 0 ? messages : null;
+    }
   }
 
   return null;

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/gemini.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/gemini.ts
@@ -43,7 +43,7 @@ type GeminiCandidate = {
 };
 
 type GeminiContent = {
-  role: 'user' | 'model';
+  role?: 'user' | 'model';
   parts: GeminiContentPart[];
 };
 
@@ -134,15 +134,14 @@ const isThinkingPart = (part: GeminiTextPart): boolean => {
 };
 
 const isGeminiContent = (obj: unknown): obj is GeminiContent => {
-  return (
-    isObject(obj) &&
-    'role' in obj &&
-    isString(obj.role) &&
-    ['user', 'model'].includes(obj.role) &&
-    has(obj, 'parts') &&
-    Array.isArray(obj.parts) &&
-    obj.parts.every(isGeminiContentPart)
-  );
+  if (!isObject(obj) || !has(obj, 'parts') || !Array.isArray(obj.parts) || !obj.parts.every(isGeminiContentPart)) {
+    return false;
+  }
+  // role may be omitted by some Gemini SDK versions; treat as valid if parts are present
+  if ('role' in obj) {
+    return isString(obj.role) && ['user', 'model'].includes(obj.role);
+  }
+  return true;
 };
 
 // Gemini SDK serializes bytes as Python literal "b'...'" with escaped hex bytes.
@@ -279,7 +278,7 @@ const processGeminiContentParts = (
 };
 
 const normalizeGeminiContentToMessages = (content: GeminiContent): ModelTraceChatMessage[] => {
-  const role = content.role === 'model' ? 'assistant' : content.role;
+  const role = content.role === 'model' || !content.role ? 'assistant' : content.role;
   const { textParts, thinking, toolCalls, functionResponses } = processGeminiContentParts(content.parts);
 
   // Emit function_response parts as individual tool messages

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/openai.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/openai.test.ts
@@ -485,6 +485,26 @@ describe('normalizeConversation', () => {
     ]);
   });
 
+  it('combines multi-part Responses API input into a single message', () => {
+    const input = {
+      input: [
+        {
+          role: 'user',
+          content: [
+            { type: 'input_text', text: 'Describe this image.' },
+            { type: 'input_image', image_url: 'data:image/jpeg;base64,abc123' },
+          ],
+        },
+      ],
+    };
+    const result = normalizeConversation(input, 'openai');
+    // Should produce a single user message, not two separate ones
+    expect(result).toHaveLength(1);
+    expect(result?.[0]).toMatchObject({ role: 'user' });
+    expect(result?.[0]?.content).toContain('Describe this image.');
+    expect(result?.[0]?.content).toContain('data:image/jpeg;base64,abc123');
+  });
+
   describe('OpenAI reasoning support', () => {
     it('handles non-streaming output with reasoning summary', () => {
       const result = normalizeConversation(MOCK_OPENAI_RESPONSES_OUTPUT_WITH_REASONING, 'openai');

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/openai.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/openai.ts
@@ -108,10 +108,17 @@ const normalizeOpenAIResponsesInputMessage = (obj: OpenAIResponsesInputMessage):
       const text = get(item, 'text');
       if (get(item, 'type') === 'input_text' && isString(text)) {
         contentParts.push({ type: 'text', text });
-      } else {
-        const imageUrl = get(item, 'image_url');
-        if (get(item, 'type') === 'input_image' && isString(imageUrl)) {
-          contentParts.push({ type: 'image_url', image_url: { url: imageUrl } });
+      } else if (get(item, 'type') === 'input_image' && isString(get(item, 'image_url'))) {
+        contentParts.push({ type: 'image_url', image_url: { url: get(item, 'image_url') as string } });
+      } else if (get(item, 'type') === 'input_file') {
+        const filename = get(item, 'filename');
+        const fileData = get(item, 'file_data');
+        if (isString(fileData) && fileData.startsWith('mlflow-attachment://')) {
+          // Render as image_url so the attachment renderer picks it up
+          // (AttachmentRenderer handles PDFs, images, audio, etc.)
+          contentParts.push({ type: 'image_url', image_url: { url: fileData } });
+        } else if (isString(filename)) {
+          contentParts.push({ type: 'text', text: `[File: ${filename}]` });
         }
       }
     }

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/openai.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/openai.ts
@@ -12,7 +12,7 @@ import type {
   OpenAIResponsesStreamingOutputDelta,
   OpenAIResponsesStreamingOutputDone,
 } from './openai.types';
-import type { ModelTraceChatMessage } from '../ModelTrace.types';
+import type { ModelTraceChatMessage, ModelTraceContentParts } from '../ModelTrace.types';
 import {
   isModelTraceChatResponse,
   isModelTraceChoices,
@@ -96,42 +96,28 @@ export const isOpenAIResponsesOutputItem = (obj: unknown): obj is OpenAIResponse
   return false;
 };
 
-const normalizeOpenAIResponsesInputItem = (
-  obj: OpenAIResponsesInputText | OpenAIResponsesInputFile | OpenAIResponsesInputImage,
-  role: OpenAIResponsesInputMessageRole,
-): ModelTraceChatMessage | null => {
-  const text = get(obj, 'text');
-  if (get(obj, 'type') === 'input_text' && isString(text)) {
-    return prettyPrintChatMessage({
-      type: 'message',
-      content: [{ type: 'text', text }],
-      role: role,
-    });
-  }
-
-  const imageUrl = get(obj, 'image_url');
-  if (get(obj, 'type') === 'input_image' && isString(imageUrl)) {
-    return prettyPrintChatMessage({
-      type: 'message',
-      content: [{ type: 'image_url', image_url: { url: imageUrl } }],
-      role: role,
-    });
-  }
-
-  // TODO: file input not supported yet
-  // if ('type' in obj && obj.type === 'input_file') {
-  //   return prettyPrintChatMessage({ type: 'message', content: obj.file_url, role: role });
-  // }
-
-  return null;
-};
-
 const normalizeOpenAIResponsesInputMessage = (obj: OpenAIResponsesInputMessage): ModelTraceChatMessage[] | null => {
   if (isString(obj.content)) {
     const message = prettyPrintChatMessage({ type: 'message', content: obj.content, role: obj.role });
     return message && [message];
   } else {
-    return obj.content.map((item) => normalizeOpenAIResponsesInputItem(item, obj.role)).filter((item) => item !== null);
+    // Combine all content parts into a single message to preserve the original
+    // multi-part structure (e.g., text + image in one user message)
+    const contentParts: ModelTraceContentParts[] = [];
+    for (const item of obj.content) {
+      const text = get(item, 'text');
+      if (get(item, 'type') === 'input_text' && isString(text)) {
+        contentParts.push({ type: 'text', text });
+      } else {
+        const imageUrl = get(item, 'image_url');
+        if (get(item, 'type') === 'input_image' && isString(imageUrl)) {
+          contentParts.push({ type: 'image_url', image_url: { url: imageUrl } });
+        }
+      }
+    }
+    if (contentParts.length === 0) return null;
+    const message = prettyPrintChatMessage({ type: 'message', content: contentParts, role: obj.role });
+    return message && [message];
   }
 };
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerAttachmentRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerAttachmentRenderer.tsx
@@ -58,9 +58,7 @@ export const ModelTraceExplorerAttachmentRenderer = ({
           </Typography.Text>
         )}
         {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
-        <audio controls>
-          <source src={objectUrl} type={contentType} />
-        </audio>
+        <audio controls css={{ width: '100%', maxWidth: 500 }} src={objectUrl} />
       </div>
     );
   }

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerAttachmentRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerAttachmentRenderer.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { LegacySkeleton, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
 
+import { exceedsRenderSizeLimit, formatFileSize } from '../../media-rendering-utils';
 import { useTraceAttachment } from '../hooks/useTraceAttachment';
 
 export const ModelTraceExplorerAttachmentRenderer = ({
@@ -17,7 +18,11 @@ export const ModelTraceExplorerAttachmentRenderer = ({
   contentType: string;
 }) => {
   const { theme } = useDesignSystemTheme();
-  const { objectUrl, isLoading, error } = useTraceAttachment({ traceId, attachmentId, contentType });
+  const { objectUrl, contentLength, isLoading, error } = useTraceAttachment({
+    traceId,
+    attachmentId,
+    contentType,
+  });
   const [previewVisible, setPreviewVisible] = useState(false);
 
   if (error) {
@@ -33,6 +38,27 @@ export const ModelTraceExplorerAttachmentRenderer = ({
 
   if (isLoading || !objectUrl) {
     return <LegacySkeleton />;
+  }
+
+  const exceedsRenderLimit = exceedsRenderSizeLimit(contentType, contentLength);
+
+  if (exceedsRenderLimit) {
+    return (
+      <div css={{ padding: theme.spacing.sm }}>
+        {title && (
+          <Typography.Text bold css={{ display: 'block', marginBottom: theme.spacing.xs }}>
+            {title}
+          </Typography.Text>
+        )}
+        <a href={objectUrl} download={`attachment-${attachmentId}`}>
+          <FormattedMessage
+            defaultMessage="Download {contentType} ({size})"
+            description="Download link for trace attachment that exceeds the rendering size limit"
+            values={{ contentType, size: formatFileSize(contentLength) }}
+          />
+        </a>
+      </div>
+    );
   }
 
   if (contentType.startsWith('image/')) {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerAttachmentRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerAttachmentRenderer.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import { LegacySkeleton, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
 
@@ -16,6 +18,7 @@ export const ModelTraceExplorerAttachmentRenderer = ({
 }) => {
   const { theme } = useDesignSystemTheme();
   const { objectUrl, isLoading, error } = useTraceAttachment({ traceId, attachmentId, contentType });
+  const [previewVisible, setPreviewVisible] = useState(false);
 
   if (error) {
     return (
@@ -43,8 +46,39 @@ export const ModelTraceExplorerAttachmentRenderer = ({
         <img
           src={objectUrl}
           alt={`Attachment ${attachmentId}`}
-          css={{ maxWidth: '100%', maxHeight: 400, borderRadius: theme.borders.borderRadiusSm }}
+          css={{
+            maxWidth: '100%',
+            maxHeight: 200,
+            borderRadius: theme.borders.borderRadiusSm,
+            cursor: 'pointer',
+            '&:hover': { boxShadow: `0 0 4px ${theme.colors.border}` },
+          }}
+          onClick={() => setPreviewVisible(true)}
         />
+        {previewVisible && (
+          <div
+            css={{
+              position: 'fixed',
+              top: 0,
+              left: 0,
+              right: 0,
+              bottom: 0,
+              backgroundColor: 'rgba(0, 0, 0, 0.7)',
+              zIndex: 1000,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              cursor: 'pointer',
+            }}
+            onClick={() => setPreviewVisible(false)}
+          >
+            <img
+              src={objectUrl}
+              alt={`Attachment ${attachmentId}`}
+              css={{ maxWidth: '90vw', maxHeight: '90vh', borderRadius: 4 }}
+            />
+          </div>
+        )}
       </div>
     );
   }

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerFieldRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerFieldRenderer.tsx
@@ -8,12 +8,37 @@ import { ModelTraceExplorerAttachmentRenderer } from './ModelTraceExplorerAttach
 import { ModelTraceExplorerChatToolsRenderer } from './ModelTraceExplorerChatToolsRenderer';
 import { ModelTraceExplorerRetrieverFieldRenderer } from './ModelTraceExplorerRetrieverFieldRenderer';
 import { ModelTraceExplorerTextFieldRenderer } from './ModelTraceExplorerTextFieldRenderer';
-import { parseAttachmentUri } from '../attachment-utils';
+import { containsAttachmentUri, parseAttachmentUri } from '../attachment-utils';
 import type { Assessment } from '../ModelTrace.types';
 import { CodeSnippetRenderMode } from '../ModelTrace.types';
 import { isModelTraceChatTool, isRetrieverDocument, normalizeConversation } from '../ModelTraceExplorer.utils';
 import { ModelTraceExplorerCodeSnippet } from '../ModelTraceExplorerCodeSnippet';
 import { ModelTraceExplorerConversation } from '../right-pane/ModelTraceExplorerConversation';
+
+const MAX_ATTACHMENT_SEARCH_DEPTH = 10;
+
+/**
+ * Recursively extract all attachment URIs from a parsed JSON value.
+ */
+const findAttachmentUris = (
+  value: unknown,
+  depth = 0,
+): { attachmentId: string; traceId: string; contentType: string }[] => {
+  if (depth > MAX_ATTACHMENT_SEARCH_DEPTH) {
+    return [];
+  }
+  if (isString(value)) {
+    const parsed = parseAttachmentUri(value);
+    return parsed ? [parsed] : [];
+  }
+  if (Array.isArray(value)) {
+    return value.flatMap((v) => findAttachmentUris(v, depth + 1));
+  }
+  if (value && typeof value === 'object') {
+    return Object.values(value).flatMap((v) => findAttachmentUris(v, depth + 1));
+  }
+  return [];
+};
 
 export const DEFAULT_MAX_VISIBLE_CHAT_MESSAGES = 3;
 
@@ -135,6 +160,27 @@ export const ModelTraceExplorerFieldRenderer = ({
 
   if (isRetrieverDocuments) {
     return <ModelTraceExplorerRetrieverFieldRenderer title={title} documents={parsedData} assessments={assessments} />;
+  }
+
+  // Check for attachment URIs embedded in complex JSON structures
+  if (containsAttachmentUri(data)) {
+    const attachments = findAttachmentUris(parsedData);
+    if (attachments.length > 0) {
+      return (
+        <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
+          {attachments.map((att) => (
+            <ModelTraceExplorerAttachmentRenderer
+              key={att.attachmentId}
+              title=""
+              attachmentId={att.attachmentId}
+              traceId={att.traceId}
+              contentType={att.contentType}
+            />
+          ))}
+          <ModelTraceExplorerCodeSnippet title={title} data={data} />
+        </div>
+      );
+    }
   }
 
   return <ModelTraceExplorerCodeSnippet title={title} data={data} />;

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/hooks/useTraceAttachment.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/hooks/useTraceAttachment.ts
@@ -19,11 +19,7 @@ export const useTraceAttachment = ({
   attachmentId: string;
   contentType: string;
 }) => {
-  const {
-    data: objectUrl,
-    isLoading,
-    error,
-  } = useQuery({
+  const { data, isLoading, error } = useQuery({
     queryKey: [TRACE_ATTACHMENT_QUERY_KEY, traceId, attachmentId],
     queryFn: async () => {
       const url = getAjaxUrl(
@@ -31,18 +27,26 @@ export const useTraceAttachment = ({
       );
       const response = await fetchOrFail(url);
       const blob = await response.blob();
-      return URL.createObjectURL(new Blob([blob], { type: contentType }));
+      return {
+        objectUrl: URL.createObjectURL(new Blob([blob], { type: contentType })),
+        contentLength: blob.size,
+      };
     },
     refetchOnWindowFocus: false,
   });
 
   useEffect(() => {
     return () => {
-      if (objectUrl) {
-        URL.revokeObjectURL(objectUrl);
+      if (data?.objectUrl) {
+        URL.revokeObjectURL(data.objectUrl);
       }
     };
-  }, [objectUrl]);
+  }, [data?.objectUrl]);
 
-  return { objectUrl: objectUrl ?? null, isLoading, error };
+  return {
+    objectUrl: data?.objectUrl ?? null,
+    contentLength: data?.contentLength ?? 0,
+    isLoading,
+    error,
+  };
 };

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessage.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessage.tsx
@@ -25,6 +25,45 @@ import { ModelTraceExplorerToolCallMessage } from './ModelTraceExplorerToolCallM
 import { CodeSnippetRenderMode, type ModelTraceChatMessage, type ModelTraceInputAudio } from '../ModelTrace.types';
 import { ModelTraceExplorerCodeSnippetBody } from '../ModelTraceExplorerCodeSnippetBody';
 
+function ClickToExpandImage({ src, alt }: { src: string; alt?: string }) {
+  const [previewVisible, setPreviewVisible] = useState(false);
+  return (
+    <>
+      <img
+        src={src}
+        alt={alt}
+        css={{
+          maxWidth: '100%',
+          maxHeight: 200,
+          cursor: 'pointer',
+          '&:hover': { boxShadow: '0 0 4px gray' },
+        }}
+        onClick={() => setPreviewVisible(true)}
+      />
+      {previewVisible && (
+        <div
+          css={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            backgroundColor: 'rgba(0, 0, 0, 0.7)',
+            zIndex: 1000,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            cursor: 'pointer',
+          }}
+          onClick={() => setPreviewVisible(false)}
+        >
+          <img src={src} alt={alt} css={{ maxWidth: '90vw', maxHeight: '90vh', borderRadius: 4 }} />
+        </div>
+      )}
+    </>
+  );
+}
+
 function AttachmentImage({ src, alt }: { src?: string; alt?: string }) {
   const { url, loading, error } = useAttachmentUrl(src ?? null);
   if (loading) {
@@ -33,12 +72,15 @@ function AttachmentImage({ src, alt }: { src?: string; alt?: string }) {
   if (error || !url) {
     return <span>{`[${alt ?? 'Failed to load image'}]`}</span>;
   }
-  return <img src={url} alt={alt} css={{ maxWidth: '100%' }} />;
+  return <ClickToExpandImage src={url} alt={alt} />;
 }
 
 const attachmentAwareImgRenderer = ({ src, alt }: { src?: string; alt?: string }) => {
   if (src && isAttachmentUri(src)) {
     return <AttachmentImage src={src} alt={alt} />;
+  }
+  if (src) {
+    return <ClickToExpandImage src={src} alt={alt} />;
   }
   return <img src={src} alt={alt} css={{ maxWidth: '100%' }} />;
 };

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessage.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessage.tsx
@@ -13,7 +13,13 @@ import {
 } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
 import { GenAIMarkdownRenderer } from '../../genai-markdown-renderer/GenAIMarkdownRenderer';
-import { attachmentAwareUrlTransform, isAttachmentUri, useAttachmentUrl } from '../attachment-utils';
+import {
+  attachmentAwareUrlTransform,
+  isAttachmentUri,
+  parseAttachmentUri,
+  useAttachmentUrl,
+} from '../attachment-utils';
+import { ModelTraceExplorerAttachmentRenderer } from '../field-renderers/ModelTraceExplorerAttachmentRenderer';
 
 import { ModelTraceExplorerChatMessageHeader } from './ModelTraceExplorerChatMessageHeader';
 import {
@@ -77,6 +83,18 @@ function AttachmentImage({ src, alt }: { src?: string; alt?: string }) {
 
 const attachmentAwareImgRenderer = ({ src, alt }: { src?: string; alt?: string }) => {
   if (src && isAttachmentUri(src)) {
+    const parsed = parseAttachmentUri(src);
+    if (parsed && !parsed.contentType.startsWith('image/')) {
+      // Non-image attachments (PDF, audio, etc.) use the full AttachmentRenderer
+      return (
+        <ModelTraceExplorerAttachmentRenderer
+          title=""
+          attachmentId={parsed.attachmentId}
+          traceId={parsed.traceId}
+          contentType={parsed.contentType}
+        />
+      );
+    }
     return <AttachmentImage src={src} alt={alt} />;
   }
   if (src) {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessage.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessage.tsx
@@ -99,6 +99,10 @@ const tryGetJsonContent = (content: string) => {
   }
 };
 
+// Threshold above which markdown rendering is skipped to prevent browser freezes
+// from extremely large strings (e.g., un-extracted base64 data).
+const MARKDOWN_RENDER_SIZE_LIMIT = 1_000_000;
+
 function ModelTraceExplorerChatMessageContent({
   content,
   shouldDisplayCodeSnippet,
@@ -121,6 +125,24 @@ function ModelTraceExplorerChatMessageContent({
         containsActiveMatch={false}
         renderMode={CodeSnippetRenderMode.JSON}
       />
+    );
+  }
+
+  if (content.length > MARKDOWN_RENDER_SIZE_LIMIT) {
+    return (
+      <div css={{ padding: theme.spacing.sm, paddingTop: 0 }}>
+        <Typography.Text color="secondary">
+          <FormattedMessage
+            defaultMessage="Content too large to render ({size}). Displaying as plain text."
+            description="Message shown when chat content exceeds the markdown rendering size limit"
+            values={{ size: `${(content.length / 1_000_000).toFixed(1)}MB` }}
+          />
+        </Typography.Text>
+        <pre css={{ whiteSpace: 'pre-wrap', wordBreak: 'break-all', maxHeight: 400, overflow: 'auto', fontSize: 12 }}>
+          {content.slice(0, 10_000)}
+          {content.length > 10_000 ? '\n\n... (truncated)' : ''}
+        </pre>
+      </div>
     );
   }
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessage.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessage.tsx
@@ -13,6 +13,7 @@ import {
 } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
 import { GenAIMarkdownRenderer } from '../../genai-markdown-renderer/GenAIMarkdownRenderer';
+import { exceedsRenderSizeLimit, formatFileSize } from '../../media-rendering-utils';
 import {
   attachmentAwareUrlTransform,
   isAttachmentUri,
@@ -71,12 +72,19 @@ function ClickToExpandImage({ src, alt }: { src: string; alt?: string }) {
 }
 
 function AttachmentImage({ src, alt }: { src?: string; alt?: string }) {
-  const { url, loading, error } = useAttachmentUrl(src ?? null);
+  const { url, contentLength, contentType, loading, error } = useAttachmentUrl(src ?? null);
   if (loading) {
     return <Spinner size="small" />;
   }
   if (error || !url) {
     return <span>{`[${alt ?? 'Failed to load image'}]`}</span>;
+  }
+  if (contentType && exceedsRenderSizeLimit(contentType, contentLength)) {
+    return (
+      <a href={url} download>
+        {`Download ${contentType} (${formatFileSize(contentLength)})`}
+      </a>
+    );
   }
   return <ClickToExpandImage src={url} alt={alt} />;
 }
@@ -257,7 +265,7 @@ function getAudioMimeType(format: string): string {
 }
 
 function AttachmentAudioPlayer({ uri }: { uri: string }) {
-  const { url, loading, error } = useAttachmentUrl(uri);
+  const { url, contentLength, contentType, loading, error } = useAttachmentUrl(uri);
   if (loading) {
     return <Spinner size="small" />;
   }
@@ -269,6 +277,13 @@ function AttachmentAudioPlayer({ uri }: { uri: string }) {
           description="Error message when trace audio attachment fails to load"
         />
       </Typography.Text>
+    );
+  }
+  if (contentType && exceedsRenderSizeLimit(contentType, contentLength)) {
+    return (
+      <a href={url} download>
+        {`Download ${contentType} (${formatFileSize(contentLength)})`}
+      </a>
     );
   }
   // eslint-disable-next-line jsx-a11y/media-has-caption

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessage.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessage.tsx
@@ -271,13 +271,13 @@ export function ModelTraceExplorerChatMessage({
           message.tool_calls.map((toolCall) => (
             <ModelTraceExplorerToolCallMessage key={toolCall.id} toolCall={toolCall} />
           ))}
-        {message.audioParts && message.audioParts.length > 0 && (
-          <ModelTraceExplorerAudioPlayer audioParts={message.audioParts} />
-        )}
         <ModelTraceExplorerChatMessageContent
           content={displayedContent}
           shouldDisplayCodeSnippet={shouldDisplayCodeSnippet}
         />
+        {message.audioParts && message.audioParts.length > 0 && (
+          <ModelTraceExplorerAudioPlayer audioParts={message.audioParts} />
+        )}
       </div>
       {isExpandable && (
         <Button

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerDefaultSpanView.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerDefaultSpanView.tsx
@@ -6,8 +6,10 @@ import { FormattedMessage } from '@databricks/i18n';
 
 import type { ModelTraceSpanNode, SearchMatch } from '../ModelTrace.types';
 import { createListFromObject } from '../ModelTraceExplorer.utils';
+import { containsAttachmentUri } from '../attachment-utils';
 import { ModelTraceExplorerCodeSnippet } from '../ModelTraceExplorerCodeSnippet';
 import { ModelTraceExplorerCollapsibleSection } from '../ModelTraceExplorerCollapsibleSection';
+import { ModelTraceExplorerFieldRenderer } from '../field-renderers/ModelTraceExplorerFieldRenderer';
 
 export function ModelTraceExplorerDefaultSpanView({
   activeSpan,
@@ -58,16 +60,20 @@ export function ModelTraceExplorerDefaultSpanView({
           }
         >
           <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
-            {inputList.map(({ key, value }, index) => (
-              <ModelTraceExplorerCodeSnippet
-                key={key || index}
-                title={key}
-                data={value}
-                searchFilter={searchFilter}
-                activeMatch={activeMatch}
-                containsActiveMatch={isActiveMatchSpan && activeMatch.section === 'inputs' && activeMatch.key === key}
-              />
-            ))}
+            {inputList.map(({ key, value }, index) =>
+              containsAttachmentUri(value) ? (
+                <ModelTraceExplorerFieldRenderer key={key || index} title={key} data={value} renderMode="default" />
+              ) : (
+                <ModelTraceExplorerCodeSnippet
+                  key={key || index}
+                  title={key}
+                  data={value}
+                  searchFilter={searchFilter}
+                  activeMatch={activeMatch}
+                  containsActiveMatch={isActiveMatchSpan && activeMatch.section === 'inputs' && activeMatch.key === key}
+                />
+              ),
+            )}
           </div>
         </ModelTraceExplorerCollapsibleSection>
       )}
@@ -85,16 +91,22 @@ export function ModelTraceExplorerDefaultSpanView({
           }
         >
           <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
-            {outputList.map(({ key, value }) => (
-              <ModelTraceExplorerCodeSnippet
-                key={key}
-                title={key}
-                data={value}
-                searchFilter={searchFilter}
-                activeMatch={activeMatch}
-                containsActiveMatch={isActiveMatchSpan && activeMatch.section === 'outputs' && activeMatch.key === key}
-              />
-            ))}
+            {outputList.map(({ key, value }) =>
+              containsAttachmentUri(value) ? (
+                <ModelTraceExplorerFieldRenderer key={key} title={key} data={value} renderMode="default" />
+              ) : (
+                <ModelTraceExplorerCodeSnippet
+                  key={key}
+                  title={key}
+                  data={value}
+                  searchFilter={searchFilter}
+                  activeMatch={activeMatch}
+                  containsActiveMatch={
+                    isActiveMatchSpan && activeMatch.section === 'outputs' && activeMatch.key === key
+                  }
+                />
+              ),
+            )}
           </div>
         </ModelTraceExplorerCollapsibleSection>
       )}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/summary-view/ModelTraceExplorerSummarySection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/summary-view/ModelTraceExplorerSummarySection.tsx
@@ -34,16 +34,9 @@ export const ModelTraceExplorerSummarySection = ({
 }) => {
   const { theme } = useDesignSystemTheme();
   const [expanded, setExpanded] = useState(false);
-  // In default mode, hide scalar fields when sibling fields contain attachment refs.
-  // This gives a clean media-only view (e.g., DALL-E output shows images without "created" timestamp).
-  const hasAttachmentRefs = data.some((item) => item.value.includes('mlflow-attachment://'));
-  const filteredData =
-    renderMode === 'default' && hasAttachmentRefs
-      ? data.filter((item) => item.value.includes('mlflow-attachment://'))
-      : data;
-  const shouldTruncateItems = filteredData.length > maxVisibleItems;
-  const visibleItems = shouldTruncateItems && !expanded ? filteredData.slice(-maxVisibleItems) : filteredData;
-  const hiddenItemCount = shouldTruncateItems ? filteredData.length - visibleItems.length : 0;
+  const shouldTruncateItems = data.length > maxVisibleItems;
+  const visibleItems = shouldTruncateItems && !expanded ? data.slice(-maxVisibleItems) : data;
+  const hiddenItemCount = shouldTruncateItems ? data.length - visibleItems.length : 0;
 
   return (
     <ModelTraceExplorerCollapsibleSection withBorder title={title} className={className} sectionKey={sectionKey}>

--- a/tests/entities/test_span_auto_extract_attachments.py
+++ b/tests/entities/test_span_auto_extract_attachments.py
@@ -416,6 +416,38 @@ def test_extracts_gemini_inline_data():
     assert att.content_bytes == PNG_BYTES
 
 
+def test_extracts_gemini_inline_data_bytes_repr():
+    # Gemini SDK Pydantic serialization produces repr(bytes) instead of base64
+    span = _make_live_span()
+    bytes_repr = repr(PNG_BYTES)
+    span.set_outputs({
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {"text": "A small image."},
+                        {
+                            "inline_data": {
+                                "mime_type": "image/png",
+                                "data": bytes_repr,
+                            }
+                        },
+                    ]
+                }
+            }
+        ]
+    })
+
+    parts = span.outputs["candidates"][0]["content"]["parts"]
+    assert parts[0] == {"text": "A small image."}
+    inline = parts[1]
+    assert inline["inline_data"]["data"].startswith("mlflow-attachment://")
+    assert len(span._attachments) == 1
+    att = next(iter(span._attachments.values()))
+    assert att.content_type == "image/png"
+    assert att.content_bytes == PNG_BYTES
+
+
 def test_gemini_inline_data_with_invalid_base64():
     span = _make_live_span()
     span.set_outputs({

--- a/tests/entities/test_span_auto_extract_attachments.py
+++ b/tests/entities/test_span_auto_extract_attachments.py
@@ -433,6 +433,57 @@ def test_gemini_inline_data_with_invalid_base64():
     assert len(span._attachments) == 0
 
 
+# --- Responses API image_generation_call pattern ---
+
+
+def test_extracts_responses_api_image_generation():
+    span = _make_live_span()
+    img_b64 = base64.b64encode(PNG_BYTES).decode()
+    span.set_outputs({
+        "output": [
+            {
+                "type": "image_generation_call",
+                "result": img_b64,
+                "output_format": "png",
+                "revised_prompt": "a blue square",
+            },
+            {
+                "type": "message",
+                "content": [{"type": "output_text", "text": "Here is the image."}],
+            },
+        ]
+    })
+
+    outputs = span.outputs
+    img_call = outputs["output"][0]
+    assert img_call["type"] == "image_generation_call"
+    assert img_call["result"].startswith("mlflow-attachment://")
+    assert img_call["revised_prompt"] == "a blue square"
+    assert img_call["output_format"] == "png"
+    msg = outputs["output"][1]
+    assert msg["type"] == "message"
+    assert len(span._attachments) == 1
+    att = next(iter(span._attachments.values()))
+    assert att.content_type == "image/png"
+    assert att.content_bytes == PNG_BYTES
+
+
+def test_responses_api_image_generation_with_invalid_base64():
+    span = _make_live_span()
+    span.set_outputs({
+        "output": [
+            {
+                "type": "image_generation_call",
+                "result": "!!!bad!!!",
+                "output_format": "png",
+            }
+        ]
+    })
+    img_call = span.outputs["output"][0]
+    assert img_call["result"] == "!!!bad!!!"
+    assert len(span._attachments) == 0
+
+
 # --- Two-pass serialization extraction ---
 
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to multimodal tracing bug bash findings

### What changes are proposed in this pull request?

**DRAFT — Combined bug bash fixes for testing. Each commit will be split into a separate PR for merge.**

This PR contains 15 fixes found during multimodal tracing bug bash testing. The fixes span Python extraction logic and JS rendering:

**Python (extraction)**
- Add Responses API `image_generation_call` extraction pattern
- Handle Gemini SDK bytes repr format (`b'\x89PNG...'`) in `inline_data` extraction

**JS (rendering)**
- Show all output fields alongside attachment renderings (summary view was filtering out non-attachment fields)
- Fix audio player 0:00/0:00 on first render (use `src` on `<audio>` instead of `<source>` child)
- Render attachments in Details & Timeline view (was only rendering in summary view)
- Allow Gemini chat rendering when `role` field is omitted
- Handle single dict contents in Gemini chat input normalization
- Fall back to OpenAI parser for LangChain traces (autolog uses OpenAI format but tags as langchain)
- Combine multi-part Responses API input into single chat message (was splitting text+image into separate user blocks)
- Render text before audio parts in chat messages (was showing audio above prompt)
- Click-to-expand modal for images (thumbnail + fullscreen overlay on click)
- Render attachments embedded in complex JSON structures (e.g., DALL-E `{"data": [{"b64_json": "..."}]}`)
- Skip markdown rendering for oversized content (>1MB) to prevent browser freezes
- Handle `input_file` content type in Responses API chat rendering (PDF uploads were silently dropped)

**Demo data**
- Add 4 multimodal demo trace types (vision, image gen, audio input, audio output) with synthetic content

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Tested with bug bash scripts covering:
- Manual attachments (18 tests)
- OpenAI autolog (7 tests)
- Anthropic autolog (6 tests)
- LangChain autolog (7 tests)
- LangChain+Anthropic (5 tests)
- Gemini autolog (7 tests)
- Manual LLM tracing (6 tests)

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fixes multiple rendering issues in multimodal trace viewing including audio player, image display, PDF rendering, and chat message formatting.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release