### PR TITLE
genai: preserve non-ASCII judge template values

### DIFF
--- a/mlflow/genai/judges/instructions_judge/__init__.py
+++ b/mlflow/genai/judges/instructions_judge/__init__.py
@@ -476,7 +476,7 @@ class InstructionsJudge(Judge):
     def _safe_json_dumps(self, value: Any) -> str:
         """Safely serialize a value to JSON, falling back to str() if JSON serialization fails."""
         try:
-            return json.dumps(value, default=str, indent=2)
+            return json.dumps(value, default=str, indent=2, ensure_ascii=False)
         except Exception:
             return str(value)
 

--- a/tests/genai/judges/test_make_judge.py
+++ b/tests/genai/judges/test_make_judge.py
@@ -1650,6 +1650,22 @@ def test_judge_accepts_valid_dict_inputs(mock_invoke_judge_model):
     assert isinstance(result, Feedback)
 
 
+def test_judge_preserves_non_ascii_template_values(mock_invoke_judge_model):
+    judge = make_judge(
+        name="unicode_judge",
+        instructions="Judge this output: {{ outputs }}",
+        feedback_value_type=str,
+        model="openai:/gpt-4",
+    )
+
+    judge(outputs={"text": "éÉàç"})
+
+    captured_messages = mock_invoke_judge_model.captured_args["prompt"]
+    user_msg = captured_messages[1]
+    assert "éÉàç" in user_msg.content
+    assert "\\u00e9" not in user_msg.content
+
+
 def test_judge_rejects_invalid_trace():
     judge = make_judge(
         name="test_judge",


### PR DESCRIPTION
## What changes are included?
- serialize judge template variables with `ensure_ascii=False` in `InstructionsJudge._safe_json_dumps`
- keep non-ASCII characters (for example `éÉàç`) readable in rendered judge prompts instead of escaped Unicode sequences
- add a regression test to verify non-ASCII output values are preserved in the prompt sent to judge models

Fixes #22622.

## Verification
- `source .venv/bin/activate && python -m pytest tests/genai/judges/test_make_judge.py -k "rejects_scalar_expectations or preserves_non_ascii_template_values"`
- Result: `2 passed`