### PR TITLE
Add Responses API `image_generation_call` auto-extraction pattern

### DIFF
--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -751,6 +751,23 @@ class LiveSpan(Span):
                     "inline_data": {**inline, "data": ref},
                 }
 
+        # OpenAI Responses API image generation:
+        # {"type": "image_generation_call", "result": "<base64>", "output_format": "png"}
+        if value.get("type") == "image_generation_call":
+            data = value.get("result")
+            fmt = value.get("output_format", "png")
+            if isinstance(data, str) and data and not data.startswith("mlflow-attachment://"):
+                if not isinstance(fmt, str) or not fmt:
+                    fmt = "png"
+                try:
+                    content_bytes = base64.b64decode(data, validate=True)
+                except Exception:
+                    return None
+                ref = self._store_attachment(
+                    Attachment(content_type=f"image/{fmt}", content_bytes=content_bytes)
+                )
+                return {**value, "result": ref}
+
         return None
 
     def set_attributes(self, attributes: dict[str, Any]):

--- a/tests/entities/test_span_auto_extract_attachments.py
+++ b/tests/entities/test_span_auto_extract_attachments.py
@@ -433,6 +433,57 @@ def test_gemini_inline_data_with_invalid_base64():
     assert len(span._attachments) == 0
 
 
+# --- Responses API image_generation_call pattern ---
+
+
+def test_extracts_responses_api_image_generation():
+    span = _make_live_span()
+    img_b64 = base64.b64encode(PNG_BYTES).decode()
+    span.set_outputs({
+        "output": [
+            {
+                "type": "image_generation_call",
+                "result": img_b64,
+                "output_format": "png",
+                "revised_prompt": "a blue square",
+            },
+            {
+                "type": "message",
+                "content": [{"type": "output_text", "text": "Here is the image."}],
+            },
+        ]
+    })
+
+    outputs = span.outputs
+    img_call = outputs["output"][0]
+    assert img_call["type"] == "image_generation_call"
+    assert img_call["result"].startswith("mlflow-attachment://")
+    assert img_call["revised_prompt"] == "a blue square"
+    assert img_call["output_format"] == "png"
+    msg = outputs["output"][1]
+    assert msg["type"] == "message"
+    assert len(span._attachments) == 1
+    att = next(iter(span._attachments.values()))
+    assert att.content_type == "image/png"
+    assert att.content_bytes == PNG_BYTES
+
+
+def test_responses_api_image_generation_with_invalid_base64():
+    span = _make_live_span()
+    span.set_outputs({
+        "output": [
+            {
+                "type": "image_generation_call",
+                "result": "!!!bad!!!",
+                "output_format": "png",
+            }
+        ]
+    })
+    img_call = span.outputs["output"][0]
+    assert img_call["result"] == "!!!bad!!!"
+    assert len(span._attachments) == 0
+
+
 # --- Two-pass serialization extraction ---
 
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22446

### What changes are proposed in this pull request?

Adds a new extraction pattern in `_try_convert_structured_content()` for the OpenAI Responses API image generation output format:

```json
{"type": "image_generation_call", "result": "<base64>", "output_format": "png"}
```

Without this, generated images from the Responses API stay inline as ~1.8MB base64 strings in the trace JSON instead of being extracted as attachments.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Added two tests:
- `test_extracts_responses_api_image_generation` — verifies base64 is extracted and replaced with `mlflow-attachment://` URI
- `test_responses_api_image_generation_with_invalid_base64` — verifies invalid base64 is left unchanged

Verified with `gpt-4o` image generation via Responses API autolog.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Images generated via the OpenAI Responses API are now automatically extracted as trace attachments and rendered inline in the UI.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release