### PR TITLE
Fix checkbox/expand toggle hitbox overlap in session grouped row header

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableSessionGroupedRows.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableSessionGroupedRows.tsx
@@ -254,15 +254,18 @@ const SessionHeaderRow = React.memo(function SessionHeaderRow({
 
   return (
     <TableRow isHeader>
-      <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
+      <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs, flexShrink: 0 }}>
         {enableRowSelection && (
-          <TableRowSelectCell
-            componentId="mlflow.genai-traces-table.session-header.select-cell"
-            checked={isSessionSelected}
-            indeterminate={isSessionIndeterminate}
-            onChange={handleToggleSelection}
-            isDisabled={isComparing}
-          />
+          // Clip the Ant checkbox's label overhang so its hitbox doesn't extend under the expand toggle.
+          <div css={{ overflow: 'hidden' }}>
+            <TableRowSelectCell
+              componentId="mlflow.genai-traces-table.session-header.select-cell"
+              checked={isSessionSelected}
+              indeterminate={isSessionIndeterminate}
+              onChange={handleToggleSelection}
+              isDisabled={isComparing}
+            />
+          </div>
         )}
         {/* Hide expand/collapse button when comparing - sessions are non-expandable in comparison mode */}
         {!isComparing && (


### PR DESCRIPTION
### Related Issues/PRs

Relates to #21324

### What changes are proposed in this pull request?

Fixes an overlap between the selection checkbox and the expand toggle button in the session grouped row header of the GenAI traces table.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Verified in the local dev server that the checkbox and expand toggle no longer share a hitbox in the session header, and that the rest of the layout/selection behavior is unchanged.

Before

https://github.com/user-attachments/assets/aecb1038-64f8-4a69-9b95-9c5acf7d3c1d


After

https://github.com/user-attachments/assets/b946caf7-8fcc-46b9-9fcd-c47ca8979269



### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix an overlap between the row-selection checkbox and the expand toggle in the session grouped row header of the GenAI traces table.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`
- [ ] `area/models`
- [ ] `area/model-registry`
- [ ] `area/scoring`
- [ ] `area/evaluation`
- [ ] `area/gateway`
- [ ] `area/prompts`
- [ ] `area/tracing`
- [ ] `area/projects`
- [x] `area/uiux`
- [ ] `area/build`
- [ ] `area/docs`

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none`
- [ ] `rn/breaking-change`
- [ ] `rn/feature`
- [ ] `rn/bug-fix`
- [ ] `rn/documentation`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release