### PR TITLE
fix: Span attributes serialized as kvlist_value instead of string_value via traces/get endpoint

### DIFF
--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -426,7 +426,10 @@ class Span:
                 # Include the MLflow trace request ID only if it's not already present in attributes
                 SpanAttributeKey.REQUEST_ID: dump_span_attribute_value(mlflow_trace_id),
                 **{
-                    attr.key: dump_span_attribute_value(_decode_otel_proto_anyvalue(attr.value))
+                    attr.key: (
+                        v if isinstance(v := _decode_otel_proto_anyvalue(attr.value), str)
+                        else dump_span_attribute_value(v)
+                    )
                     for attr in otel_proto_span.attributes
                 },
             },
@@ -469,7 +472,7 @@ class Span:
 
         otel_span.status.CopyFrom(self.status.to_otel_proto_status())
 
-        for key, value in self.attributes.items():
+        for key, value in self._span.attributes.items():
             attr = otel_span.attributes.add()
             attr.key = key
             _set_otel_proto_anyvalue(attr.value, value)

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -415,24 +415,30 @@ class Span:
             if location_id
             else generate_mlflow_trace_id_from_otel_trace_id(trace_id)
         )
+        # Decode proto attributes and store as JSON-encoded strings to match set_attribute behavior.
+        # For string values, keep JSON-encoded complex values (dict/list) as-is; dump simple strings
+        # so they round-trip correctly through _SpanAttributesRegistry.get() (which calls json.loads).
+        proto_attrs: dict[str, str] = {}
+        for attr in otel_proto_span.attributes:
+            v = _decode_otel_proto_anyvalue(attr.value)
+            if isinstance(v, str):
+                try:
+                    decoded = json.loads(v)
+                    proto_attrs[attr.key] = v if isinstance(decoded, (dict, list)) else dump_span_attribute_value(v)
+                except (json.JSONDecodeError, TypeError):
+                    proto_attrs[attr.key] = dump_span_attribute_value(v)
+            else:
+                proto_attrs[attr.key] = dump_span_attribute_value(v)
+        # Include the MLflow trace request ID only if it's not already present in attributes
+        if SpanAttributeKey.REQUEST_ID not in proto_attrs:
+            proto_attrs[SpanAttributeKey.REQUEST_ID] = dump_span_attribute_value(mlflow_trace_id)
         otel_span = OTelReadableSpan(
             name=otel_proto_span.name,
             context=build_otel_context(trace_id, span_id),
             parent=build_otel_context(trace_id, parent_id) if parent_id else None,
             start_time=otel_proto_span.start_time_unix_nano,
             end_time=otel_proto_span.end_time_unix_nano,
-            # we need to dump the attribute value to be consistent with span.set_attribute behavior
-            attributes={
-                # Include the MLflow trace request ID only if it's not already present in attributes
-                SpanAttributeKey.REQUEST_ID: dump_span_attribute_value(mlflow_trace_id),
-                **{
-                    attr.key: (
-                        v if isinstance(v := _decode_otel_proto_anyvalue(attr.value), str)
-                        else dump_span_attribute_value(v)
-                    )
-                    for attr in otel_proto_span.attributes
-                },
-            },
+            attributes=proto_attrs,
             status=OTelStatus(status_code, otel_proto_span.status.message or None),
             events=[
                 OTelEvent(
@@ -472,10 +478,20 @@ class Span:
 
         otel_span.status.CopyFrom(self.status.to_otel_proto_status())
 
-        for key, value in self._span.attributes.items():
+        for key, raw_value in self._span.attributes.items():
             attr = otel_span.attributes.add()
             attr.key = key
-            _set_otel_proto_anyvalue(attr.value, value)
+            if isinstance(raw_value, str):
+                try:
+                    decoded = json.loads(raw_value)
+                    # Keep dict/list values as JSON strings (string_value in OTLP);
+                    # decode primitive values so they use their native OTLP types.
+                    value = raw_value if isinstance(decoded, (dict, list)) else decoded
+                except (json.JSONDecodeError, TypeError):
+                    value = raw_value
+                _set_otel_proto_anyvalue(attr.value, value)
+            else:
+                _set_otel_proto_anyvalue(attr.value, raw_value)
 
         for event in self.events:
             otel_event = event.to_otel_proto()

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -424,7 +424,9 @@ class Span:
             if isinstance(v, str):
                 try:
                     decoded = json.loads(v)
-                    proto_attrs[attr.key] = v if isinstance(decoded, (dict, list)) else dump_span_attribute_value(v)
+                    proto_attrs[attr.key] = (
+                        v if isinstance(decoded, (dict, list)) else dump_span_attribute_value(v)
+                    )
                 except (json.JSONDecodeError, TypeError):
                     proto_attrs[attr.key] = dump_span_attribute_value(v)
             else:

--- a/tests/entities/test_span.py
+++ b/tests/entities/test_span.py
@@ -434,6 +434,33 @@ def test_span_to_otel_proto_conversion(sample_otel_span_for_conversion):
     assert attr_by_key["mlflow.spanOutputs"].HasField("string_value")
 
 
+def test_live_span_to_otel_proto_string_attributes():
+    """Regression test: LiveSpan attributes stored as JSON-encoded strings must be
+    decoded to plain types in OTLP output (e.g. spanType should be 'LLM', not '"LLM"').
+    Dict/list values must remain encoded as string_value."""
+    span_inputs = {"messages": [{"role": "user", "content": "hello"}]}
+    span_outputs = {"text": "world"}
+
+    tracer = _get_tracer("test")
+    with tracer.start_as_current_span("live_span_proto") as otel_span:
+        span = create_mlflow_span(otel_span, trace_id="tr-12345", span_type=SpanType.LLM)
+        span.set_inputs(span_inputs)
+        span.set_outputs(span_outputs)
+
+    otel_proto = span.to_otel_proto()
+    attr_by_key = {attr.key: attr.value for attr in otel_proto.attributes}
+
+    # String attributes should be plain strings, not JSON-quoted (e.g. "LLM" not '"LLM"')
+    assert attr_by_key["mlflow.spanType"].HasField("string_value")
+    assert attr_by_key["mlflow.spanType"].string_value == "LLM"
+
+    # Structured values should remain JSON-encoded as string_value
+    assert attr_by_key["mlflow.spanInputs"].HasField("string_value")
+    assert json.loads(attr_by_key["mlflow.spanInputs"].string_value) == span_inputs
+    assert attr_by_key["mlflow.spanOutputs"].HasField("string_value")
+    assert json.loads(attr_by_key["mlflow.spanOutputs"].string_value) == span_outputs
+
+
 def test_span_from_otel_proto_conversion():
     # Create OTel proto span
     otel_proto = OTelProtoSpan()

--- a/tests/entities/test_span.py
+++ b/tests/entities/test_span.py
@@ -427,6 +427,12 @@ def test_span_to_otel_proto_conversion(sample_otel_span_for_conversion):
     assert otel_proto.events[0].name == "event1"
     assert otel_proto.events[0].time_unix_nano == 1500000000
 
+    # Verify spanInputs and spanOutputs are encoded as string_value, not kvlist_value
+    # Regression test for https://github.com/mlflow/mlflow/issues/22430
+    attr_by_key = {attr.key: attr.value for attr in otel_proto.attributes}
+    assert attr_by_key["mlflow.spanInputs"].HasField("string_value")
+    assert attr_by_key["mlflow.spanOutputs"].HasField("string_value")
+
 
 def test_span_from_otel_proto_conversion():
     # Create OTel proto span

--- a/tests/entities/test_span.py
+++ b/tests/entities/test_span.py
@@ -437,7 +437,8 @@ def test_span_to_otel_proto_conversion(sample_otel_span_for_conversion):
 def test_live_span_to_otel_proto_string_attributes():
     """Regression test: LiveSpan attributes stored as JSON-encoded strings must be
     decoded to plain types in OTLP output (e.g. spanType should be 'LLM', not '"LLM"').
-    Dict/list values must remain encoded as string_value."""
+    Dict/list values must remain encoded as string_value.
+    """
     span_inputs = {"messages": [{"role": "user", "content": "hello"}]}
     span_outputs = {"text": "world"}
 


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #22430

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
fix: Span attributes serialized as kvlist_value instead of string_value via traces/get endpoint
### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
