### PR TITLE
Fix column resizing inconsistency between GenAI and Model Training evaluation tables

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsListTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsListTable.tsx
@@ -92,10 +92,12 @@ const columns: ColumnDef<EvaluationDataset, any>[] = [
     enableSorting: true,
   },
   {
-    id: 'actions',
+    id: COLUMN_IDS.ACTIONS,
     header: '',
     enableSorting: false,
+    enableResizing: false,
     size: 36,
+    minSize: 36,
     maxSize: 36,
     cell: ActionsCell,
   },
@@ -118,29 +120,36 @@ const ExperimentEvaluationDatasetsTableRow: React.FC<
 
     return (
       <TableRow key={row.id} className="eval-datasets-table-row" onClick={() => onSelectDataset(row.original)}>
-        {row.getVisibleCells().map((cell) => (
-          <TableCell
-            key={cell.id}
-            style={{
-              flexGrow: cell.column.getCanResize() ? 0 : 1,
-              flexBasis: cell.column.getCanResize() ? cell.column.getSize() : undefined,
-            }}
-            css={{
-              backgroundColor: isActive ? theme.colors.actionDefaultBackgroundHover : 'transparent',
-              maxWidth: cell.column.columnDef.maxSize ? `${cell.column.columnDef.maxSize}px` : 'auto',
-              minWidth: cell.column.columnDef.minSize ? `${cell.column.columnDef.minSize}px` : 'auto',
-              ...(cell.column.id === 'actions' && { paddingLeft: 0, paddingRight: 0 }),
-            }}
-          >
-            {flexRender(cell.column.columnDef.cell, cell.getContext())}
-          </TableCell>
-        ))}
+        {row.getVisibleCells().map((cell) => {
+          const isFixedWidthColumn = typeof cell.column.columnDef.size === 'number';
+
+          return (
+            <TableCell
+              key={cell.id}
+              style={{
+                flexGrow: cell.column.getCanResize() || isFixedWidthColumn ? 0 : 1,
+                flexBasis: cell.column.getCanResize() || isFixedWidthColumn ? cell.column.getSize() : undefined,
+                flexShrink: !cell.column.getCanResize() && isFixedWidthColumn ? 0 : undefined,
+              }}
+              css={{
+                backgroundColor: isActive ? theme.colors.actionDefaultBackgroundHover : 'transparent',
+                maxWidth: cell.column.columnDef.maxSize ? `${cell.column.columnDef.maxSize}px` : 'auto',
+                minWidth: cell.column.columnDef.minSize ? `${cell.column.columnDef.minSize}px` : 'auto',
+                ...(cell.column.id === COLUMN_IDS.ACTIONS && { paddingLeft: 0, paddingRight: 0 }),
+              }}
+            >
+              {flexRender(cell.column.columnDef.cell, cell.getContext())}
+            </TableCell>
+          );
+        })}
       </TableRow>
     );
   },
   // eslint-disable-next-line react-component-name/react-component-name -- TODO(FEINF-4716)
   (prev, next) => {
     return (
+      prev.row.id === next.row.id &&
+      prev.row.original === next.row.original &&
       prev.isActive === next.isActive &&
       prev.columnSizing === next.columnSizing &&
       isEqual(prev.columnVisibility, next.columnVisibility)
@@ -330,30 +339,36 @@ export const ExperimentEvaluationDatasetsListTable = ({
           scrollable
         >
           <TableRow isHeader>
-            {table.getLeafHeaders().map((header) => (
-              <TableHeader
-                key={header.id}
-                sortable={header.column.getCanSort()}
-                sortDirection={header.column.getIsSorted() as SortDirection}
-                onToggleSort={header.column.getToggleSortingHandler()}
-                componentId="mlflow.eval-datasets.column-header"
-                header={header}
-                column={header.column}
-                setColumnSizing={table.setColumnSizing}
-                isResizing={header.column.getIsResizing()}
-                css={{
-                  flexGrow: header.column.getCanResize() ? 0 : 1,
-                  maxWidth: header.column.columnDef.maxSize ? `${header.column.columnDef.maxSize}px` : 'auto',
-                  minWidth: header.column.columnDef.minSize ? `${header.column.columnDef.minSize}px` : 'auto',
-                  cursor: header.column.getCanSort() ? 'pointer' : 'default',
-                }}
-                style={{
-                  flexBasis: header.column.getCanResize() ? header.column.getSize() : undefined,
-                }}
-              >
-                {flexRender(header.column.columnDef.header, header.getContext())}
-              </TableHeader>
-            ))}
+            {table.getLeafHeaders().map((header) => {
+              const isFixedWidthColumn = typeof header.column.columnDef.size === 'number';
+
+              return (
+                <TableHeader
+                  key={header.id}
+                  sortable={header.column.getCanSort()}
+                  sortDirection={header.column.getIsSorted() as SortDirection}
+                  onToggleSort={header.column.getToggleSortingHandler()}
+                  componentId="mlflow.eval-datasets.column-header"
+                  header={header}
+                  column={header.column}
+                  setColumnSizing={table.setColumnSizing}
+                  isResizing={header.column.getIsResizing()}
+                  css={{
+                    flexGrow: header.column.getCanResize() || isFixedWidthColumn ? 0 : 1,
+                    maxWidth: header.column.columnDef.maxSize ? `${header.column.columnDef.maxSize}px` : 'auto',
+                    minWidth: header.column.columnDef.minSize ? `${header.column.columnDef.minSize}px` : 'auto',
+                    cursor: header.column.getCanSort() ? 'pointer' : 'default',
+                  }}
+                  style={{
+                    flexBasis:
+                      header.column.getCanResize() || isFixedWidthColumn ? header.column.getSize() : undefined,
+                    flexShrink: !header.column.getCanResize() && isFixedWidthColumn ? 0 : undefined,
+                  }}
+                >
+                  {flexRender(header.column.columnDef.header, header.getContext())}
+                </TableHeader>
+              );
+            })}
           </TableRow>
 
           {!isLoading &&

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsListTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsListTable.tsx
@@ -16,7 +16,7 @@ import {
   Typography,
 } from '@databricks/design-system';
 import { useIntl } from '@databricks/i18n';
-import type { ColumnDef, Row, SortDirection, SortingState } from '@tanstack/react-table';
+import type { ColumnDef, ColumnSizingState, Row, SortDirection, SortingState } from '@tanstack/react-table';
 import { flexRender, getCoreRowModel, getSortedRowModel } from '@tanstack/react-table';
 import { useReactTable_unverifiedWithReact18 as useReactTable } from '@databricks/web-shared/react-table';
 import type { EvaluationDataset } from '../types';
@@ -104,6 +104,7 @@ const columns: ColumnDef<EvaluationDataset, any>[] = [
 interface ExperimentEvaluationDatasetsTableRowProps {
   row: Row<EvaluationDataset>;
   columnVisibility: { [key: string]: boolean };
+  columnSizing: ColumnSizingState;
   isActive: boolean;
   onSelectDataset: (dataset: EvaluationDataset) => void;
 }
@@ -120,9 +121,12 @@ const ExperimentEvaluationDatasetsTableRow: React.FC<
         {row.getVisibleCells().map((cell) => (
           <TableCell
             key={cell.id}
+            style={{
+              flexGrow: cell.column.getCanResize() ? 0 : 1,
+              flexBasis: cell.column.getCanResize() ? cell.column.getSize() : undefined,
+            }}
             css={{
               backgroundColor: isActive ? theme.colors.actionDefaultBackgroundHover : 'transparent',
-              width: cell.column.columnDef.size ? `${cell.column.columnDef.size}px` : 'auto',
               maxWidth: cell.column.columnDef.maxSize ? `${cell.column.columnDef.maxSize}px` : 'auto',
               minWidth: cell.column.columnDef.minSize ? `${cell.column.columnDef.minSize}px` : 'auto',
               ...(cell.column.id === 'actions' && { paddingLeft: 0, paddingRight: 0 }),
@@ -136,7 +140,11 @@ const ExperimentEvaluationDatasetsTableRow: React.FC<
   },
   // eslint-disable-next-line react-component-name/react-component-name -- TODO(FEINF-4716)
   (prev, next) => {
-    return prev.isActive === next.isActive && isEqual(prev.columnVisibility, next.columnVisibility);
+    return (
+      prev.isActive === next.isActive &&
+      prev.columnSizing === next.columnSizing &&
+      isEqual(prev.columnVisibility, next.columnVisibility)
+    );
   },
 );
 
@@ -185,6 +193,22 @@ export const ExperimentEvaluationDatasetsListTable = ({
       {} as { [key: string]: boolean },
     ),
   );
+  const selectableColumnIds = columns
+    .map((column) => column.id ?? '')
+    .filter((columnId) => columnId && !UNSELECTABLE_COLUMN_IDS.includes(columnId));
+
+  const setAllSelectableColumnsVisibility = (isVisible: boolean) => {
+    setColumnVisibility((previousVisibility) => {
+      const nextVisibility = { ...previousVisibility };
+
+      selectableColumnIds.forEach((columnId) => {
+        nextVisibility[columnId] = isVisible;
+      });
+
+      return nextVisibility;
+    });
+  };
+
   // Control field that gets updated immediately
   const [internalSearchFilter, setInternalSearchFilter] = useState(searchFilter);
 
@@ -198,7 +222,8 @@ export const ExperimentEvaluationDatasetsListTable = ({
       enableSorting: true,
       onSortingChange: setSorting,
       getSortedRowModel: getSortedRowModel(),
-      enableColumnResizing: false,
+      enableColumnResizing: true,
+      columnResizeMode: 'onChange',
       state: {
         sorting,
         columnVisibility,
@@ -250,6 +275,19 @@ export const ExperimentEvaluationDatasetsListTable = ({
               <Button icon={<ColumnsIcon />} componentId="mlflow.eval-datasets.table-column-selector-button" />
             </DropdownMenu.Trigger>
             <DropdownMenu.Content>
+              <DropdownMenu.Item
+                componentId="mlflow.eval-datasets.table-column-selector-select-all"
+                onClick={() => setAllSelectableColumnsVisibility(true)}
+              >
+                Select all columns
+              </DropdownMenu.Item>
+              <DropdownMenu.Item
+                componentId="mlflow.eval-datasets.table-column-selector-deselect-all"
+                onClick={() => setAllSelectableColumnsVisibility(false)}
+              >
+                Deselect all columns
+              </DropdownMenu.Item>
+              <DropdownMenu.Separator />
               {columns.map(
                 (column) =>
                   !UNSELECTABLE_COLUMN_IDS.includes(column.id ?? '') && (
@@ -257,12 +295,13 @@ export const ExperimentEvaluationDatasetsListTable = ({
                       componentId="mlflow.eval-datasets.table-column-selector-checkbox"
                       key={column.id ?? ''}
                       checked={columnVisibility[column.id ?? ''] ?? false}
-                      onCheckedChange={(checked) =>
-                        setColumnVisibility({
-                          ...columnVisibility,
-                          [column.id ?? '']: checked,
-                        })
-                      }
+                      onCheckedChange={(checked) => {
+                        const columnId = column.id ?? '';
+                        setColumnVisibility((previousVisibility) => ({
+                          ...previousVisibility,
+                          [columnId]: Boolean(checked),
+                        }));
+                      }}
                     >
                       <DropdownMenu.ItemIndicator />
                       <Typography.Text>{column.header}</Typography.Text>
@@ -300,11 +339,16 @@ export const ExperimentEvaluationDatasetsListTable = ({
                 componentId="mlflow.eval-datasets.column-header"
                 header={header}
                 column={header.column}
+                setColumnSizing={table.setColumnSizing}
+                isResizing={header.column.getIsResizing()}
                 css={{
-                  width: header.column.columnDef.size ? `${header.column.columnDef.size}px` : 'auto',
+                  flexGrow: header.column.getCanResize() ? 0 : 1,
                   maxWidth: header.column.columnDef.maxSize ? `${header.column.columnDef.maxSize}px` : 'auto',
                   minWidth: header.column.columnDef.minSize ? `${header.column.columnDef.minSize}px` : 'auto',
                   cursor: header.column.getCanSort() ? 'pointer' : 'default',
+                }}
+                style={{
+                  flexBasis: header.column.getCanResize() ? header.column.getSize() : undefined,
                 }}
               >
                 {flexRender(header.column.columnDef.header, header.getContext())}
@@ -320,6 +364,7 @@ export const ExperimentEvaluationDatasetsListTable = ({
                   key={row.id}
                   row={row}
                   columnVisibility={columnVisibility}
+                  columnSizing={table.getState().columnSizing}
                   isActive={row.original.dataset_id === selectedDatasetId}
                   onSelectDataset={(dataset) => setSelectedDatasetId(dataset.dataset_id)}
                 />


### PR DESCRIPTION
Ensure evaluation dataset rows rerender when column sizing changes and use matching flex-basis sizing for headers and cells so drag updates apply immediately.

Also add select/deselect-all controls in the column selector to align behavior across evaluation run screens.

Refs #22323

<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #22323 

### What changes are proposed in this pull request?

* Ensure evaluation dataset rows rerender when column sizing changes.
* Use matching flex-basis sizing for headers and cells so drag updates apply immediately.
* Add Select all columns and Deselect all columns controls in the column selector for behavior parity across evaluation run screens.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->



https://github.com/user-attachments/assets/ecf9efd3-8be5-4b81-aea1-8bb42f90c653


### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Fixed a UI issue in evaluation datasets where column resizing did not immediately update row cells, and added bulk select/deselect controls for column visibility.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
