### PR TITLE
Consume recovery job state in the tracking UI

### DIFF
--- a/mlflow/server/js/src/common/hooks/useGetTrackingServerJobStatus.tsx
+++ b/mlflow/server/js/src/common/hooks/useGetTrackingServerJobStatus.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import type { JobProgressMetadata } from '../types';
 import { fetchAPI, getAjaxUrl } from '../utils/FetchUtils';
 import type { QueryFunctionContext, UseQueryOptions } from '../utils/reactQueryHooks';
 import { useQuery } from '../utils/reactQueryHooks';
@@ -12,13 +13,26 @@ export enum TrackingJobStatus {
   FAILED = 'FAILED',
   CANCELLED = 'CANCELLED',
   TIMEOUT = 'TIMEOUT',
+  NEEDS_RECOVERY = 'NEEDS_RECOVERY',
 }
+
+export const isTrackingJobInFlight = (status: TrackingJobStatus | undefined): boolean =>
+  status === TrackingJobStatus.PENDING ||
+  status === TrackingJobStatus.RUNNING ||
+  status === TrackingJobStatus.NEEDS_RECOVERY;
+
+export const isTrackingJobTerminal = (status: TrackingJobStatus | undefined): boolean =>
+  status === TrackingJobStatus.SUCCEEDED ||
+  status === TrackingJobStatus.FAILED ||
+  status === TrackingJobStatus.TIMEOUT ||
+  status === TrackingJobStatus.CANCELLED;
 
 export type TrackingJobQueryResult<ResultType> = (
   | {
       status:
         | TrackingJobStatus.RUNNING
         | TrackingJobStatus.PENDING
+        | TrackingJobStatus.NEEDS_RECOVERY
         | TrackingJobStatus.CANCELLED
         | TrackingJobStatus.TIMEOUT;
     }
@@ -32,9 +46,10 @@ export type TrackingJobQueryResult<ResultType> = (
       // In case of failure, the result is the error message
       result: string;
     }
-) & {
-  jobId: string;
-};
+) &
+  JobProgressMetadata & {
+    jobId: string;
+  };
 
 type QueryKey = [typeof GET_JOB_DATA_QUERY_KEY, string[] | undefined];
 
@@ -42,8 +57,8 @@ const queryFn = async ({ queryKey: [, jobIds] }: QueryFunctionContext<QueryKey>)
   const responsesData = await Promise.all(
     (jobIds ?? []).map(async (jobId) => {
       const responseData = await fetchAPI(getAjaxUrl(`ajax-api/3.0/jobs/${jobId}`));
-      const { status, result } = responseData;
-      return { jobId, status, result };
+      const { status, result, error_message, status_message, progress_payload, progress_updated_at } = responseData;
+      return { jobId, status, result, error_message, status_message, progress_payload, progress_updated_at };
     }),
   );
   return responsesData;
