### PR TITLE
fix(ui): move gateway experiment filter from IS NULL to client-side

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useExperimentListQuery.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useExperimentListQuery.test.tsx
@@ -390,8 +390,57 @@ describe('useExperimentListQuery', () => {
   });
 
   describe('gateway experiment filtering', () => {
-    it('includes gateway exclusion filter in API call', async () => {
-      mockSearchExperiments.mockResolvedValueOnce(createMockResponse(['1', '2'], undefined));
+    it('filters out gateway experiments client-side', async () => {
+      // Create response with a gateway experiment mixed in
+      const response: SearchExperimentsApiResponse = {
+        experiments: [
+          {
+            experimentId: '1',
+            name: 'Normal experiment',
+            artifactLocation: '/artifacts/1',
+            lifecycleStage: 'active',
+            lastUpdateTime: Date.now(),
+            creationTime: Date.now(),
+            tags: [],
+            allowedActions: [],
+          },
+          {
+            experimentId: '2',
+            name: 'Gateway experiment',
+            artifactLocation: '/artifacts/2',
+            lifecycleStage: 'active',
+            lastUpdateTime: Date.now(),
+            creationTime: Date.now(),
+            tags: [{ key: 'mlflow.experiment.isGateway', value: 'true' }],
+            allowedActions: [],
+          },
+          {
+            experimentId: '3',
+            name: 'Another normal experiment',
+            artifactLocation: '/artifacts/3',
+            lifecycleStage: 'active',
+            lastUpdateTime: Date.now(),
+            creationTime: Date.now(),
+            tags: [],
+            allowedActions: [],
+          },
+        ],
+      };
+      mockSearchExperiments.mockResolvedValueOnce(response);
+
+      const { result } = renderHook(() => useExperimentListQuery(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      // Gateway experiment should be filtered out client-side
+      expect(result.current.data).toHaveLength(2);
+      expect(result.current.data?.map((e) => e.experimentId)).toEqual(['1', '3']);
+    });
+
+    it('does not send IS NULL filter to the API', async () => {
+      mockSearchExperiments.mockResolvedValueOnce(createMockResponse(['1'], undefined));
 
       renderHook(() => useExperimentListQuery(), {
         wrapper: createWrapper(),
@@ -402,8 +451,8 @@ describe('useExperimentListQuery', () => {
       const apiCallData = mockSearchExperiments.mock.calls[0][0];
       const filterParam = apiCallData.find((param: [string, string]) => param?.[0] === 'filter');
 
-      expect(filterParam).toBeDefined();
-      expect(filterParam?.[1]).toContain('tags.`mlflow.experiment.isGateway` IS NULL');
+      // No filter should be sent when there are no user-specified filters
+      expect(filterParam).toBeUndefined();
     });
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useExperimentListQuery.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useExperimentListQuery.ts
@@ -52,9 +52,13 @@ function getFilters({ searchFilter, tagsFilter }: Pick<ExperimentListQueryKey['1
     filters.push(tagFilterToSql(tagFilter));
   }
 
-  // Exclude gateway experiments server-side to ensure consistent page sizes
-  filters.push(`tags.\`${EXPERIMENT_IS_GATEWAY_TAG}\` IS NULL`);
+  // Note: we previously tried to exclude gateway experiments server-side with
+  // `tags.mlflow.experiment.isGateway IS NULL`, but IS NULL is not supported
+  // by all backends (e.g., Databricks). Filter client-side instead.
 
+  if (filters.length === 0) {
+    return undefined;
+  }
   return ['filter', filters.join(' AND ')];
 }
 
@@ -66,7 +70,7 @@ const queryFn = ({ queryKey }: QueryFunctionContext<ExperimentListQueryKey>) => 
 
   const data: (string[] | undefined)[] = [['max_results', String(pageSize)], ...orderBy];
 
-  // NOTE: undefined values are fine, they're filtered out by the request helpers inside `MlflowService`
+  // NOTE: undefined values are fine, they're filtered out by `getBigIntJson` inside `MlflowService`
   data.push(getFilters({ searchFilter, tagsFilter }));
 
   if (pageToken) {
@@ -134,8 +138,12 @@ export const useExperimentListQuery = ({
   const sortedExperiments = useMemo(() => {
     const experiments = queryResult.data?.experiments;
     if (!experiments) return undefined;
-    const demo = experiments.filter(isDemoExperiment);
-    const nonDemo = experiments.filter((e) => !isDemoExperiment(e));
+    // Filter out gateway experiments client-side (IS NULL not supported by all backends)
+    const nonGateway = experiments.filter(
+      (e) => !e.tags?.some((tag) => tag.key === EXPERIMENT_IS_GATEWAY_TAG),
+    );
+    const demo = nonGateway.filter(isDemoExperiment);
+    const nonDemo = nonGateway.filter((e) => !isDemoExperiment(e));
     return [...demo, ...nonDemo];
   }, [queryResult.data?.experiments]);
 


### PR DESCRIPTION
## Related Issues/PRs

Relates to #22489

## What changes are proposed in this pull request?

The server-side filter `tags.mlflow.experiment.isGateway IS NULL` is not supported by all backends (e.g. Databricks), causing errors when listing experiments.

Changes:
- Remove the `IS NULL` filter from the API call in `getFilters`
- Add client-side filtering of gateway experiments in the `sortedExperiments` useMemo
- Return `undefined` from `getFilters` when no user-specified filters exist (avoids sending empty filter param)

Gateway experiments are rare, so filtering post-fetch has negligible impact on page sizes.

## How is this PR tested?

- [x] Updated unit tests in `useExperimentListQuery.test.tsx`:
  - New test: verifies gateway experiments are filtered out client-side
  - Updated test: verifies no `IS NULL` filter is sent to the API

## Does this PR require documentation update?
- [ ] No. Internal filtering change only.

## Release Notes

### Is this a user-facing change?

- [x] Yes. Fixes experiment listing errors on backends that don't support `IS NULL` tag filters.

### What component(s) does this PR affect?

- [ ] `area/tracking`
- [ ] `area/models`
- [ ] `area/model-registry`
- [ ] `area/scoring`
- [ ] `area/evaluation`
- [ ] `area/gateway`
- [ ] `area/prompts`
- [ ] `area/tracing`
- [ ] `area/projects`
- [x] `area/uiux`
- [ ] `area/build`
- [ ] `area/docs`

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - Small bugfix or doc update, not worth noting
- [ ] `rn/breaking-change` - Breaks an existing feature or API
- [ ] `rn/feature` - New user-facing feature
- [x] `rn/bug-fix` - User-facing bug fix
- [ ] `rn/documentation` - Documentation change

### Should this PR be included in the next patch release?

No — not a critical bugfix blocking users on the current release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)