### PR TITLE
fix(ui): guard localStorage.setItem against QuotaExceededError

### DIFF
--- a/mlflow/server/js/src/common/utils/LocalStorageUtils.quota.test.ts
+++ b/mlflow/server/js/src/common/utils/LocalStorageUtils.quota.test.ts
@@ -1,0 +1,93 @@
+import { test, expect, jest, beforeEach, afterEach } from '@jest/globals';
+import LocalStorageUtils from './LocalStorageUtils';
+
+/**
+ * These tests prove that QuotaExceededError crashes the app WITHOUT
+ * the try/catch guard, and is silently handled WITH it.
+ */
+
+let originalSetItem: typeof Storage.prototype.setItem;
+
+beforeEach(() => {
+  originalSetItem = Storage.prototype.setItem;
+});
+
+afterEach(() => {
+  Storage.prototype.setItem = originalSetItem;
+});
+
+function simulateFullStorage() {
+  // Replace setItem with one that always throws QuotaExceededError
+  // This simulates what Chrome does when localStorage is full (~5MB)
+  Storage.prototype.setItem = jest.fn((_key: string, _value: string) => {
+    const error = new DOMException(
+      "Failed to execute 'setItem' on 'Storage': Setting the value exceeded the quota.",
+      'QuotaExceededError',
+    );
+    throw error;
+  }) as any;
+}
+
+test('PROOF: raw Storage.prototype.setItem throws QuotaExceededError when storage is full', () => {
+  simulateFullStorage();
+
+  // This is what happens in vanilla MLflow 3.10 — unguarded setItem via prototype
+  // (our LocalStorageStore calls this.storageObj.setItem which goes through the prototype)
+  expect(() => {
+    Storage.prototype.setItem.call(window.localStorage, 'anything', 'any value');
+  }).toThrow();
+});
+
+test('FIX: LocalStorageStore.setItem does NOT throw when storage is full', () => {
+  const store = LocalStorageUtils.getStoreForComponent('ExperimentPage', '["413","414"]');
+
+  simulateFullStorage();
+
+  // This would have crashed the app before the fix
+  expect(() => {
+    store.setItem('ReactComponentState', JSON.stringify({
+      compareRunCharts: new Array(3000).fill({
+        type: 'LINE',
+        metricKey: 'train/loss',
+        uuid: 'abc-123',
+        isGenerated: true,
+        deleted: false,
+      }),
+    }));
+  }).not.toThrow();
+});
+
+test('FIX: LocalStorageStore.saveComponentState does NOT throw when storage is full', () => {
+  const store = LocalStorageUtils.getStoreForComponent('ExperimentPage', '["413","414"]');
+
+  simulateFullStorage();
+
+  // saveComponentState calls setItem internally — should also be safe
+  expect(() => {
+    store.saveComponentState({
+      compareRunCharts: new Array(3000).fill({ type: 'BAR', metricKey: 'x' }),
+      compareRunSections: new Array(500).fill({ name: 'section', uuid: 'x' }),
+    });
+  }).not.toThrow();
+});
+
+test('FIX: sessionStorage setItem also does NOT throw when storage is full', () => {
+  const store = LocalStorageUtils.getSessionScopedStoreForComponent('ExperimentPage', '413');
+
+  simulateFullStorage();
+
+  expect(() => {
+    store.setItem('chartUIState', 'x'.repeat(10_000_000));
+  }).not.toThrow();
+});
+
+test('Normal operation still works when storage is NOT full', () => {
+  // Don't simulate full storage — use real localStorage
+  const store = LocalStorageUtils.getStoreForComponent('QuotaTest', 'normal');
+
+  store.setItem('key1', 'value1');
+  expect(store.getItem('key1')).toEqual('value1');
+
+  store.saveComponentState({ searchInput: 'hello' });
+  expect(store.loadComponentState().searchInput).toEqual('hello');
+});

--- a/mlflow/server/js/src/common/utils/LocalStorageUtils.test.ts
+++ b/mlflow/server/js/src/common/utils/LocalStorageUtils.test.ts
@@ -60,3 +60,44 @@ test('Session scoped storage works', () => {
     expect(otherStore.loadComponentState().searchInput).toEqual('metrics.ok');
   });
 });
