### PR TITLE
Add multimodal demo traces with synthetic image and audio data

### DIFF
--- a/mlflow/demo/data.py
+++ b/mlflow/demo/data.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import base64
+import functools
+import math
+import struct
+import zlib
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -844,6 +849,218 @@ SESSION_TRACES: list[DemoTrace] = [
         turn_index=2,
     ),
 ]
+
+# =============================================================================
+# Multimodal Traces (4 traces)
+# =============================================================================
+
+
+def _generate_synthetic_png() -> str:
+    """Generate an 8x8 red square PNG as base64. ~100 chars."""
+    width, height = 8, 8
+    raw = b""
+    for _y in range(height):
+        raw += b"\x00"
+        for _x in range(width):
+            raw += b"\xff\x00\x00"
+
+    def _chunk(chunk_type: bytes, data: bytes) -> bytes:
+        c = chunk_type + data
+        return struct.pack(">I", len(data)) + c + struct.pack(">I", zlib.crc32(c) & 0xFFFFFFFF)
+
+    png = b"\x89PNG\r\n\x1a\n"
+    png += _chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0))
+    png += _chunk(b"IDAT", zlib.compress(raw))
+    png += _chunk(b"IEND", b"")
+    return base64.b64encode(png).decode()
+
+
+def _generate_synthetic_wav() -> str:
+    """Generate a 0.25s 440Hz beep as WAV base64. ~5.4KB."""
+    sample_rate = 8000
+    duration = 0.25
+    frequency = 440
+    num_samples = int(sample_rate * duration)
+
+    samples = b"".join(
+        struct.pack("<h", int(16000 * math.sin(2 * math.pi * frequency * i / sample_rate)))
+        for i in range(num_samples)
+    )
+
+    header = struct.pack("<4sI4s", b"RIFF", 36 + len(samples), b"WAVE")
+    header += struct.pack("<4sIHHIIHH", b"fmt ", 16, 1, 1, sample_rate, sample_rate * 2, 2, 16)
+    header += struct.pack("<4sI", b"data", len(samples))
+    return base64.b64encode(header + samples).decode()
+
+
+@dataclass
+class MultimodalDemoTrace:
+    """Demo trace definition for multimodal content.
+
+    Each trace has pre-built input/output dicts in OpenAI message format
+    so the generator can set them directly on spans.
+    """
+
+    name: str
+    description: str
+    span_type: str
+    inputs: dict[str, Any]
+    outputs: dict[str, Any]
+    v1_response_text: str
+    v2_response_text: str
+
+
+def _build_multimodal_traces() -> list[MultimodalDemoTrace]:
+    png_b64 = _generate_synthetic_png()
+    wav_b64 = _generate_synthetic_wav()
+
+    return [
+        # 1. Vision input: image + text → text response
+        MultimodalDemoTrace(
+            name="vision_analysis",
+            description="Analyze an uploaded image",
+            span_type="CHAT_MODEL",
+            inputs={
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "What do you see in this image?"},
+                            {
+                                "type": "image_url",
+                                "image_url": {
+                                    "url": f"data:image/png;base64,{png_b64}",
+                                },
+                            },
+                        ],
+                    }
+                ]
+            },
+            outputs={
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                        },
+                        "finish_reason": "stop",
+                    }
+                ]
+            },
+            v1_response_text=(
+                "The image appears to be a small red square. It could be a test image "
+                "or a placeholder graphic of some kind."
+            ),
+            v2_response_text=(
+                "The image shows a solid red 8×8 pixel square, likely a synthetic test "
+                "image used for validating image processing pipelines."
+            ),
+        ),
+        # 2. Image generation: text → image output (DALL-E style)
+        MultimodalDemoTrace(
+            name="image_generation",
+            description="Generate an image from a text prompt",
+            span_type="CHAT_MODEL",
+            inputs={
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "Generate a simple logo: a red square on a white background.",
+                    }
+                ]
+            },
+            outputs={
+                "data": [
+                    {
+                        "b64_json": png_b64,
+                        "revised_prompt": (
+                            "A minimalist logo featuring a solid red square "
+                            "centered on a clean white background."
+                        ),
+                    }
+                ]
+            },
+            v1_response_text="Here is the generated image.",
+            v2_response_text="Here is the generated image.",
+        ),
+        # 3. Audio input: audio + text → text response
+        MultimodalDemoTrace(
+            name="audio_transcription",
+            description="Transcribe and summarize audio input",
+            span_type="CHAT_MODEL",
+            inputs={
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "Summarize what is being said in this audio."},
+                            {
+                                "type": "input_audio",
+                                "input_audio": {
+                                    "data": wav_b64,
+                                    "format": "wav",
+                                },
+                            },
+                        ],
+                    }
+                ]
+            },
+            outputs={
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                        },
+                        "finish_reason": "stop",
+                    }
+                ]
+            },
+            v1_response_text="The audio contains a short beep tone. It sounds like a test signal.",
+            v2_response_text=(
+                "The audio contains a brief 440Hz sine tone (concert A), commonly used "
+                "as a calibration or test signal in audio systems."
+            ),
+        ),
+        # 4. Audio output: text → audio response
+        MultimodalDemoTrace(
+            name="text_to_speech",
+            description="Convert text to spoken audio",
+            span_type="CHAT_MODEL",
+            inputs={
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "Read this aloud: Welcome to MLflow Tracing.",
+                    }
+                ]
+            },
+            outputs={
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "audio": {
+                                "data": wav_b64,
+                                "transcript": "Welcome to MLflow Tracing.",
+                            },
+                        },
+                        "finish_reason": "stop",
+                    }
+                ]
+            },
+            v1_response_text="Welcome to MLflow Tracing.",
+            v2_response_text="Welcome to MLflow Tracing.",
+        ),
+    ]
+
+
+@functools.cache
+def get_multimodal_traces() -> list[MultimodalDemoTrace]:
+    """Lazy accessor to avoid running synthetic content generation at import time."""
+    return _build_multimodal_traces()
+
 
 # =============================================================================
 # Combined Trace Data

