### PR TITLE
Fall back to OpenAI parser for LangChain traces with OpenAI-format data

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
@@ -1087,10 +1087,16 @@ export const normalizeConversation = (input: any, messageFormat?: string): Model
     }
 
     switch (messageFormat) {
-      case 'langchain':
-        const langchainMessages = normalizeLangchainChatInput(input) ?? normalizeLangchainChatResult(input);
+      case 'langchain': {
+        const langchainMessages =
+          normalizeLangchainChatInput(input) ??
+          normalizeLangchainChatResult(input) ??
+          // LangChain autolog may serialize messages in OpenAI format
+          normalizeOpenAIFormats(input) ??
+          normalizeOpenAIResponsesInput(input);
         if (langchainMessages) return langchainMessages;
         break;
+      }
       case 'llamaindex':
         const llamaIndexMessages = normalizeLlamaIndexChatInput(input) ?? normalizeLlamaIndexChatResponse(input);
         if (llamaIndexMessages) return llamaIndexMessages;

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/langchain.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/langchain.test.ts
@@ -549,4 +549,45 @@ describe('normalizeConversation', () => {
       }),
     ]);
   });
+
+  it('should fall back to OpenAI parser when data is in OpenAI format', () => {
+    const openaiFormatInput = {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Describe this image.' },
+            { type: 'image_url', image_url: { url: 'data:image/jpeg;base64,abc123' } },
+          ],
+        },
+      ],
+    };
+    const result = normalizeConversation(openaiFormatInput, 'langchain');
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+    expect(result![0]).toMatchObject({ role: 'user' });
+    expect(result![0].content).toContain('Describe this image.');
+    expect(result![0].content).toContain('data:image/jpeg;base64,abc123');
+  });
+
+  it('should fall back to OpenAI parser for choices output in langchain format', () => {
+    const openaiFormatOutput = {
+      choices: [
+        {
+          message: {
+            role: 'assistant',
+            content: 'This is a photo of a cable car.',
+          },
+          finish_reason: 'stop',
+        },
+      ],
+    };
+    const result = normalizeConversation(openaiFormatOutput, 'langchain');
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+    expect(result![0]).toMatchObject({
+      role: 'assistant',
+      content: 'This is a photo of a cable car.',
+    });
+  });
 });


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22446

### What changes are proposed in this pull request?

LangChain autolog serializes messages in OpenAI format (`role: 'user'`, `choices`) but tags the span with `mlflow.message.format: langchain`. The `normalizeConversation` switch only tried the LangChain parser (which expects `type: 'human'`/`'ai'`), returned null, and broke out — the chat view never rendered.

Now the `langchain` case falls through to `normalizeOpenAIFormats` when the LangChain parsers return null.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added two tests in `langchain.test.ts`:
- `should fall back to OpenAI parser when data is in OpenAI format` — OpenAI-style `messages` input with `'langchain'` format normalizes correctly
- `should fall back to OpenAI parser for choices output in langchain format` — OpenAI-style `choices` output with `'langchain'` format normalizes correctly

All 12 LangChain chat tests pass.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. LangChain traces now render in the chat view instead of showing raw JSON, when the autolog serializes messages in OpenAI format.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release