### PR TITLE
Add job persistence schema for execution recovery

### DIFF
--- a/mlflow/store/db_migrations/versions/dc11669786a5_add_job_executor_persistence_model.py
+++ b/mlflow/store/db_migrations/versions/dc11669786a5_add_job_executor_persistence_model.py
@@ -16,8 +16,8 @@ down_revision = "ae8bbe7743c9"
 branch_labels = None
 depends_on = None
 
-_LEGACY_PENDING = 0
-_LEGACY_RUNNING = 1
+_PENDING = 0
+_RUNNING = 1
 _CANCELED = 5
 
 
@@ -28,12 +28,12 @@ def _get_json_type():
     return sa.JSON
 
 
-def _cancel_non_terminal_legacy_jobs():
+def _cancel_non_terminal_jobs():
     jobs = sa.table("jobs", sa.column("status"), sa.column("last_update_time"))
     op.execute(
         jobs
         .update()
-        .where(jobs.c.status.in_([_LEGACY_PENDING, _LEGACY_RUNNING]))
+        .where(jobs.c.status.in_([_PENDING, _RUNNING]))
         .values(status=_CANCELED, last_update_time=int(time.time() * 1000))
     )
 
@@ -80,7 +80,7 @@ def upgrade():
             unique=False,
         )
 
-    _cancel_non_terminal_legacy_jobs()
+    _cancel_non_terminal_jobs()
 
 
 def downgrade():

