### PR TITLE
Fix audio player not loading on first render in attachment view

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerAttachmentRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerAttachmentRenderer.tsx
@@ -58,9 +58,7 @@ export const ModelTraceExplorerAttachmentRenderer = ({
           </Typography.Text>
         )}
         {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
-        <audio controls>
-          <source src={objectUrl} type={contentType} />
-        </audio>
+        <audio controls css={{ width: '100%', maxWidth: 500 }} src={objectUrl} />
       </div>
     );
   }


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22446

### What changes are proposed in this pull request?

The audio player in the attachment renderer showed 0:00/0:00 on first render. Refreshing the page fixed it.

The `<audio>` element used a `<source>` child element, but browsers only read `<source>` elements when the `<audio>` is first mounted. Since the blob URL arrives asynchronously (after the component re-renders from loading→ready), the `<audio>` element was already mounted and never re-read the `<source>`.

Fix: use `src` directly on the `<audio>` element, which triggers a reload when the attribute changes. This matches the existing working pattern in `ModelTraceExplorerChatMessage.tsx`.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

No unit test added — this is a 1-line fix (net -2 lines) to a rendering component that requires browser audio element behavior to verify. The `AttachmentRenderer` has no existing rendering test infrastructure. The fix aligns with the already-working `<audio>` pattern used in the chat message component.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Audio attachments in traces now load and play correctly on first render without requiring a page refresh.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release