### PR TITLE
Combine multi-part Responses API input into a single chat message

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/openai.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/openai.test.ts
@@ -485,6 +485,26 @@ describe('normalizeConversation', () => {
     ]);
   });
 
+  it('combines multi-part Responses API input into a single message', () => {
+    const input = {
+      input: [
+        {
+          role: 'user',
+          content: [
+            { type: 'input_text', text: 'Describe this image.' },
+            { type: 'input_image', image_url: 'data:image/jpeg;base64,abc123' },
+          ],
+        },
+      ],
+    };
+    const result = normalizeConversation(input, 'openai');
+    // Should produce a single user message, not two separate ones
+    expect(result).toHaveLength(1);
+    expect(result?.[0]).toMatchObject({ role: 'user' });
+    expect(result?.[0]?.content).toContain('Describe this image.');
+    expect(result?.[0]?.content).toContain('data:image/jpeg;base64,abc123');
+  });
+
   describe('OpenAI reasoning support', () => {
     it('handles non-streaming output with reasoning summary', () => {
       const result = normalizeConversation(MOCK_OPENAI_RESPONSES_OUTPUT_WITH_REASONING, 'openai');

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/openai.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/openai.ts
@@ -12,7 +12,7 @@ import type {
   OpenAIResponsesStreamingOutputDelta,
   OpenAIResponsesStreamingOutputDone,
 } from './openai.types';
-import type { ModelTraceChatMessage } from '../ModelTrace.types';
+import type { ModelTraceChatMessage, ModelTraceContentParts } from '../ModelTrace.types';
 import {
   isModelTraceChatResponse,
   isModelTraceChoices,
@@ -96,42 +96,28 @@ export const isOpenAIResponsesOutputItem = (obj: unknown): obj is OpenAIResponse
   return false;
 };
 
-const normalizeOpenAIResponsesInputItem = (
-  obj: OpenAIResponsesInputText | OpenAIResponsesInputFile | OpenAIResponsesInputImage,
-  role: OpenAIResponsesInputMessageRole,
-): ModelTraceChatMessage | null => {
-  const text = get(obj, 'text');
-  if (get(obj, 'type') === 'input_text' && isString(text)) {
-    return prettyPrintChatMessage({
-      type: 'message',
-      content: [{ type: 'text', text }],
-      role: role,
-    });
-  }
-
-  const imageUrl = get(obj, 'image_url');
-  if (get(obj, 'type') === 'input_image' && isString(imageUrl)) {
-    return prettyPrintChatMessage({
-      type: 'message',
-      content: [{ type: 'image_url', image_url: { url: imageUrl } }],
-      role: role,
-    });
-  }
-
-  // TODO: file input not supported yet
-  // if ('type' in obj && obj.type === 'input_file') {
-  //   return prettyPrintChatMessage({ type: 'message', content: obj.file_url, role: role });
-  // }
-
-  return null;
-};
-
 const normalizeOpenAIResponsesInputMessage = (obj: OpenAIResponsesInputMessage): ModelTraceChatMessage[] | null => {
   if (isString(obj.content)) {
     const message = prettyPrintChatMessage({ type: 'message', content: obj.content, role: obj.role });
     return message && [message];
   } else {
-    return obj.content.map((item) => normalizeOpenAIResponsesInputItem(item, obj.role)).filter((item) => item !== null);
+    // Combine all content parts into a single message to preserve the original
+    // multi-part structure (e.g., text + image in one user message)
+    const contentParts: ModelTraceContentParts[] = [];
+    for (const item of obj.content) {
+      const text = get(item, 'text');
+      if (get(item, 'type') === 'input_text' && isString(text)) {
+        contentParts.push({ type: 'text', text });
+      } else {
+        const imageUrl = get(item, 'image_url');
+        if (get(item, 'type') === 'input_image' && isString(imageUrl)) {
+          contentParts.push({ type: 'image_url', image_url: { url: imageUrl } });
+        }
+      }
+    }
+    if (contentParts.length === 0) return null;
+    const message = prettyPrintChatMessage({ type: 'message', content: contentParts, role: obj.role });
+    return message && [message];
   }
 };
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22446

### What changes are proposed in this pull request?

The Responses API input normalizer created a separate chat message for each content part (`input_text`, `input_image`). So a single user message with text + image showed up as two separate "user" blocks in the chat view.

Now combines all content parts into a single message's `content` array, matching how the standard OpenAI `messages` format handles multi-part content. Also removes the now-unused `normalizeOpenAIResponsesInputItem` helper.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Added `combines multi-part Responses API input into a single message` test in `openai.test.ts` — verifies that `[input_text, input_image]` produces a single user message containing both text and image. All 13 OpenAI chat tests pass.

<img width="1335" height="805" alt="Screenshot 2026-04-08 at 6 29 51 PM" src="https://github.com/user-attachments/assets/1a9b98f3-5450-42bb-8573-48c8d683df7e" />


### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Responses API traces with multi-part input (e.g., text + image) now render as a single user message in the chat view instead of separate blocks.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release