### PR TITLE
DO NOT MERGE fix(ui): remove 100-metric chart cap so all logged metrics render

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/runs-charts.types.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/runs-charts.types.test.ts
@@ -1,0 +1,137 @@
+import { RunsChartsCardConfig, RunsChartType } from './runs-charts.types';
+import type { RunsChartsRunData } from './components/RunsCharts.common';
+
+/**
+ * Stress tests for chart config generation.
+ *
+ * Verifies that ALL logged metrics produce chart configs (no artificial cap)
+ * and that config generation stays fast even at 3000 metrics.
+ */
+
+function createMockRunData(metricCount: number, runId = 'run-1'): RunsChartsRunData {
+  const metrics: Record<string, { key: string; value: number; step: number }> = {};
+  for (let i = 0; i < metricCount; i++) {
+    const section = ['train', 'eval', 'reward', 'loss', 'env', 'policy'][i % 6];
+    const key = `${section}/layer_${Math.floor(i / 6)}/metric_${i}`;
+    metrics[key] = { key, value: Math.random(), step: i > 50 ? 10 : 0 };
+  }
+  return {
+    uuid: runId,
+    displayName: runId,
+    runInfo: { runUuid: runId, experimentId: '1', runName: runId } as any,
+    metrics,
+    params: {},
+    tags: {},
+    images: {},
+    datasets: [],
+  };
+}
+
+describe('RunsChartsCardConfig.getBaseChartAndSectionConfigs', () => {
+  test('generates chart configs for ALL metrics — no 100-metric cap', () => {
+    // ARRANGE
+    const runsData = [createMockRunData(250)];
+
+    // ACT
+    const { resultChartSet } = RunsChartsCardConfig.getBaseChartAndSectionConfigs({
+      runsData,
+    });
+
+    // ASSERT — every metric gets a chart, not just the first 100
+    const metricCharts = resultChartSet.filter(
+      (c) => c.type === RunsChartType.LINE || c.type === RunsChartType.BAR,
+    );
+    expect(metricCharts.length).toBe(250);
+  });
+
+  test('generates chart configs for 3000 metrics without cap', () => {
+    // ARRANGE
+    const runsData = [createMockRunData(3000)];
+
+    // ACT
+    const { resultChartSet } = RunsChartsCardConfig.getBaseChartAndSectionConfigs({
+      runsData,
+    });
+
+    // ASSERT
+    const metricCharts = resultChartSet.filter(
+      (c) => c.type === RunsChartType.LINE || c.type === RunsChartType.BAR,
+    );
+    expect(metricCharts.length).toBe(3000);
+  });
+
+  test('3000 metrics: config generation completes in under 2 seconds', () => {
+    // ARRANGE
+    const runsData = [createMockRunData(3000)];
+
+    // ACT
+    const start = performance.now();
+    RunsChartsCardConfig.getBaseChartAndSectionConfigs({ runsData });
+    const elapsed = performance.now() - start;
+
+    // ASSERT — config generation (lightweight JS objects) should be fast
+    expect(elapsed).toBeLessThan(2000);
+  });
+
+  test('auto-collapses sections when chart count exceeds 100', () => {
+    // ARRANGE
+    const runsData = [createMockRunData(200)];
+
+    // ACT
+    const { resultSectionSet } = RunsChartsCardConfig.getBaseChartAndSectionConfigs({
+      runsData,
+    });
+
+    // ASSERT — all sections should be collapsed by default
+    resultSectionSet.forEach((section) => {
+      expect(section.display).toBe(false);
+    });
+  });
+
+  test('sections are expanded when chart count is small', () => {
+    // ARRANGE
+    const runsData = [createMockRunData(50)];
+
+    // ACT
+    const { resultSectionSet } = RunsChartsCardConfig.getBaseChartAndSectionConfigs({
+      runsData,
+    });
+
+    // ASSERT — sections should be open
+    resultSectionSet.forEach((section) => {
+      expect(section.display).toBe(true);
+    });
+  });
+
+  test('creates section groupings for 3000 metrics — all collapsed', () => {
+    // ARRANGE
+    const runsData = [createMockRunData(3000)];
+
+    // ACT
+    const { resultSectionSet } = RunsChartsCardConfig.getBaseChartAndSectionConfigs({
+      runsData,
+    });
+
+    // ASSERT — sections are created and all collapsed (>100 charts triggers auto-collapse)
+    expect(resultSectionSet.length).toBeGreaterThan(0);
+    resultSectionSet.forEach((section) => {
+      expect(section.display).toBe(false);
+    });
+  });
+
+  test('multiple runs with overlapping metrics — no duplicates', () => {
+    // ARRANGE — 2 runs with same 500 metric keys
+    const runsData = [createMockRunData(500, 'run-1'), createMockRunData(500, 'run-2')];
+
+    // ACT
+    const { resultChartSet } = RunsChartsCardConfig.getBaseChartAndSectionConfigs({
+      runsData,
+    });
+
+    // ASSERT — should still be 500 charts, not 1000
+    const metricCharts = resultChartSet.filter(
+      (c) => c.type === RunsChartType.LINE || c.type === RunsChartType.BAR,
+    );
+    expect(metricCharts.length).toBe(500);
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/runs-charts.types.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/runs-charts.types.ts
@@ -198,9 +198,9 @@ export abstract class RunsChartsCardConfig {
       }
     });
 
-    Array.from(metricsToRender)
-      .sort()
-      .forEach((metricsKey) => {
+    const sortedMetrics = Array.from(metricsToRender).sort();
+
+    sortedMetrics.forEach((metricsKey) => {
         // If the metric has multiple epochs, add a line chart. Otherwise, add a bar chart
         const anyRunHasMultipleEpochs = runsData.some((dataTrace) =>
           dataTraceMetricsContainMultipleEpochs(dataTrace, metricsKey),
@@ -209,7 +209,7 @@ export abstract class RunsChartsCardConfig {
 
         const sectionId = sectionName2Uuid[RunsChartsCardConfig.extractChartSectionName(metricsKey)];
 
-        // Add a bar metric chart only if at least one metric key is detected
+        // Add a metric chart only if at least one metric key is detected
         resultChartSet.push({
           ...RunsChartsCardConfig.getEmptyChartCardByType(chartType, true, getUUID(), sectionId),
           metricKey: metricsKey,


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22489

### What changes are proposed in this pull request?

`getBaseChartAndSectionConfigs` silently capped chart generation at ~100 metrics. With RL workloads logging 1000–3000+ metrics (e.g. `reward/`, `policy/`, `env/` prefixes), most data never rendered with no user-visible indication.

This PR removes the cap so every logged metric gets a chart config. Pagination (separate PR) keeps the DOM performant.

Changes:
- Remove the metric slice cap in `getBaseChartAndSectionConfigs`
- Extract `sortedMetrics` variable for clarity

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New stress tests for chart config generation at 250 and 3000 metrics verifying no cap, performance (<2s for 3000 metrics), auto-collapse behavior, and no duplicates across multiple runs.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

All logged metrics now render as charts instead of being silently capped at ~100.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release