### PR TITLE
Render attachment images embedded in complex JSON structures

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/attachment-utils.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/attachment-utils.ts
@@ -94,6 +94,10 @@ export function isAttachmentUri(value: string): boolean {
   return value.startsWith('mlflow-attachment://');
 }
 
+export function containsAttachmentUri(value: string): boolean {
+  return value.includes('mlflow-attachment://');
+}
+
 /**
  * URL transform for react-markdown that preserves mlflow-attachment:// URIs.
  * Without this, the default transform strips non-standard protocols.

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerFieldRenderer.findAttachmentUris.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerFieldRenderer.findAttachmentUris.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from '@jest/globals';
+
+import { findAttachmentUris } from './ModelTraceExplorerFieldRenderer';
+
+const VALID_URI = 'mlflow-attachment://abc-123?content_type=image%2Fpng&trace_id=tr-456';
+
+describe('findAttachmentUris', () => {
+  it('extracts a top-level attachment URI string', () => {
+    const result = findAttachmentUris(VALID_URI);
+    expect(result).toEqual([{ attachmentId: 'abc-123', contentType: 'image/png', traceId: 'tr-456' }]);
+  });
+
+  it('extracts attachment URIs from a nested object', () => {
+    const result = findAttachmentUris({
+      data: [{ b64_json: VALID_URI, revised_prompt: 'a logo' }],
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].attachmentId).toBe('abc-123');
+  });
+
+  it('extracts multiple attachment URIs from arrays', () => {
+    const uri2 = 'mlflow-attachment://def-456?content_type=audio%2Fwav&trace_id=tr-789';
+    const result = findAttachmentUris([VALID_URI, { nested: uri2 }]);
+    expect(result).toHaveLength(2);
+  });
+
+  it('returns empty for non-attachment strings', () => {
+    expect(findAttachmentUris('hello world')).toEqual([]);
+    expect(findAttachmentUris('https://example.com')).toEqual([]);
+  });
+
+  it('returns empty for primitives', () => {
+    expect(findAttachmentUris(42)).toEqual([]);
+    expect(findAttachmentUris(null)).toEqual([]);
+    expect(findAttachmentUris(undefined)).toEqual([]);
+    expect(findAttachmentUris(true)).toEqual([]);
+  });
+
+  it('respects depth limit', () => {
+    // Build a structure deeper than MAX_ATTACHMENT_SEARCH_DEPTH (10)
+    let deep: unknown = VALID_URI;
+    for (let i = 0; i < 15; i++) {
+      deep = { nested: deep };
+    }
+    const result = findAttachmentUris(deep);
+    expect(result).toEqual([]);
+  });
+});

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerFieldRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerFieldRenderer.tsx
@@ -8,12 +8,38 @@ import { ModelTraceExplorerAttachmentRenderer } from './ModelTraceExplorerAttach
 import { ModelTraceExplorerChatToolsRenderer } from './ModelTraceExplorerChatToolsRenderer';
 import { ModelTraceExplorerRetrieverFieldRenderer } from './ModelTraceExplorerRetrieverFieldRenderer';
 import { ModelTraceExplorerTextFieldRenderer } from './ModelTraceExplorerTextFieldRenderer';
-import { parseAttachmentUri } from '../attachment-utils';
+import { containsAttachmentUri, parseAttachmentUri } from '../attachment-utils';
 import type { Assessment } from '../ModelTrace.types';
 import { CodeSnippetRenderMode } from '../ModelTrace.types';
 import { isModelTraceChatTool, isRetrieverDocument, normalizeConversation } from '../ModelTraceExplorer.utils';
 import { ModelTraceExplorerCodeSnippet } from '../ModelTraceExplorerCodeSnippet';
 import { ModelTraceExplorerConversation } from '../right-pane/ModelTraceExplorerConversation';
+
+const MAX_ATTACHMENT_SEARCH_DEPTH = 10;
+
+/**
+ * Recursively extract all attachment URIs from a parsed JSON value.
+ */
+export const findAttachmentUris = (
+  value: unknown,
+  depth = 0,
+): { attachmentId: string; traceId: string; contentType: string }[] => {
+  if (depth > MAX_ATTACHMENT_SEARCH_DEPTH) {
+    return [];
+  }
+  if (isString(value)) {
+    if (!value.startsWith('mlflow-attachment://')) return [];
+    const parsed = parseAttachmentUri(value);
+    return parsed ? [parsed] : [];
+  }
+  if (Array.isArray(value)) {
+    return value.flatMap((v) => findAttachmentUris(v, depth + 1));
+  }
+  if (value && typeof value === 'object') {
+    return Object.values(value).flatMap((v) => findAttachmentUris(v, depth + 1));
+  }
+  return [];
+};
 
 export const DEFAULT_MAX_VISIBLE_CHAT_MESSAGES = 3;
 
@@ -135,6 +161,27 @@ export const ModelTraceExplorerFieldRenderer = ({
 
   if (isRetrieverDocuments) {
     return <ModelTraceExplorerRetrieverFieldRenderer title={title} documents={parsedData} assessments={assessments} />;
+  }
+
+  // Check for attachment URIs embedded in complex JSON structures
+  if (containsAttachmentUri(data)) {
+    const attachments = findAttachmentUris(parsedData);
+    if (attachments.length > 0) {
+      return (
+        <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
+          {attachments.map((att) => (
+            <ModelTraceExplorerAttachmentRenderer
+              key={att.attachmentId}
+              title=""
+              attachmentId={att.attachmentId}
+              traceId={att.traceId}
+              contentType={att.contentType}
+            />
+          ))}
+          <ModelTraceExplorerCodeSnippet title={title} data={data} />
+        </div>
+      );
+    }
   }
 
   return <ModelTraceExplorerCodeSnippet title={title} data={data} />;


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22446

### What changes are proposed in this pull request?

Attachment URIs nested inside arrays or objects (e.g., DALL-E output `{"data": [{"b64_json": "mlflow-attachment://..."}]}`) were rendered as raw JSON because the `FieldRenderer` only checked for attachments in scalar string values.

Now adds:
- `containsAttachmentUri` util in `attachment-utils.ts` for checking JSON-stringified values that may embed attachment URIs
- `findAttachmentUris` — a recursive extractor (with depth limit of 10) that walks parsed JSON to find all embedded `mlflow-attachment://` URIs

When found, renders them inline above the JSON snippet.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Added 6 tests for `findAttachmentUris` in `ModelTraceExplorerFieldRenderer.findAttachmentUris.test.ts`:
- Extracts top-level URI string
- Extracts from nested objects (DALL-E format)
- Extracts multiple URIs from arrays
- Returns empty for non-attachment strings
- Returns empty for primitives (number, null, undefined, boolean)
- Respects depth limit (stops at depth 10)

<img width="1332" height="859" alt="Screenshot 2026-04-08 at 6 45 15 PM" src="https://github.com/user-attachments/assets/1c31418d-0f43-43ce-8e9c-777d08517d3e" />

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Attachment images/audio/PDFs nested inside complex JSON structures (e.g., DALL-E output arrays) now render inline in the trace view instead of showing as raw JSON.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release