### PR TITLE
[UI] Split budgets page into Policies and Alerts tabs

### DIFF
--- a/mlflow/server/js/src/gateway/components/budgets/BudgetsList.tsx
+++ b/mlflow/server/js/src/gateway/components/budgets/BudgetsList.tsx
@@ -22,6 +22,8 @@ import { useBudgetPoliciesQuery } from '../../hooks/useBudgetPoliciesQuery';
 import { useBudgetWindowsQuery } from '../../hooks/useBudgetWindowsQuery';
 import { formatBudgetAmount, formatDuration, formatOnExceeded } from './budgetFormatUtils';
 import { TimeAgo } from '../../../shared/web-shared/browse/TimeAgo';
+import { Link } from '../../../common/utils/RoutingUtils';
+import GatewayRoutes from '../../routes';
 import type { BudgetPolicy } from '../../types';
 
 const PAGE_SIZE = 10;
@@ -90,10 +92,16 @@ export const BudgetsList = ({ onEditClick, onDeleteClick }: BudgetsListProps) =>
             />
           }
           description={
-            <FormattedMessage
-              defaultMessage='Use "Create budget policy" button to set up cost limits for the AI Gateway'
-              description="Empty state message for budgets list"
-            />
+            <>
+              <FormattedMessage
+                defaultMessage="Set spending limits and control costs across your endpoints."
+                description="Empty state message for budgets list"
+              />
+              <br />
+              <Link componentId="mlflow.gateway.budgets.go_to_endpoints_link" to={GatewayRoutes.gatewayPageRoute}>
+                <FormattedMessage defaultMessage="Go to Endpoints" description="Link to endpoints page" />
+              </Link>
+            </>
           }
         />
       );

