### PR TITLE
feat(ui): add image comparison view for cross-run visual comparison

### DIFF
--- a/.github/actions/check-component-ids/componentId-registry.js
+++ b/.github/actions/check-component-ids/componentId-registry.js
@@ -1074,6 +1074,7 @@ module.exports = {
   // -- mlflow.experiment_page --
   "mlflow.experiment_page.grouped_runs.open_runs_in_new_tab": "",
   "mlflow.experiment_page.mode.artifact": "",
+  "mlflow.experiment_page.mode.images": "",
   "mlflow.experiment_page.runs.add_new_tag": "",
   "mlflow.experiment_page.runs.add_tags": "",
   "mlflow.experiment_page.scorers.advanced_settings_toggle": "",
@@ -1476,6 +1477,9 @@ module.exports = {
   "mlflow.home.workspaces_table.header.artifact_root": "",
   "mlflow.home.workspaces_table.header.description": "",
   "mlflow.home.workspaces_table.header.name": "",
+
+  // -- mlflow.images_compare --
+  "mlflow.images_compare.image_key_selector": "",
 
   // -- mlflow.issue-detection --
   "mlflow.issue-detection.category-tag": "",

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRuns.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRuns.tsx
@@ -22,6 +22,7 @@ import type { DatasetWithRunType } from './ExperimentViewDatasetDrawer';
 import { ExperimentViewDatasetDrawer } from './ExperimentViewDatasetDrawer';
 import { useExperimentViewLocalStore } from '../../hooks/useExperimentViewLocalStore';
 import { EvaluationArtifactCompareView } from '../../../evaluation-artifacts-compare/EvaluationArtifactCompareView';
+import { ImagesCompareView } from '../../../images-compare';
 import { shouldUseGetLoggedModelsBatchAPI } from '../../../../../common/utils/FeatureUtils';
 import { CreateNewRunContextProvider } from '../../hooks/useCreateNewRun';
 import { useExperimentPageViewMode } from '../../hooks/useExperimentPageViewMode';
@@ -334,6 +335,13 @@ export const ExperimentViewRuns = React.memo((props: ExperimentViewRunsProps) =>
               viewState={viewState}
               updateViewState={updateViewState}
               onDatasetSelected={datasetSelected}
+              disabled={Boolean(uiState.groupBy)}
+            />
+          )}
+          {compareRunsMode === 'IMAGES' && (
+            <ImagesCompareView
+              comparedRuns={visibleRuns}
+              autoRefreshEnabled={autoRefreshEnabled}
               disabled={Boolean(uiState.groupBy)}
             />
           )}

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsControlsFilters.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsControlsFilters.tsx
@@ -27,6 +27,7 @@ import {
   ListIcon,
   ChartLineIcon,
   TableIcon,
+  ImageIcon,
   XCircleFillIcon,
 } from '@databricks/design-system';
 import { Theme } from '@emotion/react';
@@ -228,6 +229,28 @@ export const ExperimentViewRunsControlsFilters = React.memo(
                   }
                 >
                   <TableIcon />
+                </Tooltip>
+              }
+            />
+            <SegmentedControlButton
+              value="IMAGES"
+              disabled={areRunsGrouped}
+              icon={
+                <Tooltip
+                  componentId="mlflow.experiment_page.mode.images"
+                  content={
+                    areRunsGrouped
+                      ? intl.formatMessage({
+                          defaultMessage: 'Unavailable when runs are grouped',
+                          description: 'Experiment page > view mode switch > images mode disabled tooltip',
+                        })
+                      : intl.formatMessage({
+                          defaultMessage: 'Image comparison',
+                          description: 'Experiment page > view mode switch > images comparison tooltip',
+                        })
+                  }
+                >
+                  <ImageIcon />
                 </Tooltip>
               }
             />

