### PR TITLE
fix(ui): filter hidden runs from chart data to avoid unnecessary traces

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/runs-compare/RunsCompare.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-compare/RunsCompare.tsx
@@ -5,7 +5,7 @@ import { useSelector } from 'react-redux';
 import type { MetricEntitiesByName, ChartSectionConfig, ImageEntity } from '../../types';
 import type { KeyValueEntity } from '../../../common/types';
 import { RunsChartsCardConfig } from '../runs-charts/runs-charts.types';
-import type { RunsChartType } from '../runs-charts/runs-charts.types';
+import { RunsChartType } from '../runs-charts/runs-charts.types';
 import { type SerializedRunsChartsCardConfigCard } from '../runs-charts/runs-charts.types';
 import { RunsChartsConfigureModal } from '../runs-charts/components/RunsChartsConfigureModal';
 import { createEmptyChartCardPredicate, type RunsChartsRunData } from '../runs-charts/components/RunsCharts.common';
@@ -219,7 +219,7 @@ const RunsCompareImpl = ({
   const chartData: RunsChartsRunData[] = useMemo(() => {
     if (!groupBy) {
       return comparedRuns
-        .filter((run) => run.runInfo)
+        .filter((run) => run.runInfo && !run.hidden)
         .map<RunsChartsRunData>((run) =>
           createRunDataTrace(
             run,
@@ -233,7 +233,7 @@ const RunsCompareImpl = ({
     }
 
     const groupChartDataEntries = comparedRuns
-      .filter((run) => run.groupParentInfo)
+      .filter((run) => run.groupParentInfo && !run.hidden)
       .map<RunsChartsRunData>((group) => createGroupDataTrace(group, getRunColor(group.groupParentInfo?.groupId)));
 
     return groupChartDataEntries;


### PR DESCRIPTION
## Related Issues/PRs

Relates to #22489

## What changes are proposed in this pull request?

`RunsCompare` built `RunsChartsRunData` for every run including hidden ones, creating unnecessary chart config objects and traces that slowed down rendering.

Changes:
- Add `!run.hidden` to the `comparedRuns.filter()` for ungrouped runs
- Add `!run.hidden` to the `comparedRuns.filter()` for grouped runs

## How is this PR tested?

- [x] Existing unit tests
- [ ] Manual testing — confirmed hidden runs no longer generate chart traces

## Does this PR require documentation update?
- [ ] No. Bug fix only.

## Release Notes

### Is this a user-facing change?

- [x] Yes. Hidden runs no longer generate chart data, improving rendering performance.

### What component(s) does this PR affect?

- [ ] `area/tracking`
- [ ] `area/models`
- [ ] `area/model-registry`
- [ ] `area/scoring`
- [ ] `area/evaluation`
- [ ] `area/gateway`
- [ ] `area/prompts`
- [ ] `area/tracing`
- [ ] `area/projects`
- [x] `area/uiux`
- [ ] `area/build`
- [ ] `area/docs`

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - Small bugfix or doc update, not worth noting
- [ ] `rn/breaking-change` - Breaks an existing feature or API
- [ ] `rn/feature` - New user-facing feature
- [x] `rn/bug-fix` - User-facing bug fix
- [ ] `rn/documentation` - Documentation change

### Should this PR be included in the next patch release?

No — not a critical bugfix blocking users on the current release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)