### PR TITLE
Add `logEventWithMetadata_I_CONFIRM_THERE_IS_NO_PII` to `TelemetryClient` for enriched UI telemetry

### DIFF
--- a/mlflow/server/js/src/gateway/hooks/useCreateEndpointForm.ts
+++ b/mlflow/server/js/src/gateway/hooks/useCreateEndpointForm.ts
@@ -153,6 +153,7 @@ export function useCreateEndpointForm({
       telemetryClient.logCustomEvent('mlflow.gateway.endpoint.create', 'onSubmit', {
         secretMode: values.secretMode,
         provider: values.provider,
+        model: values.modelName,
         usageTracking: String(values.usageTracking),
       });
 

--- a/mlflow/server/js/src/gateway/hooks/useCreateEndpointForm.ts
+++ b/mlflow/server/js/src/gateway/hooks/useCreateEndpointForm.ts
@@ -150,12 +150,16 @@ export function useCreateEndpointForm({
         usage_tracking: values.usageTracking,
       });
 
-      telemetryClient.dangerouslyLogEventWithMetadata('mlflow.gateway.endpoint.create', 'onSubmitSuccess', {
-        secretMode: values.secretMode,
-        provider: values.provider,
-        model: values.modelName,
-        usageTracking: String(values.usageTracking),
-      });
+      telemetryClient.logEventWithMetadata_I_CONFIRM_THERE_IS_NO_PII(
+        'mlflow.gateway.endpoint.create',
+        'onSubmitSuccess',
+        {
+          secretMode: values.secretMode,
+          provider: values.provider,
+          model: values.modelName,
+          usageTracking: String(values.usageTracking),
+        },
+      );
 
       onSuccess?.(endpointResponse.endpoint);
     } catch {

--- a/mlflow/server/js/src/gateway/hooks/useCreateEndpointForm.ts
+++ b/mlflow/server/js/src/gateway/hooks/useCreateEndpointForm.ts
@@ -150,7 +150,7 @@ export function useCreateEndpointForm({
         usage_tracking: values.usageTracking,
       });
 
-      telemetryClient.dangerouslyLogEventWithMetadata('mlflow.gateway.endpoint.create', 'onSubmit', {
+      telemetryClient.dangerouslyLogEventWithMetadata('mlflow.gateway.endpoint.create', 'onSubmitSuccess', {
         secretMode: values.secretMode,
         provider: values.provider,
         model: values.modelName,

--- a/mlflow/server/js/src/gateway/hooks/useCreateEndpointForm.ts
+++ b/mlflow/server/js/src/gateway/hooks/useCreateEndpointForm.ts
@@ -150,7 +150,7 @@ export function useCreateEndpointForm({
         usage_tracking: values.usageTracking,
       });
 
-      telemetryClient.logCustomEvent('mlflow.gateway.endpoint.create', 'onSubmit', {
+      telemetryClient.dangerouslyLogEventWithMetadata('mlflow.gateway.endpoint.create', 'onSubmit', {
         secretMode: values.secretMode,
         provider: values.provider,
         model: values.modelName,

--- a/mlflow/server/js/src/gateway/hooks/useCreateEndpointForm.ts
+++ b/mlflow/server/js/src/gateway/hooks/useCreateEndpointForm.ts
@@ -9,6 +9,7 @@ import { useProviderConfigQuery } from './useProviderConfigQuery';
 import type { ProviderModel, Endpoint } from '../types';
 import type { SecretMode } from '../components/model-configuration/types';
 import { isValidEndpointName } from '../utils/gatewayUtils';
+import { telemetryClient } from '../../telemetry/TelemetryClient';
 
 export interface CreateEndpointFormData {
   name: string;
@@ -147,6 +148,12 @@ export function useCreateEndpointForm({
           },
         ],
         usage_tracking: values.usageTracking,
+      });
+
+      telemetryClient.logCustomEvent('mlflow.gateway.endpoint.create', 'onSubmit', {
+        secretMode: values.secretMode,
+        provider: values.provider,
+        usageTracking: String(values.usageTracking),
       });
 
       onSuccess?.(endpointResponse.endpoint);

--- a/mlflow/server/js/src/telemetry/TelemetryClient.ts
+++ b/mlflow/server/js/src/telemetry/TelemetryClient.ts
@@ -26,11 +26,63 @@ const VIEW_EVENT_ALLOWLIST: ReadonlySet<string> = new Set([
 /**
  * Allowlist of metadata keys that may be attached to custom telemetry events.
  * Every value MUST be a static/enumerated string — never user-generated content.
- * To add a new key, update this type and get review approval.
+ * To add a new key, update this type and add a corresponding validator below.
  */
 type AllowedTelemetryMetadataKey = 'secretMode' | 'provider' | 'model' | 'usageTracking';
 
 export type AllowedTelemetryMetadata = Partial<Record<AllowedTelemetryMetadataKey, string | null | undefined>>;
+
+/**
+ * Runtime validators for metadata values. Keys with validators are checked before logging;
+ * values that fail validation are silently dropped. Keys without validators (e.g., 'model')
+ * are passed through — callers must ensure they come from a trusted source (e.g., API catalog).
+ */
+const METADATA_VALIDATORS: Partial<Record<AllowedTelemetryMetadataKey, ReadonlySet<string>>> = {
+  secretMode: new Set(['new', 'existing']),
+  usageTracking: new Set(['true', 'false']),
+  provider: new Set([
+    'openai',
+    'anthropic',
+    'bedrock',
+    'gemini',
+    'vertex_ai',
+    'azure',
+    'groq',
+    'databricks',
+    'xai',
+    'cohere',
+    'mistral',
+    'together_ai',
+    'fireworks_ai',
+    'replicate',
+    'huggingface',
+    'ai21',
+    'perplexity',
+    'deepinfra',
+    'nvidia_nim',
+    'cerebras',
+    'deepseek',
+    'openrouter',
+    'ollama',
+  ]),
+};
+
+function validateMetadata(metadata: AllowedTelemetryMetadata): Record<string, string | null | undefined> {
+  const validated: Record<string, string | null | undefined> = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    const allowedValues = METADATA_VALIDATORS[key as AllowedTelemetryMetadataKey];
+    if (allowedValues) {
+      if (value != null && allowedValues.has(value)) {
+        validated[key] = value;
+      }
+      // silently drop values that fail validation
+    } else {
+      // no validator for this key — pass through (e.g., 'model')
+      validated[key] = value;
+    }
+  }
+  return validated;
+}
 
 class TelemetryClient {
   private installationId: string = this.getInstallationId();
@@ -146,17 +198,21 @@ class TelemetryClient {
   }
 
   /**
-   * ⚠️ DANGEROUS: Log a telemetry event with custom metadata.
+   * Log a telemetry event with custom metadata.
    *
-   * This bypasses the Design System's valueHasNoPii guardrails.
-   * ALL metadata values MUST be:
+   * By calling this method, you confirm that ALL metadata values are:
    *   - Static/enumerated values (e.g., "new" | "existing"), NOT user-generated strings
    *   - Free of PII, secrets, tokens, or any user-identifiable information
    *
-   * Adding a new metadata key requires updating `AllowedTelemetryMetadata` in this file.
+   * Values for keys with validators (secretMode, usageTracking, provider) are checked
+   * at runtime and silently dropped if invalid. Keys without validators (e.g., model)
+   * are passed through — callers must ensure they come from a trusted source.
+   *
+   * Adding a new metadata key requires updating `AllowedTelemetryMetadataKey` in this file.
    * Do NOT pass user input, free-text fields, names, or IDs that could identify a user.
    */
-  public async dangerouslyLogEventWithMetadata(
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  public async logEventWithMetadata_I_CONFIRM_THERE_IS_NO_PII(
     componentId: string,
     eventType: string,
     metadata: AllowedTelemetryMetadata,
@@ -166,12 +222,14 @@ class TelemetryClient {
       return;
     }
 
+    const validatedMetadata = validateMetadata(metadata);
+
     const payload: Omit<TelemetryRecord, 'session_id'> = {
       installation_id: this.installationId,
       event_name: 'ui_event',
       timestamp_ns: Date.now() * 1e6,
       params: {
-        ...metadata,
+        ...validatedMetadata,
         // Spread metadata first so componentId/eventType cannot be overridden
         componentId,
         eventType,

--- a/mlflow/server/js/src/telemetry/TelemetryClient.ts
+++ b/mlflow/server/js/src/telemetry/TelemetryClient.ts
@@ -89,7 +89,7 @@ class TelemetryClient {
     });
   }
 
-  // Log a telemetry event
+  // Log a telemetry event from the Design System event provider
   public async logEvent(record: any): Promise<void> {
     const isReady = await this.ready;
     if (!isReady || !this.port) {
@@ -128,6 +128,43 @@ class TelemetryClient {
         `[TelemetryClient] Event "${record.eventType}" on component "${record.componentId}", payload:`,
         payload,
       );
+    }
+
+    this.port?.postMessage({
+      type: ClientToWorkerMessageType.LOG_EVENT,
+      payload,
+    });
+  }
+
+  /**
+   * Log a custom telemetry event with arbitrary params.
+   * Use this to attach user decisions or context to critical UI actions
+   * (e.g., form submissions) that can't be captured by Design System component events alone.
+   */
+  public async logCustomEvent(
+    componentId: string,
+    eventType: string,
+    params: Record<string, string | null | undefined>,
+  ): Promise<void> {
+    const isReady = await this.ready;
+    if (!isReady || !this.port) {
+      return;
+    }
+
+    const payload: Omit<TelemetryRecord, 'session_id'> = {
+      installation_id: this.installationId,
+      event_name: 'ui_event',
+      timestamp_ns: Date.now() * 1e6,
+      params: {
+        componentId,
+        eventType,
+        ...params,
+      },
+    };
+
+    if (process.env['NODE_ENV'] === 'development' && isTelemetryDevLoggingEnabled()) {
+      // eslint-disable-next-line no-console
+      console.log(`[TelemetryClient] Custom event "${eventType}" on "${componentId}", payload:`, payload);
     }
 
     this.port?.postMessage({

--- a/mlflow/server/js/src/telemetry/TelemetryClient.ts
+++ b/mlflow/server/js/src/telemetry/TelemetryClient.ts
@@ -23,6 +23,15 @@ const VIEW_EVENT_ALLOWLIST: ReadonlySet<string> = new Set([
   'mlflow.issue-detection.completed',
 ]);
 
+/**
+ * Allowlist of metadata keys that may be attached to custom telemetry events.
+ * Every value MUST be a static/enumerated string — never user-generated content.
+ * To add a new key, update this type and get review approval.
+ */
+type AllowedTelemetryMetadataKey = 'secretMode' | 'provider' | 'model' | 'usageTracking';
+
+export type AllowedTelemetryMetadata = Partial<Record<AllowedTelemetryMetadataKey, string | null | undefined>>;
+
 class TelemetryClient {
   private installationId: string = this.getInstallationId();
   private port: MessagePort | null = null;
@@ -137,14 +146,20 @@ class TelemetryClient {
   }
 
   /**
-   * Log a custom telemetry event with arbitrary params.
-   * Use this to attach user decisions or context to critical UI actions
-   * (e.g., form submissions) that can't be captured by Design System component events alone.
+   * ⚠️ DANGEROUS: Log a telemetry event with custom metadata.
+   *
+   * This bypasses the Design System's valueHasNoPii guardrails.
+   * ALL metadata values MUST be:
+   *   - Static/enumerated values (e.g., "new" | "existing"), NOT user-generated strings
+   *   - Free of PII, secrets, tokens, or any user-identifiable information
+   *
+   * Adding a new metadata key requires updating `AllowedTelemetryMetadata` in this file.
+   * Do NOT pass user input, free-text fields, names, or IDs that could identify a user.
    */
-  public async logCustomEvent(
+  public async dangerouslyLogEventWithMetadata(
     componentId: string,
     eventType: string,
-    params: Record<string, string | null | undefined>,
+    metadata: AllowedTelemetryMetadata,
   ): Promise<void> {
     const isReady = await this.ready;
     if (!isReady || !this.port) {
@@ -156,15 +171,16 @@ class TelemetryClient {
       event_name: 'ui_event',
       timestamp_ns: Date.now() * 1e6,
       params: {
+        ...metadata,
+        // Spread metadata first so componentId/eventType cannot be overridden
         componentId,
         eventType,
-        ...params,
       },
     };
 
     if (process.env['NODE_ENV'] === 'development' && isTelemetryDevLoggingEnabled()) {
       // eslint-disable-next-line no-console
-      console.log(`[TelemetryClient] Custom event "${eventType}" on "${componentId}", payload:`, payload);
+      console.log(`[TelemetryClient] Custom event "${eventType}" on "${componentId}", metadata:`, payload);
     }
 
     this.port?.postMessage({


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22548

### What changes are proposed in this pull request?

- Add `logEventWithMetadata_I_CONFIRM_THERE_IS_NO_PII(componentId, eventType, metadata)` method to `TelemetryClient` for attaching user decisions to critical UI telemetry events (e.g., form submissions) that can't be captured by Design System component events alone
- Restrict metadata to a typed allowlist (`AllowedTelemetryMetadataKey`) so only pre-approved, non-PII keys can be passed — adding new keys requires updating the type and getting review approval
- Add runtime validation via `METADATA_VALIDATORS` for keys with known value sets:
  - `secretMode`: `'new' | 'existing'`
  - `usageTracking`: `'true' | 'false'`
  - `provider`: 22 known providers (openai, anthropic, bedrock, etc.)
  - Invalid values are silently dropped; keys without validators (e.g., `model`) pass through
- Use it in the create endpoint form to capture `secretMode`, `provider`, `model`, and `usageTracking` on successful submit as `mlflow.gateway.endpoint.create`

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] Manual tests

Verified via `yarn type-check`, `yarn lint`, and `yarn prettier:check` (all pass). No existing telemetry tests in the codebase.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release