### PR TITLE
Add built-in deterministic code scorers to `mlflow.genai.scorers`

### DIFF
--- a/mlflow/genai/scorers/__init__.py
+++ b/mlflow/genai/scorers/__init__.py
@@ -51,6 +51,18 @@ _LAZY_IMPORTS = {
     "get_all_scorers",
 }
 
+_LAZY_CODE_SCORER_IMPORTS = {
+    "ContainsKeywords",
+    "ExactMatch",
+    "IsNotEmpty",
+    "JsonValidity",
+    "LatencyThreshold",
+    "LengthBound",
+    "NumericBound",
+    "PII",
+    "RegexMatch",
+}
+
 
 def __getattr__(name):
     """Lazily import builtin scorers to avoid circular dependency."""
@@ -59,6 +71,11 @@ def __getattr__(name):
         from mlflow.genai.scorers import builtin_scorers
 
         return getattr(builtin_scorers, name)
+
+    if name in _LAZY_CODE_SCORER_IMPORTS:
+        from mlflow.genai.scorers import builtin_code_scorers
+
+        return getattr(builtin_code_scorers, name)
 
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
@@ -72,13 +89,24 @@ def __dir__():
     # Get the default module attributes
     module_attrs = list(globals().keys())
     # Add the lazy imports
-    return sorted(set(module_attrs) | _LAZY_IMPORTS)
+    return sorted(set(module_attrs) | _LAZY_IMPORTS | _LAZY_CODE_SCORER_IMPORTS)
 
 
 # The TYPE_CHECKING block below is for static analysis tools only.
 # TYPE_CHECKING is False at runtime, so these imports never execute during normal operation.
 # This gives us the best of both worlds: type hints without circular imports.
 if TYPE_CHECKING:
