### PR TITLE
Skip markdown rendering for oversized chat content to prevent browser freezes

### DIFF
--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -1038,6 +1038,10 @@
     "defaultMessage": "Overall assessment added by LLM-as-a-judge",
     "description": "Evaluation review > assessments > tooltip > overall assessment added by LLM-as-a-judge"
   },
+  "4vrv6d": {
+    "defaultMessage": "Content too large to render ({size}). Displaying as plain text.",
+    "description": "Message shown when chat content exceeds the markdown rendering size limit"
+  },
   "4yjF8O": {
     "defaultMessage": "Show all runs",
     "description": "Menu option for revealing all hidden runs in the experiment view runs compare mode"

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/constants.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/constants.ts
@@ -33,3 +33,7 @@ export const INTERNAL_ASSESSMENT_ISSUE_DISCOVERY_JUDGE = '_issue_discovery_judge
 // Key used in assessment metadata to indicate which document (by index) the assessment references
 export const MLFLOW_SPAN_OUTPUT_KEY = 'span_output_key';
 export const CHUNK_INDEX_KEY = 'chunk_index';
+
+// Threshold (in characters) above which markdown rendering is skipped to prevent
+// browser freezes from extremely large strings (e.g., un-extracted base64 data).
+export const MARKDOWN_RENDER_SIZE_LIMIT = 1_000_000;

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessage.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessage.tsx
@@ -23,6 +23,7 @@ import {
 } from './ModelTraceExplorerChatRenderer.utils';
 import { ModelTraceExplorerToolCallMessage } from './ModelTraceExplorerToolCallMessage';
 import { CodeSnippetRenderMode, type ModelTraceChatMessage, type ModelTraceInputAudio } from '../ModelTrace.types';
+import { MARKDOWN_RENDER_SIZE_LIMIT } from '../constants';
 import { ModelTraceExplorerCodeSnippetBody } from '../ModelTraceExplorerCodeSnippetBody';
 
 function AttachmentImage({ src, alt }: { src?: string; alt?: string }) {
@@ -79,6 +80,23 @@ function ModelTraceExplorerChatMessageContent({
         containsActiveMatch={false}
         renderMode={CodeSnippetRenderMode.JSON}
       />
+    );
+  }
+
+  if (content.length > MARKDOWN_RENDER_SIZE_LIMIT) {
+    return (
+      <div css={{ padding: theme.spacing.sm, paddingTop: 0 }}>
+        <Typography.Text color="secondary">
+          <FormattedMessage
+            defaultMessage="Content too large to render ({size}). Displaying as plain text."
+            description="Message shown when chat content exceeds the markdown rendering size limit"
+            values={{ size: `${(content.length / 1_000_000).toFixed(1)}MB` }}
+          />
+        </Typography.Text>
+        <pre css={{ whiteSpace: 'pre-wrap', wordBreak: 'break-all', maxHeight: 400, overflow: 'auto', fontSize: 12 }}>
+          {content.slice(0, 10_000)}
+        </pre>
+      </div>
     );
   }
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22446

### What changes are proposed in this pull request?

When un-extracted base64 data ends up in chat message content (e.g., extraction was disabled or a new format isn't recognized), the markdown renderer attempts to parse the entire multi-MB string. This freezes the browser tab.

Adds a 1MB size guard in `ModelTraceExplorerChatMessageContent`. When content exceeds the limit, it skips the markdown renderer and shows:
- A warning message with the content size
- A plain text preview truncated to 10KB in a scrollable `<pre>` block

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

No unit test added — this is a size-based rendering guard in a component with no existing test infrastructure. The logic is a simple `content.length > 1_000_000` check with a plain text fallback. The threshold was chosen based on the observation that base64-encoded images from DALL-E are typically 1-2MB.

<img width="1372" height="727" alt="Screenshot 2026-04-08 at 6 52 36 PM" src="https://github.com/user-attachments/assets/b65aae46-6a82-40ce-8e9d-66eade0d3e7a" />


### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. The trace chat view no longer freezes when displaying very large content strings (e.g., un-extracted base64 data). Content over 1MB is shown as truncated plain text with a size warning.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release