### PR TITLE
Add `ConversationalCoherence` and `AgentPlanQuality` built-in judges

### DIFF
--- a/docs/api_reference/api_inventory.txt
+++ b/docs/api_reference/api_inventory.txt
@@ -958,11 +958,15 @@ mlflow.genai.optimize_prompts
 mlflow.genai.register_prompt
 mlflow.genai.scheduled_scorers.ScorerScheduleConfig
 mlflow.genai.scorer
+mlflow.genai.scorers.AgentPlanQuality
+mlflow.genai.scorers.AgentPlanQuality.model_post_init
 mlflow.genai.scorers.Completeness
 mlflow.genai.scorers.Completeness.get_input_fields
 mlflow.genai.scorers.Completeness.model_post_init
 mlflow.genai.scorers.ConversationCompleteness
 mlflow.genai.scorers.ConversationCompleteness.model_post_init
+mlflow.genai.scorers.ConversationalCoherence
+mlflow.genai.scorers.ConversationalCoherence.model_post_init
 mlflow.genai.scorers.ConversationalGuidelines
 mlflow.genai.scorers.ConversationalGuidelines.model_post_init
 mlflow.genai.scorers.ConversationalRoleAdherence
@@ -1022,8 +1026,10 @@ mlflow.genai.scorers.UserFrustration
 mlflow.genai.scorers.UserFrustration.model_post_init
 mlflow.genai.scorers.base.Scorer
 mlflow.genai.scorers.base.ScorerSamplingConfig
+mlflow.genai.scorers.builtin_scorers.AgentPlanQuality
 mlflow.genai.scorers.builtin_scorers.Completeness
 mlflow.genai.scorers.builtin_scorers.ConversationCompleteness
+mlflow.genai.scorers.builtin_scorers.ConversationalCoherence
 mlflow.genai.scorers.builtin_scorers.ConversationalGuidelines
 mlflow.genai.scorers.builtin_scorers.ConversationalRoleAdherence
 mlflow.genai.scorers.builtin_scorers.ConversationalSafety

--- a/docs/docs/genai/eval-monitor/scorers/llm-judge/predefined.mdx
+++ b/docs/docs/genai/eval-monitor/scorers/llm-judge/predefined.mdx
@@ -124,7 +124,9 @@ Multi-turn judges require:
 
 | Judge                                                                                                              | What does it evaluate?                                                     | Requires Session? |
 | ------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- | ----------------- |
+| <APILink fn="mlflow.genai.scorers.AgentPlanQuality">AgentPlanQuality</APILink>\*\*                                 | Is the agent's action planning and reasoning sound across the session?     | Yes               |
 | <APILink fn="mlflow.genai.scorers.ConversationCompleteness">ConversationCompleteness</APILink>\*\*                 | Does the agent address all user questions throughout the conversation?     | Yes               |
+| <APILink fn="mlflow.genai.scorers.ConversationalCoherence">ConversationalCoherence</APILink>\*\*                   | Do the assistant's responses maintain logical flow and consistency?        | Yes               |
 | <APILink fn="mlflow.genai.scorers.ConversationalGuidelines">ConversationalGuidelines</APILink>\*\*                 | Do the assistant's responses comply with provided guidelines?              | Yes               |
 | <APILink fn="mlflow.genai.scorers.ConversationalRoleAdherence">ConversationalRoleAdherence</APILink>\*\*           | Does the assistant maintain its assigned role throughout the conversation? | Yes               |
 | <APILink fn="mlflow.genai.scorers.ConversationalSafety">ConversationalSafety</APILink>\*\*                         | Are the assistant's responses safe and free of harmful content?            | Yes               |