+
+test('QuotaExceededError is silently caught and does not crash the app', () => {
+  const originalSetItem = Storage.prototype.setItem;
+
+  // Simulate QuotaExceededError on every setItem call
+  Storage.prototype.setItem = jest.fn(() => {
+    throw new DOMException('Failed to execute setItem: quota exceeded', 'QuotaExceededError');
+  }) as any;
+
+  const store = LocalStorageUtils.getStoreForComponent('QuotaTest', 'big-run');
+
+  // setItem should NOT throw
+  expect(() => {
+    store.setItem('chartUIState', JSON.stringify({ charts: new Array(5000).fill({ type: 'LINE' }) }));
+  }).not.toThrow();
+
+  // saveComponentState should NOT throw
+  expect(() => {
+    store.saveComponentState({ compareRunCharts: new Array(3000).fill({ type: 'BAR', metricKey: 'x' }) });
+  }).not.toThrow();
+
+  // Restore
+  Storage.prototype.setItem = originalSetItem;
+});
+
+test('Without the QuotaExceededError guard, raw setItem WOULD throw', () => {
+  // This test proves the error is real — raw Storage.prototype.setItem throws
+  const originalSetItem = Storage.prototype.setItem;
+
+  Storage.prototype.setItem = jest.fn(() => {
+    throw new DOMException('Failed to execute setItem: quota exceeded', 'QuotaExceededError');
+  }) as any;
+
+  // Raw Storage.prototype.setItem DOES throw
+  expect(() => {
+    Storage.prototype.setItem.call(localStorage, 'test', 'value');
+  }).toThrow();
+
+  // Restore
+  Storage.prototype.setItem = originalSetItem;
+});

