### PR TITLE
Fix 'occured' -> 'occurred' typos in mlflow trace explorer / delete-trace UI

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/GenAiDeleteTraceModal.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/GenAiDeleteTraceModal.tsx
@@ -30,7 +30,7 @@ export const GenAiDeleteTraceModal = ({
     } catch (e: any) {
       setErrorMessage(
         intl.formatMessage({
-          defaultMessage: 'An error occured while attempting to delete traces. Please refresh the page and try again.',
+          defaultMessage: 'An error occurred while attempting to delete traces. Please refresh the page and try again.',
           description: 'Experiment page > traces view controls > Delete traces modal > Error message',
         }),
       );

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/oss-notebook-renderer/ModelTraceExplorerOSSNotebookRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/oss-notebook-renderer/ModelTraceExplorerOSSNotebookRenderer.tsx
@@ -76,7 +76,7 @@ export const ModelTraceExplorerOSSNotebookRenderer = () => {
     );
   }
 
-  // some error occured
+  // some error occurred
   if (!traceData) {
     return (
       <div css={{ paddingTop: theme.spacing.md, width: 'calc(100% - 2px)' }}>
@@ -87,7 +87,7 @@ export const ModelTraceExplorerOSSNotebookRenderer = () => {
               <Typography.Paragraph>
                 <FormattedMessage
                   defaultMessage="An error occurred while attempting to fetch trace data (ID: {traceId}). Please ensure that the MLflow tracking server is running, and that the trace data exists. Error details:"
-                  description="An error message explaining that an error occured while fetching trace data"
+                  description="An error message explaining that an error occurred while fetching trace data"
                   values={{ traceId: traceIds[activeTraceIndex] }}
                 />
               </Typography.Paragraph>


### PR DESCRIPTION
Three string literals across two trace-related React components used `occured` in user-facing messages:

- `mlflow/server/js/src/shared/web-shared/genai-traces-table/components/GenAiDeleteTraceModal.tsx:33` — delete-failure modal `defaultMessage` rendered to the user.
- `mlflow/server/js/src/shared/web-shared/model-trace-explorer/oss-notebook-renderer/ModelTraceExplorerOSSNotebookRenderer.tsx` — inline comment (line 79) plus the description text shown when fetching trace data fails (line 90).

All edits are string-literal / comment changes inside React components.