--- a/mlflow/server/js/src/gateway/pages/BudgetsPage.test.tsx
+++ b/mlflow/server/js/src/gateway/pages/BudgetsPage.test.tsx
@@ -1,0 +1,117 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals';
+import userEvent from '@testing-library/user-event';
+import { renderWithDesignSystem, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
+import { MemoryRouter } from '../../common/utils/RoutingUtils';
+import BudgetsPage from './BudgetsPage';
+
+// Mock useBudgetsPage hook
+const mockUseBudgetsPage = jest.fn();
+jest.mock('../hooks/useBudgetsPage', () => ({
+  useBudgetsPage: () => mockUseBudgetsPage(),
+}));
+
+// Mock BudgetsList
+jest.mock('../components/budgets/BudgetsList', () => ({
+  BudgetsList: () => <div data-testid="budgets-list">Budget Policies List</div>,
+}));
+
+// Mock WebhooksSettings
+jest.mock('../../settings/WebhooksSettings', () => ({
+  __esModule: true,
+  default: () => <div data-testid="webhooks-settings">Webhooks Settings</div>,
+}));
+
+// Mock budget modals
+jest.mock('../components/budgets/CreateBudgetPolicyModal', () => ({
+  CreateBudgetPolicyModal: () => null,
+}));
+jest.mock('../components/budgets/EditBudgetPolicyModal', () => ({
+  EditBudgetPolicyModal: () => null,
+}));
+jest.mock('../components/budgets/DeleteBudgetPolicyModal', () => ({
+  DeleteBudgetPolicyModal: () => null,
+}));
+
+describe('BudgetsPage', () => {
+  const mockHandleCreateClick = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseBudgetsPage.mockReturnValue({
+      isCreateModalOpen: false,
+      editingPolicy: null,
+      deletingPolicy: null,
+      handleCreateClick: mockHandleCreateClick,
+      handleCreateModalClose: jest.fn(),
+      handleCreateSuccess: jest.fn(),
+      handleEditClick: jest.fn(),
+      handleEditModalClose: jest.fn(),
+      handleEditSuccess: jest.fn(),
+      handleDeleteClick: jest.fn(),
+      handleDeleteModalClose: jest.fn(),
+      handleDeleteSuccess: jest.fn(),
+    });
+  });
+
+  const renderComponent = (initialEntry = '/gateway/budgets') => {
+    return renderWithDesignSystem(
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <BudgetsPage />
+      </MemoryRouter>,
+    );
+  };
+
+  test('renders page title and breadcrumb', () => {
+    renderComponent();
+
+    expect(screen.getAllByText('Budgets').length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('renders Policies tab by default', () => {
+    renderComponent();
+
+    expect(screen.getByTestId('budgets-list')).toBeInTheDocument();
+    expect(screen.queryByTestId('webhooks-settings')).not.toBeInTheDocument();
+  });
+
+  test('renders Alerts tab when selected', async () => {
+    renderComponent();
+
+    await userEvent.click(screen.getByText('Alerts'));
+
+    expect(screen.getByTestId('webhooks-settings')).toBeInTheDocument();
+    expect(screen.queryByTestId('budgets-list')).not.toBeInTheDocument();
+  });
+
+  test('renders Alerts tab when ?tab=alerts is in URL', () => {
+    renderComponent('/gateway/budgets?tab=alerts');
+
+    expect(screen.getByTestId('webhooks-settings')).toBeInTheDocument();
+    expect(screen.queryByTestId('budgets-list')).not.toBeInTheDocument();
+  });
+
+  test('shows create button on Policies tab', () => {
+    renderComponent();
+
+    expect(screen.getByText('Create budget policy')).toBeInTheDocument();
+  });
+
+  test('hides create button on Alerts tab', async () => {
+    renderComponent();
+
+    await userEvent.click(screen.getByText('Alerts'));
+
+    expect(screen.queryByText('Create budget policy')).not.toBeInTheDocument();
+  });
+
+  test('switches back to Policies tab', async () => {
+    renderComponent();
+
+    await userEvent.click(screen.getByText('Alerts'));
+    expect(screen.getByTestId('webhooks-settings')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Policies'));
+    expect(screen.getByTestId('budgets-list')).toBeInTheDocument();
+    expect(screen.queryByTestId('webhooks-settings')).not.toBeInTheDocument();
+  });
+});

--- a/mlflow/server/js/src/gateway/pages/BudgetsPage.tsx
+++ b/mlflow/server/js/src/gateway/pages/BudgetsPage.tsx
@@ -1,13 +1,6 @@
-import {
-  Breadcrumb,
-  Button,
-  CreditCardIcon,
-  PlusIcon,
-  Typography,
-  useDesignSystemTheme,
-} from '@databricks/design-system';
+import { Breadcrumb, Button, CreditCardIcon, Tabs, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
-import { Link } from '../../common/utils/RoutingUtils';
+import { Link, useSearchParams } from '../../common/utils/RoutingUtils';
 import { GatewayLabel } from '../../common/components/GatewayNewTag';
 import GatewayRoutes from '../routes';
 import { withErrorBoundary } from '../../common/utils/withErrorBoundary';
@@ -19,8 +12,14 @@ import { DeleteBudgetPolicyModal } from '../components/budgets/DeleteBudgetPolic
 import { useBudgetsPage } from '../hooks/useBudgetsPage';
 import WebhooksSettings from '../../settings/WebhooksSettings';
 
+const VALID_TABS = ['policies', 'alerts'] as const;
+
 const BudgetsPage = () => {
   const { theme } = useDesignSystemTheme();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const tabParam = searchParams.get('tab');
+  const activeTab = VALID_TABS.includes(tabParam as (typeof VALID_TABS)[number]) ? (tabParam as string) : 'policies';
 
   const {
     isCreateModalOpen,
@@ -42,14 +41,11 @@ const BudgetsPage = () => {
       {/* Header */}
       <div
         css={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
           padding: theme.spacing.md,
-          borderBottom: `1px solid ${theme.colors.borderDecorative}`,
+          paddingBottom: 0,
         }}
       >
-        <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+        <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs, marginBottom: theme.spacing.md }}>
           <Breadcrumb includeTrailingCaret>
             <Breadcrumb.Item>
               <Link componentId="mlflow.gateway.budgets.breadcrumb_gateway_link" to={GatewayRoutes.gatewayPageRoute}>
@@ -73,47 +69,87 @@ const BudgetsPage = () => {
             </Typography.Title>
           </div>
         </div>
-        <Button
-          componentId="mlflow.gateway.budgets.create-button"
-          type="primary"
-          icon={<PlusIcon />}
-          onClick={handleCreateClick}
-        >
-          <FormattedMessage
-            defaultMessage="Create budget policy"
-            description="Gateway > Budgets page > Create budget policy button"
-          />
-        </Button>
       </div>
 
-      {/* Content */}
-      <div
-        css={{
-          flex: 1,
-          overflow: 'auto',
-          padding: theme.spacing.md,
-          display: 'flex',
-          flexDirection: 'column',
-          gap: theme.spacing.lg,
+      {/* Tabs */}
+      <Tabs.Root
+        componentId="mlflow.gateway.budgets.tabs"
+        valueHasNoPii
+        value={activeTab}
+        onValueChange={(value) => {
+          setSearchParams(
+            (params) => {
+              params.set('tab', value);
+              return params;
+            },
+            { replace: true },
+          );
         }}
+        css={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}
       >
-        <BudgetsList onEditClick={handleEditClick} onDeleteClick={handleDeleteClick} />
-        <WebhooksSettings
-          eventFilter="BUDGET_POLICY"
-          title={
-            <FormattedMessage
-              defaultMessage="Budget alert webhooks"
-              description="Budget webhooks section title on budgets page"
-            />
-          }
-          description={
-            <FormattedMessage
-              defaultMessage="Receive HTTP notifications when a budget policy is exceeded."
-              description="Budget webhooks section description on budgets page"
-            />
-          }
-        />
-      </div>
+        <div css={{ paddingLeft: theme.spacing.md, paddingRight: theme.spacing.md }}>
+          <Tabs.List>
+            <Tabs.Trigger value="policies">
+              <FormattedMessage defaultMessage="Policies" description="Tab label for budget policies" />
+            </Tabs.Trigger>
+            <Tabs.Trigger value="alerts">
+              <FormattedMessage defaultMessage="Alerts" description="Tab label for budget alerts" />
+            </Tabs.Trigger>
+          </Tabs.List>
+        </div>
+
+        <Tabs.Content
+          value="policies"
+          css={{
+            flex: 1,
+            overflow: 'auto',
+            padding: theme.spacing.md,
+            paddingTop: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: theme.spacing.md,
+          }}
+        >
+          <div css={{ display: 'flex', justifyContent: 'flex-end' }}>
+            <Button componentId="mlflow.gateway.budgets.create-button" type="primary" onClick={handleCreateClick}>
+              <FormattedMessage
+                defaultMessage="Create budget policy"
+                description="Gateway > Budgets page > Create budget policy button"
+              />
+            </Button>
+          </div>
+          <BudgetsList onEditClick={handleEditClick} onDeleteClick={handleDeleteClick} />
+        </Tabs.Content>
+
+        <Tabs.Content
+          value="alerts"
+          css={{
+            flex: 1,
+            overflow: 'auto',
+            padding: theme.spacing.md,
+            paddingTop: 0,
+          }}
+        >
+          <WebhooksSettings
+            eventFilter="BUDGET_POLICY"
+            showTitle={false}
+            showDescription={false}
+            emptyDescription={
+              <FormattedMessage
+                defaultMessage="Get notified when a budget policy is exceeded. Create a webhook to get started, or <link>learn more</link>."
+                description="Budget webhooks empty state description on budgets page"
+                values={{
+                  link: (chunks: any) => (
+                    <a href="https://mlflow.org/docs/latest/ml/webhooks/" target="_blank" rel="noopener noreferrer">
+                      {chunks}
+                    </a>
+                  ),
+                }}
+              />
+            }
+          />
+        </Tabs.Content>
+      </Tabs.Root>
 
       {/* Modals */}
       <CreateBudgetPolicyModal

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -451,6 +451,10 @@
     "defaultMessage": "Cancel",
     "description": "Cancel text to cancel the flow to copy the model"
   },
+  "0uYJoi": {
+    "defaultMessage": "Alerts",
+    "description": "Tab label for budget alerts"
+  },
   "0wxgDJ": {
     "defaultMessage": "Add tags",
     "description": "Add new prompt version tags button"
@@ -2290,6 +2294,10 @@
     "defaultMessage": "Unsafe",
     "description": "Evaluation results > safety assessment > negative value label. Displayed if evaluation result is considered as unsafe."
   },
+  "CX5ia9": {
+    "defaultMessage": "Policies",
+    "description": "Tab label for budget policies"
+  },
   "CX8ytv": {
     "defaultMessage": "Expected output",
     "description": "Evaluation review > Response section > expected output > title"
@@ -2373,10 +2381,6 @@
   "CvNffK": {
     "defaultMessage": "Provider",
     "description": "Provider column header"
-  },
-  "CwJcIQ": {
-    "defaultMessage": "Receive HTTP notifications when a budget policy is exceeded.",
-    "description": "Budget webhooks section description on budgets page"
   },
   "CyTYL6": {
     "defaultMessage": "Line chart",
@@ -5651,6 +5655,10 @@
     "defaultMessage": "Versions",
     "description": "Title text for the versions section under details tab on the\n                       model view page"
   },
+  "Z6E4o7": {
+    "defaultMessage": "Get notified when a budget policy is exceeded. Create a webhook to get started, or <link>learn more</link>.",
+    "description": "Budget webhooks empty state description on budgets page"
+  },
   "Z6kodo": {
     "defaultMessage": "Move down",
     "description": "Experiment page > compare runs tab > chart header > move down option"
@@ -5906,10 +5914,6 @@
   "aXw0NO": {
     "defaultMessage": "Please select metric",
     "description": "Placeholder text where one can select metrics from the list of available metrics to render on the graph"
-  },
-  "aZ9uZO": {
-    "defaultMessage": "Budget alert webhooks",
-    "description": "Budget webhooks section title on budgets page"
   },
   "aZV8M7": {
     "defaultMessage": "Delete",
@@ -6426,10 +6430,6 @@
   "ddAFCW": {
     "defaultMessage": "500: Internal server error",
     "description": "Generic 500 user-friendly error for the MLflow UI"
-  },
-  "ddUxQJ": {
-    "defaultMessage": "Use \"Create budget policy\" button to set up cost limits for the AI Gateway",
-    "description": "Empty state message for budgets list"
   },
   "dl0TeT": {
     "defaultMessage": "Save",
@@ -9518,6 +9518,10 @@
   "xBoybr": {
     "defaultMessage": "Tag key already exists on one or more of the selected runs. Please choose a different key.",
     "description": "Add new key-value tag modal > Duplicate tag key error"
+  },
+  "xEr8Gl": {
+    "defaultMessage": "Set spending limits and control costs across your endpoints.",
+    "description": "Empty state message for budgets list"
   },
   "xIP8WW": {
     "defaultMessage": "Are you sure you want to delete these runs?",

--- a/mlflow/server/js/src/settings/WebhooksSettings.tsx
+++ b/mlflow/server/js/src/settings/WebhooksSettings.tsx
@@ -14,9 +14,22 @@ interface WebhooksSettingsProps {
   title?: React.ReactNode;
   /** Description override */
   description?: React.ReactNode;
+  /** Whether to show the section title. Defaults to true. */
+  showTitle?: boolean;
+  /** Whether to show the section description. Defaults to true. */
+  showDescription?: boolean;
+  /** Override the empty state message shown when no webhooks exist */
+  emptyDescription?: React.ReactNode;
 }
 
-const WebhooksSettings = ({ eventFilter, title, description }: WebhooksSettingsProps) => {
+const WebhooksSettings = ({
+  eventFilter,
+  title,
+  description,
+  showTitle = true,
+  showDescription = true,
+  emptyDescription,
+}: WebhooksSettingsProps) => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
 
@@ -157,20 +170,31 @@ const WebhooksSettings = ({ eventFilter, title, description }: WebhooksSettingsP
   return (
     <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
       <div css={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        <div>
-          <Typography.Title level={4} withoutMargins>
-            {title ?? <FormattedMessage defaultMessage="Webhooks" description="Webhooks settings section title" />}
-          </Typography.Title>
-          <Typography.Text color="secondary">
-            {description ?? (
-              <FormattedMessage
-                defaultMessage="Manage webhooks to receive HTTP notifications when events occur in MLflow."
-                description="Webhooks settings section description"
-              />
+        {(showTitle || showDescription) && (
+          <div>
+            {showTitle && (
+              <Typography.Title level={4} withoutMargins>
+                {title ?? <FormattedMessage defaultMessage="Webhooks" description="Webhooks settings section title" />}
+              </Typography.Title>
             )}
-          </Typography.Text>
-        </div>
-        <Button componentId="mlflow.settings.webhooks.create-button" type="primary" onClick={openCreateModal}>
+            {showDescription && (
+              <Typography.Text color="secondary">
+                {description ?? (
+                  <FormattedMessage
+                    defaultMessage="Manage webhooks to receive HTTP notifications when events occur in MLflow."
+                    description="Webhooks settings section description"
+                  />
+                )}
+              </Typography.Text>
+            )}
+          </div>
+        )}
+        <Button
+          componentId="mlflow.settings.webhooks.create-button"
+          type="primary"
+          onClick={openCreateModal}
+          css={!showTitle && !showDescription ? { marginLeft: 'auto' } : undefined}
+        >
           <FormattedMessage defaultMessage="Create webhook" description="Create webhook button" />
         </Button>
       </div>
@@ -209,17 +233,19 @@ const WebhooksSettings = ({ eventFilter, title, description }: WebhooksSettingsP
           }}
         >
           <Typography.Text color="secondary">
-            <FormattedMessage
-              defaultMessage="No webhooks configured. Create one to get started. <link>Learn more about webhooks.</link>"
-              description="Empty state for webhooks list"
-              values={{
-                link: (chunks: any) => (
-                  <a href="https://mlflow.org/docs/latest/ml/webhooks/" target="_blank" rel="noopener noreferrer">
-                    {chunks}
-                  </a>
-                ),
-              }}
-            />
+            {emptyDescription ?? (
+              <FormattedMessage
+                defaultMessage="No webhooks configured. Create one to get started. <link>Learn more about webhooks.</link>"
+                description="Empty state for webhooks list"
+                values={{
+                  link: (chunks: any) => (
+                    <a href="https://mlflow.org/docs/latest/ml/webhooks/" target="_blank" rel="noopener noreferrer">
+                      {chunks}
+                    </a>
+                  ),
+                }}
+              />
+            )}
           </Typography.Text>
         </div>
       ) : (


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Reorganize the budgets page so budget policies and budget alert webhooks live in separate sub-tabs (like usage/logs on the usage page) instead of being stacked on the same page.

- Add Policies/Alerts tabs with URL-synced state (`?tab=policies|alerts`)
- Move create button inside Policies tab content (without plus icon)
- Add "Go to Endpoints" CTA link to budget policies empty state
- Add `showTitle`, `showDescription`, `emptyDescription` props to `WebhooksSettings` for reuse in the budgets alerts context
- Alerts empty state shows: "Get notified when a budget policy is exceeded. Create a webhook to get started, or learn more."
- Add `BudgetsPage` tests covering tab rendering, switching, and URL state

<img width="1264" height="609" alt="image" src="https://github.com/user-attachments/assets/5b1499a4-df41-4be5-bb54-379ebf14fffe" />
<img width="1229" height="536" alt="image" src="https://github.com/user-attachments/assets/2bc6a6bf-c872-448c-9111-7d6aa1eef132" />

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New `BudgetsPage.test.tsx` with 7 tests covering tab rendering, switching, URL state, and conditional create button visibility. All 10 existing `WebhooksSettings` tests pass unchanged.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