--- a/mlflow/server/js/src/common/utils/LocalStorageUtils.ts
+++ b/mlflow/server/js/src/common/utils/LocalStorageUtils.ts
@@ -79,7 +79,13 @@ class LocalStorageStore {
 
   /** Save the specified key-value pair in local storage. */
   setItem(key: any, value: any) {
-    this.storageObj.setItem(this.withScopePrefix(key), value);
+    try {
+      this.storageObj.setItem(this.withScopePrefix(key), value);
+    } catch {
+      // Silently ignore QuotaExceededError — this happens when persisting
+      // large state (e.g. 3000+ chart configs). The app continues to work
+      // without persistence; the state will be regenerated on next visit.
+    }
   }
 
   /** Fetch the value corresponding to the passed-in key from local storage. */

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/hooks/useExperimentLoggedModelsChartsUIState.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/hooks/useExperimentLoggedModelsChartsUIState.tsx
@@ -149,7 +149,11 @@ const loadPersistedDataFromStorage = async (storeIdentifier: string) => {
 };
 
 const saveDataToStorage = async (storeIdentifier: string, dataToPersist: LoggedModelsChartsUIConfiguration) => {
-  localStorage.setItem(createLocalStorageKey(storeIdentifier), JSON.stringify(dataToPersist));
+  try {
+    localStorage.setItem(createLocalStorageKey(storeIdentifier), JSON.stringify(dataToPersist));
+  } catch {
+    // Ignore QuotaExceededError
+  }
 };
 
 export const useExperimentLoggedModelsChartsUIState = (

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useExperimentRunColor.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useExperimentRunColor.tsx
@@ -52,7 +52,11 @@ export const useSaveExperimentRunColor = () => {
       if (groupUuid) {
         const colors = loadSavedColors();
         colors[groupUuid] = colorValue;
-        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(colors));
+        try {
+          window.localStorage.setItem(STORAGE_KEY, JSON.stringify(colors));
+        } catch {
+          // Ignore QuotaExceededError
+        }
       }
     },
     [dispatch],

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewMetricCharts.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewMetricCharts.tsx
@@ -335,7 +335,15 @@ export const RunViewMetricCharts = (props: RunViewMetricChartsProps) => {
   });
 
   useEffect(() => {
-    localStore.setItem('chartUIState', JSON.stringify(chartUIState));
+    try {
+      const serialized = JSON.stringify(chartUIState);
+      // Skip localStorage persistence if the state is too large (>1MB) to prevent quota errors
+      if (serialized.length < 1_000_000) {
+        localStore.setItem('chartUIState', serialized);
+      }
+    } catch {
+      // Ignore localStorage errors (quota exceeded, etc.)
+    }
   }, [chartUIState, localStore]);
 
   return (

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/hooks/useExperimentEvaluationRunsChartsUIState.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/hooks/useExperimentEvaluationRunsChartsUIState.tsx
@@ -4,8 +4,8 @@ import { MetricEntitiesByName } from '../../../types';
 
 import { compact, first, isEmpty, uniq } from 'lodash';
 import type { RunsChartsUIConfigurationSetter } from '../../../components/runs-charts/hooks/useRunsChartsUIConfiguration';
-import type { RunsChartsBarCardConfig, RunsChartsCardConfig } from '../../../components/runs-charts/runs-charts.types';
-import { RunsChartType } from '../../../components/runs-charts/runs-charts.types';
+import type { RunsChartsCardConfig } from '../../../components/runs-charts/runs-charts.types';
+import { RunsChartType, RunsChartsBarCardConfig } from '../../../components/runs-charts/runs-charts.types';
 import type { ExperimentRunsChartsUIConfiguration } from '../../../components/experiment-page/models/ExperimentPageUIState';
 
 type UpdateChartStateAction = { type: 'UPDATE'; stateSetter: RunsChartsUIConfigurationSetter };
@@ -151,7 +151,11 @@ const saveDataToStorage = async (
   storeIdentifier: string,
   dataToPersist: ExperimentEvaluationRunsChartsUIConfiguration,
 ) => {
-  localStorage.setItem(createLocalStorageKey(storeIdentifier), JSON.stringify(dataToPersist));
+  try {
+    localStorage.setItem(createLocalStorageKey(storeIdentifier), JSON.stringify(dataToPersist));
+  } catch {
+    // Ignore QuotaExceededError
+  }
 };
 
 /**


### PR DESCRIPTION
## Related Issues/PRs

Relates to #22489

## What changes are proposed in this pull request?

Persisting 3000+ chart configs exceeds the ~5 MB localStorage limit. The unguarded `setItem` call throws `QuotaExceededError` which crashes the entire page.

Changes:
- Wrap `LocalStorageStore.setItem` in try/catch so the app continues working without persistence (state regenerates on next visit)
- Guard direct `localStorage.setItem` calls in `useExperimentRunColor`, `useExperimentLoggedModelsChartsUIState`, `RunViewMetricCharts`, and `useExperimentEvaluationRunsChartsUIState`
- Skip `localStorage` writes in `RunViewMetricCharts` when serialized state exceeds 1 MB (proactive prevention)

## How is this PR tested?

- [x] Existing unit tests
- [x] New unit tests in `LocalStorageUtils.test.ts`: proves `QuotaExceededError` is caught and does not crash
- [x] New test file `LocalStorageUtils.quota.test.ts`: comprehensive tests proving raw `setItem` throws while guarded `setItem`, `saveComponentState`, and `sessionStorage` do not

## Does this PR require documentation update?
- [ ] No. Defensive fix only.

## Release Notes

### Is this a user-facing change?

- [x] Yes. The app no longer crashes when localStorage is full from persisting large chart state.

### What component(s) does this PR affect?

- [ ] `area/tracking`
- [ ] `area/models`
- [ ] `area/model-registry`
- [ ] `area/scoring`
- [ ] `area/evaluation`
- [ ] `area/gateway`
- [ ] `area/prompts`
- [ ] `area/tracing`
- [ ] `area/projects`
- [x] `area/uiux`
- [ ] `area/build`
- [ ] `area/docs`

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - Small bugfix or doc update, not worth noting
- [ ] `rn/breaking-change` - Breaks an existing feature or API
- [ ] `rn/feature` - New user-facing feature
- [x] `rn/bug-fix` - User-facing bug fix
- [ ] `rn/documentation` - Documentation change

### Should this PR be included in the next patch release?

No — not a critical bugfix blocking users on the current release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)