### PR TITLE
Handle single dict `contents` in Gemini chat input normalization

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/gemini.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/gemini.test.ts
@@ -431,4 +431,28 @@ describe('normalizeConversation', () => {
     });
     expect(result![0].content).toContain('![](data:image/png;base64,iVBORw0KGgo=)');
   });
+
+  it('should handle single dict contents (text part)', () => {
+    const input = { contents: { text: 'Say hello in one sentence.' } };
+    const result = normalizeConversation(input, 'gemini');
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+    expect(result![0]).toMatchObject({
+      role: 'user',
+      content: 'Say hello in one sentence.',
+    });
+  });
+
+  it('should handle single Content object as contents', () => {
+    const input = {
+      contents: { role: 'user', parts: [{ text: 'What is MLflow?' }] },
+    };
+    const result = normalizeConversation(input, 'gemini');
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+    expect(result![0]).toMatchObject({
+      role: 'user',
+      content: 'What is MLflow?',
+    });
+  });
 });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/gemini.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/gemini.ts
@@ -361,6 +361,18 @@ export const normalizeGeminiChatInput = (obj: unknown): ModelTraceChatMessage[] 
         return messages.length > 0 ? messages : null;
       }
     }
+
+    // Handle single content object (e.g., {"role": "user", "parts": [...]})
+    if (isGeminiContent(obj.contents)) {
+      const messages = normalizeGeminiContentToMessages(obj.contents);
+      return messages.length > 0 ? messages : null;
+    }
+
+    // Handle single part dict (e.g., {"text": "Say hello"})
+    if (isGeminiContentPart(obj.contents)) {
+      const messages = normalizeGeminiContentToMessages({ role: 'user', parts: [obj.contents] });
+      return messages.length > 0 ? messages : null;
+    }
   }
 
   return null;


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22446

### What changes are proposed in this pull request?

The Gemini SDK accepts `contents` in several forms, but the chat normalizer only handled three: a plain string, an array of `GeminiContent` objects, or an array of parts/strings. When `contents` was a single Part dict (e.g., `{"text": "Say hello"}`) or a single Content object (e.g., `{"role": "user", "parts": [...]}`), the normalizer returned null and the trace skipped the chat UI entirely.

Adds two new branches to `normalizeGeminiChatInput`:
- Single `GeminiContent` object → normalize directly
- Single `GeminiContentPart` → wrap as a user message

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added two tests in `gemini.test.ts`:
- `should handle single dict contents (text part)` — verifies `{"text": "..."}` normalizes to a user message
- `should handle single Content object as contents` — verifies `{"role": "user", "parts": [...]}` normalizes correctly

All 16 Gemini chat tests pass.

<img width="1364" height="540" alt="Screenshot 2026-04-08 at 6 20 29 PM" src="https://github.com/user-attachments/assets/b46f6e83-26b0-43de-a921-33bf411e4381" />


### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Gemini traces now render in the chat view when `contents` is a single Part dict or Content object, instead of falling back to raw JSON.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release