### PR TITLE
fix(ui): paginate chart cards and sections, auto-collapse for high metric counts

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsDraggableCardsGridSection.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsDraggableCardsGridSection.tsx
@@ -1,5 +1,5 @@
-import { Empty, useDesignSystemTheme } from '@databricks/design-system';
-import { memo, useCallback, useMemo, useRef, useState } from 'react';
+import { Button, Empty, useDesignSystemTheme } from '@databricks/design-system';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useUpdateRunsChartsUIConfiguration } from '../hooks/useRunsChartsUIConfiguration';
 import type { RunsChartsCardConfig } from '../runs-charts.types';
 import type { RunsChartsRunData } from './RunsCharts.common';
@@ -18,6 +18,7 @@ import { DRAGGABLE_CARD_TRANSITION_NAME, type RunsChartCardSetFullscreenFn } fro
 import type { RunsGroupByConfig } from '../../experiment-page/utils/experimentPage.group-row-utils';
 import type { RunsChartsGlobalLineChartConfig } from '../../experiment-page/models/ExperimentPageUIState';
 
+const CHARTS_PER_PAGE = 50;
 const rowHeightSuggestions = [300, 330, 360, 400, 500];
 
 const getColumnSuggestions = (containerWidth: number, gapSize = 8) =>
@@ -158,7 +159,7 @@ export const RunsChartsDraggableCardsGridSection = memo(
       [columns, cardHeight, theme, cardsConfig.length],
     );
 
