### PR TITLE
Allow Gemini chat rendering when `role` field is omitted

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/gemini.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/gemini.test.ts
@@ -409,4 +409,26 @@ describe('normalizeConversation', () => {
     // Should NOT contain raw Python bytes
     expect(result![0].content).not.toContain('\\x89');
   });
+
+  it('should handle output content with role omitted', () => {
+    const output = {
+      candidates: [
+        {
+          content: {
+            // role intentionally omitted — some Gemini SDK versions do this
+            parts: [{ text: 'I see a red square.' }, { inline_data: { mime_type: 'image/png', data: 'iVBORw0KGgo=' } }],
+          },
+          finish_reason: 'STOP',
+        },
+      ],
+    };
+    const result = normalizeConversation(output, 'gemini');
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+    expect(result![0]).toMatchObject({
+      role: 'assistant',
+      content: expect.stringContaining('I see a red square.'),
+    });
+    expect(result![0].content).toContain('![](data:image/png;base64,iVBORw0KGgo=)');
+  });
 });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/gemini.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/gemini.ts
@@ -43,7 +43,7 @@ type GeminiCandidate = {
 };
 
 type GeminiContent = {
-  role: 'user' | 'model';
+  role?: 'user' | 'model';
   parts: GeminiContentPart[];
 };
 
@@ -134,15 +134,19 @@ const isThinkingPart = (part: GeminiTextPart): boolean => {
 };
 
 const isGeminiContent = (obj: unknown): obj is GeminiContent => {
-  return (
-    isObject(obj) &&
-    'role' in obj &&
-    isString(obj.role) &&
-    ['user', 'model'].includes(obj.role) &&
-    has(obj, 'parts') &&
-    Array.isArray(obj.parts) &&
-    obj.parts.every(isGeminiContentPart)
-  );
+  if (!isObject(obj) || !has(obj, 'parts')) {
+    return false;
+  }
+  const record = obj as Record<string, unknown>;
+  const parts = record['parts'];
+  if (!Array.isArray(parts) || !parts.every(isGeminiContentPart)) {
+    return false;
+  }
+  // role may be omitted by some Gemini SDK versions; treat as valid if parts are present
+  if ('role' in obj) {
+    return isString(record['role']) && ['user', 'model'].includes(record['role'] as string);
+  }
+  return true;
 };
 
 // Gemini SDK serializes bytes as Python literal "b'...'" with escaped hex bytes.
@@ -279,7 +283,7 @@ const processGeminiContentParts = (
 };
 
 const normalizeGeminiContentToMessages = (content: GeminiContent): ModelTraceChatMessage[] => {
-  const role = content.role === 'model' ? 'assistant' : content.role;
+  const role = content.role === 'model' || !content.role ? 'assistant' : content.role;
   const { textParts, thinking, toolCalls, functionResponses } = processGeminiContentParts(content.parts);
 
   // Emit function_response parts as individual tool messages


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22446

### What changes are proposed in this pull request?

Some Gemini SDK versions omit the `role` field from content objects in the response. The `isGeminiContent` type guard required `role` to be present and one of `'user'`/`'model'`, so the chat normalizer rejected the entire output and the trace fell back to raw JSON rendering — no chat view, no inline image/audio rendering.

Now `role` is optional in `isGeminiContent`. When absent, `normalizeGeminiContentToMessages` defaults to `'assistant'`, matching the typical case where omitted role means a model response.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added `should handle output content with role omitted` test in `gemini.test.ts` — verifies that a candidates output with no `role` field still normalizes to an assistant message with text and inline image content. All 15 Gemini chat tests pass.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Gemini traces now render in the chat view even when the SDK omits the `role` field from response content.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release