### PR TITLE
Unify execution duration cell rendering in session header rows

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/ExecutionDurationTag.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/ExecutionDurationTag.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import { ClockIcon, Tag } from '@databricks/design-system';
+
+interface ExecutionDurationTagProps {
+  value: string;
+}
+
+export const ExecutionDurationTag: React.FC<ExecutionDurationTagProps> = ({ value }) => (
+  <Tag
+    icon={<ClockIcon />}
+    css={{ width: 'fit-content', maxWidth: '100%' }}
+    componentId="mlflow.genai-traces-table.execution-time"
+  >
+    <span
+      css={{
+        display: 'block',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+      }}
+      title={value}
+    >
+      {value}
+    </span>
+  </Tag>
+);

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/SessionHeaderCellRenderers.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/SessionHeaderCellRenderers.tsx
@@ -20,6 +20,7 @@ import {
   isFeedbackAssessment,
 } from '@databricks/web-shared/model-trace-explorer';
 
+import { ExecutionDurationTag } from './ExecutionDurationTag';
 import { NullCell } from './NullCell';
 import { SessionIdLinkWrapper } from './SessionIdLinkWrapper';
 import { StackedComponents } from './StackedComponents';
@@ -44,7 +45,7 @@ import {
 } from '../hooks/useTableColumns';
 import { TracesTableColumnType, type TracesTableColumn } from '../types';
 import { COMPARE_TO_RUN_COLOR, CURRENT_RUN_COLOR } from '../utils/Colors';