--- a/mlflow/server/js/src/experiment-tracking/components/images-compare/ImagesCompareView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/images-compare/ImagesCompareView.tsx
@@ -1,0 +1,417 @@
+import {
+  DialogCombobox,
+  DialogComboboxContent,
+  DialogComboboxOptionList,
+  DialogComboboxOptionListCheckboxItem,
+  DialogComboboxTrigger,
+  Empty,
+  ImageIcon,
+  Spinner,
+  Typography,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { FormattedMessage } from 'react-intl';
+import type { RunRowType } from '../experiment-page/utils/experimentPage.row-types';
+import type { ReduxState } from '@mlflow/mlflow/src/redux-types';
+import type { ImageEntity } from '../../types';
+import type { RunsChartsRunData } from '../runs-charts/components/RunsCharts.common';
+import { LOG_IMAGE_TAG_INDICATOR, NUM_RUNS_TO_SUPPORT_FOR_LOG_IMAGE } from '../../constants';
+import { usePopulateImagesByRunUuid } from '../experiment-page/hooks/usePopulateImagesByRunUuid';
+import { useGetExperimentRunColor } from '../experiment-page/hooks/useExperimentRunColor';
+import { useImageSliderStepMarks } from '../runs-charts/hooks/useImageSliderStepMarks';
+import { ImageGridRunHeader, ImagePlotWithHistory } from '../runs-charts/components/charts/ImageGridPlot.common';
+import { LineSmoothSlider } from '../LineSmoothSlider';
+
+const IMAGE_CARD_SIZE = 200;
+
+interface ImagesCompareViewProps {
+  comparedRuns: RunRowType[];
+  autoRefreshEnabled?: boolean;
+  disabled?: boolean;
+}
+
+export const ImagesCompareView = ({ comparedRuns, autoRefreshEnabled, disabled }: ImagesCompareViewProps) => {
+  const { theme } = useDesignSystemTheme();
+
+  if (disabled) {
+    return (
+      <div
+        css={{
+          flex: 1,
+          backgroundColor: theme.colors.backgroundSecondary,
+          height: '100%',
+          minHeight: 400,
+          width: '100%',
+          borderTop: `1px solid ${theme.colors.border}`,
+          borderLeft: `1px solid ${theme.colors.border}`,
+          paddingTop: theme.spacing.lg,
+          marginLeft: -1,
+          zIndex: 1,
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          '& > div': {
+            height: '100%',
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            alignItems: 'center',
+          },
+        }}
+      >
+        <Empty
+          title={
+            <FormattedMessage
+              defaultMessage="Image comparison not available when grouping is enabled"
+              description="Experiment page > images compare view > disabled due to run grouping > title"
+            />
+          }
+          description={
+            <FormattedMessage
+              defaultMessage="Disable run grouping in order to access the image comparison view"
+              description="Experiment page > images compare view > disabled due to run grouping > description"
+            />
+          }
+          image={<div />}
+        />
+      </div>
+    );
+  }
+
+  return <ImagesCompareViewImpl comparedRuns={comparedRuns} autoRefreshEnabled={autoRefreshEnabled} />;
+};
+
+const ImagesCompareViewImpl = ({ comparedRuns, autoRefreshEnabled }: Omit<ImagesCompareViewProps, 'disabled'>) => {
+  const { theme } = useDesignSystemTheme();
+  const getRunColor = useGetExperimentRunColor();
+
+  const { paramsByRunUuid, tagsByRunUuid, imagesByRunUuid } = useSelector((state: ReduxState) => ({
+    paramsByRunUuid: state.entities.paramsByRunUuid,
+    tagsByRunUuid: state.entities.tagsByRunUuid,
+    imagesByRunUuid: state.entities.imagesByRunUuid,
+  }));
+
+  const chartData: RunsChartsRunData[] = useMemo(
+    () =>
+      comparedRuns
+        .filter((run) => run.runInfo && !run.hidden)
+        .slice(0, NUM_RUNS_TO_SUPPORT_FOR_LOG_IMAGE)
+        .map((run) => ({
+          uuid: run.runUuid,
+          displayName: run.runInfo?.runName ?? run.runUuid,
+          runInfo: run.runInfo,
+          metrics: {},
+          params: (paramsByRunUuid[run.runUuid] || {}) as Record<string, { key: string; value: string | number }>,
+          tags: tagsByRunUuid[run.runUuid] || {},
+          images: imagesByRunUuid[run.runUuid] || {},
+          color: getRunColor(run.runUuid),
+          pinned: run.pinned,
+          pinnable: run.pinnable,
+          metricsHistory: {},
+          hidden: run.hidden,
+        })),
+    [comparedRuns, paramsByRunUuid, tagsByRunUuid, imagesByRunUuid, getRunColor],
+  );
+
+  // Fetch image metadata for runs that have logged images
+  const runsWithImages = useMemo(() => chartData.filter((run) => run.tags[LOG_IMAGE_TAG_INDICATOR]), [chartData]);
+  usePopulateImagesByRunUuid({
+    runUuids: runsWithImages.map((r) => r.uuid),
+    runUuidsIsActive: runsWithImages.map((r) => r.runInfo?.status === 'RUNNING'),
+    enabled: true,
+    autoRefreshEnabled,
+  });
+
+  const allImageKeys = useMemo(() => {
+    const keys = new Set<string>();
+    for (const run of chartData) {
+      for (const key of Object.keys(run.images)) {
+        keys.add(key);
+      }
+    }
+    return Array.from(keys).sort();
+  }, [chartData]);
+
+  const [selectedImageKeys, setSelectedImageKeys] = useState<string[]>([]);
+  const hasInitializedKeys = useRef(false);
+
+  useEffect(() => {
+    if (allImageKeys.length > 0 && !hasInitializedKeys.current) {
+      setSelectedImageKeys(allImageKeys);
+      hasInitializedKeys.current = true;
+    }
+  }, [allImageKeys]);
+
+  const handleImageKeyToggle = useCallback((key: string) => {
+    setSelectedImageKeys((prev) => (prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key]));
+  }, []);
+
+  const { stepMarks, maxMark, minMark } = useImageSliderStepMarks({
+    data: chartData,
+    selectedImageKeys,
+  });
+  const [tmpStep, setTmpStep] = useState(0);
+
+  const stepMarkLength = Object.keys(stepMarks).length;
+  const safeMinMark = stepMarkLength > 0 ? minMark : 0;
+  const safeMaxMark = stepMarkLength > 0 ? maxMark : 0;
+
+  // Derive effective step: snap to the only available step when there's just one,
+  // and fall back to minMark when the current step isn't in the marks
+  const effectiveStep =
+    stepMarkLength === 1 ? safeMinMark : stepMarkLength > 0 && !(tmpStep in stepMarks) ? safeMinMark : tmpStep;
+
+  const displayRuns = useMemo(() => {
+    if (selectedImageKeys.length === 0) return [];
+    return chartData.filter((run) =>
+      selectedImageKeys.some((key) => run.images[key] && Object.keys(run.images[key]).length > 0),
+    );
+  }, [chartData, selectedImageKeys]);
+
+  const shouldDisplayImageLimitIndicator =
+    comparedRuns.filter((run) => !run.hidden).length > NUM_RUNS_TO_SUPPORT_FOR_LOG_IMAGE;
+
+  // Loading state: runs have the logged-images tag but image metadata hasn't loaded yet
+  if (runsWithImages.length > 0 && allImageKeys.length === 0) {
+    return (
+      <div
+        css={{
+          flex: 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          height: '100%',
+          minHeight: 400,
+          width: '100%',
+          borderLeft: `1px solid ${theme.colors.border}`,
+        }}
+      >
+        <Spinner />
+      </div>
+    );
+  }
+
+  // Empty state: no runs have the logged-images tag
+  if (runsWithImages.length === 0) {
+    return (
+      <div
+        css={{
+          flex: 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          height: '100%',
+          minHeight: 400,
+          width: '100%',
+          borderLeft: `1px solid ${theme.colors.border}`,
+          '& > div': {
+            height: '100%',
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            alignItems: 'center',
+          },
+        }}
+      >
+        <Empty
+          description={
+            <FormattedMessage
+              defaultMessage="No logged images found. Use mlflow.log_image() to log images to your runs."
+              description="Experiment page > images compare view > no images empty state"
+            />
+          }
+          image={<ImageIcon />}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      css={{
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        borderLeft: `1px solid ${theme.colors.border}`,
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        css={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: theme.spacing.md,
+          padding: theme.spacing.md,
+          borderBottom: `1px solid ${theme.colors.border}`,
+          flexShrink: 0,
+        }}
+      >
+        <DialogCombobox
+          componentId="mlflow.images_compare.image_key_selector"
+          multiSelect
+          label={
+            <FormattedMessage
+              defaultMessage="Image keys"
+              description="Experiment page > images compare view > image key selector label"
+            />
+          }
+          value={selectedImageKeys}
+        >
+          <DialogComboboxTrigger showTagAfterValueCount={2} />
+          <DialogComboboxContent>
+            <DialogComboboxOptionList>
+              {allImageKeys.map((key) => (
+                <DialogComboboxOptionListCheckboxItem
+                  key={key}
+                  value={key}
+                  checked={selectedImageKeys.includes(key)}
+                  onChange={() => handleImageKeyToggle(key)}
+                >
+                  {key}
+                </DialogComboboxOptionListCheckboxItem>
+              ))}
+            </DialogComboboxOptionList>
+          </DialogComboboxContent>
+        </DialogCombobox>
+
+        {shouldDisplayImageLimitIndicator && (
+          <Typography.Text color="warning" size="sm">
+            <FormattedMessage
+              defaultMessage="Displaying images from the top {maxRuns} runs"
+              description="Experiment page > images compare view > run limit warning"
+              values={{ maxRuns: NUM_RUNS_TO_SUPPORT_FOR_LOG_IMAGE }}
+            />
+          </Typography.Text>
+        )}
+      </div>
+
+      <div
+        css={{
+          flex: 1,
+          overflow: 'auto',
+          padding: theme.spacing.md,
+        }}
+      >
+        {displayRuns.length === 0 && selectedImageKeys.length > 0 ? (
+          <div
+            css={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              height: '100%',
+              minHeight: 400,
+              width: '100%',
+              '& > div': {
+                height: '100%',
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'center',
+                alignItems: 'center',
+              },
+            }}
+          >
+            <Empty
+              description={
+                <FormattedMessage
+                  defaultMessage="No runs have images for the selected keys"
+                  description="Experiment page > images compare view > no runs for key empty state"
+                />
+              }
+              image={<ImageIcon />}
+            />
+          </div>
+        ) : (
+          <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.lg }}>
+            {selectedImageKeys.map((imageKey) => (
+              <div key={imageKey}>
+                <Typography.Text bold css={{ marginBottom: theme.spacing.xs, display: 'block' }}>
+                  {imageKey}
+                </Typography.Text>
+                <div
+                  css={{
+                    display: 'grid',
+                    gridTemplateColumns: `repeat(auto-fill, minmax(${IMAGE_CARD_SIZE}px, 1fr))`,
+                    gap: theme.spacing.sm,
+                  }}
+                >
+                  {displayRuns.map((run) => {
+                    const imageData = run.images[imageKey];
+                    if (!imageData || Object.keys(imageData).length === 0) return null;
+                    const imageMetadataByStep = Object.values(imageData as Record<string, ImageEntity>).reduce(
+                      (acc, metadata) => {
+                        if (metadata.step !== undefined) {
+                          acc[metadata.step] = metadata;
+                        }
+                        return acc;
+                      },
+                      {} as Record<number, ImageEntity>,
+                    );
+                    return (
+                      <div
+                        key={run.uuid}
+                        css={{
+                          display: 'flex',
+                          flexDirection: 'column',
+                          border: '1px solid transparent',
+                          borderRadius: theme.borders.borderRadiusSm,
+                          padding: theme.spacing.sm,
+                          '&:hover': {
+                            border: `1px solid ${theme.colors.border}`,
+                            backgroundColor: theme.colors.tableBackgroundUnselectedHover,
+                          },
+                        }}
+                      >
+                        <ImageGridRunHeader
+                          displayName={run.displayName}
+                          color={run.color}
+                          params={run.params as Record<string, { key: string; value: string | number }>}
+                          maxParamsWidth={IMAGE_CARD_SIZE}
+                        />
+                        <div css={{ marginTop: 'auto' }}>
+                          <ImagePlotWithHistory
+                            step={effectiveStep}
+                            metadataByStep={imageMetadataByStep}
+                            runUuid={run.uuid}
+                            imageSize={IMAGE_CARD_SIZE}
+                          />
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div
+        css={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: theme.spacing.md,
+          padding: `${theme.spacing.sm}px ${theme.spacing.md}px`,
+          borderTop: `1px solid ${theme.colors.border}`,
+          flexShrink: 0,
+        }}
+      >
+        <div css={{ flex: 1 }}>
+          <LineSmoothSlider
+            value={effectiveStep}
+            onChange={setTmpStep}
+            max={safeMaxMark}
+            min={safeMinMark}
+            marks={stepMarks}
+            disabled={stepMarkLength <= 1}
+            onAfterChange={setTmpStep}
+            css={{
+              '&[data-orientation="horizontal"]': { width: 'auto' },
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/components/images-compare/index.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/images-compare/index.ts
@@ -1,0 +1,1 @@
+export { ImagesCompareView } from './ImagesCompareView';

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/charts/ImageGridPlot.common.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/charts/ImageGridPlot.common.tsx
@@ -96,15 +96,15 @@ export const ImagePlot = ({ imageUrl, compressedImageUrl, imageSize, maxImageSiz
   }, [compressedImageUrl]);
 
   return (
-    <div css={{ width: imageSize || '100%', height: imageSize || '100%' }}>
+    <div css={{ width: imageSize || '100%', height: imageSize || 'auto' }}>
       <div css={{ display: 'contents' }}>
         {compressedImageUrl === undefined || imageLoading ? (
           <div
             css={{
-              width: '100%',
+              width: imageSize || '100%',
               backgroundColor: theme.colors.backgroundSecondary,
               display: 'flex',
-              aspectRatio: '1',
+              ...(imageSize && { aspectRatio: '1' }),
               justifyContent: 'center',
               alignItems: 'center',
             }}
@@ -118,7 +118,7 @@ export const ImagePlot = ({ imageUrl, compressedImageUrl, imageSize, maxImageSiz
               alignItems: 'center',
               justifyContent: 'center',
               width: imageSize || '100%',
-              aspectRatio: '1',
+              ...(imageSize && { aspectRatio: '1' }),
               maxWidth: maxImageSize,
               maxHeight: maxImageSize,
               backgroundColor: theme.colors.backgroundSecondary,

--- a/mlflow/server/js/src/experiment-tracking/types.ts
+++ b/mlflow/server/js/src/experiment-tracking/types.ts
@@ -387,6 +387,7 @@ export type ExperimentViewRunsCompareMode =
   | 'TABLE'
   | 'ARTIFACT'
   | 'CHART'
+  | 'IMAGES'
   | 'TRACES'
   | 'MODELS'
   | 'EVAL_RESULTS'

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -331,6 +331,10 @@
     "defaultMessage": "Show exceptions",
     "description": "Checkbox label for a setting that enables showing spans with exceptions in the trace explorer regardless of filter conditions."
   },
+  "/vsrM9": {
+    "defaultMessage": "Image keys",
+    "description": "Experiment page > images compare view > image key selector label"
+  },
   "/w5HDz": {
     "defaultMessage": "Create webhook",
     "description": "Create webhook modal title"
@@ -1059,6 +1063,10 @@
     "defaultMessage": "After your script runs, open the MLflow UI to review the recorded traces.",
     "description": "Introductory text for viewing traces in the MLflow UI"
   },
+  "4ZP4Dq": {
+    "defaultMessage": "Image comparison not available when grouping is enabled",
+    "description": "Experiment page > images compare view > disabled due to run grouping > title"
+  },
   "4a2Kqx": {
     "defaultMessage": "View trace",
     "description": "Link text for navigating to the corresponding judge trace"
@@ -1674,6 +1682,10 @@
   "8I9ipd": {
     "defaultMessage": "The provided value is not valid JSON",
     "description": "Error message for invalid JSON in an assessment edit form"
+  },
+  "8IIVFp": {
+    "defaultMessage": "Displaying images from the top {maxRuns} runs",
+    "description": "Experiment page > images compare view > run limit warning"
   },
   "8Uwpjw": {
     "defaultMessage": "Create run",
@@ -2582,6 +2594,10 @@
   "Dhr3pC": {
     "defaultMessage": "No traces found",
     "description": "No traces found message"
+  },
+  "Dk1yaJ": {
+    "defaultMessage": "Disable run grouping in order to access the image comparison view",
+    "description": "Experiment page > images compare view > disabled due to run grouping > description"
   },
   "Dk2itm": {
     "defaultMessage": "Pre-built LLM-as-a-judge | Trace level",
@@ -5375,6 +5391,10 @@
     "defaultMessage": "forecasting",
     "description": "A short label for experiments focused on time series forecasting"
   },
+  "VwzzRz": {
+    "defaultMessage": "No logged images found. Use mlflow.log_image() to log images to your runs.",
+    "description": "Experiment page > images compare view > no images empty state"
+  },
   "W+aLXo": {
     "defaultMessage": "Manage webhooks to receive HTTP notifications when events occur in MLflow.",
     "description": "Webhooks settings section description"
@@ -5523,6 +5543,10 @@
     "defaultMessage": "No results",
     "description": "Experiment page > sort selector > no results after filtering"
   },
+  "WpX3X2": {
+    "defaultMessage": "Image comparison",
+    "description": "Experiment page > view mode switch > images comparison tooltip"
+  },
   "Ws58cc": {
     "defaultMessage": "Groundedness",
     "description": "Evaluation results > known type of evaluation result assessment > groundedness assessment. Used to indicate if the result is grounded in context of LLMs evaluation. Label displayed if user provided custom value, e.g. \"Groundedness: moderately grounded\""
@@ -5670,6 +5694,10 @@
   "XuzIWs": {
     "defaultMessage": "Some traces are hidden by your time range filter: \"{filterLabel}\"",
     "description": "Message shown when traces are hidden by time filter"
+  },
+  "Xvi6g/": {
+    "defaultMessage": "Unavailable when runs are grouped",
+    "description": "Experiment page > view mode switch > images mode disabled tooltip"
   },
   "XvzXs3": {
     "defaultMessage": "The parallel coordinates chart shows runs with columns that are either numbers or strings. If a column has string entries, the runs corresponding to the 30 most recent unique values will be shown. Only runs with all relevant metrics and/or parameters will be displayed.",
@@ -9506,6 +9534,10 @@
   "ubeHow": {
     "defaultMessage": "Input",
     "description": "Column header for the input in the runs table on the logged model details page"
+  },
+  "uclIDD": {
+    "defaultMessage": "No runs have images for the selected keys",
+    "description": "Experiment page > images compare view > no runs for key empty state"
   },
   "ue/dsm": {
     "defaultMessage": "Pending",


### PR DESCRIPTION
### Related Issues/PRs

Closes #22324

### What changes are proposed in this pull request?

Adds a new **Images** comparison mode to the experiment runs view toolbar (alongside Table, Chart, and Artifact). When selected, it renders a dedicated `ImagesCompareView` panel that lets users compare logged images across runs side-by-side.

**What changed:**

- Added `'IMAGES'` to the `ExperimentViewRunsCompareMode` type union
- Added a 4th `SegmentedControlButton` with `ImageIcon` to the runs view toolbar (disabled when runs are grouped, same as Artifact mode)
- Created `ImagesCompareView` component (`images-compare/ImagesCompareView.tsx`) that:
  - Shows a `DialogCombobox` dropdown to select an image key (prompt) — union of all keys across runs
  - Displays all runs' images for the selected key in a responsive CSS grid (`repeat(auto-fill, minmax(200px, 1fr))`)
  - Includes a `LineSmoothSlider` step scrubber synced across all runs
  - Shows run name, color pill, and hyperparameters via `ImageGridRunHeader`
  - Handles empty states (no images logged, no data for selected key, no image at selected step)
  - Respects the 10-run limit (`NUM_RUNS_TO_SUPPORT_FOR_LOG_IMAGE`) with a warning indicator
- Reuses existing infrastructure: `usePopulateImagesByRunUuid`, `ImagePlotWithHistory`, `ImageGridRunHeader`, `useImageSliderStepMarks`, `LineSmoothSlider`, Redux `imagesByRunUuid` state

**Why this is needed:**

The existing Image Grid chart in the Chart view shows runs stacked vertically inside small 600px cards — you can only see one run's image at a time and must scroll to compare. With 10 runs × 10 prompts, this means opening individual run pages. The new Images mode shows all runs at a glance in a grid, with a single prompt selector and step slider.

### How is this PR tested?

- [x] Manual tests
- [x] End-to-end test with real training data

 **E2E test:**
Ran 3 FLUX.2 Klein 4B LoRA fine-tuning runs using [ai-toolkit](https://github.com/ostris/ai-toolkit) on Apple Silicon (MPS), each with different hyperparameters. Images logged at multiple training steps using `mlflow.log_image(key=, step=)`.

 | Run | Seed | LR | LoRA Rank | Steps |
 |---|---|---|---|---|
 | able-eel-609 | 42 | 1e-4 | 16 | 30 |
 | judicious-snipe-239 | 99 | 2e-4 | 16 | 10 |
 | nimble-goat-559 | 7 | 5e-5 | 8 | 10 |

 Verified:
 - 3 runs displayed side-by-side in the image grid
 - Image key selector switches between prompts (cat on beach, robot painting, woman playing chess)
 - Step slider scrubs through training steps — images update across all runs
 - Compressed webp thumbnails render correctly
 - Run headers show name + color pill + truncated params
 - Empty state on experiment with no logged images — shows guidance message
 - All 4 view modes (Table, Chart, Artifact, Images) coexist without regressions
 - TypeScript type check passes, Prettier formatted, i18n keys extracted

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/7b73aa6a-1605-44d8-b393-b9a7ed1075f0" />

 
### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Adds a new "Images" comparison mode button in the experiment runs toolbar that displays logged images from all runs side-by-side in a grid, with a prompt selector and step slider for cross-run visual comparison.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release