### PR TITLE
fix(ui): default runsHiddenMode to HIDEALL for performance

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/models/ExperimentPageUIState.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/models/ExperimentPageUIState.tsx
@@ -163,7 +163,7 @@ export const createExperimentPageUIState = (): ExperimentPageUIState => ({
   runsPinned: [],
   runsHidden: [],
   runsVisibilityMap: {},
-  runsHiddenMode: RUNS_VISIBILITY_MODE.FIRST_10_RUNS,
+  runsHiddenMode: RUNS_VISIBILITY_MODE.HIDEALL,
   compareRunCharts: undefined,
   compareRunSections: undefined,
   viewMaximized: false,


### PR DESCRIPTION
## Related Issues/PRs

Relates to #22489

## What changes are proposed in this pull request?

With experiments logging 1000+ metrics, rendering even 10 runs on first load generates thousands of chart components and traces, causing the browser tab to freeze or crash.

Changes:
- Change the default `runsHiddenMode` from `FIRST_10_RUNS` to `HIDEALL` in `createExperimentPageUIState`

Users start with a fast page and explicitly select which runs to visualize. This is a one-line change in `ExperimentPageUIState.tsx`.

## How is this PR tested?

- [x] Existing unit tests
- [ ] Manual testing — confirmed fast initial page load with high metric count experiments

## Does this PR require documentation update?
- [ ] No. Default behavior change only.

## Release Notes

### Is this a user-facing change?

- [x] Yes. Experiment pages now default to hiding all runs instead of showing the first 10, preventing browser freezing with high metric count experiments. Users select which runs to view.

### What component(s) does this PR affect?

- [ ] `area/tracking`
- [ ] `area/models`
- [ ] `area/model-registry`
- [ ] `area/scoring`
- [ ] `area/evaluation`
- [ ] `area/gateway`
- [ ] `area/prompts`
- [ ] `area/tracing`
- [ ] `area/projects`
- [x] `area/uiux`
- [ ] `area/build`
- [ ] `area/docs`

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - Small bugfix or doc update, not worth noting
- [ ] `rn/breaking-change` - Breaks an existing feature or API
- [ ] `rn/feature` - New user-facing feature
- [x] `rn/bug-fix` - User-facing bug fix
- [ ] `rn/documentation` - Documentation change

### Should this PR be included in the next patch release?

No — not a critical bugfix blocking users on the current release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)