### PR TITLE
Add click-to-expand modal for trace attachment images

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerAttachmentRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerAttachmentRenderer.tsx
@@ -1,4 +1,6 @@
-import { LegacySkeleton, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { useState } from 'react';
+
+import { LegacySkeleton, Modal, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
 
 import { useTraceAttachment } from '../hooks/useTraceAttachment';
@@ -16,6 +18,7 @@ export const ModelTraceExplorerAttachmentRenderer = ({
 }) => {
   const { theme } = useDesignSystemTheme();
   const { objectUrl, isLoading, error } = useTraceAttachment({ traceId, attachmentId, contentType });
+  const [previewVisible, setPreviewVisible] = useState(false);
 
   if (error) {
     return (
@@ -43,8 +46,28 @@ export const ModelTraceExplorerAttachmentRenderer = ({
         <img
           src={objectUrl}
           alt={`Attachment ${attachmentId}`}
-          css={{ maxWidth: '100%', maxHeight: 400, borderRadius: theme.borders.borderRadiusSm }}
+          css={{
+            maxWidth: '100%',
+            maxHeight: 200,
+            borderRadius: theme.borders.borderRadiusSm,
+            cursor: 'pointer',
+            '&:hover': { boxShadow: `0 0 4px ${theme.colors.border}` },
+          }}
+          onClick={() => setPreviewVisible(true)}
         />
+        <Modal
+          componentId="shared.model-trace-explorer.attachment-image-preview"
+          title=""
+          visible={previewVisible}
+          onCancel={() => setPreviewVisible(false)}
+          onOk={() => setPreviewVisible(false)}
+        >
+          <img
+            src={objectUrl}
+            alt={`Attachment ${attachmentId}`}
+            css={{ maxWidth: '100%', maxHeight: '70vh', display: 'block' }}
+          />
+        </Modal>
       </div>
     );
   }

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessage.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessage.tsx
@@ -7,6 +7,7 @@ import {
   ChevronRightIcon,
   ChevronUpIcon,
   LightbulbIcon,
+  Modal,
   Spinner,
   Typography,
   useDesignSystemTheme,
@@ -32,6 +33,35 @@ import { CodeSnippetRenderMode, type ModelTraceChatMessage, type ModelTraceInput
 import { MARKDOWN_RENDER_SIZE_LIMIT } from '../constants';
 import { ModelTraceExplorerCodeSnippetBody } from '../ModelTraceExplorerCodeSnippetBody';
 
+function ClickToExpandImage({ src, alt }: { src: string; alt?: string }) {
+  const { theme } = useDesignSystemTheme();
+  const [previewVisible, setPreviewVisible] = useState(false);
+  return (
+    <>
+      <img
+        src={src}
+        alt={alt}
+        css={{
+          maxWidth: '100%',
+          maxHeight: 200,
+          cursor: 'pointer',
+          '&:hover': { boxShadow: `0 0 4px ${theme.colors.border}` },
+        }}
+        onClick={() => setPreviewVisible(true)}
+      />
+      <Modal
+        componentId="shared.model-trace-explorer.image-preview"
+        title=""
+        visible={previewVisible}
+        onCancel={() => setPreviewVisible(false)}
+        onOk={() => setPreviewVisible(false)}
+      >
+        <img src={src} alt={alt} css={{ maxWidth: '100%', maxHeight: '70vh', display: 'block' }} />
+      </Modal>
+    </>
+  );
+}
+
 function AttachmentImage({ src, alt }: { src?: string; alt?: string }) {
   const { url, loading, error } = useAttachmentUrl(src ?? null);
   if (loading) {
@@ -40,7 +70,7 @@ function AttachmentImage({ src, alt }: { src?: string; alt?: string }) {
   if (error || !url) {
     return <span>{`[${alt ?? 'Failed to load image'}]`}</span>;
   }
-  return <img src={url} alt={alt} css={{ maxWidth: '100%' }} />;
+  return <ClickToExpandImage src={url} alt={alt} />;
 }
 
 const attachmentAwareImgRenderer = ({ src, alt }: { src?: string; alt?: string }) => {
@@ -58,6 +88,9 @@ const attachmentAwareImgRenderer = ({ src, alt }: { src?: string; alt?: string }
       );
     }
     return <AttachmentImage src={src} alt={alt} />;
+  }
+  if (src) {
+    return <ClickToExpandImage src={src} alt={alt} />;
   }
   return <img src={src} alt={alt} css={{ maxWidth: '100%' }} />;
 };


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22446

### What changes are proposed in this pull request?

Large images in trace attachments took up excessive screen space. This adds a click-to-expand pattern consistent with how MLflow artifact images work:

- **Thumbnail**: Reduced `maxHeight` from 400 to 200, with `cursor: pointer` and hover shadow
- **Fullscreen modal**: Click the thumbnail to open a dark overlay showing the image at up to 90vw/90vh. Click the overlay to close.

Applied consistently in both rendering paths:
- `AttachmentRenderer` (summary/detail view)
- `ChatMessage` (chat view) — both attachment images and regular URL images use the same `ClickToExpandImage` component

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

No unit test added — this is a visual UX change (thumbnail + overlay modal) in rendering components with no existing test infrastructure. The `ClickToExpandImage` component is a simple state toggle (`useState`) controlling a fixed overlay div.

<img width="1377" height="740" alt="Screenshot 2026-04-13 at 4 50 06 PM" src="https://github.com/user-attachments/assets/ace22c04-c16f-441f-8c19-a0719788fbfd" />

<img width="1151" height="788" alt="Screenshot 2026-04-13 at 4 55 45 PM" src="https://github.com/user-attachments/assets/8b02326e-fe7d-4b2f-93bc-b85e049308e6" />



### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Trace attachment images now display as compact thumbnails (200px max height) with click-to-expand fullscreen preview, keeping the trace view compact while still allowing detailed inspection.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release