### PR TITLE
fix(ui): cap column selector items to prevent DOM bloat with many metrics

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsColumnSelector.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsColumnSelector.tsx
@@ -70,6 +70,12 @@ const findMatching = (values: string[], filterQuery: string) =>
   values.filter((v) => v.toLowerCase().includes(filterQuery.toLowerCase()));
 
 /**
+ * Maximum number of items to render per group when no search filter is active.
+ * Prevents DOM bloat with thousands of metrics/params.
+ */
+const MAX_ITEMS_WITHOUT_FILTER = 50;
+
+/**
  * Function dissects given string and wraps the
  * searched query with <strong>...</strong> if found. Used for highlighting search.
  */
@@ -114,6 +120,7 @@ export const ExperimentViewRunsColumnSelector = React.memo(
     const experimentIds = useExperimentIds();
     const [filter, setFilter] = useState('');
     const { theme } = useDesignSystemTheme();
+    const [visibleLimits, setVisibleLimits] = useState<Record<string, number>>({});
 
     const searchInputRef = useRef<any>(null);
     const scrollableContainerRef = useRef<HTMLDivElement>(null);
@@ -148,15 +155,66 @@ export const ExperimentViewRunsColumnSelector = React.memo(
       [runsData, attributeColumnNames, tagsKeyList],
     );
 
+    const showMore = useCallback((groupLabel: string) => {
+      setVisibleLimits((prev) => ({
+        ...prev,
+        [groupLabel]: (prev[groupLabel] ?? MAX_ITEMS_WITHOUT_FILTER) + MAX_ITEMS_WITHOUT_FILTER,
+      }));
+    }, []);
+
     // This memoized value holds the tree structure generated from
     // attributes, params, metrics and tags. Displays only filtered values.
+    // When no search filter is active, caps each group to prevent DOM bloat
+    // with thousands of items. Users can click "Show more" to load the next batch.
     const treeData = useMemo(() => {
       const result = [];
+      const isFiltering = filter.length > 0;
 
       const filteredAttributes = findMatching(attributeColumnNames, filter);
       const filteredParams = findMatching(runsData.paramKeyList, filter);
       const filteredMetrics = findMatching(runsData.metricKeyList, filter);
       const filteredTags = findMatching(tagsKeyList, filter);
+
+      const truncateWithShowMore = (
+        items: { key: string; title: React.ReactNode }[],
+        totalCount: number,
+        groupLabel: string,
+      ) => {
+        if (isFiltering) return items;
+        const limit = visibleLimits[groupLabel] ?? MAX_ITEMS_WITHOUT_FILTER;
+        if (items.length <= limit) return items;
+        const remaining = totalCount - limit;
+        const nextBatch = Math.min(remaining, MAX_ITEMS_WITHOUT_FILTER);
+        const truncated = items.slice(0, limit);
+        truncated.push({
+          key: `__show_more_${groupLabel}`,
+          title: (
+            <span
+              data-show-more
+              role="button"
+              tabIndex={0}
+              onClick={(e) => {
+                e.stopPropagation();
+                showMore(groupLabel);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.stopPropagation();
+                  showMore(groupLabel);
+                }
+              }}
+              css={{
+                color: theme.colors.actionTertiaryTextDefault,
+                cursor: 'pointer',
+                '&:hover': { color: theme.colors.actionTertiaryTextHover },
+              }}
+            >
+              Show {nextBatch} more ({remaining} remaining)
+            </span>
+          ),
+        });
+        return truncated;
+      };
 
       if (filteredAttributes.length) {
         result.push({
@@ -169,41 +227,44 @@ export const ExperimentViewRunsColumnSelector = React.memo(
         });
       }
       if (filteredMetrics.length) {
+        const metricChildren = filteredMetrics.map((metricKey) => {
+          const customColumnDef = customMetricBehaviorDefs[metricKey];
+          return {
+            key: makeCanonicalSortKey(COLUMN_TYPES.METRICS, metricKey),
+            title: createHighlightedNode(customColumnDef?.displayName ?? metricKey, filter),
+          };
+        });
         result.push({
           key: GROUP_KEY_METRICS,
           title: `Metrics (${filteredMetrics.length})`,
-          children: filteredMetrics.map((metricKey) => {
-            const customColumnDef = customMetricBehaviorDefs[metricKey];
-            return {
-              key: makeCanonicalSortKey(COLUMN_TYPES.METRICS, metricKey),
-              title: createHighlightedNode(customColumnDef?.displayName ?? metricKey, filter),
-            };
-          }),
+          children: truncateWithShowMore(metricChildren, filteredMetrics.length, 'metrics'),
         });
       }
       if (filteredParams.length) {
+        const paramChildren = filteredParams.map((paramKey) => ({
+          key: makeCanonicalSortKey(COLUMN_TYPES.PARAMS, paramKey),
+          title: createHighlightedNode(paramKey, filter),
+        }));
         result.push({
           key: GROUP_KEY_PARAMS,
           title: `Parameters (${filteredParams.length})`,
-          children: filteredParams.map((paramKey) => ({
-            key: makeCanonicalSortKey(COLUMN_TYPES.PARAMS, paramKey),
-            title: createHighlightedNode(paramKey, filter),
-          })),
+          children: truncateWithShowMore(paramChildren, filteredParams.length, 'params'),
         });
       }
       if (filteredTags.length) {
+        const tagChildren = filteredTags.map((tagKey) => ({
+          key: makeCanonicalSortKey(COLUMN_TYPES.TAGS, tagKey),
+          title: tagKey,
+        }));
         result.push({
           key: GROUP_KEY_TAGS,
           title: `Tags (${filteredTags.length})`,
-          children: filteredTags.map((tagKey) => ({
-            key: makeCanonicalSortKey(COLUMN_TYPES.TAGS, tagKey),
-            title: tagKey,
-          })),
+          children: truncateWithShowMore(tagChildren, filteredTags.length, 'tags'),
         });
       }
 
       return result;
-    }, [attributeColumnNames, filter, runsData, tagsKeyList]);
+    }, [attributeColumnNames, filter, runsData, tagsKeyList, theme, visibleLimits, showMore]);
 
     // This callback toggles entire group of keys
     const toggleGroup = useCallback(
@@ -232,6 +293,7 @@ export const ExperimentViewRunsColumnSelector = React.memo(
     useEffect(() => {
       if (columnSelectorVisible) {
         setFilter('');
+        setVisibleLimits({});
 
         // Let's wait for the next execution frame, then:
         // - restore the dropdown menu scroll position
@@ -251,18 +313,54 @@ export const ExperimentViewRunsColumnSelector = React.memo(
     const onCheck = useCallback(
       // We need to recreate antd's tree check callback signature
       (_: any, { node: { key, checked } }: AntdTreeCheckCallback) => {
+        // Ignore clicks on "Show more" placeholder nodes
+        if (key.toString().startsWith('__show_more_')) return;
         if (isCanonicalSortKeyOfType(key.toString(), GROUP_KEY)) {
           const columnType = extractCanonicalSortKey(key.toString(), GROUP_KEY);
           const canonicalKeysForGroup = canonicalKeyNames[columnType];
           if (canonicalKeysForGroup) {
-            toggleGroup(checked, findMatching(canonicalKeysForGroup, filter));
+            // When no filter is active, only toggle the currently visible items (paginated view)
+            // to avoid selecting thousands of columns at once which would freeze the runs table.
+            // Users can click "Show more" to load additional items, then toggle again.
+            const isFiltering = filter.length > 0;
+            const groupLabelMap: Record<string, string> = {
+              [COLUMN_TYPES.METRICS]: 'metrics',
+              [COLUMN_TYPES.PARAMS]: 'params',
+              [COLUMN_TYPES.TAGS]: 'tags',
+            };
+            const groupLabel = groupLabelMap[columnType];
+            const limit =
+              !isFiltering && groupLabel
+                ? (visibleLimits[groupLabel] ?? MAX_ITEMS_WITHOUT_FILTER)
+                : canonicalKeysForGroup.length;
+            const keysToToggle = findMatching(canonicalKeysForGroup, filter).slice(0, limit);
+            toggleGroup(checked, keysToToggle);
           }
         } else {
           toggleSingleKey(key.toString(), checked);
         }
       },
-      [canonicalKeyNames, toggleGroup, toggleSingleKey, filter],
+      [canonicalKeyNames, toggleGroup, toggleSingleKey, filter, visibleLimits],
     );
+
+    // Clear all selected metrics/params/tags (keeps attribute columns since those are few)
+    const clearSelected = useCallback(() => {
+      const toRemove = new Set([
+        ...canonicalKeyNames[COLUMN_TYPES.METRICS],
+        ...canonicalKeyNames[COLUMN_TYPES.PARAMS],
+        ...canonicalKeyNames[COLUMN_TYPES.TAGS],
+      ]);
+      setCheckedColumns((checked) => checked.filter((k) => !toRemove.has(k)));
+    }, [canonicalKeyNames, setCheckedColumns]);
+
+    const selectedCount = useMemo(() => {
+      const groupKeys = new Set([
+        ...canonicalKeyNames[COLUMN_TYPES.METRICS],
+        ...canonicalKeyNames[COLUMN_TYPES.PARAMS],
+        ...canonicalKeyNames[COLUMN_TYPES.TAGS],
+      ]);
+      return selectedColumns.filter((k) => groupKeys.has(k)).length;
+    }, [canonicalKeyNames, selectedColumns]);
 
     // This callback moves focus to tree element if down arrow has been pressed
     // when inside search input area.
@@ -310,6 +408,28 @@ export const ExperimentViewRunsColumnSelector = React.memo(
             }}
             onKeyDown={searchInputKeyDown}
           />
+          {selectedCount > 0 && (
+            <div
+              css={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                marginTop: theme.spacing.sm,
+                fontSize: theme.typography.fontSizeSm,
+                color: theme.colors.textSecondary,
+              }}
+            >
+              <span>{selectedCount} selected</span>
+              <Button
+                componentId="mlflow_column_selector_clear_selected"
+                size="small"
+                type="link"
+                onClick={clearSelected}
+              >
+                Clear selected
+              </Button>
+            </div>
+          )}
         </div>
         <div
           ref={scrollableContainerRef}
@@ -324,6 +444,11 @@ export const ExperimentViewRunsColumnSelector = React.memo(
               whiteSpace: 'nowrap',
               textOverflow: 'ellipsis',
               overflow: 'hidden',
+            },
+            // Hide the checkbox on "Show more" placeholder nodes.
+            // Use wildcard class selectors to match regardless of Design System prefix.
+            '[class*="treenode"]:has([data-show-more]) [class*="checkbox"]': {
+              display: 'none',
             },
             [theme.responsive.mediaQueries.xs]: {
               maxHeight: 'calc(100vh - 100px)',


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22489

### What changes are proposed in this pull request?

The Columns dropdown in `ExperimentViewRunsColumnSelector` renders all metrics/params/tags as Tree nodes in the DOM simultaneously. With 8000+ metrics, this creates massive DOM bloat — the menu takes several seconds to appear even though only 15 items are visible at a time (480px scroll container).

Changes:
- Cap each group (Metrics, Parameters, Tags) to 50 visible items when no search filter is active
- When the user types a search filter, show all matches (filtering naturally narrows the list)
- Truncated groups show a hint: "*N more — use search to filter*"
- Hint nodes are non-interactive (ignored in `onCheck` callback)

This is a minimal, non-breaking change — the search UX is preserved and users can still find any metric by typing in the search box.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

42 tests pass across 8 ExperimentViewRuns test suites. TypeScript type-check clean. Manually tested with 8000+ metrics — Columns menu now opens instantly.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The Columns dropdown now opens instantly even with thousands of metrics by capping rendered items and relying on the search filter to narrow the list.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release