### PR TITLE
Add test for custom fields round-trip in `Model` save/load

### DIFF
--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -266,6 +266,38 @@ def test_model_metadata():
         assert loaded_model.metadata["metadata_key"] == "metadata_value"
 
 
+def test_model_custom_fields_round_trip():
+    m = Model(
+        artifact_path="model",
+        run_id="123",
+        flavors={"flavor1": {"a": 1}},
+        custom_string="hello",
+        custom_int=42,
+        custom_dict={"nested_key": "nested_value"},
+        custom_list=[1, 2, 3],
+    )
+    assert m.custom_string == "hello"
+    assert m.custom_int == 42
+    assert m.custom_dict == {"nested_key": "nested_value"}
+    assert m.custom_list == [1, 2, 3]
+
+    d = m.to_dict()
+    assert d["custom_string"] == "hello"
+    assert d["custom_int"] == 42
+    assert d["custom_dict"] == {"nested_key": "nested_value"}
+    assert d["custom_list"] == [1, 2, 3]
+
+    with TempDir() as tmp:
+        path = tmp.path("MLmodel")
+        m.save(path)
+        loaded = Model.load(path)
+    assert loaded.custom_string == "hello"
+    assert loaded.custom_int == 42
+    assert loaded.custom_dict == {"nested_key": "nested_value"}
+    assert loaded.custom_list == [1, 2, 3]
+    assert m == loaded
+
+
 def test_load_model_without_mlflow_version():
     with TempDir(chdr=True) as tmp:
         model = Model(artifact_path="model", run_id="1234", mlflow_version=None)


### PR DESCRIPTION
### Related Issues/PRs

Closes #1781

### What changes are proposed in this pull request?

Issue #1781 requested that the `Model` class support arbitrary custom fields in the MLmodel YAML file without failing on load. The production code already supports this via `**kwargs` in `Model.__init__` (stored with `self.__dict__.update(kwargs)`) and iterating `self.__dict__` in `to_dict()` / `from_dict()`. However, there was no test verifying this behavior, meaning it could regress silently.

This PR adds `test_model_custom_fields_round_trip` to `tests/models/test_model.py`, covering:
- Custom string, int, dict, and list fields stored as instance attributes
- Serialization via `to_dict()`
- Full save/load round-trip through YAML (`Model.save()` → `Model.load()`)
- Equality check after round-trip

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

```
uv run --frozen pytest tests/models/test_model.py::test_model_custom_fields_round_trip -v
# 1 passed
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release