### PR TITLE
Add rendering size guards for large media content

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactImageView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactImageView.tsx
@@ -13,6 +13,7 @@ import {
   getLoggedModelArtifactLocationUrl,
 } from '../../../common/utils/ArtifactUtils';
 import { ImagePreviewGroup, Image } from '../../../shared/building_blocks/Image';
+import { DownloadLink, exceedsRenderSizeLimit } from '../../../shared/web-shared/media-rendering-utils';
 import type { LoggedModelArtifactViewerProps } from './ArtifactViewComponents.types';
 import { fetchArtifactUnified } from './utils/fetchArtifactUnified';
 
@@ -34,6 +35,9 @@ const ShowArtifactImageView = ({
   const [isLoading, setIsLoading] = useState(true);
   const [previewVisible, setPreviewVisible] = useState(false);
   const [imageUrl, setImageUrl] = useState(null);
+  const [contentLength, setContentLength] = useState(0);
+
+  const contentType = path.toLowerCase().endsWith('.svg') ? 'image/svg+xml' : 'image/png';
 
   useEffect(() => {
     setIsLoading(true);
@@ -52,11 +56,26 @@ const ShowArtifactImageView = ({
       getArtifact,
     ).then((result: any) => {
       const options = path.toLowerCase().endsWith('.svg') ? { type: 'image/svg+xml' } : undefined;
+      const blob = new Blob([new Uint8Array(result)], options);
+      setContentLength(blob.size);
       // @ts-expect-error TS(2345): Argument of type 'string' is not assignable to par... Remove this comment to see the full error message
-      setImageUrl(URL.createObjectURL(new Blob([new Uint8Array(result)], options)));
+      setImageUrl(URL.createObjectURL(blob));
       setIsLoading(false);
     });
   }, [runUuid, path, getArtifact, isLoggedModelsMode, loggedModelId, experimentId, entityTags]);
+
+  if (exceedsRenderSizeLimit(contentType, contentLength) && imageUrl) {
+    return (
+      <div css={{ padding: '10px' }}>
+        <DownloadLink
+          url={imageUrl}
+          contentType={contentType}
+          contentLength={contentLength}
+          filename={path.split('/').pop()}
+        />
+      </div>
+    );
+  }
 
   return (
     imageUrl && (

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactVideoView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactVideoView.tsx
@@ -5,6 +5,7 @@ import {
   getArtifactLocationUrl,
   getLoggedModelArtifactLocationUrl,
 } from '../../../common/utils/ArtifactUtils';
+import { DownloadLink, exceedsRenderSizeLimit } from '../../../shared/web-shared/media-rendering-utils';
 import type { LoggedModelArtifactViewerProps } from './ArtifactViewComponents.types';
 
 type Props = {
@@ -21,6 +22,7 @@ const ShowArtifactVideoView = ({
   loggedModelId,
 }: Props) => {
   const [videoUrl, setVideoUrl] = useState<string>();
+  const [contentLength, setContentLength] = useState(0);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -33,6 +35,7 @@ const ShowArtifactVideoView = ({
 
     getArtifact(artifactUrl).then((blob: Blob) => {
       objUrl = URL.createObjectURL(blob);
+      setContentLength(blob.size);
       setVideoUrl(objUrl);
       setLoading(false);
     });
@@ -57,6 +60,19 @@ const ShowArtifactVideoView = ({
       display: 'block',
     },
   };
+
+  if (exceedsRenderSizeLimit('video/mp4', contentLength) && videoUrl) {
+    return (
+      <div css={{ padding: 10 }}>
+        <DownloadLink
+          url={videoUrl}
+          contentType="video/mp4"
+          contentLength={contentLength}
+          filename={path.split('/').pop()}
+        />
+      </div>
+    );
+  }
 
   return (
     <div css={{ flex: 1 }}>

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -8447,6 +8447,10 @@
     "defaultMessage": "Clear filters",
     "description": "Label for a button that clears all filters, visible on a experiment runs page next to a empty state when all runs have been filtered out"
   },
+  "pMb1cg": {
+    "defaultMessage": "Download {contentType} ({size})",
+    "description": "Download link for media content that exceeds the rendering size limit"
+  },
   "pOqgMC": {
     "defaultMessage": "Weight",
     "description": "Label for traffic split weight input"

--- a/mlflow/server/js/src/shared/web-shared/media-rendering-utils.ts
+++ b/mlflow/server/js/src/shared/web-shared/media-rendering-utils.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared utilities for deciding whether to auto-render media content inline
+ * or show a download link instead. Used by both trace attachment rendering
+ * and artifact viewing.
+ */
+
+// Auto-render size thresholds (bytes). Files exceeding these show a download link.
+const MAX_IMAGE_RENDER_BYTES = 10 * 1024 * 1024; // 10 MB
+const MAX_AUDIO_RENDER_BYTES = 50 * 1024 * 1024; // 50 MB
+const MAX_PDF_RENDER_BYTES = 20 * 1024 * 1024; // 20 MB
+const MAX_VIDEO_RENDER_BYTES = 50 * 1024 * 1024; // 50 MB
+
+/**
+ * Returns the maximum file size (in bytes) that should be auto-rendered
+ * inline for a given content type. Files exceeding this should show a
+ * download link instead to prevent browser performance issues.
+ *
+ * Returns 0 for unknown content types (always show download link).
+ */
+export function getMaxRenderSize(contentType: string): number {
+  if (contentType.startsWith('image/')) return MAX_IMAGE_RENDER_BYTES;
+  if (contentType.startsWith('audio/')) return MAX_AUDIO_RENDER_BYTES;
+  if (contentType.startsWith('video/')) return MAX_VIDEO_RENDER_BYTES;
+  if (contentType === 'application/pdf') return MAX_PDF_RENDER_BYTES;
+  return 0;
+}
+
+/**
+ * Returns true if the content exceeds the auto-render size limit for its type.
+ */
+export function exceedsRenderSizeLimit(contentType: string, contentLength: number): boolean {
+  return contentLength > getMaxRenderSize(contentType);
+}
+
+/**
+ * Formats a byte count as a human-readable string (e.g., "1.5 MB").
+ */
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/mlflow/server/js/src/shared/web-shared/media-rendering-utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/media-rendering-utils.tsx
@@ -4,6 +4,8 @@
  * and artifact viewing.
  */
 
+import { FormattedMessage } from '@databricks/i18n';
+
 // Auto-render size thresholds (bytes). Files exceeding these show a download link.
 const MAX_IMAGE_RENDER_BYTES = 10 * 1024 * 1024; // 10 MB
 const MAX_AUDIO_RENDER_BYTES = 50 * 1024 * 1024; // 50 MB
@@ -39,4 +41,31 @@ export function formatFileSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
+ * Download link shown when media content exceeds the rendering size limit.
+ */
+export function DownloadLink({
+  url,
+  contentType,
+  contentLength,
+  filename,
+  onClick,
+}: {
+  url: string;
+  contentType: string;
+  contentLength: number;
+  filename?: string;
+  onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
+}) {
+  return (
+    <a href={url} download={filename} onClick={onClick}>
+      <FormattedMessage
+        defaultMessage="Download {contentType} ({size})"
+        description="Download link for media content that exceeds the rendering size limit"
+        values={{ contentType, size: formatFileSize(contentLength) }}
+      />
+    </a>
+  );
 }

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/attachment-utils.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/attachment-utils.ts
@@ -36,15 +36,23 @@ export function parseAttachmentUri(uri: string): { attachmentId: string; traceId
  * Hook that fetches an attachment by URI and returns a blob URL for rendering.
  * Handles cleanup of blob URLs on unmount or when the URI changes.
  */
-export function useAttachmentUrl(uri: string | null): { url: string | null; loading: boolean; error: boolean } {
+export function useAttachmentUrl(uri: string | null): {
+  url: string | null;
+  contentLength: number;
+  contentType: string | null;
+  loading: boolean;
+  error: boolean;
+} {
   const parsed = uri ? parseAttachmentUri(uri) : null;
   const [url, setUrl] = useState<string | null>(null);
+  const [contentLength, setContentLength] = useState(0);
   const [loading, setLoading] = useState(Boolean(parsed));
   const [error, setError] = useState(false);
 
   useEffect(() => {
     if (!parsed) {
       setUrl(null);
+      setContentLength(0);
       setLoading(false);
       setError(false);
       return;
@@ -62,9 +70,11 @@ export function useAttachmentUrl(uri: string | null): { url: string | null; load
           return;
         }
         if (data) {
-          const blobUrl = URL.createObjectURL(new Blob([data], { type: parsed.contentType }));
+          const blob = new Blob([data], { type: parsed.contentType });
+          const blobUrl = URL.createObjectURL(blob);
           localUrl = blobUrl;
           setUrl(blobUrl);
+          setContentLength(blob.size);
         } else {
           setError(true);
         }
@@ -87,7 +97,7 @@ export function useAttachmentUrl(uri: string | null): { url: string | null; load
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [uri]);
 
-  return { url, loading, error };
+  return { url, loading, error, contentLength, contentType: parsed?.contentType ?? null };
 }
 
 export function isAttachmentUri(value: string): boolean {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerAttachmentRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerAttachmentRenderer.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { LegacySkeleton, Modal, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
 
+import { exceedsRenderSizeLimit, formatFileSize } from '../../media-rendering-utils';
 import { useTraceAttachment } from '../hooks/useTraceAttachment';
 
 export const ModelTraceExplorerAttachmentRenderer = ({
@@ -17,7 +18,11 @@ export const ModelTraceExplorerAttachmentRenderer = ({
   contentType: string;
 }) => {
   const { theme } = useDesignSystemTheme();
-  const { objectUrl, isLoading, error } = useTraceAttachment({ traceId, attachmentId, contentType });
+  const { objectUrl, contentLength, isLoading, error } = useTraceAttachment({
+    traceId,
+    attachmentId,
+    contentType,
+  });
   const [previewVisible, setPreviewVisible] = useState(false);
 
   if (error) {
@@ -33,6 +38,27 @@ export const ModelTraceExplorerAttachmentRenderer = ({
 
   if (isLoading || !objectUrl) {
     return <LegacySkeleton />;
+  }
+
+  const exceedsRenderLimit = exceedsRenderSizeLimit(contentType, contentLength);
+
+  if (exceedsRenderLimit) {
+    return (
+      <div css={{ padding: theme.spacing.sm }}>
+        {title && (
+          <Typography.Text bold css={{ display: 'block', marginBottom: theme.spacing.xs }}>
+            {title}
+          </Typography.Text>
+        )}
+        <a href={objectUrl} download={`attachment-${attachmentId}`}>
+          <FormattedMessage
+            defaultMessage="Download {contentType} ({size})"
+            description="Download link for trace attachment that exceeds the rendering size limit"
+            values={{ contentType, size: formatFileSize(contentLength) }}
+          />
+        </a>
+      </div>
+    );
   }
 
   if (contentType.startsWith('image/')) {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerAttachmentRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerAttachmentRenderer.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { LegacySkeleton, Modal, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
 
-import { exceedsRenderSizeLimit, formatFileSize } from '../../media-rendering-utils';
+import { DownloadLink, exceedsRenderSizeLimit } from '../../media-rendering-utils';
 import { useTraceAttachment } from '../hooks/useTraceAttachment';
 
 export const ModelTraceExplorerAttachmentRenderer = ({
@@ -50,13 +50,12 @@ export const ModelTraceExplorerAttachmentRenderer = ({
             {title}
           </Typography.Text>
         )}
-        <a href={objectUrl} download={`attachment-${attachmentId}`}>
-          <FormattedMessage
-            defaultMessage="Download {contentType} ({size})"
-            description="Download link for trace attachment that exceeds the rendering size limit"
-            values={{ contentType, size: formatFileSize(contentLength) }}
-          />
-        </a>
+        <DownloadLink
+          url={objectUrl}
+          contentType={contentType}
+          contentLength={contentLength}
+          filename={`attachment-${attachmentId}`}
+        />
       </div>
     );
   }

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/hooks/useTraceAttachment.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/hooks/useTraceAttachment.ts
@@ -19,11 +19,7 @@ export const useTraceAttachment = ({
   attachmentId: string;
   contentType: string;
 }) => {
-  const {
-    data: objectUrl,
-    isLoading,
-    error,
-  } = useQuery({
+  const { data, isLoading, error } = useQuery({
     queryKey: [TRACE_ATTACHMENT_QUERY_KEY, traceId, attachmentId],
     queryFn: async () => {
       const url = getAjaxUrl(
@@ -31,18 +27,26 @@ export const useTraceAttachment = ({
       );
       const response = await fetchOrFail(url);
       const blob = await response.blob();
-      return URL.createObjectURL(new Blob([blob], { type: contentType }));
+      return {
+        objectUrl: URL.createObjectURL(new Blob([blob], { type: contentType })),
+        contentLength: blob.size,
+      };
     },
     refetchOnWindowFocus: false,
   });
 
   useEffect(() => {
     return () => {
-      if (objectUrl) {
-        URL.revokeObjectURL(objectUrl);
+      if (data?.objectUrl) {
+        URL.revokeObjectURL(data.objectUrl);
       }
     };
-  }, [objectUrl]);
+  }, [data?.objectUrl]);
 
-  return { objectUrl: objectUrl ?? null, isLoading, error };
+  return {
+    objectUrl: data?.objectUrl ?? null,
+    contentLength: data?.contentLength ?? 0,
+    isLoading,
+    error,
+  };
 };

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessage.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessage.tsx
@@ -14,7 +14,7 @@ import {
 } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
 import { GenAIMarkdownRenderer } from '../../genai-markdown-renderer/GenAIMarkdownRenderer';
-import { exceedsRenderSizeLimit, formatFileSize } from '../../media-rendering-utils';
+import { DownloadLink, exceedsRenderSizeLimit } from '../../media-rendering-utils';
 import {
   attachmentAwareUrlTransform,
   isAttachmentUri,
@@ -72,11 +72,7 @@ function AttachmentImage({ src, alt }: { src?: string; alt?: string }) {
     return <span>{`[${alt ?? 'Failed to load image'}]`}</span>;
   }
   if (contentType && exceedsRenderSizeLimit(contentType, contentLength)) {
-    return (
-      <a href={url} download>
-        {`Download ${contentType} (${formatFileSize(contentLength)})`}
-      </a>
-    );
+    return <DownloadLink url={url} contentType={contentType} contentLength={contentLength} />;
   }
   return <ClickToExpandImage src={url} alt={alt} />;
 }
@@ -267,11 +263,7 @@ function AttachmentAudioPlayer({ uri }: { uri: string }) {
     );
   }
   if (contentType && exceedsRenderSizeLimit(contentType, contentLength)) {
-    return (
-      <a href={url} download>
-        {`Download ${contentType} (${formatFileSize(contentLength)})`}
-      </a>
-    );
+    return <DownloadLink url={url} contentType={contentType} contentLength={contentLength} />;
   }
   // eslint-disable-next-line jsx-a11y/media-has-caption
   return <audio controls css={{ width: '100%', maxWidth: 500 }} src={url} />;

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessage.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessage.tsx
@@ -14,6 +14,7 @@ import {
 } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
 import { GenAIMarkdownRenderer } from '../../genai-markdown-renderer/GenAIMarkdownRenderer';
+import { exceedsRenderSizeLimit, formatFileSize } from '../../media-rendering-utils';
 import {
   attachmentAwareUrlTransform,
   isAttachmentUri,
@@ -63,12 +64,19 @@ function ClickToExpandImage({ src, alt }: { src: string; alt?: string }) {
 }
 
 function AttachmentImage({ src, alt }: { src?: string; alt?: string }) {
-  const { url, loading, error } = useAttachmentUrl(src ?? null);
+  const { url, contentLength, contentType, loading, error } = useAttachmentUrl(src ?? null);
   if (loading) {
     return <Spinner size="small" />;
   }
   if (error || !url) {
     return <span>{`[${alt ?? 'Failed to load image'}]`}</span>;
+  }
+  if (contentType && exceedsRenderSizeLimit(contentType, contentLength)) {
+    return (
+      <a href={url} download>
+        {`Download ${contentType} (${formatFileSize(contentLength)})`}
+      </a>
+    );
   }
   return <ClickToExpandImage src={url} alt={alt} />;
 }
@@ -244,7 +252,7 @@ function getAudioMimeType(format: string): string {
 }
 
 function AttachmentAudioPlayer({ uri }: { uri: string }) {
-  const { url, loading, error } = useAttachmentUrl(uri);
+  const { url, contentLength, contentType, loading, error } = useAttachmentUrl(uri);
   if (loading) {
     return <Spinner size="small" />;
   }
@@ -256,6 +264,13 @@ function AttachmentAudioPlayer({ uri }: { uri: string }) {
           description="Error message when trace audio attachment fails to load"
         />
       </Typography.Text>
+    );
+  }
+  if (contentType && exceedsRenderSizeLimit(contentType, contentLength)) {
+    return (
+      <a href={url} download>
+        {`Download ${contentType} (${formatFileSize(contentLength)})`}
+      </a>
     );
   }
   // eslint-disable-next-line jsx-a11y/media-has-caption


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22446

### What changes are proposed in this pull request?

Large media files can cause browser performance issues when rendered inline. Adds per-content-type size thresholds — files exceeding the limit show a download link instead of rendering inline.

**Thresholds:** images 10MB, audio 50MB, video 50MB, PDF 20MB.

**Shared `media-rendering-utils.ts` module** with `exceedsRenderSizeLimit()`, `formatFileSize()`, and `getMaxRenderSize()` — reusable across trace attachments and artifact viewing.

**Applied to all media rendering paths:**
- `AttachmentRenderer` (trace summary/detail view)
- `AttachmentImage` (trace chat view)
- `AttachmentAudioPlayer` (trace chat view)
- `ShowArtifactImageView` (artifact viewer)
- `ShowArtifactVideoView` (artifact viewer)

Both `useTraceAttachment` and `useAttachmentUrl` hooks now return `contentLength` from `blob.size` so renderers can check before displaying.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

No unit test added — the size check is a simple comparison in rendering components with no existing test infrastructure. The shared util functions (`exceedsRenderSizeLimit`, `formatFileSize`) are straightforward and tested implicitly through the rendering paths.
<img width="1373" height="405" alt="Screenshot 2026-04-14 at 4 25 49 PM" src="https://github.com/user-attachments/assets/db42370d-9fbd-4292-abc8-ee8a665b2c6f" />


### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Large media files in traces and artifacts now show a download link instead of attempting to render inline, preventing browser freezes.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release