-    const cardsToRender = useMemo(() => {
+    const allFilteredCards = useMemo(() => {
       const isEmptyChartCard = createEmptyChartCardPredicate(chartRunData);
       return cardsConfig.filter((cardConfig) => {
         if (!hideEmptyCharts) {
@@ -167,6 +168,17 @@ export const RunsChartsDraggableCardsGridSection = memo(
         return !isEmptyChartCard(cardConfig);
       });
     }, [cardsConfig, chartRunData, hideEmptyCharts]);
+
+    const [visibleCount, setVisibleCount] = useState(CHARTS_PER_PAGE);
+    // Reset pagination when the card list changes (e.g., switching experiments)
+    useEffect(() => {
+      setVisibleCount(CHARTS_PER_PAGE);
+    }, [allFilteredCards.length]);
+    const cardsToRender = useMemo(() => {
+      return allFilteredCards.slice(0, visibleCount);
+    }, [allFilteredCards, visibleCount]);
+    const hasMoreCards = allFilteredCards.length > visibleCount;
+    const remainingCards = allFilteredCards.length - visibleCount;
 
     // Calculate the transforms for each card based on the dragged card and its position.
     const cardTransforms = useMemo(() => {
@@ -310,84 +322,96 @@ export const RunsChartsDraggableCardsGridSection = memo(
     );
 
     return (
-      <div
-        ref={gridBoxRef}
-        css={[
-          { position: 'relative' },
-          cardsToRender.length > 0 && {
-            display: 'grid',
-            gap: theme.spacing.sm,
-          },
-        ]}
-        style={{
-          gridTemplateColumns: 'repeat(' + columns + ', 1fr)',
-          ...(draggedCardUuid && {
-            [DRAGGABLE_CARD_TRANSITION_NAME]: 'transform 0.1s',
-          }),
-        }}
-        data-testid="draggable-chart-cards-grid"
-        onMouseMove={mouseMove}
-        onMouseLeave={() => {
-          setPositionInSection(null);
-        }}
-      >
-        {(draggedCardUuid || resizePreview) && (
-          <Global
-            styles={{
-              'body, :host': {
-                userSelect: 'none',
-              },
-            }}
-          />
-        )}
-        {cardsToRender.length === 0 && (
-          <div css={{ display: 'flex', justifyContent: 'center', minHeight: 160 }}>
-            <Empty
-              title={
-                <FormattedMessage
-                  defaultMessage="No charts in this section"
-                  description="Runs compare page > Charts tab > No charts placeholder title"
-                />
-              }
-              description={
-                <FormattedMessage
-                  defaultMessage="Click 'Add chart' or drag and drop to add charts here."
-                  description="Runs compare page > Charts tab > No charts placeholder description"
-                />
-              }
+      <>
+        <div
+          ref={gridBoxRef}
+          css={[
+            { position: 'relative' },
+            cardsToRender.length > 0 && {
+              display: 'grid',
+              gap: theme.spacing.sm,
+            },
+          ]}
+          style={{
+            gridTemplateColumns: 'repeat(' + columns + ', 1fr)',
+            ...(draggedCardUuid && {
+              [DRAGGABLE_CARD_TRANSITION_NAME]: 'transform 0.1s',
+            }),
+          }}
+          data-testid="draggable-chart-cards-grid"
+          onMouseMove={mouseMove}
+          onMouseLeave={() => {
+            setPositionInSection(null);
+          }}
+        >
+          {(draggedCardUuid || resizePreview) && (
+            <Global
+              styles={{
+                'body, :host': {
+                  userSelect: 'none',
+                },
+              }}
             />
+          )}
+          {cardsToRender.length === 0 && (
+            <div css={{ display: 'flex', justifyContent: 'center', minHeight: 160 }}>
+              <Empty
+                title={
+                  <FormattedMessage
+                    defaultMessage="No charts in this section"
+                    description="Runs compare page > Charts tab > No charts placeholder title"
+                  />
+                }
+                description={
+                  <FormattedMessage
+                    defaultMessage="Click 'Add chart' or drag and drop to add charts here."
+                    description="Runs compare page > Charts tab > No charts placeholder description"
+                  />
+                }
+              />
+            </div>
+          )}
+          {cardsToRender.map((cardConfig, index, array) => {
+            return (
+              <RunsChartsDraggableCard
+                key={cardConfig.uuid}
+                uuid={cardConfig.uuid ?? ''}
+                translateBy={cardTransforms[cardConfig.uuid ?? '']}
+                onResizeStart={onResizeStart}
+                onResizeStop={onResizeStop}
+                onResize={onResize}
+                cardConfig={cardConfig}
+                chartRunData={chartRunData}
+                onReorderWith={onSwapCards}
+                index={index}
+                height={cardHeight}
+                canMoveDown={Boolean(array[index + 1])}
+                canMoveUp={Boolean(array[index - 1])}
+                canMoveToTop={index > 0}
+                canMoveToBottom={index < array.length - 1}
+                previousChartUuid={array[index - 1]?.uuid}
+                nextChartUuid={array[index + 1]?.uuid}
+                hideEmptyCharts={hideEmptyCharts}
+                firstChartUuid={array[0]?.uuid}
+                lastChartUuid={array[array.length - 1]?.uuid}
+                {...cardProps}
+              />
+            );
+          })}
+          {dragPreview && <RunsChartsDraggablePreview {...dragPreview} />}
+          {resizePreview && <RunsChartsDraggablePreview {...resizePreview} />}
+        </div>
+        {hasMoreCards && (
+          <div css={{ display: 'flex', justifyContent: 'center', padding: theme.spacing.md }}>
+            <Button
+              componentId="mlflow_show_more_charts"
+              onClick={() => setVisibleCount((prev) => prev + CHARTS_PER_PAGE)}
+            >
+              Show {Math.min(remainingCards, CHARTS_PER_PAGE)} more charts ({remainingCards} remaining)
+            </Button>
           </div>
         )}
-        {cardsToRender.map((cardConfig, index, array) => {
-          return (
-            <RunsChartsDraggableCard
-              key={cardConfig.uuid}
-              uuid={cardConfig.uuid ?? ''}
-              translateBy={cardTransforms[cardConfig.uuid ?? '']}
-              onResizeStart={onResizeStart}
-              onResizeStop={onResizeStop}
-              onResize={onResize}
-              cardConfig={cardConfig}
-              chartRunData={chartRunData}
-              onReorderWith={onSwapCards}
-              index={index}
-              height={cardHeight}
-              canMoveDown={Boolean(array[index + 1])}
-              canMoveUp={Boolean(array[index - 1])}
-              canMoveToTop={index > 0}
-              canMoveToBottom={index < array.length - 1}
-              previousChartUuid={array[index - 1]?.uuid}
-              nextChartUuid={array[index + 1]?.uuid}
-              hideEmptyCharts={hideEmptyCharts}
-              firstChartUuid={array[0]?.uuid}
-              lastChartUuid={array[array.length - 1]?.uuid}
-              {...cardProps}
-            />
-          );
-        })}
-        {dragPreview && <RunsChartsDraggablePreview {...dragPreview} />}
-        {resizePreview && <RunsChartsDraggablePreview {...resizePreview} />}
-      </div>
+      </>
     );
   },
 );

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/sections/RunsChartsSectionAccordion.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/sections/RunsChartsSectionAccordion.tsx
@@ -14,9 +14,8 @@ import { RunsChartType } from '../../runs-charts.types';
 import MetricChartsAccordion, { METRIC_CHART_SECTION_HEADER_SIZE } from '../../../MetricChartsAccordion';
 import { RunsChartsSectionHeader } from './RunsChartsSectionHeader';
 import { RunsChartsSection } from './RunsChartsSection';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { getUUID } from '@mlflow/mlflow/src/common/utils/ActionUtils';
-import { useState } from 'react';
 import { Button, PlusIcon } from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
 import { Empty } from '@databricks/design-system';
@@ -316,6 +315,15 @@ export const RunsChartsSectionAccordion = ({
     return { sectionsToRender: compareRunSectionsFiltered, chartsToRender: compareRunChartsFiltered };
   }, [search, compareRunCharts, compareRunSections]);
 
+  const SECTIONS_PER_PAGE = 20;
+  const [visibleSectionCount, setVisibleSectionCount] = useState(SECTIONS_PER_PAGE);
+  const totalSections = (sectionsToRender || []).length;
+  const paginatedSections = useMemo(
+    () => (sectionsToRender || []).slice(0, visibleSectionCount),
+    [sectionsToRender, visibleSectionCount],
+  );
+  const hasMoreSections = totalSections > visibleSectionCount;
+
   const isSearching = search !== '';
 
   if (!compareRunSections || !compareRunCharts) {
@@ -365,7 +373,7 @@ export const RunsChartsSectionAccordion = ({
   return (
     <div>
       <MetricChartsAccordion activeKey={activeKey} onActiveKeyChange={onActivePanelChange}>
-        {(sectionsToRender || []).map((sectionConfig: ChartSectionConfig, index: number) => {
+        {paginatedSections.map((sectionConfig: ChartSectionConfig, index: number) => {
           const sectionCharts = (chartsToRender || []).filter((config: RunsChartsCardConfig) => {
             const section = (config as RunsChartsBarCardConfig).metricSectionId;
             return !config.deleted && section === sectionConfig.uuid;
@@ -415,6 +423,16 @@ export const RunsChartsSectionAccordion = ({
           );
         })}
       </MetricChartsAccordion>
+      {hasMoreSections && (
+        <div css={{ display: 'flex', justifyContent: 'center', padding: theme.spacing.md }}>
+          <Button
+            componentId="mlflow_show_more_sections"
+            onClick={() => setVisibleSectionCount((prev) => prev + SECTIONS_PER_PAGE)}
+          >
+            Show {Math.min(totalSections - visibleSectionCount, SECTIONS_PER_PAGE)} more sections ({totalSections - visibleSectionCount} remaining)
+          </Button>
+        </div>
+      )}
       {!isSearching && (
         <div>
           <Button

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/runs-charts.types.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/runs-charts.types.ts
@@ -246,11 +246,14 @@ export abstract class RunsChartsCardConfig {
       ...[MLFLOW_MODEL_METRIC_NAME, MLFLOW_SYSTEM_METRIC_NAME].filter((name) => enabledSectionNames.includes(name)),
     ];
 
+    // Auto-collapse sections when there are many charts to prevent browser performance issues
+    const collapseByDefault = resultChartSet.length > 100;
+
     // Create section configs
     const resultSectionSet: ChartSectionConfig[] = sortedSectionNames.map((sectionName) => ({
       uuid: sectionName2Uuid[sectionName],
       name: sectionName,
-      display: true,
+      display: !collapseByDefault,
       isReordered: false,
       deleted: false,
       isGenerated: true,


### PR DESCRIPTION
## Related Issues/PRs

Relates to #22489

## What changes are proposed in this pull request?

All chart cards and accordion sections rendered simultaneously, causing multi-second layout/paint times and tab crashes with 1000+ metrics.

Changes:
- Paginate chart cards at 50 per page with a "Show more" button in `RunsChartsDraggableCardsGridSection`
- Paginate accordion sections at 20 per page with a "Show more" button in `RunsChartsSectionAccordion`
- Auto-collapse all generated sections when chart count exceeds 100 in `getBaseChartAndSectionConfigs`
- Reset pagination when the card list changes (e.g., switching experiments)

This keeps the initial render fast while preserving full access to all charts and sections via progressive loading.

## How is this PR tested?

- [x] Existing unit tests
- [ ] Manual testing with experiments logging 3000+ metrics — confirmed fast initial render with progressive loading

## Does this PR require documentation update?
- [ ] No. UX improvement only, no API changes.

## Release Notes

### Is this a user-facing change?

- [x] Yes. Charts and sections are now paginated with "Show more" buttons, and sections auto-collapse when there are more than 100 charts. This prevents browser freezing with high metric counts.

### What component(s) does this PR affect?

- [ ] `area/tracking`
- [ ] `area/models`
- [ ] `area/model-registry`
- [ ] `area/scoring`
- [ ] `area/evaluation`
- [ ] `area/gateway`
- [ ] `area/prompts`
- [ ] `area/tracing`
- [ ] `area/projects`
- [x] `area/uiux`
- [ ] `area/build`
- [ ] `area/docs`

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - Small bugfix or doc update, not worth noting
- [ ] `rn/breaking-change` - Breaks an existing feature or API
- [ ] `rn/feature` - New user-facing feature
- [x] `rn/bug-fix` - User-facing bug fix
- [ ] `rn/documentation` - Documentation change

### Should this PR be included in the next patch release?

No — not a critical bugfix blocking users on the current release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)