### PR TITLE
Cache Databricks host credentials in telemetry processing

### DIFF
--- a/mlflow/telemetry/client.py
+++ b/mlflow/telemetry/client.py
@@ -45,6 +45,8 @@ def _get_cached_databricks_host_creds(tracking_uri: str):
     return get_databricks_host_creds(tracking_uri)
 
 
+# Cache per tracking URI; 16 is more than enough for any realistic number of
+# distinct tracking URIs within a single process.
 @lru_cache(maxsize=16)
 def _fetch_server_info(tracking_uri: str) -> dict[str, Any] | None:
     try:

--- a/mlflow/telemetry/client.py
+++ b/mlflow/telemetry/client.py
@@ -38,8 +38,13 @@ from mlflow.utils.rest_utils import http_request
 _DATABRICKS_SCHEMES = ("databricks", "databricks-uc", "uc")
 
 
-# Cache per tracking URI; 16 is more than enough for any realistic number of
-# distinct tracking URIs within a single process.
+@lru_cache(maxsize=1)
+def _get_cached_databricks_host_creds(tracking_uri: str):
+    from mlflow.utils.databricks_utils import get_databricks_host_creds
+
+    return get_databricks_host_creds(tracking_uri)
+
+
 @lru_cache(maxsize=16)
 def _fetch_server_info(tracking_uri: str) -> dict[str, Any] | None:
     try:
@@ -290,10 +295,9 @@ class TelemetryClient:
 
     def _forward_to_databricks(self, records: list[Record], request_timeout: float = 1):
         from mlflow.tracking._tracking_service.utils import get_tracking_uri
-        from mlflow.utils.databricks_utils import get_databricks_host_creds
 
         try:
-            creds = get_databricks_host_creds(get_tracking_uri())
+            creds = _get_cached_databricks_host_creds(get_tracking_uri())
         except Exception as e:
             _log_error(f"Failed to get Databricks credentials for telemetry: {e}")
             return


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22295

### What changes are proposed in this pull request?

Adds a module-level `lru_cache`-d wrapper `_get_cached_databricks_host_creds` in `mlflow/telemetry/client.py` so that Databricks credential lookup is performed at most once per unique tracking URI per process, rather than on every telemetry batch sent to Databricks.

The pattern mirrors the existing `_fetch_server_info` cache already in the same file.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request was AI-assisted by Isaac.