### PR TITLE
fix(ui): pre-compute section-to-charts map to avoid O(n²) filtering

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/sections/RunsChartsSectionAccordion.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/sections/RunsChartsSectionAccordion.tsx
@@ -316,6 +316,20 @@ export const RunsChartsSectionAccordion = ({
     return { sectionsToRender: compareRunSectionsFiltered, chartsToRender: compareRunChartsFiltered };
   }, [search, compareRunCharts, compareRunSections]);
 
+  // Pre-compute section→charts mapping to avoid O(n²) filtering
+  const chartsBySectionId = useMemo(() => {
+    const map: Record<string, RunsChartsCardConfig[]> = {};
+    for (const config of chartsToRender || []) {
+      if (config.deleted) continue;
+      const sectionId = (config as RunsChartsBarCardConfig).metricSectionId;
+      if (sectionId) {
+        if (!map[sectionId]) map[sectionId] = [];
+        map[sectionId].push(config);
+      }
+    }
+    return map;
+  }, [chartsToRender]);
+
   const isSearching = search !== '';
 
   if (!compareRunSections || !compareRunCharts) {
@@ -366,10 +380,7 @@ export const RunsChartsSectionAccordion = ({
     <div>
       <MetricChartsAccordion activeKey={activeKey} onActiveKeyChange={onActivePanelChange}>
         {(sectionsToRender || []).map((sectionConfig: ChartSectionConfig, index: number) => {
-          const sectionCharts = (chartsToRender || []).filter((config: RunsChartsCardConfig) => {
-            const section = (config as RunsChartsBarCardConfig).metricSectionId;
-            return !config.deleted && section === sectionConfig.uuid;
-          });
+          const sectionCharts = chartsBySectionId[sectionConfig.uuid] || [];
 
           return (
             <Accordion.Panel


### PR DESCRIPTION
## Related Issues/PRs

Relates to #22489

## What changes are proposed in this pull request?

`RunsChartsSectionAccordion` re-scanned the entire chart array for every section to find its children. At 3000 charts × 50 sections this caused a visible rendering bottleneck.

This PR builds a `Record<sectionId, cards[]>` once in `useMemo` and looks up by section UUID — O(n) total instead of O(n×m).

Changes:
- Add `chartsBySectionId` useMemo that pre-computes a section→charts mapping
- Replace the per-section inline `.filter()` with a direct map lookup

## How is this PR tested?

- [x] Existing unit tests
- [ ] Manual testing with experiments logging 3000+ metrics — confirmed faster section rendering

## Does this PR require documentation update?
- [ ] No. Internal rendering optimization only.

## Release Notes

### Is this a user-facing change?

- [x] Yes. Faster chart section rendering for experiments with many metrics.

### What component(s) does this PR affect?

- [ ] `area/tracking`
- [ ] `area/models`
- [ ] `area/model-registry`
- [ ] `area/scoring`
- [ ] `area/evaluation`
- [ ] `area/gateway`
- [ ] `area/prompts`
- [ ] `area/tracing`
- [ ] `area/projects`
- [x] `area/uiux`
- [ ] `area/build`
- [ ] `area/docs`

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - Small bugfix or doc update, not worth noting
- [ ] `rn/breaking-change` - Breaks an existing feature or API
- [ ] `rn/feature` - New user-facing feature
- [x] `rn/bug-fix` - User-facing bug fix
- [ ] `rn/documentation` - Documentation change

### Should this PR be included in the next patch release?

No — not a critical bugfix blocking users on the current release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)