### PR TITLE
Fix: Preserve signature in ConversationSimulation traced_predict (#22590)

### DIFF
--- a/mlflow/genai/simulators/simulator.py
+++ b/mlflow/genai/simulators/simulator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import inspect
 import logging
 import math
@@ -769,6 +770,9 @@ class ConversationSimulator:
         #     predict_fn call. The goal/persona/turn metadata is used for trace comparison UI
         #     since message content may differ between simulation runs.
         @mlflow.trace(name=f"simulation_turn_{turn}", span_type="CHAIN")
+        @functools.wraps(
+            predict_fn
+        )  # Preserves signature for tracing (fixes #22590)
         def traced_predict(**kwargs):
             metadata = {
                 TraceMetadataKey.TRACE_SESSION: trace_session_id,


### PR DESCRIPTION
Closes #22590

### What changes are proposed in this pull request?

This PR fixes a bug in `mlflow/genai/simulators/simulator.py` where the `traced_predict` function inside `ConversationSimulation` loses the original function's typing signature due to missing `@functools.wraps`.

**The Problem:**
The `traced_predict` wrapper function was defined without `@functools.wraps(predict_fn)`. Consequently:
1. The wrapper exposed a generic `**kwargs` signature instead of the original function's specific arguments (e.g., `messages`, `temperature`).
2. MLflow Tracing introspected this generic signature and logged inputs as `{"kwargs": {...}}`.
3. This broke custom message rendering in the MLflow UI for GenAI simulations.

**The Fix:**
- Added `import functools` to the imports.
- Added `@functools.wraps(predict_fn)` decorator immediately after `@mlflow.trace(...)`.
- This ensures the wrapper preserves the original function's name, docstring, and **signature**, allowing MLflow to correctly log and display trace inputs.

### How is this PR tested?

- [x] Manual tests

**Verification Steps:**
1. **Reproduction:** Created a standalone script demonstrating that decorators without `functools.wraps` lose signatures (`(**kwargs)`), while those with it preserve them (`(messages, temperature)`).
2. **Source Verification:** Confirmed via local script that the fix correctly applies the decorator and import in `simulator.py`.
3. **Alignment:** The fix implements the exact solution suggested by the issue reporter in #22590.

*(Note: Full CI checks like `clint` and `taplo` were skipped locally due to Windows platform incompatibility, but core logic and `ruff` formatting have been validated.)*

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed an issue in GenAI Conversation Simulation where trace inputs were incorrectly logged as generic `kwargs` instead of preserving the original function arguments, causing UI rendering issues.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release