@@ -66,10 +81,7 @@ export const useGetTrackingServerJobStatus = <T = any,>(
   // Determine if any of the jobs are still running
   const areJobsRunning =
     isEnabled &&
-    (queryResult.isLoading ||
-      queryResult.data?.some(
-        (response) => response.status === TrackingJobStatus.PENDING || response.status === TrackingJobStatus.RUNNING,
-      ));
+    (queryResult.isLoading || queryResult.data?.some((response) => isTrackingJobInFlight(response.status)));
 
   const jobResults = useMemo(
     () =>

--- a/mlflow/server/js/src/common/hooks/useGetTrackingServerJobStatus.tsx
+++ b/mlflow/server/js/src/common/hooks/useGetTrackingServerJobStatus.tsx
@@ -11,7 +11,7 @@ export enum TrackingJobStatus {
   PENDING = 'PENDING',
   SUCCEEDED = 'SUCCEEDED',
   FAILED = 'FAILED',
-  CANCELLED = 'CANCELLED',
+  CANCELED = 'CANCELED',
   TIMEOUT = 'TIMEOUT',
   NEEDS_RECOVERY = 'NEEDS_RECOVERY',
 }
@@ -25,7 +25,7 @@ export const isTrackingJobTerminal = (status: TrackingJobStatus | undefined): bo
   status === TrackingJobStatus.SUCCEEDED ||
   status === TrackingJobStatus.FAILED ||
   status === TrackingJobStatus.TIMEOUT ||
-  status === TrackingJobStatus.CANCELLED;
+  status === TrackingJobStatus.CANCELED;
 
 export type TrackingJobQueryResult<ResultType> = (
   | {
@@ -33,7 +33,7 @@ export type TrackingJobQueryResult<ResultType> = (
         | TrackingJobStatus.RUNNING
         | TrackingJobStatus.PENDING
         | TrackingJobStatus.NEEDS_RECOVERY
-        | TrackingJobStatus.CANCELLED
+        | TrackingJobStatus.CANCELED
         | TrackingJobStatus.TIMEOUT;
     }
   | {

--- a/mlflow/server/js/src/common/types.ts
+++ b/mlflow/server/js/src/common/types.ts
@@ -7,3 +7,17 @@ export interface KeyValueEntity {
   key: string;
   value: string;
 }
+
+export interface JobProgressPayload {
+  phase?: string;
+  completed?: number;
+  total?: number;
+  unit?: string;
+}
+
+export interface JobProgressMetadata {
+  error_message?: string | null;
+  status_message?: string | null;
+  progress_payload?: JobProgressPayload | null;
+  progress_updated_at?: number | null;
+}

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/hooks/useFetchJobStatus.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/hooks/useFetchJobStatus.test.tsx
@@ -51,6 +51,10 @@ describe('useFetchJobStatus', () => {
       expect(isJobComplete(JobStatus.RUNNING)).toBe(false);
     });
 
+    test('returns false for NEEDS_RECOVERY status', () => {
+      expect(isJobComplete(JobStatus.NEEDS_RECOVERY)).toBe(false);
+    });
+
     test('returns false for undefined status', () => {
       expect(isJobComplete(undefined)).toBe(false);
     });
@@ -168,6 +172,22 @@ describe('useFetchJobStatus', () => {
       });
 
       expect(fetchAPI).toHaveBeenCalledTimes(2);
+    });
+
+    test('fetches needs recovery job status', async () => {
+      const mockResponse = {
+        status: JobStatus.NEEDS_RECOVERY,
+        result: null,
+      };
+      jest.mocked(fetchAPI).mockResolvedValue(mockResponse);
+
+      const { result } = renderHook(() => useFetchJobStatus({ jobId: 'job-recovery' }), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.status).toBe(JobStatus.NEEDS_RECOVERY);
+        expect(result.current.result).toBeNull();
+        expect(result.current.isLoading).toBe(false);
+      });
     });
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/hooks/useFetchJobStatus.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/hooks/useFetchJobStatus.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@databricks/web-shared/query-client';
 import { fetchAPI, getAjaxUrl } from '@mlflow/mlflow/src/common/utils/FetchUtils';
+import type { JobProgressMetadata } from '../../../../common/types';
 
 export const FETCH_JOB_STATUS_QUERY_KEY = 'FETCH_JOB_STATUS';
 
@@ -10,9 +11,10 @@ export enum JobStatus {
   FAILED = 'FAILED',
   TIMEOUT = 'TIMEOUT',
   CANCELED = 'CANCELED',
+  NEEDS_RECOVERY = 'NEEDS_RECOVERY',
 }
 
-export interface FetchJobStatusResponse {
+export interface FetchJobStatusResponse extends JobProgressMetadata {
   status: JobStatus;
   result?: unknown;
   status_details?: {
@@ -31,7 +33,7 @@ export const isJobComplete = (status: JobStatus | undefined): boolean => {
   );
 };
 
-export interface UseFetchJobStatusResult {
+export interface UseFetchJobStatusResult extends JobProgressMetadata {
   status: JobStatus | undefined;
   result: unknown;
   status_details?: {
@@ -73,6 +75,10 @@ export const useFetchJobStatus = ({
   return {
     status: data?.status,
     result: data?.result,
+    error_message: data?.error_message,
+    status_message: data?.status_message,
+    progress_payload: data?.progress_payload,
+    progress_updated_at: data?.progress_updated_at,
     status_details: data?.status_details,
     isLoading,
     isFetching,

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/overview/IssueDetectionRunOverview.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/overview/IssueDetectionRunOverview.tsx
@@ -44,6 +44,7 @@ export const IssueDetectionRunOverview = ({
   const {
     status: jobStatus,
     result: rawResult,
+    error_message: rawErrorMessage,
     status_details: jobStatusDetails,
     isLoading: isLoadingJobStatus,
     error: jobStatusError,
@@ -54,7 +55,12 @@ export const IssueDetectionRunOverview = ({
 
   // Parse issue-specific result format from job if available
   const isFailed = jobStatus === JobStatus.FAILED || jobStatus === JobStatus.TIMEOUT;
-  const jobErrorMessage = isFailed && typeof rawResult === 'string' ? rawResult : undefined;
+  const jobErrorMessage =
+    isFailed && typeof rawErrorMessage === 'string'
+      ? rawErrorMessage
+      : isFailed && typeof rawResult === 'string'
+        ? rawResult
+        : undefined;
   const jobResult =
     !isFailed && typeof rawResult === 'object' && rawResult !== null ? (rawResult as IssueJobResult) : undefined;
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTracesAsync.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTracesAsync.test.tsx
@@ -415,6 +415,77 @@ describe('useEvaluateTracesAsync', () => {
     }, 30000);
   });
 
+  describe('Recovery state polling', () => {
+    it('should continue polling when a job enters NEEDS_RECOVERY before succeeding', async () => {
+      const traceId = 'trace-1';
+      const experimentId = 'exp-123';
+      const jobId = 'job-recovering';
+      const serializedScorer = 'mock-serialized-scorer';
+
+      const mockTrace = createMockTrace(traceId);
+      const traces = new Map([[traceId, mockTrace]]);
+
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/traces/search', (_req, res, ctx) => {
+          return res(ctx.json({ traces: [{ trace_id: traceId }], next_page_token: undefined }));
+        }),
+        rest.post('ajax-api/3.0/mlflow/scorer/invoke', (_req, res, ctx) => {
+          return res(ctx.json({ jobs: [{ job_id: jobId }] }));
+        }),
+      );
+
+      let jobStatusCallCount = 0;
+      server.use(
+        rest.get(`ajax-api/3.0/jobs/${jobId}`, (_req, res, ctx) => {
+          jobStatusCallCount++;
+          if (jobStatusCallCount === 1) {
+            return res(ctx.json({ status: 'NEEDS_RECOVERY' }));
+          }
+          return res(
+            ctx.json({
+              status: 'SUCCEEDED',
+              result: {
+                [traceId]: {
+                  assessments: [
+                    {
+                      assessment_name: 'test_scorer',
+                      numeric_value: 0.9,
+                      rationale: 'Recovered successfully',
+                    },
+                  ],
+                },
+              },
+            }),
+          );
+        }),
+      );
+
+      setupTraceFetchHandlers(server, traces);
+
+      const { result } = renderHook(() => useEvaluateTracesAsync({}), { wrapper });
+
+      act(() => {
+        const [evaluateFunction] = result.current;
+        evaluateFunction({
+          itemIds: ['trace-1'],
+          locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
+          experimentId,
+          judgeInstructions: 'Test instructions',
+          serializedScorer,
+        });
+      });
+
+      await waitFor(() => {
+        expect(result.current[1].isLoading).toBe(false);
+        expect(result.current[1].latestEvaluation).not.toBeNull();
+        expect(result.current[1].error).toBeNull();
+      });
+
+      expect(jobStatusCallCount).toBeGreaterThanOrEqual(2);
+      expect(result.current[1].error).toBeNull();
+    });
+  });
+
   describe('Reset Functionality', () => {
     it('should reset state when reset is called', async () => {
       const traceId = 'trace-1';
@@ -509,7 +580,7 @@ describe('useEvaluateTracesAsync', () => {
         }),
         // Cancel endpoint - fire-and-forget, just acknowledge
         rest.patch('ajax-api/3.0/jobs/cancel/:jobId', (_req, res, ctx) => {
-          return res(ctx.json({ status: 'CANCELLED' }));
+          return res(ctx.json({ status: 'CANCELED' }));
         }),
       );
 
@@ -935,11 +1006,12 @@ describe('useEvaluateTracesAsync', () => {
             }),
           );
         }),
-        // Second job fails but has per-trace results for trace-2 and trace-3
+        // Second job times out but still returns per-trace results for trace-2 and trace-3
         rest.get('ajax-api/3.0/jobs/job-partial-fail', (_req, res, ctx) => {
           return res(
             ctx.json({
-              status: 'FAILED',
+              status: 'TIMEOUT',
+              error_message: 'Evaluation timed out',
               result: {
                 'trace-2': {
                   assessments: [{ assessment_name: 'scorer', numeric_value: 0.8 }],

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTracesAsync.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTracesAsync.tsx
@@ -1,12 +1,17 @@
 import { fetchAPI, getAjaxUrl } from '../../../common/utils/FetchUtils';
 import { useMutation, useQueryClient } from '../../../common/utils/reactQueryHooks';
+import type { JobProgressMetadata } from '../../../common/types';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { FeedbackAssessment, ModelTrace } from '../../../shared/web-shared/model-trace-explorer';
 import type { EvaluateTracesParams } from './types';
 import { useGetTraceIdsForEvaluation } from './useGetTracesForEvaluation';
 import type { JudgeEvaluationResult, SessionJudgeEvaluationResult } from './useEvaluateTraces.common';
 import { getMlflowTraceV3ForEvaluation } from './useEvaluateTraces.common';
-import { TrackingJobStatus } from '../../../common/hooks/useGetTrackingServerJobStatus';
+import {
+  isTrackingJobInFlight,
+  isTrackingJobTerminal,
+  TrackingJobStatus,
+} from '../../../common/hooks/useGetTrackingServerJobStatus';
 import { compact, uniq, zipObject } from 'lodash';
 import type { SessionForEvaluation } from './useGetSessionsForEvaluation';
 import { useGetSessionsForEvaluation } from './useGetSessionsForEvaluation';
@@ -15,19 +20,27 @@ import { parseJSONSafe } from '../../../common/utils/TagUtils';
 
 const JOB_POLLING_INTERVAL = 1500;
 
-type JobStatusMap = Record<string, { status: TrackingJobStatus; result?: unknown }>;
+type JobStatusMap = Record<
+  string,
+  JobProgressMetadata & {
+    status: TrackingJobStatus;
+    result?: unknown;
+  }
+>;
 
 type EvaluateTracesAsyncJobResult = Record<
   string,
   { assessments: FeedbackAssessment[]; failures?: { error_code: string; error_message: string }[] }
 >;
 
+const isInFlightStatus = (status: TrackingJobStatus | undefined): boolean => !status || isTrackingJobInFlight(status);
+
 /** Check if any job is still running or pending */
 const isJobsLoading = (jobStatuses: JobStatusMap, jobIds: string[]): boolean => {
   if (!jobIds.length) return true; // No jobs yet = still loading
   return jobIds.some((id) => {
     const status = jobStatuses[id]?.status;
-    return !status || status === TrackingJobStatus.RUNNING || status === TrackingJobStatus.PENDING;
+    return isInFlightStatus(status);
   });
 };
 
@@ -65,12 +78,12 @@ const deriveRequestStatus = (evaluationRequest: ScorerEvaluation): TrackingJobSt
   const { jobIds, jobStatuses } = evaluationRequest;
   if (!jobIds.length) return TrackingJobStatus.PENDING;
   const statuses = jobIds.map((id) => jobStatuses[id]?.status);
-  if (
-    statuses.some((status) => !status || status === TrackingJobStatus.RUNNING || status === TrackingJobStatus.PENDING)
-  ) {
+  if (statuses.some((status) => isInFlightStatus(status))) {
     return statuses.some((status) => status === TrackingJobStatus.RUNNING)
       ? TrackingJobStatus.RUNNING
-      : TrackingJobStatus.PENDING;
+      : statuses.some((status) => status === TrackingJobStatus.NEEDS_RECOVERY)
+        ? TrackingJobStatus.NEEDS_RECOVERY
+        : TrackingJobStatus.PENDING;
   }
   // All jobs are complete - check if at least one succeeded
   return statuses.includes(TrackingJobStatus.SUCCEEDED) ? TrackingJobStatus.SUCCEEDED : TrackingJobStatus.FAILED;
@@ -97,8 +110,11 @@ const buildResults = (evaluationRequest: ScorerEvaluation): JudgeEvaluationResul
 
   for (const jobId of jobIds) {
     const job = jobStatuses[jobId];
-    if (job?.status !== TrackingJobStatus.FAILED) {
+    if (job?.status !== TrackingJobStatus.FAILED && job?.status !== TrackingJobStatus.TIMEOUT) {
       continue;
+    }
+    if (!failedJobError && typeof job.error_message === 'string') {
+      failedJobError = job.error_message;
     }
     if (!failedJobError && typeof job.result === 'string') {
       failedJobError = job.result;
@@ -111,7 +127,10 @@ const buildResults = (evaluationRequest: ScorerEvaluation): JudgeEvaluationResul
   }
 
   // Default error for traces without results when some jobs failed
-  const hasFailedJobs = jobIds.some((id) => jobStatuses[id]?.status === TrackingJobStatus.FAILED);
+  const hasFailedJobs = jobIds.some(
+    (id) =>
+      jobStatuses[id]?.status === TrackingJobStatus.FAILED || jobStatuses[id]?.status === TrackingJobStatus.TIMEOUT,
+  );
   const defaultError = hasFailedJobs ? failedJobError || 'Evaluation job failed' : null;
 
   if (sessionsData) {
@@ -162,8 +181,14 @@ const buildResults = (evaluationRequest: ScorerEvaluation): JudgeEvaluationResul
 const extractError = (jobStatuses: JobStatusMap, jobIds: string[]): Error => {
   for (const jobId of jobIds) {
     const job = jobStatuses[jobId];
-    if (job?.status === TrackingJobStatus.FAILED) {
-      return new Error(typeof job.result === 'string' ? job.result : 'Job failed');
+    if (job?.status === TrackingJobStatus.FAILED || job?.status === TrackingJobStatus.TIMEOUT) {
+      return new Error(
+        typeof job.error_message === 'string'
+          ? job.error_message
+          : typeof job.result === 'string'
+            ? job.result
+            : 'Job failed',
+      );
     }
   }
   return new Error('Unknown error');
@@ -203,7 +228,7 @@ export const useEvaluateTracesAsync = ({
         }
         for (const jobId of ev.jobIds) {
           const status = ev.jobStatuses[jobId]?.status;
-          if (status !== TrackingJobStatus.SUCCEEDED && status !== TrackingJobStatus.FAILED) {
+          if (!isTrackingJobTerminal(status)) {
             jobsToPoll.push(jobId);
           }
         }
@@ -217,9 +242,22 @@ export const useEvaluateTracesAsync = ({
         jobsToPoll.map(async (jobId) => {
           try {
             const res = await fetchAPI(getAjaxUrl(`ajax-api/3.0/jobs/${jobId}`));
-            return { jobId, status: res.status as TrackingJobStatus, result: res.result };
+            return {
+              jobId,
+              status: res.status as TrackingJobStatus,
+              result: res.result,
+              error_message: res.error_message,
+              status_message: res.status_message,
+              progress_payload: res.progress_payload,
+              progress_updated_at: res.progress_updated_at,
+            };
           } catch {
-            return { jobId, status: TrackingJobStatus.FAILED, result: 'Failed to fetch job status' };
+            return {
+              jobId,
+              status: TrackingJobStatus.FAILED,
+              result: 'Failed to fetch job status',
+              error_message: 'Failed to fetch job status',
+            };
           }
         }),
       );
@@ -227,10 +265,11 @@ export const useEvaluateTracesAsync = ({
       setEvaluations((prev) => {
         const next = { ...prev };
         // Update job statuses for each evaluation request
-        for (const { jobId, status, result } of results) {
+        for (const polledJob of results) {
+          const { jobId } = polledJob;
           for (const evaluationRequest of Object.values(next)) {
             if (evaluationRequest.jobIds.includes(jobId)) {
-              const newJobStatuses = { ...evaluationRequest.jobStatuses, [jobId]: { status, result } };
+              const newJobStatuses = { ...evaluationRequest.jobStatuses, [jobId]: polledJob };
               next[evaluationRequest.requestKey] = {
                 ...evaluationRequest,
                 jobStatuses: newJobStatuses,


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22428
Relates to https://github.com/mlflow/rfcs/pull/2
Blocked by #22521

### What changes are proposed in this pull request?

This PR splits the frontend consumer changes out of #22428 on top of #22521.

It updates the existing tracking job status hooks and scorer polling flows to treat `NEEDS_RECOVERY` as in-flight, plumb the new progress and error metadata from the backend contract, and prefer the dedicated `error_message` field for failure display. The final commit in this branch also renames the shared tracking hook's canceled enum spelling to match the API payloads.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Test commands:
- `yarn test --watch=false src/experiment-tracking/components/run-page/hooks/useFetchJobStatus.test.tsx src/experiment-tracking/pages/experiment-scorers/useEvaluateTracesAsync.test.tsx src/experiment-tracking/components/run-page/overview/IssueDetectionProgress.test.tsx`

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the \"Small Bugfixes and Documentation Updates\" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release