### PR TITLE
Fix running genai evaluate on readonly traces

### DIFF
--- a/mlflow/genai/evaluation/harness.py
+++ b/mlflow/genai/evaluation/harness.py
@@ -1009,7 +1009,10 @@ def _should_clone_trace(
 
     # If the trace is stored in a UC table, clone it to the user's experiment
     # so that we don't need MODIFY permission on the source UC schema.
-    if trace.info.trace_location.uc_schema is not None:
+    if (
+        trace.info.trace_location.uc_schema is not None
+        or trace.info.trace_location.uc_table_prefix is not None
+    ):
         return True
 
     # Check if the trace is from the same experiment. If it isn't, we need to clone the trace

--- a/mlflow/genai/evaluation/harness.py
+++ b/mlflow/genai/evaluation/harness.py
@@ -1007,9 +1007,10 @@ def _should_clone_trace(
     if trace is None:
         return False
 
-    # If the trace is stored in UC table, we don't clone the trace
+    # If the trace is stored in a UC table, clone it to the user's experiment
+    # so that we don't need MODIFY permission on the source UC schema.
     if trace.info.trace_location.uc_schema is not None:
-        return False
+        return True
 
     # Check if the trace is from the same experiment. If it isn't, we need to clone the trace
     trace_experiment = trace.info.trace_location.mlflow_experiment

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -18,13 +18,14 @@ from mlflow.entities.trace import Trace
 from mlflow.entities.trace_data import TraceData
 from mlflow.exceptions import MlflowException
 from mlflow.genai.datasets import EvaluationDataset, create_dataset
-from mlflow.genai.evaluation.entities import EvaluationResult
+from mlflow.genai.evaluation.entities import EvalItem, EvaluationResult
 from mlflow.genai.evaluation.harness import (
     AUTO_INITIAL_RPS,
+    _run_predict,
     _should_clone_trace,
     backpressure_buffer,
 )
-from mlflow.genai.evaluation.rate_limiter import RPSRateLimiter
+from mlflow.genai.evaluation.rate_limiter import NoOpRateLimiter, RPSRateLimiter
 from mlflow.genai.scorers.base import scorer
 from mlflow.genai.scorers.builtin_scorers import RelevanceToQuery
 from mlflow.genai.simulators import ConversationSimulator
@@ -1931,24 +1932,18 @@ def test_adaptive_rate_reduces_on_429(monkeypatch):
     assert rate_after_throttle[0] < AUTO_INITIAL_RPS
 
 
-@pytest.mark.parametrize(
-    ("trace_or_none", "run_id"),
-    [
-        (None, "run-1"),
-        (
-            Trace(
-                info=create_test_trace_info_with_uc_table(
-                    trace_id="tr-uc", catalog_name="catalog", schema_name="schema"
-                ),
-                data=TraceData(spans=[]),
-            ),
-            "run-1",
+def test_should_clone_trace_returns_false_for_none():
+    assert _should_clone_trace(None, run_id="run-1") is False
+
+
+def test_should_clone_trace_returns_true_for_uc_schema():
+    trace = Trace(
+        info=create_test_trace_info_with_uc_table(
+            trace_id="tr-uc", catalog_name="catalog", schema_name="schema"
         ),
-    ],
-    ids=["none_trace", "uc_schema_trace"],
-)
-def test_should_clone_trace_returns_false_early(trace_or_none, run_id):
-    assert _should_clone_trace(trace_or_none, run_id=run_id) is False
+        data=TraceData(spans=[]),
+    )
+    assert _should_clone_trace(trace, run_id="run-1") is True
 
 
 @pytest.mark.parametrize(
@@ -2000,3 +1995,39 @@ def test_should_clone_trace_does_not_call_get_experiment_id_when_provided(mlflow
     ):
         _should_clone_trace(mlflow_experiment_trace, run_id="run-1", experiment_id="exp-123")
         mock_get_exp.assert_not_called()
+
+
+def test_run_predict_copies_uc_trace_instead_of_linking():
+    uc_trace = Trace(
+        info=create_test_trace_info_with_uc_table(
+            trace_id="tr-uc", catalog_name="catalog", schema_name="schema"
+        ),
+        data=TraceData(spans=[]),
+    )
+    eval_item = EvalItem(
+        request_id="req-1",
+        inputs={"q": "hello"},
+        outputs=None,
+        expectations={},
+        trace=uc_trace,
+    )
+    cloned_trace_id = "cloned-trace-id"
+    cloned_trace = mock.MagicMock()
+
+    with (
+        mock.patch(
+            "mlflow.genai.evaluation.harness.copy_trace_to_experiment",
+            return_value=cloned_trace_id,
+        ) as mock_copy,
+        mock.patch("mlflow.get_trace", return_value=cloned_trace),
+        mock.patch("mlflow.genai.evaluation.harness.MlflowClient") as mock_client_cls,
+    ):
+        _run_predict(
+            eval_item,
+            predict_fn=None,
+            run_id=None,
+            rate_limiter=NoOpRateLimiter(),
+        )
+        mock_copy.assert_called_once_with(uc_trace.to_dict())
+        mock_client_cls.return_value.link_traces_to_run.assert_not_called()
+    assert eval_item.trace is cloned_trace


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [ ] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
