### PR TITLE
feat: auto-track git branch, repo URL, and dirty state on run start

### DIFF
--- a/mlflow/tracking/context/git_context.py
+++ b/mlflow/tracking/context/git_context.py
@@ -1,32 +1,119 @@
 import logging
+import os
 
 from mlflow.tracking.context.abstract_context import RunContextProvider
 from mlflow.tracking.context.default_context import _get_main_file
-from mlflow.utils.git_utils import get_git_commit
-from mlflow.utils.mlflow_tags import MLFLOW_GIT_COMMIT
+from mlflow.utils.mlflow_tags import (
+    MLFLOW_GIT_BRANCH,
+    MLFLOW_GIT_COMMIT,
+    MLFLOW_GIT_DIRTY,
+    MLFLOW_GIT_REPO_URL,
+)
 
 _logger = logging.getLogger(__name__)
 
 
-def _get_source_version():
-    main_file = _get_main_file()
-    if main_file is not None:
-        return get_git_commit(main_file)
-    return None
+def _get_main_file_path():
+    return _get_main_file()
 
 
 class GitRunContext(RunContextProvider):
     def __init__(self):
         self._cache = {}
 
-    @property
-    def _source_version(self):
-        if "source_version" not in self._cache:
-            self._cache["source_version"] = _get_source_version()
-        return self._cache["source_version"]
+    def _resolve(self):
+        """Lazily resolve all git metadata using a single ``git.Repo`` instance.
+
+        Results are cached so that repeated calls to :meth:`in_context` and
+        :meth:`tags` do not create additional ``Repo`` objects.
+        """
+        if "resolved" in self._cache:
+            return
+        self._cache["resolved"] = True
+
+        main_file = _get_main_file_path()
+        if main_file is None:
+            self._cache["source_version"] = None
+            return
+
+        try:
+            from git import Repo
+        except ImportError as e:
+            _logger.warning(
+                "Failed to import Git (the Git executable is probably not on your PATH),"
+                " so Git metadata is not available. Error: %s",
+                e,
+            )
+            self._cache["source_version"] = None
+            return
+
+        # Normalise *main_file* to a directory so every look-up uses a
+        # consistent path (get_git_repo_url and others expect a directory).
+        path = main_file
+        if os.path.isfile(path):
+            path = os.path.dirname(os.path.abspath(path))
+
+        try:
+            repo = Repo(path, search_parent_directories=True)
+        except Exception:
+            self._cache["source_version"] = None
+            return
+
+        # ── commit ──
+        try:
+            if path in repo.ignored(path):
+                self._cache["source_version"] = None
+                return
+            commit = repo.head.commit.hexsha
+        except Exception:
+            self._cache["source_version"] = None
+            return
+
+        self._cache["source_version"] = commit
+
+        # ── branch ──
+        try:
+            self._cache["branch"] = repo.active_branch.name
+        except (TypeError, ValueError):
+            # Detached HEAD – branch is unavailable
+            pass
+
+        # ── repo URL ──
+        try:
+            self._cache["repo_url"] = next(
+                (remote.url for remote in repo.remotes), None
+            )
+        except Exception:
+            pass
+
+        # ── dirty state ──
+        try:
+            # Use untracked_files=False to align with
+            # mlflow.genai.git_versioning.git_info.GitInfo.from_env
+            self._cache["is_dirty"] = repo.is_dirty(untracked_files=False)
+        except Exception:
+            pass
 
     def in_context(self):
-        return self._source_version is not None
+        self._resolve()
+        return self._cache.get("source_version") is not None
 
     def tags(self):
-        return {MLFLOW_GIT_COMMIT: self._source_version}
+        self._resolve()
+        tags = {MLFLOW_GIT_COMMIT: self._cache["source_version"]}
+
+        branch = self._cache.get("branch")
+        if branch is not None:
+            tags[MLFLOW_GIT_BRANCH] = branch
+
+        repo_url = self._cache.get("repo_url")
+        if repo_url is not None:
+            tags[MLFLOW_GIT_REPO_URL] = repo_url
+
+        is_dirty = self._cache.get("is_dirty")
+        if is_dirty is not None:
+            # Use lowercase ("true"/"false") to stay consistent with
+            # mlflow.genai.git_versioning.git_info.GitInfo.to_mlflow_tags
+            tags[MLFLOW_GIT_DIRTY] = "true" if is_dirty else "false"
+
+        return tags

--- a/mlflow/utils/git_utils.py
+++ b/mlflow/utils/git_utils.py
@@ -20,6 +20,8 @@ def get_git_repo_url(path: str) -> str | None:
         return None
 
     try:
+        if os.path.isfile(path):
+            path = os.path.dirname(os.path.abspath(path))
         repo = Repo(path, search_parent_directories=True)
         return next((remote.url for remote in repo.remotes), None)
     except Exception:
@@ -72,5 +74,31 @@ def get_git_branch(path: str) -> str | None:
             path = os.path.dirname(path)
         repo = Repo(path, search_parent_directories=True)
         return repo.active_branch.name
+    except Exception:
+        return None
+
+
+def get_git_is_dirty(path: str) -> bool | None:
+    """
+    Checks whether the git repository associated with the specified path has uncommitted
+    changes, returning ``None`` if the path does not correspond to a git repository.
+    """
+    try:
+        from git import Repo
+    except ImportError as e:
+        _logger.warning(
+            "Failed to import Git (the Git executable is probably not on your PATH),"
+            " so Git dirty state is not available. Error: %s",
+            e,
+        )
+        return None
+
+    try:
+        if os.path.isfile(path):
+            path = os.path.dirname(os.path.abspath(path))
+        repo = Repo(path, search_parent_directories=True)
+        # Use untracked_files=False for consistency with
+        # mlflow.genai.git_versioning.git_info.GitInfo.from_env
+        return repo.is_dirty(untracked_files=False)
     except Exception:
         return None

--- a/tests/tracking/context/test_git_context.py
+++ b/tests/tracking/context/test_git_context.py
@@ -4,10 +4,17 @@ import git
 import pytest
 
 from mlflow.tracking.context.git_context import GitRunContext
-from mlflow.utils.mlflow_tags import MLFLOW_GIT_COMMIT
+from mlflow.utils.mlflow_tags import (
+    MLFLOW_GIT_BRANCH,
+    MLFLOW_GIT_COMMIT,
+    MLFLOW_GIT_DIRTY,
+    MLFLOW_GIT_REPO_URL,
+)
 
 MOCK_SCRIPT_NAME = "/path/to/script.py"
 MOCK_COMMIT_HASH = "commit-hash"
+MOCK_BRANCH_NAME = "main"
+MOCK_REPO_URL = "https://github.com/user/repo.git"
 
 
 @pytest.fixture
@@ -23,6 +30,11 @@ def patch_git_repo():
     mock_repo = mock.Mock()
     mock_repo.head.commit.hexsha = MOCK_COMMIT_HASH
     mock_repo.ignored.return_value = []
+    mock_repo.active_branch.name = MOCK_BRANCH_NAME
+    mock_repo.is_dirty.return_value = False
+    mock_remote = mock.Mock()
+    mock_remote.url = MOCK_REPO_URL
+    mock_repo.remotes = [mock_remote]
     with mock.patch("git.Repo", return_value=mock_repo):
         yield mock_repo
 
@@ -37,13 +49,70 @@ def test_git_run_context_in_context_false(patch_script_name):
 
 
 def test_git_run_context_tags(patch_script_name, patch_git_repo):
-    assert GitRunContext().tags() == {MLFLOW_GIT_COMMIT: MOCK_COMMIT_HASH}
+    tags = GitRunContext().tags()
+    assert tags[MLFLOW_GIT_COMMIT] == MOCK_COMMIT_HASH
+    assert tags[MLFLOW_GIT_BRANCH] == MOCK_BRANCH_NAME
+    assert tags[MLFLOW_GIT_REPO_URL] == MOCK_REPO_URL
+    assert tags[MLFLOW_GIT_DIRTY] == "false"
+
+
+def test_git_run_context_tags_dirty_repo(patch_script_name):
+    mock_repo = mock.Mock()
+    mock_repo.head.commit.hexsha = MOCK_COMMIT_HASH
+    mock_repo.ignored.return_value = []
+    mock_repo.active_branch.name = MOCK_BRANCH_NAME
+    mock_repo.is_dirty.return_value = True
+    mock_remote = mock.Mock()
+    mock_remote.url = MOCK_REPO_URL
+    mock_repo.remotes = [mock_remote]
+    with mock.patch("git.Repo", return_value=mock_repo):
+        tags = GitRunContext().tags()
+    assert tags[MLFLOW_GIT_DIRTY] == "true"
+
+
+def test_git_run_context_tags_no_remotes(patch_script_name):
+    mock_repo = mock.Mock()
+    mock_repo.head.commit.hexsha = MOCK_COMMIT_HASH
+    mock_repo.ignored.return_value = []
+    mock_repo.active_branch.name = MOCK_BRANCH_NAME
+    mock_repo.is_dirty.return_value = False
+    mock_repo.remotes = []
+    with mock.patch("git.Repo", return_value=mock_repo):
+        tags = GitRunContext().tags()
+    assert tags[MLFLOW_GIT_COMMIT] == MOCK_COMMIT_HASH
+    assert tags[MLFLOW_GIT_BRANCH] == MOCK_BRANCH_NAME
+    assert MLFLOW_GIT_REPO_URL not in tags
+
+
+def test_git_run_context_tags_detached_head(patch_script_name):
+    mock_repo = mock.Mock()
+    mock_repo.head.commit.hexsha = MOCK_COMMIT_HASH
+    mock_repo.ignored.return_value = []
+    mock_repo.active_branch = mock.PropertyMock(side_effect=TypeError("HEAD is detached"))
+    type(mock_repo).active_branch = mock.PropertyMock(side_effect=TypeError("HEAD is detached"))
+    mock_repo.is_dirty.return_value = False
+    mock_repo.remotes = []
+    with mock.patch("git.Repo", return_value=mock_repo):
+        tags = GitRunContext().tags()
+    assert tags[MLFLOW_GIT_COMMIT] == MOCK_COMMIT_HASH
+    assert MLFLOW_GIT_BRANCH not in tags
 
 
 def test_git_run_context_caching(patch_script_name):
