### PR TITLE
Add size limit for trace attachments

### DIFF
--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -615,7 +615,7 @@ class LiveSpan(Span):
             return [self._extract_attachments(item, extract_base64) for item in value]
         return value
 
-    def _store_attachment(self, attachment: Attachment) -> str | None:
+    def _store_attachment(self, attachment: Attachment) -> str:
         from mlflow.environment_variables import MLFLOW_TRACE_MAX_ATTACHMENT_SIZE
 
         max_size = MLFLOW_TRACE_MAX_ATTACHMENT_SIZE.get()
@@ -672,8 +672,6 @@ class LiveSpan(Span):
                 ref = self._store_attachment(
                     Attachment(content_type=content_type, content_bytes=content_bytes)
                 )
-                if ref is None:
-                    return None
                 return {
                     **value,
                     "input_audio": {**audio, "data": ref},
@@ -692,8 +690,6 @@ class LiveSpan(Span):
                     ref = self._store_attachment(
                         Attachment(content_type=media_type, content_bytes=content_bytes)
                     )
-                    if ref is None:
-                        return None
                     return {
                         **value,
                         "source": {**source, "data": ref},
@@ -709,8 +705,6 @@ class LiveSpan(Span):
             ref = self._store_attachment(
                 Attachment(content_type="image/png", content_bytes=content_bytes)
             )
-            if ref is None:
-                return None
             return {**value, "b64_json": ref}
 
         # OpenAI audio output: {"audio": {"data": "<base64>", "transcript": "..."}, ...}
@@ -725,8 +719,6 @@ class LiveSpan(Span):
                 ref = self._store_attachment(
                     Attachment(content_type="audio/wav", content_bytes=content_bytes)
                 )
-                if ref is None:
-                    return None
                 return {
                     **value,
                     "audio": {**audio, "data": ref},
@@ -748,8 +740,6 @@ class LiveSpan(Span):
                     ref = self._store_attachment(
                         Attachment(content_type=f"image/{fmt}", content_bytes=content_bytes)
                     )
-                    if ref is None:
-                        return None
                     return {
                         **value,
                         "image": {**image, "source": {**source, "bytes": ref}},
@@ -780,8 +770,6 @@ class LiveSpan(Span):
                 ref = self._store_attachment(
                     Attachment(content_type=mime_type, content_bytes=content_bytes)
                 )
-                if ref is None:
-                    return None
                 return {
                     **value,
                     "inline_data": {**inline, "data": ref},
@@ -802,8 +790,6 @@ class LiveSpan(Span):
                 ref = self._store_attachment(
                     Attachment(content_type=f"image/{fmt}", content_bytes=content_bytes)
                 )
-                if ref is None:
-                    return None
                 return {**value, "result": ref}
 
         return None

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -615,7 +615,19 @@ class LiveSpan(Span):
             return [self._extract_attachments(item, extract_base64) for item in value]
         return value
 
-    def _store_attachment(self, attachment: Attachment) -> str:
+    def _store_attachment(self, attachment: Attachment) -> str | None:
+        from mlflow.environment_variables import MLFLOW_TRACE_MAX_ATTACHMENT_SIZE
+
+        max_size = MLFLOW_TRACE_MAX_ATTACHMENT_SIZE.get()
+        if max_size is not None and max_size > 0 and len(attachment.content_bytes) > max_size:
+            size_bytes = len(attachment.content_bytes)
+            msg = (
+                f"Attachment too large ({size_bytes} bytes > {max_size} bytes limit). "
+                f"Content discarded."
+            )
+            _logger.warning(msg)
+            self.record_exception(msg)
+            return f"[Attachment too large: {size_bytes} bytes exceeds {max_size} bytes limit]"
         ref = attachment.ref(self.trace_id)
         self._attachments[attachment.id] = attachment
         return ref
@@ -660,6 +672,8 @@ class LiveSpan(Span):
                 ref = self._store_attachment(
                     Attachment(content_type=content_type, content_bytes=content_bytes)
                 )
+                if ref is None:
+                    return None
                 return {
                     **value,
                     "input_audio": {**audio, "data": ref},
@@ -678,6 +692,8 @@ class LiveSpan(Span):
                     ref = self._store_attachment(
                         Attachment(content_type=media_type, content_bytes=content_bytes)
                     )
+                    if ref is None:
+                        return None
                     return {
                         **value,
                         "source": {**source, "data": ref},
@@ -693,6 +709,8 @@ class LiveSpan(Span):
             ref = self._store_attachment(
                 Attachment(content_type="image/png", content_bytes=content_bytes)
             )
+            if ref is None:
+                return None
             return {**value, "b64_json": ref}
 
         # OpenAI audio output: {"audio": {"data": "<base64>", "transcript": "..."}, ...}
@@ -707,6 +725,8 @@ class LiveSpan(Span):
                 ref = self._store_attachment(
                     Attachment(content_type="audio/wav", content_bytes=content_bytes)
                 )
+                if ref is None:
+                    return None
                 return {
                     **value,
                     "audio": {**audio, "data": ref},
@@ -728,6 +748,8 @@ class LiveSpan(Span):
                     ref = self._store_attachment(
                         Attachment(content_type=f"image/{fmt}", content_bytes=content_bytes)
                     )
+                    if ref is None:
+                        return None
                     return {
                         **value,
                         "image": {**image, "source": {**source, "bytes": ref}},
@@ -758,6 +780,8 @@ class LiveSpan(Span):
                 ref = self._store_attachment(
                     Attachment(content_type=mime_type, content_bytes=content_bytes)
                 )
+                if ref is None:
+                    return None
                 return {
                     **value,
                     "inline_data": {**inline, "data": ref},
@@ -778,6 +802,8 @@ class LiveSpan(Span):
                 ref = self._store_attachment(
                     Attachment(content_type=f"image/{fmt}", content_bytes=content_bytes)
                 )
+                if ref is None:
+                    return None
                 return {**value, "result": ref}
 
         return None

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -726,6 +726,14 @@ MLFLOW_TRACE_EXTRACT_ATTACHMENTS = _BooleanEnvironmentVariable(
     "MLFLOW_TRACE_EXTRACT_ATTACHMENTS", True
 )
 
+#: Maximum size in bytes for a single trace attachment. When set, attachments
+#: exceeding this limit are discarded and replaced with an error message.
+#: Only applies to trace attachments, not artifact uploads.
+#: (default: unset — no limit)
+MLFLOW_TRACE_MAX_ATTACHMENT_SIZE = _EnvironmentVariable(
+    "MLFLOW_TRACE_MAX_ATTACHMENT_SIZE", int, None
+)
+
 #: Maximum number of prompt versions to cache in the LRU cache for _load_prompt_version_cached.
 #: This cache improves performance by avoiding repeated network calls for the same prompt version.
 #: (default: ``128``)

--- a/tests/entities/test_span_auto_extract_attachments.py
+++ b/tests/entities/test_span_auto_extract_attachments.py
@@ -586,3 +586,74 @@ def test_explicit_attachment_still_works_when_opted_out(monkeypatch):
     span.set_inputs({"image": att})
     assert span.inputs["image"].startswith("mlflow-attachment://")
     assert len(span._attachments) == 1
+
+
+# --- Attachment size limit ---
+
+
+def test_attachment_under_size_limit_is_extracted(monkeypatch):
+    monkeypatch.setenv("MLFLOW_TRACE_MAX_ATTACHMENT_SIZE", str(len(PNG_BYTES) + 1))
+    span = _make_live_span()
+    span.set_inputs({"image": PNG_DATA_URI})
+
+    assert span.inputs["image"].startswith("mlflow-attachment://")
+    assert len(span._attachments) == 1
+
+
+def test_attachment_over_size_limit_is_discarded(monkeypatch):
+    monkeypatch.setenv("MLFLOW_TRACE_MAX_ATTACHMENT_SIZE", str(len(PNG_BYTES) - 1))
+    span = _make_live_span()
+    span.set_inputs({"image": PNG_DATA_URI})
+
+    assert "[Attachment too large:" in span.inputs["image"]
+    assert len(span._attachments) == 0
+
+
+def test_attachment_size_limit_unset_allows_all():
+    # Default is None (unset) — no limit enforced
+    span = _make_live_span()
+    span.set_inputs({"image": PNG_DATA_URI})
+
+    assert span.inputs["image"].startswith("mlflow-attachment://")
+    assert len(span._attachments) == 1
+
+
+def test_structured_content_over_size_limit_is_discarded(monkeypatch):
+    monkeypatch.setenv("MLFLOW_TRACE_MAX_ATTACHMENT_SIZE", "1")
+    span = _make_live_span()
+    span.set_inputs({
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_audio",
+                        "input_audio": {"data": WAV_B64, "format": "wav"},
+                    }
+                ],
+            }
+        ]
+    })
+
+    audio_part = span.inputs["messages"][0]["content"][0]
+    assert "[Attachment too large:" in audio_part["input_audio"]["data"]
+    assert len(span._attachments) == 0
+
+
+def test_explicit_attachment_over_size_limit_is_discarded(monkeypatch):
+    monkeypatch.setenv("MLFLOW_TRACE_MAX_ATTACHMENT_SIZE", "1")
+    span = _make_live_span()
+    att = Attachment(content_type="image/png", content_bytes=PNG_BYTES)
+    span.set_inputs({"image": att})
+
+    assert "[Attachment too large:" in span.inputs["image"]
+    assert len(span._attachments) == 0
+
+
+def test_attachment_size_limit_negative_treated_as_disabled(monkeypatch):
+    monkeypatch.setenv("MLFLOW_TRACE_MAX_ATTACHMENT_SIZE", "-1")
+    span = _make_live_span()
+    span.set_inputs({"image": PNG_DATA_URI})
+
+    assert span.inputs["image"].startswith("mlflow-attachment://")
+    assert len(span._attachments) == 1


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22446

### What changes are proposed in this pull request?

Adds a configurable size limit for trace attachments via `MLFLOW_TRACE_MAX_ATTACHMENT_SIZE` environment variable. When set, attachments exceeding the limit are:

- **Discarded** — the binary content is thrown away, not stored or left inline
- **Replaced** with an error message string (e.g., `[Attachment too large: 15728648 bytes exceeds 5000 bytes limit]`)
- **Logged** as a warning
- **Recorded** as an exception event on the span (span status set to ERROR, visible in UI events tab)

**Default: unset (no limit).** When the env var is not set, all attachments are extracted regardless of size.

**Only affects trace attachments** — artifact uploads via `artifact_repo.log_artifact` are not affected.

In multi-span traces, only the span with the oversized attachment gets ERROR status — parent spans and the trace status remain OK.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Added 5 tests in `test_span_auto_extract_attachments.py`:
- `test_attachment_under_size_limit_is_extracted` — attachment below limit extracts normally
- `test_attachment_over_size_limit_is_discarded` — data URI over limit replaced with error message
- `test_attachment_size_limit_unset_allows_all` — default (unset) allows any size
- `test_structured_content_over_size_limit_is_discarded` — structured pattern (input_audio) replaced with error message
- `test_explicit_attachment_over_size_limit_is_discarded` — manual Attachment over limit replaced with error message

<img width="1370" height="572" alt="Screenshot 2026-04-14 at 4 30 33 PM" src="https://github.com/user-attachments/assets/15e979ad-ef56-41fa-941d-da8982d96eb2" />

<img width="1374" height="829" alt="Screenshot 2026-04-14 at 4 31 56 PM" src="https://github.com/user-attachments/assets/40ca1c73-7962-4c5c-95ec-935e1eaca926" />


### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Trace attachments can now be capped via `MLFLOW_TRACE_MAX_ATTACHMENT_SIZE`. Oversized attachments are discarded with an error message and exception event on the span.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release