--- a/mlflow/genai/judges/prompts/agent_plan_quality.py
+++ b/mlflow/genai/judges/prompts/agent_plan_quality.py
@@ -1,0 +1,36 @@
+# NB: User-facing name for the agent plan quality assessment.
+AGENT_PLAN_QUALITY_ASSESSMENT_NAME = "agent_plan_quality"
+
+AGENT_PLAN_QUALITY_PROMPT = """\
+Consider the following conversation history between a user and an agent, including any tool calls \
+and intermediate reasoning steps. Your task is to evaluate the quality of the agent's action \
+planning and reasoning across the session and output exactly one label: "yes" or "no".
+
+Evaluate the agent's planning for the following quality criteria:
+- Goal decomposition: The agent breaks the user's request into well-defined, achievable subgoals \
+that together cover the request, rather than jumping straight to execution without a plan.
+- Logical ordering: Steps and tool calls are sequenced in a reasonable order, with prerequisites \
+satisfied before dependent steps, and without obvious out-of-order actions.
+- Step relevance: Each planned step or tool call clearly advances the user's goal; the agent does \
+not invoke unrelated tools, perform busy work, or pursue tangents that do not contribute to the outcome.
+- Adaptivity: When a step fails, returns unexpected results, or reveals new information, the agent \
+updates its plan accordingly instead of mechanically continuing the original sequence.
+- Termination: The agent stops once the goal is achieved, or explicitly surfaces the remaining \
+uncertainty to the user; it does not loop indefinitely or keep acting after the task is done.
+
+Evaluation guidelines:
+- Focus on the agent's planning and reasoning behavior, not on surface phrasing.
+- A plan is acceptable even if implicit, as long as the sequence of actions demonstrates the \
+criteria above.
+- Do not penalize the agent for exploratory steps that are justified by missing information, \
+provided the exploration is bounded and on-topic.
+- Tool failures, invalid arguments, or external errors are acceptable if the agent recognizes and \
+recovers from them; they are not acceptable if the agent ignores them and proceeds as if they \
+succeeded.
+- Ask-for-clarification is valid planning behavior when the request is genuinely ambiguous.
+
+Output "yes" if the agent's planning is sound overall across the session. Output "no" only if \
+there is at least one clear planning failure as defined above.
+
+<conversation>{{ conversation }}</conversation>
+"""  # noqa: E501

--- a/mlflow/genai/judges/prompts/conversational_coherence.py
+++ b/mlflow/genai/judges/prompts/conversational_coherence.py
@@ -1,0 +1,34 @@
+# NB: User-facing name for the conversational coherence assessment.
+CONVERSATIONAL_COHERENCE_ASSESSMENT_NAME = "conversational_coherence"
+
+CONVERSATIONAL_COHERENCE_PROMPT = """\
+Consider the following conversation history between a user and an assistant. Your task is to \
+evaluate the logical flow and consistency of the assistant's responses across the entire \
+conversation and output exactly one label: "yes" or "no".
+
+Evaluate the assistant's responses for the following coherence criteria:
+- Logical progression: Each assistant response follows logically from prior turns and preserves the \
+thread of discussion rather than abruptly switching topics without reason.
+- Internal consistency: The assistant does not contradict its own earlier statements, facts, or \
+commitments within the conversation.
+- Reference resolution: The assistant correctly resolves pronouns, ellipses, and references to \
+previously discussed entities instead of losing track of subjects.
+- Context retention: The assistant remembers and uses information the user has already provided, \
+rather than re-asking for the same details or ignoring established context.
+- Topic continuity: When the user continues a topic, the assistant stays on topic; when the user \
+legitimately changes topics, the assistant transitions cleanly.
+
+Evaluation guidelines:
+- Focus exclusively on the assistant's responses. Incoherent or contradictory user messages do not \
+by themselves make the conversation incoherent.
+- A conversation is coherent if the assistant maintains a clear, consistent, and contextually \
+appropriate dialogue across turns, even if individual turns are short.
+- Asking the user to clarify ambiguous requests is coherent behavior and should not be penalized.
+- Minor stylistic variation or rephrasing between turns is acceptable as long as meaning is preserved.
+- Do not penalize the assistant for correcting itself when it explicitly acknowledges the correction.
+
+Output "yes" if the assistant's responses are coherent throughout the conversation. Output "no" \
+only if at least one assistant response contains a clear coherence failure as defined above.
+
+<conversation>{{ conversation }}</conversation>
+"""  # noqa: E501

