### PR TITLE
Render attachments inline in Details & Timeline span view

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/attachment-utils.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/attachment-utils.ts
@@ -94,6 +94,10 @@ export function isAttachmentUri(value: string): boolean {
   return value.startsWith('mlflow-attachment://');
 }
 
+export function containsAttachmentUri(value: string): boolean {
+  return value.includes('mlflow-attachment://');
+}
+
 /**
  * URL transform for react-markdown that preserves mlflow-attachment:// URIs.
  * Without this, the default transform strips non-standard protocols.

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerDefaultSpanView.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerDefaultSpanView.tsx
@@ -6,8 +6,10 @@ import { FormattedMessage } from '@databricks/i18n';
 
 import type { ModelTraceSpanNode, SearchMatch } from '../ModelTrace.types';
 import { createListFromObject } from '../ModelTraceExplorer.utils';
+import { containsAttachmentUri } from '../attachment-utils';
 import { ModelTraceExplorerCodeSnippet } from '../ModelTraceExplorerCodeSnippet';
 import { ModelTraceExplorerCollapsibleSection } from '../ModelTraceExplorerCollapsibleSection';
+import { ModelTraceExplorerFieldRenderer } from '../field-renderers/ModelTraceExplorerFieldRenderer';
 
 export function ModelTraceExplorerDefaultSpanView({
   activeSpan,
@@ -58,16 +60,23 @@ export function ModelTraceExplorerDefaultSpanView({
           }
         >
           <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
-            {inputList.map(({ key, value }, index) => (
-              <ModelTraceExplorerCodeSnippet
-                key={key || index}
-                title={key}
-                data={value}
-                searchFilter={searchFilter}
-                activeMatch={activeMatch}
-                containsActiveMatch={isActiveMatchSpan && activeMatch.section === 'inputs' && activeMatch.key === key}
-              />
-            ))}
+            {/* Attachment fields use FieldRenderer (which handles inline rendering of images,
+                audio, PDF). Non-attachment fields use CodeSnippet to preserve search highlighting
+                and jump-to-match behavior (FieldRenderer doesn't support these props). */}
+            {inputList.map(({ key, value }, index) =>
+              containsAttachmentUri(value) ? (
+                <ModelTraceExplorerFieldRenderer key={key || index} title={key} data={value} renderMode="default" />
+              ) : (
+                <ModelTraceExplorerCodeSnippet
+                  key={key || index}
+                  title={key}
+                  data={value}
+                  searchFilter={searchFilter}
+                  activeMatch={activeMatch}
+                  containsActiveMatch={isActiveMatchSpan && activeMatch.section === 'inputs' && activeMatch.key === key}
+                />
+              ),
+            )}
           </div>
         </ModelTraceExplorerCollapsibleSection>
       )}
@@ -85,16 +94,22 @@ export function ModelTraceExplorerDefaultSpanView({
           }
         >
           <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
-            {outputList.map(({ key, value }) => (
-              <ModelTraceExplorerCodeSnippet
-                key={key}
-                title={key}
-                data={value}
-                searchFilter={searchFilter}
-                activeMatch={activeMatch}
-                containsActiveMatch={isActiveMatchSpan && activeMatch.section === 'outputs' && activeMatch.key === key}
-              />
-            ))}
+            {outputList.map(({ key, value }) =>
+              containsAttachmentUri(value) ? (
+                <ModelTraceExplorerFieldRenderer key={key} title={key} data={value} renderMode="default" />
+              ) : (
+                <ModelTraceExplorerCodeSnippet
+                  key={key}
+                  title={key}
+                  data={value}
+                  searchFilter={searchFilter}
+                  activeMatch={activeMatch}
+                  containsActiveMatch={
+                    isActiveMatchSpan && activeMatch.section === 'outputs' && activeMatch.key === key
+                  }
+                />
+              ),
+            )}
           </div>
         </ModelTraceExplorerCollapsibleSection>
       )}


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22446

### What changes are proposed in this pull request?

The Details & Timeline view used `CodeSnippet` for all span fields, so `mlflow-attachment://` URIs rendered as raw text instead of inline images/audio/PDF. This meant attachments on child spans (which only appear in this view, not the summary) never rendered.

Now fields containing attachment URIs are routed to `FieldRenderer` (which handles attachment detection and rendering) instead of `CodeSnippet`. Also adds a `containsAttachmentUri` util for checking JSON-stringified values that may embed attachment URIs.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

No unit test added — `DefaultSpanView` is a rendering component with heavy dependencies (design system theme, collapsible sections, search matching) and no existing test infrastructure. The new `containsAttachmentUri` util is a single `string.includes()` call. The routing logic is a conditional that delegates to existing, tested components (`FieldRenderer`, `CodeSnippet`).

<img width="1378" height="811" alt="Screenshot 2026-04-08 at 6 02 40 PM" src="https://github.com/user-attachments/assets/a92b7d09-8842-4b9d-b411-107b26fec122" />


### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Trace attachments (images, audio, PDF) on child spans now render inline in the Details & Timeline view instead of showing as raw URI text.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release