### PR TITLE
Encode attachment size in `mlflow-attachment://` URI

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/media-rendering-utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/media-rendering-utils.tsx
@@ -4,6 +4,7 @@
  * and artifact viewing.
  */
 
+import { Typography } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
 
 // Auto-render size thresholds (bytes). Files exceeding these show a download link.
@@ -84,15 +85,12 @@ export function DownloadLink({
 
   if (onFetchDownload) {
     return (
-      <a
-        href="#"
-        onClick={(e) => {
-          e.preventDefault();
-          void onFetchDownload().catch(() => undefined);
-        }}
+      <Typography.Link
+        componentId="shared.media-rendering-utils.fetch-download"
+        onClick={() => void onFetchDownload().catch(() => undefined)}
       >
         {label}
-      </a>
+      </Typography.Link>
     );
   }
 

--- a/mlflow/server/js/src/shared/web-shared/media-rendering-utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/media-rendering-utils.tsx
@@ -88,7 +88,7 @@ export function DownloadLink({
         href="#"
         onClick={(e) => {
           e.preventDefault();
-          onFetchDownload();
+          void onFetchDownload().catch(() => undefined);
         }}
       >
         {label}

--- a/mlflow/server/js/src/shared/web-shared/media-rendering-utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/media-rendering-utils.tsx
@@ -45,6 +45,11 @@ export function formatFileSize(bytes: number): string {
 
 /**
  * Download link shown when media content exceeds the rendering size limit.
+ *
+ * When `url` is provided, renders a standard `<a>` download link.
+ * When `onFetchDownload` is provided instead, renders a clickable link that
+ * fetches the content on demand — used when the blob wasn't pre-fetched
+ * because the URI's size param indicated it exceeded the render limit.
  */
 export function DownloadLink({
   url,
@@ -52,20 +57,44 @@ export function DownloadLink({
   contentLength,
   filename,
   onClick,
+  onFetchDownload,
 }: {
-  url: string;
+  url?: string | null;
   contentType: string;
   contentLength: number;
   filename?: string;
   onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
+  onFetchDownload?: () => Promise<void>;
 }) {
-  return (
-    <a href={url} download={filename} onClick={onClick}>
-      <FormattedMessage
-        defaultMessage="Download {contentType} ({size})"
-        description="Download link for media content that exceeds the rendering size limit"
-        values={{ contentType, size: formatFileSize(contentLength) }}
-      />
-    </a>
+  const label = (
+    <FormattedMessage
+      defaultMessage="Download {contentType} ({size})"
+      description="Download link for media content that exceeds the rendering size limit"
+      values={{ contentType, size: formatFileSize(contentLength) }}
+    />
   );
+
+  if (url) {
+    return (
+      <a href={url} download={filename} onClick={onClick}>
+        {label}
+      </a>
+    );
+  }
+
+  if (onFetchDownload) {
+    return (
+      <a
+        href="#"
+        onClick={(e) => {
+          e.preventDefault();
+          onFetchDownload();
+        }}
+      >
+        {label}
+      </a>
+    );
+  }
+
+  return <span>{label}</span>;
 }

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/attachment-utils.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/attachment-utils.ts
@@ -1,5 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
+import { exceedsRenderSizeLimit } from '../media-rendering-utils';
 import { fetchOrFail, getAjaxUrl } from './ModelTraceExplorer.request.utils';
 
 async function getTraceAttachment(requestId: string, attachmentId: string): Promise<ArrayBuffer | undefined> {
@@ -14,7 +15,29 @@ async function getTraceAttachment(requestId: string, attachmentId: string): Prom
   }
 }
 
-export function parseAttachmentUri(uri: string): { attachmentId: string; traceId: string; contentType: string } | null {
+/**
+ * Programmatically fetches a blob and triggers a browser download.
+ */
+async function fetchAndDownload(traceId: string, attachmentId: string, contentType: string) {
+  const url = getAjaxUrl(
+    `ajax-api/2.0/mlflow/get-trace-artifact?request_id=${encodeURIComponent(traceId)}&path=${encodeURIComponent(attachmentId)}`,
+  );
+  const response = await fetchOrFail(url);
+  const arrayBuffer = await response.arrayBuffer();
+  const blob = new Blob([arrayBuffer], { type: contentType });
+  const blobUrl = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = blobUrl;
+  a.download = `attachment-${attachmentId}`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(blobUrl);
+}
+
+export function parseAttachmentUri(
+  uri: string,
+): { attachmentId: string; traceId: string; contentType: string; size?: number } | null {
   try {
     const parsed = new URL(uri);
     if (parsed.protocol !== 'mlflow-attachment:') {
@@ -26,7 +49,9 @@ export function parseAttachmentUri(uri: string): { attachmentId: string; traceId
     if (!attachmentId || !contentType || !traceId) {
       return null;
     }
-    return { attachmentId, contentType, traceId };
+    const sizeStr = parsed.searchParams.get('size');
+    const size = sizeStr ? Number(sizeStr) : undefined;
+    return { attachmentId, contentType, traceId, ...(size !== undefined && !Number.isNaN(size) ? { size } : {}) };
   } catch {
     return null;
   }
@@ -42,17 +67,23 @@ export function useAttachmentUrl(uri: string | null): {
   contentType: string | null;
   loading: boolean;
   error: boolean;
+  triggerDownload?: () => Promise<void>;
 } {
   const parsed = uri ? parseAttachmentUri(uri) : null;
+
+  // If the URI encodes a size that exceeds the render limit, skip the fetch entirely
+  // and let callers show a download link immediately.
+  const skipFetch = Boolean(parsed?.size !== undefined && exceedsRenderSizeLimit(parsed.contentType, parsed.size));
+
   const [url, setUrl] = useState<string | null>(null);
-  const [contentLength, setContentLength] = useState(0);
-  const [loading, setLoading] = useState(Boolean(parsed));
+  const [contentLength, setContentLength] = useState(skipFetch && parsed?.size ? parsed.size : 0);
+  const [loading, setLoading] = useState(Boolean(parsed) && !skipFetch);
   const [error, setError] = useState(false);
 
   useEffect(() => {
-    if (!parsed) {
+    if (!parsed || skipFetch) {
       setUrl(null);
-      setContentLength(0);
+      setContentLength(skipFetch && parsed?.size ? parsed.size : 0);
       setLoading(false);
       setError(false);
       return;
@@ -97,7 +128,20 @@ export function useAttachmentUrl(uri: string | null): {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [uri]);
 
-  return { url, loading, error, contentLength, contentType: parsed?.contentType ?? null };
+  const triggerDownload = useCallback(
+    () => fetchAndDownload(parsed!.traceId, parsed!.attachmentId, parsed!.contentType),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [uri],
+  );
+
+  return {
+    url,
+    loading,
+    error,
+    contentLength,
+    contentType: parsed?.contentType ?? null,
+    triggerDownload: skipFetch ? triggerDownload : undefined,
+  };
 }
 
 export function isAttachmentUri(value: string): boolean {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/attachment-utils.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/attachment-utils.ts
@@ -128,11 +128,13 @@ export function useAttachmentUrl(uri: string | null): {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [uri]);
 
-  const triggerDownload = useCallback(
-    () => fetchAndDownload(parsed!.traceId, parsed!.attachmentId, parsed!.contentType),
+  const triggerDownload = useCallback(() => {
+    if (parsed) {
+      return fetchAndDownload(parsed.traceId, parsed.attachmentId, parsed.contentType);
+    }
+    return Promise.resolve();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [uri],
-  );
+  }, [uri]);
 
   return {
     url,

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/attachment-utils.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/attachment-utils.ts
@@ -18,7 +18,7 @@ async function getTraceAttachment(requestId: string, attachmentId: string): Prom
 /**
  * Programmatically fetches a blob and triggers a browser download.
  */
-async function fetchAndDownload(traceId: string, attachmentId: string, contentType: string) {
+export async function fetchAndDownload(traceId: string, attachmentId: string, contentType: string) {
   const url = getAjaxUrl(
     `ajax-api/2.0/mlflow/get-trace-artifact?request_id=${encodeURIComponent(traceId)}&path=${encodeURIComponent(attachmentId)}`,
   );
@@ -52,7 +52,7 @@ export function parseAttachmentUri(
     const sizeStr = parsed.searchParams.get('size');
     const parsedSize = sizeStr ? Number(sizeStr) : undefined;
     const size =
-      parsedSize !== undefined && Number.isFinite(parsedSize) && Number.isInteger(parsedSize) && parsedSize >= 0
+      parsedSize !== undefined && Number.isFinite(parsedSize) && Number.isInteger(parsedSize) && parsedSize > 0
         ? parsedSize
         : undefined;
     return { attachmentId, contentType, traceId, ...(size !== undefined ? { size } : {}) };

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/attachment-utils.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/attachment-utils.ts
@@ -50,8 +50,12 @@ export function parseAttachmentUri(
       return null;
     }
     const sizeStr = parsed.searchParams.get('size');
-    const size = sizeStr ? Number(sizeStr) : undefined;
-    return { attachmentId, contentType, traceId, ...(size !== undefined && !Number.isNaN(size) ? { size } : {}) };
+    const parsedSize = sizeStr ? Number(sizeStr) : undefined;
+    const size =
+      parsedSize !== undefined && Number.isFinite(parsedSize) && Number.isInteger(parsedSize) && parsedSize >= 0
+        ? parsedSize
+        : undefined;
+    return { attachmentId, contentType, traceId, ...(size !== undefined ? { size } : {}) };
   } catch {
     return null;
   }

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerAttachmentRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerAttachmentRenderer.tsx
@@ -11,17 +11,20 @@ export const ModelTraceExplorerAttachmentRenderer = ({
   attachmentId,
   traceId,
   contentType,
+  size,
 }: {
   title: string;
   attachmentId: string;
   traceId: string;
   contentType: string;
+  size?: number;
 }) => {
   const { theme } = useDesignSystemTheme();
-  const { objectUrl, contentLength, isLoading, error } = useTraceAttachment({
+  const { objectUrl, contentLength, isLoading, error, triggerDownload } = useTraceAttachment({
     traceId,
     attachmentId,
     contentType,
+    size,
   });
   const [previewVisible, setPreviewVisible] = useState(false);
 
@@ -36,7 +39,7 @@ export const ModelTraceExplorerAttachmentRenderer = ({
     );
   }
 
-  if (isLoading || !objectUrl) {
+  if (isLoading) {
     return <LegacySkeleton />;
   }
 
@@ -50,14 +53,27 @@ export const ModelTraceExplorerAttachmentRenderer = ({
             {title}
           </Typography.Text>
         )}
-        <DownloadLink
-          url={objectUrl}
-          contentType={contentType}
-          contentLength={contentLength}
-          filename={`attachment-${attachmentId}`}
-        />
+        {objectUrl ? (
+          <DownloadLink
+            url={objectUrl}
+            contentType={contentType}
+            contentLength={contentLength}
+            filename={`attachment-${attachmentId}`}
+          />
+        ) : (
+          <DownloadLink
+            contentType={contentType}
+            contentLength={contentLength}
+            filename={`attachment-${attachmentId}`}
+            onFetchDownload={triggerDownload}
+          />
+        )}
       </div>
     );
+  }
+
+  if (!objectUrl) {
+    return <LegacySkeleton />;
   }
 
   if (contentType.startsWith('image/')) {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerFieldRenderer.parseAttachmentUri.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerFieldRenderer.parseAttachmentUri.test.ts
@@ -61,12 +61,9 @@ describe('parseAttachmentUri', () => {
     expect(result?.size).toBeUndefined();
   });
 
-  it('omits size for non-integer values', () => {
-    const cases = ['abc', '1.5', '-1', 'Infinity', 'NaN', ''];
-    for (const bad of cases) {
-      const uri = `mlflow-attachment://abc-123?content_type=image%2Fpng&trace_id=tr-456&size=${bad}`;
-      const result = parseAttachmentUri(uri);
-      expect(result?.size).toBeUndefined();
-    }
+  it.each(['abc', '1.5', '-1', '0', 'Infinity', 'NaN', ''])('omits invalid size value: %s', (bad) => {
+    const uri = `mlflow-attachment://abc-123?content_type=image%2Fpng&trace_id=tr-456&size=${bad}`;
+    const result = parseAttachmentUri(uri);
+    expect(result?.size).toBeUndefined();
   });
 });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerFieldRenderer.parseAttachmentUri.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerFieldRenderer.parseAttachmentUri.test.ts
@@ -38,4 +38,35 @@ describe('parseAttachmentUri', () => {
     expect(parseAttachmentUri('hello world')).toBeNull();
     expect(parseAttachmentUri('{"key": "value"}')).toBeNull();
   });
+
+  it('parses a valid size parameter', () => {
+    const uri = 'mlflow-attachment://abc-123?content_type=image%2Fpng&trace_id=tr-456&size=1048576';
+    const result = parseAttachmentUri(uri);
+    expect(result).toEqual({
+      attachmentId: 'abc-123',
+      contentType: 'image/png',
+      traceId: 'tr-456',
+      size: 1048576,
+    });
+  });
+
+  it('omits size when not present in URI', () => {
+    const uri = 'mlflow-attachment://abc-123?content_type=image%2Fpng&trace_id=tr-456';
+    const result = parseAttachmentUri(uri);
+    expect(result).toEqual({
+      attachmentId: 'abc-123',
+      contentType: 'image/png',
+      traceId: 'tr-456',
+    });
+    expect(result?.size).toBeUndefined();
+  });
+
+  it('omits size for non-integer values', () => {
+    const cases = ['abc', '1.5', '-1', 'Infinity', 'NaN', ''];
+    for (const bad of cases) {
+      const uri = `mlflow-attachment://abc-123?content_type=image%2Fpng&trace_id=tr-456&size=${bad}`;
+      const result = parseAttachmentUri(uri);
+      expect(result?.size).toBeUndefined();
+    }
+  });
 });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerFieldRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerFieldRenderer.tsx
@@ -23,7 +23,7 @@ const MAX_ATTACHMENT_SEARCH_DEPTH = 10;
 export const findAttachmentUris = (
   value: unknown,
   depth = 0,
-): { attachmentId: string; traceId: string; contentType: string }[] => {
+): { attachmentId: string; traceId: string; contentType: string; size?: number }[] => {
   if (depth > MAX_ATTACHMENT_SEARCH_DEPTH) {
     return [];
   }
@@ -148,6 +148,7 @@ export const ModelTraceExplorerFieldRenderer = ({
             attachmentId={attachment.attachmentId}
             traceId={attachment.traceId}
             contentType={attachment.contentType}
+            size={attachment.size}
           />
         );
       }
@@ -176,6 +177,7 @@ export const ModelTraceExplorerFieldRenderer = ({
               attachmentId={att.attachmentId}
               traceId={att.traceId}
               contentType={att.contentType}
+              size={att.size}
             />
           ))}
           <ModelTraceExplorerCodeSnippet title={title} data={data} />

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/attachment-utils.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/attachment-utils.ts
@@ -19,7 +19,7 @@ export function parseAttachmentUri(
     const sizeStr = parsed.searchParams.get('size');
     const parsedSize = sizeStr ? Number(sizeStr) : undefined;
     const size =
-      parsedSize !== undefined && Number.isFinite(parsedSize) && Number.isInteger(parsedSize) && parsedSize >= 0
+      parsedSize !== undefined && Number.isFinite(parsedSize) && Number.isInteger(parsedSize) && parsedSize > 0
         ? parsedSize
         : undefined;
     return { attachmentId, contentType, traceId, ...(size !== undefined ? { size } : {}) };

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/attachment-utils.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/attachment-utils.ts
@@ -2,7 +2,9 @@
  * Parses an mlflow-attachment:// URI into its component parts.
  * Returns null if the URI is not a valid attachment URI.
  */
-export function parseAttachmentUri(uri: string): { attachmentId: string; traceId: string; contentType: string } | null {
+export function parseAttachmentUri(
+  uri: string,
+): { attachmentId: string; traceId: string; contentType: string; size?: number } | null {
   try {
     const parsed = new URL(uri);
     if (parsed.protocol !== 'mlflow-attachment:') {
@@ -14,7 +16,9 @@ export function parseAttachmentUri(uri: string): { attachmentId: string; traceId
     if (!attachmentId || !contentType || !traceId) {
       return null;
     }
-    return { attachmentId, contentType, traceId };
+    const sizeStr = parsed.searchParams.get('size');
+    const size = sizeStr ? Number(sizeStr) : undefined;
+    return { attachmentId, contentType, traceId, ...(size !== undefined && !Number.isNaN(size) ? { size } : {}) };
   } catch {
     return null;
   }

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/attachment-utils.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/attachment-utils.ts
@@ -17,8 +17,12 @@ export function parseAttachmentUri(
       return null;
     }
     const sizeStr = parsed.searchParams.get('size');
-    const size = sizeStr ? Number(sizeStr) : undefined;
-    return { attachmentId, contentType, traceId, ...(size !== undefined && !Number.isNaN(size) ? { size } : {}) };
+    const parsedSize = sizeStr ? Number(sizeStr) : undefined;
+    const size =
+      parsedSize !== undefined && Number.isFinite(parsedSize) && Number.isInteger(parsedSize) && parsedSize >= 0
+        ? parsedSize
+        : undefined;
+    return { attachmentId, contentType, traceId, ...(size !== undefined ? { size } : {}) };
   } catch {
     return null;
   }

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/hooks/useTraceAttachment.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/hooks/useTraceAttachment.ts
@@ -1,24 +1,54 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 
 import { fetchOrFail } from '@mlflow/mlflow/src/common/utils/FetchUtils';
+import { exceedsRenderSizeLimit } from '../../media-rendering-utils';
 import { useQuery } from '../../query-client/queryClient';
 import { getAjaxUrl } from '../ModelTraceExplorer.request.utils';
 
 const TRACE_ATTACHMENT_QUERY_KEY = 'traceAttachment';
 
 /**
+ * Programmatically fetches a blob and triggers a browser download.
+ */
+async function fetchAndDownload(traceId: string, attachmentId: string, contentType: string) {
+  const url = getAjaxUrl(
+    `ajax-api/2.0/mlflow/get-trace-artifact?request_id=${encodeURIComponent(traceId)}&path=${encodeURIComponent(attachmentId)}`,
+  );
+  const response = await fetchOrFail(url);
+  const blob = await response.blob();
+  const blobUrl = URL.createObjectURL(new Blob([blob], { type: contentType }));
+  const a = document.createElement('a');
+  a.href = blobUrl;
+  a.download = `attachment-${attachmentId}`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(blobUrl);
+}
+
+/**
  * Fetches a trace attachment and returns a blob object URL for rendering.
  * Handles blob URL cleanup on unmount or when the attachment changes.
+ *
+ * When `size` is provided and exceeds the render limit for the content type,
+ * the fetch is skipped entirely and only `contentLength` is returned, allowing
+ * callers to show a download link without downloading the full blob.
+ * A `triggerDownload` callback is provided so users can still download on demand.
  */
 export const useTraceAttachment = ({
   traceId,
   attachmentId,
   contentType,
+  size,
 }: {
   traceId: string;
   attachmentId: string;
   contentType: string;
+  size?: number;
 }) => {
+  // Skip the fetch when we already know the content exceeds the render limit
+  const skipFetch = size !== undefined && exceedsRenderSizeLimit(contentType, size);
+
   const { data, isLoading, error } = useQuery({
     queryKey: [TRACE_ATTACHMENT_QUERY_KEY, traceId, attachmentId],
     queryFn: async () => {
@@ -32,6 +62,7 @@ export const useTraceAttachment = ({
         contentLength: blob.size,
       };
     },
+    enabled: !skipFetch,
     refetchOnWindowFocus: false,
   });
 
@@ -43,10 +74,16 @@ export const useTraceAttachment = ({
     };
   }, [data?.objectUrl]);
 
+  const triggerDownload = useCallback(
+    () => fetchAndDownload(traceId, attachmentId, contentType),
+    [traceId, attachmentId, contentType],
+  );
+
   return {
     objectUrl: data?.objectUrl ?? null,
-    contentLength: data?.contentLength ?? 0,
-    isLoading,
+    contentLength: skipFetch ? (size ?? 0) : (data?.contentLength ?? 0),
+    isLoading: skipFetch ? false : isLoading,
     error,
+    triggerDownload: skipFetch ? triggerDownload : undefined,
   };
 };

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/hooks/useTraceAttachment.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/hooks/useTraceAttachment.ts
@@ -3,28 +3,10 @@ import { useCallback, useEffect } from 'react';
 import { fetchOrFail } from '@mlflow/mlflow/src/common/utils/FetchUtils';
 import { exceedsRenderSizeLimit } from '../../media-rendering-utils';
 import { useQuery } from '../../query-client/queryClient';
+import { fetchAndDownload } from '../attachment-utils';
 import { getAjaxUrl } from '../ModelTraceExplorer.request.utils';
 
 const TRACE_ATTACHMENT_QUERY_KEY = 'traceAttachment';
-
-/**
- * Programmatically fetches a blob and triggers a browser download.
- */
-async function fetchAndDownload(traceId: string, attachmentId: string, contentType: string) {
-  const url = getAjaxUrl(
-    `ajax-api/2.0/mlflow/get-trace-artifact?request_id=${encodeURIComponent(traceId)}&path=${encodeURIComponent(attachmentId)}`,
-  );
-  const response = await fetchOrFail(url);
-  const blob = await response.blob();
-  const blobUrl = URL.createObjectURL(new Blob([blob], { type: contentType }));
-  const a = document.createElement('a');
-  a.href = blobUrl;
-  a.download = `attachment-${attachmentId}`;
-  document.body.appendChild(a);
-  a.click();
-  document.body.removeChild(a);
-  URL.revokeObjectURL(blobUrl);
-}
 
 /**
  * Fetches a trace attachment and returns a blob object URL for rendering.

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessage.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessage.tsx
@@ -64,15 +64,22 @@ function ClickToExpandImage({ src, alt }: { src: string; alt?: string }) {
 }
 
 function AttachmentImage({ src, alt }: { src?: string; alt?: string }) {
-  const { url, contentLength, contentType, loading, error } = useAttachmentUrl(src ?? null);
+  const { url, contentLength, contentType, loading, error, triggerDownload } = useAttachmentUrl(src ?? null);
   if (loading) {
     return <Spinner size="small" />;
   }
+  if (contentType && exceedsRenderSizeLimit(contentType, contentLength)) {
+    return (
+      <DownloadLink
+        url={url}
+        contentType={contentType}
+        contentLength={contentLength}
+        onFetchDownload={triggerDownload}
+      />
+    );
+  }
   if (error || !url) {
     return <span>{`[${alt ?? 'Failed to load image'}]`}</span>;
-  }
-  if (contentType && exceedsRenderSizeLimit(contentType, contentLength)) {
-    return <DownloadLink url={url} contentType={contentType} contentLength={contentLength} />;
   }
   return <ClickToExpandImage src={url} alt={alt} />;
 }
@@ -88,6 +95,7 @@ const attachmentAwareImgRenderer = ({ src, alt }: { src?: string; alt?: string }
           attachmentId={parsed.attachmentId}
           traceId={parsed.traceId}
           contentType={parsed.contentType}
+          size={parsed.size}
         />
       );
     }
@@ -248,9 +256,19 @@ function getAudioMimeType(format: string): string {
 }
 
 function AttachmentAudioPlayer({ uri }: { uri: string }) {
-  const { url, contentLength, contentType, loading, error } = useAttachmentUrl(uri);
+  const { url, contentLength, contentType, loading, error, triggerDownload } = useAttachmentUrl(uri);
   if (loading) {
     return <Spinner size="small" />;
+  }
+  if (contentType && exceedsRenderSizeLimit(contentType, contentLength)) {
+    return (
+      <DownloadLink
+        url={url}
+        contentType={contentType}
+        contentLength={contentLength}
+        onFetchDownload={triggerDownload}
+      />
+    );
   }
   if (error || !url) {
     return (
@@ -261,9 +279,6 @@ function AttachmentAudioPlayer({ uri }: { uri: string }) {
         />
       </Typography.Text>
     );
-  }
-  if (contentType && exceedsRenderSizeLimit(contentType, contentLength)) {
-    return <DownloadLink url={url} contentType={contentType} contentLength={contentLength} />;
   }
   // eslint-disable-next-line jsx-a11y/media-has-caption
   return <audio controls css={{ width: '100%', maxWidth: 500 }} src={url} />;

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessage.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessage.tsx
@@ -68,7 +68,7 @@ function AttachmentImage({ src, alt }: { src?: string; alt?: string }) {
   if (loading) {
     return <Spinner size="small" />;
   }
-  if (contentType && exceedsRenderSizeLimit(contentType, contentLength)) {
+  if ((url || triggerDownload) && contentType && exceedsRenderSizeLimit(contentType, contentLength)) {
     return (
       <DownloadLink
         url={url}
@@ -260,7 +260,7 @@ function AttachmentAudioPlayer({ uri }: { uri: string }) {
   if (loading) {
     return <Spinner size="small" />;
   }
-  if (contentType && exceedsRenderSizeLimit(contentType, contentLength)) {
+  if ((url || triggerDownload) && contentType && exceedsRenderSizeLimit(contentType, contentLength)) {
     return (
       <DownloadLink
         url={url}

--- a/mlflow/tracing/attachments.py
+++ b/mlflow/tracing/attachments.py
@@ -63,7 +63,7 @@ class Attachment:
             size = int(size_str) if size_str else None
         except ValueError:
             size = None
-        if size is not None and size < 0:
+        if size is not None and size <= 0:
             size = None
         return {
             "attachment_id": attachment_id,

--- a/mlflow/tracing/attachments.py
+++ b/mlflow/tracing/attachments.py
@@ -40,11 +40,15 @@ class Attachment:
         return self._content_bytes
 
     def ref(self, trace_id: str) -> str:
-        query = urlencode({"content_type": self._content_type, "trace_id": trace_id})
+        query = urlencode({
+            "content_type": self._content_type,
+            "trace_id": trace_id,
+            "size": str(len(self._content_bytes)),
+        })
         return f"mlflow-attachment://{self._id}?{query}"
 
     @staticmethod
-    def parse_ref(ref_uri: str) -> dict[str, str] | None:
+    def parse_ref(ref_uri: str) -> dict[str, str | int | None] | None:
         parsed = urlparse(ref_uri)
         if parsed.scheme != "mlflow-attachment":
             return None
@@ -54,8 +58,10 @@ class Attachment:
         trace_id = params.get("trace_id", [None])[0]
         if not attachment_id or not content_type or not trace_id:
             return None
+        size_str = params.get("size", [None])[0]
         return {
             "attachment_id": attachment_id,
             "content_type": content_type,
             "trace_id": trace_id,
+            "size": int(size_str) if size_str else None,
         }

--- a/mlflow/tracing/attachments.py
+++ b/mlflow/tracing/attachments.py
@@ -59,9 +59,13 @@ class Attachment:
         if not attachment_id or not content_type or not trace_id:
             return None
         size_str = params.get("size", [None])[0]
+        try:
+            size = int(size_str) if size_str else None
+        except ValueError:
+            size = None
         return {
             "attachment_id": attachment_id,
             "content_type": content_type,
             "trace_id": trace_id,
-            "size": int(size_str) if size_str else None,
+            "size": size,
         }

--- a/mlflow/tracing/attachments.py
+++ b/mlflow/tracing/attachments.py
@@ -63,6 +63,8 @@ class Attachment:
             size = int(size_str) if size_str else None
         except ValueError:
             size = None
+        if size is not None and size < 0:
+            size = None
         return {
             "attachment_id": attachment_id,
             "content_type": content_type,

--- a/tests/tracing/test_attachments.py
+++ b/tests/tracing/test_attachments.py
@@ -57,6 +57,7 @@ def test_attachment_ref():
     parsed = Attachment.parse_ref(ref)
     assert parsed["content_type"] == "image/png"
     assert parsed["trace_id"] == "tr-abc123"
+    assert parsed["size"] == 4
 
 
 def test_parse_ref_valid():
@@ -67,6 +68,7 @@ def test_parse_ref_valid():
     assert parsed["attachment_id"] == att.id
     assert parsed["content_type"] == "audio/wav"
     assert parsed["trace_id"] == "tr-xyz"
+    assert parsed["size"] == 4
 
 
 def test_parse_ref_invalid():
@@ -85,3 +87,22 @@ def test_ref_roundtrips_special_characters_in_content_type():
     ref = att.ref("tr-123")
     parsed = Attachment.parse_ref(ref)
     assert parsed["content_type"] == "application/vnd.custom+json"
+    assert parsed["size"] == 4
+
+
+def test_parse_ref_without_size():
+    uri = "mlflow-attachment://abc-123?content_type=image%2Fpng&trace_id=tr-456"
+    parsed = Attachment.parse_ref(uri)
+    assert parsed is not None
+    assert parsed["attachment_id"] == "abc-123"
+    assert parsed["content_type"] == "image/png"
+    assert parsed["trace_id"] == "tr-456"
+    assert parsed["size"] is None
+
+
+def test_ref_size_reflects_content_length():
+    content = b"x" * 1024
+    att = Attachment(content_type="image/png", content_bytes=content)
+    ref = att.ref("tr-001")
+    parsed = Attachment.parse_ref(ref)
+    assert parsed["size"] == 1024

--- a/tests/tracing/test_attachments.py
+++ b/tests/tracing/test_attachments.py
@@ -106,3 +106,10 @@ def test_ref_size_reflects_content_length():
     ref = att.ref("tr-001")
     parsed = Attachment.parse_ref(ref)
     assert parsed["size"] == 1024
+
+
+def test_parse_ref_malformed_size():
+    uri = "mlflow-attachment://abc-123?content_type=image%2Fpng&trace_id=tr-456&size=abc"
+    parsed = Attachment.parse_ref(uri)
+    assert parsed is not None
+    assert parsed["size"] is None

--- a/tests/tracing/test_attachments.py
+++ b/tests/tracing/test_attachments.py
@@ -108,7 +108,7 @@ def test_ref_size_reflects_content_length():
     assert parsed["size"] == 1024
 
 
-@pytest.mark.parametrize("bad_size", ["abc", "-1", "-100"])
+@pytest.mark.parametrize("bad_size", ["abc", "-1", "-100", "0"])
 def test_parse_ref_invalid_size(bad_size):
     uri = f"mlflow-attachment://abc-123?content_type=image%2Fpng&trace_id=tr-456&size={bad_size}"
     parsed = Attachment.parse_ref(uri)

--- a/tests/tracing/test_attachments.py
+++ b/tests/tracing/test_attachments.py
@@ -108,8 +108,9 @@ def test_ref_size_reflects_content_length():
     assert parsed["size"] == 1024
 
 
-def test_parse_ref_malformed_size():
-    uri = "mlflow-attachment://abc-123?content_type=image%2Fpng&trace_id=tr-456&size=abc"
+@pytest.mark.parametrize("bad_size", ["abc", "-1", "-100"])
+def test_parse_ref_invalid_size(bad_size):
+    uri = f"mlflow-attachment://abc-123?content_type=image%2Fpng&trace_id=tr-456&size={bad_size}"
     parsed = Attachment.parse_ref(uri)
     assert parsed is not None
     assert parsed["size"] is None


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22574

### What changes are proposed in this pull request?

Adds a `&size=<bytes>` query parameter to the `mlflow-attachment://` URI at extraction time. The attachment size is already known when the URI is generated (the bytes are in memory), so encoding it in the URI lets the UI check whether content exceeds the render threshold without downloading the full blob first.

**Python:**
- `Attachment.ref()` now includes `size=len(content_bytes)` in the query params
- `Attachment.parse_ref()` extracts the `size` field as an optional int

**Frontend:**
- Both `parseAttachmentUri` functions extract the `size` param
- `useTraceAttachment` and `useAttachmentUrl` hooks skip the blob fetch when the URI's size exceeds `exceedsRenderSizeLimit()`, showing a download link immediately instead
- Clicking the download link triggers a fetch-and-download on demand (same mechanism as existing artifact downloads in `ArtifactView.tsx`)
- `DownloadLink` component updated to support `onFetchDownload` callback for the skip-fetch case
- Backwards compatible — URIs without `size` still work (hooks fall back to fetching as before)

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New Python tests for `ref()` size encoding, `parse_ref()` size extraction, backwards compatibility with old URIs, and size reflecting content length. Manual testing with real files (images, audio, PDF) and synthetic oversized content to verify inline rendering for small files and immediate download links for large files.

<img width="1374" height="414" alt="Screenshot 2026-04-16 at 10 42 25 AM" src="https://github.com/user-attachments/assets/d79b5c66-c475-4008-9255-42192409dccf" />
<img width="1375" height="440" alt="Screenshot 2026-04-16 at 10 42 34 AM" src="https://github.com/user-attachments/assets/40fca4dd-4ab1-4133-bcf1-4c3424295e7e" />

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release