### PR TITLE
Add `kriscon-db` and `PattaraS` to team-review reviewer pool

### DIFF
--- a/.github/workflows/team-review.js
+++ b/.github/workflows/team-review.js
@@ -1,5 +1,14 @@
 const STATS_ISSUE_NUMBER = 19428;
-const MEMBERS = ["B-Step62", "daniellok-db", "harupy", "serena-ruan", "TomeHirata", "WeichenXu123"];
+const MEMBERS = [
+  "B-Step62",
+  "daniellok-db",
+  "harupy",
+  "kriscon-db",
+  "PattaraS",
+  "serena-ruan",
+  "TomeHirata",
+  "WeichenXu123",
+];
 
 async function loadStats(github, owner, repo) {
   try {


### PR DESCRIPTION
### Related Issues/PRs

Relates to #19428

### What changes are proposed in this pull request?

Add `kriscon-db` (Kris Concepcion) and `PattaraS` (Pattara Sukprasert) to the `MEMBERS` list in `.github/workflows/team-review.js` so they are eligible for fair-distribution reviewer auto-assignment. Also reformatted the array onto multiple lines for readability.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release