### PR TITLE
Add DNF package manager support to `dev-env-setup.sh`

### DIFF
--- a/dev/dev-env-setup.sh
+++ b/dev/dev-env-setup.sh
@@ -104,6 +104,15 @@ case "$(uname -s)" in
   *)                             machine=unknown;;
 esac
 
+# Detect Linux package manager
+if command -v dnf >/dev/null 2>&1; then
+  pkg_manager=dnf
+elif command -v apt-get >/dev/null 2>&1; then
+  pkg_manager=apt
+else
+  pkg_manager=unknown
+fi
+
 load_progress() {
   if [[ ! -f "$PROGRESS_FILE" ]]; then
     echo "0" > "$PROGRESS_FILE"
@@ -186,10 +195,19 @@ check_and_install_pyenv() {
         brew install pyenv
         brew install openssl readline sqlite3 xz zlib libomp
       elif [[ "$machine" == linux ]]; then
-        sudo apt-get update -y
-        sudo apt-get install -y make build-essential libssl-dev zlib1g-dev \
-          libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
-          libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
+        if [[ "$pkg_manager" == dnf ]]; then
+          sudo dnf install -y make gcc zlib-devel bzip2 bzip2-devel readline-devel sqlite \
+            sqlite-devel openssl-devel tk-devel libffi-devel xz-devel wget curl llvm \
+            libxml2-devel xmlsec1-devel patch
+        elif [[ "$pkg_manager" == apt ]]; then
+          sudo apt-get update -y
+          sudo apt-get install -y make build-essential libssl-dev zlib1g-dev \
+            libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
+            libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
+        else
+          echo "Unsupported package manager. Please install pyenv dependencies manually: https://github.com/pyenv/pyenv/wiki#suggested-build-environment"
+          exit 1
+        fi
         # Install pyenv from source
         git clone --depth 1 https://github.com/pyenv/pyenv.git "$HOME/.pyenv"
         PYENV_ROOT="$HOME/.pyenv"
@@ -318,11 +336,17 @@ check_and_install_pandoc() {
         check_and_install_brew "pandoc"
         brew install pandoc
       elif [[ "$machine" == linux ]]; then
-        # Install pandoc via deb package as `apt-get` gives too old version
-        TEMP_DEB=$(mktemp) &&
-          wget --directory-prefix $TEMP_DEB https://github.com/jgm/pandoc/releases/download/2.16.2/pandoc-2.16.2-1-amd64.deb &&
-          sudo dpkg --install $(find $TEMP_DEB -name '*.deb') &&
-          rm -rf $TEMP_DEB
+        if [[ "$pkg_manager" == dnf ]]; then
+          sudo dnf install -y pandoc
+        elif [[ "$pkg_manager" == apt ]]; then
+          # Install pandoc via deb package as `apt-get` gives too old version
+          TEMP_DEB=$(mktemp) &&
+            wget --directory-prefix $TEMP_DEB https://github.com/jgm/pandoc/releases/download/2.16.2/pandoc-2.16.2-1-amd64.deb &&
+            sudo dpkg --install $(find $TEMP_DEB -name '*.deb') &&
+            rm -rf $TEMP_DEB
+        else
+          echo "Unsupported package manager. Please install pandoc >= 2.2.1 manually: https://pandoc.org/installing.html"
+        fi
       else
         echo "Unsupported operating system environment: $machine. This setup script only supports MacOS and Linux. For other operating systems, please follow the manual setup instruction here: https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.md#manual-python-development-environment-configuration "
         exit 1


### PR DESCRIPTION
### Related Issues/PRs

Relates to #N/A

### What changes are proposed in this pull request?

The `dev/dev-env-setup.sh` script previously assumed `apt-get` for all Linux installs,
making it fail on RPM-based distros (Fedora, RHEL, CentOS, etc.).

This PR:
- Detects the Linux package manager at startup (`dnf` vs `apt-get`)
- Uses the appropriate package manager for pyenv dependency installation
- Uses `dnf install -y pandoc` on DNF systems (instead of manually downloading a `.deb`)
- Prints a clear error message with a link to manual instructions when neither `dnf` nor `apt-get` is found

### How is this PR tested?

- [x] Manual tests

Tested on Fedora 43 (dnf) and verified the existing apt-get path remains unchanged.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`dev/dev-env-setup.sh` now supports Fedora/RHEL/CentOS (DNF-based) Linux distributions in addition to Debian/Ubuntu (APT-based) systems.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)