--- a/mlflow/genai/scorers/__init__.py
+++ b/mlflow/genai/scorers/__init__.py
@@ -27,7 +27,9 @@ FRAMEWORK_METADATA_KEY = "mlflow.scorer.framework"
 
 # Define the attributes that should be lazily loaded
 _LAZY_IMPORTS = {
+    "AgentPlanQuality",
     "Completeness",
+    "ConversationalCoherence",
     "ConversationalGuidelines",
     "ConversationalRoleAdherence",
     "ConversationalSafety",
@@ -80,7 +82,9 @@ def __dir__():
 # This gives us the best of both worlds: type hints without circular imports.
 if TYPE_CHECKING:
     from mlflow.genai.scorers.builtin_scorers import (
+        AgentPlanQuality,
         Completeness,
+        ConversationalCoherence,
         ConversationalGuidelines,
         ConversationalRoleAdherence,
         ConversationalSafety,
@@ -105,7 +109,9 @@ if TYPE_CHECKING:
     )
 
 __all__ = [
+    "AgentPlanQuality",
     "Completeness",
+    "ConversationalCoherence",
     "ConversationalGuidelines",
     "ConversationalRoleAdherence",
     "ConversationalSafety",

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -24,6 +24,10 @@ from mlflow.genai.judges.base import Judge, JudgeField
 from mlflow.genai.judges.builtin import _MODEL_API_DOC
 from mlflow.genai.judges.constants import _AFFIRMATIVE_VALUES, _NEGATIVE_VALUES
 from mlflow.genai.judges.instructions_judge import InstructionsJudge
+from mlflow.genai.judges.prompts.agent_plan_quality import (
+    AGENT_PLAN_QUALITY_ASSESSMENT_NAME,
+    AGENT_PLAN_QUALITY_PROMPT,
+)
 from mlflow.genai.judges.prompts.completeness import (
     COMPLETENESS_ASSESSMENT_NAME,
     COMPLETENESS_PROMPT,
@@ -34,6 +38,10 @@ from mlflow.genai.judges.prompts.context_sufficiency import (
 from mlflow.genai.judges.prompts.conversation_completeness import (
     CONVERSATION_COMPLETENESS_ASSESSMENT_NAME,
     CONVERSATION_COMPLETENESS_PROMPT,
+)
+from mlflow.genai.judges.prompts.conversational_coherence import (
+    CONVERSATIONAL_COHERENCE_ASSESSMENT_NAME,
+    CONVERSATIONAL_COHERENCE_PROMPT,
 )
 from mlflow.genai.judges.prompts.conversational_guidelines import (
     CONVERSATIONAL_GUIDELINES_ASSESSMENT_NAME,
@@ -2729,6 +2737,161 @@ class ConversationalGuidelines(BuiltInSessionLevelScorer):
             guidelines = [guidelines]
         formatted_guidelines = "\n".join(f"<guideline>{g}</guideline>" for g in guidelines)
         return CONVERSATIONAL_GUIDELINES_PROMPT.replace("{{ guidelines }}", formatted_guidelines)
+
+
+@experimental(version="3.12.0")
+@format_docstring(_MODEL_API_DOC)
+class ConversationalCoherence(BuiltInSessionLevelScorer):
+    """
+    Conversational coherence evaluates whether the assistant's responses maintain logical flow
+    and consistency across a multi-turn conversation.
+
+    This scorer analyzes the complete conversation to identify coherence failures such as
+    self-contradictions, unresolved references, abrupt topic switches, forgotten context, or
+    responses that do not follow logically from prior turns.
+
+    You can invoke the scorer directly with a session for testing, or pass it to
+    `mlflow.genai.evaluate` for running full evaluation on a dataset.
+
+    Args:
+        name: The name of the scorer. Defaults to "conversational_coherence".
+        model: {{ model }}
+
+    Example (direct usage):
+
+    .. code-block:: python
+
+        import mlflow
+        from mlflow.genai.scorers import ConversationalCoherence
+
+        # Retrieve a list of traces with the same session ID
+        session = mlflow.search_traces(
+            experiment_ids=[experiment_id],
+            filter_string=f"metadata.`mlflow.trace.session` = '{session_id}'",
+            return_type="list",
+        )
+
+        assessment = ConversationalCoherence()(session=session)
+        print(assessment)  # Feedback with value "yes" or "no"
+
+    Example (with evaluate):
+
+    .. code-block:: python
+
+        import mlflow
+        from mlflow.genai.scorers import ConversationalCoherence
+
+        session = mlflow.search_traces(
+            experiment_ids=[experiment_id],
+            filter_string=f"metadata.`mlflow.trace.session` = '{session_id}'",
+            return_type="list",
+        )
+        result = mlflow.genai.evaluate(data=session, scorers=[ConversationalCoherence()])
+    """
+
+    name: str = CONVERSATIONAL_COHERENCE_ASSESSMENT_NAME
+    model: str | None = None
+    description: str = (
+        "Evaluate whether the assistant's responses maintain logical flow and consistency "
+        "across a multi-turn conversation."
+    )
+
+    @property
+    def feedback_value_type(self) -> Any:
+        return Literal["yes", "no"]
+
+    def _create_judge(self) -> Judge:
+        return InstructionsJudge(
+            name=self.name,
+            instructions=self.instructions,
+            model=self.model,
+            description=self.description,
+            feedback_value_type=self.feedback_value_type,
+            generate_rationale_first=True,
+            inference_params=self.inference_params,
+        )
+
+    @property
+    def instructions(self) -> str:
+        return CONVERSATIONAL_COHERENCE_PROMPT
+
+
+@experimental(version="3.12.0")
+@format_docstring(_MODEL_API_DOC)
+class AgentPlanQuality(BuiltInSessionLevelScorer):
+    """
+    Agent plan quality evaluates whether an agent's action planning and reasoning are sound
+    across a multi-turn session, including tool calls and intermediate steps.
+
+    This scorer analyzes the agent's trajectory to judge goal decomposition, step ordering,
+    step relevance, adaptation to tool failures or unexpected results, and termination
+    behavior. It is designed for agentic systems that decompose tasks into multiple steps.
+
+    You can invoke the scorer directly with a session for testing, or pass it to
+    `mlflow.genai.evaluate` for running full evaluation on a dataset.
+
+    Args:
+        name: The name of the scorer. Defaults to "agent_plan_quality".
+        model: {{ model }}
+
+    Example (direct usage):
+
+    .. code-block:: python
+
+        import mlflow
+        from mlflow.genai.scorers import AgentPlanQuality
+
+        # Retrieve a list of traces with the same session ID
+        session = mlflow.search_traces(
+            experiment_ids=[experiment_id],
+            filter_string=f"metadata.`mlflow.trace.session` = '{session_id}'",
+            return_type="list",
+        )
+
+        assessment = AgentPlanQuality()(session=session)
+        print(assessment)  # Feedback with value "yes" or "no"
+
+    Example (with evaluate):
+
+    .. code-block:: python
+
+        import mlflow
+        from mlflow.genai.scorers import AgentPlanQuality
+
+        session = mlflow.search_traces(
+            experiment_ids=[experiment_id],
+            filter_string=f"metadata.`mlflow.trace.session` = '{session_id}'",
+            return_type="list",
+        )
+        result = mlflow.genai.evaluate(data=session, scorers=[AgentPlanQuality()])
+    """
+
+    name: str = AGENT_PLAN_QUALITY_ASSESSMENT_NAME
+    model: str | None = None
+    description: str = (
+        "Evaluate the quality of the agent's action planning and reasoning across a "
+        "multi-turn session, including tool calls and intermediate steps."
+    )
+
+    @property
+    def feedback_value_type(self) -> Any:
+        return Literal["yes", "no"]
+
+    def _create_judge(self) -> Judge:
+        return InstructionsJudge(
+            name=self.name,
+            instructions=self.instructions,
+            model=self.model,
+            description=self.description,
+            feedback_value_type=self.feedback_value_type,
+            generate_rationale_first=True,
+            include_tool_calls_in_conversation=True,
+            inference_params=self.inference_params,
+        )
+
+    @property
+    def instructions(self) -> str:
+        return AGENT_PLAN_QUALITY_PROMPT
 
 
 # Internal implementation detail for KnowledgeRetention - not part of public API

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -14,7 +14,9 @@ from mlflow.genai.judges.base import JudgeField
 from mlflow.genai.judges.builtin import CategoricalRating
 from mlflow.genai.judges.utils import FieldExtraction
 from mlflow.genai.scorers import (
+    AgentPlanQuality,
     Completeness,
+    ConversationalCoherence,
     ConversationalGuidelines,
     ConversationalRoleAdherence,
     ConversationalSafety,
@@ -630,6 +632,8 @@ def test_get_all_scorers():
         "ConversationalSafety",
         "ConversationalToolCallEfficiency",
         "ConversationalRoleAdherence",
+        "ConversationalCoherence",
+        "AgentPlanQuality",
         "KnowledgeRetention",
         "ToolCallEfficiency",
         "ToolCallCorrectness",
@@ -1998,6 +2002,196 @@ def test_conversational_role_adherence_instructions():
     instructions = scorer.instructions
     assert "role" in instructions.lower()
     assert "persona" in instructions.lower() or "boundaries" in instructions.lower()
+
+
+def test_conversational_coherence_with_session():
+    session_id = "test_session_coherence"
+    traces = []
+    for i, (question, answer) in enumerate([
+        ("What's the capital of France?", "The capital of France is Paris."),
+        ("And what's its population?", "Paris has about 2.1 million residents."),
+        ("What language do they speak there?", "French is the primary language in Paris."),
+    ]):
+        with mlflow.start_span(name=f"turn_{i}") as span:
+            span.set_inputs({"question": question})
+            span.set_outputs(answer)
+            mlflow.update_current_trace(metadata={TraceMetadataKey.TRACE_SESSION: session_id})
+        traces.append(mlflow.get_trace(span.trace_id))
+
+    with patch(
+        "mlflow.genai.judges.instructions_judge.invoke_judge_model",
+        return_value=Feedback(
+            name="conversational_coherence",
+            value="yes",
+            rationale="Responses follow logically and maintain context across turns",
+        ),
+    ) as mock_invoke_judge:
+        scorer = ConversationalCoherence()
+        result = scorer(session=traces)
+
+        assert result.name == "conversational_coherence"
+        assert result.value == "yes"
+        assert result.rationale == "Responses follow logically and maintain context across turns"
+        mock_invoke_judge.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("name", "model", "expected_name"),
+    [
+        (None, None, "conversational_coherence"),
+        ("custom_coherence_check", "openai:/gpt-4", "custom_coherence_check"),
+    ],
+)
+def test_conversational_coherence_with_custom_name_and_model(name, model, expected_name):
+    session_id = "test_session_coherence_custom"
+    traces = []
+    with mlflow.start_span(name="single_turn") as span:
+        span.set_inputs({"question": "Test question"})
+        span.set_outputs("Test response")
+        mlflow.update_current_trace(metadata={TraceMetadataKey.TRACE_SESSION: session_id})
+    traces.append(mlflow.get_trace(span.trace_id))
+
+    with patch(
+        "mlflow.genai.judges.instructions_judge.invoke_judge_model",
+        return_value=Feedback(name=expected_name, value="yes", rationale="Coherent"),
+    ) as mock_invoke_judge:
+        kwargs = {}
+        if name:
+            kwargs["name"] = name
+        if model:
+            kwargs["model"] = model
+        scorer = ConversationalCoherence(**kwargs)
+        result = scorer(session=traces)
+
+        assert result.name == expected_name
+        assert result.value == "yes"
+        assert result.rationale == "Coherent"
+        mock_invoke_judge.assert_called_once()
+
+
+def test_conversational_coherence_get_input_fields():
+    scorer = ConversationalCoherence()
+    fields = scorer.get_input_fields()
+    field_names = [field.name for field in fields]
+    assert field_names == ["session"]
+
+
+def test_conversational_coherence_instructions():
+    scorer = ConversationalCoherence()
+    instructions = scorer.instructions
+    assert "conversation" in instructions.lower()
+    assert "coheren" in instructions.lower() or "logical" in instructions.lower()
+    assert "consisten" in instructions.lower()
+
+
+def test_conversational_coherence_rejects_unexpected_kwargs():
+    scorer = ConversationalCoherence()
+    with pytest.raises(TypeError, match="unexpected keyword argument"):
+        scorer(trace="dummy")
+
+
+def test_agent_plan_quality_with_session():
+    session_id = "test_session_plan_quality"
+    traces = []
+    for i, (question, tool_name, tool_input, tool_output, answer) in enumerate([
+        (
+            "Book a flight to Tokyo next Friday",
+            "search_flights",
+            {"destination": "Tokyo", "date": "next Friday"},
+            "3 flights available",
+            "I found 3 flights to Tokyo next Friday.",
+        ),
+        (
+            "Pick the cheapest one and reserve it",
+            "reserve_flight",
+            {"flight_id": "F1"},
+            "Reservation confirmed: F1",
+            "Reserved the cheapest flight (F1).",
+        ),
+    ]):
+        with mlflow.start_span(name=f"turn_{i}") as span:
+            span.set_inputs({"question": question})
+            span.set_outputs(answer)
+            mlflow.update_current_trace(metadata={TraceMetadataKey.TRACE_SESSION: session_id})
+
+            with mlflow.start_span(name=tool_name, span_type=SpanType.TOOL) as tool_span:
+                tool_span.set_inputs(tool_input)
+                tool_span.set_outputs(tool_output)
+
+        traces.append(mlflow.get_trace(span.trace_id))
+
+    mock_feedback = Feedback(
+        name="agent_plan_quality",
+        value=CategoricalRating.YES,
+        rationale="Agent decomposed the task into sensible steps and adapted to user follow-up",
+    )
+
+    with patch(
+        "mlflow.genai.judges.instructions_judge.invoke_judge_model",
+        return_value=mock_feedback,
+    ) as mock_invoke_judge:
+        scorer = AgentPlanQuality()
+        result = scorer(session=traces)
+
+        assert result.name == "agent_plan_quality"
+        assert result.value == CategoricalRating.YES
+        mock_invoke_judge.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("name", "model", "expected_name"),
+    [
+        (None, None, "agent_plan_quality"),
+        ("custom_plan_judge", "openai:/gpt-4", "custom_plan_judge"),
+    ],
+)
+def test_agent_plan_quality_with_custom_name_and_model(name, model, expected_name):
+    session_id = "test_session_plan_quality_custom"
+    traces = []
+    with mlflow.start_span(name="agent_turn") as span:
+        span.set_inputs({"question": "Test task"})
+        span.set_outputs("Test plan")
+        mlflow.update_current_trace(metadata={TraceMetadataKey.TRACE_SESSION: session_id})
+    traces.append(mlflow.get_trace(span.trace_id))
+
+    with patch(
+        "mlflow.genai.judges.instructions_judge.invoke_judge_model",
+        return_value=Feedback(name=expected_name, value="yes", rationale="Sound plan"),
+    ) as mock_invoke_judge:
+        kwargs = {}
+        if name:
+            kwargs["name"] = name
+        if model:
+            kwargs["model"] = model
+        scorer = AgentPlanQuality(**kwargs)
+        result = scorer(session=traces)
+
+        assert result.name == expected_name
+        assert result.value == "yes"
+        assert result.rationale == "Sound plan"
+        mock_invoke_judge.assert_called_once()
+
+
+def test_agent_plan_quality_get_input_fields():
+    scorer = AgentPlanQuality()
+    fields = scorer.get_input_fields()
+    field_names = [field.name for field in fields]
+    assert field_names == ["session"]
+
+
+def test_agent_plan_quality_instructions():
+    scorer = AgentPlanQuality()
+    instructions = scorer.instructions
+    assert "plan" in instructions.lower()
+    assert "goal" in instructions.lower() or "decomposition" in instructions.lower()
+    assert "tool" in instructions.lower()
+
+
+def test_agent_plan_quality_judge_includes_tool_calls():
+    """Plan quality must see tool-call context to evaluate ordering, relevance, and recovery."""
+    scorer = AgentPlanQuality()
+    judge = scorer._create_judge()
+    assert judge._include_tool_calls_in_conversation is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Related Issues/PRs

Addresses #19061 — adds the two remaining multi-turn judges proposed in that FR: `ConversationalCoherence` and `AgentPlanQuality`. (The other judges in that issue — `ConversationalSafety`, `ConversationalToolCallEfficiency`, `ConversationalRoleAdherence` — already ship as built-in scorers.)

### What changes are proposed in this pull request?

Two new session-level built-in scorers in `mlflow.genai.scorers`, wired through the existing `BuiltInSessionLevelScorer` / `InstructionsJudge` machinery. Both are drop-in with no new dependencies.

**`ConversationalCoherence`** — evaluates whether the assistant's responses across a multi-turn conversation are logically coherent. Rubric covers:

- Logical progression across turns
- Internal consistency (no self-contradictions)
- Reference resolution (pronouns, ellipses, prior entities)
- Context retention of user-provided information
- Topic continuity and clean transitions

**`AgentPlanQuality`** — evaluates the quality of an agent's action planning and reasoning across a session (including tool calls and intermediate steps). Rubric covers:

- Goal decomposition into achievable subgoals
- Logical ordering and prerequisite satisfaction
- Step relevance (no busy work or tangents)
- Adaptivity when tools fail or return unexpected results
- Termination once the goal is achieved

Uses `include_tool_calls_in_conversation=True` so the judge sees the tool trajectory when scoring plans.

**Files changed:**

| File | Change |
| ---- | ------ |
| `mlflow/genai/judges/prompts/conversational_coherence.py` | **New.** Prompt + assessment name constant. |
| `mlflow/genai/judges/prompts/agent_plan_quality.py` | **New.** Prompt + assessment name constant. |
| `mlflow/genai/scorers/builtin_scorers.py` | Added `ConversationalCoherence` and `AgentPlanQuality` classes (both `BuiltInSessionLevelScorer` subclasses) and the corresponding prompt imports. |
| `mlflow/genai/scorers/__init__.py` | Added both classes to `_LAZY_IMPORTS`, the `TYPE_CHECKING` block, and `__all__` (alphabetically). |
| `tests/genai/scorers/test_builtin_scorers.py` | 13 new unit tests + updated `test_get_all_scorers` expected set. |
| `docs/docs/genai/eval-monitor/scorers/llm-judge/predefined.mdx` | Added both judges to the multi-turn judges table. |
| `docs/api_reference/api_inventory.txt` | Added the new public API symbols. |

Both scorers return `Literal["yes", "no"]`, default to the shared built-in judge model, and support the usual `name=` / `model=` constructor overrides consistent with the rest of the library.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

New tests for each scorer cover session invocation, the custom-name/custom-model parametrization, `get_input_fields` contract (`["session"]`), prompt content (keyword checks), kwargs validation, and — for `AgentPlanQuality` — that the underlying `InstructionsJudge` is created with `_include_tool_calls_in_conversation=True` so tool trajectories are actually fed to the model.

Verification on this branch:
- `pytest tests/genai/scorers/test_builtin_scorers.py` → **141 passed, 4 skipped, 0 failures** (13 new tests pass, zero regressions in existing 128 tests).
- `pytest tests/genai/scorers/test_serialization.py` → **20 passed** (built-in scorer serialization round-trip is unaffected).
- `ruff check` + `ruff format --check` across all touched files → clean.

### Does this PR require documentation update?

- [x] Yes. `docs/docs/genai/eval-monitor/scorers/llm-judge/predefined.mdx` has been updated to list both new judges in the multi-turn built-in judges table, and `docs/api_reference/api_inventory.txt` has been updated to include the new public API symbols.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Two new built-in LLM judges, `mlflow.genai.scorers.ConversationalCoherence` and `mlflow.genai.scorers.AgentPlanQuality`, are now available for multi-turn evaluation. They drop into `mlflow.genai.evaluate(..., scorers=[...])` the same way as the existing `ConversationalSafety` / `ConversationalRoleAdherence` scorers.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release