### PR TITLE
Implement SQLAlchemy trace archival pass

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -340,6 +340,8 @@ from mlflow.utils.validation import (
     _validate_batch_log_api_req,
     _validate_experiment_artifact_location,
     _validate_experiment_artifact_location_length,
+    _validate_trace_archival_location,
+    _validate_trace_archival_retention_string,
     invalid_value,
     missing_value,
 )
@@ -1134,7 +1136,14 @@ def _validate_workspace_default_artifact_root(value: str | None) -> str | None:
 
 
 def _validate_workspace_trace_archival_location(value: str | None) -> str | None:
-    return _validate_optional_workspace_storage_location(value, "trace_archival_config.location")
+    validated = _validate_optional_workspace_storage_location(
+        value, "trace_archival_config.location"
+    )
+    if validated in (None, ""):
+        return validated
+    return _validate_trace_archival_location(
+        validated, parameter_name="trace_archival_config.location"
+    )
 
 
 def _validate_workspace_trace_archival_retention(value: str | None) -> str | None:
@@ -1145,19 +1154,9 @@ def _validate_workspace_trace_archival_retention(value: str | None) -> str | Non
     if not trimmed:
         return ""
 
-    if len(trimmed) > 32:
-        raise MlflowException.invalid_parameter_value(
-            "Invalid value for 'trace_archival_config.retention'. Maximum length is 32 characters."
-        )
-
-    if re.fullmatch(r"[1-9][0-9]*[mhd]", trimmed) is None:
-        raise MlflowException.invalid_parameter_value(
-            "Invalid value for 'trace_archival_config.retention'. Expected a duration in the "
-            "form `<int><unit>`, where unit is one of 'm', 'h', or 'd' (for example '30d' "
-            "or '12h')."
-        )
-
-    return trimmed
+    return _validate_trace_archival_retention_string(
+        trimmed, parameter_name="trace_archival_config.retention"
+    )
 
 
 def _get_workspace_request_message(

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -334,6 +334,7 @@ from mlflow.utils.validation import (
     _validate_batch_log_api_req,
     _validate_experiment_artifact_location,
     _validate_experiment_artifact_location_length,
+    _validate_trace_archival_location,
     _validate_trace_archival_retention_string,
     invalid_value,
     missing_value,
@@ -1129,7 +1130,14 @@ def _validate_workspace_default_artifact_root(value: str | None) -> str | None:
 
 
 def _validate_workspace_trace_archival_location(value: str | None) -> str | None:
-    return _validate_optional_workspace_storage_location(value, "trace_archival_config.location")
+    validated = _validate_optional_workspace_storage_location(
+        value, "trace_archival_config.location"
+    )
+    if validated in (None, ""):
+        return validated
+    return _validate_trace_archival_location(
+        validated, parameter_name="trace_archival_config.location"
+    )
 
 
 def _validate_workspace_trace_archival_retention(value: str | None) -> str | None:

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -334,6 +334,7 @@ from mlflow.utils.validation import (
     _validate_batch_log_api_req,
     _validate_experiment_artifact_location,
     _validate_experiment_artifact_location_length,
+    _validate_trace_archival_retention_string,
     invalid_value,
     missing_value,
 )
@@ -1139,19 +1140,9 @@ def _validate_workspace_trace_archival_retention(value: str | None) -> str | Non
     if not trimmed:
         return ""
 
-    if len(trimmed) > 32:
-        raise MlflowException.invalid_parameter_value(
-            "Invalid value for 'trace_archival_config.retention'. Maximum length is 32 characters."
-        )
-
-    if re.fullmatch(r"[1-9][0-9]*[mhd]", trimmed) is None:
-        raise MlflowException.invalid_parameter_value(
-            "Invalid value for 'trace_archival_config.retention'. Expected a duration in the "
-            "form `<int><unit>`, where unit is one of 'm', 'h', or 'd' (for example '30d' "
-            "or '12h')."
-        )
-
-    return trimmed
+    return _validate_trace_archival_retention_string(
+        trimmed, parameter_name="trace_archival_config.retention"
+    )
 
 
 def _get_workspace_request_message(

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -27,6 +27,7 @@ from mlflow.environment_variables import (
 )
 from mlflow.exceptions import (
     MlflowException,
+    MlflowNotImplementedException,
     MlflowTraceDataCorrupted,
     MlflowTraceDataNotFound,
 )
@@ -269,7 +270,7 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
                 raise MlflowTraceDataCorrupted(request_id=self.resource.id) from e
 
     def download_archived_trace_data(self) -> TraceData:
-        raise MlflowException.invalid_parameter_value(
+        raise MlflowNotImplementedException(
             "Databricks trace artifact repositories do not yet support ARCHIVE_REPO trace payloads."
         )
 
@@ -305,12 +306,12 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
                 self._signed_url_upload_file(cred, temp_file)
 
     def upload_archived_trace_data(self, trace_data: TraceData) -> None:
-        raise MlflowException.invalid_parameter_value(
+        raise MlflowNotImplementedException(
             "Databricks trace artifact repositories do not yet support ARCHIVE_REPO trace payloads."
         )
 
     def upload_archived_trace_data_bytes(self, data: bytes) -> None:
-        raise MlflowException.invalid_parameter_value(
+        raise MlflowNotImplementedException(
             "Databricks trace artifact repositories do not yet support ARCHIVE_REPO trace payloads."
         )
 

--- a/mlflow/store/db_migrations/versions/da6fb0208061_add_workspaces_trace_archival_location.py
+++ b/mlflow/store/db_migrations/versions/da6fb0208061_add_workspaces_trace_archival_location.py
@@ -1,7 +1,7 @@
 """add trace archival workspace columns
 
 Revision ID: da6fb0208061
-Revises: ae8bbe7743c9
+Revises: 7d34483879f0
 
 Create Date: 2026-04-03 10:50:46.501372
 

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -12,6 +12,7 @@ import time
 import uuid
 from collections import defaultdict
 from dataclasses import dataclass, field
+from enum import Enum
 from functools import reduce
 from pathlib import PurePath
 from typing import Any, TypedDict, TypeVar
@@ -21,7 +22,7 @@ import sqlalchemy
 import sqlalchemy.orm
 import sqlalchemy.sql.expression as sql
 from sqlalchemy import and_, case, distinct, exists, func, or_, select, sql
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm import Query, Session, aliased, joinedload, selectinload
 from sqlalchemy.sql.elements import ColumnElement
 from sqlalchemy.sql.selectable import Select, Subquery
@@ -81,7 +82,12 @@ from mlflow.entities.trace_metrics import (
 )
 from mlflow.entities.trace_state import TraceState
 from mlflow.entities.trace_status import TraceStatus
-from mlflow.exceptions import MlflowException, MlflowTracingException
+from mlflow.exceptions import (
+    MlflowException,
+    MlflowNotImplementedException,
+    MlflowTraceArchivalMalformedTrace,
+    MlflowTracingException,
+)
 from mlflow.genai.judges.instructions_judge import (
     EXPECTATIONS_FIELD,
     InstructionsJudge,
@@ -110,6 +116,7 @@ from mlflow.protos.databricks_pb2 import (
     ErrorCode,
 )
 from mlflow.store.analytics import trace_correlation
+from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.store.db.db_types import MSSQL, MYSQL
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.tracking import (
@@ -162,6 +169,7 @@ from mlflow.store.tracking.utils.sql_trace_metrics_utils import (
     query_metrics,
     validate_query_trace_metrics_params,
 )
+from mlflow.store.workspace.abstract_store import ResolvedTraceArchivalConfig
 from mlflow.telemetry.events import UpdateIssueEvent
 from mlflow.telemetry.track import record_usage_event
 from mlflow.tracing.analysis import TraceFilterCorrelationResult
@@ -170,10 +178,13 @@ from mlflow.tracing.constant import (
     SpanAttributeKey,
     SpansLocation,
     TokenUsageKey,
+    TraceArchivalFailureReason,
+    TraceExperimentTagKey,
     TraceMetadataKey,
     TraceSizeStatsKey,
     TraceTagKey,
 )
+from mlflow.tracing.otel.otel_archival import TRACE_ARCHIVAL_FILENAME, spans_to_traces_data_pb
 from mlflow.tracing.otel.translation import (
     translate_loaded_span,
     translate_span_when_storing,
@@ -183,6 +194,9 @@ from mlflow.tracing.otel.translation import (
 from mlflow.tracing.utils import (
     TraceJSONEncoder,
     generate_request_id_v2,
+)
+from mlflow.tracing.utils.artifact_utils import (
+    get_archive_uri_for_trace,
 )
 from mlflow.tracing.utils.truncation import _get_truncated_preview
 from mlflow.utils.file_utils import local_file_uri_to_path
@@ -212,6 +226,7 @@ from mlflow.utils.uri import (
     resolve_uri_if_local,
 )
 from mlflow.utils.validation import (
+    _parse_trace_archival_duration_config,
     _resolve_experiment_ids_and_locations,
     _validate_batch_log_data,
     _validate_batch_log_limits,
@@ -225,9 +240,11 @@ from mlflow.utils.validation import (
     _validate_param_keys_unique,
     _validate_run_id,
     _validate_tag,
+    _validate_trace_archival_location,
+    _validate_trace_archival_retention_string,
     _validate_trace_tag,
 )
-from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
+from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME, WORKSPACES_DIR_NAME
 
 _T = TypeVar("_T")
 
@@ -249,6 +266,84 @@ class DatasetFilter(TypedDict, total=False):
 
     dataset_name: str
     dataset_digest: str
+
+
+_TRACE_ARCHIVAL_DURATION_MULTIPLIER_MILLIS = {
+    "m": 60 * 1000,
+    "h": 60 * 60 * 1000,
+    "d": 24 * 60 * 60 * 1000,
+}
+# Keep grouped experiment scans well below backend parameter limits (notably MSSQL's 2100).
+_TRACE_ARCHIVAL_EXPERIMENT_ID_CHUNK_SIZE = 1000
+
+
+class _ArchiveNowRemainingState(str, Enum):
+    DONE = "done"
+    ARCHIVABLE = "archivable"
+    TRANSIENT = "transient"
+    BLOCKED_UNMARKED = "blocked_unmarked"
+    TERMINAL_FAILURES_ONLY = "terminal_failures_only"
+
+
+@dataclass(frozen=True)
+class _ArchiveNowRequest:
+    older_than_millis: int | None
+
+    @classmethod
+    def from_tag_value(cls, value: str | None) -> _ArchiveNowRequest | None:
+        if value is None:
+            return None
+
+        try:
+            older_than = _parse_trace_archival_duration_config(
+                value,
+                duration_key="older_than",
+                allow_missing_duration=True,
+            )
+            return cls(older_than_millis=_parse_trace_archival_duration_millis(older_than))
+        except MlflowException:
+            _logger.warning(
+                "Ignoring malformed trace archive-now tag value: %r",
+                value,
+            )
+            return None
+
+
+@dataclass(frozen=True)
+class _ArchiveNowCleanupRequest:
+    experiment_id: str
+    raw_value: str
+    parsed_request: _ArchiveNowRequest
+
+
+@dataclass(frozen=True)
+class _TraceArchiveCandidate:
+    trace_id: str
+    experiment_id: str
+    timestamp_ms: int
+
+
+def _parse_trace_archival_duration_millis(value: str | None) -> int | None:
+    if value is None:
+        return None
+
+    trimmed = _validate_trace_archival_retention_string(value)
+    amount = trimmed[:-1]
+    unit = trimmed[-1]
+    return int(amount) * _TRACE_ARCHIVAL_DURATION_MULTIPLIER_MILLIS[unit]
+
+
+def _parse_experiment_trace_archival_retention_millis(value: str | None) -> int | None:
+    try:
+        duration = _parse_trace_archival_duration_config(
+            value,
+            duration_key="value",
+            expected_type="duration",
+        )
+        return _parse_trace_archival_duration_millis(duration)
+    except MlflowException:
+        _logger.warning("Ignoring invalid trace archival retention tag value: %r", value)
+        return None
 
 
 class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
@@ -3357,12 +3452,13 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 )
                 new_tag_keys = {t.key for t in tags}
                 if db_sql_trace_info:
+                    # Duplicate start_trace() calls must keep any store-managed tags already
+                    # attached to the trace, including archival state written after log_spans().
                     for tag in db_sql_trace_info.tags:
                         if tag.key not in new_tag_keys:
                             sql_trace_info.tags.append(
                                 SqlTraceTag(request_id=trace_id, key=tag.key, value=tag.value)
                             )
-                            break
 
                     new_metric_keys = {m.key for m in sql_trace_info.metrics}
                     for metric in db_sql_trace_info.metrics:
@@ -4632,6 +4728,27 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 .all()
             }
 
+            if existing_traces:
+                archived_trace_ids = sorted(
+                    request_id
+                    for (request_id,) in session
+                    .query(SqlTraceTag.request_id)
+                    .filter(
+                        SqlTraceTag.request_id.in_(list(existing_traces)),
+                        SqlTraceTag.key == TraceTagKey.SPANS_LOCATION,
+                        SqlTraceTag.value == SpansLocation.ARCHIVE_REPO.value,
+                    )
+                    .all()
+                )
+                if archived_trace_ids:
+                    archived_trace_list = ", ".join(
+                        f"'{trace_id}'" for trace_id in archived_trace_ids
+                    )
+                    raise MlflowException(
+                        f"Cannot log spans to archived traces: {archived_trace_list}.",
+                        error_code=INVALID_STATE,
+                    )
+
             # --- Phase 2: Create missing traces ---
             # On IntegrityError (concurrent start_trace race), roll back and retry so that
             # previously flushed trace_infos (which session.rollback() would undo) are
@@ -5094,15 +5211,812 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
 
             return [sql_trace_info.to_mlflow_entity() for sql_trace_info in sql_trace_infos]
 
+    def archive_traces(
+        self,
+        *,
+        default_trace_archival_location: str,
+        default_retention: str,
+        long_retention_allowlist: set[str] | list[str] | None = None,
+        max_traces: int | None = None,
+    ) -> int:
+        if max_traces is not None and max_traces <= 0:
+            raise MlflowException.invalid_parameter_value(
+                f"`max_traces` must be a positive integer, received {max_traces}."
+            )
+        if not default_trace_archival_location:
+            raise MlflowException.invalid_parameter_value(
+                "`default_trace_archival_location` must be provided."
+            )
+        default_trace_archival_location = _validate_trace_archival_location(
+            default_trace_archival_location, parameter_name="default_trace_archival_location"
+        )
+        if not default_retention:
+            raise MlflowException.invalid_parameter_value("`default_retention` must be provided.")
+
+        now_millis = self._get_archive_traces_now_millis()
+        long_retention_allowlist = {
+            str(experiment_id) for experiment_id in long_retention_allowlist or []
+        }
+        trace_archival_config = self.resolve_trace_archival_config(
+            default_trace_archival_location=default_trace_archival_location,
+            default_retention=default_retention,
+        )
+        # The public API already required broader-scope defaults, so `None` here means config
+        # resolution dropped a caller-provided value instead of preserving or overriding it.
+        if trace_archival_config.config.location is None:
+            raise MlflowException(
+                "Trace archival config resolution returned no archival location.",
+                error_code=INTERNAL_ERROR,
+            )
+        if trace_archival_config.config.retention is None:
+            raise MlflowException(
+                "Trace archival config resolution returned no archival retention.",
+                error_code=INTERNAL_ERROR,
+            )
+        self._validate_trace_archival_destination(trace_archival_config=trace_archival_config)
+        broader_retention_millis = _parse_trace_archival_duration_millis(
+            trace_archival_config.config.retention
+        )
+
+        with self.ManagedSessionMaker() as session:
+            archive_now_requests, candidates = self._plan_trace_archival(
+                session=session,
+                now_millis=now_millis,
+                broader_retention_millis=broader_retention_millis,
+                long_retention_allowlist=long_retention_allowlist,
+                max_traces=max_traces,
+            )
+        return self._execute_trace_archival_plan(
+            archive_now_requests=archive_now_requests,
+            candidates=candidates,
+            trace_archival_config=trace_archival_config,
+            max_traces=max_traces,
+            now_millis=now_millis,
+        )
+
+    def _plan_trace_archival(
+        self,
+        *,
+        session: Session,
+        now_millis: int,
+        broader_retention_millis: int,
+        long_retention_allowlist: set[str],
+        max_traces: int | None,
+    ) -> tuple[list[_ArchiveNowCleanupRequest], list[_TraceArchiveCandidate]]:
+        archive_now_requests: list[_ArchiveNowCleanupRequest] = []
+        # Group archive-now experiments by cutoff so experiments requesting the same urgency
+        # can share a candidate query instead of scanning one experiment at a time.
+        archive_now_cutoff_groups: dict[int | None, list[str]] = defaultdict(list)
+        regular_cutoff_groups: dict[int, list[str]] = defaultdict(list)
+        for experiment_id, experiment_tags in self._get_active_experiment_trace_archival_tags(
+            session
+        ):
+            archive_now_raw = experiment_tags.get(TraceExperimentTagKey.ARCHIVE_NOW)
+            archive_now = _ArchiveNowRequest.from_tag_value(archive_now_raw)
+            if archive_now and archive_now_raw is not None:
+                archive_now_requests.append(
+                    _ArchiveNowCleanupRequest(
+                        experiment_id=experiment_id,
+                        raw_value=archive_now_raw,
+                        parsed_request=archive_now,
+                    )
+                )
+                archive_now_cutoff_groups[
+                    now_millis - archive_now.older_than_millis
+                    if archive_now.older_than_millis is not None
+                    else None
+                ].append(experiment_id)
+
+            retention_millis = self._resolve_effective_trace_archival_retention_millis(
+                experiment_id=experiment_id,
+                experiment_tags=experiment_tags,
+                broader_retention_millis=broader_retention_millis,
+                long_retention_allowlist=long_retention_allowlist,
+            )
+            archive_now_covers_retention = archive_now is not None and (
+                archive_now.older_than_millis is None
+                or archive_now.older_than_millis <= retention_millis
+            )
+            if retention_millis and not archive_now_covers_retention:
+                regular_cutoff_groups[now_millis - retention_millis].append(experiment_id)
+
+        archive_now_candidates = self._collect_grouped_trace_archive_candidates(
+            session=session,
+            cutoff_groups=archive_now_cutoff_groups,
+            max_traces=max_traces,
+        )
+
+        regular_candidates: list[_TraceArchiveCandidate] = []
+        if max_traces is None or len(archive_now_candidates) < max_traces:
+            regular_candidates = self._collect_grouped_trace_archive_candidates(
+                session=session,
+                cutoff_groups=regular_cutoff_groups,
+                max_traces=max_traces,
+            )
+
+        return (
+            archive_now_requests,
+            self._dedupe_trace_archive_candidates(archive_now_candidates, regular_candidates),
+        )
+
+    def _collect_grouped_trace_archive_candidates(
+        self,
+        *,
+        session: Session,
+        cutoff_groups: dict[int | None, list[str]],
+        max_traces: int | None,
+    ) -> list[_TraceArchiveCandidate]:
+        candidates: list[_TraceArchiveCandidate] = []
+        for cutoff, experiment_ids in cutoff_groups.items():
+            candidates = self._merge_limited_trace_archive_candidates(
+                candidates,
+                self._find_archivable_trace_candidates_for_experiments(
+                    session=session,
+                    experiment_ids=experiment_ids,
+                    max_timestamp_millis=cutoff,
+                    limit=max_traces,
+                ),
+                limit=max_traces,
+            )
+        return candidates
+
+    def _execute_trace_archival_plan(
+        self,
+        *,
+        archive_now_requests: list[_ArchiveNowCleanupRequest],
+        candidates: list[_TraceArchiveCandidate],
+        trace_archival_config: ResolvedTraceArchivalConfig,
+        max_traces: int | None,
+        now_millis: int,
+    ) -> int:
+        archive_now_experiment_ids = {r.experiment_id for r in archive_now_requests}
+        retryable_failure_experiment_ids: set[str] = set()
+        archived_count = 0
+        candidates_to_archive = candidates if max_traces is None else candidates[:max_traces]
+        try:
+            for candidate in candidates_to_archive:
+                try:
+                    if self._archive_trace_candidate(
+                        trace_id=candidate.trace_id,
+                        trace_archival_config=trace_archival_config,
+                    ):
+                        archived_count += 1
+                except MlflowNotImplementedException:
+                    raise
+                except (MlflowException, SQLAlchemyError):
+                    _logger.warning(
+                        "Failed to archive trace %s; leaving it eligible for retry.",
+                        candidate.trace_id,
+                        exc_info=True,
+                    )
+                    if candidate.experiment_id in archive_now_experiment_ids:
+                        retryable_failure_experiment_ids.add(candidate.experiment_id)
+        finally:
+            self._clear_completed_archive_now_requests(
+                archive_now_requests=archive_now_requests,
+                now_millis=now_millis,
+                retryable_failure_experiment_ids=retryable_failure_experiment_ids,
+            )
+        return archived_count
+
+    def _get_archive_traces_now_millis(self) -> int:
+        """Return the wall-clock cutoff time for this archival pass.
+
+        This small wrapper exists so tests can freeze the scheduler clock without
+        patching the shared time utility.
+        """
+        return get_current_time_millis()
+
+    def _validate_trace_archival_destination(
+        self, *, trace_archival_config: ResolvedTraceArchivalConfig
+    ) -> None:
+        resolved_root = _validate_trace_archival_location(
+            trace_archival_config.config.location,
+            parameter_name="resolved_trace_archival_location",
+        )
+        if trace_archival_config.append_workspace_prefix and (
+            workspace_name := self._get_trace_archival_workspace_name()
+        ):
+            resolved_root = append_to_uri_path(resolved_root, WORKSPACES_DIR_NAME, workspace_name)
+
+        # Fail deterministic repository/config problems once per pass instead of misclassifying
+        # them as retryable per-trace archival errors.
+        get_artifact_repository(
+            append_to_uri_path(
+                resolved_root,
+                "0",
+                self.TRACE_FOLDER_NAME,
+                "preflight",
+                self.ARTIFACTS_FOLDER_NAME,
+            )
+        )
+
+    def _get_trace_archival_workspace_name(self) -> str | None:
+        """Return the workspace path segment for workspace-scoped archival roots."""
+        return None
+
+    def _resolve_effective_trace_archival_retention_millis(
+        self,
+        *,
+        experiment_id: str,
+        experiment_tags: dict[str, str],
+        broader_retention_millis: int,
+        long_retention_allowlist: set[str],
+    ) -> int:
+        experiment_retention_millis = _parse_experiment_trace_archival_retention_millis(
+            experiment_tags.get(TraceExperimentTagKey.ARCHIVAL_RETENTION)
+        )
+        if experiment_retention_millis is None:
+            return broader_retention_millis
+
+        if experiment_retention_millis <= broader_retention_millis:
+            return experiment_retention_millis
+
+        if experiment_id in long_retention_allowlist:
+            return experiment_retention_millis
+
+        return broader_retention_millis
+
+    def _get_active_experiment_trace_archival_tags(
+        self, session: Session
+    ) -> list[tuple[str, dict[str, str]]]:
+        # Fetch active experiments with only the archival-related tags consulted by the scheduler.
+        # The outer join keeps experiments that inherit defaults, and the single query avoids both
+        # joined-loading unrelated tags and building a large Python-side IN list.
+        rows = (
+            self
+            ._get_query(session, SqlExperiment)
+            .outerjoin(
+                SqlExperimentTag,
+                and_(
+                    SqlExperimentTag.experiment_id == SqlExperiment.experiment_id,
+                    SqlExperimentTag.key.in_([
+                        TraceExperimentTagKey.ARCHIVE_NOW,
+                        TraceExperimentTagKey.ARCHIVAL_RETENTION,
+                    ]),
+                ),
+            )
+            .with_entities(
+                SqlExperiment.experiment_id, SqlExperimentTag.key, SqlExperimentTag.value
+            )
+            .filter(SqlExperiment.lifecycle_stage == LifecycleStage.ACTIVE)
+            .order_by(SqlExperiment.experiment_id.asc(), SqlExperimentTag.key.asc())
+            .all()
+        )
+
+        experiments: list[tuple[str, dict[str, str]]] = []
+        current_experiment_id: str | None = None
+        current_tags: dict[str, str] | None = None
+        for experiment_id, key, value in rows:
+            experiment_id = str(experiment_id)
+            if experiment_id != current_experiment_id:
+                current_experiment_id = experiment_id
+                current_tags = {}
+                experiments.append((experiment_id, current_tags))
+            if key is not None:
+                current_tags[key] = value
+
+        return experiments
+
+    @staticmethod
+    def _merge_limited_trace_archive_candidates(
+        existing_candidates: list[_TraceArchiveCandidate],
+        new_candidates: list[_TraceArchiveCandidate],
+        *,
+        limit: int | None,
+    ) -> list[_TraceArchiveCandidate]:
+        def sort_key(candidate: _TraceArchiveCandidate) -> tuple[int, str]:
+            return candidate.timestamp_ms, candidate.trace_id
+
+        if limit is None:
+            return sorted([*existing_candidates, *new_candidates], key=sort_key)
+        if limit <= 0:
+            return []
+        if not existing_candidates:
+            return sorted(new_candidates, key=sort_key)[:limit]
+        if not new_candidates:
+            return sorted(existing_candidates, key=sort_key)[:limit]
+
+        return sorted([*existing_candidates, *new_candidates], key=sort_key)[:limit]
+
+    @staticmethod
+    def _dedupe_trace_archive_candidates(
+        archive_now_candidates: list[_TraceArchiveCandidate],
+        regular_candidates: list[_TraceArchiveCandidate],
+    ) -> list[_TraceArchiveCandidate]:
+        deduped: list[_TraceArchiveCandidate] = []
+        seen_trace_ids: set[str] = set()
+        for candidates in (
+            sorted(archive_now_candidates, key=lambda c: (c.timestamp_ms, c.trace_id)),
+            sorted(regular_candidates, key=lambda c: (c.timestamp_ms, c.trace_id)),
+        ):
+            for candidate in candidates:
+                if candidate.trace_id in seen_trace_ids:
+                    continue
+                deduped.append(candidate)
+                seen_trace_ids.add(candidate.trace_id)
+        return deduped
+
+    def _find_archivable_trace_candidates_for_experiments(
+        self,
+        *,
+        session: Session,
+        experiment_ids: list[str],
+        max_timestamp_millis: int | None,
+        limit: int | None = None,
+    ) -> list[_TraceArchiveCandidate]:
+        if not experiment_ids:
+            return []
+
+        spans_outside_tracking_store = exists().where(
+            and_(
+                SqlTraceTag.request_id == SqlTraceInfo.request_id,
+                SqlTraceTag.key == TraceTagKey.SPANS_LOCATION,
+                SqlTraceTag.value != SpansLocation.TRACKING_STORE.value,
+            )
+        )
+        archival_failure_exists = exists().where(
+            and_(
+                SqlTraceTag.request_id == SqlTraceInfo.request_id,
+                SqlTraceTag.key == TraceTagKey.ARCHIVAL_FAILURE,
+            )
+        )
+        non_empty_span_exists = exists().where(
+            and_(
+                SqlSpan.trace_id == SqlTraceInfo.request_id,
+                SqlSpan.content != "",
+            )
+        )
+
+        candidates: list[_TraceArchiveCandidate] = []
+        for chunk_start in range(0, len(experiment_ids), _TRACE_ARCHIVAL_EXPERIMENT_ID_CHUNK_SIZE):
+            # Query experiment ids in chunks to keep the SQL IN list bounded.
+            experiment_id_chunk = [
+                int(experiment_id)
+                for experiment_id in experiment_ids[
+                    chunk_start : chunk_start + _TRACE_ARCHIVAL_EXPERIMENT_ID_CHUNK_SIZE
+                ]
+            ]
+            statement = (
+                self
+                ._trace_query(session)
+                .with_entities(
+                    SqlTraceInfo.request_id, SqlTraceInfo.experiment_id, SqlTraceInfo.timestamp_ms
+                )
+                .filter(
+                    SqlTraceInfo.experiment_id.in_(experiment_id_chunk),
+                    SqlTraceInfo.status != TraceState.IN_PROGRESS.value,
+                    ~spans_outside_tracking_store,
+                    ~archival_failure_exists,
+                    non_empty_span_exists,
+                )
+                .order_by(SqlTraceInfo.timestamp_ms.asc(), SqlTraceInfo.request_id.asc())
+            )
+            if max_timestamp_millis is not None:
+                statement = statement.filter(SqlTraceInfo.timestamp_ms <= max_timestamp_millis)
+            if limit is not None:
+                statement = statement.limit(limit)
+
+            chunk_candidates = [
+                _TraceArchiveCandidate(
+                    trace_id=trace_id,
+                    experiment_id=str(experiment_id),
+                    timestamp_ms=timestamp_ms,
+                )
+                for trace_id, experiment_id, timestamp_ms in statement.all()
+            ]
+            if limit is None:
+                candidates.extend(chunk_candidates)
+            else:
+                candidates = self._merge_limited_trace_archive_candidates(
+                    candidates, chunk_candidates, limit=limit
+                )
+
+        if limit is None:
+            return sorted(
+                candidates, key=lambda candidate: (candidate.timestamp_ms, candidate.trace_id)
+            )
+        return candidates
+
+    def _archive_trace_candidate(
+        self,
+        *,
+        trace_id: str,
+        trace_archival_config: ResolvedTraceArchivalConfig,
+    ) -> bool:
+        snapshot = self._load_trace_archival_snapshot(trace_id)
+        if snapshot is None:
+            return False
+
+        trace_info, snapshot_rows = snapshot
+        try:
+            archived_pb = self._serialize_trace_archival_snapshot_to_pb(snapshot_rows)
+        except MlflowTraceArchivalMalformedTrace:
+            _logger.warning("Marking trace %s as MALFORMED_TRACE during archival.", trace_id)
+            self._mark_trace_archival_failure(
+                trace_id=trace_id,
+                failure_reason=TraceArchivalFailureReason.MALFORMED_TRACE.value,
+            )
+            return False
+
+        artifact_uri = self._get_archival_repository_artifact_uri(
+            trace_info=trace_info,
+            trace_archival_config=trace_archival_config,
+        )
+        artifact_repo = get_artifact_repository(artifact_uri)
+
+        try:
+            artifact_repo.upload_archived_trace_data_bytes(archived_pb)
+        except MlflowNotImplementedException:
+            _logger.warning(
+                "Marking trace %s as UNSUPPORTED_ARCHIVE_REPOSITORY during archival.",
+                trace_id,
+            )
+            self._mark_trace_archival_failure(
+                trace_id=trace_id,
+                failure_reason=TraceArchivalFailureReason.UNSUPPORTED_ARCHIVE_REPOSITORY.value,
+            )
+            return False
+        except Exception as e:
+            # Normalize backend-specific upload errors so the outer archival loop
+            # can treat them as retryable without depending on repository internals.
+            raise MlflowException("Trace archival upload failed.") from e
+        try:
+            finalized = self._finalize_archived_trace(
+                trace_id=trace_id,
+                snapshot_rows=snapshot_rows,
+                artifact_uri=artifact_uri,
+            )
+        except Exception as e:
+            self._delete_unreferenced_archived_trace_payload(
+                trace_id=trace_id,
+                artifact_uri=artifact_uri,
+                artifact_repo=artifact_repo,
+            )
+            if isinstance(e, MlflowException):
+                raise
+            # Normalize unexpected finalize-time errors after cleanup so the
+            # outer archival loop can retry them consistently.
+            raise MlflowException("Trace archival finalization failed.") from e
+
+        if not finalized:
+            self._delete_unreferenced_archived_trace_payload(
+                trace_id=trace_id,
+                artifact_uri=artifact_uri,
+                artifact_repo=artifact_repo,
+            )
+        return finalized
+
+    def _load_trace_archival_snapshot(
+        self, trace_id: str
+    ) -> tuple[TraceInfo, list[tuple[str, str]]] | None:
+        with self.ManagedSessionMaker() as session:
+            sql_trace_info = (
+                self
+                ._trace_query(session)
+                .options(joinedload(SqlTraceInfo.tags), joinedload(SqlTraceInfo.spans))
+                .filter(SqlTraceInfo.request_id == trace_id)
+                .one_or_none()
+            )
+            if sql_trace_info is None:
+                return None
+
+            trace_info = sql_trace_info.to_mlflow_entity()
+            if not self._is_trace_actionable_for_archival(trace_info, sql_trace_info.spans):
+                return None
+
+            snapshot_rows = sorted((span.span_id, span.content) for span in sql_trace_info.spans)
+            return trace_info, snapshot_rows
+
+    def _serialize_trace_archival_snapshot_to_pb(
+        self, snapshot_rows: list[tuple[str, str]]
+    ) -> bytes:
+        try:
+            spans = [
+                Span.from_dict(translate_loaded_span(json.loads(content)))
+                for _, content in snapshot_rows
+            ]
+            return spans_to_traces_data_pb(spans)
+        except (MlflowException, TypeError, ValueError, AttributeError) as e:
+            raise MlflowTraceArchivalMalformedTrace(str(e)) from e
+
+    def _is_trace_actionable_for_archival(
+        self, trace_info: TraceInfo, spans: list[SqlSpan]
+    ) -> bool:
+        spans_location = trace_info.tags.get(TraceTagKey.SPANS_LOCATION)
+        if spans_location not in (None, SpansLocation.TRACKING_STORE.value):
+            return False
+        if TraceTagKey.ARCHIVAL_FAILURE in trace_info.tags:
+            return False
+        if trace_info.state == TraceState.IN_PROGRESS:
+            return False
+        return any(span.content != "" for span in spans)
+
+    def _get_archival_repository_artifact_uri(
+        self,
+        *,
+        trace_info: TraceInfo,
+        trace_archival_config: ResolvedTraceArchivalConfig,
+    ) -> str:
+        resolved_root = trace_archival_config.config.location
+        append_workspace_prefix = trace_archival_config.append_workspace_prefix
+        if resolved_root is None:
+            raise MlflowException(
+                "Trace archival config resolution returned no archival location.",
+                error_code=INTERNAL_ERROR,
+            )
+
+        if append_workspace_prefix and (
+            workspace_name := self._get_trace_archival_workspace_name()
+        ):
+            resolved_root = append_to_uri_path(resolved_root, WORKSPACES_DIR_NAME, workspace_name)
+
+        return append_to_uri_path(
+            resolved_root,
+            str(trace_info.experiment_id),
+            self.TRACE_FOLDER_NAME,
+            trace_info.trace_id,
+            self.ARTIFACTS_FOLDER_NAME,
+        )
+
+    def _delete_unreferenced_archived_trace_payload(
+        self,
+        *,
+        trace_id: str,
+        artifact_uri: str,
+        artifact_repo,
+    ) -> None:
+        with self.ManagedSessionMaker() as session:
+            sql_trace_info = (
+                self
+                ._trace_query(session)
+                .options(joinedload(SqlTraceInfo.tags))
+                .filter(SqlTraceInfo.request_id == trace_id)
+                .one_or_none()
+            )
+            if sql_trace_info is not None:
+                trace_info = sql_trace_info.to_mlflow_entity()
+                if (
+                    trace_info.tags.get(TraceTagKey.SPANS_LOCATION)
+                    == SpansLocation.ARCHIVE_REPO.value
+                    and trace_info.tags.get(TraceTagKey.ARCHIVE_LOCATION) == artifact_uri
+                ):
+                    return
+
+        try:
+            artifact_repo.delete_artifacts(TRACE_ARCHIVAL_FILENAME)
+        except Exception:
+            _logger.warning(
+                "Failed to delete unreferenced archived payload for trace %s.",
+                trace_id,
+                exc_info=True,
+            )
+
+    def _finalize_archived_trace(
+        self,
+        *,
+        trace_id: str,
+        snapshot_rows: list[tuple[str, str]],
+        artifact_uri: str,
+    ) -> bool:
+        with self.ManagedSessionMaker() as session:
+            sql_trace_info = (
+                self
+                ._trace_query(session, for_update_or_delete=True)
+                .options(joinedload(SqlTraceInfo.tags), joinedload(SqlTraceInfo.spans))
+                .filter(SqlTraceInfo.request_id == trace_id)
+                .one_or_none()
+            )
+            if sql_trace_info is None:
+                return False
+
+            trace_info = sql_trace_info.to_mlflow_entity()
+            if not self._is_trace_actionable_for_archival(trace_info, sql_trace_info.spans):
+                return False
+
+            # Do a snapshot comparison as defense in depth for non-cooperating writers
+            # or backend-specific lock gaps.
+            current_snapshot_rows = sorted(
+                (span.span_id, span.content) for span in sql_trace_info.spans
+            )
+            if current_snapshot_rows != snapshot_rows:
+                _logger.info(
+                    (
+                        "Skipping archival finalization for trace %s because its DB-backed spans "
+                        "changed."
+                    ),
+                    trace_id,
+                )
+                return False
+
+            (
+                session
+                .query(SqlSpan)
+                .filter(SqlSpan.trace_id == trace_id)
+                .update({SqlSpan.content: ""}, synchronize_session=False)
+            )
+            session.merge(
+                SqlTraceTag(
+                    request_id=trace_id,
+                    key=TraceTagKey.SPANS_LOCATION,
+                    value=SpansLocation.ARCHIVE_REPO.value,
+                )
+            )
+            session.merge(
+                SqlTraceTag(
+                    request_id=trace_id,
+                    key=TraceTagKey.ARCHIVE_LOCATION,
+                    value=artifact_uri,
+                )
+            )
+            (
+                session
+                .query(SqlTraceTag)
+                .filter(
+                    SqlTraceTag.request_id == trace_id,
+                    SqlTraceTag.key == TraceTagKey.ARCHIVAL_FAILURE,
+                )
+                .delete(synchronize_session=False)
+            )
+            return True
+
+    def _mark_trace_archival_failure(self, *, trace_id: str, failure_reason: str) -> None:
+        with self.ManagedSessionMaker() as session:
+            sql_trace_info = (
+                self
+                ._trace_query(session, for_update_or_delete=True)
+                .options(joinedload(SqlTraceInfo.tags))
+                .filter(SqlTraceInfo.request_id == trace_id)
+                .one_or_none()
+            )
+            if sql_trace_info is None:
+                return
+
+            spans_location = next(
+                (tag.value for tag in sql_trace_info.tags if tag.key == TraceTagKey.SPANS_LOCATION),
+                None,
+            )
+            if spans_location not in (None, SpansLocation.TRACKING_STORE.value):
+                return
+
+            session.merge(
+                SqlTraceTag(
+                    request_id=trace_id,
+                    key=TraceTagKey.ARCHIVAL_FAILURE,
+                    value=failure_reason,
+                )
+            )
+
+    def _clear_completed_archive_now_requests(
+        self,
+        *,
+        archive_now_requests: list[_ArchiveNowCleanupRequest],
+        now_millis: int,
+        retryable_failure_experiment_ids: set[str] | None = None,
+    ) -> None:
+        if not archive_now_requests:
+            return
+
+        with self.ManagedSessionMaker() as session:
+            for request in archive_now_requests:
+                if (
+                    retryable_failure_experiment_ids
+                    and request.experiment_id in retryable_failure_experiment_ids
+                ):
+                    continue
+
+                older_than_cutoff = (
+                    now_millis - request.parsed_request.older_than_millis
+                    if request.parsed_request.older_than_millis is not None
+                    else None
+                )
+                if self._get_archive_now_remaining_state(
+                    session=session,
+                    experiment_id=request.experiment_id,
+                    max_timestamp_millis=older_than_cutoff,
+                ) in (
+                    _ArchiveNowRemainingState.ARCHIVABLE,
+                    _ArchiveNowRemainingState.TRANSIENT,
+                    _ArchiveNowRemainingState.BLOCKED_UNMARKED,
+                ):
+                    continue
+
+                (
+                    session
+                    .query(SqlExperimentTag)
+                    .filter(
+                        SqlExperimentTag.experiment_id == int(request.experiment_id),
+                        SqlExperimentTag.key == TraceExperimentTagKey.ARCHIVE_NOW,
+                        # Only clear the request we started with; a newer archive-now value may
+                        # have been written while this archival pass was still running.
+                        SqlExperimentTag.value == request.raw_value,
+                    )
+                    .delete(synchronize_session=False)
+                )
+
+    def _get_archive_now_remaining_state(
+        self,
+        *,
+        session: Session,
+        experiment_id: str,
+        max_timestamp_millis: int | None,
+    ) -> _ArchiveNowRemainingState:
+        spans_outside_tracking_store = exists().where(
+            and_(
+                SqlTraceTag.request_id == SqlTraceInfo.request_id,
+                SqlTraceTag.key == TraceTagKey.SPANS_LOCATION,
+                SqlTraceTag.value != SpansLocation.TRACKING_STORE.value,
+            )
+        )
+        archival_failure_exists = exists().where(
+            and_(
+                SqlTraceTag.request_id == SqlTraceInfo.request_id,
+                SqlTraceTag.key == TraceTagKey.ARCHIVAL_FAILURE,
+            )
+        )
+        non_empty_span_exists = exists().where(
+            and_(
+                SqlSpan.trace_id == SqlTraceInfo.request_id,
+                SqlSpan.content != "",
+            )
+        )
+
+        remaining_statement = (
+            self
+            ._trace_query(session)
+            .with_entities(SqlTraceInfo.request_id)
+            .filter(
+                SqlTraceInfo.experiment_id == int(experiment_id),
+                ~spans_outside_tracking_store,
+            )
+        )
+        if max_timestamp_millis is not None:
+            remaining_statement = remaining_statement.filter(
+                SqlTraceInfo.timestamp_ms <= max_timestamp_millis
+            )
+
+        if remaining_statement.first() is None:
+            return _ArchiveNowRemainingState.DONE
+
+        if (
+            remaining_statement.filter(
+                SqlTraceInfo.status != TraceState.IN_PROGRESS.value,
+                ~archival_failure_exists,
+                non_empty_span_exists,
+            ).first()
+            is not None
+        ):
+            return _ArchiveNowRemainingState.ARCHIVABLE
+
+        if (
+            remaining_statement.filter(
+                SqlTraceInfo.status == TraceState.IN_PROGRESS.value,
+                ~archival_failure_exists,
+            ).first()
+            is not None
+        ):
+            return _ArchiveNowRemainingState.TRANSIENT
+
+        # Only clear archive-now once the remaining traces are either fully processed
+        # or explicitly marked as terminal archival failures.
+        if remaining_statement.filter(~archival_failure_exists).first() is not None:
+            return _ArchiveNowRemainingState.BLOCKED_UNMARKED
+
+        return _ArchiveNowRemainingState.TERMINAL_FAILURES_ONLY
+
     def _get_spans_with_trace_info(
         self, trace_info: TraceInfo, spans: list[SqlSpan], allow_partial: bool = True
     ) -> list[Span] | None:
-        # if the tag doesn't exist then the trace is not stored in the tracking store,
-        # we should rely on the artifact repo to get the trace data
-        if trace_info.tags.get(TraceTagKey.SPANS_LOCATION) != SpansLocation.TRACKING_STORE.value:
-            # This check is required so that the handler can capture the exception
-            # and load data from artifact repo instead
+        spans_location = trace_info.tags.get(TraceTagKey.SPANS_LOCATION)
+        if spans_location == SpansLocation.ARCHIVE_REPO.value:
+            artifact_repo = get_artifact_repository(get_archive_uri_for_trace(trace_info))
+            return artifact_repo.download_archived_trace_data().spans
+
+        # ARTIFACT_REPO traces still rely on the existing handler/client fallback path because the
+        # trace artifact URI may use a proxy-only scheme such as mlflow-artifacts://.
+        if spans_location != SpansLocation.TRACKING_STORE.value:
             raise MlflowTracingException("Trace data not stored in tracking store")
+
         sql_spans = sorted(
             spans,
             key=lambda s: (

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -85,7 +85,6 @@ from mlflow.entities.trace_status import TraceStatus
 from mlflow.exceptions import (
     MlflowException,
     MlflowNotImplementedException,
-    MlflowTraceDataException,
     MlflowTracingException,
 )
 from mlflow.genai.judges.instructions_judge import (
@@ -5166,12 +5165,15 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             for sql_trace_info in sql_trace_infos:
                 trace_info = sql_trace_info.to_mlflow_entity()
                 # Preserve batch semantics: skip traces whose span payloads cannot be
-                # reconstructed instead of failing the entire batch.
+                # reconstructed instead of failing the entire batch.  Catch the
+                # broader MlflowTracingException so that archive-repo download
+                # failures and non-DB span locations are handled the same way as
+                # corrupt or missing trace data.
                 try:
                     spans = self._get_spans_with_trace_info(
                         trace_info, sql_trace_info.spans, allow_partial=False
                     )
-                except MlflowTraceDataException as e:
+                except MlflowTracingException as e:
                     _logger.warning(
                         "Skipping trace %s during batch_get_traces because its span data could "
                         "not be loaded (%s).",

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -240,6 +240,7 @@ from mlflow.utils.validation import (
     _validate_param_keys_unique,
     _validate_run_id,
     _validate_tag,
+    _validate_trace_archival_location,
     _validate_trace_archival_retention_string,
     _validate_trace_tag,
 )
@@ -327,7 +328,8 @@ def _parse_trace_archival_duration_millis(value: str | None) -> int | None:
         return None
 
     trimmed = _validate_trace_archival_retention_string(value)
-    amount, unit = trimmed[:-1], trimmed[-1]
+    amount = trimmed[:-1]
+    unit = trimmed[-1]
     return int(amount) * _TRACE_ARCHIVAL_DURATION_MULTIPLIER_MILLIS[unit]
 
 
@@ -5230,6 +5232,9 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             raise MlflowException.invalid_parameter_value(
                 "`default_trace_archival_location` must be provided."
             )
+        default_trace_archival_location = _validate_trace_archival_location(
+            default_trace_archival_location, parameter_name="default_trace_archival_location"
+        )
         if not default_retention:
             raise MlflowException.invalid_parameter_value("`default_retention` must be provided.")
 

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -12,6 +12,7 @@ import time
 import uuid
 from collections import defaultdict
 from dataclasses import dataclass, field
+from enum import Enum
 from functools import reduce
 from pathlib import PurePath
 from typing import Any, TypedDict, TypeVar
@@ -81,7 +82,12 @@ from mlflow.entities.trace_metrics import (
 )
 from mlflow.entities.trace_state import TraceState
 from mlflow.entities.trace_status import TraceStatus
-from mlflow.exceptions import MlflowException, MlflowTracingException
+from mlflow.exceptions import (
+    MlflowException,
+    MlflowNotImplementedException,
+    MlflowTraceDataException,
+    MlflowTracingException,
+)
 from mlflow.genai.judges.instructions_judge import (
     EXPECTATIONS_FIELD,
     InstructionsJudge,
@@ -110,6 +116,7 @@ from mlflow.protos.databricks_pb2 import (
     ErrorCode,
 )
 from mlflow.store.analytics import trace_correlation
+from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.store.db.db_types import MSSQL, MYSQL
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.tracking import (
@@ -162,6 +169,7 @@ from mlflow.store.tracking.utils.sql_trace_metrics_utils import (
     query_metrics,
     validate_query_trace_metrics_params,
 )
+from mlflow.store.workspace.abstract_store import ResolvedTraceArchivalConfig
 from mlflow.telemetry.events import UpdateIssueEvent
 from mlflow.telemetry.track import record_usage_event
 from mlflow.tracing.analysis import TraceFilterCorrelationResult
@@ -170,10 +178,13 @@ from mlflow.tracing.constant import (
     SpanAttributeKey,
     SpansLocation,
     TokenUsageKey,
+    TraceArchivalFailureReason,
+    TraceExperimentTagKey,
     TraceMetadataKey,
     TraceSizeStatsKey,
     TraceTagKey,
 )
+from mlflow.tracing.otel.otel_archival import TRACE_ARCHIVAL_FILENAME
 from mlflow.tracing.otel.translation import (
     translate_loaded_span,
     translate_span_when_storing,
@@ -183,6 +194,9 @@ from mlflow.tracing.otel.translation import (
 from mlflow.tracing.utils import (
     TraceJSONEncoder,
     generate_request_id_v2,
+)
+from mlflow.tracing.utils.artifact_utils import (
+    get_archive_uri_for_trace,
 )
 from mlflow.tracing.utils.truncation import _get_truncated_preview
 from mlflow.utils.file_utils import local_file_uri_to_path
@@ -212,6 +226,7 @@ from mlflow.utils.uri import (
     resolve_uri_if_local,
 )
 from mlflow.utils.validation import (
+    _parse_trace_archival_duration_config,
     _resolve_experiment_ids_and_locations,
     _validate_batch_log_data,
     _validate_batch_log_limits,
@@ -225,9 +240,10 @@ from mlflow.utils.validation import (
     _validate_param_keys_unique,
     _validate_run_id,
     _validate_tag,
+    _validate_trace_archival_retention_string,
     _validate_trace_tag,
 )
-from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
+from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME, WORKSPACES_DIR_NAME
 
 _T = TypeVar("_T")
 
@@ -249,6 +265,83 @@ class DatasetFilter(TypedDict, total=False):
 
     dataset_name: str
     dataset_digest: str
+
+
+_TRACE_ARCHIVAL_DURATION_MULTIPLIER_MILLIS = {
+    "m": 60 * 1000,
+    "h": 60 * 60 * 1000,
+    "d": 24 * 60 * 60 * 1000,
+}
+# Keep grouped experiment scans well below backend parameter limits (notably MSSQL's 2100).
+_TRACE_ARCHIVAL_EXPERIMENT_ID_CHUNK_SIZE = 1000
+
+
+class _ArchiveNowRemainingState(str, Enum):
+    DONE = "done"
+    ARCHIVABLE = "archivable"
+    TRANSIENT = "transient"
+    BLOCKED_UNMARKED = "blocked_unmarked"
+    TERMINAL_FAILURES_ONLY = "terminal_failures_only"
+
+
+@dataclass(frozen=True)
+class _ArchiveNowRequest:
+    older_than_millis: int | None
+
+    @classmethod
+    def from_tag_value(cls, value: str | None) -> _ArchiveNowRequest | None:
+        if value is None:
+            return None
+
+        try:
+            older_than = _parse_trace_archival_duration_config(
+                value,
+                duration_key="older_than",
+                allow_missing_duration=True,
+            )
+            return cls(older_than_millis=_parse_trace_archival_duration_millis(older_than))
+        except MlflowException:
+            _logger.warning(
+                "Ignoring malformed trace archive-now tag value: %r",
+                value,
+            )
+            return None
+
+
+@dataclass(frozen=True)
+class _ArchiveNowCleanupRequest:
+    experiment_id: str
+    raw_value: str
+    parsed_request: _ArchiveNowRequest
+
+
+@dataclass(frozen=True)
+class _TraceArchiveCandidate:
+    trace_id: str
+    experiment_id: str
+    timestamp_ms: int
+
+
+def _parse_trace_archival_duration_millis(value: str | None) -> int | None:
+    if value is None:
+        return None
+
+    trimmed = _validate_trace_archival_retention_string(value)
+    amount, unit = trimmed[:-1], trimmed[-1]
+    return int(amount) * _TRACE_ARCHIVAL_DURATION_MULTIPLIER_MILLIS[unit]
+
+
+def _parse_experiment_trace_archival_retention_millis(value: str | None) -> int | None:
+    try:
+        duration = _parse_trace_archival_duration_config(
+            value,
+            duration_key="value",
+            expected_type="duration",
+        )
+        return _parse_trace_archival_duration_millis(duration)
+    except MlflowException:
+        _logger.warning("Ignoring invalid trace archival retention tag value: %r", value)
+        return None
 
 
 class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
@@ -3355,12 +3448,13 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 )
                 new_tag_keys = {t.key for t in tags}
                 if db_sql_trace_info:
+                    # Duplicate start_trace() calls must keep any store-managed tags already
+                    # attached to the trace, including archival state written after log_spans().
                     for tag in db_sql_trace_info.tags:
                         if tag.key not in new_tag_keys:
                             sql_trace_info.tags.append(
                                 SqlTraceTag(request_id=trace_id, key=tag.key, value=tag.value)
                             )
-                            break
 
                     new_metric_keys = {m.key for m in sql_trace_info.metrics}
                     for metric in db_sql_trace_info.metrics:
@@ -4626,6 +4720,27 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 .all()
             }
 
+            if existing_traces:
+                archived_trace_ids = sorted(
+                    request_id
+                    for (request_id,) in session
+                    .query(SqlTraceTag.request_id)
+                    .filter(
+                        SqlTraceTag.request_id.in_(list(existing_traces)),
+                        SqlTraceTag.key == TraceTagKey.SPANS_LOCATION,
+                        SqlTraceTag.value == SpansLocation.ARCHIVE_REPO.value,
+                    )
+                    .all()
+                )
+                if archived_trace_ids:
+                    archived_trace_list = ", ".join(
+                        f"'{trace_id}'" for trace_id in archived_trace_ids
+                    )
+                    raise MlflowException(
+                        f"Cannot log spans to archived traces: {archived_trace_list}.",
+                        error_code=INVALID_STATE,
+                    )
+
             # --- Phase 2: Create missing traces ---
             # On IntegrityError (concurrent start_trace race), roll back and retry so that
             # previously flushed trace_infos (which session.rollback() would undo) are
@@ -5048,11 +5163,22 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             traces = []
             for sql_trace_info in sql_trace_infos:
                 trace_info = sql_trace_info.to_mlflow_entity()
-                # batch_get_traces is depended by search_traces, so we need to return
-                # complete traces only
-                if spans := self._get_spans_with_trace_info(
-                    trace_info, sql_trace_info.spans, allow_partial=False
-                ):
+                # Preserve batch semantics: skip traces whose span payloads cannot be
+                # reconstructed instead of failing the entire batch.
+                try:
+                    spans = self._get_spans_with_trace_info(
+                        trace_info, sql_trace_info.spans, allow_partial=False
+                    )
+                except MlflowTraceDataException as e:
+                    _logger.warning(
+                        "Skipping trace %s during batch_get_traces because its span data could "
+                        "not be loaded (%s).",
+                        trace_info.trace_id,
+                        getattr(e, "ctx", "unknown"),
+                        exc_info=_logger.isEnabledFor(logging.DEBUG),
+                    )
+                    continue
+                if spans:
                     traces.append(Trace(info=trace_info, data=TraceData(spans=spans)))
 
             return traces
@@ -5088,15 +5214,782 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
 
             return [sql_trace_info.to_mlflow_entity() for sql_trace_info in sql_trace_infos]
 
+    def archive_traces(
+        self,
+        *,
+        default_trace_archival_location: str,
+        default_retention: str,
+        long_retention_allowlist: set[str] | list[str] | None = None,
+        max_traces: int | None = None,
+    ) -> int:
+        if max_traces is not None and max_traces <= 0:
+            raise MlflowException.invalid_parameter_value(
+                f"`max_traces` must be a positive integer, received {max_traces}."
+            )
+        if not default_trace_archival_location:
+            raise MlflowException.invalid_parameter_value(
+                "`default_trace_archival_location` must be provided."
+            )
+        if not default_retention:
+            raise MlflowException.invalid_parameter_value("`default_retention` must be provided.")
+
+        now_millis = self._get_archive_traces_now_millis()
+        long_retention_allowlist = {
+            str(experiment_id) for experiment_id in long_retention_allowlist or []
+        }
+        trace_archival_config = self.resolve_trace_archival_config(
+            default_trace_archival_location=default_trace_archival_location,
+            default_retention=default_retention,
+        )
+        # The public API already required broader-scope defaults, so `None` here means config
+        # resolution dropped a caller-provided value instead of preserving or overriding it.
+        if trace_archival_config.config.location is None:
+            raise MlflowException(
+                "Trace archival config resolution returned no archival location.",
+                error_code=INTERNAL_ERROR,
+            )
+        if trace_archival_config.config.retention is None:
+            raise MlflowException(
+                "Trace archival config resolution returned no archival retention.",
+                error_code=INTERNAL_ERROR,
+            )
+        broader_retention_millis = _parse_trace_archival_duration_millis(
+            trace_archival_config.config.retention
+        )
+
+        with self.ManagedSessionMaker() as session:
+            archive_now_requests, candidates = self._plan_trace_archival(
+                session=session,
+                now_millis=now_millis,
+                broader_retention_millis=broader_retention_millis,
+                long_retention_allowlist=long_retention_allowlist,
+                max_traces=max_traces,
+            )
+        return self._execute_trace_archival_plan(
+            archive_now_requests=archive_now_requests,
+            candidates=candidates,
+            trace_archival_config=trace_archival_config,
+            max_traces=max_traces,
+            now_millis=now_millis,
+        )
+
+    def _plan_trace_archival(
+        self,
+        *,
+        session: Session,
+        now_millis: int,
+        broader_retention_millis: int,
+        long_retention_allowlist: set[str],
+        max_traces: int | None,
+    ) -> tuple[list[_ArchiveNowCleanupRequest], list[_TraceArchiveCandidate]]:
+        archive_now_requests: list[_ArchiveNowCleanupRequest] = []
+        # Group archive-now experiments by cutoff so experiments requesting the same urgency
+        # can share a candidate query instead of scanning one experiment at a time.
+        archive_now_cutoff_groups: dict[int | None, list[str]] = defaultdict(list)
+        regular_cutoff_groups: dict[int, list[str]] = defaultdict(list)
+        for experiment_id, experiment_tags in self._get_active_experiment_trace_archival_tags(
+            session
+        ):
+            archive_now_raw = experiment_tags.get(TraceExperimentTagKey.ARCHIVE_NOW)
+            archive_now = _ArchiveNowRequest.from_tag_value(archive_now_raw)
+            if archive_now and archive_now_raw is not None:
+                archive_now_requests.append(
+                    _ArchiveNowCleanupRequest(
+                        experiment_id=experiment_id,
+                        raw_value=archive_now_raw,
+                        parsed_request=archive_now,
+                    )
+                )
+                archive_now_cutoff_groups[
+                    now_millis - archive_now.older_than_millis
+                    if archive_now.older_than_millis is not None
+                    else None
+                ].append(experiment_id)
+
+            retention_millis = self._resolve_effective_trace_archival_retention_millis(
+                experiment_id=experiment_id,
+                experiment_tags=experiment_tags,
+                broader_retention_millis=broader_retention_millis,
+                long_retention_allowlist=long_retention_allowlist,
+            )
+            archive_now_covers_retention = archive_now is not None and (
+                archive_now.older_than_millis is None
+                or archive_now.older_than_millis <= retention_millis
+            )
+            if retention_millis and not archive_now_covers_retention:
+                regular_cutoff_groups[now_millis - retention_millis].append(experiment_id)
+
+        archive_now_candidates = self._collect_grouped_trace_archive_candidates(
+            session=session,
+            cutoff_groups=archive_now_cutoff_groups,
+            max_traces=max_traces,
+        )
+
+        regular_candidates: list[_TraceArchiveCandidate] = []
+        if max_traces is None or len(archive_now_candidates) < max_traces:
+            regular_candidates = self._collect_grouped_trace_archive_candidates(
+                session=session,
+                cutoff_groups=regular_cutoff_groups,
+                max_traces=max_traces,
+            )
+
+        return (
+            archive_now_requests,
+            self._dedupe_trace_archive_candidates(archive_now_candidates, regular_candidates),
+        )
+
+    def _collect_grouped_trace_archive_candidates(
+        self,
+        *,
+        session: Session,
+        cutoff_groups: dict[int | None, list[str]],
+        max_traces: int | None,
+    ) -> list[_TraceArchiveCandidate]:
+        candidates: list[_TraceArchiveCandidate] = []
+        for cutoff, experiment_ids in cutoff_groups.items():
+            candidates = self._merge_limited_trace_archive_candidates(
+                candidates,
+                self._find_archivable_trace_candidates_for_experiments(
+                    session=session,
+                    experiment_ids=experiment_ids,
+                    max_timestamp_millis=cutoff,
+                    limit=max_traces,
+                ),
+                limit=max_traces,
+            )
+        return candidates
+
+    def _execute_trace_archival_plan(
+        self,
+        *,
+        archive_now_requests: list[_ArchiveNowCleanupRequest],
+        candidates: list[_TraceArchiveCandidate],
+        trace_archival_config: ResolvedTraceArchivalConfig,
+        max_traces: int | None,
+        now_millis: int,
+    ) -> int:
+        archive_now_experiment_ids = {r.experiment_id for r in archive_now_requests}
+        retryable_failure_experiment_ids: set[str] = set()
+        archived_count = 0
+        candidates_to_archive = candidates if max_traces is None else candidates[:max_traces]
+        try:
+            for candidate in candidates_to_archive:
+                try:
+                    if self._archive_trace_candidate(
+                        trace_id=candidate.trace_id,
+                        trace_archival_config=trace_archival_config,
+                    ):
+                        archived_count += 1
+                except Exception:
+                    _logger.warning(
+                        "Failed to archive trace %s; leaving it eligible for retry.",
+                        candidate.trace_id,
+                        exc_info=True,
+                    )
+                    if candidate.experiment_id in archive_now_experiment_ids:
+                        retryable_failure_experiment_ids.add(candidate.experiment_id)
+        finally:
+            self._clear_completed_archive_now_requests(
+                archive_now_requests=archive_now_requests,
+                now_millis=now_millis,
+                retryable_failure_experiment_ids=retryable_failure_experiment_ids,
+            )
+        return archived_count
+
+    def _get_archive_traces_now_millis(self) -> int:
+        """Return the wall-clock cutoff time for this archival pass.
+
+        This small wrapper exists so tests can freeze the scheduler clock without
+        patching the shared time utility.
+        """
+        return get_current_time_millis()
+
+    def _get_trace_archival_workspace_name(self) -> str | None:
+        """Return the workspace path segment for workspace-scoped archival roots."""
+        return None
+
+    def _resolve_effective_trace_archival_retention_millis(
+        self,
+        *,
+        experiment_id: str,
+        experiment_tags: dict[str, str],
+        broader_retention_millis: int,
+        long_retention_allowlist: set[str],
+    ) -> int:
+        experiment_retention_millis = _parse_experiment_trace_archival_retention_millis(
+            experiment_tags.get(TraceExperimentTagKey.ARCHIVAL_RETENTION)
+        )
+        if experiment_retention_millis is None:
+            return broader_retention_millis
+
+        if experiment_retention_millis <= broader_retention_millis:
+            return experiment_retention_millis
+
+        if experiment_id in long_retention_allowlist:
+            return experiment_retention_millis
+
+        return broader_retention_millis
+
+    def _get_active_experiment_trace_archival_tags(
+        self, session: Session
+    ) -> list[tuple[str, dict[str, str]]]:
+        # Fetch active experiments with only the archival-related tags consulted by the scheduler.
+        # The outer join keeps experiments that inherit defaults, and the single query avoids both
+        # joined-loading unrelated tags and building a large Python-side IN list.
+        rows = (
+            self
+            ._get_query(session, SqlExperiment)
+            .outerjoin(
+                SqlExperimentTag,
+                and_(
+                    SqlExperimentTag.experiment_id == SqlExperiment.experiment_id,
+                    SqlExperimentTag.key.in_([
+                        TraceExperimentTagKey.ARCHIVE_NOW,
+                        TraceExperimentTagKey.ARCHIVAL_RETENTION,
+                    ]),
+                ),
+            )
+            .with_entities(
+                SqlExperiment.experiment_id, SqlExperimentTag.key, SqlExperimentTag.value
+            )
+            .filter(SqlExperiment.lifecycle_stage == LifecycleStage.ACTIVE)
+            .order_by(SqlExperiment.experiment_id.asc(), SqlExperimentTag.key.asc())
+            .all()
+        )
+
+        experiments: list[tuple[str, dict[str, str]]] = []
+        current_experiment_id: str | None = None
+        current_tags: dict[str, str] | None = None
+        for experiment_id, key, value in rows:
+            experiment_id = str(experiment_id)
+            if experiment_id != current_experiment_id:
+                current_experiment_id = experiment_id
+                current_tags = {}
+                experiments.append((experiment_id, current_tags))
+            if key is not None:
+                current_tags[key] = value
+
+        return experiments
+
+    @staticmethod
+    def _merge_limited_trace_archive_candidates(
+        existing_candidates: list[_TraceArchiveCandidate],
+        new_candidates: list[_TraceArchiveCandidate],
+        *,
+        limit: int | None,
+    ) -> list[_TraceArchiveCandidate]:
+        if limit is None:
+            return sorted(
+                [*existing_candidates, *new_candidates],
+                key=lambda candidate: (candidate.timestamp_ms, candidate.trace_id),
+            )
+        if limit <= 0:
+            return []
+        if not existing_candidates:
+            return new_candidates[:limit]
+        if not new_candidates:
+            return existing_candidates[:limit]
+
+        return sorted(
+            [*existing_candidates, *new_candidates],
+            key=lambda candidate: (candidate.timestamp_ms, candidate.trace_id),
+        )[:limit]
+
+    @staticmethod
+    def _dedupe_trace_archive_candidates(
+        archive_now_candidates: list[_TraceArchiveCandidate],
+        regular_candidates: list[_TraceArchiveCandidate],
+    ) -> list[_TraceArchiveCandidate]:
+        deduped: list[_TraceArchiveCandidate] = []
+        seen_trace_ids: set[str] = set()
+        for candidates in (
+            sorted(archive_now_candidates, key=lambda c: (c.timestamp_ms, c.trace_id)),
+            sorted(regular_candidates, key=lambda c: (c.timestamp_ms, c.trace_id)),
+        ):
+            for candidate in candidates:
+                if candidate.trace_id in seen_trace_ids:
+                    continue
+                deduped.append(candidate)
+                seen_trace_ids.add(candidate.trace_id)
+        return deduped
+
+    def _find_archivable_trace_candidates_for_experiments(
+        self,
+        *,
+        session: Session,
+        experiment_ids: list[str],
+        max_timestamp_millis: int | None,
+        limit: int | None = None,
+    ) -> list[_TraceArchiveCandidate]:
+        if not experiment_ids:
+            return []
+
+        spans_outside_tracking_store = exists().where(
+            and_(
+                SqlTraceTag.request_id == SqlTraceInfo.request_id,
+                SqlTraceTag.key == TraceTagKey.SPANS_LOCATION,
+                SqlTraceTag.value != SpansLocation.TRACKING_STORE.value,
+            )
+        )
+        archival_failure_exists = exists().where(
+            and_(
+                SqlTraceTag.request_id == SqlTraceInfo.request_id,
+                SqlTraceTag.key == TraceTagKey.ARCHIVAL_FAILURE,
+            )
+        )
+        non_empty_span_exists = exists().where(
+            and_(
+                SqlSpan.trace_id == SqlTraceInfo.request_id,
+                SqlSpan.content != "",
+            )
+        )
+
+        candidates: list[_TraceArchiveCandidate] = []
+        for chunk_start in range(0, len(experiment_ids), _TRACE_ARCHIVAL_EXPERIMENT_ID_CHUNK_SIZE):
+            # Query experiment ids in chunks to keep the SQL IN list bounded.
+            experiment_id_chunk = [
+                int(experiment_id)
+                for experiment_id in experiment_ids[
+                    chunk_start : chunk_start + _TRACE_ARCHIVAL_EXPERIMENT_ID_CHUNK_SIZE
+                ]
+            ]
+            statement = (
+                self
+                ._trace_query(session)
+                .with_entities(
+                    SqlTraceInfo.request_id, SqlTraceInfo.experiment_id, SqlTraceInfo.timestamp_ms
+                )
+                .filter(
+                    SqlTraceInfo.experiment_id.in_(experiment_id_chunk),
+                    SqlTraceInfo.status != TraceState.IN_PROGRESS.value,
+                    ~spans_outside_tracking_store,
+                    ~archival_failure_exists,
+                    non_empty_span_exists,
+                )
+                .order_by(SqlTraceInfo.timestamp_ms.asc(), SqlTraceInfo.request_id.asc())
+            )
+            if max_timestamp_millis is not None:
+                statement = statement.filter(SqlTraceInfo.timestamp_ms <= max_timestamp_millis)
+            if limit is not None:
+                statement = statement.limit(limit)
+
+            chunk_candidates = [
+                _TraceArchiveCandidate(
+                    trace_id=trace_id,
+                    experiment_id=str(experiment_id),
+                    timestamp_ms=timestamp_ms,
+                )
+                for trace_id, experiment_id, timestamp_ms in statement.all()
+            ]
+            if limit is None:
+                candidates.extend(chunk_candidates)
+            else:
+                candidates = self._merge_limited_trace_archive_candidates(
+                    candidates, chunk_candidates, limit=limit
+                )
+
+        if limit is None:
+            return sorted(
+                candidates, key=lambda candidate: (candidate.timestamp_ms, candidate.trace_id)
+            )
+        return candidates
+
+    def _archive_trace_candidate(
+        self,
+        *,
+        trace_id: str,
+        trace_archival_config: ResolvedTraceArchivalConfig,
+    ) -> bool:
+        from mlflow.exceptions import MlflowTraceArchivalMalformedTrace
+
+        snapshot = self._load_trace_archival_snapshot(trace_id)
+        if snapshot is None:
+            return False
+
+        trace_info, snapshot_rows = snapshot
+        try:
+            archived_pb = self._serialize_trace_archival_snapshot_to_pb(snapshot_rows)
+        except MlflowTraceArchivalMalformedTrace:
+            _logger.warning("Marking trace %s as MALFORMED_TRACE during archival.", trace_id)
+            self._mark_trace_archival_failure(
+                trace_id=trace_id,
+                failure_reason=TraceArchivalFailureReason.MALFORMED_TRACE.value,
+            )
+            return False
+
+        artifact_uri = self._get_archival_repository_artifact_uri(
+            trace_info=trace_info,
+            trace_archival_config=trace_archival_config,
+        )
+        artifact_repo = get_artifact_repository(artifact_uri)
+
+        try:
+            artifact_repo.upload_archived_trace_data_bytes(archived_pb)
+        except MlflowNotImplementedException:
+            _logger.warning(
+                "Marking trace %s as UNSUPPORTED_ARCHIVE_REPOSITORY during archival.",
+                trace_id,
+            )
+            self._mark_trace_archival_failure(
+                trace_id=trace_id,
+                failure_reason=TraceArchivalFailureReason.UNSUPPORTED_ARCHIVE_REPOSITORY.value,
+            )
+            return False
+        try:
+            finalized = self._finalize_archived_trace(
+                trace_id=trace_id,
+                snapshot_rows=snapshot_rows,
+                artifact_uri=artifact_uri,
+            )
+        except Exception:
+            self._delete_unreferenced_archived_trace_payload(
+                trace_id=trace_id,
+                artifact_uri=artifact_uri,
+                artifact_repo=artifact_repo,
+            )
+            raise
+
+        if not finalized:
+            self._delete_unreferenced_archived_trace_payload(
+                trace_id=trace_id,
+                artifact_uri=artifact_uri,
+                artifact_repo=artifact_repo,
+            )
+        return finalized
+
+    def _load_trace_archival_snapshot(
+        self, trace_id: str
+    ) -> tuple[TraceInfo, list[tuple[str, str]]] | None:
+        with self.ManagedSessionMaker() as session:
+            sql_trace_info = (
+                self
+                ._trace_query(session)
+                .options(joinedload(SqlTraceInfo.tags), joinedload(SqlTraceInfo.spans))
+                .filter(SqlTraceInfo.request_id == trace_id)
+                .one_or_none()
+            )
+            if sql_trace_info is None:
+                return None
+
+            trace_info = sql_trace_info.to_mlflow_entity()
+            if not self._is_trace_actionable_for_archival(trace_info, sql_trace_info.spans):
+                return None
+
+            snapshot_rows = sorted((span.span_id, span.content) for span in sql_trace_info.spans)
+            return trace_info, snapshot_rows
+
+    def _serialize_trace_archival_snapshot_to_pb(
+        self, snapshot_rows: list[tuple[str, str]]
+    ) -> bytes:
+        from mlflow.exceptions import MlflowTraceArchivalMalformedTrace
+        from mlflow.tracing.otel.otel_archival import spans_to_traces_data_pb
+
+        try:
+            spans = [
+                Span.from_dict(translate_loaded_span(json.loads(content)))
+                for _, content in snapshot_rows
+            ]
+            return spans_to_traces_data_pb(spans)
+        except (MlflowException, TypeError, ValueError) as e:
+            raise MlflowTraceArchivalMalformedTrace(str(e)) from e
+
+    def _is_trace_actionable_for_archival(
+        self, trace_info: TraceInfo, spans: list[SqlSpan]
+    ) -> bool:
+        spans_location = trace_info.tags.get(TraceTagKey.SPANS_LOCATION)
+        if spans_location not in (None, SpansLocation.TRACKING_STORE.value):
+            return False
+        if TraceTagKey.ARCHIVAL_FAILURE in trace_info.tags:
+            return False
+        if trace_info.state == TraceState.IN_PROGRESS:
+            return False
+        return any(span.content != "" for span in spans)
+
+    def _get_archival_repository_artifact_uri(
+        self,
+        *,
+        trace_info: TraceInfo,
+        trace_archival_config: ResolvedTraceArchivalConfig,
+    ) -> str:
+        resolved_root = trace_archival_config.config.location
+        append_workspace_prefix = trace_archival_config.append_workspace_prefix
+        if resolved_root is None:
+            raise MlflowException(
+                "Trace archival config resolution returned no archival location.",
+                error_code=INTERNAL_ERROR,
+            )
+
+        if append_workspace_prefix and (
+            workspace_name := self._get_trace_archival_workspace_name()
+        ):
+            resolved_root = append_to_uri_path(resolved_root, WORKSPACES_DIR_NAME, workspace_name)
+
+        return append_to_uri_path(
+            resolved_root,
+            str(trace_info.experiment_id),
+            self.TRACE_FOLDER_NAME,
+            trace_info.trace_id,
+            self.ARTIFACTS_FOLDER_NAME,
+        )
+
+    def _delete_unreferenced_archived_trace_payload(
+        self,
+        *,
+        trace_id: str,
+        artifact_uri: str,
+        artifact_repo,
+    ) -> None:
+        with self.ManagedSessionMaker() as session:
+            sql_trace_info = (
+                self
+                ._trace_query(session)
+                .options(joinedload(SqlTraceInfo.tags))
+                .filter(SqlTraceInfo.request_id == trace_id)
+                .one_or_none()
+            )
+            if sql_trace_info is not None:
+                trace_info = sql_trace_info.to_mlflow_entity()
+                if (
+                    trace_info.tags.get(TraceTagKey.SPANS_LOCATION)
+                    == SpansLocation.ARCHIVE_REPO.value
+                    and trace_info.tags.get(TraceTagKey.ARCHIVE_LOCATION) == artifact_uri
+                ):
+                    return
+
+        try:
+            artifact_repo.delete_artifacts(TRACE_ARCHIVAL_FILENAME)
+        except Exception:
+            _logger.warning(
+                "Failed to delete unreferenced archived payload for trace %s.",
+                trace_id,
+                exc_info=True,
+            )
+
+    def _finalize_archived_trace(
+        self,
+        *,
+        trace_id: str,
+        snapshot_rows: list[tuple[str, str]],
+        artifact_uri: str,
+    ) -> bool:
+        with self.ManagedSessionMaker() as session:
+            sql_trace_info = (
+                self
+                ._trace_query(session, for_update_or_delete=True)
+                .options(joinedload(SqlTraceInfo.tags), joinedload(SqlTraceInfo.spans))
+                .filter(SqlTraceInfo.request_id == trace_id)
+                .one_or_none()
+            )
+            if sql_trace_info is None:
+                return False
+
+            trace_info = sql_trace_info.to_mlflow_entity()
+            if not self._is_trace_actionable_for_archival(trace_info, sql_trace_info.spans):
+                return False
+
+            # Do a snapshot comparison as defense in depth for non-cooperating writers
+            # or backend-specific lock gaps.
+            current_snapshot_rows = sorted(
+                (span.span_id, span.content) for span in sql_trace_info.spans
+            )
+            if current_snapshot_rows != snapshot_rows:
+                _logger.info(
+                    (
+                        "Skipping archival finalization for trace %s because its DB-backed spans "
+                        "changed."
+                    ),
+                    trace_id,
+                )
+                return False
+
+            (
+                session
+                .query(SqlSpan)
+                .filter(SqlSpan.trace_id == trace_id)
+                .update({SqlSpan.content: ""}, synchronize_session=False)
+            )
+            session.merge(
+                SqlTraceTag(
+                    request_id=trace_id,
+                    key=TraceTagKey.SPANS_LOCATION,
+                    value=SpansLocation.ARCHIVE_REPO.value,
+                )
+            )
+            session.merge(
+                SqlTraceTag(
+                    request_id=trace_id,
+                    key=TraceTagKey.ARCHIVE_LOCATION,
+                    value=artifact_uri,
+                )
+            )
+            (
+                session
+                .query(SqlTraceTag)
+                .filter(
+                    SqlTraceTag.request_id == trace_id,
+                    SqlTraceTag.key == TraceTagKey.ARCHIVAL_FAILURE,
+                )
+                .delete(synchronize_session=False)
+            )
+            return True
+
+    def _mark_trace_archival_failure(self, *, trace_id: str, failure_reason: str) -> None:
+        with self.ManagedSessionMaker() as session:
+            sql_trace_info = (
+                self
+                ._trace_query(session, for_update_or_delete=True)
+                .options(joinedload(SqlTraceInfo.tags))
+                .filter(SqlTraceInfo.request_id == trace_id)
+                .one_or_none()
+            )
+            if sql_trace_info is None:
+                return
+
+            spans_location = next(
+                (tag.value for tag in sql_trace_info.tags if tag.key == TraceTagKey.SPANS_LOCATION),
+                None,
+            )
+            if spans_location not in (None, SpansLocation.TRACKING_STORE.value):
+                return
+
+            session.merge(
+                SqlTraceTag(
+                    request_id=trace_id,
+                    key=TraceTagKey.ARCHIVAL_FAILURE,
+                    value=failure_reason,
+                )
+            )
+
+    def _clear_completed_archive_now_requests(
+        self,
+        *,
+        archive_now_requests: list[_ArchiveNowCleanupRequest],
+        now_millis: int,
+        retryable_failure_experiment_ids: set[str] | None = None,
+    ) -> None:
+        if not archive_now_requests:
+            return
+
+        with self.ManagedSessionMaker() as session:
+            for request in archive_now_requests:
+                if (
+                    retryable_failure_experiment_ids
+                    and request.experiment_id in retryable_failure_experiment_ids
+                ):
+                    continue
+
+                older_than_cutoff = (
+                    now_millis - request.parsed_request.older_than_millis
+                    if request.parsed_request.older_than_millis is not None
+                    else None
+                )
+                if self._get_archive_now_remaining_state(
+                    session=session,
+                    experiment_id=request.experiment_id,
+                    max_timestamp_millis=older_than_cutoff,
+                ) in (
+                    _ArchiveNowRemainingState.ARCHIVABLE,
+                    _ArchiveNowRemainingState.TRANSIENT,
+                    _ArchiveNowRemainingState.BLOCKED_UNMARKED,
+                ):
+                    continue
+
+                (
+                    session
+                    .query(SqlExperimentTag)
+                    .filter(
+                        SqlExperimentTag.experiment_id == int(request.experiment_id),
+                        SqlExperimentTag.key == TraceExperimentTagKey.ARCHIVE_NOW,
+                        # Only clear the request we started with; a newer archive-now value may
+                        # have been written while this archival pass was still running.
+                        SqlExperimentTag.value == request.raw_value,
+                    )
+                    .delete(synchronize_session=False)
+                )
+
+    def _get_archive_now_remaining_state(
+        self,
+        *,
+        session: Session,
+        experiment_id: str,
+        max_timestamp_millis: int | None,
+    ) -> _ArchiveNowRemainingState:
+        spans_outside_tracking_store = exists().where(
+            and_(
+                SqlTraceTag.request_id == SqlTraceInfo.request_id,
+                SqlTraceTag.key == TraceTagKey.SPANS_LOCATION,
+                SqlTraceTag.value != SpansLocation.TRACKING_STORE.value,
+            )
+        )
+        archival_failure_exists = exists().where(
+            and_(
+                SqlTraceTag.request_id == SqlTraceInfo.request_id,
+                SqlTraceTag.key == TraceTagKey.ARCHIVAL_FAILURE,
+            )
+        )
+        non_empty_span_exists = exists().where(
+            and_(
+                SqlSpan.trace_id == SqlTraceInfo.request_id,
+                SqlSpan.content != "",
+            )
+        )
+
+        remaining_statement = (
+            self
+            ._trace_query(session)
+            .with_entities(SqlTraceInfo.request_id)
+            .filter(
+                SqlTraceInfo.experiment_id == int(experiment_id),
+                ~spans_outside_tracking_store,
+            )
+        )
+        if max_timestamp_millis is not None:
+            remaining_statement = remaining_statement.filter(
+                SqlTraceInfo.timestamp_ms <= max_timestamp_millis
+            )
+
+        if remaining_statement.first() is None:
+            return _ArchiveNowRemainingState.DONE
+
+        if (
+            remaining_statement.filter(
+                SqlTraceInfo.status != TraceState.IN_PROGRESS.value,
+                ~archival_failure_exists,
+                non_empty_span_exists,
+            ).first()
+            is not None
+        ):
+            return _ArchiveNowRemainingState.ARCHIVABLE
+
+        if (
+            remaining_statement.filter(
+                SqlTraceInfo.status == TraceState.IN_PROGRESS.value,
+                ~archival_failure_exists,
+            ).first()
+            is not None
+        ):
+            return _ArchiveNowRemainingState.TRANSIENT
+
+        # Only clear archive-now once the remaining traces are either fully processed
+        # or explicitly marked as terminal archival failures.
+        if remaining_statement.filter(~archival_failure_exists).first() is not None:
+            return _ArchiveNowRemainingState.BLOCKED_UNMARKED
+
+        return _ArchiveNowRemainingState.TERMINAL_FAILURES_ONLY
+
     def _get_spans_with_trace_info(
         self, trace_info: TraceInfo, spans: list[SqlSpan], allow_partial: bool = True
     ) -> list[Span] | None:
-        # if the tag doesn't exist then the trace is not stored in the tracking store,
-        # we should rely on the artifact repo to get the trace data
-        if trace_info.tags.get(TraceTagKey.SPANS_LOCATION) != SpansLocation.TRACKING_STORE.value:
-            # This check is required so that the handler can capture the exception
-            # and load data from artifact repo instead
+        spans_location = trace_info.tags.get(TraceTagKey.SPANS_LOCATION)
+        if spans_location == SpansLocation.ARCHIVE_REPO.value:
+            artifact_repo = get_artifact_repository(get_archive_uri_for_trace(trace_info))
+            return artifact_repo.download_archived_trace_data().spans
+
+        # ARTIFACT_REPO traces still rely on the existing handler/client fallback path because the
+        # trace artifact URI may use a proxy-only scheme such as mlflow-artifacts://.
+        if spans_location != SpansLocation.TRACKING_STORE.value:
             raise MlflowTracingException("Trace data not stored in tracking store")
+
         sql_spans = sorted(
             spans,
             key=lambda s: (

--- a/mlflow/store/tracking/sqlalchemy_workspace_store.py
+++ b/mlflow/store/tracking/sqlalchemy_workspace_store.py
@@ -409,6 +409,9 @@ class WorkspaceAwareSqlAlchemyStore(WorkspaceAwareMixin, SqlAlchemyStore):
             self._get_active_workspace(),
         )
 
+    def _get_trace_archival_workspace_name(self) -> str | None:
+        return self._get_active_workspace()
+
     def _ensure_default_workspace_experiment(self) -> None:
         """
         Ensure the default experiment exists in the provider's default workspace when enabled.

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -144,6 +144,7 @@ class TraceExperimentTagKey:
 
 class TraceArchivalFailureReason(str, Enum):
     MALFORMED_TRACE = "MALFORMED_TRACE"
+    UNSUPPORTED_ARCHIVE_REPOSITORY = "UNSUPPORTED_ARCHIVE_REPOSITORY"
 
 
 class AssessmentMetadataKey:

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -78,6 +78,8 @@ MAX_INPUT_TAG_VALUE_SIZE = 500
 MAX_REGISTERED_MODEL_ALIAS_LENGTH = 255
 MAX_TRACE_TAG_KEY_LENGTH = 250
 MAX_TRACE_TAG_VAL_LENGTH = 8000
+MAX_TRACE_ARCHIVAL_RETENTION_LENGTH = 32
+_TRACE_ARCHIVAL_RETENTION_REGEX = re.compile(r"^[1-9][0-9]*[mhd]$")
 
 PARAM_VALIDATION_MSG = """
 
@@ -130,6 +132,105 @@ def not_integer_value(path, value):
 
 def exceeds_maximum_length(path, limit):
     return f"'{path}' exceeds the maximum length of {limit} characters"
+
+
+def _validate_trace_archival_retention_string(
+    value: Any, *, parameter_name: str | None = None
+) -> str:
+    if not is_string_type(value):
+        if parameter_name is not None:
+            raise MlflowException.invalid_parameter_value(
+                f"Invalid value for '{parameter_name}'. Expected a duration in the form "
+                "`<int><unit>`, where unit is one of 'm', 'h', or 'd' (for example '30d' or "
+                "'12h')."
+            )
+        raise MlflowException.invalid_parameter_value(
+            "Trace archival retention must be in the form `<int><unit>`, "
+            "where unit is one of 'm', 'h', or 'd'."
+        )
+
+    trimmed = value.strip()
+    if len(trimmed) > MAX_TRACE_ARCHIVAL_RETENTION_LENGTH:
+        if parameter_name is not None:
+            raise MlflowException.invalid_parameter_value(
+                f"Invalid value for '{parameter_name}'. Maximum length is 32 characters."
+            )
+        raise MlflowException.invalid_parameter_value(
+            "Trace archival duration must be at most 32 characters."
+        )
+
+    if _TRACE_ARCHIVAL_RETENTION_REGEX.fullmatch(trimmed) is None:
+        if parameter_name is not None:
+            raise MlflowException.invalid_parameter_value(
+                f"Invalid value for '{parameter_name}'. Expected a duration in the form "
+                "`<int><unit>`, where unit is one of 'm', 'h', or 'd' (for example '30d' or "
+                "'12h')."
+            )
+        raise MlflowException.invalid_parameter_value(
+            "Trace archival retention must be in the form `<int><unit>`, "
+            "where unit is one of 'm', 'h', or 'd'."
+        )
+
+    return trimmed
+
+
+def _validate_trace_archival_location(value: Any, *, parameter_name: str | None = None) -> str:
+    if not is_string_type(value):
+        if parameter_name is not None:
+            raise MlflowException.invalid_parameter_value(
+                f"Invalid value for '{parameter_name}'. Expected a URI string."
+            )
+        raise MlflowException.invalid_parameter_value(
+            "Trace archival location must be a URI string."
+        )
+
+    trimmed = value.strip()
+    parsed = urllib.parse.urlparse(trimmed)
+    if parsed.scheme == "mlflow-artifacts":
+        if parameter_name is not None:
+            raise MlflowException.invalid_parameter_value(
+                f"Invalid value for '{parameter_name}'. Trace archival location cannot use "
+                "the proxy-only `mlflow-artifacts:` scheme."
+            )
+        raise MlflowException.invalid_parameter_value(
+            "Trace archival location cannot use the proxy-only `mlflow-artifacts:` scheme."
+        )
+
+    return trimmed
+
+
+def _parse_trace_archival_duration_config(
+    value: str | None,
+    *,
+    duration_key: str,
+    expected_type: str | None = None,
+    allow_missing_duration: bool = False,
+) -> str | None:
+    if value is None:
+        return None
+
+    try:
+        payload = json.loads(value)
+    except Exception as e:
+        raise MlflowException.invalid_parameter_value(
+            "Trace archival config must be encoded as a JSON object."
+        ) from e
+
+    if not isinstance(payload, dict):
+        raise MlflowException.invalid_parameter_value(
+            "Trace archival config must be encoded as a JSON object."
+        )
+
+    if expected_type is not None and payload.get("type") != expected_type:
+        raise MlflowException.invalid_parameter_value(
+            f"Trace archival config must use type '{expected_type}'."
+        )
+
+    duration_value = payload.get(duration_key)
+    if duration_value is None and allow_missing_duration:
+        return None
+
+    return _validate_trace_archival_retention_string(duration_value)
 
 
 def append_to_json_path(currentPath, value):

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -78,6 +78,8 @@ MAX_INPUT_TAG_VALUE_SIZE = 500
 MAX_REGISTERED_MODEL_ALIAS_LENGTH = 255
 MAX_TRACE_TAG_KEY_LENGTH = 250
 MAX_TRACE_TAG_VAL_LENGTH = 8000
+MAX_TRACE_ARCHIVAL_RETENTION_LENGTH = 32
+_TRACE_ARCHIVAL_RETENTION_REGEX = re.compile(r"^[1-9][0-9]*[mhd]$")
 
 PARAM_VALIDATION_MSG = """
 
@@ -130,6 +132,80 @@ def not_integer_value(path, value):
 
 def exceeds_maximum_length(path, limit):
     return f"'{path}' exceeds the maximum length of {limit} characters"
+
+
+def _validate_trace_archival_retention_string(
+    value: Any, *, parameter_name: str | None = None
+) -> str:
+    if not is_string_type(value):
+        if parameter_name is not None:
+            raise MlflowException.invalid_parameter_value(
+                f"Invalid value for '{parameter_name}'. Expected a duration in the form "
+                "`<int><unit>`, where unit is one of 'm', 'h', or 'd' (for example '30d' or "
+                "'12h')."
+            )
+        raise MlflowException.invalid_parameter_value(
+            "Trace archival retention must be in the form `<int><unit>`, "
+            "where unit is one of 'm', 'h', or 'd'."
+        )
+
+    trimmed = value.strip()
+    if len(trimmed) > MAX_TRACE_ARCHIVAL_RETENTION_LENGTH:
+        if parameter_name is not None:
+            raise MlflowException.invalid_parameter_value(
+                f"Invalid value for '{parameter_name}'. Maximum length is 32 characters."
+            )
+        raise MlflowException.invalid_parameter_value(
+            "Trace archival duration must be at most 32 characters."
+        )
+
+    if _TRACE_ARCHIVAL_RETENTION_REGEX.fullmatch(trimmed) is None:
+        if parameter_name is not None:
+            raise MlflowException.invalid_parameter_value(
+                f"Invalid value for '{parameter_name}'. Expected a duration in the form "
+                "`<int><unit>`, where unit is one of 'm', 'h', or 'd' (for example '30d' or "
+                "'12h')."
+            )
+        raise MlflowException.invalid_parameter_value(
+            "Trace archival retention must be in the form `<int><unit>`, "
+            "where unit is one of 'm', 'h', or 'd'."
+        )
+
+    return trimmed
+
+
+def _parse_trace_archival_duration_config(
+    value: str | None,
+    *,
+    duration_key: str,
+    expected_type: str | None = None,
+    allow_missing_duration: bool = False,
+) -> str | None:
+    if value is None:
+        return None
+
+    try:
+        payload = json.loads(value)
+    except Exception as e:
+        raise MlflowException.invalid_parameter_value(
+            "Trace archival config must be encoded as a JSON object."
+        ) from e
+
+    if not isinstance(payload, dict):
+        raise MlflowException.invalid_parameter_value(
+            "Trace archival config must be encoded as a JSON object."
+        )
+
+    if expected_type is not None and payload.get("type") != expected_type:
+        raise MlflowException.invalid_parameter_value(
+            f"Trace archival config must use type '{expected_type}'."
+        )
+
+    duration_value = payload.get(duration_key)
+    if duration_value is None and allow_missing_duration:
+        return None
+
+    return _validate_trace_archival_retention_string(duration_value)
 
 
 def append_to_json_path(currentPath, value):

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -174,6 +174,31 @@ def _validate_trace_archival_retention_string(
     return trimmed
 
 
+def _validate_trace_archival_location(value: Any, *, parameter_name: str | None = None) -> str:
+    if not is_string_type(value):
+        if parameter_name is not None:
+            raise MlflowException.invalid_parameter_value(
+                f"Invalid value for '{parameter_name}'. Expected a URI string."
+            )
+        raise MlflowException.invalid_parameter_value(
+            "Trace archival location must be a URI string."
+        )
+
+    trimmed = value.strip()
+    parsed = urllib.parse.urlparse(trimmed)
+    if parsed.scheme == "mlflow-artifacts":
+        if parameter_name is not None:
+            raise MlflowException.invalid_parameter_value(
+                f"Invalid value for '{parameter_name}'. Trace archival location cannot use "
+                "the proxy-only `mlflow-artifacts:` scheme."
+            )
+        raise MlflowException.invalid_parameter_value(
+            "Trace archival location cannot use the proxy-only `mlflow-artifacts:` scheme."
+        )
+
+    return trimmed
+
+
 def _parse_trace_archival_duration_config(
     value: str | None,
     *,

--- a/tests/server/test_workspace_endpoints.py
+++ b/tests/server/test_workspace_endpoints.py
@@ -310,6 +310,27 @@ def test_create_workspace_rejects_invalid_trace_archival_location(
     mock_workspace_store.create_workspace.assert_not_called()
 
 
+def test_create_workspace_rejects_proxy_only_trace_archival_location(
+    app, mock_workspace_store, mock_tracking_store
+):
+    with app.test_client() as client:
+        response = client.post(
+            "/api/3.0/mlflow/workspaces",
+            json={
+                "name": "team-proxy",
+                "trace_archival_config": {"location": "mlflow-artifacts:/archive/team-proxy"},
+            },
+        )
+
+    assert response.status_code == 400
+    payload = _workspace_to_json(response.get_data(True))
+    assert payload["message"] == (
+        "Invalid value for 'trace_archival_config.location'. Trace archival location cannot use "
+        "the proxy-only `mlflow-artifacts:` scheme."
+    )
+    mock_workspace_store.create_workspace.assert_not_called()
+
+
 def test_update_workspace_rejects_invalid_trace_archival_retention(app, mock_workspace_store):
     with app.test_client() as client:
         response = client.patch(

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -12,7 +12,7 @@ from requests.models import Response
 
 from mlflow.entities import TraceData
 from mlflow.entities.file_info import FileInfo as FileInfoEntity
-from mlflow.exceptions import MlflowException
+from mlflow.exceptions import MlflowException, MlflowNotImplementedException
 from mlflow.protos.databricks_artifacts_pb2 import (
     ArtifactCredentialInfo,
     ArtifactCredentialType,
@@ -1645,7 +1645,7 @@ def test_download_trace_data(databricks_artifact_repo_trace, cred_type):
 
 
 def test_download_archived_trace_data_rejects_archive_repo(databricks_artifact_repo_trace):
-    with pytest.raises(MlflowException, match="do not yet support ARCHIVE_REPO"):
+    with pytest.raises(MlflowNotImplementedException, match="do not yet support ARCHIVE_REPO"):
         databricks_artifact_repo_trace.download_archived_trace_data()
 
 
@@ -1675,12 +1675,12 @@ def test_upload_trace_data(databricks_artifact_repo_trace, cred_type):
 
 
 def test_upload_archived_trace_data_rejects_archive_repo(databricks_artifact_repo_trace):
-    with pytest.raises(MlflowException, match="do not yet support ARCHIVE_REPO"):
+    with pytest.raises(MlflowNotImplementedException, match="do not yet support ARCHIVE_REPO"):
         databricks_artifact_repo_trace.upload_archived_trace_data(TraceData(spans=[]))
 
 
 def test_upload_archived_trace_data_bytes_rejects_archive_repo(databricks_artifact_repo_trace):
-    with pytest.raises(MlflowException, match="do not yet support ARCHIVE_REPO"):
+    with pytest.raises(MlflowNotImplementedException, match="do not yet support ARCHIVE_REPO"):
         databricks_artifact_repo_trace.upload_archived_trace_data_bytes(b"trace-data")
 
 

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store.py
@@ -18,10 +18,11 @@ from opentelemetry import trace as trace_api
 from opentelemetry.sdk.resources import Resource as _OTelResource
 from opentelemetry.sdk.trace import ReadableSpan as OTelReadableSpan
 from packaging.version import Version
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
 import mlflow
 import mlflow.db
+import mlflow.store.tracking.sqlalchemy_store as sqlalchemy_store_module
 from mlflow import entities
 from mlflow.entities import (
     AssessmentSource,
@@ -51,16 +52,24 @@ from mlflow.entities.span import Span, create_mlflow_span
 from mlflow.entities.trace_info import TraceInfo
 from mlflow.entities.trace_state import TraceState
 from mlflow.entities.trace_status import TraceStatus
-from mlflow.entities.workspace import TraceArchivalConfig
+from mlflow.entities.workspace import TraceArchivalConfig, Workspace
 from mlflow.environment_variables import (
     MLFLOW_ENABLE_WORKSPACES,
     MLFLOW_TRACKING_URI,
 )
-from mlflow.exceptions import MlflowException, MlflowTracingException
+from mlflow.exceptions import (
+    MlflowException,
+    MlflowNotImplementedException,
+    MlflowTraceDataCorrupted,
+    MlflowTraceDataNotFound,
+    MlflowTracingException,
+)
 from mlflow.models import Model
 from mlflow.protos.databricks_pb2 import (
     BAD_REQUEST,
+    INTERNAL_ERROR,
     INVALID_PARAMETER_VALUE,
+    INVALID_STATE,
     RESOURCE_DOES_NOT_EXIST,
     TEMPORARILY_UNAVAILABLE,
     ErrorCode,
@@ -108,20 +117,24 @@ from mlflow.store.tracking.dbmodels.models import (
 from mlflow.store.tracking.sqlalchemy_store import (
     SqlAlchemyStore,
     _get_orderby_clauses,
+    _TraceArchiveCandidate,
 )
 from mlflow.store.tracking.sqlalchemy_workspace_store import WorkspaceAwareSqlAlchemyStore
+from mlflow.store.workspace.abstract_store import ResolvedTraceArchivalConfig
 from mlflow.tracing.constant import (
     MAX_CHARS_IN_TRACE_INFO_TAGS_VALUE,
     CostKey,
     SpanAttributeKey,
     SpansLocation,
+    TraceArchivalFailureReason,
+    TraceExperimentTagKey,
     TraceMetadataKey,
     TraceSizeStatsKey,
     TraceTagKey,
 )
 from mlflow.tracing.utils import TraceJSONEncoder
 from mlflow.utils import mlflow_tags
-from mlflow.utils.file_utils import TempDir
+from mlflow.utils.file_utils import TempDir, local_file_uri_to_path
 from mlflow.utils.mlflow_tags import (
     MLFLOW_ARTIFACT_LOCATION,
     MLFLOW_DATASET_CONTEXT,
@@ -130,7 +143,7 @@ from mlflow.utils.mlflow_tags import (
 from mlflow.utils.name_utils import _GENERATOR_PREDICATES
 from mlflow.utils.os import is_windows
 from mlflow.utils.time import get_current_time_millis
-from mlflow.utils.uri import extract_db_type_from_uri
+from mlflow.utils.uri import append_to_uri_path, extract_db_type_from_uri
 from mlflow.utils.validation import (
     MAX_DATASET_DIGEST_SIZE,
     MAX_DATASET_NAME_SIZE,
@@ -143,7 +156,7 @@ from mlflow.utils.validation import (
     MAX_TAG_VAL_LENGTH,
 )
 from mlflow.utils.workspace_context import WorkspaceContext
-from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
+from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME, WORKSPACES_DIR_NAME
 
 from tests.integration.utils import invoke_cli_runner
 from tests.store.tracking.test_file_store import assert_dataset_inputs_equal
@@ -441,6 +454,29 @@ def _cleanup_database(store: SqlAlchemyStore):
         # Recreate the default experiment (id=0) so that tests using the global registry
         # cache (e.g., mlflow.start_run()) can still find it after cleanup.
         store._create_default_experiment(session)
+
+    if isinstance(store, WorkspaceAwareSqlAlchemyStore):
+        provider = store._get_workspace_provider_instance()
+
+        # Reset workspace-level overrides when tests share a cached workspace store
+        # against a long-lived backend store URI.
+        for workspace in provider.list_workspaces():
+            if workspace.name != DEFAULT_WORKSPACE_NAME:
+                provider.delete_workspace(workspace.name)
+
+        provider.update_workspace(
+            Workspace(
+                name=DEFAULT_WORKSPACE_NAME,
+                default_artifact_root="",
+                trace_archival_location="",
+                trace_archival_retention="",
+            )
+        )
+
+        with provider._artifact_root_cache_lock:
+            provider._artifact_root_cache.clear()
+        with provider._trace_archival_config_cache_lock:
+            provider._trace_archival_config_cache.clear()
 
 
 def _create_experiments(store: SqlAlchemyStore, names) -> str | list[str]:
@@ -5075,6 +5111,28 @@ def _create_trace(
     return store.start_trace(trace_info)
 
 
+def _archive_traces(
+    store: SqlAlchemyStore,
+    *,
+    default_trace_archival_location: str,
+    default_retention: str,
+    long_retention_allowlist: set[str] | list[str] | None = None,
+    max_traces: int | None = 100,
+    now_millis: int | None = None,
+) -> int:
+    kwargs = {
+        "default_trace_archival_location": default_trace_archival_location,
+        "default_retention": default_retention,
+        "long_retention_allowlist": long_retention_allowlist,
+        "max_traces": max_traces,
+    }
+    if now_millis is None:
+        return store.archive_traces(**kwargs)
+
+    with mock.patch.object(store, "_get_archive_traces_now_millis", return_value=now_millis):
+        return store.archive_traces(**kwargs)
+
+
 @pytest.fixture
 def store_with_traces(store):
     exp1 = store.create_experiment("exp1")
@@ -8278,6 +8336,53 @@ def test_log_spans_multiple_traces(store: SqlAlchemyStore):
 
         span_row2 = session.query(SqlSpan).filter_by(trace_id="tr-multi-2").one()
         assert span_row2.name == "span_trace2"
+
+
+def test_log_spans_rejects_archived_trace_in_multi_trace_batch(store: SqlAlchemyStore):
+    experiment_id = store.create_experiment("test_multi_trace_archived_experiment")
+    archived_trace_id = "tr-multi-archived"
+    fresh_trace_id = "tr-multi-fresh"
+
+    store.log_spans(
+        experiment_id,
+        [
+            create_test_span(
+                archived_trace_id,
+                span_id=1,
+                start_ns=1_000_000_000,
+                end_ns=2_000_000_000,
+            )
+        ],
+    )
+    store.set_trace_tag(
+        archived_trace_id, TraceTagKey.SPANS_LOCATION, SpansLocation.ARCHIVE_REPO.value
+    )
+    store.set_trace_tag(archived_trace_id, TraceTagKey.ARCHIVE_LOCATION, "dbfs:/archive/tr-multi")
+
+    with pytest.raises(
+        MlflowException, match=f"Cannot log spans to archived traces: '{archived_trace_id}'"
+    ) as exc_info:
+        store.log_spans(
+            experiment_id,
+            [
+                create_test_span(
+                    archived_trace_id,
+                    span_id=2,
+                    start_ns=3_000_000_000,
+                    end_ns=4_000_000_000,
+                ),
+                create_test_span(
+                    fresh_trace_id,
+                    span_id=3,
+                    start_ns=5_000_000_000,
+                    end_ns=6_000_000_000,
+                ),
+            ],
+        )
+
+    assert exc_info.value.error_code == ErrorCode.Name(INVALID_STATE)
+    with store.ManagedSessionMaker() as session:
+        assert session.query(SqlSpan).filter_by(trace_id=fresh_trace_id).count() == 0
 
 
 @pytest.mark.asyncio
@@ -13720,6 +13825,78 @@ def test_log_spans_then_start_trace_preserves_tag(store: SqlAlchemyStore):
     assert trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.TRACKING_STORE.value
 
 
+def test_log_spans_then_start_trace_preserves_archived_trace_tags(store: SqlAlchemyStore):
+    experiment_id = store.create_experiment("test_preserve_archived_trace_tags")
+    trace_id = f"tr-{uuid.uuid4().hex}"
+    archive_location = "s3://bucket/archive/traces.pb"
+
+    span = create_test_span(
+        trace_id=trace_id,
+        name="test_span",
+        span_id=111,
+        status=trace_api.StatusCode.OK,
+        start_ns=1_000_000_000,
+        end_ns=2_000_000_000,
+        trace_num=12345,
+    )
+    store.log_spans(experiment_id, [span])
+    store.set_trace_tag(trace_id, TraceTagKey.SPANS_LOCATION, SpansLocation.ARCHIVE_REPO.value)
+    store.set_trace_tag(trace_id, TraceTagKey.ARCHIVE_LOCATION, archive_location)
+
+    trace_info_for_start = TraceInfo(
+        trace_id=trace_id,
+        trace_location=trace_location.TraceLocation.from_experiment_id(experiment_id),
+        request_time=1000,
+        execution_duration=1000,
+        state=TraceState.OK,
+        tags={"custom_tag": "value"},
+        trace_metadata={"source": "test"},
+    )
+    store.start_trace(trace_info_for_start)
+
+    trace_info = store.get_trace_info(trace_id)
+    assert trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.ARCHIVE_REPO.value
+    assert trace_info.tags[TraceTagKey.ARCHIVE_LOCATION] == archive_location
+
+
+def test_log_spans_then_start_trace_preserves_archival_failure_tag(store: SqlAlchemyStore):
+    experiment_id = store.create_experiment("test_preserve_archival_failure_tag")
+    trace_id = f"tr-{uuid.uuid4().hex}"
+
+    span = create_test_span(
+        trace_id=trace_id,
+        name="test_span",
+        span_id=111,
+        status=trace_api.StatusCode.OK,
+        start_ns=1_000_000_000,
+        end_ns=2_000_000_000,
+        trace_num=12345,
+    )
+    store.log_spans(experiment_id, [span])
+    store.set_trace_tag(
+        trace_id,
+        TraceTagKey.ARCHIVAL_FAILURE,
+        TraceArchivalFailureReason.MALFORMED_TRACE.value,
+    )
+
+    trace_info_for_start = TraceInfo(
+        trace_id=trace_id,
+        trace_location=trace_location.TraceLocation.from_experiment_id(experiment_id),
+        request_time=1000,
+        execution_duration=1000,
+        state=TraceState.OK,
+        tags={"custom_tag": "value"},
+        trace_metadata={"source": "test"},
+    )
+    store.start_trace(trace_info_for_start)
+
+    trace_info = store.get_trace_info(trace_id)
+    assert trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.TRACKING_STORE.value
+    assert trace_info.tags[TraceTagKey.ARCHIVAL_FAILURE] == (
+        TraceArchivalFailureReason.MALFORMED_TRACE.value
+    )
+
+
 def test_log_spans_then_start_trace_preserves_preview(store: SqlAlchemyStore):
     experiment_id = store.create_experiment("test_preview_preserved")
     trace_id = f"tr-{uuid.uuid4().hex}"
@@ -14234,3 +14411,1911 @@ def test_get_decrypted_secret_integration_multiple_secrets(store):
 
     assert decrypted1 == {"api_key": "key-1"}
     assert decrypted2 == {"api_key": "key-2"}
+
+
+def test_archive_traces_archives_db_backed_trace_payloads(
+    store: SqlAlchemyStore, workspaces_enabled: bool
+):
+    exp_id = store.create_experiment("archive-db-backed")
+    now_millis = 10 * 24 * 60 * 60 * 1000
+    old_trace_id = "tr-archive-old"
+    new_trace_id = "tr-archive-new"
+    old_request_time = now_millis - 3 * 24 * 60 * 60 * 1000  # 3 days old
+    new_request_time = now_millis - 60 * 60 * 1000  # 1 hour old
+
+    _create_trace(store, old_trace_id, exp_id, request_time=old_request_time)
+    _create_trace(store, new_trace_id, exp_id, request_time=new_request_time)
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                old_trace_id,
+                span_id=111,
+                start_ns=old_request_time * 1_000_000,
+                end_ns=(old_request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                new_trace_id,
+                span_id=222,
+                start_ns=new_request_time * 1_000_000,
+                end_ns=(new_request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+    original_trace_artifact_uri = store.get_trace_info(old_trace_id).tags[MLFLOW_ARTIFACT_LOCATION]
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        archived = _archive_traces(
+            store,
+            default_trace_archival_location=archive_root.as_uri(),
+            default_retention="1d",
+            now_millis=now_millis,
+        )
+        assert archived == 1
+
+        trace_info = store.get_trace_info(old_trace_id)
+        assert trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.ARCHIVE_REPO.value
+        if workspaces_enabled:
+            expected_archive_uri = append_to_uri_path(
+                archive_root.as_uri(),
+                WORKSPACES_DIR_NAME,
+                DEFAULT_WORKSPACE_NAME,
+                exp_id,
+                SqlAlchemyStore.TRACE_FOLDER_NAME,
+                old_trace_id,
+                SqlAlchemyStore.ARTIFACTS_FOLDER_NAME,
+            )
+            expected_archive_path = (
+                archive_root
+                / WORKSPACES_DIR_NAME
+                / DEFAULT_WORKSPACE_NAME
+                / exp_id
+                / SqlAlchemyStore.TRACE_FOLDER_NAME
+                / old_trace_id
+                / SqlAlchemyStore.ARTIFACTS_FOLDER_NAME
+                / "traces.pb"
+            )
+        else:
+            expected_archive_uri = append_to_uri_path(
+                archive_root.as_uri(),
+                exp_id,
+                SqlAlchemyStore.TRACE_FOLDER_NAME,
+                old_trace_id,
+                SqlAlchemyStore.ARTIFACTS_FOLDER_NAME,
+            )
+            expected_archive_path = (
+                archive_root
+                / exp_id
+                / SqlAlchemyStore.TRACE_FOLDER_NAME
+                / old_trace_id
+                / SqlAlchemyStore.ARTIFACTS_FOLDER_NAME
+                / "traces.pb"
+            )
+        assert trace_info.tags[MLFLOW_ARTIFACT_LOCATION] == original_trace_artifact_uri
+        assert trace_info.tags[TraceTagKey.ARCHIVE_LOCATION] == expected_archive_uri
+        assert expected_archive_path.is_file()
+
+        with store.ManagedSessionMaker() as session:
+            archived_span = session.query(SqlSpan).filter(SqlSpan.trace_id == old_trace_id).one()
+            fresh_span = session.query(SqlSpan).filter(SqlSpan.trace_id == new_trace_id).one()
+            assert archived_span.content == ""
+            assert fresh_span.content != ""
+
+        from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
+
+        archived_trace_data = get_artifact_repository(
+            trace_info.tags[TraceTagKey.ARCHIVE_LOCATION]
+        ).download_archived_trace_data()
+        assert len(archived_trace_data.spans) == 1
+        assert archived_trace_data.spans[0].name == "test_span"
+        assert store.get_trace(old_trace_id).data.spans[0].name == "test_span"
+        assert store.batch_get_traces([old_trace_id])[0].data.spans[0].name == "test_span"
+
+        assert (
+            _archive_traces(
+                store,
+                default_trace_archival_location=archive_root.as_uri(),
+                default_retention="1d",
+                now_millis=now_millis,
+            )
+            == 0
+        )
+
+
+def test_batch_get_traces_raises_for_archived_traces_with_missing_payload(
+    store: SqlAlchemyStore,
+):
+    exp_id = store.create_experiment("archive-batch-get-missing-payload")
+    archived_trace_id = "tr-archive-missing-payload"
+    healthy_trace_id = "tr-archive-batch-healthy"
+    now_millis = 25 * 24 * 60 * 60 * 1000
+    archived_request_time = now_millis - 2 * 24 * 60 * 60 * 1000
+    healthy_request_time = now_millis - 12 * 60 * 60 * 1000
+
+    _create_trace(store, archived_trace_id, exp_id, request_time=archived_request_time)
+    _create_trace(store, healthy_trace_id, exp_id, request_time=healthy_request_time)
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                archived_trace_id,
+                span_id=151,
+                start_ns=archived_request_time * 1_000_000,
+                end_ns=(archived_request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                healthy_trace_id,
+                span_id=152,
+                start_ns=healthy_request_time * 1_000_000,
+                end_ns=(healthy_request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+
+    with TempDir() as tmp:
+        from mlflow.tracing.otel.otel_archival import TRACE_ARCHIVAL_FILENAME
+
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        archived = _archive_traces(
+            store,
+            default_trace_archival_location=archive_root.as_uri(),
+            default_retention="1d",
+            now_millis=now_millis,
+        )
+
+        assert archived == 1
+        archived_trace_info = store.get_trace_info(archived_trace_id)
+        archive_payload_path = (
+            Path(local_file_uri_to_path(archived_trace_info.tags[TraceTagKey.ARCHIVE_LOCATION]))
+            / TRACE_ARCHIVAL_FILENAME
+        )
+        assert archive_payload_path.is_file()
+        archive_payload_path.unlink()
+
+        with pytest.raises(MlflowTraceDataNotFound, match="Trace data not found"):
+            store.batch_get_traces([archived_trace_id, healthy_trace_id])
+
+
+def test_archived_trace_with_spanless_payload_raises_corruption(
+    store: SqlAlchemyStore,
+):
+    exp_id = store.create_experiment("archive-spanless-payload")
+    trace_id = "tr-archive-spanless-payload"
+    now_millis = 25 * 24 * 60 * 60 * 1000
+    request_time = now_millis - 2 * 24 * 60 * 60 * 1000
+
+    _create_trace(store, trace_id, exp_id, request_time=request_time)
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                trace_id,
+                span_id=151,
+                start_ns=request_time * 1_000_000,
+                end_ns=(request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+
+    with TempDir() as tmp:
+        from opentelemetry.proto.trace.v1.trace_pb2 import TracesData
+
+        from mlflow.tracing.otel.otel_archival import TRACE_ARCHIVAL_FILENAME
+
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        archived = _archive_traces(
+            store,
+            default_trace_archival_location=archive_root.as_uri(),
+            default_retention="1d",
+            now_millis=now_millis,
+        )
+
+        assert archived == 1
+        archived_trace_info = store.get_trace_info(trace_id)
+        archive_payload_path = (
+            Path(local_file_uri_to_path(archived_trace_info.tags[TraceTagKey.ARCHIVE_LOCATION]))
+            / TRACE_ARCHIVAL_FILENAME
+        )
+        assert archive_payload_path.is_file()
+
+        traces_data = TracesData()
+        traces_data.resource_spans.add().scope_spans.add()
+        archive_payload_path.write_bytes(traces_data.SerializeToString())
+
+        with pytest.raises(MlflowTraceDataCorrupted, match="Trace data is corrupted"):
+            store.get_trace(trace_id)
+        with pytest.raises(MlflowTraceDataCorrupted, match="Trace data is corrupted"):
+            store.batch_get_traces([trace_id])
+
+
+def test_archive_traces_preserve_root_first_span_order(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("archive-span-order")
+    trace_id = "tr-archive-span-order"
+    now_millis = 12 * 24 * 60 * 60 * 1000
+    request_time = now_millis - 3 * 24 * 60 * 60 * 1000
+
+    _create_trace(store, trace_id, exp_id, request_time=request_time)
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                trace_id,
+                name="root",
+                span_id=999,
+                start_ns=request_time * 1_000_000,
+                end_ns=(request_time + 1_000) * 1_000_000,
+            ),
+            create_test_span(
+                trace_id,
+                name="child",
+                span_id=111,
+                parent_id=999,
+                start_ns=(request_time + 1) * 1_000_000,
+                end_ns=(request_time + 900) * 1_000_000,
+            ),
+        ],
+    )
+
+    assert [span.name for span in store.get_trace(trace_id).data.spans] == ["root", "child"]
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        archived = _archive_traces(
+            store,
+            default_trace_archival_location=archive_root.as_uri(),
+            default_retention="1d",
+            now_millis=now_millis,
+        )
+        assert archived == 1
+        assert [span.name for span in store.get_trace(trace_id).data.spans] == ["root", "child"]
+        assert [span.name for span in store.batch_get_traces([trace_id])[0].data.spans] == [
+            "root",
+            "child",
+        ]
+
+
+def test_archive_traces_preserves_trace_attachment_location(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("archive-attachments")
+    trace_id = "tr-archive-attachments"
+    now_millis = 25 * 24 * 60 * 60 * 1000
+    request_time = now_millis - 2 * 24 * 60 * 60 * 1000
+    attachment_id = str(uuid.uuid4())
+    attachment_bytes = b"attachment-bytes"
+
+    _create_trace(store, trace_id, exp_id, request_time=request_time)
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                trace_id,
+                span_id=919,
+                start_ns=request_time * 1_000_000,
+                end_ns=(request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+    trace_info = store.get_trace_info(trace_id)
+
+    from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
+
+    get_artifact_repository(trace_info.tags[MLFLOW_ARTIFACT_LOCATION]).upload_attachment(
+        attachment_id, attachment_bytes
+    )
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        archived = _archive_traces(
+            store,
+            default_trace_archival_location=archive_root.as_uri(),
+            default_retention="1d",
+            now_millis=now_millis,
+        )
+
+    assert archived == 1
+    trace_info = store.get_trace_info(trace_id)
+    assert trace_info.tags[MLFLOW_ARTIFACT_LOCATION].endswith(
+        f"/{exp_id}/traces/{trace_id}/artifacts"
+    )
+    assert TraceTagKey.ARCHIVE_LOCATION in trace_info.tags
+    assert (
+        get_artifact_repository(
+            trace_info.tags[MLFLOW_ARTIFACT_LOCATION]
+        ).download_trace_attachment(attachment_id)
+        == attachment_bytes
+    )
+
+
+def test_archive_traces_raises_when_default_root_is_unset_and_no_workspace_override(
+    store: SqlAlchemyStore, workspaces_enabled: bool
+):
+    if workspaces_enabled:
+        workspace_store = store._get_workspace_provider_instance()
+        workspace_store.update_workspace(
+            Workspace(
+                name=DEFAULT_WORKSPACE_NAME,
+                trace_archival_location="",
+            )
+        )
+
+    exp_id = store.create_experiment("archive-default-root")
+    now_millis = 15 * 24 * 60 * 60 * 1000
+    trace_id = "tr-archive-default-root"
+    request_time = now_millis - 2 * 24 * 60 * 60 * 1000  # 2 days old
+
+    _create_trace(store, trace_id, exp_id, request_time=request_time)
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                trace_id,
+                span_id=113,
+                start_ns=request_time * 1_000_000,
+                end_ns=(request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+    with pytest.raises(MlflowException, match="default_trace_archival_location") as exc_info:
+        _archive_traces(
+            store,
+            default_trace_archival_location=None,
+            default_retention="1d",
+            now_millis=now_millis,
+        )
+    assert exc_info.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+
+def test_archive_traces_raises_when_default_retention_is_unset(store: SqlAlchemyStore):
+    with pytest.raises(MlflowException, match="default_retention") as exc_info:
+        store.archive_traces(
+            default_trace_archival_location="s3://archive/default",
+            default_retention=None,
+        )
+    assert exc_info.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+
+def test_archive_traces_rejects_proxy_only_default_root(store: SqlAlchemyStore):
+    with pytest.raises(MlflowException, match="proxy-only `mlflow-artifacts:` scheme") as exc_info:
+        store.archive_traces(
+            default_trace_archival_location="mlflow-artifacts:/archive/default",
+            default_retention="1d",
+        )
+    assert exc_info.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+
+def test_archive_traces_rejects_unregistered_archive_scheme_before_processing_candidates(
+    store: SqlAlchemyStore,
+):
+    with pytest.raises(MlflowException, match="Could not find a registered artifact repository"):
+        store.archive_traces(
+            default_trace_archival_location="unknown-scheme://archive/default",
+            default_retention="1d",
+        )
+
+
+def test_archive_traces_raises_when_default_retention_exceeds_max_length(
+    store: SqlAlchemyStore,
+):
+    with pytest.raises(MlflowException, match="at most 32 characters") as exc_info:
+        store.archive_traces(
+            default_trace_archival_location="s3://archive/default",
+            default_retention=f"{'1' * 32}d",
+        )
+    assert exc_info.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+
+def test_archive_traces_treats_unset_max_traces_as_unbounded(store: SqlAlchemyStore, monkeypatch):
+    store.create_experiment("archive-unbounded")
+    archived_trace_ids = []
+    candidates = [
+        _TraceArchiveCandidate(
+            trace_id=f"tr-unbounded-{idx}",
+            experiment_id="0",
+            timestamp_ms=idx,
+        )
+        for idx in range(101)
+    ]
+
+    def _capture_find_archivable_trace_candidates_for_experiments(
+        *, session, experiment_ids, max_timestamp_millis, limit
+    ):
+        assert limit is None
+        return candidates
+
+    def _capture_archive_trace_candidate(*, trace_id, trace_archival_config):
+        archived_trace_ids.append(trace_id)
+        return True
+
+    monkeypatch.setattr(
+        store,
+        "_find_archivable_trace_candidates_for_experiments",
+        _capture_find_archivable_trace_candidates_for_experiments,
+    )
+    monkeypatch.setattr(
+        store,
+        "_archive_trace_candidate",
+        _capture_archive_trace_candidate,
+    )
+
+    archived = store.archive_traces(
+        default_trace_archival_location="s3://archive/default",
+        default_retention="30d",
+    )
+
+    assert archived == len(candidates)
+    assert archived_trace_ids == [candidate.trace_id for candidate in candidates]
+
+
+def test_archive_traces_raises_internal_error_when_resolution_returns_no_location(
+    store: SqlAlchemyStore, monkeypatch
+):
+    def _broken_resolve_trace_archival_config(
+        *, default_trace_archival_location, default_retention
+    ):
+        return ResolvedTraceArchivalConfig(
+            config=TraceArchivalConfig(location=None, retention=default_retention),
+            append_workspace_prefix=False,
+        )
+
+    monkeypatch.setattr(
+        store,
+        "resolve_trace_archival_config",
+        _broken_resolve_trace_archival_config,
+    )
+
+    with pytest.raises(
+        MlflowException, match="config resolution returned no archival location"
+    ) as exc_info:
+        store.archive_traces(
+            default_trace_archival_location="s3://archive/default",
+            default_retention="1d",
+        )
+    assert exc_info.value.error_code == ErrorCode.Name(INTERNAL_ERROR)
+
+
+def test_archive_traces_raises_internal_error_when_resolution_returns_no_retention(
+    store: SqlAlchemyStore, monkeypatch
+):
+    def _broken_resolve_trace_archival_config(
+        *, default_trace_archival_location, default_retention
+    ):
+        return ResolvedTraceArchivalConfig(
+            config=TraceArchivalConfig(
+                location=default_trace_archival_location,
+                retention=None,
+            ),
+            append_workspace_prefix=False,
+        )
+
+    monkeypatch.setattr(
+        store,
+        "resolve_trace_archival_config",
+        _broken_resolve_trace_archival_config,
+    )
+
+    with pytest.raises(
+        MlflowException, match="config resolution returned no archival retention"
+    ) as exc_info:
+        store.archive_traces(
+            default_trace_archival_location="s3://archive/default",
+            default_retention="1d",
+        )
+    assert exc_info.value.error_code == ErrorCode.Name(INTERNAL_ERROR)
+
+
+def test_archive_traces_respects_experiment_retention_and_archive_now(store: SqlAlchemyStore):
+    now_millis = 20 * 24 * 60 * 60 * 1000
+    exp_short_retention = store.create_experiment("archive-short-retention")
+    exp_archive_now = store.create_experiment("archive-now")
+    short_old_request_time = now_millis - 2 * 24 * 60 * 60 * 1000  # 2 days old
+    short_new_request_time = now_millis - 12 * 60 * 60 * 1000  # 12 hours old
+    now_old_request_time = now_millis - 2 * 24 * 60 * 60 * 1000  # 2 days old
+    now_new_request_time = now_millis - 2 * 60 * 60 * 1000  # 2 hours old
+
+    store.set_experiment_tag(
+        exp_short_retention,
+        ExperimentTag(
+            TraceExperimentTagKey.ARCHIVAL_RETENTION,
+            json.dumps({"type": "duration", "value": "1d"}),
+        ),
+    )
+    store.set_experiment_tag(
+        exp_archive_now,
+        ExperimentTag(TraceExperimentTagKey.ARCHIVE_NOW, json.dumps({"older_than": "1d"})),
+    )
+
+    _create_trace(
+        store,
+        "tr-short-old",
+        exp_short_retention,
+        request_time=short_old_request_time,
+    )
+    _create_trace(
+        store,
+        "tr-short-new",
+        exp_short_retention,
+        request_time=short_new_request_time,
+    )
+    _create_trace(
+        store,
+        "tr-now-old",
+        exp_archive_now,
+        request_time=now_old_request_time,
+    )
+    _create_trace(
+        store,
+        "tr-now-new",
+        exp_archive_now,
+        request_time=now_new_request_time,
+    )
+    store.log_spans(
+        exp_short_retention,
+        [
+            create_test_span(
+                "tr-short-old",
+                span_id=111,
+                start_ns=short_old_request_time * 1_000_000,
+                end_ns=(short_old_request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+    store.log_spans(
+        exp_short_retention,
+        [
+            create_test_span(
+                "tr-short-new",
+                span_id=112,
+                start_ns=short_new_request_time * 1_000_000,
+                end_ns=(short_new_request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+    store.log_spans(
+        exp_archive_now,
+        [
+            create_test_span(
+                "tr-now-old",
+                span_id=211,
+                start_ns=now_old_request_time * 1_000_000,
+                end_ns=(now_old_request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+    store.log_spans(
+        exp_archive_now,
+        [
+            create_test_span(
+                "tr-now-new",
+                span_id=212,
+                start_ns=now_new_request_time * 1_000_000,
+                end_ns=(now_new_request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        archived = _archive_traces(
+            store,
+            default_trace_archival_location=archive_root.as_uri(),
+            default_retention="30d",
+            now_millis=now_millis,
+        )
+
+    assert archived == 2
+    assert store.get_trace_info("tr-short-old").tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.ARCHIVE_REPO.value
+    )
+    assert store.get_trace_info("tr-now-old").tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.ARCHIVE_REPO.value
+    )
+    assert store.get_trace_info("tr-short-new").tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.TRACKING_STORE.value
+    )
+    assert store.get_trace_info("tr-now-new").tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.TRACKING_STORE.value
+    )
+    assert TraceExperimentTagKey.ARCHIVE_NOW not in store.get_experiment(exp_archive_now).tags
+
+
+def test_archive_traces_skips_regular_pass_when_archive_now_covers_retention(
+    store: SqlAlchemyStore, monkeypatch
+):
+    now_millis = 20 * 24 * 60 * 60 * 1000
+    day_millis = 24 * 60 * 60 * 1000
+    exp_id = store.create_experiment("archive-now-covers-retention")
+    find_calls = []
+
+    store.set_experiment_tag(
+        exp_id,
+        ExperimentTag(
+            TraceExperimentTagKey.ARCHIVAL_RETENTION,
+            json.dumps({"type": "duration", "value": "7d"}),
+        ),
+    )
+    store.set_experiment_tag(
+        exp_id,
+        ExperimentTag(TraceExperimentTagKey.ARCHIVE_NOW, json.dumps({"older_than": "1d"})),
+    )
+
+    def _capture_find_archivable_trace_candidates_for_experiments(
+        *, session, experiment_ids, max_timestamp_millis, limit
+    ):
+        find_calls.append((tuple(experiment_ids), max_timestamp_millis, limit))
+        return []
+
+    monkeypatch.setattr(
+        store,
+        "_find_archivable_trace_candidates_for_experiments",
+        _capture_find_archivable_trace_candidates_for_experiments,
+    )
+
+    archived = _archive_traces(
+        store,
+        default_trace_archival_location="s3://archive/default",
+        default_retention="30d",
+        now_millis=now_millis,
+    )
+
+    assert archived == 0
+    assert ((exp_id,), now_millis - day_millis, 100) in find_calls
+    assert all(
+        exp_id not in experiment_ids or max_timestamp_millis != now_millis - 7 * day_millis
+        for experiment_ids, max_timestamp_millis, _ in find_calls
+    )
+
+
+def test_archive_traces_keeps_oldest_archive_now_candidates_when_bounded(
+    store: SqlAlchemyStore, monkeypatch
+):
+    exp_older = store.create_experiment("archive-now-bounded-older")
+    exp_newer = store.create_experiment("archive-now-bounded-newer")
+    archived_trace_ids = []
+
+    for exp_id in (exp_older, exp_newer):
+        store.set_experiment_tag(
+            exp_id,
+            ExperimentTag(TraceExperimentTagKey.ARCHIVE_NOW, json.dumps({})),
+        )
+
+    grouped_candidates = [
+        _TraceArchiveCandidate(
+            trace_id="tr-oldest",
+            experiment_id=exp_newer,
+            timestamp_ms=10,
+        ),
+        _TraceArchiveCandidate(
+            trace_id="tr-second-oldest",
+            experiment_id=exp_older,
+            timestamp_ms=20,
+        ),
+        _TraceArchiveCandidate(
+            trace_id="tr-third-oldest",
+            experiment_id=exp_newer,
+            timestamp_ms=30,
+        ),
+        _TraceArchiveCandidate(
+            trace_id="tr-fourth-oldest",
+            experiment_id=exp_older,
+            timestamp_ms=40,
+        ),
+    ]
+
+    def _capture_find_archivable_trace_candidates_for_experiments(
+        *, session, experiment_ids, max_timestamp_millis, limit
+    ):
+        assert experiment_ids == [exp_older, exp_newer]
+        assert max_timestamp_millis is None
+        assert limit == 2
+        return grouped_candidates
+
+    def _capture_archive_trace_candidate(*, trace_id, trace_archival_config):
+        archived_trace_ids.append(trace_id)
+        return True
+
+    monkeypatch.setattr(
+        store,
+        "_find_archivable_trace_candidates_for_experiments",
+        _capture_find_archivable_trace_candidates_for_experiments,
+    )
+    monkeypatch.setattr(
+        store,
+        "_archive_trace_candidate",
+        _capture_archive_trace_candidate,
+    )
+
+    archived = store.archive_traces(
+        default_trace_archival_location="s3://archive/default",
+        default_retention="30d",
+        max_traces=2,
+    )
+
+    assert archived == 2
+    assert archived_trace_ids == ["tr-oldest", "tr-second-oldest"]
+
+
+def test_archive_traces_groups_regular_candidate_queries_by_shared_cutoff(
+    store: SqlAlchemyStore, monkeypatch
+):
+    now_millis = 20 * 24 * 60 * 60 * 1000
+    exp_first = store.create_experiment("archive-regular-grouped-first")
+    exp_second = store.create_experiment("archive-regular-grouped-second")
+    find_calls = []
+
+    def _capture_find_archivable_trace_candidates_for_experiments(
+        *, session, experiment_ids, max_timestamp_millis, limit
+    ):
+        find_calls.append((tuple(experiment_ids), max_timestamp_millis, limit))
+        return []
+
+    monkeypatch.setattr(
+        store,
+        "_find_archivable_trace_candidates_for_experiments",
+        _capture_find_archivable_trace_candidates_for_experiments,
+    )
+
+    archived = _archive_traces(
+        store,
+        default_trace_archival_location="s3://archive/default",
+        default_retention="30d",
+        now_millis=now_millis,
+    )
+
+    assert archived == 0
+    assert len(find_calls) == 1
+    experiment_ids, max_timestamp_millis, limit = find_calls[0]
+    assert set(experiment_ids) == {"0", exp_first, exp_second}
+    assert max_timestamp_millis == now_millis - 30 * 24 * 60 * 60 * 1000
+    assert limit == 100
+
+
+def test_archive_traces_chunks_large_experiment_groups_and_keeps_oldest_candidates(
+    store: SqlAlchemyStore, monkeypatch
+):
+    monkeypatch.setattr(sqlalchemy_store_module, "_TRACE_ARCHIVAL_EXPERIMENT_ID_CHUNK_SIZE", 2)
+
+    now_millis = 40 * 24 * 60 * 60 * 1000
+    exp_recent = store.create_experiment("archive-chunked-recent")
+    exp_oldest = store.create_experiment("archive-chunked-oldest")
+    exp_second_oldest = store.create_experiment("archive-chunked-second-oldest")
+
+    trace_configs = [
+        (exp_recent, "tr-chunked-recent", now_millis - 3 * 24 * 60 * 60 * 1000, 811),
+        (exp_oldest, "tr-chunked-oldest", now_millis - 5 * 24 * 60 * 60 * 1000, 812),
+        (
+            exp_second_oldest,
+            "tr-chunked-second-oldest",
+            now_millis - 4 * 24 * 60 * 60 * 1000,
+            813,
+        ),
+    ]
+    for exp_id, trace_id, request_time, span_id in trace_configs:
+        _create_trace(store, trace_id, exp_id, request_time=request_time)
+        store.log_spans(
+            exp_id,
+            [
+                create_test_span(
+                    trace_id,
+                    span_id=span_id,
+                    start_ns=request_time * 1_000_000,
+                    end_ns=(request_time + 1_000) * 1_000_000,
+                )
+            ],
+        )
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        archived = _archive_traces(
+            store,
+            default_trace_archival_location=archive_root.as_uri(),
+            default_retention="1d",
+            max_traces=2,
+            now_millis=now_millis,
+        )
+
+    assert archived == 2
+    assert store.get_trace_info("tr-chunked-oldest").tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.ARCHIVE_REPO.value
+    )
+    assert store.get_trace_info("tr-chunked-second-oldest").tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.ARCHIVE_REPO.value
+    )
+    assert store.get_trace_info("tr-chunked-recent").tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.TRACKING_STORE.value
+    )
+
+
+def test_archive_traces_keeps_regular_pass_when_archive_now_is_narrower(
+    store: SqlAlchemyStore,
+):
+    day_millis = 24 * 60 * 60 * 1000
+    now_millis = 60 * day_millis
+    exp_id = store.create_experiment("archive-now-narrower-than-retention")
+    archive_now_trace_time = now_millis - 40 * day_millis
+    retention_trace_time = now_millis - 10 * day_millis
+    recent_trace_time = now_millis - 2 * day_millis
+
+    store.set_experiment_tag(
+        exp_id,
+        ExperimentTag(
+            TraceExperimentTagKey.ARCHIVAL_RETENTION,
+            json.dumps({"type": "duration", "value": "7d"}),
+        ),
+    )
+    store.set_experiment_tag(
+        exp_id,
+        ExperimentTag(TraceExperimentTagKey.ARCHIVE_NOW, json.dumps({"older_than": "30d"})),
+    )
+
+    for trace_id, request_time in (
+        ("tr-now-priority", archive_now_trace_time),
+        ("tr-now-retention", retention_trace_time),
+        ("tr-now-recent", recent_trace_time),
+    ):
+        _create_trace(store, trace_id, exp_id, request_time=request_time)
+        store.log_spans(
+            exp_id,
+            [
+                create_test_span(
+                    trace_id,
+                    span_id=request_time,
+                    start_ns=request_time * 1_000_000,
+                    end_ns=(request_time + 1_000) * 1_000_000,
+                )
+            ],
+        )
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        archived = _archive_traces(
+            store,
+            default_trace_archival_location=archive_root.as_uri(),
+            default_retention="30d",
+            now_millis=now_millis,
+        )
+
+    assert archived == 2
+    assert store.get_trace_info("tr-now-priority").tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.ARCHIVE_REPO.value
+    )
+    assert store.get_trace_info("tr-now-retention").tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.ARCHIVE_REPO.value
+    )
+    assert store.get_trace_info("tr-now-recent").tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.TRACKING_STORE.value
+    )
+    assert TraceExperimentTagKey.ARCHIVE_NOW not in store.get_experiment(exp_id).tags
+
+
+def test_archive_traces_queries_all_archive_now_groups_before_selecting_bounded_batch(
+    store: SqlAlchemyStore,
+):
+    exp_first = store.create_experiment("archive-now-first-group")
+    exp_second = store.create_experiment("archive-now-second-group")
+    for experiment_id, older_than in ((exp_first, "1d"), (exp_second, "2d")):
+        store.set_experiment_tag(
+            experiment_id,
+            ExperimentTag(
+                TraceExperimentTagKey.ARCHIVE_NOW, json.dumps({"older_than": older_than})
+            ),
+        )
+
+    first_candidate = sqlalchemy_store_module._TraceArchiveCandidate(
+        trace_id="tr-archive-now-newer",
+        experiment_id=exp_first,
+        timestamp_ms=10,
+    )
+    second_candidate = sqlalchemy_store_module._TraceArchiveCandidate(
+        trace_id="tr-archive-now-older",
+        experiment_id=exp_second,
+        timestamp_ms=1,
+    )
+    archived_trace_ids = []
+
+    def record_archive_candidate(*, trace_id, trace_archival_config):
+        archived_trace_ids.append(trace_id)
+        return True
+
+    with (
+        mock.patch.object(
+            store,
+            "_find_archivable_trace_candidates_for_experiments",
+            side_effect=[[first_candidate], [second_candidate]],
+        ) as mock_find_candidates,
+        mock.patch.object(
+            store, "_archive_trace_candidate", side_effect=record_archive_candidate
+        ) as mock_archive_candidate,
+    ):
+        archived = _archive_traces(
+            store,
+            default_trace_archival_location="file:///unused-archive-root",
+            default_retention="30d",
+            max_traces=1,
+            now_millis=40 * 24 * 60 * 60 * 1000,
+        )
+
+    assert archived == 1
+    assert mock_find_candidates.call_count == 2
+    assert archived_trace_ids == ["tr-archive-now-older"]
+    mock_archive_candidate.assert_called_once()
+
+
+def test_archive_traces_queries_all_regular_groups_before_selecting_bounded_batch(
+    store: SqlAlchemyStore,
+):
+    exp_first = store.create_experiment("archive-regular-first-group")
+    exp_second = store.create_experiment("archive-regular-second-group")
+    for experiment_id, retention in ((exp_first, "1d"), (exp_second, "2d")):
+        store.set_experiment_tag(
+            experiment_id,
+            ExperimentTag(
+                TraceExperimentTagKey.ARCHIVAL_RETENTION,
+                json.dumps({"type": "duration", "value": retention}),
+            ),
+        )
+
+    first_candidate = sqlalchemy_store_module._TraceArchiveCandidate(
+        trace_id="tr-regular-newer",
+        experiment_id=exp_first,
+        timestamp_ms=10,
+    )
+    second_candidate = sqlalchemy_store_module._TraceArchiveCandidate(
+        trace_id="tr-regular-older",
+        experiment_id=exp_second,
+        timestamp_ms=1,
+    )
+    archived_trace_ids = []
+    queried_experiment_ids = []
+
+    def record_archive_candidate(*, trace_id, trace_archival_config):
+        archived_trace_ids.append(trace_id)
+        return True
+
+    def find_candidates(*, experiment_ids, session, max_timestamp_millis, limit):
+        queried_experiment_ids.append(tuple(experiment_ids))
+        if experiment_ids == [exp_first]:
+            return [first_candidate]
+        if experiment_ids == [exp_second]:
+            return [second_candidate]
+        return []
+
+    with (
+        mock.patch.object(
+            store,
+            "_find_archivable_trace_candidates_for_experiments",
+            side_effect=find_candidates,
+        ) as mock_find_candidates,
+        mock.patch.object(
+            store, "_archive_trace_candidate", side_effect=record_archive_candidate
+        ) as mock_archive_candidate,
+    ):
+        archived = _archive_traces(
+            store,
+            default_trace_archival_location="file:///unused-archive-root",
+            default_retention="30d",
+            max_traces=1,
+            now_millis=40 * 24 * 60 * 60 * 1000,
+        )
+
+    assert archived == 1
+    assert (exp_first,) in queried_experiment_ids
+    assert (exp_second,) in queried_experiment_ids
+    assert mock_find_candidates.call_count >= 2
+    assert archived_trace_ids == ["tr-regular-older"]
+    mock_archive_candidate.assert_called_once()
+
+
+def test_archive_traces_respects_workspace_trace_archival_location_overrides(
+    store: SqlAlchemyStore, workspaces_enabled: bool
+):
+    if not workspaces_enabled:
+        pytest.skip("Workspace root override behavior only applies when workspaces are enabled.")
+
+    workspace_store = store._get_workspace_provider_instance()
+    exp_id = store.create_experiment("archive-workspace-override")
+    now_millis = 30 * 24 * 60 * 60 * 1000
+    old_request_time = now_millis - 2 * 24 * 60 * 60 * 1000  # 2 days old
+    new_request_time = now_millis - 12 * 60 * 60 * 1000  # 12 hours old
+
+    with TempDir() as tmp:
+        server_archive_root = Path(tmp.path("server-archive"))
+        workspace_artifact_root = Path(tmp.path("workspace-artifacts"))
+        workspace_archive_root = Path(tmp.path("workspace-archive"))
+        server_archive_root.mkdir()
+        workspace_artifact_root.mkdir()
+        workspace_archive_root.mkdir()
+        workspace_store.update_workspace(
+            Workspace(
+                name=DEFAULT_WORKSPACE_NAME,
+                default_artifact_root=workspace_artifact_root.as_uri(),
+                trace_archival_location=workspace_archive_root.as_uri(),
+            )
+        )
+
+        _create_trace(
+            store,
+            "tr-workspace-old",
+            exp_id,
+            request_time=old_request_time,
+        )
+        _create_trace(
+            store,
+            "tr-workspace-new",
+            exp_id,
+            request_time=new_request_time,
+        )
+        store.log_spans(
+            exp_id,
+            [
+                create_test_span(
+                    "tr-workspace-old",
+                    span_id=311,
+                    start_ns=old_request_time * 1_000_000,
+                    end_ns=(old_request_time + 1_000) * 1_000_000,
+                )
+            ],
+        )
+        store.log_spans(
+            exp_id,
+            [
+                create_test_span(
+                    "tr-workspace-new",
+                    span_id=312,
+                    start_ns=new_request_time * 1_000_000,
+                    end_ns=(new_request_time + 1_000) * 1_000_000,
+                )
+            ],
+        )
+
+        archived = _archive_traces(
+            store,
+            default_trace_archival_location=server_archive_root.as_uri(),
+            default_retention="1d",
+            now_millis=now_millis,
+        )
+
+        assert archived == 1
+        archived_trace_info = store.get_trace_info("tr-workspace-old")
+        expected_workspace_archive_uri = append_to_uri_path(
+            workspace_archive_root.as_uri(),
+            exp_id,
+            SqlAlchemyStore.TRACE_FOLDER_NAME,
+            "tr-workspace-old",
+            SqlAlchemyStore.ARTIFACTS_FOLDER_NAME,
+        )
+        assert archived_trace_info.tags[TraceTagKey.ARCHIVE_LOCATION] == (
+            expected_workspace_archive_uri
+        )
+        assert (
+            workspace_archive_root
+            / exp_id
+            / SqlAlchemyStore.TRACE_FOLDER_NAME
+            / "tr-workspace-old"
+            / SqlAlchemyStore.ARTIFACTS_FOLDER_NAME
+            / "traces.pb"
+        ).is_file()
+        assert not (
+            workspace_artifact_root
+            / exp_id
+            / SqlAlchemyStore.TRACE_FOLDER_NAME
+            / "tr-workspace-old"
+            / SqlAlchemyStore.ARTIFACTS_FOLDER_NAME
+            / "traces.pb"
+        ).exists()
+        assert not (
+            server_archive_root
+            / WORKSPACES_DIR_NAME
+            / DEFAULT_WORKSPACE_NAME
+            / exp_id
+            / SqlAlchemyStore.TRACE_FOLDER_NAME
+            / "tr-workspace-old"
+            / SqlAlchemyStore.ARTIFACTS_FOLDER_NAME
+            / "traces.pb"
+        ).exists()
+
+    assert store.get_trace_info("tr-workspace-new").tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.TRACKING_STORE.value
+    )
+
+
+def test_archive_traces_respects_workspace_trace_archival_retention(
+    store: SqlAlchemyStore, workspaces_enabled: bool
+):
+    if not workspaces_enabled:
+        pytest.skip("Workspace retention behavior only applies when workspaces are enabled.")
+
+    workspace_store = store._get_workspace_provider_instance()
+    workspace_store.update_workspace(
+        Workspace(name=DEFAULT_WORKSPACE_NAME, trace_archival_retention="1d")
+    )
+    exp_id = store.create_experiment("archive-workspace-retention")
+    now_millis = 35 * 24 * 60 * 60 * 1000
+    old_request_time = now_millis - 2 * 24 * 60 * 60 * 1000  # 2 days old
+    new_request_time = now_millis - 12 * 60 * 60 * 1000  # 12 hours old
+
+    _create_trace(store, "tr-workspace-retention-old", exp_id, request_time=old_request_time)
+    _create_trace(store, "tr-workspace-retention-new", exp_id, request_time=new_request_time)
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                "tr-workspace-retention-old",
+                span_id=321,
+                start_ns=old_request_time * 1_000_000,
+                end_ns=(old_request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                "tr-workspace-retention-new",
+                span_id=322,
+                start_ns=new_request_time * 1_000_000,
+                end_ns=(new_request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        archived = _archive_traces(
+            store,
+            default_trace_archival_location=archive_root.as_uri(),
+            default_retention="30d",
+            now_millis=now_millis,
+        )
+
+    assert archived == 1
+    assert store.get_trace_info("tr-workspace-retention-old").tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.ARCHIVE_REPO.value
+    )
+    assert store.get_trace_info("tr-workspace-retention-new").tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.TRACKING_STORE.value
+    )
+
+
+def test_archive_traces_respects_workspace_retention_long_retention_allowlist(
+    store: SqlAlchemyStore, workspaces_enabled: bool
+):
+    if not workspaces_enabled:
+        pytest.skip("Workspace retention behavior only applies when workspaces are enabled.")
+
+    workspace_store = store._get_workspace_provider_instance()
+    workspace_store.update_workspace(
+        Workspace(name=DEFAULT_WORKSPACE_NAME, trace_archival_retention="30d")
+    )
+    exp_allowlisted = store.create_experiment("archive-workspace-allowlisted")
+    exp_not_allowlisted = store.create_experiment("archive-workspace-not-allowlisted")
+    now_millis = 180 * 24 * 60 * 60 * 1000
+    request_time = now_millis - 45 * 24 * 60 * 60 * 1000  # 45 days old
+
+    for exp_id in (exp_allowlisted, exp_not_allowlisted):
+        store.set_experiment_tag(
+            exp_id,
+            ExperimentTag(
+                TraceExperimentTagKey.ARCHIVAL_RETENTION,
+                json.dumps({"type": "duration", "value": "90d"}),
+            ),
+        )
+
+    _create_trace(store, "tr-workspace-allowlisted", exp_allowlisted, request_time=request_time)
+    _create_trace(
+        store,
+        "tr-workspace-not-allowlisted",
+        exp_not_allowlisted,
+        request_time=request_time,
+    )
+    store.log_spans(
+        exp_allowlisted,
+        [
+            create_test_span(
+                "tr-workspace-allowlisted",
+                span_id=331,
+                start_ns=request_time * 1_000_000,
+                end_ns=(request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+    store.log_spans(
+        exp_not_allowlisted,
+        [
+            create_test_span(
+                "tr-workspace-not-allowlisted",
+                span_id=332,
+                start_ns=request_time * 1_000_000,
+                end_ns=(request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        archived = _archive_traces(
+            store,
+            default_trace_archival_location=archive_root.as_uri(),
+            default_retention="120d",
+            long_retention_allowlist={exp_allowlisted},
+            now_millis=now_millis,
+        )
+
+    assert archived == 1
+    assert store.get_trace_info("tr-workspace-allowlisted").tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.TRACKING_STORE.value
+    )
+    assert (
+        store.get_trace_info("tr-workspace-not-allowlisted").tags[TraceTagKey.SPANS_LOCATION]
+        == SpansLocation.ARCHIVE_REPO.value
+    )
+
+
+def test_archive_traces_noops_when_candidate_becomes_stale(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("archive-stale-candidate")
+    trace_id = "tr-stale-candidate"
+    now_millis = 40 * 24 * 60 * 60 * 1000
+    _create_trace(store, trace_id, exp_id, request_time=now_millis - 2 * 24 * 60 * 60 * 1000)
+    store.log_spans(exp_id, [create_test_span(trace_id, span_id=411)])
+
+    from mlflow.store.artifact.artifact_repo import ArtifactRepository
+
+    original_upload_archived_trace_data_bytes = ArtifactRepository.upload_archived_trace_data_bytes
+
+    def upload_bytes_and_mutate(self, data):
+        original_upload_archived_trace_data_bytes(self, data)
+        store.log_spans(exp_id, [create_test_span(trace_id, span_id=412)])
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        archive_payload_path = (
+            archive_root
+            / exp_id
+            / SqlAlchemyStore.TRACE_FOLDER_NAME
+            / trace_id
+            / SqlAlchemyStore.ARTIFACTS_FOLDER_NAME
+            / "traces.pb"
+        )
+        with mock.patch.object(
+            ArtifactRepository, "upload_archived_trace_data_bytes", new=upload_bytes_and_mutate
+        ):
+            archived = _archive_traces(
+                store,
+                default_trace_archival_location=archive_root.as_uri(),
+                default_retention="1d",
+                now_millis=now_millis,
+            )
+        assert not archive_payload_path.exists()
+
+    assert archived == 0
+    assert store.get_trace_info(trace_id).tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.TRACKING_STORE.value
+    )
+    with store.ManagedSessionMaker() as session:
+        contents = (
+            session
+            .query(SqlSpan.content)
+            .filter(SqlSpan.trace_id == trace_id)
+            .order_by(SqlSpan.span_id.asc())
+            .all()
+        )
+        assert all(content for (content,) in contents)
+
+
+def test_log_spans_rejects_archived_trace(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("archive-reject-log-spans")
+    trace_id = "tr-archive-reject-log-spans"
+    now_millis = 42 * 24 * 60 * 60 * 1000
+    request_time = now_millis - 2 * 24 * 60 * 60 * 1000
+
+    _create_trace(store, trace_id, exp_id, request_time=request_time)
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                trace_id,
+                span_id=421,
+                start_ns=request_time * 1_000_000,
+                end_ns=(request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        archived = _archive_traces(
+            store,
+            default_trace_archival_location=archive_root.as_uri(),
+            default_retention="1d",
+            now_millis=now_millis,
+        )
+
+        assert archived == 1
+        archived_trace_info = store.get_trace_info(trace_id)
+        assert (
+            archived_trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.ARCHIVE_REPO.value
+        )
+        archived_trace = store.get_trace(trace_id)
+
+        with pytest.raises(
+            MlflowException, match=f"Cannot log spans to archived traces: '{trace_id}'"
+        ) as exc_info:
+            store.log_spans(
+                exp_id,
+                [
+                    create_test_span(
+                        trace_id,
+                        span_id=422,
+                        start_ns=(request_time + 2_000) * 1_000_000,
+                        end_ns=(request_time + 3_000) * 1_000_000,
+                    )
+                ],
+            )
+
+        assert exc_info.value.error_code == ErrorCode.Name(INVALID_STATE)
+        trace_info = store.get_trace_info(trace_id)
+        assert trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.ARCHIVE_REPO.value
+        assert (
+            trace_info.tags[TraceTagKey.ARCHIVE_LOCATION]
+            == archived_trace_info.tags[TraceTagKey.ARCHIVE_LOCATION]
+        )
+        assert [span.span_id for span in store.get_trace(trace_id).data.spans] == [
+            span.span_id for span in archived_trace.data.spans
+        ]
+        with store.ManagedSessionMaker() as session:
+            contents = (
+                session
+                .query(SqlSpan.content)
+                .filter(SqlSpan.trace_id == trace_id)
+                .order_by(SqlSpan.span_id.asc())
+                .all()
+            )
+            assert contents == [("",)]
+
+
+def test_archive_traces_continues_after_upload_failure_and_cleans_up_completed_archive_now_requests(
+    store: SqlAlchemyStore,
+):
+    exp_fail = store.create_experiment("archive-upload-failure")
+    exp_success = store.create_experiment("archive-upload-success")
+    fail_trace_id = "tr-upload-failure"
+    success_trace_id = "tr-upload-success"
+    now_millis = 45 * 24 * 60 * 60 * 1000
+    fail_request_time = now_millis - 3 * 24 * 60 * 60 * 1000
+    success_request_time = now_millis - 2 * 24 * 60 * 60 * 1000
+
+    for exp_id in (exp_fail, exp_success):
+        store.set_experiment_tag(
+            exp_id,
+            ExperimentTag(TraceExperimentTagKey.ARCHIVE_NOW, json.dumps({})),
+        )
+
+    _create_trace(store, fail_trace_id, exp_fail, request_time=fail_request_time)
+    _create_trace(store, success_trace_id, exp_success, request_time=success_request_time)
+    store.log_spans(
+        exp_fail,
+        [
+            create_test_span(
+                fail_trace_id,
+                span_id=711,
+                start_ns=fail_request_time * 1_000_000,
+                end_ns=(fail_request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+    store.log_spans(
+        exp_success,
+        [
+            create_test_span(
+                success_trace_id,
+                span_id=712,
+                start_ns=success_request_time * 1_000_000,
+                end_ns=(success_request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+
+    from mlflow.store.artifact.artifact_repo import ArtifactRepository
+
+    original_upload_archived_trace_data_bytes = ArtifactRepository.upload_archived_trace_data_bytes
+    call_count = [0]
+
+    def upload_bytes_with_failure(self, data):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            raise RuntimeError("simulated archive upload failure")
+        return original_upload_archived_trace_data_bytes(self, data)
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        with mock.patch.object(
+            ArtifactRepository,
+            "upload_archived_trace_data_bytes",
+            new=upload_bytes_with_failure,
+        ):
+            archived = _archive_traces(
+                store,
+                default_trace_archival_location=archive_root.as_uri(),
+                default_retention="365d",
+                now_millis=now_millis,
+            )
+
+    assert archived == 1
+    assert store.get_trace_info(fail_trace_id).tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.TRACKING_STORE.value
+    )
+    assert store.get_trace_info(success_trace_id).tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.ARCHIVE_REPO.value
+    )
+    assert TraceExperimentTagKey.ARCHIVE_NOW in store.get_experiment(exp_fail).tags
+    assert TraceExperimentTagKey.ARCHIVE_NOW not in store.get_experiment(exp_success).tags
+
+
+def test_archive_traces_keeps_new_archive_now_request_added_mid_pass(
+    store: SqlAlchemyStore, monkeypatch
+):
+    now_millis = 62 * 24 * 60 * 60 * 1000
+    exp_id = store.create_experiment("archive-now-tag-replaced-mid-pass")
+    original_request = json.dumps({"older_than": "30d"})
+    replacement_request = json.dumps({"older_than": "1h"})
+    archived_trace_ids = []
+
+    store.set_experiment_tag(
+        exp_id, ExperimentTag(TraceExperimentTagKey.ARCHIVE_NOW, original_request)
+    )
+
+    def _find_candidates(*, session, experiment_ids, max_timestamp_millis, limit):
+        if exp_id in experiment_ids:
+            return [
+                _TraceArchiveCandidate(
+                    trace_id="tr-replaced-request",
+                    experiment_id=exp_id,
+                    timestamp_ms=1,
+                )
+            ]
+        return []
+
+    def _archive_candidate(*, trace_id, trace_archival_config):
+        archived_trace_ids.append(trace_id)
+        store.set_experiment_tag(
+            exp_id, ExperimentTag(TraceExperimentTagKey.ARCHIVE_NOW, replacement_request)
+        )
+        return True
+
+    monkeypatch.setattr(
+        store,
+        "_find_archivable_trace_candidates_for_experiments",
+        _find_candidates,
+    )
+    monkeypatch.setattr(store, "_archive_trace_candidate", _archive_candidate)
+    monkeypatch.setattr(store, "_get_archive_now_remaining_state", lambda **_: "done")
+
+    archived = _archive_traces(
+        store,
+        default_trace_archival_location="file:///unused-archive-root",
+        default_retention="365d",
+        max_traces=1,
+        now_millis=now_millis,
+    )
+
+    assert archived == 1
+    assert archived_trace_ids == ["tr-replaced-request"]
+    assert (
+        store.get_experiment(exp_id).tags[TraceExperimentTagKey.ARCHIVE_NOW] == replacement_request
+    )
+
+
+@pytest.mark.parametrize("invalid_content", ["not-json", "[]"], ids=["invalid-json", "wrong-shape"])
+def test_archive_traces_marks_malformed_traces_and_excludes_retries(
+    store: SqlAlchemyStore, invalid_content: str
+):
+    exp_id = store.create_experiment("archive-malformed-trace")
+    trace_id = "tr-malformed"
+    now_millis = 50 * 24 * 60 * 60 * 1000
+
+    _create_trace(store, trace_id, exp_id, request_time=now_millis - 2 * 24 * 60 * 60 * 1000)
+    store.log_spans(exp_id, [create_test_span(trace_id, span_id=511)])
+    store.set_experiment_tag(
+        exp_id, ExperimentTag(TraceExperimentTagKey.ARCHIVE_NOW, json.dumps({}))
+    )
+
+    with store.ManagedSessionMaker() as session:
+        (
+            session
+            .query(SqlSpan)
+            .filter(SqlSpan.trace_id == trace_id)
+            .update({SqlSpan.content: invalid_content}, synchronize_session=False)
+        )
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        archived = _archive_traces(
+            store,
+            default_trace_archival_location=archive_root.as_uri(),
+            default_retention="365d",
+            now_millis=now_millis,
+        )
+        archived_again = _archive_traces(
+            store,
+            default_trace_archival_location=archive_root.as_uri(),
+            default_retention="365d",
+            now_millis=now_millis,
+        )
+
+    assert archived == 0
+    assert archived_again == 0
+    trace_info = store.get_trace_info(trace_id)
+    assert trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.TRACKING_STORE.value
+    assert trace_info.tags[TraceTagKey.ARCHIVAL_FAILURE] == (
+        TraceArchivalFailureReason.MALFORMED_TRACE.value
+    )
+    assert TraceExperimentTagKey.ARCHIVE_NOW not in store.get_experiment(exp_id).tags
+
+
+def test_archive_traces_marks_serializer_failures_as_malformed_and_excludes_retries(
+    store: SqlAlchemyStore,
+):
+    exp_id = store.create_experiment("archive-serializer-malformed-trace")
+    trace_id = "tr-serializer-malformed"
+    now_millis = 55 * 24 * 60 * 60 * 1000
+
+    _create_trace(store, trace_id, exp_id, request_time=now_millis - 2 * 24 * 60 * 60 * 1000)
+    store.log_spans(exp_id, [create_test_span(trace_id, span_id=561)])
+    store.set_experiment_tag(
+        exp_id, ExperimentTag(TraceExperimentTagKey.ARCHIVE_NOW, json.dumps({}))
+    )
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        with mock.patch(
+            "mlflow.store.tracking.sqlalchemy_store.spans_to_traces_data_pb",
+            side_effect=MlflowException.invalid_parameter_value("simulated malformed trace"),
+        ):
+            archived = _archive_traces(
+                store,
+                default_trace_archival_location=archive_root.as_uri(),
+                default_retention="365d",
+                now_millis=now_millis,
+            )
+            archived_again = _archive_traces(
+                store,
+                default_trace_archival_location=archive_root.as_uri(),
+                default_retention="365d",
+                now_millis=now_millis,
+            )
+
+    assert archived == 0
+    assert archived_again == 0
+    trace_info = store.get_trace_info(trace_id)
+    assert trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.TRACKING_STORE.value
+    assert trace_info.tags[TraceTagKey.ARCHIVAL_FAILURE] == (
+        TraceArchivalFailureReason.MALFORMED_TRACE.value
+    )
+    assert TraceExperimentTagKey.ARCHIVE_NOW not in store.get_experiment(exp_id).tags
+
+
+def test_archive_traces_marks_unsupported_archive_repository_as_terminal_failure(
+    store: SqlAlchemyStore,
+):
+    exp_fail = store.create_experiment("archive-unsupported-repository")
+    exp_success = store.create_experiment("archive-supported-repository")
+    fail_trace_id = "tr-unsupported-repository"
+    success_trace_id = "tr-supported-repository"
+    now_millis = 57 * 24 * 60 * 60 * 1000
+
+    _create_trace(store, fail_trace_id, exp_fail, request_time=now_millis - 2 * 24 * 60 * 60 * 1000)
+    _create_trace(
+        store, success_trace_id, exp_success, request_time=now_millis - 24 * 60 * 60 * 1000
+    )
+    store.log_spans(exp_fail, [create_test_span(fail_trace_id, span_id=571)])
+    store.log_spans(exp_success, [create_test_span(success_trace_id, span_id=572)])
+    for exp_id in (exp_fail, exp_success):
+        store.set_experiment_tag(
+            exp_id, ExperimentTag(TraceExperimentTagKey.ARCHIVE_NOW, json.dumps({}))
+        )
+
+    from mlflow.store.artifact.artifact_repo import ArtifactRepository
+
+    original_upload_archived_trace_data_bytes = ArtifactRepository.upload_archived_trace_data_bytes
+
+    def upload_bytes_unsupported(self, data):
+        if fail_trace_id in self.artifact_uri:
+            raise MlflowNotImplementedException(
+                "Databricks trace artifact repositories do not yet support ARCHIVE_REPO trace "
+                "payloads."
+            )
+        return original_upload_archived_trace_data_bytes(self, data)
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        with mock.patch.object(
+            ArtifactRepository,
+            "upload_archived_trace_data_bytes",
+            new=upload_bytes_unsupported,
+        ):
+            archived = _archive_traces(
+                store,
+                default_trace_archival_location=archive_root.as_uri(),
+                default_retention="365d",
+                now_millis=now_millis,
+            )
+
+    assert archived == 1
+    fail_trace_info = store.get_trace_info(fail_trace_id)
+    assert fail_trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.TRACKING_STORE.value
+    assert fail_trace_info.tags[TraceTagKey.ARCHIVAL_FAILURE] == (
+        TraceArchivalFailureReason.UNSUPPORTED_ARCHIVE_REPOSITORY.value
+    )
+    success_trace_info = store.get_trace_info(success_trace_id)
+    assert success_trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.ARCHIVE_REPO.value
+    assert TraceExperimentTagKey.ARCHIVE_NOW not in store.get_experiment(exp_fail).tags
+    assert TraceExperimentTagKey.ARCHIVE_NOW not in store.get_experiment(exp_success).tags
+
+
+def test_archive_traces_keeps_archive_now_when_only_unmarked_non_archivable_traces_remain(
+    store: SqlAlchemyStore,
+):
+    exp_id = store.create_experiment("archive-now-terminal-non-archivable")
+    trace_id = "tr-terminal-non-archivable"
+    now_millis = 58 * 24 * 60 * 60 * 1000
+
+    _create_trace(store, trace_id, exp_id, request_time=now_millis - 2 * 24 * 60 * 60 * 1000)
+    store.set_experiment_tag(
+        exp_id, ExperimentTag(TraceExperimentTagKey.ARCHIVE_NOW, json.dumps({}))
+    )
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        archived = _archive_traces(
+            store,
+            default_trace_archival_location=archive_root.as_uri(),
+            default_retention="365d",
+            now_millis=now_millis,
+        )
+
+    assert archived == 0
+    trace_info = store.get_trace_info(trace_id)
+    assert trace_info.tags.get(TraceTagKey.SPANS_LOCATION) is None
+    assert TraceTagKey.ARCHIVAL_FAILURE not in trace_info.tags
+    assert TraceExperimentTagKey.ARCHIVE_NOW in store.get_experiment(exp_id).tags
+
+
+def test_archive_traces_raises_unexpected_deserialization_errors(
+    store: SqlAlchemyStore,
+):
+    exp_id = store.create_experiment("archive-unexpected-deserialize-error")
+    trace_id = "tr-unexpected-deserialize-error"
+    now_millis = 59 * 24 * 60 * 60 * 1000
+    request_time = now_millis - 2 * 24 * 60 * 60 * 1000
+
+    _create_trace(store, trace_id, exp_id, request_time=request_time)
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                trace_id,
+                span_id=581,
+                start_ns=request_time * 1_000_000,
+                end_ns=(request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+    store.set_experiment_tag(
+        exp_id, ExperimentTag(TraceExperimentTagKey.ARCHIVE_NOW, json.dumps({}))
+    )
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        with mock.patch.object(
+            store,
+            "_serialize_trace_archival_snapshot_to_pb",
+            side_effect=RuntimeError("simulated unexpected serialize failure"),
+        ):
+            with pytest.raises(RuntimeError, match="simulated unexpected serialize failure"):
+                _archive_traces(
+                    store,
+                    default_trace_archival_location=archive_root.as_uri(),
+                    default_retention="365d",
+                    now_millis=now_millis,
+                )
+
+    trace_info = store.get_trace_info(trace_id)
+    assert trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.TRACKING_STORE.value
+    assert TraceTagKey.ARCHIVAL_FAILURE not in trace_info.tags
+    assert TraceExperimentTagKey.ARCHIVE_NOW in store.get_experiment(exp_id).tags
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        MlflowException("simulated retryable archival failure"),
+        OSError("simulated storage error"),
+    ],
+    ids=["mlflow-error", "os-error"],
+)
+def test_archive_traces_leaves_retryable_errors_retryable(store: SqlAlchemyStore, error: Exception):
+    exp_id = store.create_experiment("archive-retryable-mlflow-error")
+    trace_id = "tr-retryable-mlflow-error"
+    now_millis = 60 * 24 * 60 * 60 * 1000
+    request_time = now_millis - 2 * 24 * 60 * 60 * 1000
+
+    _create_trace(store, trace_id, exp_id, request_time=request_time)
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                trace_id,
+                span_id=582,
+                start_ns=request_time * 1_000_000,
+                end_ns=(request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+    store.set_experiment_tag(
+        exp_id, ExperimentTag(TraceExperimentTagKey.ARCHIVE_NOW, json.dumps({}))
+    )
+
+    with TempDir() as tmp:
+        from mlflow.store.artifact.artifact_repo import ArtifactRepository
+
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        with mock.patch.object(
+            ArtifactRepository,
+            "upload_archived_trace_data_bytes",
+            side_effect=error,
+        ):
+            archived = _archive_traces(
+                store,
+                default_trace_archival_location=archive_root.as_uri(),
+                default_retention="365d",
+                now_millis=now_millis,
+            )
+
+        assert archived == 0
+        assert TraceExperimentTagKey.ARCHIVE_NOW in store.get_experiment(exp_id).tags
+
+        archived_again = _archive_traces(
+            store,
+            default_trace_archival_location=archive_root.as_uri(),
+            default_retention="365d",
+            now_millis=now_millis,
+        )
+
+    assert archived_again == 1
+    trace_info = store.get_trace_info(trace_id)
+    assert trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.ARCHIVE_REPO.value
+    assert TraceTagKey.ARCHIVAL_FAILURE not in trace_info.tags
+    assert TraceExperimentTagKey.ARCHIVE_NOW not in store.get_experiment(exp_id).tags
+
+
+def test_archive_traces_leaves_sqlalchemy_errors_retryable(
+    store: SqlAlchemyStore,
+):
+    exp_id = store.create_experiment("archive-retryable-sqlalchemy-error")
+    trace_id = "tr-retryable-sqlalchemy-error"
+    now_millis = 61 * 24 * 60 * 60 * 1000
+    request_time = now_millis - 2 * 24 * 60 * 60 * 1000
+
+    _create_trace(store, trace_id, exp_id, request_time=request_time)
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                trace_id,
+                span_id=583,
+                start_ns=request_time * 1_000_000,
+                end_ns=(request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+    store.set_experiment_tag(
+        exp_id, ExperimentTag(TraceExperimentTagKey.ARCHIVE_NOW, json.dumps({}))
+    )
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        with mock.patch.object(
+            store,
+            "_load_trace_archival_snapshot",
+            side_effect=SQLAlchemyError("simulated retryable db failure"),
+        ):
+            archived = _archive_traces(
+                store,
+                default_trace_archival_location=archive_root.as_uri(),
+                default_retention="365d",
+                now_millis=now_millis,
+            )
+
+        assert archived == 0
+        assert TraceExperimentTagKey.ARCHIVE_NOW in store.get_experiment(exp_id).tags
+
+        archived_again = _archive_traces(
+            store,
+            default_trace_archival_location=archive_root.as_uri(),
+            default_retention="365d",
+            now_millis=now_millis,
+        )
+
+    assert archived_again == 1
+    trace_info = store.get_trace_info(trace_id)
+    assert trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.ARCHIVE_REPO.value
+    assert TraceTagKey.ARCHIVAL_FAILURE not in trace_info.tags
+    assert TraceExperimentTagKey.ARCHIVE_NOW not in store.get_experiment(exp_id).tags
+
+
+def test_archive_traces_keeps_archive_now_when_matching_traces_are_transiently_blocked(
+    store: SqlAlchemyStore,
+):
+    exp_id = store.create_experiment("archive-now-transiently-blocked")
+    now_millis = 60 * 24 * 60 * 60 * 1000
+    archivable_trace_id = "tr-now-archivable"
+    in_progress_trace_id = "tr-now-in-progress"
+    request_time = now_millis - 2 * 24 * 60 * 60 * 1000  # 2 days old
+
+    store.set_experiment_tag(
+        exp_id, ExperimentTag(TraceExperimentTagKey.ARCHIVE_NOW, json.dumps({}))
+    )
+    _create_trace(store, archivable_trace_id, exp_id, request_time=request_time)
+    _create_trace(
+        store,
+        in_progress_trace_id,
+        exp_id,
+        request_time=request_time,
+        state=TraceState.IN_PROGRESS,
+    )
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                archivable_trace_id,
+                span_id=611,
+                start_ns=request_time * 1_000_000,
+                end_ns=(request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        archived = _archive_traces(
+            store,
+            default_trace_archival_location=archive_root.as_uri(),
+            default_retention="365d",
+            now_millis=now_millis,
+        )
+
+    assert archived == 1
+    assert store.get_trace_info(archivable_trace_id).tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.ARCHIVE_REPO.value
+    )
+    assert TraceExperimentTagKey.ARCHIVE_NOW in store.get_experiment(exp_id).tags

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -14726,6 +14726,15 @@ def test_archive_traces_raises_when_default_retention_is_unset(store: SqlAlchemy
     assert exc_info.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
 
+def test_archive_traces_rejects_proxy_only_default_root(store: SqlAlchemyStore):
+    with pytest.raises(MlflowException, match="proxy-only `mlflow-artifacts:` scheme") as exc_info:
+        store.archive_traces(
+            default_trace_archival_location="mlflow-artifacts:/archive/default",
+            default_retention="1d",
+        )
+    assert exc_info.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+
 def test_archive_traces_raises_when_default_retention_exceeds_max_length(
     store: SqlAlchemyStore,
 ):

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -22,6 +22,7 @@ from sqlalchemy.exc import IntegrityError
 
 import mlflow
 import mlflow.db
+import mlflow.store.tracking.sqlalchemy_store as sqlalchemy_store_module
 from mlflow import entities
 from mlflow.entities import (
     AssessmentSource,
@@ -51,16 +52,18 @@ from mlflow.entities.span import Span, create_mlflow_span
 from mlflow.entities.trace_info import TraceInfo
 from mlflow.entities.trace_state import TraceState
 from mlflow.entities.trace_status import TraceStatus
-from mlflow.entities.workspace import TraceArchivalConfig
+from mlflow.entities.workspace import TraceArchivalConfig, Workspace
 from mlflow.environment_variables import (
     MLFLOW_ENABLE_WORKSPACES,
     MLFLOW_TRACKING_URI,
 )
-from mlflow.exceptions import MlflowException, MlflowTracingException
+from mlflow.exceptions import MlflowException, MlflowNotImplementedException, MlflowTracingException
 from mlflow.models import Model
 from mlflow.protos.databricks_pb2 import (
     BAD_REQUEST,
+    INTERNAL_ERROR,
     INVALID_PARAMETER_VALUE,
+    INVALID_STATE,
     RESOURCE_DOES_NOT_EXIST,
     TEMPORARILY_UNAVAILABLE,
     ErrorCode,
@@ -108,20 +111,24 @@ from mlflow.store.tracking.dbmodels.models import (
 from mlflow.store.tracking.sqlalchemy_store import (
     SqlAlchemyStore,
     _get_orderby_clauses,
+    _TraceArchiveCandidate,
 )
 from mlflow.store.tracking.sqlalchemy_workspace_store import WorkspaceAwareSqlAlchemyStore
+from mlflow.store.workspace.abstract_store import ResolvedTraceArchivalConfig
 from mlflow.tracing.constant import (
     MAX_CHARS_IN_TRACE_INFO_TAGS_VALUE,
     CostKey,
     SpanAttributeKey,
     SpansLocation,
+    TraceArchivalFailureReason,
+    TraceExperimentTagKey,
     TraceMetadataKey,
     TraceSizeStatsKey,
     TraceTagKey,
 )
 from mlflow.tracing.utils import TraceJSONEncoder
 from mlflow.utils import mlflow_tags
-from mlflow.utils.file_utils import TempDir
+from mlflow.utils.file_utils import TempDir, local_file_uri_to_path
 from mlflow.utils.mlflow_tags import (
     MLFLOW_ARTIFACT_LOCATION,
     MLFLOW_DATASET_CONTEXT,
@@ -130,7 +137,7 @@ from mlflow.utils.mlflow_tags import (
 from mlflow.utils.name_utils import _GENERATOR_PREDICATES
 from mlflow.utils.os import is_windows
 from mlflow.utils.time import get_current_time_millis
-from mlflow.utils.uri import extract_db_type_from_uri
+from mlflow.utils.uri import append_to_uri_path, extract_db_type_from_uri
 from mlflow.utils.validation import (
     MAX_DATASET_DIGEST_SIZE,
     MAX_DATASET_NAME_SIZE,
@@ -143,7 +150,7 @@ from mlflow.utils.validation import (
     MAX_TAG_VAL_LENGTH,
 )
 from mlflow.utils.workspace_context import WorkspaceContext
-from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
+from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME, WORKSPACES_DIR_NAME
 
 from tests.integration.utils import invoke_cli_runner
 from tests.store.tracking.test_file_store import assert_dataset_inputs_equal
@@ -441,6 +448,29 @@ def _cleanup_database(store: SqlAlchemyStore):
         # Recreate the default experiment (id=0) so that tests using the global registry
         # cache (e.g., mlflow.start_run()) can still find it after cleanup.
         store._create_default_experiment(session)
+
+    if isinstance(store, WorkspaceAwareSqlAlchemyStore):
+        provider = store._get_workspace_provider_instance()
+
+        # Reset workspace-level overrides when tests share a cached workspace store
+        # against a long-lived backend store URI.
+        for workspace in provider.list_workspaces():
+            if workspace.name != DEFAULT_WORKSPACE_NAME:
+                provider.delete_workspace(workspace.name)
+
+        provider.update_workspace(
+            Workspace(
+                name=DEFAULT_WORKSPACE_NAME,
+                default_artifact_root="",
+                trace_archival_location="",
+                trace_archival_retention="",
+            )
+        )
+
+        with provider._artifact_root_cache_lock:
+            provider._artifact_root_cache.clear()
+        with provider._trace_archival_config_cache_lock:
+            provider._trace_archival_config_cache.clear()
 
 
 def _create_experiments(store: SqlAlchemyStore, names) -> str | list[str]:
@@ -5073,6 +5103,28 @@ def _create_trace(
     return store.start_trace(trace_info)
 
 
+def _archive_traces(
+    store: SqlAlchemyStore,
+    *,
+    default_trace_archival_location: str,
+    default_retention: str,
+    long_retention_allowlist: set[str] | list[str] | None = None,
+    max_traces: int | None = 100,
+    now_millis: int | None = None,
+) -> int:
+    kwargs = {
+        "default_trace_archival_location": default_trace_archival_location,
+        "default_retention": default_retention,
+        "long_retention_allowlist": long_retention_allowlist,
+        "max_traces": max_traces,
+    }
+    if now_millis is None:
+        return store.archive_traces(**kwargs)
+
+    with mock.patch.object(store, "_get_archive_traces_now_millis", return_value=now_millis):
+        return store.archive_traces(**kwargs)
+
+
 @pytest.fixture
 def store_with_traces(store):
     exp1 = store.create_experiment("exp1")
@@ -8276,6 +8328,53 @@ def test_log_spans_multiple_traces(store: SqlAlchemyStore):
 
         span_row2 = session.query(SqlSpan).filter_by(trace_id="tr-multi-2").one()
         assert span_row2.name == "span_trace2"
+
+
+def test_log_spans_rejects_archived_trace_in_multi_trace_batch(store: SqlAlchemyStore):
+    experiment_id = store.create_experiment("test_multi_trace_archived_experiment")
+    archived_trace_id = "tr-multi-archived"
+    fresh_trace_id = "tr-multi-fresh"
+
+    store.log_spans(
+        experiment_id,
+        [
+            create_test_span(
+                archived_trace_id,
+                span_id=1,
+                start_ns=1_000_000_000,
+                end_ns=2_000_000_000,
+            )
+        ],
+    )
+    store.set_trace_tag(
+        archived_trace_id, TraceTagKey.SPANS_LOCATION, SpansLocation.ARCHIVE_REPO.value
+    )
+    store.set_trace_tag(archived_trace_id, TraceTagKey.ARCHIVE_LOCATION, "dbfs:/archive/tr-multi")
+
+    with pytest.raises(
+        MlflowException, match=f"Cannot log spans to archived traces: '{archived_trace_id}'"
+    ) as exc_info:
+        store.log_spans(
+            experiment_id,
+            [
+                create_test_span(
+                    archived_trace_id,
+                    span_id=2,
+                    start_ns=3_000_000_000,
+                    end_ns=4_000_000_000,
+                ),
+                create_test_span(
+                    fresh_trace_id,
+                    span_id=3,
+                    start_ns=5_000_000_000,
+                    end_ns=6_000_000_000,
+                ),
+            ],
+        )
+
+    assert exc_info.value.error_code == ErrorCode.Name(INVALID_STATE)
+    with store.ManagedSessionMaker() as session:
+        assert session.query(SqlSpan).filter_by(trace_id=fresh_trace_id).count() == 0
 
 
 @pytest.mark.asyncio
@@ -13718,6 +13817,78 @@ def test_log_spans_then_start_trace_preserves_tag(store: SqlAlchemyStore):
     assert trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.TRACKING_STORE.value
 
 
+def test_log_spans_then_start_trace_preserves_archived_trace_tags(store: SqlAlchemyStore):
+    experiment_id = store.create_experiment("test_preserve_archived_trace_tags")
+    trace_id = f"tr-{uuid.uuid4().hex}"
+    archive_location = "s3://bucket/archive/traces.pb"
+
+    span = create_test_span(
+        trace_id=trace_id,
+        name="test_span",
+        span_id=111,
+        status=trace_api.StatusCode.OK,
+        start_ns=1_000_000_000,
+        end_ns=2_000_000_000,
+        trace_num=12345,
+    )
+    store.log_spans(experiment_id, [span])
+    store.set_trace_tag(trace_id, TraceTagKey.SPANS_LOCATION, SpansLocation.ARCHIVE_REPO.value)
+    store.set_trace_tag(trace_id, TraceTagKey.ARCHIVE_LOCATION, archive_location)
+
+    trace_info_for_start = TraceInfo(
+        trace_id=trace_id,
+        trace_location=trace_location.TraceLocation.from_experiment_id(experiment_id),
+        request_time=1000,
+        execution_duration=1000,
+        state=TraceState.OK,
+        tags={"custom_tag": "value"},
+        trace_metadata={"source": "test"},
+    )
+    store.start_trace(trace_info_for_start)
+
+    trace_info = store.get_trace_info(trace_id)
+    assert trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.ARCHIVE_REPO.value
+    assert trace_info.tags[TraceTagKey.ARCHIVE_LOCATION] == archive_location
+
+
+def test_log_spans_then_start_trace_preserves_archival_failure_tag(store: SqlAlchemyStore):
+    experiment_id = store.create_experiment("test_preserve_archival_failure_tag")
+    trace_id = f"tr-{uuid.uuid4().hex}"
+
+    span = create_test_span(
+        trace_id=trace_id,
+        name="test_span",
+        span_id=111,
+        status=trace_api.StatusCode.OK,
+        start_ns=1_000_000_000,
+        end_ns=2_000_000_000,
+        trace_num=12345,
+    )
+    store.log_spans(experiment_id, [span])
+    store.set_trace_tag(
+        trace_id,
+        TraceTagKey.ARCHIVAL_FAILURE,
+        TraceArchivalFailureReason.MALFORMED_TRACE.value,
+    )
+
+    trace_info_for_start = TraceInfo(
+        trace_id=trace_id,
+        trace_location=trace_location.TraceLocation.from_experiment_id(experiment_id),
+        request_time=1000,
+        execution_duration=1000,
+        state=TraceState.OK,
+        tags={"custom_tag": "value"},
+        trace_metadata={"source": "test"},
+    )
+    store.start_trace(trace_info_for_start)
+
+    trace_info = store.get_trace_info(trace_id)
+    assert trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.TRACKING_STORE.value
+    assert trace_info.tags[TraceTagKey.ARCHIVAL_FAILURE] == (
+        TraceArchivalFailureReason.MALFORMED_TRACE.value
+    )
+
+
 def test_log_spans_then_start_trace_preserves_preview(store: SqlAlchemyStore):
     experiment_id = store.create_experiment("test_preview_preserved")
     trace_id = f"tr-{uuid.uuid4().hex}"
@@ -14230,3 +14401,1718 @@ def test_get_decrypted_secret_integration_multiple_secrets(store):
 
     assert decrypted1 == {"api_key": "key-1"}
     assert decrypted2 == {"api_key": "key-2"}
+
+
+def test_archive_traces_archives_db_backed_trace_payloads(
+    store: SqlAlchemyStore, workspaces_enabled: bool
+):
+    exp_id = store.create_experiment("archive-db-backed")
+    now_millis = 10 * 24 * 60 * 60 * 1000
+    old_trace_id = "tr-archive-old"
+    new_trace_id = "tr-archive-new"
+    old_request_time = now_millis - 3 * 24 * 60 * 60 * 1000  # 3 days old
+    new_request_time = now_millis - 60 * 60 * 1000  # 1 hour old
+
+    _create_trace(store, old_trace_id, exp_id, request_time=old_request_time)
+    _create_trace(store, new_trace_id, exp_id, request_time=new_request_time)
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                old_trace_id,
+                span_id=111,
+                start_ns=old_request_time * 1_000_000,
+                end_ns=(old_request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                new_trace_id,
+                span_id=222,
+                start_ns=new_request_time * 1_000_000,
+                end_ns=(new_request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+    original_trace_artifact_uri = store.get_trace_info(old_trace_id).tags[MLFLOW_ARTIFACT_LOCATION]
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        archived = _archive_traces(
+            store,
+            default_trace_archival_location=archive_root.as_uri(),
+            default_retention="1d",
+            now_millis=now_millis,
+        )
+        assert archived == 1
+
+        trace_info = store.get_trace_info(old_trace_id)
+        assert trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.ARCHIVE_REPO.value
+        if workspaces_enabled:
+            expected_archive_uri = append_to_uri_path(
+                archive_root.as_uri(),
+                WORKSPACES_DIR_NAME,
+                DEFAULT_WORKSPACE_NAME,
+                exp_id,
+                SqlAlchemyStore.TRACE_FOLDER_NAME,
+                old_trace_id,
+                SqlAlchemyStore.ARTIFACTS_FOLDER_NAME,
+            )
+            expected_archive_path = (
+                archive_root
+                / WORKSPACES_DIR_NAME
+                / DEFAULT_WORKSPACE_NAME
+                / exp_id
+                / SqlAlchemyStore.TRACE_FOLDER_NAME
+                / old_trace_id
+                / SqlAlchemyStore.ARTIFACTS_FOLDER_NAME
+                / "traces.pb"
+            )
+        else:
+            expected_archive_uri = append_to_uri_path(
+                archive_root.as_uri(),
+                exp_id,
+                SqlAlchemyStore.TRACE_FOLDER_NAME,
+                old_trace_id,
+                SqlAlchemyStore.ARTIFACTS_FOLDER_NAME,
+            )
+            expected_archive_path = (
+                archive_root
+                / exp_id
+                / SqlAlchemyStore.TRACE_FOLDER_NAME
+                / old_trace_id
+                / SqlAlchemyStore.ARTIFACTS_FOLDER_NAME
+                / "traces.pb"
+            )
+        assert trace_info.tags[MLFLOW_ARTIFACT_LOCATION] == original_trace_artifact_uri
+        assert trace_info.tags[TraceTagKey.ARCHIVE_LOCATION] == expected_archive_uri
+        assert expected_archive_path.is_file()
+
+        with store.ManagedSessionMaker() as session:
+            archived_span = session.query(SqlSpan).filter(SqlSpan.trace_id == old_trace_id).one()
+            fresh_span = session.query(SqlSpan).filter(SqlSpan.trace_id == new_trace_id).one()
+            assert archived_span.content == ""
+            assert fresh_span.content != ""
+
+        from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
+
+        archived_trace_data = get_artifact_repository(
+            trace_info.tags[TraceTagKey.ARCHIVE_LOCATION]
+        ).download_archived_trace_data()
+        assert len(archived_trace_data.spans) == 1
+        assert archived_trace_data.spans[0].name == "test_span"
+        assert store.get_trace(old_trace_id).data.spans[0].name == "test_span"
+        assert store.batch_get_traces([old_trace_id])[0].data.spans[0].name == "test_span"
+
+        assert (
+            _archive_traces(
+                store,
+                default_trace_archival_location=archive_root.as_uri(),
+                default_retention="1d",
+                now_millis=now_millis,
+            )
+            == 0
+        )
+
+
+def test_batch_get_traces_skips_archived_traces_with_missing_payload(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("archive-batch-get-missing-payload")
+    archived_trace_id = "tr-archive-missing-payload"
+    healthy_trace_id = "tr-archive-batch-healthy"
+    now_millis = 25 * 24 * 60 * 60 * 1000
+    archived_request_time = now_millis - 2 * 24 * 60 * 60 * 1000
+    healthy_request_time = now_millis - 12 * 60 * 60 * 1000
+
+    _create_trace(store, archived_trace_id, exp_id, request_time=archived_request_time)
+    _create_trace(store, healthy_trace_id, exp_id, request_time=healthy_request_time)
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                archived_trace_id,
+                span_id=151,
+                start_ns=archived_request_time * 1_000_000,
+                end_ns=(archived_request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                healthy_trace_id,
+                span_id=152,
+                start_ns=healthy_request_time * 1_000_000,
+                end_ns=(healthy_request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+
+    with TempDir() as tmp:
+        from mlflow.tracing.otel.otel_archival import TRACE_ARCHIVAL_FILENAME
+
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        archived = _archive_traces(
+            store,
+            default_trace_archival_location=archive_root.as_uri(),
+            default_retention="1d",
+            now_millis=now_millis,
+        )
+
+        assert archived == 1
+        archived_trace_info = store.get_trace_info(archived_trace_id)
+        archive_payload_path = (
+            Path(local_file_uri_to_path(archived_trace_info.tags[TraceTagKey.ARCHIVE_LOCATION]))
+            / TRACE_ARCHIVAL_FILENAME
+        )
+        assert archive_payload_path.is_file()
+        archive_payload_path.unlink()
+
+        traces = store.batch_get_traces([archived_trace_id, healthy_trace_id])
+
+    assert [trace.info.trace_id for trace in traces] == [healthy_trace_id]
+    assert traces[0].data.spans[0].name == "test_span"
+
+
+def test_archive_traces_preserve_root_first_span_order(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("archive-span-order")
+    trace_id = "tr-archive-span-order"
+    now_millis = 12 * 24 * 60 * 60 * 1000
+    request_time = now_millis - 3 * 24 * 60 * 60 * 1000
+
+    _create_trace(store, trace_id, exp_id, request_time=request_time)
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                trace_id,
+                name="root",
+                span_id=999,
+                start_ns=request_time * 1_000_000,
+                end_ns=(request_time + 1_000) * 1_000_000,
+            ),
+            create_test_span(
+                trace_id,
+                name="child",
+                span_id=111,
+                parent_id=999,
+                start_ns=(request_time + 1) * 1_000_000,
+                end_ns=(request_time + 900) * 1_000_000,
+            ),
+        ],
+    )
+
+    assert [span.name for span in store.get_trace(trace_id).data.spans] == ["root", "child"]
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        archived = _archive_traces(
+            store,
+            default_trace_archival_location=archive_root.as_uri(),
+            default_retention="1d",
+            now_millis=now_millis,
+        )
+        assert archived == 1
+        assert [span.name for span in store.get_trace(trace_id).data.spans] == ["root", "child"]
+        assert [span.name for span in store.batch_get_traces([trace_id])[0].data.spans] == [
+            "root",
+            "child",
+        ]
+
+
+def test_archive_traces_preserves_trace_attachment_location(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("archive-attachments")
+    trace_id = "tr-archive-attachments"
+    now_millis = 25 * 24 * 60 * 60 * 1000
+    request_time = now_millis - 2 * 24 * 60 * 60 * 1000
+    attachment_id = str(uuid.uuid4())
+    attachment_bytes = b"attachment-bytes"
+
+    _create_trace(store, trace_id, exp_id, request_time=request_time)
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                trace_id,
+                span_id=919,
+                start_ns=request_time * 1_000_000,
+                end_ns=(request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+    trace_info = store.get_trace_info(trace_id)
+
+    from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
+
+    get_artifact_repository(trace_info.tags[MLFLOW_ARTIFACT_LOCATION]).upload_attachment(
+        attachment_id, attachment_bytes
+    )
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        archived = _archive_traces(
+            store,
+            default_trace_archival_location=archive_root.as_uri(),
+            default_retention="1d",
+            now_millis=now_millis,
+        )
+
+    assert archived == 1
+    trace_info = store.get_trace_info(trace_id)
+    assert trace_info.tags[MLFLOW_ARTIFACT_LOCATION].endswith(
+        f"/{exp_id}/traces/{trace_id}/artifacts"
+    )
+    assert TraceTagKey.ARCHIVE_LOCATION in trace_info.tags
+    assert (
+        get_artifact_repository(
+            trace_info.tags[MLFLOW_ARTIFACT_LOCATION]
+        ).download_trace_attachment(attachment_id)
+        == attachment_bytes
+    )
+
+
+def test_archive_traces_raises_when_default_root_is_unset_and_no_workspace_override(
+    store: SqlAlchemyStore, workspaces_enabled: bool
+):
+    if workspaces_enabled:
+        workspace_store = store._get_workspace_provider_instance()
+        workspace_store.update_workspace(
+            Workspace(
+                name=DEFAULT_WORKSPACE_NAME,
+                trace_archival_location="",
+            )
+        )
+
+    exp_id = store.create_experiment("archive-default-root")
+    now_millis = 15 * 24 * 60 * 60 * 1000
+    trace_id = "tr-archive-default-root"
+    request_time = now_millis - 2 * 24 * 60 * 60 * 1000  # 2 days old
+
+    _create_trace(store, trace_id, exp_id, request_time=request_time)
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                trace_id,
+                span_id=113,
+                start_ns=request_time * 1_000_000,
+                end_ns=(request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+    with pytest.raises(MlflowException, match="default_trace_archival_location") as exc_info:
+        _archive_traces(
+            store,
+            default_trace_archival_location=None,
+            default_retention="1d",
+            now_millis=now_millis,
+        )
+    assert exc_info.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+
+def test_archive_traces_raises_when_default_retention_is_unset(store: SqlAlchemyStore):
+    with pytest.raises(MlflowException, match="default_retention") as exc_info:
+        store.archive_traces(
+            default_trace_archival_location="s3://archive/default",
+            default_retention=None,
+        )
+    assert exc_info.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+
+def test_archive_traces_raises_when_default_retention_exceeds_max_length(
+    store: SqlAlchemyStore,
+):
+    with pytest.raises(MlflowException, match="at most 32 characters") as exc_info:
+        store.archive_traces(
+            default_trace_archival_location="s3://archive/default",
+            default_retention=f"{'1' * 32}d",
+        )
+    assert exc_info.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+
+def test_archive_traces_treats_unset_max_traces_as_unbounded(store: SqlAlchemyStore, monkeypatch):
+    store.create_experiment("archive-unbounded")
+    archived_trace_ids = []
+    candidates = [
+        _TraceArchiveCandidate(
+            trace_id=f"tr-unbounded-{idx}",
+            experiment_id="0",
+            timestamp_ms=idx,
+        )
+        for idx in range(101)
+    ]
+
+    def _capture_find_archivable_trace_candidates_for_experiments(
+        *, session, experiment_ids, max_timestamp_millis, limit
+    ):
+        assert limit is None
+        return candidates
+
+    def _capture_archive_trace_candidate(*, trace_id, trace_archival_config):
+        archived_trace_ids.append(trace_id)
+        return True
+
+    monkeypatch.setattr(
+        store,
+        "_find_archivable_trace_candidates_for_experiments",
+        _capture_find_archivable_trace_candidates_for_experiments,
+    )
+    monkeypatch.setattr(
+        store,
+        "_archive_trace_candidate",
+        _capture_archive_trace_candidate,
+    )
+
+    archived = store.archive_traces(
+        default_trace_archival_location="s3://archive/default",
+        default_retention="30d",
+    )
+
+    assert archived == len(candidates)
+    assert archived_trace_ids == [candidate.trace_id for candidate in candidates]
+
+
+def test_archive_traces_raises_internal_error_when_resolution_returns_no_location(
+    store: SqlAlchemyStore, monkeypatch
+):
+    def _broken_resolve_trace_archival_config(
+        *, default_trace_archival_location, default_retention
+    ):
+        return ResolvedTraceArchivalConfig(
+            config=TraceArchivalConfig(location=None, retention=default_retention),
+            append_workspace_prefix=False,
+        )
+
+    monkeypatch.setattr(
+        store,
+        "resolve_trace_archival_config",
+        _broken_resolve_trace_archival_config,
+    )
+
+    with pytest.raises(
+        MlflowException, match="config resolution returned no archival location"
+    ) as exc_info:
+        store.archive_traces(
+            default_trace_archival_location="s3://archive/default",
+            default_retention="1d",
+        )
+    assert exc_info.value.error_code == ErrorCode.Name(INTERNAL_ERROR)
+
+
+def test_archive_traces_raises_internal_error_when_resolution_returns_no_retention(
+    store: SqlAlchemyStore, monkeypatch
+):
+    def _broken_resolve_trace_archival_config(
+        *, default_trace_archival_location, default_retention
+    ):
+        return ResolvedTraceArchivalConfig(
+            config=TraceArchivalConfig(
+                location=default_trace_archival_location,
+                retention=None,
+            ),
+            append_workspace_prefix=False,
+        )
+
+    monkeypatch.setattr(
+        store,
+        "resolve_trace_archival_config",
+        _broken_resolve_trace_archival_config,
+    )
+
+    with pytest.raises(
+        MlflowException, match="config resolution returned no archival retention"
+    ) as exc_info:
+        store.archive_traces(
+            default_trace_archival_location="s3://archive/default",
+            default_retention="1d",
+        )
+    assert exc_info.value.error_code == ErrorCode.Name(INTERNAL_ERROR)
+
+
+def test_archive_traces_respects_experiment_retention_and_archive_now(store: SqlAlchemyStore):
+    now_millis = 20 * 24 * 60 * 60 * 1000
+    exp_short_retention = store.create_experiment("archive-short-retention")
+    exp_archive_now = store.create_experiment("archive-now")
+    short_old_request_time = now_millis - 2 * 24 * 60 * 60 * 1000  # 2 days old
+    short_new_request_time = now_millis - 12 * 60 * 60 * 1000  # 12 hours old
+    now_old_request_time = now_millis - 2 * 24 * 60 * 60 * 1000  # 2 days old
+    now_new_request_time = now_millis - 2 * 60 * 60 * 1000  # 2 hours old
+
+    store.set_experiment_tag(
+        exp_short_retention,
+        ExperimentTag(
+            TraceExperimentTagKey.ARCHIVAL_RETENTION,
+            json.dumps({"type": "duration", "value": "1d"}),
+        ),
+    )
+    store.set_experiment_tag(
+        exp_archive_now,
+        ExperimentTag(TraceExperimentTagKey.ARCHIVE_NOW, json.dumps({"older_than": "1d"})),
+    )
+
+    _create_trace(
+        store,
+        "tr-short-old",
+        exp_short_retention,
+        request_time=short_old_request_time,
+    )
+    _create_trace(
+        store,
+        "tr-short-new",
+        exp_short_retention,
+        request_time=short_new_request_time,
+    )
+    _create_trace(
+        store,
+        "tr-now-old",
+        exp_archive_now,
+        request_time=now_old_request_time,
+    )
+    _create_trace(
+        store,
+        "tr-now-new",
+        exp_archive_now,
+        request_time=now_new_request_time,
+    )
+    store.log_spans(
+        exp_short_retention,
+        [
+            create_test_span(
+                "tr-short-old",
+                span_id=111,
+                start_ns=short_old_request_time * 1_000_000,
+                end_ns=(short_old_request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+    store.log_spans(
+        exp_short_retention,
+        [
+            create_test_span(
+                "tr-short-new",
+                span_id=112,
+                start_ns=short_new_request_time * 1_000_000,
+                end_ns=(short_new_request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+    store.log_spans(
+        exp_archive_now,
+        [
+            create_test_span(
+                "tr-now-old",
+                span_id=211,
+                start_ns=now_old_request_time * 1_000_000,
+                end_ns=(now_old_request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+    store.log_spans(
+        exp_archive_now,
+        [
+            create_test_span(
+                "tr-now-new",
+                span_id=212,
+                start_ns=now_new_request_time * 1_000_000,
+                end_ns=(now_new_request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        archived = _archive_traces(
+            store,
+            default_trace_archival_location=archive_root.as_uri(),
+            default_retention="30d",
+            now_millis=now_millis,
+        )
+
+    assert archived == 2
+    assert store.get_trace_info("tr-short-old").tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.ARCHIVE_REPO.value
+    )
+    assert store.get_trace_info("tr-now-old").tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.ARCHIVE_REPO.value
+    )
+    assert store.get_trace_info("tr-short-new").tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.TRACKING_STORE.value
+    )
+    assert store.get_trace_info("tr-now-new").tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.TRACKING_STORE.value
+    )
+    assert TraceExperimentTagKey.ARCHIVE_NOW not in store.get_experiment(exp_archive_now).tags
+
+
+def test_archive_traces_skips_regular_pass_when_archive_now_covers_retention(
+    store: SqlAlchemyStore, monkeypatch
+):
+    now_millis = 20 * 24 * 60 * 60 * 1000
+    day_millis = 24 * 60 * 60 * 1000
+    exp_id = store.create_experiment("archive-now-covers-retention")
+    find_calls = []
+
+    store.set_experiment_tag(
+        exp_id,
+        ExperimentTag(
+            TraceExperimentTagKey.ARCHIVAL_RETENTION,
+            json.dumps({"type": "duration", "value": "7d"}),
+        ),
+    )
+    store.set_experiment_tag(
+        exp_id,
+        ExperimentTag(TraceExperimentTagKey.ARCHIVE_NOW, json.dumps({"older_than": "1d"})),
+    )
+
+    def _capture_find_archivable_trace_candidates_for_experiments(
+        *, session, experiment_ids, max_timestamp_millis, limit
+    ):
+        find_calls.append((tuple(experiment_ids), max_timestamp_millis, limit))
+        return []
+
+    monkeypatch.setattr(
+        store,
+        "_find_archivable_trace_candidates_for_experiments",
+        _capture_find_archivable_trace_candidates_for_experiments,
+    )
+
+    archived = _archive_traces(
+        store,
+        default_trace_archival_location="s3://archive/default",
+        default_retention="30d",
+        now_millis=now_millis,
+    )
+
+    assert archived == 0
+    assert ((exp_id,), now_millis - day_millis, 100) in find_calls
+    assert all(
+        exp_id not in experiment_ids or max_timestamp_millis != now_millis - 7 * day_millis
+        for experiment_ids, max_timestamp_millis, _ in find_calls
+    )
+
+
+def test_archive_traces_keeps_oldest_archive_now_candidates_when_bounded(
+    store: SqlAlchemyStore, monkeypatch
+):
+    exp_older = store.create_experiment("archive-now-bounded-older")
+    exp_newer = store.create_experiment("archive-now-bounded-newer")
+    archived_trace_ids = []
+
+    for exp_id in (exp_older, exp_newer):
+        store.set_experiment_tag(
+            exp_id,
+            ExperimentTag(TraceExperimentTagKey.ARCHIVE_NOW, json.dumps({})),
+        )
+
+    grouped_candidates = [
+        _TraceArchiveCandidate(
+            trace_id="tr-oldest",
+            experiment_id=exp_newer,
+            timestamp_ms=10,
+        ),
+        _TraceArchiveCandidate(
+            trace_id="tr-second-oldest",
+            experiment_id=exp_older,
+            timestamp_ms=20,
+        ),
+        _TraceArchiveCandidate(
+            trace_id="tr-third-oldest",
+            experiment_id=exp_newer,
+            timestamp_ms=30,
+        ),
+        _TraceArchiveCandidate(
+            trace_id="tr-fourth-oldest",
+            experiment_id=exp_older,
+            timestamp_ms=40,
+        ),
+    ]
+
+    def _capture_find_archivable_trace_candidates_for_experiments(
+        *, session, experiment_ids, max_timestamp_millis, limit
+    ):
+        assert experiment_ids == [exp_older, exp_newer]
+        assert max_timestamp_millis is None
+        assert limit == 2
+        return grouped_candidates
+
+    def _capture_archive_trace_candidate(*, trace_id, trace_archival_config):
+        archived_trace_ids.append(trace_id)
+        return True
+
+    monkeypatch.setattr(
+        store,
+        "_find_archivable_trace_candidates_for_experiments",
+        _capture_find_archivable_trace_candidates_for_experiments,
+    )
+    monkeypatch.setattr(
+        store,
+        "_archive_trace_candidate",
+        _capture_archive_trace_candidate,
+    )
+
+    archived = store.archive_traces(
+        default_trace_archival_location="s3://archive/default",
+        default_retention="30d",
+        max_traces=2,
+    )
+
+    assert archived == 2
+    assert archived_trace_ids == ["tr-oldest", "tr-second-oldest"]
+
+
+def test_archive_traces_groups_regular_candidate_queries_by_shared_cutoff(
+    store: SqlAlchemyStore, monkeypatch
+):
+    now_millis = 20 * 24 * 60 * 60 * 1000
+    exp_first = store.create_experiment("archive-regular-grouped-first")
+    exp_second = store.create_experiment("archive-regular-grouped-second")
+    find_calls = []
+
+    def _capture_find_archivable_trace_candidates_for_experiments(
+        *, session, experiment_ids, max_timestamp_millis, limit
+    ):
+        find_calls.append((tuple(experiment_ids), max_timestamp_millis, limit))
+        return []
+
+    monkeypatch.setattr(
+        store,
+        "_find_archivable_trace_candidates_for_experiments",
+        _capture_find_archivable_trace_candidates_for_experiments,
+    )
+
+    archived = _archive_traces(
+        store,
+        default_trace_archival_location="s3://archive/default",
+        default_retention="30d",
+        now_millis=now_millis,
+    )
+
+    assert archived == 0
+    assert len(find_calls) == 1
+    experiment_ids, max_timestamp_millis, limit = find_calls[0]
+    assert set(experiment_ids) == {"0", exp_first, exp_second}
+    assert max_timestamp_millis == now_millis - 30 * 24 * 60 * 60 * 1000
+    assert limit == 100
+
+
+def test_archive_traces_chunks_large_experiment_groups_and_keeps_oldest_candidates(
+    store: SqlAlchemyStore, monkeypatch
+):
+    monkeypatch.setattr(sqlalchemy_store_module, "_TRACE_ARCHIVAL_EXPERIMENT_ID_CHUNK_SIZE", 2)
+
+    now_millis = 40 * 24 * 60 * 60 * 1000
+    exp_recent = store.create_experiment("archive-chunked-recent")
+    exp_oldest = store.create_experiment("archive-chunked-oldest")
+    exp_second_oldest = store.create_experiment("archive-chunked-second-oldest")
+
+    trace_configs = [
+        (exp_recent, "tr-chunked-recent", now_millis - 3 * 24 * 60 * 60 * 1000, 811),
+        (exp_oldest, "tr-chunked-oldest", now_millis - 5 * 24 * 60 * 60 * 1000, 812),
+        (
+            exp_second_oldest,
+            "tr-chunked-second-oldest",
+            now_millis - 4 * 24 * 60 * 60 * 1000,
+            813,
+        ),
+    ]
+    for exp_id, trace_id, request_time, span_id in trace_configs:
+        _create_trace(store, trace_id, exp_id, request_time=request_time)
+        store.log_spans(
+            exp_id,
+            [
+                create_test_span(
+                    trace_id,
+                    span_id=span_id,
+                    start_ns=request_time * 1_000_000,
+                    end_ns=(request_time + 1_000) * 1_000_000,
+                )
+            ],
+        )
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        archived = _archive_traces(
+            store,
+            default_trace_archival_location=archive_root.as_uri(),
+            default_retention="1d",
+            max_traces=2,
+            now_millis=now_millis,
+        )
+
+    assert archived == 2
+    assert store.get_trace_info("tr-chunked-oldest").tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.ARCHIVE_REPO.value
+    )
+    assert store.get_trace_info("tr-chunked-second-oldest").tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.ARCHIVE_REPO.value
+    )
+    assert store.get_trace_info("tr-chunked-recent").tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.TRACKING_STORE.value
+    )
+
+
+def test_archive_traces_keeps_regular_pass_when_archive_now_is_narrower(
+    store: SqlAlchemyStore,
+):
+    day_millis = 24 * 60 * 60 * 1000
+    now_millis = 60 * day_millis
+    exp_id = store.create_experiment("archive-now-narrower-than-retention")
+    archive_now_trace_time = now_millis - 40 * day_millis
+    retention_trace_time = now_millis - 10 * day_millis
+    recent_trace_time = now_millis - 2 * day_millis
+
+    store.set_experiment_tag(
+        exp_id,
+        ExperimentTag(
+            TraceExperimentTagKey.ARCHIVAL_RETENTION,
+            json.dumps({"type": "duration", "value": "7d"}),
+        ),
+    )
+    store.set_experiment_tag(
+        exp_id,
+        ExperimentTag(TraceExperimentTagKey.ARCHIVE_NOW, json.dumps({"older_than": "30d"})),
+    )
+
+    for trace_id, request_time in (
+        ("tr-now-priority", archive_now_trace_time),
+        ("tr-now-retention", retention_trace_time),
+        ("tr-now-recent", recent_trace_time),
+    ):
+        _create_trace(store, trace_id, exp_id, request_time=request_time)
+        store.log_spans(
+            exp_id,
+            [
+                create_test_span(
+                    trace_id,
+                    span_id=request_time,
+                    start_ns=request_time * 1_000_000,
+                    end_ns=(request_time + 1_000) * 1_000_000,
+                )
+            ],
+        )
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        archived = _archive_traces(
+            store,
+            default_trace_archival_location=archive_root.as_uri(),
+            default_retention="30d",
+            now_millis=now_millis,
+        )
+
+    assert archived == 2
+    assert store.get_trace_info("tr-now-priority").tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.ARCHIVE_REPO.value
+    )
+    assert store.get_trace_info("tr-now-retention").tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.ARCHIVE_REPO.value
+    )
+    assert store.get_trace_info("tr-now-recent").tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.TRACKING_STORE.value
+    )
+    assert TraceExperimentTagKey.ARCHIVE_NOW not in store.get_experiment(exp_id).tags
+
+
+def test_archive_traces_queries_all_archive_now_groups_before_selecting_bounded_batch(
+    store: SqlAlchemyStore,
+):
+    exp_first = store.create_experiment("archive-now-first-group")
+    exp_second = store.create_experiment("archive-now-second-group")
+    for experiment_id, older_than in ((exp_first, "1d"), (exp_second, "2d")):
+        store.set_experiment_tag(
+            experiment_id,
+            ExperimentTag(
+                TraceExperimentTagKey.ARCHIVE_NOW, json.dumps({"older_than": older_than})
+            ),
+        )
+
+    first_candidate = sqlalchemy_store_module._TraceArchiveCandidate(
+        trace_id="tr-archive-now-newer",
+        experiment_id=exp_first,
+        timestamp_ms=10,
+    )
+    second_candidate = sqlalchemy_store_module._TraceArchiveCandidate(
+        trace_id="tr-archive-now-older",
+        experiment_id=exp_second,
+        timestamp_ms=1,
+    )
+    archived_trace_ids = []
+
+    def record_archive_candidate(*, trace_id, trace_archival_config):
+        archived_trace_ids.append(trace_id)
+        return True
+
+    with (
+        mock.patch.object(
+            store,
+            "_find_archivable_trace_candidates_for_experiments",
+            side_effect=[[first_candidate], [second_candidate]],
+        ) as mock_find_candidates,
+        mock.patch.object(
+            store, "_archive_trace_candidate", side_effect=record_archive_candidate
+        ) as mock_archive_candidate,
+    ):
+        archived = _archive_traces(
+            store,
+            default_trace_archival_location="file:///unused-archive-root",
+            default_retention="30d",
+            max_traces=1,
+            now_millis=40 * 24 * 60 * 60 * 1000,
+        )
+
+    assert archived == 1
+    assert mock_find_candidates.call_count == 2
+    assert archived_trace_ids == ["tr-archive-now-older"]
+    mock_archive_candidate.assert_called_once()
+
+
+def test_archive_traces_queries_all_regular_groups_before_selecting_bounded_batch(
+    store: SqlAlchemyStore,
+):
+    exp_first = store.create_experiment("archive-regular-first-group")
+    exp_second = store.create_experiment("archive-regular-second-group")
+    for experiment_id, retention in ((exp_first, "1d"), (exp_second, "2d")):
+        store.set_experiment_tag(
+            experiment_id,
+            ExperimentTag(
+                TraceExperimentTagKey.ARCHIVAL_RETENTION,
+                json.dumps({"type": "duration", "value": retention}),
+            ),
+        )
+
+    first_candidate = sqlalchemy_store_module._TraceArchiveCandidate(
+        trace_id="tr-regular-newer",
+        experiment_id=exp_first,
+        timestamp_ms=10,
+    )
+    second_candidate = sqlalchemy_store_module._TraceArchiveCandidate(
+        trace_id="tr-regular-older",
+        experiment_id=exp_second,
+        timestamp_ms=1,
+    )
+    archived_trace_ids = []
+    queried_experiment_ids = []
+
+    def record_archive_candidate(*, trace_id, trace_archival_config):
+        archived_trace_ids.append(trace_id)
+        return True
+
+    def find_candidates(*, experiment_ids, session, max_timestamp_millis, limit):
+        queried_experiment_ids.append(tuple(experiment_ids))
+        if experiment_ids == [exp_first]:
+            return [first_candidate]
+        if experiment_ids == [exp_second]:
+            return [second_candidate]
+        return []
+
+    with (
+        mock.patch.object(
+            store,
+            "_find_archivable_trace_candidates_for_experiments",
+            side_effect=find_candidates,
+        ) as mock_find_candidates,
+        mock.patch.object(
+            store, "_archive_trace_candidate", side_effect=record_archive_candidate
+        ) as mock_archive_candidate,
+    ):
+        archived = _archive_traces(
+            store,
+            default_trace_archival_location="file:///unused-archive-root",
+            default_retention="30d",
+            max_traces=1,
+            now_millis=40 * 24 * 60 * 60 * 1000,
+        )
+
+    assert archived == 1
+    assert (exp_first,) in queried_experiment_ids
+    assert (exp_second,) in queried_experiment_ids
+    assert mock_find_candidates.call_count >= 2
+    assert archived_trace_ids == ["tr-regular-older"]
+    mock_archive_candidate.assert_called_once()
+
+
+def test_archive_traces_respects_workspace_trace_archival_location_overrides(
+    store: SqlAlchemyStore, workspaces_enabled: bool
+):
+    if not workspaces_enabled:
+        pytest.skip("Workspace root override behavior only applies when workspaces are enabled.")
+
+    workspace_store = store._get_workspace_provider_instance()
+    exp_id = store.create_experiment("archive-workspace-override")
+    now_millis = 30 * 24 * 60 * 60 * 1000
+    old_request_time = now_millis - 2 * 24 * 60 * 60 * 1000  # 2 days old
+    new_request_time = now_millis - 12 * 60 * 60 * 1000  # 12 hours old
+
+    with TempDir() as tmp:
+        server_archive_root = Path(tmp.path("server-archive"))
+        workspace_artifact_root = Path(tmp.path("workspace-artifacts"))
+        workspace_archive_root = Path(tmp.path("workspace-archive"))
+        server_archive_root.mkdir()
+        workspace_artifact_root.mkdir()
+        workspace_archive_root.mkdir()
+        workspace_store.update_workspace(
+            Workspace(
+                name=DEFAULT_WORKSPACE_NAME,
+                default_artifact_root=workspace_artifact_root.as_uri(),
+                trace_archival_location=workspace_archive_root.as_uri(),
+            )
+        )
+
+        _create_trace(
+            store,
+            "tr-workspace-old",
+            exp_id,
+            request_time=old_request_time,
+        )
+        _create_trace(
+            store,
+            "tr-workspace-new",
+            exp_id,
+            request_time=new_request_time,
+        )
+        store.log_spans(
+            exp_id,
+            [
+                create_test_span(
+                    "tr-workspace-old",
+                    span_id=311,
+                    start_ns=old_request_time * 1_000_000,
+                    end_ns=(old_request_time + 1_000) * 1_000_000,
+                )
+            ],
+        )
+        store.log_spans(
+            exp_id,
+            [
+                create_test_span(
+                    "tr-workspace-new",
+                    span_id=312,
+                    start_ns=new_request_time * 1_000_000,
+                    end_ns=(new_request_time + 1_000) * 1_000_000,
+                )
+            ],
+        )
+
+        archived = _archive_traces(
+            store,
+            default_trace_archival_location=server_archive_root.as_uri(),
+            default_retention="1d",
+            now_millis=now_millis,
+        )
+
+        assert archived == 1
+        archived_trace_info = store.get_trace_info("tr-workspace-old")
+        expected_workspace_archive_uri = append_to_uri_path(
+            workspace_archive_root.as_uri(),
+            exp_id,
+            SqlAlchemyStore.TRACE_FOLDER_NAME,
+            "tr-workspace-old",
+            SqlAlchemyStore.ARTIFACTS_FOLDER_NAME,
+        )
+        assert archived_trace_info.tags[TraceTagKey.ARCHIVE_LOCATION] == (
+            expected_workspace_archive_uri
+        )
+        assert (
+            workspace_archive_root
+            / exp_id
+            / SqlAlchemyStore.TRACE_FOLDER_NAME
+            / "tr-workspace-old"
+            / SqlAlchemyStore.ARTIFACTS_FOLDER_NAME
+            / "traces.pb"
+        ).is_file()
+        assert not (
+            workspace_artifact_root
+            / exp_id
+            / SqlAlchemyStore.TRACE_FOLDER_NAME
+            / "tr-workspace-old"
+            / SqlAlchemyStore.ARTIFACTS_FOLDER_NAME
+            / "traces.pb"
+        ).exists()
+        assert not (
+            server_archive_root
+            / WORKSPACES_DIR_NAME
+            / DEFAULT_WORKSPACE_NAME
+            / exp_id
+            / SqlAlchemyStore.TRACE_FOLDER_NAME
+            / "tr-workspace-old"
+            / SqlAlchemyStore.ARTIFACTS_FOLDER_NAME
+            / "traces.pb"
+        ).exists()
+
+    assert store.get_trace_info("tr-workspace-new").tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.TRACKING_STORE.value
+    )
+
+
+def test_archive_traces_respects_workspace_trace_archival_retention(
+    store: SqlAlchemyStore, workspaces_enabled: bool
+):
+    if not workspaces_enabled:
+        pytest.skip("Workspace retention behavior only applies when workspaces are enabled.")
+
+    workspace_store = store._get_workspace_provider_instance()
+    workspace_store.update_workspace(
+        Workspace(name=DEFAULT_WORKSPACE_NAME, trace_archival_retention="1d")
+    )
+    exp_id = store.create_experiment("archive-workspace-retention")
+    now_millis = 35 * 24 * 60 * 60 * 1000
+    old_request_time = now_millis - 2 * 24 * 60 * 60 * 1000  # 2 days old
+    new_request_time = now_millis - 12 * 60 * 60 * 1000  # 12 hours old
+
+    _create_trace(store, "tr-workspace-retention-old", exp_id, request_time=old_request_time)
+    _create_trace(store, "tr-workspace-retention-new", exp_id, request_time=new_request_time)
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                "tr-workspace-retention-old",
+                span_id=321,
+                start_ns=old_request_time * 1_000_000,
+                end_ns=(old_request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                "tr-workspace-retention-new",
+                span_id=322,
+                start_ns=new_request_time * 1_000_000,
+                end_ns=(new_request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        archived = _archive_traces(
+            store,
+            default_trace_archival_location=archive_root.as_uri(),
+            default_retention="30d",
+            now_millis=now_millis,
+        )
+
+    assert archived == 1
+    assert store.get_trace_info("tr-workspace-retention-old").tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.ARCHIVE_REPO.value
+    )
+    assert store.get_trace_info("tr-workspace-retention-new").tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.TRACKING_STORE.value
+    )
+
+
+def test_archive_traces_respects_workspace_retention_long_retention_allowlist(
+    store: SqlAlchemyStore, workspaces_enabled: bool
+):
+    if not workspaces_enabled:
+        pytest.skip("Workspace retention behavior only applies when workspaces are enabled.")
+
+    workspace_store = store._get_workspace_provider_instance()
+    workspace_store.update_workspace(
+        Workspace(name=DEFAULT_WORKSPACE_NAME, trace_archival_retention="30d")
+    )
+    exp_allowlisted = store.create_experiment("archive-workspace-allowlisted")
+    exp_not_allowlisted = store.create_experiment("archive-workspace-not-allowlisted")
+    now_millis = 180 * 24 * 60 * 60 * 1000
+    request_time = now_millis - 45 * 24 * 60 * 60 * 1000  # 45 days old
+
+    for exp_id in (exp_allowlisted, exp_not_allowlisted):
+        store.set_experiment_tag(
+            exp_id,
+            ExperimentTag(
+                TraceExperimentTagKey.ARCHIVAL_RETENTION,
+                json.dumps({"type": "duration", "value": "90d"}),
+            ),
+        )
+
+    _create_trace(store, "tr-workspace-allowlisted", exp_allowlisted, request_time=request_time)
+    _create_trace(
+        store,
+        "tr-workspace-not-allowlisted",
+        exp_not_allowlisted,
+        request_time=request_time,
+    )
+    store.log_spans(
+        exp_allowlisted,
+        [
+            create_test_span(
+                "tr-workspace-allowlisted",
+                span_id=331,
+                start_ns=request_time * 1_000_000,
+                end_ns=(request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+    store.log_spans(
+        exp_not_allowlisted,
+        [
+            create_test_span(
+                "tr-workspace-not-allowlisted",
+                span_id=332,
+                start_ns=request_time * 1_000_000,
+                end_ns=(request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        archived = _archive_traces(
+            store,
+            default_trace_archival_location=archive_root.as_uri(),
+            default_retention="120d",
+            long_retention_allowlist={exp_allowlisted},
+            now_millis=now_millis,
+        )
+
+    assert archived == 1
+    assert store.get_trace_info("tr-workspace-allowlisted").tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.TRACKING_STORE.value
+    )
+    assert (
+        store.get_trace_info("tr-workspace-not-allowlisted").tags[TraceTagKey.SPANS_LOCATION]
+        == SpansLocation.ARCHIVE_REPO.value
+    )
+
+
+def test_archive_traces_noops_when_candidate_becomes_stale(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("archive-stale-candidate")
+    trace_id = "tr-stale-candidate"
+    now_millis = 40 * 24 * 60 * 60 * 1000
+    _create_trace(store, trace_id, exp_id, request_time=now_millis - 2 * 24 * 60 * 60 * 1000)
+    store.log_spans(exp_id, [create_test_span(trace_id, span_id=411)])
+
+    from mlflow.store.artifact.artifact_repo import ArtifactRepository
+
+    original_upload_archived_trace_data_bytes = ArtifactRepository.upload_archived_trace_data_bytes
+
+    def upload_bytes_and_mutate(self, data):
+        original_upload_archived_trace_data_bytes(self, data)
+        store.log_spans(exp_id, [create_test_span(trace_id, span_id=412)])
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        archive_payload_path = (
+            archive_root
+            / exp_id
+            / SqlAlchemyStore.TRACE_FOLDER_NAME
+            / trace_id
+            / SqlAlchemyStore.ARTIFACTS_FOLDER_NAME
+            / "traces.pb"
+        )
+        with mock.patch.object(
+            ArtifactRepository, "upload_archived_trace_data_bytes", new=upload_bytes_and_mutate
+        ):
+            archived = _archive_traces(
+                store,
+                default_trace_archival_location=archive_root.as_uri(),
+                default_retention="1d",
+                now_millis=now_millis,
+            )
+        assert not archive_payload_path.exists()
+
+    assert archived == 0
+    assert store.get_trace_info(trace_id).tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.TRACKING_STORE.value
+    )
+    with store.ManagedSessionMaker() as session:
+        contents = (
+            session
+            .query(SqlSpan.content)
+            .filter(SqlSpan.trace_id == trace_id)
+            .order_by(SqlSpan.span_id.asc())
+            .all()
+        )
+        assert all(content for (content,) in contents)
+
+
+def test_log_spans_rejects_archived_trace(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("archive-reject-log-spans")
+    trace_id = "tr-archive-reject-log-spans"
+    now_millis = 42 * 24 * 60 * 60 * 1000
+    request_time = now_millis - 2 * 24 * 60 * 60 * 1000
+
+    _create_trace(store, trace_id, exp_id, request_time=request_time)
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                trace_id,
+                span_id=421,
+                start_ns=request_time * 1_000_000,
+                end_ns=(request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        archived = _archive_traces(
+            store,
+            default_trace_archival_location=archive_root.as_uri(),
+            default_retention="1d",
+            now_millis=now_millis,
+        )
+
+        assert archived == 1
+        archived_trace_info = store.get_trace_info(trace_id)
+        assert (
+            archived_trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.ARCHIVE_REPO.value
+        )
+        archived_trace = store.get_trace(trace_id)
+
+        with pytest.raises(
+            MlflowException, match=f"Cannot log spans to archived traces: '{trace_id}'"
+        ) as exc_info:
+            store.log_spans(
+                exp_id,
+                [
+                    create_test_span(
+                        trace_id,
+                        span_id=422,
+                        start_ns=(request_time + 2_000) * 1_000_000,
+                        end_ns=(request_time + 3_000) * 1_000_000,
+                    )
+                ],
+            )
+
+        assert exc_info.value.error_code == ErrorCode.Name(INVALID_STATE)
+        trace_info = store.get_trace_info(trace_id)
+        assert trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.ARCHIVE_REPO.value
+        assert (
+            trace_info.tags[TraceTagKey.ARCHIVE_LOCATION]
+            == archived_trace_info.tags[TraceTagKey.ARCHIVE_LOCATION]
+        )
+        assert [span.span_id for span in store.get_trace(trace_id).data.spans] == [
+            span.span_id for span in archived_trace.data.spans
+        ]
+        with store.ManagedSessionMaker() as session:
+            contents = (
+                session
+                .query(SqlSpan.content)
+                .filter(SqlSpan.trace_id == trace_id)
+                .order_by(SqlSpan.span_id.asc())
+                .all()
+            )
+            assert contents == [("",)]
+
+
+def test_archive_traces_continues_after_upload_failure_and_cleans_up_completed_archive_now_requests(
+    store: SqlAlchemyStore,
+):
+    exp_fail = store.create_experiment("archive-upload-failure")
+    exp_success = store.create_experiment("archive-upload-success")
+    fail_trace_id = "tr-upload-failure"
+    success_trace_id = "tr-upload-success"
+    now_millis = 45 * 24 * 60 * 60 * 1000
+    fail_request_time = now_millis - 3 * 24 * 60 * 60 * 1000
+    success_request_time = now_millis - 2 * 24 * 60 * 60 * 1000
+
+    for exp_id in (exp_fail, exp_success):
+        store.set_experiment_tag(
+            exp_id,
+            ExperimentTag(TraceExperimentTagKey.ARCHIVE_NOW, json.dumps({})),
+        )
+
+    _create_trace(store, fail_trace_id, exp_fail, request_time=fail_request_time)
+    _create_trace(store, success_trace_id, exp_success, request_time=success_request_time)
+    store.log_spans(
+        exp_fail,
+        [
+            create_test_span(
+                fail_trace_id,
+                span_id=711,
+                start_ns=fail_request_time * 1_000_000,
+                end_ns=(fail_request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+    store.log_spans(
+        exp_success,
+        [
+            create_test_span(
+                success_trace_id,
+                span_id=712,
+                start_ns=success_request_time * 1_000_000,
+                end_ns=(success_request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+
+    from mlflow.store.artifact.artifact_repo import ArtifactRepository
+
+    original_upload_archived_trace_data_bytes = ArtifactRepository.upload_archived_trace_data_bytes
+    call_count = [0]
+
+    def upload_bytes_with_failure(self, data):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            raise RuntimeError("simulated archive upload failure")
+        return original_upload_archived_trace_data_bytes(self, data)
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        with mock.patch.object(
+            ArtifactRepository,
+            "upload_archived_trace_data_bytes",
+            new=upload_bytes_with_failure,
+        ):
+            archived = _archive_traces(
+                store,
+                default_trace_archival_location=archive_root.as_uri(),
+                default_retention="365d",
+                now_millis=now_millis,
+            )
+
+    assert archived == 1
+    assert store.get_trace_info(fail_trace_id).tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.TRACKING_STORE.value
+    )
+    assert store.get_trace_info(success_trace_id).tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.ARCHIVE_REPO.value
+    )
+    assert TraceExperimentTagKey.ARCHIVE_NOW in store.get_experiment(exp_fail).tags
+    assert TraceExperimentTagKey.ARCHIVE_NOW not in store.get_experiment(exp_success).tags
+
+
+def test_archive_traces_keeps_new_archive_now_request_added_mid_pass(
+    store: SqlAlchemyStore, monkeypatch
+):
+    now_millis = 62 * 24 * 60 * 60 * 1000
+    exp_id = store.create_experiment("archive-now-tag-replaced-mid-pass")
+    original_request = json.dumps({"older_than": "30d"})
+    replacement_request = json.dumps({"older_than": "1h"})
+    archived_trace_ids = []
+
+    store.set_experiment_tag(
+        exp_id, ExperimentTag(TraceExperimentTagKey.ARCHIVE_NOW, original_request)
+    )
+
+    def _find_candidates(*, session, experiment_ids, max_timestamp_millis, limit):
+        if exp_id in experiment_ids:
+            return [
+                _TraceArchiveCandidate(
+                    trace_id="tr-replaced-request",
+                    experiment_id=exp_id,
+                    timestamp_ms=1,
+                )
+            ]
+        return []
+
+    def _archive_candidate(*, trace_id, trace_archival_config):
+        archived_trace_ids.append(trace_id)
+        store.set_experiment_tag(
+            exp_id, ExperimentTag(TraceExperimentTagKey.ARCHIVE_NOW, replacement_request)
+        )
+        return True
+
+    monkeypatch.setattr(
+        store,
+        "_find_archivable_trace_candidates_for_experiments",
+        _find_candidates,
+    )
+    monkeypatch.setattr(store, "_archive_trace_candidate", _archive_candidate)
+    monkeypatch.setattr(store, "_get_archive_now_remaining_state", lambda **_: "done")
+
+    archived = _archive_traces(
+        store,
+        default_trace_archival_location="file:///unused-archive-root",
+        default_retention="365d",
+        max_traces=1,
+        now_millis=now_millis,
+    )
+
+    assert archived == 1
+    assert archived_trace_ids == ["tr-replaced-request"]
+    assert (
+        store.get_experiment(exp_id).tags[TraceExperimentTagKey.ARCHIVE_NOW] == replacement_request
+    )
+
+
+def test_archive_traces_marks_malformed_traces_and_excludes_retries(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("archive-malformed-trace")
+    trace_id = "tr-malformed"
+    now_millis = 50 * 24 * 60 * 60 * 1000
+
+    _create_trace(store, trace_id, exp_id, request_time=now_millis - 2 * 24 * 60 * 60 * 1000)
+    store.log_spans(exp_id, [create_test_span(trace_id, span_id=511)])
+    store.set_experiment_tag(
+        exp_id, ExperimentTag(TraceExperimentTagKey.ARCHIVE_NOW, json.dumps({}))
+    )
+
+    with store.ManagedSessionMaker() as session:
+        (
+            session
+            .query(SqlSpan)
+            .filter(SqlSpan.trace_id == trace_id)
+            .update({SqlSpan.content: "not-json"}, synchronize_session=False)
+        )
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        archived = _archive_traces(
+            store,
+            default_trace_archival_location=archive_root.as_uri(),
+            default_retention="365d",
+            now_millis=now_millis,
+        )
+        archived_again = _archive_traces(
+            store,
+            default_trace_archival_location=archive_root.as_uri(),
+            default_retention="365d",
+            now_millis=now_millis,
+        )
+
+    assert archived == 0
+    assert archived_again == 0
+    trace_info = store.get_trace_info(trace_id)
+    assert trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.TRACKING_STORE.value
+    assert trace_info.tags[TraceTagKey.ARCHIVAL_FAILURE] == (
+        TraceArchivalFailureReason.MALFORMED_TRACE.value
+    )
+    assert TraceExperimentTagKey.ARCHIVE_NOW not in store.get_experiment(exp_id).tags
+
+
+def test_archive_traces_marks_serializer_failures_as_malformed_and_excludes_retries(
+    store: SqlAlchemyStore,
+):
+    exp_id = store.create_experiment("archive-serializer-malformed-trace")
+    trace_id = "tr-serializer-malformed"
+    now_millis = 55 * 24 * 60 * 60 * 1000
+
+    _create_trace(store, trace_id, exp_id, request_time=now_millis - 2 * 24 * 60 * 60 * 1000)
+    store.log_spans(exp_id, [create_test_span(trace_id, span_id=561)])
+    store.set_experiment_tag(
+        exp_id, ExperimentTag(TraceExperimentTagKey.ARCHIVE_NOW, json.dumps({}))
+    )
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        with mock.patch(
+            "mlflow.tracing.otel.otel_archival.spans_to_traces_data_pb",
+            side_effect=MlflowException.invalid_parameter_value("simulated malformed trace"),
+        ):
+            archived = _archive_traces(
+                store,
+                default_trace_archival_location=archive_root.as_uri(),
+                default_retention="365d",
+                now_millis=now_millis,
+            )
+            archived_again = _archive_traces(
+                store,
+                default_trace_archival_location=archive_root.as_uri(),
+                default_retention="365d",
+                now_millis=now_millis,
+            )
+
+    assert archived == 0
+    assert archived_again == 0
+    trace_info = store.get_trace_info(trace_id)
+    assert trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.TRACKING_STORE.value
+    assert trace_info.tags[TraceTagKey.ARCHIVAL_FAILURE] == (
+        TraceArchivalFailureReason.MALFORMED_TRACE.value
+    )
+    assert TraceExperimentTagKey.ARCHIVE_NOW not in store.get_experiment(exp_id).tags
+
+
+def test_archive_traces_marks_unsupported_archive_repository_as_terminal_failure(
+    store: SqlAlchemyStore,
+):
+    exp_id = store.create_experiment("archive-unsupported-repository")
+    trace_id = "tr-unsupported-repository"
+    now_millis = 57 * 24 * 60 * 60 * 1000
+
+    _create_trace(store, trace_id, exp_id, request_time=now_millis - 2 * 24 * 60 * 60 * 1000)
+    store.log_spans(exp_id, [create_test_span(trace_id, span_id=571)])
+    store.set_experiment_tag(
+        exp_id, ExperimentTag(TraceExperimentTagKey.ARCHIVE_NOW, json.dumps({}))
+    )
+
+    from mlflow.store.artifact.artifact_repo import ArtifactRepository
+
+    def upload_bytes_unsupported(self, data):
+        raise MlflowNotImplementedException(
+            "Databricks trace artifact repositories do not yet support ARCHIVE_REPO trace payloads."
+        )
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        with mock.patch.object(
+            ArtifactRepository,
+            "upload_archived_trace_data_bytes",
+            new=upload_bytes_unsupported,
+        ):
+            archived = _archive_traces(
+                store,
+                default_trace_archival_location=archive_root.as_uri(),
+                default_retention="365d",
+                now_millis=now_millis,
+            )
+            archived_again = _archive_traces(
+                store,
+                default_trace_archival_location=archive_root.as_uri(),
+                default_retention="365d",
+                now_millis=now_millis,
+            )
+
+    assert archived == 0
+    assert archived_again == 0
+    trace_info = store.get_trace_info(trace_id)
+    assert trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.TRACKING_STORE.value
+    assert trace_info.tags[TraceTagKey.ARCHIVAL_FAILURE] == (
+        TraceArchivalFailureReason.UNSUPPORTED_ARCHIVE_REPOSITORY.value
+    )
+    assert TraceExperimentTagKey.ARCHIVE_NOW not in store.get_experiment(exp_id).tags
+
+
+def test_archive_traces_keeps_archive_now_when_only_unmarked_non_archivable_traces_remain(
+    store: SqlAlchemyStore,
+):
+    exp_id = store.create_experiment("archive-now-terminal-non-archivable")
+    trace_id = "tr-terminal-non-archivable"
+    now_millis = 58 * 24 * 60 * 60 * 1000
+
+    _create_trace(store, trace_id, exp_id, request_time=now_millis - 2 * 24 * 60 * 60 * 1000)
+    store.set_experiment_tag(
+        exp_id, ExperimentTag(TraceExperimentTagKey.ARCHIVE_NOW, json.dumps({}))
+    )
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        archived = _archive_traces(
+            store,
+            default_trace_archival_location=archive_root.as_uri(),
+            default_retention="365d",
+            now_millis=now_millis,
+        )
+
+    assert archived == 0
+    trace_info = store.get_trace_info(trace_id)
+    assert trace_info.tags.get(TraceTagKey.SPANS_LOCATION) is None
+    assert TraceTagKey.ARCHIVAL_FAILURE not in trace_info.tags
+    assert TraceExperimentTagKey.ARCHIVE_NOW in store.get_experiment(exp_id).tags
+
+
+def test_archive_traces_leaves_unexpected_deserialization_errors_retryable(
+    store: SqlAlchemyStore,
+):
+    exp_id = store.create_experiment("archive-unexpected-deserialize-error")
+    trace_id = "tr-unexpected-deserialize-error"
+    now_millis = 59 * 24 * 60 * 60 * 1000
+    request_time = now_millis - 2 * 24 * 60 * 60 * 1000
+
+    _create_trace(store, trace_id, exp_id, request_time=request_time)
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                trace_id,
+                span_id=581,
+                start_ns=request_time * 1_000_000,
+                end_ns=(request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+    store.set_experiment_tag(
+        exp_id, ExperimentTag(TraceExperimentTagKey.ARCHIVE_NOW, json.dumps({}))
+    )
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        with mock.patch.object(
+            store,
+            "_serialize_trace_archival_snapshot_to_pb",
+            side_effect=RuntimeError("simulated unexpected serialize failure"),
+        ):
+            archived = _archive_traces(
+                store,
+                default_trace_archival_location=archive_root.as_uri(),
+                default_retention="365d",
+                now_millis=now_millis,
+            )
+
+        assert archived == 0
+        assert TraceExperimentTagKey.ARCHIVE_NOW in store.get_experiment(exp_id).tags
+
+        archived_again = _archive_traces(
+            store,
+            default_trace_archival_location=archive_root.as_uri(),
+            default_retention="365d",
+            now_millis=now_millis,
+        )
+
+    assert archived_again == 1
+    trace_info = store.get_trace_info(trace_id)
+    assert trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.ARCHIVE_REPO.value
+    assert TraceTagKey.ARCHIVAL_FAILURE not in trace_info.tags
+    assert TraceExperimentTagKey.ARCHIVE_NOW not in store.get_experiment(exp_id).tags
+
+
+def test_archive_traces_keeps_archive_now_when_matching_traces_are_transiently_blocked(
+    store: SqlAlchemyStore,
+):
+    exp_id = store.create_experiment("archive-now-transiently-blocked")
+    now_millis = 60 * 24 * 60 * 60 * 1000
+    archivable_trace_id = "tr-now-archivable"
+    in_progress_trace_id = "tr-now-in-progress"
+    request_time = now_millis - 2 * 24 * 60 * 60 * 1000  # 2 days old
+
+    store.set_experiment_tag(
+        exp_id, ExperimentTag(TraceExperimentTagKey.ARCHIVE_NOW, json.dumps({}))
+    )
+    _create_trace(store, archivable_trace_id, exp_id, request_time=request_time)
+    _create_trace(
+        store,
+        in_progress_trace_id,
+        exp_id,
+        request_time=request_time,
+        state=TraceState.IN_PROGRESS,
+    )
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                archivable_trace_id,
+                span_id=611,
+                start_ns=request_time * 1_000_000,
+                end_ns=(request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        archived = _archive_traces(
+            store,
+            default_trace_archival_location=archive_root.as_uri(),
+            default_retention="365d",
+            now_millis=now_millis,
+        )
+
+    assert archived == 1
+    assert store.get_trace_info(archivable_trace_id).tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.ARCHIVE_REPO.value
+    )
+    assert TraceExperimentTagKey.ARCHIVE_NOW in store.get_experiment(exp_id).tags

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -12,6 +12,7 @@ from mlflow.utils.os import is_windows
 from mlflow.utils.validation import (
     MAX_TAG_VAL_LENGTH,
     _is_numeric,
+    _parse_trace_archival_duration_config,
     _validate_batch_log_data,
     _validate_batch_log_limits,
     _validate_db_type_string,
@@ -106,6 +107,33 @@ BAD_ALIAS_NAMES = [
 )
 def test_path_not_unique(path, expected):
     assert path_not_unique(path) is expected
+
+
+def test_parse_trace_archival_duration_config_archive_now():
+    assert (
+        _parse_trace_archival_duration_config(
+            '{"older_than": " 7d "}',
+            duration_key="older_than",
+            allow_missing_duration=True,
+        )
+        == "7d"
+    )
+
+
+def test_parse_trace_archival_duration_config_experiment_retention():
+    assert (
+        _parse_trace_archival_duration_config(
+            '{"type": "duration", "value": "12h"}',
+            duration_key="value",
+            expected_type="duration",
+        )
+        == "12h"
+    )
+
+
+def test_parse_trace_archival_duration_config_rejects_non_object():
+    with pytest.raises(MlflowException, match="JSON object"):
+        _parse_trace_archival_duration_config('["1d"]', duration_key="value")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/mlflow/rfcs/blob/main/rfcs/0001-trace-archival/0001-trace-archival.md

### What changes are proposed in this pull request?

This PR is intentionally scoped to the base SQLAlchemy archival pass only. Two pieces are split into follow-up PRs to keep review size manageable:

- write/archival coordination hardening will land in a follow-up PR
- archived-trace retrieval plumbing will land in a later follow-up PR

Please scope review here to the archival candidate selection, export, finalization logic, and the associated tests. If you notice issues around late `log_spans()` races or archived-trace retrieval behavior, those are already planned for the follow-up PRs above.

Known non-blocking limitations that still apply to this PR:
- permanent trace deletion does not yet clean up archived `traces.pb` objects, so archived payloads can still be orphaned; that is a separate follow-up outside this PR split
- archived `traces.pb` payloads preserve MLflow’s current flattened trace model rather than full OTLP `ResourceSpans` / `ScopeSpans` fidelity; this is inherited from the existing DB-backed span representation rather than introduced by the follow-up PRs
- `mlflow.trace.archiveLocation` is not being made server-side immutable in this stack; that matches the existing `mlflow.artifactLocation` behavior and would need to be tightened uniformly in a separate change

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests


### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
