### PR TITLE
Fix span inputs logged as kwargs in ConversationSimulation

### DIFF
--- a/mlflow/genai/simulators/simulator.py
+++ b/mlflow/genai/simulators/simulator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import inspect
 import logging
 import math
@@ -769,6 +770,7 @@ class ConversationSimulator:
         #     predict_fn call. The goal/persona/turn metadata is used for trace comparison UI
         #     since message content may differ between simulation runs.
         @mlflow.trace(name=f"simulation_turn_{turn}", span_type="CHAIN")
+        @functools.wraps(predict_fn)
         def traced_predict(**kwargs):
             metadata = {
                 TraceMetadataKey.TRACE_SESSION: trace_session_id,


### PR DESCRIPTION
### Related Issues/PRs

Closes #22590

### What changes are proposed in this pull request?

Without `functools.wraps`, `traced_predict` exposes only a `**kwargs` signature, which causes `mlflow.trace` to record inputs as `{"kwargs": {"messages": [...]}}` instead of using the actual parameter names from `predict_fn`. Adding `@functools.wraps(predict_fn)` preserves the original function's signature so span inputs are logged correctly and the custom message rendering in the UI works as expected.

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a bug where `ConversationSimulation` was logging span inputs as `{"kwargs": {...}}` instead of the actual parameter names, which broke custom message rendering in the MLflow UI.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release