### PR TITLE
Show all output fields alongside attachment renderings in summary view

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/summary-view/ModelTraceExplorerSummarySection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/summary-view/ModelTraceExplorerSummarySection.tsx
@@ -34,16 +34,9 @@ export const ModelTraceExplorerSummarySection = ({
 }) => {
   const { theme } = useDesignSystemTheme();
   const [expanded, setExpanded] = useState(false);
-  // In default mode, hide scalar fields when sibling fields contain attachment refs.
-  // This gives a clean media-only view (e.g., DALL-E output shows images without "created" timestamp).
-  const hasAttachmentRefs = data.some((item) => item.value.includes('mlflow-attachment://'));
-  const filteredData =
-    renderMode === 'default' && hasAttachmentRefs
-      ? data.filter((item) => item.value.includes('mlflow-attachment://'))
-      : data;
-  const shouldTruncateItems = filteredData.length > maxVisibleItems;
-  const visibleItems = shouldTruncateItems && !expanded ? filteredData.slice(-maxVisibleItems) : filteredData;
-  const hiddenItemCount = shouldTruncateItems ? filteredData.length - visibleItems.length : 0;
+  const shouldTruncateItems = data.length > maxVisibleItems;
+  const visibleItems = shouldTruncateItems && !expanded ? data.slice(-maxVisibleItems) : data;
+  const hiddenItemCount = shouldTruncateItems ? data.length - visibleItems.length : 0;
 
   return (
     <ModelTraceExplorerCollapsibleSection withBorder title={title} className={className} sectionKey={sectionKey}>


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22446

### What changes are proposed in this pull request?

The summary view in `ModelTraceExplorerSummarySection` filtered out non-attachment fields (text, numbers, timestamps) when any sibling field contained an `mlflow-attachment://` URI. For example, a DALL-E output with `{"created": 1234, "image": "mlflow-attachment://..."}` would only show the image — the `created` timestamp was hidden.

This removes the filtering so all fields render. The `FieldRenderer` already handles both scalars and attachments inline.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

No unit test added — this is a pure removal of filtering logic (net -7 lines), making the component simpler. The `SummarySection` is a rendering component with heavy dependencies (design system theme, collapsible section context) that has no existing test infrastructure.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. The trace summary view now shows all output fields (text, numbers, etc.) alongside attachment renderings instead of hiding them.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release