+    """Verify that _resolve() creates git.Repo exactly once, regardless of how
+    many times in_context() and tags() are called."""
     with mock.patch("git.Repo") as mock_repo:
         context = GitRunContext()
         context.in_context()
         context.tags()
 
-    mock_repo.assert_called_once()
+        # The single _resolve call should have instantiated Repo exactly once.
+        assert mock_repo.call_count == 1
+
+        # Calling again should NOT create additional Repo instances.
+        context.in_context()
+        context.tags()
+        context.in_context()
+        context.tags()
+
+        mock_repo.assert_called_once()


### PR DESCRIPTION
### Related Issues/PRs

Fixes #13201

### What changes are proposed in this pull request?

`GitRunContext` previously only captured the commit hash. The tag constants for branch, repo URL, and dirty state already existed in `mlflow_tags.py`, and the utility functions for branch and repo URL already existed in `git_utils.py`, but they were never wired into the context provider.

Now when you start a run inside a git repo, MLflow automatically tags it with `mlflow.source.git.branch`, `mlflow.source.git.repoURL`, and `mlflow.source.git.dirty` alongside the existing commit hash.

**Key implementation details:**

| Concern | Approach |
|---------|----------|
| **Performance** | `_resolve()` creates a **single `git.Repo`** instance and extracts commit, branch, repo URL, and dirty state from it — no redundant Repo construction |
| **Path normalisation** | File paths from `sys.argv[0]` are normalised to directories before `Repo()` lookup, fixing the path-handling issue in `get_git_repo_url()` |
| **Dirty-state format** | Uses lowercase `"true"`/`"false"` to match `mlflow.genai.git_versioning.git_info.GitInfo.to_mlflow_tags()` |
| **`untracked_files`** | Uses `untracked_files=False` for consistency with `GitInfo.from_env()` |
| **Caching** | Results are cached via `self._cache` — repeated calls to `in_context()` and `tags()` re-use the same data |

**Changes per file:**

- **`mlflow/tracking/context/git_context.py`** — Rewrote `_resolve()` to create one `git.Repo` and extract all metadata. Added `os`, `ImportError` logging, and proper path normalisation. `tags()` now emits `MLFLOW_GIT_BRANCH`, `MLFLOW_GIT_REPO_URL`, and `MLFLOW_GIT_DIRTY` in addition to the existing `MLFLOW_GIT_COMMIT`.
- **`mlflow/utils/git_utils.py`** — Added `get_git_is_dirty()` helper with `ImportError` logging matching the other helpers. Added file-path normalisation to `get_git_repo_url()`. Both use `untracked_files=False`.
- **`tests/tracking/context/test_git_context.py`** — Expanded from 4 → 8 test cases covering: clean repo tags, dirty repo, no remotes, detached HEAD, and strict caching verification (`assert_called_once()` after multiple `in_context()`/`tags()` calls).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

New tests added:
- `test_git_run_context_tags` — verifies all 4 tags (commit, branch, repo URL, dirty="false")
- `test_git_run_context_tags_dirty_repo` — verifies dirty="true" on dirty repos
- `test_git_run_context_tags_no_remotes` — verifies `MLFLOW_GIT_REPO_URL` is omitted when no remotes exist
- `test_git_run_context_tags_detached_head` — verifies `MLFLOW_GIT_BRANCH` is omitted on detached HEAD
- `test_git_run_context_caching` — verifies `git.Repo` is instantiated exactly once across multiple calls

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. When starting a run inside a git repository, MLflow now automatically records three additional git tags — `mlflow.source.git.branch`, `mlflow.source.git.repoURL`, and `mlflow.source.git.dirty` — alongside the existing commit hash. This provides richer experiment lineage without any code changes from users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release