-import { escapeCssSpecialCharacters, highlightSearchInText } from '../utils/DisplayUtils';
+import { escapeCssSpecialCharacters, highlightSearchInText, normalizeDurationString } from '../utils/DisplayUtils';
 import {
   convertFeedbackAssessmentToRunEvalAssessment,
   getExperimentIdFromTraceLocation,
@@ -554,40 +555,21 @@ export const SessionHeaderCell: React.FC<SessionHeaderCellProps> = ({
     }
   } else if (column.id === EXECUTION_DURATION_COLUMN_ID) {
     // Duration - sum all execution durations
-    const duration = traces.length > 0 ? calculateSessionDuration(traces) : null;
-    const otherDuration = otherTraces && otherTraces.length > 0 ? calculateSessionDuration(otherTraces) : null;
+    const duration = traces.length > 0 ? normalizeDurationString(calculateSessionDuration(traces) ?? undefined) : null;
+    const otherDuration =
+      otherTraces && otherTraces.length > 0
+        ? normalizeDurationString(calculateSessionDuration(otherTraces) ?? undefined)
+        : null;
 
     if (isComparing) {
       cellContent = (
         <StackedComponents
-          first={
-            duration ? (
-              <div css={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={duration}>
-                {duration}
-              </div>
-            ) : (
-              <NullCell isComparing />
-            )
-          }
-          second={
-            otherDuration ? (
-              <div css={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={otherDuration}>
-                {otherDuration}
-              </div>
-            ) : (
-              <NullCell isComparing />
-            )
-          }
+          first={duration ? <ExecutionDurationTag value={duration} /> : <NullCell isComparing />}
+          second={otherDuration ? <ExecutionDurationTag value={otherDuration} /> : <NullCell isComparing />}
         />
       );
     } else {
-      cellContent = duration ? (
-        <div css={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={duration}>
-          {duration}
-        </div>
-      ) : (
-        <NullCell />
-      );
+      cellContent = duration ? <ExecutionDurationTag value={duration} /> : <NullCell />;
     }
   } else if (column.id === SIMULATION_GOAL_COLUMN_ID) {
     // Goal column - show the simulation goal (same for matched sessions, so show once)

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/rendererFunctions.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/rendererFunctions.tsx
@@ -13,7 +13,6 @@ import {
   Typography,
   useDesignSystemTheme,
   UserIcon,
-  ClockIcon,
 } from '@databricks/design-system';
 import { FormattedMessage, useIntl, type IntlShape } from '@databricks/i18n';
 import type { ModelTraceInfoV3 } from '../../model-trace-explorer/ModelTrace.types';
@@ -22,6 +21,7 @@ import { useModelTraceExplorerRunJudgesContext } from '../../model-trace-explore
 
 import { GenAITracesTableContext } from '../GenAITracesTableContext';
 
+import { ExecutionDurationTag } from './ExecutionDurationTag';
 import { IssuesCell } from './IssuesCell';
 import { LoggedModelCell } from './LoggedModelCell';
 import { NullCell } from './NullCell';
@@ -66,7 +66,7 @@ import {
 import type { AssessmentInfo, EvalTraceComparisonEntry } from '../types';
 import { getUniqueValueCountsBySourceId } from '../utils/AggregationUtils';
 import { COMPARE_TO_RUN_COLOR, CURRENT_RUN_COLOR } from '../utils/Colors';
-import { highlightSearchInText, timeSinceStr } from '../utils/DisplayUtils';
+import { highlightSearchInText, normalizeDurationString, timeSinceStr } from '../utils/DisplayUtils';
 import { shouldEnableTagGrouping } from '../utils/FeatureUtils';
 import {
   getCustomMetadataKeyFromColumnId,
@@ -957,72 +957,15 @@ export const traceInfoCellRenderer = (
       />
     );
   } else if (colId === EXECUTION_DURATION_COLUMN_ID) {
-    // Parse and reformat time values from the backend. Keep up to 3 decimal places for float values,
-    // trim trailing zeros and the dot if there are no decimal places
-    const normalizeFloatValue = (val?: string) => {
-      if (val === undefined) {
-        return undefined;
-      }
-      const floatVal = parseFloat(val);
-      const unit = val
-        ?.replace?.(/[0-9.]/g, '')
-        .trim()
-        .toLowerCase();
-      if (isNil(floatVal) || isNaN(floatVal)) {
-        return undefined;
-      }
-      return [floatVal.toFixed(3).replace(/\.?0+$/, ''), unit].filter(Boolean).join('');
-    };
-
-    const value = normalizeFloatValue(currentTraceInfo?.[EXECUTION_DURATION_COLUMN_ID]);
-    const otherValue = normalizeFloatValue(otherTraceInfo?.[EXECUTION_DURATION_COLUMN_ID]);
+    const value = normalizeDurationString(currentTraceInfo?.[EXECUTION_DURATION_COLUMN_ID]);
+    const otherValue = normalizeDurationString(otherTraceInfo?.[EXECUTION_DURATION_COLUMN_ID]);
 
     return (
       <StackedComponents
-        first={
-          !isNil(value) ? (
-            <Tag
-              icon={<ClockIcon />}
-              css={{ width: 'fit-content', maxWidth: '100%' }}
-              componentId="mlflow.genai-traces-table.execution-time"
-            >
-              <span
-                css={{
-                  display: 'block',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                }}
-                title={value}
-              >
-                {value}
-              </span>
-            </Tag>
-          ) : (
-            <NullCell isComparing={isComparing} />
-          )
-        }
+        first={!isNil(value) ? <ExecutionDurationTag value={value} /> : <NullCell isComparing={isComparing} />}
         second={
           isComparing &&
-          (!isNil(otherValue) ? (
-            <Tag
-              icon={<ClockIcon />}
-              css={{ width: 'fit-content', maxWidth: '100%' }}
-              componentId="mlflow.genai-traces-table.execution-time"
-            >
-              <span
-                css={{
-                  display: 'block',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                }}
-                title={otherValue}
-              >
-                {otherValue}
-              </span>
-            </Tag>
-          ) : (
-            <NullCell isComparing={isComparing} />
-          ))
+          (!isNil(otherValue) ? <ExecutionDurationTag value={otherValue} /> : <NullCell isComparing={isComparing} />)
         }
       />
     );

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/DisplayUtils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/DisplayUtils.tsx
@@ -14,6 +14,25 @@ export function displayPercentage(fraction: number, numDecimalsDisplayPercentage
   return Number((fraction * 100).toFixed(numDecimalsDisplayPercentage)).toString();
 }
 
+/**
+ * Parse a duration string like "34.00000000000002ms" or "5.100s", round the numeric
+ * part to up to 3 decimals, strip trailing zeros, and reattach the unit.
+ */
+export function normalizeDurationString(val?: string): string | undefined {
+  if (val === undefined) {
+    return undefined;
+  }
+  const floatVal = parseFloat(val);
+  const unit = val
+    ?.replace?.(/[0-9.]/g, '')
+    .trim()
+    .toLowerCase();
+  if (isNil(floatVal) || isNaN(floatVal)) {
+    return undefined;
+  }
+  return [floatVal.toFixed(3).replace(/\.?0+$/, ''), unit].filter(Boolean).join('');
+}
+
 export function displayFloat(value: number | undefined | null, numDecimals = 3) {
   if (isNil(value)) {
     return 'null';


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

Session-grouped rows and regular trace rows now share a single component for the execution duration cell, so the session header's duration renders as a `Tag` with a `ClockIcon` (matching the non-session cell) instead of a plain text span.

- Extracted the shared `Tag` + `ClockIcon` markup into `ExecutionDurationTag` and consume it from both `rendererFunctions.tsx` and `SessionHeaderCellRenderers.tsx`.
- Promoted the inline `normalizeFloatValue` helper in `rendererFunctions.tsx` to an exported `normalizeDurationString` in `utils/DisplayUtils.tsx` and applied it to the session totals too. This fixes floating-point artifacts — e.g. a session total of `34.00000000000002ms` now renders as `34ms`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Before:

<img width="1728" height="958" alt="Screenshot 2026-04-17 at 3 37 17 PM" src="https://github.com/user-attachments/assets/fc463203-2d71-4cd9-bac1-1a76284585ee" />

After:

<img width="1728" height="968" alt="Screenshot 2026-04-17 at 3 37 52 PM" src="https://github.com/user-attachments/assets/e075b515-6cf0-4e83-bb8f-c388b925d58b" />


### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

The session header row in the GenAI traces table now renders its execution duration using the same `Tag` component as individual trace rows, and cleans up floating-point artifacts in the summed duration (e.g. `34.00000000000002ms` → `34ms`).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`
- [ ] `area/models`
- [ ] `area/model-registry`
- [ ] `area/scoring`
- [ ] `area/evaluation`
- [ ] `area/gateway`
- [ ] `area/prompts`
- [ ] `area/tracing`
- [ ] `area/projects`
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`
- [ ] `area/docs`

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none`
- [ ] `rn/breaking-change`
- [ ] `rn/feature`
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release