--- a/mlflow/store/db_migrations/versions/dc11669786a5_add_job_executor_persistence_model.py
+++ b/mlflow/store/db_migrations/versions/dc11669786a5_add_job_executor_persistence_model.py
@@ -1,0 +1,101 @@
+"""add job executor persistence model
+
+Create Date: 2026-04-07 14:19:33.487151
+
+"""
+
+import time
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import mssql
+
+# revision identifiers, used by Alembic.
+revision = "dc11669786a5"
+down_revision = "ae8bbe7743c9"
+branch_labels = None
+depends_on = None
+
+_LEGACY_PENDING = 0
+_LEGACY_RUNNING = 1
+_CANCELED = 5
+
+
+def _get_json_type():
+    dialect_name = op.get_bind().dialect.name
+    if dialect_name == "mssql":
+        return mssql.JSON
+    return sa.JSON
+
+
+def _cancel_non_terminal_legacy_jobs():
+    jobs = sa.table("jobs", sa.column("status"), sa.column("last_update_time"))
+    op.execute(
+        jobs
+        .update()
+        .where(jobs.c.status.in_([_LEGACY_PENDING, _LEGACY_RUNNING]))
+        .values(status=_CANCELED, last_update_time=int(time.time() * 1000))
+    )
+
+
+def upgrade():
+    json_type = _get_json_type()
+
+    op.create_table(
+        "scheduler_leases",
+        sa.Column("lease_key", sa.String(length=255), nullable=False),
+        sa.Column("acquired_at", sa.BigInteger(), nullable=False),
+        sa.Column("ttl_seconds", sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint("lease_key", name="scheduler_leases_pk"),
+    )
+
+    op.create_table(
+        "job_locks",
+        sa.Column("lock_key", sa.String(length=255), nullable=False),
+        sa.Column("job_id", sa.String(length=36), nullable=False),
+        sa.Column("acquired_at", sa.BigInteger(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["job_id"],
+            ["jobs.id"],
+            name="fk_job_locks_job_id",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("lock_key", name="job_locks_pk"),
+    )
+
+    with op.batch_alter_table("job_locks") as batch_op:
+        batch_op.create_index("index_job_locks_job_id", ["job_id"], unique=False)
+
+    with op.batch_alter_table("jobs") as batch_op:
+        batch_op.add_column(sa.Column("executor_backend", sa.String(length=255), nullable=True))
+        batch_op.add_column(sa.Column("lease_expires_at", sa.BigInteger(), nullable=True))
+        batch_op.add_column(sa.Column("status_message", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("progress_payload", json_type, nullable=True))
+        batch_op.add_column(sa.Column("progress_updated_at", sa.BigInteger(), nullable=True))
+        batch_op.add_column(sa.Column("token_hash", sa.String(length=64), nullable=True))
+        batch_op.add_column(sa.Column("scoped_permissions", json_type, nullable=True))
+        batch_op.create_index(
+            "index_jobs_status_lease_expires_at",
+            ["status", "lease_expires_at"],
+            unique=False,
+        )
+
+    _cancel_non_terminal_legacy_jobs()
+
+
+def downgrade():
+    with op.batch_alter_table("jobs") as batch_op:
+        batch_op.drop_index("index_jobs_status_lease_expires_at")
+        batch_op.drop_column("scoped_permissions")
+        batch_op.drop_column("token_hash")
+        batch_op.drop_column("progress_updated_at")
+        batch_op.drop_column("progress_payload")
+        batch_op.drop_column("status_message")
+        batch_op.drop_column("lease_expires_at")
+        batch_op.drop_column("executor_backend")
+
+    with op.batch_alter_table("job_locks") as batch_op:
+        batch_op.drop_index("index_job_locks_job_id")
+
+    op.drop_table("job_locks")
+    op.drop_table("scheduler_leases")

--- a/mlflow/store/jobs/abstract_store.py
+++ b/mlflow/store/jobs/abstract_store.py
@@ -3,7 +3,19 @@ from typing import Any, Iterator
 
 from mlflow.entities._job import Job
 from mlflow.entities._job_status import JobStatus
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.utils.annotations import developer_stable
+
+
+class JobTerminalStateUpdateException(MlflowException):
+    """Raised when attempting to update a job that is already terminal."""
+
+    def __init__(self, job_id: str, status: str):
+        super().__init__(
+            f"The Job {job_id} is already finalized with status: {status}, it can't be updated.",
+            error_code=INVALID_PARAMETER_VALUE,
+        )
 
 
 @developer_stable

--- a/mlflow/store/jobs/sqlalchemy_store.py
+++ b/mlflow/store/jobs/sqlalchemy_store.py
@@ -145,7 +145,7 @@ class SqlAlchemyJobStore(AbstractJobStore):
         with self.ManagedSessionMaker() as session:
             job = self._get_sql_job(session, job_id)
 
-            if JobStatus.is_finalized(job.status):
+            if JobStatus.is_finalized(JobStatus.from_int(job.status)):
                 raise MlflowException.invalid_parameter_value(
                     "The Job "
                     f"{job_id} is already finalized with status: {JobStatus.from_int(job.status)}, "
@@ -256,7 +256,7 @@ class SqlAlchemyJobStore(AbstractJobStore):
         with self.ManagedSessionMaker() as session:
             job = self._get_sql_job(session, job_id)
 
-            if JobStatus.is_finalized(job.status):
+            if JobStatus.is_finalized(JobStatus.from_int(job.status)):
                 raise MlflowException.invalid_parameter_value(
                     "The Job "
                     f"{job_id} is already finalized with status: {JobStatus.from_int(job.status)}, "
@@ -464,7 +464,7 @@ class SqlAlchemyJobStore(AbstractJobStore):
         with self.ManagedSessionMaker() as session:
             job = self._get_sql_job(session, job_id)
 
-            if JobStatus.is_finalized(job.status):
+            if JobStatus.is_finalized(JobStatus.from_int(job.status)):
                 raise JobTerminalStateUpdateException(job_id, JobStatus.from_int(job.status))
 
             # Merge new status details with existing

--- a/mlflow/store/jobs/sqlalchemy_store.py
+++ b/mlflow/store/jobs/sqlalchemy_store.py
@@ -14,7 +14,7 @@ from mlflow.store.db.utils import (
     _safe_initialize_tables,
     create_sqlalchemy_engine_with_retry,
 )
-from mlflow.store.jobs.abstract_store import AbstractJobStore
+from mlflow.store.jobs.abstract_store import AbstractJobStore, JobTerminalStateUpdateException
 from mlflow.store.tracking.dbmodels.models import SqlJob
 from mlflow.utils.time import get_current_time_millis
 from mlflow.utils.uri import extract_db_type_from_uri
@@ -86,6 +86,23 @@ class SqlAlchemyJobStore(AbstractJobStore):
             instance.workspace = DEFAULT_WORKSPACE_NAME
         return instance
 
+    @staticmethod
+    def _clear_job_transient_fields(job: SqlJob) -> None:
+        # TODO: Move job lifecycle transition policy out of the store once the
+        # framework owns a shared state-machine/transition layer. The store
+        # should still apply the resulting field updates atomically.
+        job.lease_expires_at = None
+        job.status_message = None
+        job.progress_payload = None
+        job.progress_updated_at = None
+        job.token_hash = None
+        job.scoped_permissions = None
+
+    @classmethod
+    def _reset_job_for_pending(cls, job: SqlJob) -> None:
+        job.result = None
+        cls._clear_job_transient_fields(job)
+
     def create_job(self, job_name: str, params: str, timeout: float | None = None) -> Job:
         """
         Create a new job with the specified function and parameters.
@@ -119,19 +136,30 @@ class SqlAlchemyJobStore(AbstractJobStore):
             session.flush()
             return job.to_mlflow_entity()
 
-    def _update_job(self, job_id: str, new_status: JobStatus, result: str | None = None) -> Job:
+    def _update_job(
+        self,
+        job_id: str,
+        new_status: JobStatus,
+        result: str | None = None,
+    ) -> Job:
         with self.ManagedSessionMaker() as session:
             job = self._get_sql_job(session, job_id)
 
             if JobStatus.is_finalized(job.status):
-                raise MlflowException(
-                    f"The Job {job_id} is already finalized with status: {job.status}, "
+                raise MlflowException.invalid_parameter_value(
+                    "The Job "
+                    f"{job_id} is already finalized with status: {JobStatus.from_int(job.status)}, "
                     "it can't be updated."
                 )
 
             job.status = new_status.to_int()
-            if result is not None:
-                job.result = result
+            if new_status == JobStatus.PENDING:
+                self._reset_job_for_pending(job)
+            else:
+                if result is not None:
+                    job.result = result
+                if JobStatus.is_finalized(new_status):
+                    self._clear_job_transient_fields(job)
             job.last_update_time = get_current_time_millis()
             return job.to_mlflow_entity()
 
@@ -228,12 +256,22 @@ class SqlAlchemyJobStore(AbstractJobStore):
         with self.ManagedSessionMaker() as session:
             job = self._get_sql_job(session, job_id)
 
+            if JobStatus.is_finalized(job.status):
+                raise MlflowException.invalid_parameter_value(
+                    "The Job "
+                    f"{job_id} is already finalized with status: {JobStatus.from_int(job.status)}, "
+                    "it can't be updated."
+                )
+
             if job.retry_count >= max_retries:
                 job.status = JobStatus.FAILED.to_int()
                 job.result = error
+                self._clear_job_transient_fields(job)
+                job.last_update_time = get_current_time_millis()
                 return None
             job.retry_count += 1
             job.status = JobStatus.PENDING.to_int()
+            self._reset_job_for_pending(job)
             job.last_update_time = get_current_time_millis()
             return job.retry_count
 
@@ -425,6 +463,9 @@ class SqlAlchemyJobStore(AbstractJobStore):
         """
         with self.ManagedSessionMaker() as session:
             job = self._get_sql_job(session, job_id)
+
+            if JobStatus.is_finalized(job.status):
+                raise JobTerminalStateUpdateException(job_id, JobStatus.from_int(job.status))
 
             # Merge new status details with existing
             current_details = job.status_details or {}

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -22,7 +22,7 @@ from sqlalchemy import (
     UnicodeText,
     UniqueConstraint,
 )
-from sqlalchemy.ext.mutable import MutableDict
+from sqlalchemy.ext.mutable import MutableDict, MutableList
 from sqlalchemy.inspection import inspect
 from sqlalchemy.orm import backref, relationship
 
@@ -111,8 +111,9 @@ RunStatusTypes = [
 ]
 
 
-# Create MutableJSON type for tracking mutations in JSON columns
+# Create mutable JSON types for tracking mutations in JSON columns.
 MutableJSON = MutableDict.as_mutable(JSON)
+MutableJSONArray = MutableList.as_mutable(JSON)
 
 
 class SqlExperiment(Base):
@@ -2333,6 +2334,41 @@ class SqlJob(Base):
     Last Update time of experiment: `BigInteger`.
     """
 
+    executor_backend = Column(String(255), nullable=True)
+    """
+    Persisted executor backend name for retry, cancellation, and recovery: `String` (limit 255).
+    """
+
+    lease_expires_at = Column(BigInteger(), nullable=True)
+    """
+    Lease expiration timestamp in milliseconds since the UNIX epoch: `BigInteger`.
+    """
+
+    status_message = Column(Text, nullable=True)
+    """
+    Latest best-effort in-flight status message: `Text`.
+    """
+
+    progress_payload = Column(MutableJSON, nullable=True)
+    """
+    Latest best-effort structured progress payload: `JSON`.
+    """
+
+    progress_updated_at = Column(BigInteger(), nullable=True)
+    """
+    Progress update timestamp in milliseconds since the UNIX epoch: `BigInteger`.
+    """
+
+    token_hash = Column(String(64), nullable=True)
+    """
+    SHA-256 hex digest of the remote execution token: `String` (limit 64).
+    """
+
+    scoped_permissions = Column(MutableJSONArray, nullable=True)
+    """
+    Persisted remote-execution scoped permissions list: `JSON`.
+    """
+
     status_details = Column(MutableJSON, nullable=True)
     """
     Job status details: `JSON`.
@@ -2347,6 +2383,11 @@ class SqlJob(Base):
             "workspace",
             "status",
             "creation_time",
+        ),
+        Index(
+            "index_jobs_status_lease_expires_at",
+            "status",
+            "lease_expires_at",
         ),
     )
 
@@ -2376,6 +2417,68 @@ class SqlJob(Base):
             workspace=self.workspace,
             status_details=self.status_details,
         )
+
+
+class SqlJobLock(Base):
+    """
+    DB model for framework-managed exclusive job locks.
+
+    These are recorded in the ``job_locks`` table.
+    """
+
+    __tablename__ = "job_locks"
+
+    lock_key = Column(String(255), nullable=False)
+    """
+    Framework-computed exclusive lock key: `String` (limit 255). Primary key.
+    """
+
+    job_id = Column(String(36), ForeignKey("jobs.id", ondelete="CASCADE"), nullable=False)
+    """
+    Holding job ID: `String` (limit 36). Foreign key into ``jobs`` table.
+    """
+
+    acquired_at = Column(BigInteger(), default=get_current_time_millis, nullable=False)
+    """
+    Lock acquisition timestamp in milliseconds since the UNIX epoch: `BigInteger`.
+    """
+
+    __table_args__ = (
+        PrimaryKeyConstraint("lock_key", name="job_locks_pk"),
+        Index("index_job_locks_job_id", "job_id"),
+    )
+
+    def __repr__(self):
+        return f"<SqlJobLock ({self.lock_key}, {self.job_id})>"
+
+
+class SqlSchedulerLease(Base):
+    """
+    DB model for framework-managed scheduler leases. These are recorded in the
+    ``scheduler_leases`` table.
+    """
+
+    __tablename__ = "scheduler_leases"
+
+    lease_key = Column(String(255), nullable=False)
+    """
+    Scheduler lease key: `String` (limit 255). Primary key.
+    """
+
+    acquired_at = Column(BigInteger(), default=get_current_time_millis, nullable=False)
+    """
+    Lease acquisition / renewal timestamp in milliseconds since the UNIX epoch: `BigInteger`.
+    """
+
+    ttl_seconds = Column(Integer, nullable=False)
+    """
+    Lease time-to-live in seconds: `Integer`.
+    """
+
+    __table_args__ = (PrimaryKeyConstraint("lease_key", name="scheduler_leases_pk"),)
+
+    def __repr__(self):
+        return f"<SqlSchedulerLease ({self.lease_key}, {self.acquired_at})>"
 
 
 class SqlGatewaySecret(Base):

--- a/tests/db/schemas/mssql.sql
+++ b/tests/db/schemas/mssql.sql
@@ -92,6 +92,13 @@ CREATE TABLE jobs (
 	last_update_time BIGINT NOT NULL,
 	workspace VARCHAR(63) COLLATE "SQL_Latin1_General_CP1_CI_AS" DEFAULT ('default') NOT NULL,
 	status_details NVARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	executor_backend VARCHAR(255) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	lease_expires_at BIGINT,
+	status_message VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	progress_payload NVARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	progress_updated_at BIGINT,
+	token_hash VARCHAR(64) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	scoped_permissions NVARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	CONSTRAINT jobs_pk PRIMARY KEY (id)
 )
 
@@ -103,6 +110,14 @@ CREATE TABLE registered_models (
 	description VARCHAR(5000) COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	workspace VARCHAR(63) COLLATE "SQL_Latin1_General_CP1_CI_AS" DEFAULT ('default') NOT NULL,
 	CONSTRAINT registered_model_pk PRIMARY KEY (workspace, name)
+)
+
+
+CREATE TABLE scheduler_leases (
+	lease_key VARCHAR(255) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	acquired_at BIGINT NOT NULL,
+	ttl_seconds INTEGER NOT NULL,
+	CONSTRAINT scheduler_leases_pk PRIMARY KEY (lease_key)
 )
 
 
@@ -216,6 +231,15 @@ CREATE TABLE experiment_tags (
 	experiment_id INTEGER NOT NULL,
 	CONSTRAINT experiment_tag_pk PRIMARY KEY (key, experiment_id),
 	CONSTRAINT "FK__experimen__exper__628FA481" FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+)
+
+
+CREATE TABLE job_locks (
+	lock_key VARCHAR(255) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	job_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	acquired_at BIGINT NOT NULL,
+	CONSTRAINT job_locks_pk PRIMARY KEY (lock_key),
+	CONSTRAINT fk_job_locks_job_id FOREIGN KEY(job_id) REFERENCES jobs (id) ON DELETE CASCADE
 )
 
 

--- a/tests/db/schemas/mysql.sql
+++ b/tests/db/schemas/mysql.sql
@@ -93,6 +93,13 @@ CREATE TABLE jobs (
 	last_update_time BIGINT NOT NULL,
 	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
 	status_details JSON,
+	executor_backend VARCHAR(255),
+	lease_expires_at BIGINT,
+	status_message TEXT,
+	progress_payload JSON,
+	progress_updated_at BIGINT,
+	token_hash VARCHAR(64),
+	scoped_permissions JSON,
 	PRIMARY KEY (id)
 )
 
@@ -104,6 +111,14 @@ CREATE TABLE registered_models (
 	description VARCHAR(5000),
 	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
 	PRIMARY KEY (workspace, name)
+)
+
+
+CREATE TABLE scheduler_leases (
+	lease_key VARCHAR(255) NOT NULL,
+	acquired_at BIGINT NOT NULL,
+	ttl_seconds INTEGER NOT NULL,
+	CONSTRAINT scheduler_leases_pk PRIMARY KEY (lease_key)
 )
 
 
@@ -217,6 +232,15 @@ CREATE TABLE experiment_tags (
 	experiment_id INTEGER NOT NULL,
 	PRIMARY KEY (key, experiment_id),
 	CONSTRAINT experiment_tags_ibfk_1 FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+)
+
+
+CREATE TABLE job_locks (
+	lock_key VARCHAR(255) NOT NULL,
+	job_id VARCHAR(36) NOT NULL,
+	acquired_at BIGINT NOT NULL,
+	PRIMARY KEY (lock_key),
+	CONSTRAINT fk_job_locks_job_id FOREIGN KEY(job_id) REFERENCES jobs (id) ON DELETE CASCADE
 )
 
 

--- a/tests/db/schemas/postgresql.sql
+++ b/tests/db/schemas/postgresql.sql
@@ -93,6 +93,13 @@ CREATE TABLE jobs (
 	last_update_time BIGINT NOT NULL,
 	workspace VARCHAR(63) DEFAULT 'default'::character varying NOT NULL,
 	status_details JSON,
+	executor_backend VARCHAR(255),
+	lease_expires_at BIGINT,
+	status_message TEXT,
+	progress_payload JSON,
+	progress_updated_at BIGINT,
+	token_hash VARCHAR(64),
+	scoped_permissions JSON,
 	CONSTRAINT jobs_pk PRIMARY KEY (id)
 )
 
@@ -104,6 +111,14 @@ CREATE TABLE registered_models (
 	description VARCHAR(5000),
 	workspace VARCHAR(63) DEFAULT 'default'::character varying NOT NULL,
 	CONSTRAINT registered_model_pk PRIMARY KEY (workspace, name)
+)
+
+
+CREATE TABLE scheduler_leases (
+	lease_key VARCHAR(255) NOT NULL,
+	acquired_at BIGINT NOT NULL,
+	ttl_seconds INTEGER NOT NULL,
+	CONSTRAINT scheduler_leases_pk PRIMARY KEY (lease_key)
 )
 
 
@@ -218,6 +233,15 @@ CREATE TABLE experiment_tags (
 	experiment_id INTEGER NOT NULL,
 	CONSTRAINT experiment_tag_pk PRIMARY KEY (key, experiment_id),
 	CONSTRAINT experiment_tags_experiment_id_fkey FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+)
+
+
+CREATE TABLE job_locks (
+	lock_key VARCHAR(255) NOT NULL,
+	job_id VARCHAR(36) NOT NULL,
+	acquired_at BIGINT NOT NULL,
+	CONSTRAINT job_locks_pk PRIMARY KEY (lock_key),
+	CONSTRAINT fk_job_locks_job_id FOREIGN KEY(job_id) REFERENCES jobs (id) ON DELETE CASCADE
 )
 
 

--- a/tests/db/schemas/sqlite.sql
+++ b/tests/db/schemas/sqlite.sql
@@ -93,6 +93,13 @@ CREATE TABLE jobs (
 	last_update_time BIGINT NOT NULL,
 	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
 	status_details JSON,
+	executor_backend VARCHAR(255),
+	lease_expires_at BIGINT,
+	status_message TEXT,
+	progress_payload JSON,
+	progress_updated_at BIGINT,
+	token_hash VARCHAR(64),
+	scoped_permissions JSON,
 	CONSTRAINT jobs_pk PRIMARY KEY (id)
 )
 
@@ -104,6 +111,14 @@ CREATE TABLE registered_models (
 	description VARCHAR(5000),
 	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
 	CONSTRAINT registered_model_pk PRIMARY KEY (workspace, name)
+)
+
+
+CREATE TABLE scheduler_leases (
+	lease_key VARCHAR(255) NOT NULL,
+	acquired_at BIGINT NOT NULL,
+	ttl_seconds INTEGER NOT NULL,
+	CONSTRAINT scheduler_leases_pk PRIMARY KEY (lease_key)
 )
 
 
@@ -218,6 +233,15 @@ CREATE TABLE experiment_tags (
 	experiment_id INTEGER NOT NULL,
 	CONSTRAINT experiment_tag_pk PRIMARY KEY (key, experiment_id),
 	FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+)
+
+
+CREATE TABLE job_locks (
+	lock_key VARCHAR(255) NOT NULL,
+	job_id VARCHAR(36) NOT NULL,
+	acquired_at BIGINT NOT NULL,
+	CONSTRAINT job_locks_pk PRIMARY KEY (lock_key),
+	CONSTRAINT fk_job_locks_job_id FOREIGN KEY(job_id) REFERENCES jobs (id) ON DELETE CASCADE
 )
 
 

--- a/tests/db/test_job_persistence_migration.py
+++ b/tests/db/test_job_persistence_migration.py
@@ -1,0 +1,136 @@
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic import command
+
+from mlflow.entities._job_status import JobStatus
+from mlflow.environment_variables import MLFLOW_ENABLE_WORKSPACES
+from mlflow.store.db.utils import _get_alembic_config
+from mlflow.store.jobs.sqlalchemy_workspace_store import WorkspaceAwareSqlAlchemyJobStore
+from mlflow.store.tracking.dbmodels.initial_models import Base as InitialBase
+from mlflow.utils.workspace_context import WorkspaceContext
+
+REVISION = "dc11669786a5"
+PREVIOUS_REVISION = "ae8bbe7743c9"
+
+_LEGACY_JOBS = sa.table(
+    "jobs",
+    sa.column("id"),
+    sa.column("creation_time"),
+    sa.column("job_name"),
+    sa.column("params"),
+    sa.column("workspace"),
+    sa.column("timeout"),
+    sa.column("status"),
+    sa.column("result"),
+    sa.column("retry_count"),
+    sa.column("last_update_time"),
+    sa.column("status_details"),
+)
+
+
+def _prepare_database(tmp_path: Path):
+    db_path = tmp_path / "job_persistence_migration.sqlite"
+    db_url = f"sqlite:///{db_path}"
+    engine = sa.create_engine(db_url)
+    InitialBase.metadata.create_all(engine)
+    config = _get_alembic_config(db_url)
+    command.upgrade(config, PREVIOUS_REVISION)
+    return engine, config, db_url
+
+
+def test_job_persistence_migration_adds_schema_and_cancels_legacy_non_terminal_jobs(
+    tmp_path: Path,
+):
+    engine, config, _ = _prepare_database(tmp_path)
+
+    with engine.begin() as conn:
+        conn.execute(
+            sa.insert(_LEGACY_JOBS),
+            [
+                {
+                    "id": "job-pending",
+                    "creation_time": 1000,
+                    "job_name": "pending_job",
+                    "params": "{}",
+                    "workspace": "default",
+                    "timeout": None,
+                    "status": JobStatus.PENDING.to_int(),
+                    "result": None,
+                    "retry_count": 0,
+                    "last_update_time": 1000,
+                    "status_details": None,
+                },
+                {
+                    "id": "job-running",
+                    "creation_time": 2000,
+                    "job_name": "running_job",
+                    "params": "{}",
+                    "workspace": "default",
+                    "timeout": None,
+                    "status": JobStatus.RUNNING.to_int(),
+                    "result": None,
+                    "retry_count": 0,
+                    "last_update_time": 2000,
+                    "status_details": None,
+                },
+                {
+                    "id": "job-succeeded",
+                    "creation_time": 3000,
+                    "job_name": "succeeded_job",
+                    "params": "{}",
+                    "workspace": "default",
+                    "timeout": None,
+                    "status": JobStatus.SUCCEEDED.to_int(),
+                    "result": "ok",
+                    "retry_count": 0,
+                    "last_update_time": 3000,
+                    "status_details": None,
+                },
+            ],
+        )
+
+    command.upgrade(config, REVISION)
+
+    inspector = sa.inspect(engine)
+    assert "job_locks" in inspector.get_table_names()
+    assert "scheduler_leases" in inspector.get_table_names()
+
+    job_columns = {column["name"] for column in inspector.get_columns("jobs")}
+    assert {
+        "executor_backend",
+        "lease_expires_at",
+        "status_message",
+        "progress_payload",
+        "progress_updated_at",
+        "token_hash",
+        "scoped_permissions",
+    }.issubset(job_columns)
+
+    jobs = sa.table("jobs", sa.column("id"), sa.column("status"))
+    with engine.connect() as conn:
+        migrated_statuses = {
+            row.id: row.status for row in conn.execute(sa.select(jobs.c.id, jobs.c.status))
+        }
+
+    assert migrated_statuses["job-pending"] == JobStatus.CANCELED.to_int()
+    assert migrated_statuses["job-running"] == JobStatus.CANCELED.to_int()
+    assert migrated_statuses["job-succeeded"] == JobStatus.SUCCEEDED.to_int()
+
+
+def test_workspace_aware_job_store_works_after_job_persistence_migration(
+    monkeypatch,
+    tmp_path: Path,
+):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+    _, config, db_url = _prepare_database(tmp_path)
+    command.upgrade(config, REVISION)
+
+    store = WorkspaceAwareSqlAlchemyJobStore(db_url)
+
+    with WorkspaceContext("team-a"):
+        job = store.create_job("test_job", '{"value": 1}')
+        fetched = store.get_job(job.job_id)
+
+    assert fetched.workspace == "team-a"
+    assert fetched.status == JobStatus.PENDING

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -93,6 +93,13 @@ CREATE TABLE jobs (
 	last_update_time BIGINT NOT NULL,
 	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
 	status_details JSON,
+	executor_backend VARCHAR(255),
+	lease_expires_at BIGINT,
+	status_message TEXT,
+	progress_payload JSON,
+	progress_updated_at BIGINT,
+	token_hash VARCHAR(64),
+	scoped_permissions JSON,
 	CONSTRAINT jobs_pk PRIMARY KEY (id)
 )
 
@@ -104,6 +111,14 @@ CREATE TABLE registered_models (
 	description VARCHAR(5000),
 	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
 	CONSTRAINT registered_model_pk PRIMARY KEY (workspace, name)
+)
+
+
+CREATE TABLE scheduler_leases (
+	lease_key VARCHAR(255) NOT NULL,
+	acquired_at BIGINT NOT NULL,
+	ttl_seconds INTEGER NOT NULL,
+	CONSTRAINT scheduler_leases_pk PRIMARY KEY (lease_key)
 )
 
 
@@ -218,6 +233,15 @@ CREATE TABLE experiment_tags (
 	experiment_id INTEGER NOT NULL,
 	CONSTRAINT experiment_tag_pk PRIMARY KEY (key, experiment_id),
 	FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+)
+
+
+CREATE TABLE job_locks (
+	lock_key VARCHAR(255) NOT NULL,
+	job_id VARCHAR(36) NOT NULL,
+	acquired_at BIGINT NOT NULL,
+	CONSTRAINT job_locks_pk PRIMARY KEY (lock_key),
+	CONSTRAINT fk_job_locks_job_id FOREIGN KEY(job_id) REFERENCES jobs (id) ON DELETE CASCADE
 )
 
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22428
Relates to https://github.com/mlflow/rfcs/pull/2

### What changes are proposed in this pull request?

This PR splits the DB layer out of #22428 so the persistence model can be reviewed independently from the later API and frontend plumbing.

It adds the recovery-specific job columns, coordination tables, migration behavior for legacy non-terminal jobs, schema fixtures, and migration coverage. It also includes a small follow-up correctness commit that converts persisted integer job statuses back to `JobStatus` values before calling `is_finalized()` in the SQLAlchemy job store.

The `SqlJob.to_mlflow_entity()` wiring for the new fields is intentionally deferred to the next stacked PR.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Test commands:
- `uv run pytest tests/db/test_job_persistence_migration.py tests/store/tracking/test_sqlalchemy_store_schema.py -q`

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the \"Small Bugfixes and Documentation Updates\" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release