--- a/mlflow/demo/generators/evaluation.py
+++ b/mlflow/demo/generators/evaluation.py
@@ -317,7 +317,9 @@ class EvaluationDemoGenerator(BaseDemoGenerator):
 
         return expectation_count
 
-    def _find_expected_answer(self, query: str) -> str | None:
+    def _find_expected_answer(self, query: str | None) -> str | None:
+        if not query:
+            return None
         query_lower = query.lower().strip()
         if query_lower in EXPECTED_ANSWERS:
             return EXPECTED_ANSWERS[query_lower]

--- a/mlflow/demo/generators/traces.py
+++ b/mlflow/demo/generators/traces.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import hashlib
 import logging
 import random
@@ -22,6 +23,8 @@ from mlflow.demo.data import (
     RAG_TRACES,
     SESSION_TRACES,
     DemoTrace,
+    MultimodalDemoTrace,
+    get_multimodal_traces,
 )
 from mlflow.entities import SpanType
 from mlflow.tracing.constant import SpanAttributeKey, TraceMetadataKey
@@ -34,7 +37,7 @@ DEMO_TRACE_TYPE_TAG = "mlflow.demo.trace_type"
 DEMO_START_TIME_TAG = "mlflow.demo.start_time_ms"
 DEMO_END_TIME_TAG = "mlflow.demo.end_time_ms"
 
-_TOTAL_TRACES_PER_VERSION = 17
+_TOTAL_TRACES_PER_VERSION = 21
 
 
 @dataclass(frozen=True)
@@ -203,6 +206,14 @@ class TracesDemoGenerator(BaseDemoGenerator):
             if trace_id := self._create_prompt_trace(
                 trace_def, version, start_ns, end_ns, prompt_version_num
             ):
+                trace_ids.append(trace_id)
+            trace_index += 1
+
+        for trace_def in get_multimodal_traces():
+            start_ns, end_ns = _get_trace_timestamps(trace_index, version)
+            min_start_ns = min(min_start_ns, start_ns)
+            max_end_ns = max(max_end_ns, end_ns)
+            if trace_id := self._create_multimodal_trace(trace_def, version, start_ns, end_ns):
                 trace_ids.append(trace_id)
             trace_index += 1
 
@@ -523,6 +534,55 @@ class TracesDemoGenerator(BaseDemoGenerator):
         self._link_prompt_to_trace(trace_def.prompt_template.prompt_name, trace_id, prompt_version)
 
         return trace_id