+    from mlflow.genai.scorers.builtin_code_scorers import (
+        PII,
+        ContainsKeywords,
+        ExactMatch,
+        IsNotEmpty,
+        JsonValidity,
+        LatencyThreshold,
+        LengthBound,
+        NumericBound,
+        RegexMatch,
+    )
     from mlflow.genai.scorers.builtin_scorers import (
         Completeness,
         ConversationalGuidelines,
@@ -106,17 +134,26 @@ if TYPE_CHECKING:
 
 __all__ = [
     "Completeness",
+    "ContainsKeywords",
     "ConversationalGuidelines",
     "ConversationalRoleAdherence",
     "ConversationalSafety",
     "ConversationalToolCallEfficiency",
     "ConversationCompleteness",
     "Correctness",
+    "ExactMatch",
     "ExpectationsGuidelines",
     "Fluency",
     "Guidelines",
     "Equivalence",
+    "IsNotEmpty",
+    "JsonValidity",
     "KnowledgeRetention",
+    "LatencyThreshold",
+    "LengthBound",
+    "NumericBound",
+    "PII",
+    "RegexMatch",
     "RelevanceToQuery",
     "RetrievalGroundedness",
     "RetrievalRelevance",

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -331,7 +331,13 @@ class Scorer(BaseModel):
             # Import here to avoid circular imports
             from mlflow.genai.scorers.builtin_scorers import BuiltInScorer
 
-            return BuiltInScorer.model_validate(obj)
+            try:
+                return BuiltInScorer.model_validate(obj)
+            except MlflowException:
+                # Fall back to code scorers if not found in LLM-based scorers
+                from mlflow.genai.scorers.builtin_code_scorers import BuiltInCodeScorer
+
+                return BuiltInCodeScorer.model_validate(obj)
 
         # Handle decorator scorers
         elif serialized.call_source and serialized.call_signature and serialized.original_func_name:

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -333,7 +333,9 @@ class Scorer(BaseModel):
 
             try:
                 return BuiltInScorer.model_validate(obj)
-            except MlflowException:
+            except MlflowException as e:
+                if "Unknown builtin scorer class" not in str(e):
+                    raise
                 # Fall back to code scorers if not found in LLM-based scorers
                 from mlflow.genai.scorers.builtin_code_scorers import BuiltInCodeScorer
 

--- a/mlflow/genai/scorers/builtin_code_scorers.py
+++ b/mlflow/genai/scorers/builtin_code_scorers.py
@@ -1,4 +1,5 @@
 import json
+import math
 import re
 from dataclasses import asdict
 from typing import Any, Literal
@@ -453,6 +454,12 @@ class NumericBound(BuiltInCodeScorer):
             return self._make_feedback(
                 value=False,
                 rationale=f"Output {outputs!r} cannot be converted to a number.",
+            )
+
+        if not math.isfinite(numeric_value):
+            return self._make_feedback(
+                value=False,
+                rationale=f"Output {outputs!r} is not a finite number.",
             )
 
         violations = []

--- a/mlflow/genai/scorers/builtin_code_scorers.py
+++ b/mlflow/genai/scorers/builtin_code_scorers.py
@@ -27,6 +27,21 @@ _PII_PATTERNS: dict[str, re.Pattern] = {
 }
 
 
+def _passes_luhn(number_str: str) -> bool:
+    """Validate a number string using the Luhn algorithm."""
+    digits = [int(d) for d in number_str if d.isdigit()]
+    if len(digits) < 13:
+        return False
+    checksum = 0
+    for i, d in enumerate(reversed(digits)):
+        if i % 2 == 1:
+            d *= 2
+            if d > 9:
+                d -= 9
+        checksum += d
+    return checksum % 10 == 0
+
+
 def _to_str(value: Any) -> str:
     if value is None:
         return ""
@@ -45,6 +60,13 @@ class BuiltInCodeScorer(Scorer):
 
     name: str
     required_columns: set[str] = set()
+
+    def validate_columns(self, columns: set[str]) -> None:
+        missing = self.required_columns - columns
+        if missing:
+            raise MlflowException.invalid_parameter_value(
+                f"Scorer '{self.name}' requires columns {missing} not present in dataset."
+            )
 
     @property
     def kind(self) -> ScorerKind:
@@ -207,6 +229,10 @@ class JsonValidity(BuiltInCodeScorer):
 
 class RegexMatch(BuiltInCodeScorer):
     """Check whether the output matches a regex pattern.
+
+    Note:
+        Ensure regex patterns are efficient. Patterns with nested quantifiers
+        (e.g., ``(a+)+b``) may cause slow execution on large outputs.
 
     Args:
         name: The name of the scorer. Defaults to ``"regex_match"``.
@@ -519,6 +545,8 @@ class PII(BuiltInCodeScorer):
         detected = {}
         for pii_type, pattern in patterns.items():
             matches = pattern.findall(text)
+            if pii_type == "credit_card":
+                matches = [m for m in matches if _passes_luhn(m)]
             if matches:
                 detected[pii_type] = len(matches)
 

--- a/mlflow/genai/scorers/builtin_code_scorers.py
+++ b/mlflow/genai/scorers/builtin_code_scorers.py
@@ -1,0 +1,527 @@
+import json
+import re
+from dataclasses import asdict
+from typing import Any, Literal
+
+import pydantic
+
+import mlflow
+from mlflow.entities.assessment import Feedback
+from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
+from mlflow.entities.trace import Trace
+from mlflow.exceptions import MlflowException
+from mlflow.genai.scorers.base import (
+    _SERIALIZATION_VERSION,
+    Scorer,
+    ScorerKind,
+    SerializedScorer,
+)
+
+# Common PII regex patterns
+_PII_PATTERNS: dict[str, re.Pattern] = {
+    "email": re.compile(r"[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+"),
+    "phone": re.compile(r"(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}"),
+    "ssn": re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),
+    "credit_card": re.compile(r"\b(?:\d[ -]*?){13,19}\b"),
+}
+
+
+def _to_str(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
+class BuiltInCodeScorer(Scorer):
+    """Base class for built-in deterministic code scorers.
+
+    These scorers run without LLM calls and produce instant, reproducible results.
+    They complement the existing LLM-based judges by providing structural and
+    safety checks on model outputs.
+    """
+
+    name: str
+    required_columns: set[str] = set()
+
+    @property
+    def kind(self) -> ScorerKind:
+        return ScorerKind.BUILTIN
+
+    def _make_feedback(self, *, value: bool, rationale: str) -> Feedback:
+        return Feedback(
+            name=self.name,
+            value=value,
+            rationale=rationale,
+            source=AssessmentSource(
+                source_type=AssessmentSourceType.CODE,
+                source_id=f"mlflow.scorers.{self.__class__.__name__}",
+            ),
+        )
+
+    def model_dump(self, **kwargs) -> dict[str, Any]:
+        pydantic_model_data = pydantic.BaseModel.model_dump(self, mode="json", **kwargs)
+
+        serialized = SerializedScorer(
+            name=self.name,
+            description=self.description,
+            aggregations=self.aggregations,
+            is_session_level_scorer=self.is_session_level_scorer,
+            mlflow_version=mlflow.__version__,
+            serialization_version=_SERIALIZATION_VERSION,
+            builtin_scorer_class=self.__class__.__name__,
+            builtin_scorer_pydantic_data=pydantic_model_data,
+        )
+
+        return asdict(serialized)
+
+    @classmethod
+    def model_validate(cls, obj: SerializedScorer | dict[str, Any]) -> "BuiltInCodeScorer":
+        from mlflow.genai.scorers import builtin_code_scorers
+
+        if isinstance(obj, SerializedScorer):
+            serialized = obj
+        else:
+            if not isinstance(obj, dict) or "builtin_scorer_class" not in obj:
+                raise MlflowException.invalid_parameter_value(
+                    f"Invalid builtin code scorer data: expected a dictionary with "
+                    f"'builtin_scorer_class' field, got {type(obj).__name__}."
+                )
+            try:
+                serialized = SerializedScorer(**obj)
+            except Exception as e:
+                raise MlflowException.invalid_parameter_value(
+                    f"Failed to parse serialized scorer data: {e}"
+                )
+
+        try:
+            scorer_class = getattr(builtin_code_scorers, serialized.builtin_scorer_class)
+        except AttributeError:
+            raise MlflowException.invalid_parameter_value(
+                f"Unknown builtin code scorer class: {serialized.builtin_scorer_class}"
+            )
+
+        constructor_args = serialized.builtin_scorer_pydantic_data or {}
+        return scorer_class(**constructor_args)
+
+
+class ExactMatch(BuiltInCodeScorer):
+    """Check whether the output exactly matches the expected response.
+
+    Args:
+        name: The name of the scorer. Defaults to ``"exact_match"``.
+
+    Example:
+
+    .. code-block:: python
+
+        from mlflow.genai.scorers import ExactMatch
+
+        scorer = ExactMatch()
+        feedback = scorer(outputs="hello", expectations={"expected_response": "hello"})
+        print(feedback.value)  # True
+    """
+
+    name: str = "exact_match"
+    required_columns: set[str] = {"outputs", "expectations"}
+
+    def __call__(
+        self,
+        *,
+        outputs: Any = None,
+        expectations: dict[str, Any] | None = None,
+    ) -> Feedback:
+        output_str = _to_str(outputs)
+        expected = ""
+        if isinstance(expectations, dict):
+            expected = _to_str(expectations.get("expected_response", ""))
+        else:
+            expected = _to_str(expectations)
+
+        match = output_str == expected
+        rationale = (
+            "Output matches expected response."
+            if match
+            else f"Output does not match expected response. "
+            f"Expected: {expected!r}, Got: {output_str!r}"
+        )
+        return self._make_feedback(value=match, rationale=rationale)
+
+
+class JsonValidity(BuiltInCodeScorer):
+    """Check whether the output is valid JSON, optionally with required keys.
+
+    Args:
+        name: The name of the scorer. Defaults to ``"json_validity"``.
+        required_keys: Optional list of top-level keys that must be present
+            in the parsed JSON object.
+
+    Example:
+
+    .. code-block:: python
+
+        from mlflow.genai.scorers import JsonValidity
+
+        scorer = JsonValidity(required_keys=["answer", "sources"])
+        feedback = scorer(outputs='{"answer": "yes", "sources": []}')
+        print(feedback.value)  # True
+    """
+
+    name: str = "json_validity"
+    required_keys: list[str] | None = None
+
+    def __call__(self, *, outputs: Any = None) -> Feedback:
+        text = _to_str(outputs)
+
+        try:
+            parsed = json.loads(text)
+        except (json.JSONDecodeError, TypeError):
+            return self._make_feedback(
+                value=False,
+                rationale=f"Output is not valid JSON: {text[:200]!r}",
+            )
+
+        if self.required_keys:
+            if not isinstance(parsed, dict):
+                return self._make_feedback(
+                    value=False,
+                    rationale=f"JSON output is not an object (got {type(parsed).__name__}), "
+                    f"cannot check required keys.",
+                )
+            missing = [k for k in self.required_keys if k not in parsed]
+            if missing:
+                return self._make_feedback(
+                    value=False,
+                    rationale=f"JSON output is missing required keys: {missing}",
+                )
+
+        return self._make_feedback(
+            value=True,
+            rationale="Output is valid JSON"
+            + (f" with all required keys: {self.required_keys}" if self.required_keys else "")
+            + ".",
+        )
+
+
+class RegexMatch(BuiltInCodeScorer):
+    """Check whether the output matches a regex pattern.
+
+    Args:
+        name: The name of the scorer. Defaults to ``"regex_match"``.
+        pattern: The regex pattern to search for in the output.
+        full_match: If ``True``, require the entire output to match the pattern (using
+            ``re.fullmatch``). If ``False`` (default), search for the pattern anywhere
+            in the output (using ``re.search``).
+
+    Example:
+
+    .. code-block:: python
+
+        from mlflow.genai.scorers import RegexMatch
+
+        scorer = RegexMatch(pattern=r"\\d{3}-\\d{4}")
+        feedback = scorer(outputs="Call 555-1234 for info")
+        print(feedback.value)  # True
+    """
+
+    name: str = "regex_match"
+    pattern: str
+    full_match: bool = False
+
+    def __call__(self, *, outputs: Any = None) -> Feedback:
+        text = _to_str(outputs)
+
+        try:
+            if self.full_match:
+                matched = bool(re.fullmatch(self.pattern, text))
+            else:
+                matched = bool(re.search(self.pattern, text))
+        except re.error as e:
+            return self._make_feedback(
+                value=False,
+                rationale=f"Invalid regex pattern {self.pattern!r}: {e}",
+            )
+
+        rationale = (
+            f"Output {'fully matches' if self.full_match else 'matches'} pattern {self.pattern!r}."
+            if matched
+            else f"Output does not match pattern {self.pattern!r}."
+        )
+        return self._make_feedback(value=matched, rationale=rationale)
+
+
+class ContainsKeywords(BuiltInCodeScorer):
+    """Check whether the output contains all required keywords or phrases.
+
+    Args:
+        name: The name of the scorer. Defaults to ``"contains_keywords"``.
+        keywords: List of keywords or phrases that must appear in the output.
+        case_sensitive: Whether the keyword check is case-sensitive. Defaults to ``False``.
+
+    Example:
+
+    .. code-block:: python
+
+        from mlflow.genai.scorers import ContainsKeywords
+
+        scorer = ContainsKeywords(keywords=["disclaimer", "not financial advice"])
+        feedback = scorer(outputs="Disclaimer: This is not financial advice.")
+        print(feedback.value)  # True
+    """
+
+    name: str = "contains_keywords"
+    keywords: list[str]
+    case_sensitive: bool = False
+
+    def __call__(self, *, outputs: Any = None) -> Feedback:
+        text = _to_str(outputs)
+        check_text = text if self.case_sensitive else text.lower()
+
+        missing = []
+        for keyword in self.keywords:
+            check_keyword = keyword if self.case_sensitive else keyword.lower()
+            if check_keyword not in check_text:
+                missing.append(keyword)
+
+        if missing:
+            return self._make_feedback(
+                value=False,
+                rationale=f"Output is missing keywords: {missing}",
+            )
+        return self._make_feedback(
+            value=True,
+            rationale=f"Output contains all required keywords: {self.keywords}",
+        )
+
+
+class LengthBound(BuiltInCodeScorer):
+    """Check whether the output length is within specified bounds.
+
+    Args:
+        name: The name of the scorer. Defaults to ``"length_bound"``.
+        min_length: Minimum allowed length (inclusive). Defaults to ``None`` (no minimum).
+        max_length: Maximum allowed length (inclusive). Defaults to ``None`` (no maximum).
+        unit: Unit of measurement: ``"chars"`` or ``"words"``. Defaults to ``"chars"``.
+
+    Example:
+
+    .. code-block:: python
+
+        from mlflow.genai.scorers import LengthBound
+
+        scorer = LengthBound(min_length=10, max_length=500, unit="chars")
+        feedback = scorer(outputs="A short response.")
+        print(feedback.value)  # True
+    """
+
+    name: str = "length_bound"
+    min_length: int | None = None
+    max_length: int | None = None
+    unit: Literal["chars", "words"] = "chars"
+
+    def __call__(self, *, outputs: Any = None) -> Feedback:
+        text = _to_str(outputs)
+
+        length = len(text.split()) if self.unit == "words" else len(text)
+
+        violations = []
+        if self.min_length is not None and length < self.min_length:
+            violations.append(f"below minimum of {self.min_length}")
+        if self.max_length is not None and length > self.max_length:
+            violations.append(f"above maximum of {self.max_length}")
+
+        if violations:
+            return self._make_feedback(
+                value=False,
+                rationale=f"Output length {length} {self.unit} is "
+                + " and ".join(violations)
+                + ".",
+            )
+        return self._make_feedback(
+            value=True,
+            rationale=f"Output length {length} {self.unit} is within bounds"
+            + (f" (min={self.min_length})" if self.min_length is not None else "")
+            + (f" (max={self.max_length})" if self.max_length is not None else "")
+            + ".",
+        )
+
+
+class IsNotEmpty(BuiltInCodeScorer):
+    """Check whether the output is non-empty and non-whitespace.
+
+    Args:
+        name: The name of the scorer. Defaults to ``"is_not_empty"``.
+
+    Example:
+
+    .. code-block:: python
+
+        from mlflow.genai.scorers import IsNotEmpty
+
+        scorer = IsNotEmpty()
+        feedback = scorer(outputs="Hello, world!")
+        print(feedback.value)  # True
+    """
+
+    name: str = "is_not_empty"
+
+    def __call__(self, *, outputs: Any = None) -> Feedback:
+        text = _to_str(outputs)
+        is_non_empty = bool(text.strip())
+
+        return self._make_feedback(
+            value=is_non_empty,
+            rationale="Output is non-empty."
+            if is_non_empty
+            else "Output is empty or contains only whitespace.",
+        )
+
+
+class LatencyThreshold(BuiltInCodeScorer):
+    """Check whether the trace execution latency is under a threshold.
+
+    This scorer requires a trace object to extract the execution duration.
+
+    Args:
+        name: The name of the scorer. Defaults to ``"latency_threshold"``.
+        max_latency_seconds: Maximum allowed latency in seconds.
+
+    Example:
+
+    .. code-block:: python
+
+        from mlflow.genai.scorers import LatencyThreshold
+
+        scorer = LatencyThreshold(max_latency_seconds=3.0)
+        feedback = scorer(trace=my_trace)
+        print(feedback.value)  # True if latency < 3s
+    """
+
+    name: str = "latency_threshold"
+    max_latency_seconds: float
+    required_columns: set[str] = {"trace"}
+
+    def __call__(self, *, trace: Trace | None = None) -> Feedback:
+        if trace is None or trace.info.execution_duration is None:
+            return self._make_feedback(
+                value=False,
+                rationale="No trace or execution duration available to measure latency.",
+            )
+
+        latency_seconds = trace.info.execution_duration / 1000.0
+        within_threshold = latency_seconds <= self.max_latency_seconds
+
+        return self._make_feedback(
+            value=within_threshold,
+            rationale=f"Execution latency {latency_seconds:.3f}s is "
+            + (
+                f"within threshold of {self.max_latency_seconds}s."
+                if within_threshold
+                else f"above threshold of {self.max_latency_seconds}s."
+            ),
+        )
+
+
+class NumericBound(BuiltInCodeScorer):
+    """Check whether a numeric output is within a specified range.
+
+    Args:
+        name: The name of the scorer. Defaults to ``"numeric_bound"``.
+        min_value: Minimum allowed value (inclusive). Defaults to ``None`` (no minimum).
+        max_value: Maximum allowed value (inclusive). Defaults to ``None`` (no maximum).
+
+    Example:
+
+    .. code-block:: python
+
+        from mlflow.genai.scorers import NumericBound
+
+        scorer = NumericBound(min_value=0.0, max_value=1.0)
+        feedback = scorer(outputs=0.85)
+        print(feedback.value)  # True
+    """
+
+    name: str = "numeric_bound"
+    min_value: float | None = None
+    max_value: float | None = None
+
+    def __call__(self, *, outputs: Any = None) -> Feedback:
+        try:
+            numeric_value = float(outputs)
+        except (TypeError, ValueError):
+            return self._make_feedback(
+                value=False,
+                rationale=f"Output {outputs!r} cannot be converted to a number.",
+            )
+
+        violations = []
+        if self.min_value is not None and numeric_value < self.min_value:
+            violations.append(f"below minimum of {self.min_value}")
+        if self.max_value is not None and numeric_value > self.max_value:
+            violations.append(f"above maximum of {self.max_value}")
+
+        if violations:
+            return self._make_feedback(
+                value=False,
+                rationale=f"Numeric value {numeric_value} is " + " and ".join(violations) + ".",
+            )
+        return self._make_feedback(
+            value=True,
+            rationale=f"Numeric value {numeric_value} is within bounds"
+            + (f" (min={self.min_value})" if self.min_value is not None else "")
+            + (f" (max={self.max_value})" if self.max_value is not None else "")
+            + ".",
+        )
+
+
+class PII(BuiltInCodeScorer):
+    """Check whether the output contains personally identifiable information (PII).
+
+    Detects common PII patterns using regex: email addresses, phone numbers,
+    Social Security numbers, and credit card numbers. Returns ``True`` (pass) when
+    **no** PII is detected, and ``False`` (fail) when PII is found.
+
+    Args:
+        name: The name of the scorer. Defaults to ``"pii_detection"``.
+        pii_types: Optional list of PII types to check. Valid values are
+            ``"email"``, ``"phone"``, ``"ssn"``, ``"credit_card"``.
+            Defaults to all types.
+
+    Example:
+
+    .. code-block:: python
+
+        from mlflow.genai.scorers import PII
+
+        scorer = PII()
+        feedback = scorer(outputs="Contact me at user@example.com")
+        print(feedback.value)  # False (PII detected)
+    """
+
+    name: str = "pii_detection"
+    pii_types: list[Literal["email", "phone", "ssn", "credit_card"]] | None = None
+
+    def __call__(self, *, outputs: Any = None) -> Feedback:
+        text = _to_str(outputs)
+
+        patterns = _PII_PATTERNS
+        if self.pii_types:
+            patterns = {k: v for k, v in _PII_PATTERNS.items() if k in self.pii_types}
+
+        detected = {}
+        for pii_type, pattern in patterns.items():
+            matches = pattern.findall(text)
+            if matches:
+                detected[pii_type] = len(matches)
+
+        if detected:
+            details = ", ".join(f"{count} {pii_type}" for pii_type, count in detected.items())
+            return self._make_feedback(
+                value=False,
+                rationale=f"PII detected in output: {details}.",
+            )
+        return self._make_feedback(
+            value=True,
+            rationale="No PII detected in output.",
+        )

--- a/tests/genai/scorers/test_builtin_code_scorers.py
+++ b/tests/genai/scorers/test_builtin_code_scorers.py
@@ -1,0 +1,381 @@
+from unittest.mock import MagicMock
+
+from mlflow.entities.assessment_source import AssessmentSourceType
+from mlflow.genai.scorers import (
+    PII,
+    ContainsKeywords,
+    ExactMatch,
+    IsNotEmpty,
+    JsonValidity,
+    LatencyThreshold,
+    LengthBound,
+    NumericBound,
+    RegexMatch,
+)
+from mlflow.genai.scorers.base import ScorerKind
+
+# ── ExactMatch ──────────────────────────────────────────────────────────────
+
+
+class TestExactMatch:
+    def test_match(self):
+        scorer = ExactMatch()
+        fb = scorer(outputs="hello", expectations={"expected_response": "hello"})
+        assert fb.value is True
+        assert "matches" in fb.rationale
+
+    def test_no_match(self):
+        scorer = ExactMatch()
+        fb = scorer(outputs="hi", expectations={"expected_response": "hello"})
+        assert fb.value is False
+        assert "does not match" in fb.rationale
+
+    def test_none_outputs(self):
+        scorer = ExactMatch()
+        fb = scorer(outputs=None, expectations={"expected_response": ""})
+        assert fb.value is True
+
+    def test_none_expectations(self):
+        scorer = ExactMatch()
+        fb = scorer(outputs="hello", expectations=None)
+        assert fb.value is False
+
+    def test_non_dict_expectations(self):
+        scorer = ExactMatch()
+        fb = scorer(outputs="hello", expectations="hello")
+        assert fb.value is True
+
+    def test_feedback_source(self):
+        scorer = ExactMatch()
+        fb = scorer(outputs="a", expectations={"expected_response": "a"})
+        assert fb.source.source_type == AssessmentSourceType.CODE
+        assert "ExactMatch" in fb.source.source_id
+
+    def test_kind(self):
+        assert ExactMatch().kind == ScorerKind.BUILTIN
+
+    def test_name_default(self):
+        assert ExactMatch().name == "exact_match"
+
+    def test_custom_name(self):
+        assert ExactMatch(name="my_match").name == "my_match"
+
+
+# ── JsonValidity ────────────────────────────────────────────────────────────
+
+
+class TestJsonValidity:
+    def test_valid_json_object(self):
+        fb = JsonValidity()(outputs='{"key": "value"}')
+        assert fb.value is True
+
+    def test_valid_json_array(self):
+        fb = JsonValidity()(outputs="[1, 2, 3]")
+        assert fb.value is True
+
+    def test_invalid_json(self):
+        fb = JsonValidity()(outputs="not json")
+        assert fb.value is False
+        assert "not valid JSON" in fb.rationale
+
+    def test_empty_string(self):
+        fb = JsonValidity()(outputs="")
+        assert fb.value is False
+
+    def test_required_keys_present(self):
+        fb = JsonValidity(required_keys=["a", "b"])(outputs='{"a": 1, "b": 2, "c": 3}')
+        assert fb.value is True
+        assert "required keys" in fb.rationale
+
+    def test_required_keys_missing(self):
+        fb = JsonValidity(required_keys=["a", "b"])(outputs='{"a": 1}')
+        assert fb.value is False
+        assert "missing required keys" in fb.rationale
+        assert "b" in fb.rationale
+
+    def test_required_keys_not_object(self):
+        fb = JsonValidity(required_keys=["a"])(outputs="[1, 2]")
+        assert fb.value is False
+        assert "not an object" in fb.rationale
+
+    def test_none_outputs(self):
+        fb = JsonValidity()(outputs=None)
+        assert fb.value is False
+
+
+# ── RegexMatch ──────────────────────────────────────────────────────────────
+
+
+class TestRegexMatch:
+    def test_search_match(self):
+        fb = RegexMatch(pattern=r"\d{3}-\d{4}")(outputs="Call 555-1234")
+        assert fb.value is True
+
+    def test_search_no_match(self):
+        fb = RegexMatch(pattern=r"\d{3}-\d{4}")(outputs="no numbers here")
+        assert fb.value is False
+
+    def test_full_match(self):
+        fb = RegexMatch(pattern=r"\d+", full_match=True)(outputs="12345")
+        assert fb.value is True
+
+    def test_full_match_fails(self):
+        fb = RegexMatch(pattern=r"\d+", full_match=True)(outputs="abc12345")
+        assert fb.value is False
+
+    def test_invalid_regex(self):
+        fb = RegexMatch(pattern=r"[")(outputs="test")
+        assert fb.value is False
+        assert "Invalid regex" in fb.rationale
+
+    def test_none_outputs(self):
+        fb = RegexMatch(pattern=r".")(outputs=None)
+        assert fb.value is False
+
+
+# ── ContainsKeywords ────────────────────────────────────────────────────────
+
+
+class TestContainsKeywords:
+    def test_all_present(self):
+        fb = ContainsKeywords(keywords=["hello", "world"])(outputs="hello world")
+        assert fb.value is True
+
+    def test_missing_keyword(self):
+        fb = ContainsKeywords(keywords=["hello", "world"])(outputs="hello there")
+        assert fb.value is False
+        assert "world" in fb.rationale
+
+    def test_case_insensitive(self):
+        fb = ContainsKeywords(keywords=["Hello"])(outputs="HELLO world")
+        assert fb.value is True
+
+    def test_case_sensitive(self):
+        fb = ContainsKeywords(keywords=["Hello"], case_sensitive=True)(outputs="HELLO world")
+        assert fb.value is False
+
+    def test_phrase_keyword(self):
+        fb = ContainsKeywords(keywords=["not financial advice"])(
+            outputs="This is not financial advice."
+        )
+        assert fb.value is True
+
+    def test_none_outputs(self):
+        fb = ContainsKeywords(keywords=["a"])(outputs=None)
+        assert fb.value is False
+
+
+# ── LengthBound ─────────────────────────────────────────────────────────────
+
+
+class TestLengthBound:
+    def test_within_char_bounds(self):
+        fb = LengthBound(min_length=1, max_length=100)(outputs="hello")
+        assert fb.value is True
+
+    def test_below_min_chars(self):
+        fb = LengthBound(min_length=10)(outputs="hi")
+        assert fb.value is False
+        assert "below minimum" in fb.rationale
+
+    def test_above_max_chars(self):
+        fb = LengthBound(max_length=5)(outputs="hello world")
+        assert fb.value is False
+        assert "above maximum" in fb.rationale
+
+    def test_word_count(self):
+        fb = LengthBound(min_length=2, max_length=5, unit="words")(outputs="hello beautiful world")
+        assert fb.value is True
+
+    def test_word_count_below(self):
+        fb = LengthBound(min_length=3, unit="words")(outputs="one two")
+        assert fb.value is False
+
+    def test_no_bounds(self):
+        fb = LengthBound()(outputs="anything")
+        assert fb.value is True
+
+    def test_none_outputs(self):
+        fb = LengthBound(min_length=1)(outputs=None)
+        assert fb.value is False
+
+
+# ── IsNotEmpty ──────────────────────────────────────────────────────────────
+
+
+class TestIsNotEmpty:
+    def test_non_empty(self):
+        fb = IsNotEmpty()(outputs="hello")
+        assert fb.value is True
+
+    def test_empty_string(self):
+        fb = IsNotEmpty()(outputs="")
+        assert fb.value is False
+
+    def test_whitespace_only(self):
+        fb = IsNotEmpty()(outputs="   \t\n  ")
+        assert fb.value is False
+
+    def test_none_outputs(self):
+        fb = IsNotEmpty()(outputs=None)
+        assert fb.value is False
+
+    def test_non_string(self):
+        fb = IsNotEmpty()(outputs=42)
+        assert fb.value is True
+
+
+# ── LatencyThreshold ────────────────────────────────────────────────────────
+
+
+class TestLatencyThreshold:
+    def _make_trace(self, duration_ms):
+        trace = MagicMock()
+        trace.info.execution_duration = duration_ms
+        return trace
+
+    def test_within_threshold(self):
+        fb = LatencyThreshold(max_latency_seconds=3.0)(trace=self._make_trace(2000))
+        assert fb.value is True
+        assert "within threshold" in fb.rationale
+
+    def test_exceeds_threshold(self):
+        fb = LatencyThreshold(max_latency_seconds=1.0)(trace=self._make_trace(2000))
+        assert fb.value is False
+        assert "above threshold" in fb.rationale
+
+    def test_exact_threshold(self):
+        fb = LatencyThreshold(max_latency_seconds=2.0)(trace=self._make_trace(2000))
+        assert fb.value is True
+
+    def test_no_trace(self):
+        fb = LatencyThreshold(max_latency_seconds=1.0)(trace=None)
+        assert fb.value is False
+
+    def test_no_duration(self):
+        trace = MagicMock()
+        trace.info.execution_duration = None
+        fb = LatencyThreshold(max_latency_seconds=1.0)(trace=trace)
+        assert fb.value is False
+
+
+# ── NumericBound ────────────────────────────────────────────────────────────
+
+
+class TestNumericBound:
+    def test_within_bounds(self):
+        fb = NumericBound(min_value=0.0, max_value=1.0)(outputs=0.5)
+        assert fb.value is True
+
+    def test_below_min(self):
+        fb = NumericBound(min_value=0.0)(outputs=-1)
+        assert fb.value is False
+        assert "below minimum" in fb.rationale
+
+    def test_above_max(self):
+        fb = NumericBound(max_value=100)(outputs=150)
+        assert fb.value is False
+        assert "above maximum" in fb.rationale
+
+    def test_string_numeric(self):
+        fb = NumericBound(min_value=0)(outputs="42")
+        assert fb.value is True
+
+    def test_non_numeric(self):
+        fb = NumericBound()(outputs="not a number")
+        assert fb.value is False
+        assert "cannot be converted" in fb.rationale
+
+    def test_none_outputs(self):
+        fb = NumericBound()(outputs=None)
+        assert fb.value is False
+
+    def test_boundary_values(self):
+        scorer = NumericBound(min_value=0.0, max_value=1.0)
+        assert scorer(outputs=0.0).value is True
+        assert scorer(outputs=1.0).value is True
+
+    def test_no_bounds(self):
+        fb = NumericBound()(outputs=999999)
+        assert fb.value is True
+
+
+# ── PII ─────────────────────────────────────────────────────────────────────
+
+
+class TestPII:
+    def test_no_pii(self):
+        fb = PII()(outputs="Hello, how can I help you?")
+        assert fb.value is True
+        assert "No PII" in fb.rationale
+
+    def test_email_detected(self):
+        fb = PII()(outputs="Contact me at user@example.com")
+        assert fb.value is False
+        assert "email" in fb.rationale
+
+    def test_phone_detected(self):
+        fb = PII()(outputs="Call me at 555-123-4567")
+        assert fb.value is False
+        assert "phone" in fb.rationale
+
+    def test_ssn_detected(self):
+        fb = PII()(outputs="My SSN is 123-45-6789")
+        assert fb.value is False
+        assert "ssn" in fb.rationale
+
+    def test_filter_pii_types(self):
+        fb = PII(pii_types=["email"])(outputs="Call 555-123-4567")
+        assert fb.value is True  # phone not checked
+
+    def test_filter_pii_types_match(self):
+        fb = PII(pii_types=["email"])(outputs="Email: user@example.com")
+        assert fb.value is False
+
+    def test_none_outputs(self):
+        fb = PII()(outputs=None)
+        assert fb.value is True
+
+    def test_multiple_pii(self):
+        fb = PII()(outputs="Contact user@a.com or user@b.com, call 555-123-4567")
+        assert fb.value is False
+        assert "email" in fb.rationale
+        assert "phone" in fb.rationale
+
+
+# ── Serialization ───────────────────────────────────────────────────────────
+
+
+class TestBuiltInCodeScorerSerialization:
+    def test_round_trip(self):
+        scorer = JsonValidity(required_keys=["answer"])
+        dumped = scorer.model_dump()
+        assert dumped["builtin_scorer_class"] == "JsonValidity"
+        assert dumped["builtin_scorer_pydantic_data"]["required_keys"] == ["answer"]
+
+        from mlflow.genai.scorers.builtin_code_scorers import BuiltInCodeScorer
+
+        restored = BuiltInCodeScorer.model_validate(dumped)
+        assert isinstance(restored, JsonValidity)
+        assert restored.required_keys == ["answer"]
+
+    def test_round_trip_via_scorer_base(self):
+        from mlflow.genai.scorers.base import Scorer
+
+        scorer = LengthBound(min_length=10, max_length=200, unit="words")
+        dumped = scorer.model_dump()
+        restored = Scorer.model_validate(dumped)
+        assert isinstance(restored, LengthBound)
+        assert restored.min_length == 10
+        assert restored.max_length == 200
+        assert restored.unit == "words"
+
+    def test_round_trip_regex_match(self):
+        from mlflow.genai.scorers.base import Scorer
+
+        scorer = RegexMatch(pattern=r"\d+", full_match=True)
+        dumped = scorer.model_dump()
+        restored = Scorer.model_validate(dumped)
+        assert isinstance(restored, RegexMatch)
+        assert restored.pattern == r"\d+"
+        assert restored.full_match is True

--- a/tests/genai/scorers/test_builtin_code_scorers.py
+++ b/tests/genai/scorers/test_builtin_code_scorers.py
@@ -1,6 +1,9 @@
 from unittest.mock import MagicMock
 
+import pytest
+
 from mlflow.entities.assessment_source import AssessmentSourceType
+from mlflow.exceptions import MlflowException
 from mlflow.genai.scorers import (
     PII,
     ContainsKeywords,
@@ -357,6 +360,17 @@ class TestPII:
         assert "email" in fb.rationale
         assert "phone" in fb.rationale
 
+    def test_credit_card_detected(self):
+        # Visa test number (passes Luhn)
+        fb = PII()(outputs="My card is 4111111111111111")
+        assert fb.value is False
+        assert "credit_card" in fb.rationale
+
+    def test_credit_card_luhn_rejects_random_digits(self):
+        # 16 random digits that fail Luhn should not be flagged as credit card
+        fb = PII(pii_types=["credit_card"])(outputs="Ref: 1234567890123456")
+        assert fb.value is True
+
 
 # ── Serialization ───────────────────────────────────────────────────────────
 
@@ -394,3 +408,17 @@ class TestBuiltInCodeScorerSerialization:
         assert isinstance(restored, RegexMatch)
         assert restored.pattern == r"\d+"
         assert restored.full_match is True
+
+
+# ── validate_columns ────────────────────────────────────────────────────────
+
+
+class TestValidateColumns:
+    def test_validate_columns_passes(self):
+        scorer = ExactMatch()
+        scorer.validate_columns({"outputs", "expectations"})
+
+    def test_validate_columns_missing(self):
+        scorer = ExactMatch()
+        with pytest.raises(MlflowException, match="requires columns"):
+            scorer.validate_columns({"outputs"})

--- a/tests/genai/scorers/test_builtin_code_scorers.py
+++ b/tests/genai/scorers/test_builtin_code_scorers.py
@@ -299,6 +299,21 @@ class TestNumericBound:
         fb = NumericBound()(outputs=999999)
         assert fb.value is True
 
+    def test_nan_rejected(self):
+        fb = NumericBound(min_value=0, max_value=1)(outputs=float("nan"))
+        assert fb.value is False
+        assert "not a finite number" in fb.rationale
+
+    def test_inf_rejected(self):
+        fb = NumericBound()(outputs=float("inf"))
+        assert fb.value is False
+        assert "not a finite number" in fb.rationale
+
+    def test_negative_inf_rejected(self):
+        fb = NumericBound()(outputs=float("-inf"))
+        assert fb.value is False
+        assert "not a finite number" in fb.rationale
+
 
 # ── PII ─────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
### Related Issues/PRs

Closes #20827

### What changes are proposed in this pull request?

This PR implements Phase 1 of issue #20827: 9 built-in deterministic `BuiltInCodeScorer` implementations that complement the existing LLM judges with instant, free, and reproducible structural and safety checks.

#### New file: `mlflow/genai/scorers/builtin_code_scorers.py`

Introduces `BuiltInCodeScorer(Scorer)` — a lightweight base class that extends `Scorer` directly (not `Judge`) since these scorers require no LLM. The base provides serialization/deserialization via `SerializedScorer`, returns `ScorerKind.BUILTIN`, and implements `validate_columns()` for parity with `BuiltInScorer`.

The 9 new scorers:

| Scorer | What it checks | Key parameters |
|---|---|---|
| `ExactMatch` | Output equals `expected_response` | — |
| `JsonValidity` | Output is valid JSON, optionally with required top-level keys | `required_keys` |
| `RegexMatch` | Output matches a regex pattern | `pattern`, `full_match` |
| `ContainsKeywords` | All keywords present in output | `keywords`, `case_sensitive` |
| `LengthBound` | Output length within min/max | `min_length`, `max_length`, `unit` (`chars`/`words`) |
| `IsNotEmpty` | Output is non-empty and non-whitespace | — |
| `LatencyThreshold` | Trace latency ≤ threshold | `max_latency_seconds` |
| `NumericBound` | Numeric output within range (rejects NaN/inf) | `min_value`, `max_value` |
| `PII` | No PII detected (returns `True` = pass when clean) | `pii_types` (`email`, `phone`, `ssn`, `credit_card`) |

All scorers return `Feedback` with `AssessmentSourceType.CODE` and an informative rationale string, giving UI parity with LLM judges.

**Notable implementation details:**
- `NumericBound` uses `math.isfinite()` to explicitly reject NaN, inf, and -inf values.
- `PII` credit card detection uses Luhn checksum validation after regex matching to eliminate false positives from arbitrary digit sequences.

#### Changes to `mlflow/genai/scorers/__init__.py`

- Added `_LAZY_CODE_SCORER_IMPORTS` set mirroring the existing lazy-import pattern
- Extended `__getattr__`, `__dir__`, `TYPE_CHECKING` block, and `__all__` to export all 9 new scorers

#### Changes to `mlflow/genai/scorers/base.py`

- Added fallback in `Scorer.model_validate` to try `BuiltInCodeScorer.model_validate` when `BuiltInScorer.model_validate` raises for an unknown class name, so code scorers share the same deserialization entry point
- The fallback is narrowly scoped: only "Unknown builtin scorer class" errors fall through; other `MlflowException` errors (corrupted data, invalid structure) propagate correctly

#### New file: `tests/genai/scorers/test_builtin_code_scorers.py`

72 unit tests covering all 9 scorers: happy path, `None`/empty inputs, boundary values, error paths, non-finite numeric handling, credit card Luhn validation, column validation, and 3 serialization round-trips.

#### Usage example

```python
from mlflow.genai.scorers import (
    JsonValidity, ContainsKeywords, LengthBound, IsNotEmpty,
    Correctness, Safety,
)

results = mlflow.genai.evaluate(
    data=eval_data,
    predict_fn=my_model,
    scorers=[
        IsNotEmpty(),
        JsonValidity(required_keys=["answer", "sources"]),
        LengthBound(max_length=500, unit="words"),
        ContainsKeywords(keywords=["not financial advice"]),
        Correctness(),
        Safety(),
    ],
)
```

**Out of scope (Phase 2):** Gating infrastructure — running code scorers before LLM judges and skipping expensive judges on structural failures. Tracked in #20827.

### How is this PR tested?

- [x] New unit/integration tests

```
uv run --frozen pytest tests/genai/scorers/test_builtin_code_scorers.py -v
# 72 passed in 16.84s

uv run --frozen pytest tests/genai/scorers/test_serialization.py -v
# 20 passed — no regressions

uv run --frozen ruff check (all 4 changed files)
# All checks passed

uv run --frozen ruff format --check (all 4 changed files)
# All files already formatted
```

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

The 9 new scorer classes follow the same docstring style as existing built-in scorers and will appear in autodoc via `__all__`. A dedicated docs page (like the existing per-scorer pages under `docs/docs/genai/eval-monitor/scorers/`) can be added as a follow-up once the API is reviewed.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add 9 built-in deterministic code scorers (`ExactMatch`, `JsonValidity`, `RegexMatch`, `ContainsKeywords`, `LengthBound`, `IsNotEmpty`, `LatencyThreshold`, `NumericBound`, `PII`) to `mlflow.genai.scorers`. These scorers run without LLM calls — instant, free, and reproducible — and can be mixed with existing LLM judges in `mlflow.genai.evaluate()`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release