### PR TITLE
Fix incorrect cost calculation for Anthropic cached requests

### DIFF
--- a/mlflow/anthropic/autolog.py
+++ b/mlflow/anthropic/autolog.py
@@ -185,6 +185,13 @@ def _parse_usage(output: Any) -> dict[str, int] | None:
                 usage_dict[TokenUsageKey.CACHE_READ_INPUT_TOKENS] = cached
             if (created := getattr(usage, "cache_creation_input_tokens", None)) is not None:
                 usage_dict[TokenUsageKey.CACHE_CREATION_INPUT_TOKENS] = created
+            # Anthropic reports input_tokens excluding cache tokens. Normalize to
+            # include them, consistent with OpenAI/Gemini and cost_per_token().
+            # Same logic as _normalize_anthropic_input_tokens in gateway/providers/anthropic.py.
+            cache_total = (cached or 0) + (created or 0)
+            if cache_total:
+                usage_dict[TokenUsageKey.INPUT_TOKENS] += cache_total
+                usage_dict[TokenUsageKey.TOTAL_TOKENS] += cache_total
             return usage_dict
     except Exception as e:
         _logger.debug(f"Failed to parse token usage from output: {e}")

--- a/mlflow/anthropic/autolog.py
+++ b/mlflow/anthropic/autolog.py
@@ -188,8 +188,7 @@ def _parse_usage(output: Any) -> dict[str, int] | None:
             # Anthropic reports input_tokens excluding cache tokens. Normalize to
             # include them, consistent with OpenAI/Gemini and cost_per_token().
             # Same logic as _normalize_anthropic_input_tokens in gateway/providers/anthropic.py.
-            cache_total = (cached or 0) + (created or 0)
-            if cache_total:
+            if cache_total := (cached or 0) + (created or 0):
                 usage_dict[TokenUsageKey.INPUT_TOKENS] += cache_total
                 usage_dict[TokenUsageKey.TOTAL_TOKENS] += cache_total
             return usage_dict

--- a/mlflow/gateway/providers/litellm.py
+++ b/mlflow/gateway/providers/litellm.py
@@ -6,6 +6,7 @@ from typing import Any, AsyncIterable
 
 from mlflow.exceptions import MlflowException
 from mlflow.gateway.config import EndpointConfig, LiteLLMConfig
+from mlflow.gateway.providers.anthropic import _normalize_anthropic_input_tokens
 from mlflow.gateway.providers.base import BaseProvider, PassthroughAction, ProviderAdapter
 from mlflow.gateway.schemas import chat, embeddings
 from mlflow.gateway.utils import parse_sse_lines
@@ -273,7 +274,8 @@ class LiteLLMProvider(BaseProvider):
             cache_read_key="cache_read_input_tokens",
             cache_creation_key="cache_creation_input_tokens",
         ):
-            return token_usage
+            # Anthropic reports input_tokens excluding cache tokens — normalize.
+            return _normalize_anthropic_input_tokens(token_usage)
 
         # Try Gemini format
         return self._extract_token_usage_from_dict(

--- a/tests/anthropic/test_anthropic_autolog.py
+++ b/tests/anthropic/test_anthropic_autolog.py
@@ -439,18 +439,20 @@ def test_messages_autolog_with_cached_tokens(is_async, mock_litellm_cost):
     assert traces[0].info.status == "OK"
     span = traces[0].data.spans[0]
 
+    # Anthropic's input_tokens (50) excludes cache tokens. After normalization:
+    # input_tokens = 50 + 25 (cache_read) + 15 (cache_creation) = 90
     assert span.get_attribute(SpanAttributeKey.CHAT_USAGE) == {
-        TokenUsageKey.INPUT_TOKENS: 50,
+        TokenUsageKey.INPUT_TOKENS: 90,
         TokenUsageKey.OUTPUT_TOKENS: 20,
-        TokenUsageKey.TOTAL_TOKENS: 70,
+        TokenUsageKey.TOTAL_TOKENS: 110,
         TokenUsageKey.CACHE_READ_INPUT_TOKENS: 25,
         TokenUsageKey.CACHE_CREATION_INPUT_TOKENS: 15,
     }
 
     assert traces[0].info.token_usage == {
-        TokenUsageKey.INPUT_TOKENS: 50,
+        TokenUsageKey.INPUT_TOKENS: 90,
         TokenUsageKey.OUTPUT_TOKENS: 20,
-        TokenUsageKey.TOTAL_TOKENS: 70,
+        TokenUsageKey.TOTAL_TOKENS: 110,
         TokenUsageKey.CACHE_READ_INPUT_TOKENS: 25,
         TokenUsageKey.CACHE_CREATION_INPUT_TOKENS: 15,
     }

--- a/tests/gateway/providers/test_litellm.py
+++ b/tests/gateway/providers/test_litellm.py
@@ -856,9 +856,9 @@ def test_litellm_extract_passthrough_token_usage_anthropic_with_cached_tokens():
         PassthroughAction.ANTHROPIC_MESSAGES, result
     )
     assert token_usage == {
-        "input_tokens": 100,
+        "input_tokens": 140,
         "output_tokens": 50,
-        "total_tokens": 150,
+        "total_tokens": 190,
         "cache_read_input_tokens": 25,
         "cache_creation_input_tokens": 15,
     }


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Relates to #22444

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Anthropic's API reports `input_tokens` as only the non-cached portion, unlike OpenAI and Gemini which include cache tokens in their `prompt_tokens`/`prompt_token_count`. This caused `cost_per_token()` to miscalculate costs because it expects `prompt_tokens` to include all input tokens (it subtracts cache tokens internally to price each category).

This PR normalizes `input_tokens` to include `cache_read_input_tokens` and `cache_creation_input_tokens` in two places:
- `mlflow/anthropic/autolog.py`: direct Anthropic SDK usage
- `mlflow/gateway/providers/litellm.py`: LiteLLM gateway with Anthropic format responses

This mirrors the existing normalization in `gateway/providers/anthropic.py` (`_normalize_anthropic_input_tokens`) which already handles this correctly for the direct Anthropic gateway provider.

**Note:** the LangChain+Anthropic path (`mlflow/langchain/utils/chat.py`) has the same issue but cannot be safely fixed without provider context, as the shared `_parse_token_counts` function handles both OpenAI and Anthropic formats. This should be addressed separately.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

Fix incorrect cost calculation for Anthropic cached requests when using the Anthropic SDK directly or via LiteLLM gateway. `cost_per_token()` previously undercounted input costs because Anthropic's `input_tokens` excludes cache tokens.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