+
+    def _create_multimodal_trace(
+        self,
+        trace_def: MultimodalDemoTrace,
+        version: Literal["v1", "v2"],
+        start_ns: int,
+        end_ns: int,
+    ) -> str | None:
+        """Create a multimodal trace with pre-built inputs/outputs."""
+        response_text = (
+            trace_def.v1_response_text if version == "v1" else trace_def.v2_response_text
+        )
+        prompt_tokens = 200
+        completion_tokens = _estimate_tokens(response_text)
+
+        model = GPT_5_2
+
+        # Deep copy to avoid mutating shared trace definition data
+        outputs = copy.deepcopy(trace_def.outputs)
+        # Inject version-specific response text into outputs
+        match outputs:
+            case {"choices": [*choices]}:
+                for choice in choices:
+                    match choice:
+                        case {"message": {"content": None, **rest}} if "audio" not in rest:
+                            choice["message"]["content"] = response_text
+
+        root = mlflow.start_span_no_context(
+            name=trace_def.name,
+            span_type=trace_def.span_type,
+            inputs=trace_def.inputs,
+            attributes={
+                SpanAttributeKey.MESSAGE_FORMAT: "openai",
+                SpanAttributeKey.CHAT_USAGE: {
+                    "input_tokens": prompt_tokens,
+                    "output_tokens": completion_tokens,
+                    "total_tokens": prompt_tokens + completion_tokens,
+                },
+                SpanAttributeKey.MODEL: model.name,
+                SpanAttributeKey.MODEL_PROVIDER: model.provider,
+                SpanAttributeKey.LLM_COST: _compute_cost(model, prompt_tokens, completion_tokens),
+            },
+            metadata={DEMO_VERSION_TAG: version, DEMO_TRACE_TYPE_TAG: "multimodal"},
+            start_time_ns=start_ns,
+        )
+        root.set_outputs(outputs)
+        root.end(end_time_ns=end_ns)
+
+        return root.trace_id
 
     def _link_prompt_to_trace(
         self, short_prompt_name: str, trace_id: str, prompt_version: str = "1"

--- a/tests/demo/test_cli.py
+++ b/tests/demo/test_cli.py
@@ -101,7 +101,7 @@ def test_cli_creates_traces():
 
     # Filter for demo traces only (exclude evaluation traces created by evaluate())
     demo_traces = [t for t in all_traces if t.info.trace_metadata.get(DEMO_VERSION_TAG)]
-    assert len(demo_traces) == 34
+    assert len(demo_traces) == 42
 
 
 def test_cli_creates_evaluation_datasets():

--- a/tests/demo/test_demo_integration.py
+++ b/tests/demo/test_demo_integration.py
@@ -151,7 +151,7 @@ def test_traces_creates_on_server(client, traces_generator):
     traces = client.search_traces(locations=[experiment.experiment_id], max_results=200)
 
     assert len(traces) == len(result.entity_ids)
-    assert len(traces) == 34
+    assert len(traces) == 42
 
 
 def test_traces_have_expected_span_types(client, traces_generator):
@@ -171,6 +171,10 @@ def test_traces_have_expected_span_types(client, traces_generator):
     assert "chat_agent" in all_span_names
     assert "prompt_chain" in all_span_names
     assert "render_prompt" in all_span_names
+    assert "vision_analysis" in all_span_names
+    assert "image_generation" in all_span_names
+    assert "audio_transcription" in all_span_names
+    assert "text_to_speech" in all_span_names
 
 
 def test_traces_session_metadata(client, traces_generator):
@@ -197,8 +201,8 @@ def test_traces_version_metadata(client, traces_generator):
     v1_traces = [t for t in traces if t.info.trace_metadata.get(DEMO_VERSION_TAG) == "v1"]
     v2_traces = [t for t in traces if t.info.trace_metadata.get(DEMO_VERSION_TAG) == "v2"]
 
-    assert len(v1_traces) == 17
-    assert len(v2_traces) == 17
+    assert len(v1_traces) == 21
+    assert len(v2_traces) == 21
 
 
 def test_traces_type_metadata(client, traces_generator):
@@ -216,11 +220,15 @@ def test_traces_type_metadata(client, traces_generator):
     session_traces = [
         t for t in traces if t.info.trace_metadata.get(DEMO_TRACE_TYPE_TAG) == "session"
     ]
+    multimodal_traces = [
+        t for t in traces if t.info.trace_metadata.get(DEMO_TRACE_TYPE_TAG) == "multimodal"
+    ]
 
     assert len(rag_traces) == 4
     assert len(agent_traces) == 4
     assert len(prompt_traces) == 12
     assert len(session_traces) == 14
+    assert len(multimodal_traces) == 8
 
 
 def test_traces_creates_time_range_tags(client, traces_generator):
@@ -240,7 +248,7 @@ def test_traces_delete_removes_all(client, traces_generator):
 
     experiment = client.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
     traces_before = client.search_traces(locations=[experiment.experiment_id], max_results=200)
-    assert len(traces_before) == 34
+    assert len(traces_before) == 42
 
     traces_generator.delete_demo()
 
@@ -309,9 +317,13 @@ def test_evaluation_datasets_have_records(client, evaluation_generator):
     baseline_session_df = baseline_session_datasets[0].to_df()
     improved_session_df = improved_session_datasets[0].to_df()
 
-    # Trace-level dataset merges v1 + v2 non-session traces (10 unique queries,
-    # merge_records deduplicates by inputs so v2 records overwrite v1)
-    assert len(trace_level_df) == 10
+    # Trace-level dataset deduplicates by SHA-256 hash of JSON-serialized inputs.
+    # v2 records overwrite v1 when inputs are identical. Multimodal traces with
+    # auto-extracted attachments get unique mlflow-attachment:// UUIDs per version,
+    # so vision/audio input traces don't dedup (2 rows each), while text-only
+    # input traces (image_gen, tts) do dedup (1 row each).
+    # 10 text traces + 2 multimodal deduped + 4 multimodal not deduped = 16
+    assert len(trace_level_df) == 16
     # Session datasets have 7 traces each (v1 and v2)
     assert len(baseline_session_df) == 7
     assert len(improved_session_df) == 7

--- a/tests/demo/test_traces_generator.py
+++ b/tests/demo/test_traces_generator.py
@@ -107,10 +107,10 @@ def test_traces_have_version_metadata():
     v1_traces = [t for t in traces if t.info.trace_metadata.get(DEMO_VERSION_TAG) == "v1"]
     v2_traces = [t for t in traces if t.info.trace_metadata.get(DEMO_VERSION_TAG) == "v2"]
 
-    # 2 RAG + 2 agent + 6 prompt + 7 session = 17 per version
-    assert len(v1_traces) == 17
-    assert len(v2_traces) == 17
-    assert len(traces) == 34
+    # 2 RAG + 2 agent + 6 prompt + 4 multimodal + 7 session = 21 per version
+    assert len(v1_traces) == 21
+    assert len(v2_traces) == 21
+    assert len(traces) == 42
 
 
 def test_traces_have_type_metadata():


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22446

### What changes are proposed in this pull request?

Adds 4 multimodal trace types to the demo data generator so the MLflow Demo experiment showcases multimodal tracing features out of the box:

- **Vision**: image input + text response
- **Image generation**: text input + image output (DALL-E style `b64_json`)
- **Audio input**: audio + text prompt → text response
- **Audio output**: text prompt → spoken audio response (with transcript)

Uses programmatically generated synthetic content to avoid bloating the package:
- 8×8 red square PNG (~100 bytes base64)
- 0.25s 440Hz sine wave WAV (~5.4KB base64)

Auto-extraction converts the embedded base64 to `mlflow-attachment://` URIs at trace creation time. Each trace uses OpenAI message format with appropriate `mlflow.message.format` attribute.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Updated existing demo integration tests:
- `test_traces_version_metadata`: 17 → 21 traces per version
- `test_traces_type_metadata`: added `multimodal` type assertion (8 traces)
- `test_traces_have_expected_span_types`: added multimodal span names

<img width="1367" height="582" alt="Screenshot 2026-04-08 at 6 57 26 PM" src="https://github.com/user-attachments/assets/55b7eaa3-c831-4cb3-809a-4982feabf477" />
<img width="1362" height="617" alt="Screenshot 2026-04-08 at 6 57 43 PM" src="https://github.com/user-attachments/assets/b9ac7195-b03e-436e-aebe-4604bc3416f8" />
<img width="1367" height="596" alt="Screenshot 2026-04-08 at 6 58 04 PM" src="https://github.com/user-attachments/assets/82527266-fac9-4b07-a0ac-85afbdd68507" />
<img width="1362" height="632" alt="Screenshot 2026-04-08 at 6 58 32 PM" src="https://github.com/user-attachments/assets/ce739e4f-6826-40af-976a-0a053ce018c8" />


### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. The MLflow Demo experiment now includes multimodal traces (vision, image generation, audio input/output) showcasing attachment rendering features.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release