### PR TITLE
Clarify full text search availability in search traces docs

### DIFF
--- a/docs/docs/genai/tracing/search-traces.mdx
+++ b/docs/docs/genai/tracing/search-traces.mdx
@@ -55,19 +55,19 @@ The `search_traces` API uses a SQL-like Domain Specific Language (DSL) for query
 
 ### Supported Filters and Comparators
 
-| Field Type           | Fields                                                               | Operators                                                     | Examples                                    |
-| -------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------- |
-| **Trace Status**     | `trace.status`                                                       | `=`, `!=`                                                     | trace.status = "OK"                         |
-| **Trace Timestamps** | `trace.timestamp_ms`, `trace.execution_time_ms`, `trace.end_time_ms` | `=`, `!=`, `>`, `<`, `>=`, `<=`                               | trace.end_time_ms > 1762408895531           |
-| **Trace IDs**        | `trace.run_id`                                                       | `=`                                                           | trace.run_id = "run_id"                     |
-| **String Fields**    | `trace.client_request_id`, `trace.name`                              | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`                           | trace.name LIKE "%Generate%"                |
-| **Linked Prompts**   | `prompt`                                                             | `=` (format: `"name/version"`)                                | prompt = "qa-system-prompt/4"               |
-| **Span Name/Type**   | `span.name`, `span.type`                                             | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`                           | span.type RLIKE "^LLM"                      |
-| **Tags**             | `tag.<key>`                                                          | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`, `IS NULL`, `IS NOT NULL` | tag.key = "value"                           |
-| **Metadata**         | `metadata.<key>`                                                     | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`, `IS NULL`, `IS NOT NULL` | metadata.\`mlflow.trace.user\` = "user_123" |
-| **Feedback**         | `feedback.<name>`                                                    | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`                           | feedback.rating = "excellent"               |
-| **Expectations**     | `expectation.<name>`                                                 | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`                           | expectation.result = "pass"                 |
-| **Full Text**        | `trace.text`                                                         | `LIKE` (with `%` wildcards)                                   | trace.text LIKE "%tell me a story"          |
+| Field Type                                | Fields                                                               | Operators                                                     | Examples                                    |
+| ----------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------- |
+| **Trace Status**                          | `trace.status`                                                       | `=`, `!=`                                                     | trace.status = "OK"                         |
+| **Trace Timestamps**                      | `trace.timestamp_ms`, `trace.execution_time_ms`, `trace.end_time_ms` | `=`, `!=`, `>`, `<`, `>=`, `<=`                               | trace.end_time_ms > 1762408895531           |
+| **Trace IDs**                             | `trace.run_id`                                                       | `=`                                                           | trace.run_id = "run_id"                     |
+| **String Fields**                         | `trace.client_request_id`, `trace.name`                              | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`                           | trace.name LIKE "%Generate%"                |
+| **Linked Prompts**                        | `prompt`                                                             | `=` (format: `"name/version"`)                                | prompt = "qa-system-prompt/4"               |
+| **Span Name/Type**                        | `span.name`, `span.type`                                             | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`                           | span.type RLIKE "^LLM"                      |
+| **Tags**                                  | `tag.<key>`                                                          | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`, `IS NULL`, `IS NOT NULL` | tag.key = "value"                           |
+| **Metadata**                              | `metadata.<key>`                                                     | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`, `IS NULL`, `IS NOT NULL` | metadata.\`mlflow.trace.user\` = "user_123" |
+| **Feedback**                              | `feedback.<name>`                                                    | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`                           | feedback.rating = "excellent"               |
+| **Expectations**                          | `expectation.<name>`                                                 | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`                           | expectation.result = "pass"                 |
+| **Full Text** (OSS SQLAlchemy store only) | `trace.text`                                                         | `LIKE` (with `%` wildcards)                                   | trace.text LIKE "%tell me a story"          |
 
 **Value Syntax:**
 
@@ -84,7 +84,7 @@ The `search_traces` API uses a SQL-like Domain Specific Language (DSL) for query
 
 ### Example Queries
 
-#### Full Text Search
+#### Full Text Search (OSS SQLAlchemy store only)
 
 Search for any contents existing in your trace.
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #21319

### What changes are proposed in this pull request?

Add "(OSS SQLAlchemy store only)" note to the full text search (`trace.text`) filter in the search traces documentation. The `trace.text` filter key is not supported by Databricks managed MLflow. Since this OSS doc is heavily referenced by Databricks managed docs, this clarification helps avoid confusion for users on managed platforms.

Updated both the filter key reference table and the example queries section heading.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Verified docs build and render correctly locally.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release