### PR TITLE
Fix Gemini autolog image test to expect `mlflow-attachment://` URIs

### DIFF
--- a/tests/gemini/test_gemini_autolog.py
+++ b/tests/gemini/test_gemini_autolog.py
@@ -269,11 +269,13 @@ def test_generate_content_image_autolog(mock_litellm_cost):
     assert span.span_type == SpanType.LLM
     assert span.inputs["model"] == "gemini-1.5-flash"
     extra = {"display_name": None} if google_gemini_version >= Version("1.15.0") else {}
-    assert span.inputs["contents"][0]["inline_data"] == {
-        "data": "b'image'",
-        "mime_type": "image/jpeg",
-        **extra,
-    }
+    inline_data = span.inputs["contents"][0]["inline_data"]
+    assert inline_data["mime_type"] == "image/jpeg"
+    # Auto-extraction replaces bytes repr with mlflow-attachment:// URI
+    assert inline_data["data"].startswith("mlflow-attachment://")
+    assert "content_type=image%2Fjpeg" in inline_data["data"]
+    if extra:
+        assert inline_data["display_name"] is None
     assert span.inputs["contents"][1] == "Caption this image"
     assert span.outputs == _DUMMY_GENERATE_CONTENT_RESPONSE.model_dump()
     assert span.model_name == "gemini-1.5-flash"
@@ -283,11 +285,12 @@ def test_generate_content_image_autolog(mock_litellm_cost):
     assert span1.span_type == SpanType.LLM
     assert span1.parent_id == span.span_id
     assert span1.inputs["model"] == "gemini-1.5-flash"
-    assert span1.inputs["contents"][0]["inline_data"] == {
-        "data": "b'image'",
-        "mime_type": "image/jpeg",
-        **extra,
-    }
+    inline_data1 = span1.inputs["contents"][0]["inline_data"]
+    assert inline_data1["mime_type"] == "image/jpeg"
+    assert inline_data1["data"].startswith("mlflow-attachment://")
+    assert "content_type=image%2Fjpeg" in inline_data1["data"]
+    if extra:
+        assert inline_data1["display_name"] is None
     assert span1.inputs["contents"][1] == "Caption this image"
     assert span1.outputs == _DUMMY_GENERATE_CONTENT_RESPONSE.model_dump()
 


### PR DESCRIPTION
### Related Issues/PRs

Fixes cross-version test failure from #22453

### What changes are proposed in this pull request?

PR #22453 added auto-extraction of Gemini SDK bytes repr format (`b'\x89PNG...'`) into `mlflow-attachment://` URIs. The `test_generate_content_image_autolog` test still expected the raw bytes repr string `"b'image'"` in the span's `inline_data.data` field.

Updated the test to assert that:
- `inline_data.data` starts with `mlflow-attachment://`
- The attachment URI contains the correct `content_type=image%2Fjpeg` parameter
- `mime_type` and `display_name` fields are unchanged

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

The fixed test `test_generate_content_image_autolog` passes locally.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release