### PR TITLE
Handle `input_file` content type in Responses API chat rendering

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/openai.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/openai.test.ts
@@ -505,6 +505,49 @@ describe('normalizeConversation', () => {
     expect(result?.[0]?.content).toContain('data:image/jpeg;base64,abc123');
   });
 
+  it('handles input_file content in Responses API input', () => {
+    const input = {
+      input: [
+        {
+          role: 'user',
+          content: [
+            { type: 'input_text', text: 'What is in this file?' },
+            {
+              type: 'input_file',
+              filename: 'test.pdf',
+              file_data: 'mlflow-attachment://pdf-123?content_type=application%2Fpdf&trace_id=tr-456',
+            },
+          ],
+        },
+      ],
+    };
+    const result = normalizeConversation(input, 'openai');
+    expect(result).toHaveLength(1);
+    expect(result?.[0]).toMatchObject({ role: 'user' });
+    expect(result?.[0]?.content).toContain('What is in this file?');
+    // The attachment URI should be passed through as an image_url for rendering
+    expect(result?.[0]?.content).toContain('mlflow-attachment://pdf-123');
+  });
+
+  it('handles input_file with non-attachment data as filename text', () => {
+    const input = {
+      input: [
+        {
+          role: 'user',
+          content: [
+            { type: 'input_text', text: 'Summarize this.' },
+            { type: 'input_file', filename: 'report.pdf', file_data: 'data:application/pdf;base64,abc' },
+          ],
+        },
+      ],
+    };
+    const result = normalizeConversation(input, 'openai');
+    expect(result).toHaveLength(1);
+    expect(result?.[0]?.content).toContain('Summarize this.');
+    // Non-attachment file_data falls back to filename text
+    expect(result?.[0]?.content).toContain('[File: report.pdf]');
+  });
+
   describe('OpenAI reasoning support', () => {
     it('handles non-streaming output with reasoning summary', () => {
       const result = normalizeConversation(MOCK_OPENAI_RESPONSES_OUTPUT_WITH_REASONING, 'openai');

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/openai.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/openai.ts
@@ -108,10 +108,17 @@ const normalizeOpenAIResponsesInputMessage = (obj: OpenAIResponsesInputMessage):
       const text = get(item, 'text');
       if (get(item, 'type') === 'input_text' && isString(text)) {
         contentParts.push({ type: 'text', text });
-      } else {
-        const imageUrl = get(item, 'image_url');
-        if (get(item, 'type') === 'input_image' && isString(imageUrl)) {
-          contentParts.push({ type: 'image_url', image_url: { url: imageUrl } });
+      } else if (get(item, 'type') === 'input_image' && isString(get(item, 'image_url'))) {
+        contentParts.push({ type: 'image_url', image_url: { url: get(item, 'image_url') as string } });
+      } else if (get(item, 'type') === 'input_file') {
+        const filename = get(item, 'filename');
+        const fileData = get(item, 'file_data');
+        if (isString(fileData) && fileData.startsWith('mlflow-attachment://')) {
+          // Render as image_url so the attachment renderer picks it up
+          // (AttachmentRenderer handles PDFs, images, audio, etc.)
+          contentParts.push({ type: 'image_url', image_url: { url: fileData } });
+        } else if (isString(filename)) {
+          contentParts.push({ type: 'text', text: `[File: ${filename}]` });
         }
       }
     }

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessage.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessage.tsx
@@ -13,7 +13,13 @@ import {
 } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
 import { GenAIMarkdownRenderer } from '../../genai-markdown-renderer/GenAIMarkdownRenderer';
-import { attachmentAwareUrlTransform, isAttachmentUri, useAttachmentUrl } from '../attachment-utils';
+import {
+  attachmentAwareUrlTransform,
+  isAttachmentUri,
+  parseAttachmentUri,
+  useAttachmentUrl,
+} from '../attachment-utils';
+import { ModelTraceExplorerAttachmentRenderer } from '../field-renderers/ModelTraceExplorerAttachmentRenderer';
 
 import { ModelTraceExplorerChatMessageHeader } from './ModelTraceExplorerChatMessageHeader';
 import {
@@ -38,6 +44,18 @@ function AttachmentImage({ src, alt }: { src?: string; alt?: string }) {
 
 const attachmentAwareImgRenderer = ({ src, alt }: { src?: string; alt?: string }) => {
   if (src && isAttachmentUri(src)) {
+    const parsed = parseAttachmentUri(src);
+    if (parsed && !parsed.contentType.startsWith('image/')) {
+      // Non-image attachments (PDF, audio, etc.) use the full AttachmentRenderer
+      return (
+        <ModelTraceExplorerAttachmentRenderer
+          title=""
+          attachmentId={parsed.attachmentId}
+          traceId={parsed.traceId}
+          contentType={parsed.contentType}
+        />
+      );
+    }
     return <AttachmentImage src={src} alt={alt} />;
   }
   return <img src={src} alt={alt} css={{ maxWidth: '100%' }} />;


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22446
Depends on #22459

### What changes are proposed in this pull request?

The Responses API `input_file` content type (used for PDF uploads) was silently dropped by the chat normalizer — the file never appeared in the chat view.

Two changes:

1. **`openai.ts`**: The normalizer now handles `input_file` parts. When `file_data` is an `mlflow-attachment://` URI, it's passed through as an `image_url` content part so the attachment renderer picks it up. Otherwise, falls back to showing `[File: filename]` as text.

2. **`ModelTraceExplorerChatMessage.tsx`**: The `attachmentAwareImgRenderer` now checks the attachment's content type. Non-image attachments (PDF, audio) are routed to the full `AttachmentRenderer` (which handles PDFs as iframes, audio as players, etc.) instead of the image-only `<img>` renderer.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Added two tests in `openai.test.ts`:
- `handles input_file content in Responses API input` — verifies attachment URI is passed through for rendering
- `handles input_file with non-attachment data as filename text` — verifies non-attachment file_data falls back to `[File: filename]` text

All 15 OpenAI chat tests pass.

<img width="1349" height="854" alt="Screenshot 2026-04-08 at 7 07 40 PM" src="https://github.com/user-attachments/assets/0e784cf8-92b6-4043-aeb7-a270ab69419f" />


### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. PDF files uploaded via the Responses API `input_file` type now render in the trace chat view instead of being silently dropped.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release