### PR TITLE
Handle Gemini SDK bytes repr format in `inline_data` extraction

### DIFF
--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -1,3 +1,4 @@
+import ast
 import base64
 import json
 import logging
@@ -733,16 +734,27 @@ class LiveSpan(Span):
                     }
 
         # Google Gemini: {"inline_data": {"mime_type": "image/png", "data": "<base64>"}}
+        # The Gemini SDK (Pydantic) may serialize bytes as a Python repr string
+        # (e.g., "b'\\x89PNG...'") instead of base64, so we handle both formats.
         if isinstance(inline := value.get("inline_data"), dict):
             data = inline.get("data")
             mime_type = inline.get("mime_type", "application/octet-stream")
             if isinstance(data, str) and data and not data.startswith("mlflow-attachment://"):
                 if not isinstance(mime_type, str) or not mime_type:
                     mime_type = "application/octet-stream"
-                try:
-                    content_bytes = base64.b64decode(data, validate=True)
-                except Exception:
-                    return None
+                content_bytes = None
+                if data.startswith(("b'", 'b"')):
+                    try:
+                        parsed = ast.literal_eval(data)
+                        if isinstance(parsed, bytes):
+                            content_bytes = parsed
+                    except Exception:
+                        pass
+                if content_bytes is None:
+                    try:
+                        content_bytes = base64.b64decode(data, validate=True)
+                    except Exception:
+                        return None
                 ref = self._store_attachment(
                     Attachment(content_type=mime_type, content_bytes=content_bytes)
                 )

--- a/tests/entities/test_span_auto_extract_attachments.py
+++ b/tests/entities/test_span_auto_extract_attachments.py
@@ -416,6 +416,38 @@ def test_extracts_gemini_inline_data():
     assert att.content_bytes == PNG_BYTES
 
 
+def test_extracts_gemini_inline_data_bytes_repr():
+    # Gemini SDK Pydantic serialization produces repr(bytes) instead of base64
+    span = _make_live_span()
+    bytes_repr = repr(PNG_BYTES)
+    span.set_outputs({
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {"text": "A small image."},
+                        {
+                            "inline_data": {
+                                "mime_type": "image/png",
+                                "data": bytes_repr,
+                            }
+                        },
+                    ]
+                }
+            }
+        ]
+    })
+
+    parts = span.outputs["candidates"][0]["content"]["parts"]
+    assert parts[0] == {"text": "A small image."}
+    inline = parts[1]
+    assert inline["inline_data"]["data"].startswith("mlflow-attachment://")
+    assert len(span._attachments) == 1
+    att = next(iter(span._attachments.values()))
+    assert att.content_type == "image/png"
+    assert att.content_bytes == PNG_BYTES
+
+
 def test_gemini_inline_data_with_invalid_base64():
     span = _make_live_span()
     span.set_outputs({


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22446

### What changes are proposed in this pull request?

The Gemini SDK (Pydantic) serializes `bytes` fields as Python repr strings (e.g., `"b'\x89PNG...'"`) instead of base64 when models are serialized to JSON. The `inline_data` extraction pattern called `base64.b64decode()` on this, which silently failed, so Gemini image/audio attachments were never extracted.

Now detects the bytes repr format (`b'...'` or `b"..."`) and parses it with `ast.literal_eval` before falling back to base64 decoding.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added `test_extracts_gemini_inline_data_bytes_repr` — verifies that a Python bytes repr string in `inline_data.data` is correctly parsed and extracted as an attachment. Existing `test_extracts_gemini_inline_data` (base64 format) and `test_gemini_inline_data_with_invalid_base64` continue to pass.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Gemini SDK traces now correctly extract inline image and audio data as attachments, even when the SDK serializes bytes in Python repr format.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release