### PR TITLE
Avoid materializing numeric values array in assessment aggregation

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/types.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/types.ts
@@ -119,9 +119,9 @@ export interface AssessmentAggregates {
   currentCounts?: AssessmentRunCounts;
   otherCounts?: AssessmentRunCounts;
 
-  // Numeric values for the current run and other run.
-  currentNumericValues?: number[];
-  otherNumericValues?: number[];
+  // Numeric averages for the current run and other run.
+  currentNumericAverage?: number;
+  otherNumericAverage?: number;
 
   currentNumRootCause: number;
   otherNumRootCause: number;
@@ -365,6 +365,7 @@ export type NumericAggregate = {
   min: number;
   max: number;
   maxCount: number;
+  average: number;
   counts: NumericAggregateCount[];
 };
 

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/AggregationUtils.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/AggregationUtils.test.ts
@@ -1246,7 +1246,7 @@ describe('buildAggregatesFromCountMetrics', () => {
       { assessmentName: 'score', assessmentValue: '10.0', count: 15 },
     ];
     const result = buildAggregatesFromCountMetrics(info, metricsData, []);
-    expect(result.currentNumericValues).toHaveLength(45);
+    expect(result.currentNumericAverage).toBeCloseTo((1 * 10 + 5 * 20 + 10 * 15) / 45);
     expect(result.currentNumericAggregate).toBeDefined();
     expect(result.currentNumericAggregate?.min).toBe(1);
     expect(result.currentNumericAggregate?.max).toBe(10);

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/AggregationUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/AggregationUtils.ts
@@ -333,9 +333,35 @@ export function getNumericAggregate(numericValues: number[]): NumericAggregate |
     return undefined;
   }
 
+  const valueCounts = new Map<number, number>();
+  for (const value of numericValues) {
+    valueCounts.set(value, (valueCounts.get(value) ?? 0) + 1);
+  }
+  return getNumericAggregateFromCounts(valueCounts);
+}
+
+export function getNumericAggregateFromCounts(valueCounts: Map<number, number>): NumericAggregate | undefined {
+  if (valueCounts.size === 0) {
+    return undefined;
+  }
+
+  let min = Infinity;
+  let max = -Infinity;
+  let sum = 0;
+  let total = 0;
+  for (const [value, count] of valueCounts) {
+    if (value < min) min = value;
+    if (value > max) max = value;
+    sum += value * count;
+    total += count;
+  }
+
+  if (total === 0) {
+    return undefined;
+  }
+
+  const average = sum / total;
   const numericAggregateCounts: NumericAggregateCount[] = [];
-  const min = Math.min(...numericValues);
-  const max = Math.max(...numericValues);
 
   // Set a minimum bucket size of 0.01, since the data is displayed in 2 decimal places.
   // Show at most 10 buckets.
@@ -343,26 +369,26 @@ export function getNumericAggregate(numericValues: number[]): NumericAggregate |
   let maxCount = 0;
 
   if (min === max) {
-    numericAggregateCounts.push({ lower: min, upper: max, count: numericValues.length });
+    numericAggregateCounts.push({ lower: min, upper: max, count: total });
+    maxCount = total;
   } else {
     for (let i = min; i < max; i += bucketSize) {
       numericAggregateCounts.push({ lower: i, upper: Math.min(i + bucketSize, max), count: 0 });
     }
-  }
+    numericAggregateCounts.sort((a, b) => a.lower - b.lower);
 
-  numericAggregateCounts.sort((a, b) => a.lower - b.lower);
-  for (const numericValue of numericValues) {
-    const bucket = numericAggregateCounts.find(
-      (bucket) =>
-        numericValue >= bucket.lower &&
-        (numericValue < bucket.upper || (numericValue === bucket.upper && numericValue === max)),
-    );
-    if (bucket) {
-      bucket.count++;
-      maxCount = Math.max(maxCount, bucket.count);
+    for (const [value, count] of valueCounts) {
+      const bucket = numericAggregateCounts.find(
+        (b) => value >= b.lower && (value < b.upper || (value === b.upper && value === max)),
+      );
+      if (bucket) {
+        bucket.count += count;
+        maxCount = Math.max(maxCount, bucket.count);
+      }
     }
   }
-  return { min, max, maxCount, counts: numericAggregateCounts };
+
+  return { min, max, maxCount, average, counts: numericAggregateCounts };
 }
 
 export function getAssessmentNumericAggregates(
@@ -414,29 +440,6 @@ function getAssessmentRunValueCounts(
   return valueCounts;
 }
 
-function getAssessmentRunNumericValues(
-  assessmentInfo: AssessmentInfo,
-  evalResults: RunEvaluationTracesDataEntry[],
-): number[] | undefined {
-  if (assessmentInfo.dtype !== 'numeric') {
-    return undefined;
-  }
-  const values: number[] = [];
-  evalResults.forEach((evalResult) => {
-    const assessment = assessmentInfo.isOverall
-      ? first(evalResult.overallAssessments)
-      : first(evalResult.responseAssessmentsByName[assessmentInfo.name]);
-    if (assessment) {
-      const value = getEvaluationResultAssessmentValue(assessment);
-
-      if (!isNil(value)) {
-        values.push(Number(value));
-      }
-    }
-  });
-  return values;
-}
-
 function getRootCauseAssessmentCount(
   assessmentInfo: AssessmentInfo,
   evalResults: RunEvaluationTracesDataEntry[],
@@ -464,6 +467,7 @@ export function getAssessmentAggregates(
   const otherAssessmentAggregates = getAssessmentRunValueCounts(assessmentInfo, otherEvalResults);
 
   const currentNumericAggregates = getAssessmentNumericAggregates(assessmentInfo, currentEvalResults);
+  const otherNumericAggregates = getAssessmentNumericAggregates(assessmentInfo, otherEvalResults);
 
   const assessmentFilters = allAssessmentFilters.filter((filter) => filter.assessmentName === assessmentInfo.name);
 
@@ -471,8 +475,8 @@ export function getAssessmentAggregates(
     assessmentInfo,
     currentCounts: currentAssessmentAggregates,
     otherCounts: otherAssessmentAggregates,
-    currentNumericValues: getAssessmentRunNumericValues(assessmentInfo, currentEvalResults),
-    otherNumericValues: getAssessmentRunNumericValues(assessmentInfo, otherEvalResults),
+    currentNumericAverage: currentNumericAggregates?.average,
+    otherNumericAverage: otherNumericAggregates?.average,
     currentNumericAggregate: currentNumericAggregates,
     currentNumRootCause: getRootCauseAssessmentCount(assessmentInfo, currentEvalResults),
     otherNumRootCause: getRootCauseAssessmentCount(assessmentInfo, otherEvalResults),
@@ -791,24 +795,26 @@ export function getUniqueValueCountsBySourceId(
 function buildCountsFromMetrics(
   assessmentInfo: AssessmentInfo,
   metricsData: AssessmentCountMetrics['data'],
-): { counts: AssessmentRunCounts; numericValues: number[] } {
+): AssessmentRunCounts {
   const relevant = metricsData.filter((m) => m.assessmentName === assessmentInfo.name);
   const counts: AssessmentRunCounts = new Map();
-  const numericValues: number[] = [];
 
   for (const metric of relevant) {
     const typedValue = parseMetricAssessmentValue(metric.assessmentValue);
-    if (assessmentInfo.dtype === 'numeric' && typeof typedValue === 'number') {
-      counts.set(typedValue, metric.count);
-      for (let i = 0; i < metric.count; i++) {
-        numericValues.push(typedValue);
-      }
-    } else {
-      counts.set(typedValue, metric.count);
-    }
+    counts.set(typedValue, metric.count);
   }
 
-  return { counts, numericValues };
+  return counts;
+}
+
+function toNumericCounts(counts: AssessmentRunCounts): Map<number, number> {
+  const result = new Map<number, number>();
+  for (const [key, count] of counts) {
+    if (typeof key === 'number') {
+      result.set(key, count);
+    }
+  }
+  return result;
 }
 
 /**
@@ -841,16 +847,20 @@ export function buildAggregatesFromCountMetrics(
   allAssessmentFilters: AssessmentFilter[],
   otherMetricsData?: AssessmentCountMetrics['data'],
 ): AssessmentAggregates {
-  const current = buildCountsFromMetrics(assessmentInfo, metricsData);
-  const other = otherMetricsData ? buildCountsFromMetrics(assessmentInfo, otherMetricsData) : undefined;
+  const currentCounts = buildCountsFromMetrics(assessmentInfo, metricsData);
+  const otherCounts = otherMetricsData ? buildCountsFromMetrics(assessmentInfo, otherMetricsData) : undefined;
   const assessmentFilters = allAssessmentFilters.filter((f) => f.assessmentName === assessmentInfo.name);
 
   if (assessmentInfo.dtype === 'numeric') {
+    const currentNumericCounts = toNumericCounts(currentCounts);
+    const otherNumericCounts = otherCounts ? toNumericCounts(otherCounts) : undefined;
+    const currentAggregate = getNumericAggregateFromCounts(currentNumericCounts);
+    const otherAggregate = otherNumericCounts ? getNumericAggregateFromCounts(otherNumericCounts) : undefined;
     return {
       assessmentInfo,
-      currentNumericValues: current.numericValues,
-      otherNumericValues: other?.numericValues,
-      currentNumericAggregate: getNumericAggregate(current.numericValues),
+      currentNumericAverage: currentAggregate?.average,
+      otherNumericAverage: otherAggregate?.average,
+      currentNumericAggregate: currentAggregate,
       currentNumRootCause: 0,
       otherNumRootCause: 0,
       assessmentFilters,
@@ -859,8 +869,8 @@ export function buildAggregatesFromCountMetrics(
 
   return {
     assessmentInfo,
-    currentCounts: current.counts,
-    otherCounts: other?.counts,
+    currentCounts,
+    otherCounts,
     currentNumRootCause: 0,
     otherNumRootCause: 0,
     assessmentFilters,

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/DisplayUtils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/DisplayUtils.tsx
@@ -37,20 +37,11 @@ export function getDisplayOverallScoreAndChange(
   aggregateType: 'average' | 'percentage-true' | 'categorical';
 } {
   if (assessmentInfo.dtype === 'numeric') {
-    // Compute the average score for displayScore, and the change in average for displayScoreChange.
-    const currentNumericValues = assessmentDisplayInfo.currentNumericValues;
-    const otherNumericValues = assessmentDisplayInfo.otherNumericValues;
+    const currentAverage = assessmentDisplayInfo.currentNumericAverage ?? NaN;
+    const otherAverage = assessmentDisplayInfo.otherNumericAverage;
 
-    let currentAverage = NaN;
-    let otherAverage = NaN;
-    if (currentNumericValues) {
-      currentAverage = currentNumericValues.reduce((a, b) => a + b, 0) / currentNumericValues.length;
-    }
-    if (otherNumericValues) {
-      otherAverage = otherNumericValues.reduce((a, b) => a + b, 0) / otherNumericValues.length;
-    }
     const displayScore = displayFloat(currentAverage, 2);
-    const scoreChange = otherNumericValues ? currentAverage - otherAverage : undefined;
+    const scoreChange = otherAverage !== undefined ? currentAverage - otherAverage : undefined;
     const changeDirection = scoreChange ? (scoreChange > 0 ? 'up' : 'down') : 'none';
 
     const displayScoreChange = scoreChange


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/22482/files) to review incremental changes.
- [**stack/pagination-part-9**](https://github.com/mlflow/mlflow/pull/22482) [[Files changed](https://github.com/mlflow/mlflow/pull/22482/files)]
  - [stack/pagination-part-8](https://github.com/mlflow/mlflow/pull/22447) [[Files changed](https://github.com/mlflow/mlflow/pull/22447/files/82c3403f694e2ecd50e4fb275b19442c81138d01..455049c9a75acb7736f1fe2295066d34e4fac482)]

---------
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

Previously, we constructed the numeric average + histogram data by pushing every single data point to an array, and passing it to the existing aggregation function.

However, now that we rely on the metrics endpoint for the header, the user could potentially have a million traces which would result in tons of data points.

This PR changes it so that we can construct the histogram and avg using the metric endpoint data (`{ value: <value>, count: <count> }`), rather than having to materialize the full array. Now instead of `O(assessments)` it is `O(unique assessment values)`.

We could still run into a problem if the user has many unique values, but we can fix it if we get reports (in this case i think we would have to remove the histogram).

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Histogram and average still works in both paginated and non paginated views:


https://github.com/user-attachments/assets/173a5104-0732-4ebe-be7c-10645514fd10



### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
