### PR TITLE
Enable third-party scorer registration in OSS MLflow

### DIFF
--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -453,15 +453,20 @@ class Scorer(BaseModel):
                     f"found in module '{module_path}'."
                 )
             init_kwargs: dict[str, Any] = dict(data.get("kwargs") or {})
-            # Two shapes of third-party class exist: (a) the base wrapper
-            # (`RagasScorer`, `DeepEvalScorer`, …) has no `metric_name` ClassVar
-            # and expects `metric_name=` as an argument, and (b) concrete
-            # subclasses like `ExactMatch` pin `metric_name: ClassVar[str] =
-            # "ExactMatch"` and forward to `super().__init__` internally, so
-            # passing it again raises "multiple values for keyword argument".
-            # Only pass the kwarg when the class hasn't already pinned it.
-            if getattr(scorer_class, "metric_name", None) != metric_name:
+            # Two shapes of third-party class: (a) base wrappers (`RagasScorer` etc.)
+            # have no `metric_name` ClassVar — pass it as a kwarg; (b) concrete
+            # subclasses (`ExactMatch`) pin it via ClassVar and forward to
+            # `super().__init__`, so re-passing raises "multiple values".
+            class_metric_name = getattr(scorer_class, "metric_name", None)
+            if class_metric_name is None:
                 init_kwargs["metric_name"] = metric_name
+            elif class_metric_name != metric_name:
+                raise MlflowException.invalid_parameter_value(
+                    f"Third-party scorer '{serialized.name}': stored metric_name "
+                    f"'{metric_name}' does not match class {module_path}.{class_name} "
+                    f"(ClassVar metric_name='{class_metric_name}'). The class may "
+                    f"have been renamed."
+                )
             model = data.get("model")
             if model is not None:
                 init_kwargs["model"] = model

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -1069,19 +1069,11 @@ class Scorer(BaseModel):
             object.__setattr__(copy, "_cached_dump", dict(self._cached_dump))
         return copy
 
-    def _third_party_accepts_model(self) -> bool:
-        """Whether this third-party scorer's constructor accepts a `model=` kwarg.
-
-        Defaults to True. Subclasses whose concrete metrics reject `model` for some
-        variants (e.g. RAGAS deterministic metrics via `_validate_args`) override
-        this to return False for those variants.
-        """
-        return True
-
     def _rebuild_third_party_copy(self) -> "Scorer":
         """Rebuild a third-party scorer wrapper by re-invoking `__init__`.
 
-        Subclasses must populate `_metric_name`, `_model` (may be None), and
+        Subclasses must populate `_metric_name`, `_model` (None when the concrete
+        metric rejects `model=`, e.g. RAGAS/DeepEval deterministic metrics), and
         `_metric_kwargs` in their `__init__` for this to work. Preserves
         user-facing overrides (``name``, ``description``, ``aggregations``) and
         any cached serialization dump.
@@ -1096,7 +1088,7 @@ class Scorer(BaseModel):
         if class_metric_name != metric_name:
             init_kwargs["metric_name"] = metric_name
         model = getattr(self, "_model", None)
-        if model is not None and self._third_party_accepts_model():
+        if model is not None:
             init_kwargs["model"] = model
         new_instance = type(self)(**init_kwargs)
 

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -413,7 +413,7 @@ class Scorer(BaseModel):
             module_path = data.get("module") or ""
             class_name = data.get("class")
             metric_name = data.get("metric_name")
-            if not any(
+            if ".." in module_path or not any(
                 module_path == m or module_path.startswith(m + ".")
                 for m in THIRD_PARTY_SCORER_ALLOWED_MODULES
             ):
@@ -990,7 +990,9 @@ class Scorer(BaseModel):
 
     def _create_copy(self) -> "Scorer":
         self._check_can_be_registered(
-            error_message="Scorer must be a builtin or decorator scorer to be copied."
+            error_message=(
+                "Scorer must be a builtin, decorator, or third-party scorer to be copied."
+            )
         )
 
         if self.kind == ScorerKind.THIRD_PARTY:

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -118,11 +118,8 @@ class SerializedScorer:
     # MemoryAugmentedJudge fields (for aligned judges)
     memory_augmented_judge_data: dict[str, Any] | None = None
 
-    # Third-party scorer fields (for wrappers around RAGAS / DeepEval / TruLens / Phoenix
-    # metrics). Shape:
-    #   {"module": "mlflow.genai.scorers.ragas", "class": "RagasScorer",
-    #    "metric_name": "Faithfulness", "model": "openai:/gpt-4o",
-    #    "kwargs": {"threshold": 0.5}}
+    # For RAGAS / DeepEval / TruLens / Phoenix wrappers. Shape:
+    #   {"module": ..., "class": ..., "metric_name": ..., "model": ..., "kwargs": {...}}
     third_party_scorer_data: dict[str, Any] | None = None
 
     def __post_init__(self):
@@ -258,33 +255,35 @@ class Scorer(BaseModel):
         return f"{base_repr[:-1]}, sample_rate={self.sample_rate}, filter_string={filter_string})"
 
     def model_dump(self, **kwargs) -> dict[str, Any]:
-        """Override model_dump to include source code."""
-
-        # Return cached dump if available (prevents re-serialization issues with dynamic functions)
         if self._cached_dump is not None:
             return self._cached_dump
 
-        # Check if this is a decorator scorer
+        if self.kind == ScorerKind.THIRD_PARTY:
+            serialized = SerializedScorer(
+                name=self.name,
+                description=self.description,
+                aggregations=self.aggregations,
+                is_session_level_scorer=self.is_session_level_scorer,
+                mlflow_version=mlflow.__version__,
+                serialization_version=_SERIALIZATION_VERSION,
+                third_party_scorer_data={
+                    "module": type(self).__module__,
+                    "class": type(self).__name__,
+                    "metric_name": self._metric_name,
+                    "model": self._model,
+                    "kwargs": dict(self._metric_kwargs),
+                },
+            )
+            self._cached_dump = asdict(serialized)
+            return self._cached_dump
+
         if not getattr(self, "_original_func", None):
-            # BuiltInScorer overrides `model_dump`, so this is neither a builtin scorer nor a
-            # decorator scorer. Third-party scorer wrappers (RagasScorer / DeepEvalScorer /
-            # TruLensScorer / PhoenixScorer) override `model_dump` themselves via
-            # `_build_third_party_dump`, so they never hit this branch.
             raise MlflowException.invalid_parameter_value(
                 f"Unsupported scorer type: {self.__class__.__name__}. "
-                f"Scorer serialization only supports:\n"
-                f"1. Builtin scorers (from mlflow.genai.scorers.builtin_scorers)\n"
-                f"2. Decorator-created scorers (using @scorer decorator)\n"
-                f"3. Third-party scorer wrappers that override model_dump "
-                f"(e.g., RagasScorer, DeepEvalScorer)\n"
-                f"Direct subclassing of Scorer is not supported for serialization. "
-                f"Please use the @scorer decorator instead."
+                f"Use a builtin scorer, the @scorer decorator, or a third-party wrapper."
             )
 
-        # Decorator scorer - extract and store source code
         source_info = self._extract_source_code_info()
-
-        # Create serialized scorer with all fields at once
         serialized = SerializedScorer(
             name=self.name,
             description=self.description,
@@ -295,41 +294,6 @@ class Scorer(BaseModel):
             call_source=source_info.get("call_source"),
             call_signature=source_info.get("call_signature"),
             original_func_name=source_info.get("original_func_name"),
-        )
-        self._cached_dump = asdict(serialized)
-        return self._cached_dump
-
-    def _build_third_party_dump(
-        self,
-        *,
-        metric_name: str,
-        model: str | None,
-        metric_kwargs: dict[str, Any] | None,
-    ) -> dict[str, Any]:
-        """Build a cached `SerializedScorer` dump for a third-party scorer wrapper.
-
-        Third-party scorer subclasses (RagasScorer, DeepEvalScorer, TruLensScorer,
-        PhoenixScorer) are thin wrappers around a named metric class from an external
-        library, so we only need to persist the wrapper identity plus the constructor
-        args — not arbitrary source code. Subclasses call this from their overridden
-        `model_dump`.
-        """
-        if self._cached_dump is not None:
-            return self._cached_dump
-        serialized = SerializedScorer(
-            name=self.name,
-            description=self.description,
-            aggregations=self.aggregations,
-            is_session_level_scorer=self.is_session_level_scorer,
-            mlflow_version=mlflow.__version__,
-            serialization_version=_SERIALIZATION_VERSION,
-            third_party_scorer_data={
-                "module": type(self).__module__,
-                "class": type(self).__name__,
-                "metric_name": metric_name,
-                "model": model,
-                "kwargs": dict(metric_kwargs or {}),
-            },
         )
         self._cached_dump = asdict(serialized)
         return self._cached_dump
@@ -444,9 +408,59 @@ class Scorer(BaseModel):
 
             return MemoryAugmentedJudge._from_serialized(serialized)
 
-        # Handle third-party scorer wrappers (RAGAS / DeepEval / TruLens / Phoenix).
         elif serialized.third_party_scorer_data is not None:
-            return cls._reconstruct_third_party_scorer(serialized)
+            data = serialized.third_party_scorer_data
+            module_path = data.get("module") or ""
+            class_name = data.get("class")
+            metric_name = data.get("metric_name")
+            if not any(
+                module_path == m or module_path.startswith(m + ".")
+                for m in THIRD_PARTY_SCORER_ALLOWED_MODULES
+            ):
+                raise MlflowException.invalid_parameter_value(
+                    f"Third-party scorer '{serialized.name}': module '{module_path}' is not "
+                    f"in the allow-list {sorted(THIRD_PARTY_SCORER_ALLOWED_MODULES)}."
+                )
+            if not class_name or not metric_name:
+                raise MlflowException.invalid_parameter_value(
+                    f"Third-party scorer '{serialized.name}': missing required fields in "
+                    f"third_party_scorer_data (class, metric_name)."
+                )
+            try:
+                module = importlib.import_module(module_path)
+            except ImportError as e:
+                raise MlflowException.invalid_parameter_value(
+                    f"Third-party scorer '{serialized.name}': could not import "
+                    f"'{module_path}'. Is the underlying library installed? {e}"
+                )
+            scorer_class = getattr(module, class_name, None)
+            if scorer_class is None:
+                raise MlflowException.invalid_parameter_value(
+                    f"Third-party scorer '{serialized.name}': class '{class_name}' not "
+                    f"found in module '{module_path}'."
+                )
+            init_kwargs: dict[str, Any] = dict(data.get("kwargs") or {})
+            # Concrete subclasses (e.g. DeepEval `ExactMatch`) hardcode `metric_name`
+            # in their __init__; passing it again raises "multiple values".
+            if getattr(scorer_class, "metric_name", None) != metric_name:
+                init_kwargs["metric_name"] = metric_name
+            model = data.get("model")
+            if model is not None:
+                init_kwargs["model"] = model
+            try:
+                scorer_instance = scorer_class(**init_kwargs)
+            except Exception as e:
+                raise MlflowException.invalid_parameter_value(
+                    f"Third-party scorer '{serialized.name}': failed to instantiate "
+                    f"{module_path}.{class_name}: {e}"
+                )
+            scorer_instance.name = serialized.name
+            if serialized.description is not None:
+                scorer_instance.description = serialized.description
+            if serialized.aggregations is not None:
+                scorer_instance.aggregations = serialized.aggregations
+            object.__setattr__(scorer_instance, "_cached_dump", asdict(serialized))
+            return scorer_instance
 
         # Invalid serialized data
         else:
@@ -532,79 +546,6 @@ class Scorer(BaseModel):
         # Cache the serialized data to prevent re-serialization issues with dynamic functions
         original_serialized_data = asdict(serialized)
         object.__setattr__(scorer_instance, "_cached_dump", original_serialized_data)
-        return scorer_instance
-
-    @classmethod
-    def _reconstruct_third_party_scorer(cls, serialized: SerializedScorer) -> "Scorer":
-        data = serialized.third_party_scorer_data or {}
-        module_path = data.get("module")
-        class_name = data.get("class")
-        metric_name = data.get("metric_name")
-        model = data.get("model")
-        metric_kwargs = dict(data.get("kwargs") or {})
-
-        # Concrete scorer subclasses may live in sub-packages (e.g. the RAGAS `ExactMatch`
-        # class lives in `mlflow.genai.scorers.ragas.scorers.comparison_metrics`), so we
-        # allow any module that matches one of the allowed roots or a sub-package of one.
-        if not any(
-            module_path == allowed or module_path.startswith(allowed + ".")
-            for allowed in THIRD_PARTY_SCORER_ALLOWED_MODULES
-        ):
-            raise MlflowException.invalid_parameter_value(
-                f"Failed to load third-party scorer '{serialized.name}': module "
-                f"'{module_path}' is not in the allow-list of known third-party "
-                f"scorer modules ({sorted(THIRD_PARTY_SCORER_ALLOWED_MODULES)})."
-            )
-        if not class_name or not metric_name:
-            raise MlflowException.invalid_parameter_value(
-                f"Failed to load third-party scorer '{serialized.name}': missing "
-                f"required fields in third_party_scorer_data (class, metric_name)."
-            )
-
-        try:
-            module = importlib.import_module(module_path)
-        except ImportError as e:
-            raise MlflowException.invalid_parameter_value(
-                f"Failed to load third-party scorer '{serialized.name}': could not "
-                f"import module '{module_path}'. Ensure the underlying library is "
-                f"installed in the current environment. Error: {e}"
-            )
-
-        scorer_class = getattr(module, class_name, None)
-        if scorer_class is None:
-            raise MlflowException.invalid_parameter_value(
-                f"Failed to load third-party scorer '{serialized.name}': class "
-                f"'{class_name}' was not found in module '{module_path}'."
-            )
-
-        # Concrete metric subclasses (e.g. DeepEval `ExactMatch`) often hardcode
-        # `metric_name` in their `__init__` and forward it to `super().__init__`, so
-        # passing `metric_name=` into the subclass raises "multiple values for
-        # keyword argument". Only pass it when the class hasn't already pinned it.
-        class_metric_name = getattr(scorer_class, "metric_name", None)
-        init_kwargs: dict[str, Any] = dict(metric_kwargs)
-        if class_metric_name != metric_name:
-            init_kwargs["metric_name"] = metric_name
-        if model is not None:
-            init_kwargs["model"] = model
-        try:
-            scorer_instance = scorer_class(**init_kwargs)
-        except Exception as e:
-            raise MlflowException.invalid_parameter_value(
-                f"Failed to instantiate third-party scorer '{serialized.name}' "
-                f"({module_path}.{class_name}): {e}"
-            )
-
-        # Preserve the original name / description / aggregations from the serialized
-        # record so renaming via `register(name=...)` survives the round trip.
-        scorer_instance.name = serialized.name
-        if serialized.description is not None:
-            scorer_instance.description = serialized.description
-        if serialized.aggregations is not None:
-            scorer_instance.aggregations = serialized.aggregations
-
-        # Cache the serialized data so re-dumping produces the same payload.
-        object.__setattr__(scorer_instance, "_cached_dump", asdict(serialized))
         return scorer_instance
 
     def run(self, *, inputs=None, outputs=None, expectations=None, trace=None, session=None):
@@ -1048,58 +989,29 @@ class Scorer(BaseModel):
         )
 
     def _create_copy(self) -> "Scorer":
-        """
-        Create a copy of this scorer instance.
-        """
         self._check_can_be_registered(
             error_message="Scorer must be a builtin or decorator scorer to be copied."
         )
 
-        # Third-party scorer wrappers often hold non-deepcopyable state inside their
-        # underlying metric instance (e.g., the RAGAS `instructor` client wraps an
-        # object with a recursive `__getattr__` that blows the call stack on deepcopy).
-        # Rebuild a fresh wrapper by re-invoking `__init__` with the stashed args
-        # instead of recursively copying the whole metric graph.
         if self.kind == ScorerKind.THIRD_PARTY:
-            return self._rebuild_third_party_copy()
-
-        copy = self.model_copy(deep=True)
-        # Duplicate the cached dump so modifications to the copy don't affect the original
+            # RAGAS metrics wrap an `instructor` client whose recursive __getattr__
+            # blows the call stack on deepcopy — rebuild via __init__ instead.
+            init_kwargs = dict(self._metric_kwargs)
+            if getattr(type(self), "metric_name", None) != self._metric_name:
+                init_kwargs["metric_name"] = self._metric_name
+            if self._model is not None:
+                init_kwargs["model"] = self._model
+            copy = type(self)(**init_kwargs)
+            copy.name = self.name
+            if self.description is not None:
+                copy.description = self.description
+            if self.aggregations is not None:
+                copy.aggregations = self.aggregations
+        else:
+            copy = self.model_copy(deep=True)
         if self._cached_dump is not None:
             object.__setattr__(copy, "_cached_dump", dict(self._cached_dump))
         return copy
-
-    def _rebuild_third_party_copy(self) -> "Scorer":
-        """Rebuild a third-party scorer wrapper by re-invoking `__init__`.
-
-        Subclasses must populate `_metric_name`, `_model` (None when the concrete
-        metric rejects `model=`, e.g. RAGAS/DeepEval deterministic metrics), and
-        `_metric_kwargs` in their `__init__` for this to work. Preserves
-        user-facing overrides (``name``, ``description``, ``aggregations``) and
-        any cached serialization dump.
-        """
-        init_kwargs = dict(getattr(self, "_metric_kwargs", {}))
-        metric_name = getattr(self, "_metric_name", None) or self.name
-        # Concrete metric subclasses (e.g. DeepEval `ExactMatch`) often hardcode
-        # `metric_name` and forward it to `super().__init__`, so passing it from
-        # outside raises "multiple values for keyword argument". Only pass it
-        # when the class hasn't already pinned it via a ClassVar.
-        class_metric_name = getattr(type(self), "metric_name", None)
-        if class_metric_name != metric_name:
-            init_kwargs["metric_name"] = metric_name
-        model = getattr(self, "_model", None)
-        if model is not None:
-            init_kwargs["model"] = model
-        new_instance = type(self)(**init_kwargs)
-
-        new_instance.name = self.name
-        if self.description is not None:
-            new_instance.description = self.description
-        if self.aggregations is not None:
-            new_instance.aggregations = self.aggregations
-        if self._cached_dump is not None:
-            object.__setattr__(new_instance, "_cached_dump", dict(self._cached_dump))
-        return new_instance
 
     def _check_can_be_registered(self, error_message: str | None = None) -> None:
         from mlflow.genai.scorers.registry import DatabricksStore, _get_scorer_store
@@ -1121,9 +1033,6 @@ class Scorer(BaseModel):
                 DECORATOR_SCORER_REGISTRATION_NOT_SUPPORTED_ERROR
             )
 
-        # Third-party scorer wrappers (RAGAS / DeepEval / TruLens / Phoenix) can be
-        # registered against OSS MLflow backends but are not yet supported by the
-        # Databricks scorer hosting layer.
         if self.kind == ScorerKind.THIRD_PARTY and is_databricks_uri(get_tracking_uri()):
             raise MlflowException.invalid_parameter_value(
                 THIRD_PARTY_SCORER_REGISTRATION_NOT_SUPPORTED_ON_DATABRICKS_ERROR

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -255,6 +255,9 @@ class Scorer(BaseModel):
         return f"{base_repr[:-1]}, sample_rate={self.sample_rate}, filter_string={filter_string})"
 
     def model_dump(self, **kwargs) -> dict[str, Any]:
+        """Override model_dump to include source code."""
+
+        # Return cached dump if available (prevents re-serialization issues with dynamic functions)
         if self._cached_dump is not None:
             return self._cached_dump
 
@@ -277,13 +280,23 @@ class Scorer(BaseModel):
             self._cached_dump = asdict(serialized)
             return self._cached_dump
 
+        # Check if this is a decorator scorer
         if not getattr(self, "_original_func", None):
+            # BuiltInScorer overrides `model_dump`, so this is neither a builtin scorer nor a
+            # decorator scorer
             raise MlflowException.invalid_parameter_value(
                 f"Unsupported scorer type: {self.__class__.__name__}. "
-                f"Use a builtin scorer, the @scorer decorator, or a third-party wrapper."
+                f"Scorer serialization only supports:\n"
+                f"1. Builtin scorers (from mlflow.genai.scorers.builtin_scorers)\n"
+                f"2. Decorator-created scorers (using @scorer decorator)\n"
+                f"Direct subclassing of Scorer is not supported for serialization. "
+                f"Please use the @scorer decorator instead."
             )
 
+        # Decorator scorer - extract and store source code
         source_info = self._extract_source_code_info()
+
+        # Create serialized scorer with all fields at once
         serialized = SerializedScorer(
             name=self.name,
             description=self.description,
@@ -989,6 +1002,9 @@ class Scorer(BaseModel):
         )
 
     def _create_copy(self) -> "Scorer":
+        """
+        Create a copy of this scorer instance.
+        """
         self._check_can_be_registered(
             error_message=(
                 "Scorer must be a builtin, decorator, or third-party scorer to be copied."
@@ -1011,6 +1027,7 @@ class Scorer(BaseModel):
                 copy.aggregations = self.aggregations
         else:
             copy = self.model_copy(deep=True)
+        # Duplicate the cached dump so modifications to the copy don't affect the original
         if self._cached_dump is not None:
             object.__setattr__(copy, "_cached_dump", dict(self._cached_dump))
         return copy

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -426,7 +426,7 @@ class Scorer(BaseModel):
             module_path = data.get("module") or ""
             class_name = data.get("class")
             metric_name = data.get("metric_name")
-            if ".." in module_path or not any(
+            if not any(
                 module_path == m or module_path.startswith(m + ".")
                 for m in THIRD_PARTY_SCORER_ALLOWED_MODULES
             ):
@@ -453,8 +453,13 @@ class Scorer(BaseModel):
                     f"found in module '{module_path}'."
                 )
             init_kwargs: dict[str, Any] = dict(data.get("kwargs") or {})
-            # Concrete subclasses (e.g. DeepEval `ExactMatch`) hardcode `metric_name`
-            # in their __init__; passing it again raises "multiple values".
+            # Two shapes of third-party class exist: (a) the base wrapper
+            # (`RagasScorer`, `DeepEvalScorer`, …) has no `metric_name` ClassVar
+            # and expects `metric_name=` as an argument, and (b) concrete
+            # subclasses like `ExactMatch` pin `metric_name: ClassVar[str] =
+            # "ExactMatch"` and forward to `super().__init__` internally, so
+            # passing it again raises "multiple values for keyword argument".
+            # Only pass the kwarg when the class hasn't already pinned it.
             if getattr(scorer_class, "metric_name", None) != metric_name:
                 init_kwargs["metric_name"] = metric_name
             model = data.get("model")
@@ -1012,8 +1017,12 @@ class Scorer(BaseModel):
         )
 
         if self.kind == ScorerKind.THIRD_PARTY:
-            # RAGAS metrics wrap an `instructor` client whose recursive __getattr__
-            # blows the call stack on deepcopy — rebuild via __init__ instead.
+            # Rebuild via `__init__` rather than `model_copy(deep=True)`: some
+            # third-party metric instances (notably RAGAS metrics, which hold an
+            # `instructor`-wrapped LLM client) contain objects whose `__getattr__`
+            # recurses into themselves when deepcopy walks them, overflowing the
+            # stack. Re-running `__init__` with the stored args produces a clean
+            # wrapper without touching the underlying metric's state.
             init_kwargs = dict(self._metric_kwargs)
             if getattr(type(self), "metric_name", None) != self._metric_name:
                 init_kwargs["metric_name"] = self._metric_name

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -1,4 +1,5 @@
 import functools
+import importlib
 import inspect
 import json
 import logging
@@ -16,6 +17,8 @@ from mlflow.entities.trace import Trace
 from mlflow.exceptions import MlflowException
 from mlflow.genai.scorers.scorer_utils import (
     DECORATOR_SCORER_REGISTRATION_NOT_SUPPORTED_ERROR,
+    THIRD_PARTY_SCORER_ALLOWED_MODULES,
+    THIRD_PARTY_SCORER_REGISTRATION_NOT_SUPPORTED_ON_DATABRICKS_ERROR,
 )
 from mlflow.telemetry.events import ScorerCallEvent
 from mlflow.telemetry.track import record_usage_event
@@ -57,6 +60,7 @@ _ALLOWED_SCORERS_FOR_REGISTRATION = [
     ScorerKind.INSTRUCTIONS,
     ScorerKind.GUIDELINES,
     ScorerKind.MEMORY_AUGMENTED,
+    ScorerKind.THIRD_PARTY,
 ]
 
 
@@ -114,12 +118,20 @@ class SerializedScorer:
     # MemoryAugmentedJudge fields (for aligned judges)
     memory_augmented_judge_data: dict[str, Any] | None = None
 
+    # Third-party scorer fields (for wrappers around RAGAS / DeepEval / TruLens / Phoenix
+    # metrics). Shape:
+    #   {"module": "mlflow.genai.scorers.ragas", "class": "RagasScorer",
+    #    "metric_name": "Faithfulness", "model": "openai:/gpt-4o",
+    #    "kwargs": {"threshold": 0.5}}
+    third_party_scorer_data: dict[str, Any] | None = None
+
     def __post_init__(self):
         """Validate that exactly one type of scorer fields is present."""
         has_builtin_fields = self.builtin_scorer_class is not None
         has_decorator_fields = self.call_source is not None
         has_instructions_fields = self.instructions_judge_pydantic_data is not None
         has_memory_augmented_fields = self.memory_augmented_judge_data is not None
+        has_third_party_fields = self.third_party_scorer_data is not None
 
         # Count how many field types are present
         field_count = sum([
@@ -127,6 +139,7 @@ class SerializedScorer:
             has_decorator_fields,
             has_instructions_fields,
             has_memory_augmented_fields,
+            has_third_party_fields,
         ])
 
         if field_count == 0:
@@ -134,7 +147,8 @@ class SerializedScorer:
                 "SerializedScorer must have either builtin scorer fields "
                 "(builtin_scorer_class), decorator scorer fields (call_source), "
                 "instructions judge fields (instructions_judge_pydantic_data), "
-                "or memory augmented judge fields (memory_augmented_judge_data) present"
+                "memory augmented judge fields (memory_augmented_judge_data), "
+                "or third-party scorer fields (third_party_scorer_data) present"
             )
 
         if field_count > 1:
@@ -253,12 +267,16 @@ class Scorer(BaseModel):
         # Check if this is a decorator scorer
         if not getattr(self, "_original_func", None):
             # BuiltInScorer overrides `model_dump`, so this is neither a builtin scorer nor a
-            # decorator scorer
+            # decorator scorer. Third-party scorer wrappers (RagasScorer / DeepEvalScorer /
+            # TruLensScorer / PhoenixScorer) override `model_dump` themselves via
+            # `_build_third_party_dump`, so they never hit this branch.
             raise MlflowException.invalid_parameter_value(
                 f"Unsupported scorer type: {self.__class__.__name__}. "
                 f"Scorer serialization only supports:\n"
                 f"1. Builtin scorers (from mlflow.genai.scorers.builtin_scorers)\n"
                 f"2. Decorator-created scorers (using @scorer decorator)\n"
+                f"3. Third-party scorer wrappers that override model_dump "
+                f"(e.g., RagasScorer, DeepEvalScorer)\n"
                 f"Direct subclassing of Scorer is not supported for serialization. "
                 f"Please use the @scorer decorator instead."
             )
@@ -277,6 +295,41 @@ class Scorer(BaseModel):
             call_source=source_info.get("call_source"),
             call_signature=source_info.get("call_signature"),
             original_func_name=source_info.get("original_func_name"),
+        )
+        self._cached_dump = asdict(serialized)
+        return self._cached_dump
+
+    def _build_third_party_dump(
+        self,
+        *,
+        metric_name: str,
+        model: str | None,
+        metric_kwargs: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        """Build a cached `SerializedScorer` dump for a third-party scorer wrapper.
+
+        Third-party scorer subclasses (RagasScorer, DeepEvalScorer, TruLensScorer,
+        PhoenixScorer) are thin wrappers around a named metric class from an external
+        library, so we only need to persist the wrapper identity plus the constructor
+        args — not arbitrary source code. Subclasses call this from their overridden
+        `model_dump`.
+        """
+        if self._cached_dump is not None:
+            return self._cached_dump
+        serialized = SerializedScorer(
+            name=self.name,
+            description=self.description,
+            aggregations=self.aggregations,
+            is_session_level_scorer=self.is_session_level_scorer,
+            mlflow_version=mlflow.__version__,
+            serialization_version=_SERIALIZATION_VERSION,
+            third_party_scorer_data={
+                "module": type(self).__module__,
+                "class": type(self).__name__,
+                "metric_name": metric_name,
+                "model": model,
+                "kwargs": dict(metric_kwargs or {}),
+            },
         )
         self._cached_dump = asdict(serialized)
         return self._cached_dump
@@ -391,6 +444,10 @@ class Scorer(BaseModel):
 
             return MemoryAugmentedJudge._from_serialized(serialized)
 
+        # Handle third-party scorer wrappers (RAGAS / DeepEval / TruLens / Phoenix).
+        elif serialized.third_party_scorer_data is not None:
+            return cls._reconstruct_third_party_scorer(serialized)
+
         # Invalid serialized data
         else:
             raise MlflowException.invalid_parameter_value(
@@ -475,6 +532,79 @@ class Scorer(BaseModel):
         # Cache the serialized data to prevent re-serialization issues with dynamic functions
         original_serialized_data = asdict(serialized)
         object.__setattr__(scorer_instance, "_cached_dump", original_serialized_data)
+        return scorer_instance
+
+    @classmethod
+    def _reconstruct_third_party_scorer(cls, serialized: SerializedScorer) -> "Scorer":
+        data = serialized.third_party_scorer_data or {}
+        module_path = data.get("module")
+        class_name = data.get("class")
+        metric_name = data.get("metric_name")
+        model = data.get("model")
+        metric_kwargs = dict(data.get("kwargs") or {})
+
+        # Concrete scorer subclasses may live in sub-packages (e.g. the RAGAS `ExactMatch`
+        # class lives in `mlflow.genai.scorers.ragas.scorers.comparison_metrics`), so we
+        # allow any module that matches one of the allowed roots or a sub-package of one.
+        if not any(
+            module_path == allowed or module_path.startswith(allowed + ".")
+            for allowed in THIRD_PARTY_SCORER_ALLOWED_MODULES
+        ):
+            raise MlflowException.invalid_parameter_value(
+                f"Failed to load third-party scorer '{serialized.name}': module "
+                f"'{module_path}' is not in the allow-list of known third-party "
+                f"scorer modules ({sorted(THIRD_PARTY_SCORER_ALLOWED_MODULES)})."
+            )
+        if not class_name or not metric_name:
+            raise MlflowException.invalid_parameter_value(
+                f"Failed to load third-party scorer '{serialized.name}': missing "
+                f"required fields in third_party_scorer_data (class, metric_name)."
+            )
+
+        try:
+            module = importlib.import_module(module_path)
+        except ImportError as e:
+            raise MlflowException.invalid_parameter_value(
+                f"Failed to load third-party scorer '{serialized.name}': could not "
+                f"import module '{module_path}'. Ensure the underlying library is "
+                f"installed in the current environment. Error: {e}"
+            )
+
+        scorer_class = getattr(module, class_name, None)
+        if scorer_class is None:
+            raise MlflowException.invalid_parameter_value(
+                f"Failed to load third-party scorer '{serialized.name}': class "
+                f"'{class_name}' was not found in module '{module_path}'."
+            )
+
+        # Concrete metric subclasses (e.g. DeepEval `ExactMatch`) often hardcode
+        # `metric_name` in their `__init__` and forward it to `super().__init__`, so
+        # passing `metric_name=` into the subclass raises "multiple values for
+        # keyword argument". Only pass it when the class hasn't already pinned it.
+        class_metric_name = getattr(scorer_class, "metric_name", None)
+        init_kwargs: dict[str, Any] = dict(metric_kwargs)
+        if class_metric_name != metric_name:
+            init_kwargs["metric_name"] = metric_name
+        if model is not None:
+            init_kwargs["model"] = model
+        try:
+            scorer_instance = scorer_class(**init_kwargs)
+        except Exception as e:
+            raise MlflowException.invalid_parameter_value(
+                f"Failed to instantiate third-party scorer '{serialized.name}' "
+                f"({module_path}.{class_name}): {e}"
+            )
+
+        # Preserve the original name / description / aggregations from the serialized
+        # record so renaming via `register(name=...)` survives the round trip.
+        scorer_instance.name = serialized.name
+        if serialized.description is not None:
+            scorer_instance.description = serialized.description
+        if serialized.aggregations is not None:
+            scorer_instance.aggregations = serialized.aggregations
+
+        # Cache the serialized data so re-dumping produces the same payload.
+        object.__setattr__(scorer_instance, "_cached_dump", asdict(serialized))
         return scorer_instance
 
     def run(self, *, inputs=None, outputs=None, expectations=None, trace=None, session=None):
@@ -925,11 +1055,59 @@ class Scorer(BaseModel):
             error_message="Scorer must be a builtin or decorator scorer to be copied."
         )
 
+        # Third-party scorer wrappers often hold non-deepcopyable state inside their
+        # underlying metric instance (e.g., the RAGAS `instructor` client wraps an
+        # object with a recursive `__getattr__` that blows the call stack on deepcopy).
+        # Rebuild a fresh wrapper by re-invoking `__init__` with the stashed args
+        # instead of recursively copying the whole metric graph.
+        if self.kind == ScorerKind.THIRD_PARTY:
+            return self._rebuild_third_party_copy()
+
         copy = self.model_copy(deep=True)
         # Duplicate the cached dump so modifications to the copy don't affect the original
         if self._cached_dump is not None:
             object.__setattr__(copy, "_cached_dump", dict(self._cached_dump))
         return copy
+
+    def _third_party_accepts_model(self) -> bool:
+        """Whether this third-party scorer's constructor accepts a `model=` kwarg.
+
+        Defaults to True. Subclasses whose concrete metrics reject `model` for some
+        variants (e.g. RAGAS deterministic metrics via `_validate_args`) override
+        this to return False for those variants.
+        """
+        return True
+
+    def _rebuild_third_party_copy(self) -> "Scorer":
+        """Rebuild a third-party scorer wrapper by re-invoking `__init__`.
+
+        Subclasses must populate `_metric_name`, `_model` (may be None), and
+        `_metric_kwargs` in their `__init__` for this to work. Preserves
+        user-facing overrides (``name``, ``description``, ``aggregations``) and
+        any cached serialization dump.
+        """
+        init_kwargs = dict(getattr(self, "_metric_kwargs", {}))
+        metric_name = getattr(self, "_metric_name", None) or self.name
+        # Concrete metric subclasses (e.g. DeepEval `ExactMatch`) often hardcode
+        # `metric_name` and forward it to `super().__init__`, so passing it from
+        # outside raises "multiple values for keyword argument". Only pass it
+        # when the class hasn't already pinned it via a ClassVar.
+        class_metric_name = getattr(type(self), "metric_name", None)
+        if class_metric_name != metric_name:
+            init_kwargs["metric_name"] = metric_name
+        model = getattr(self, "_model", None)
+        if model is not None and self._third_party_accepts_model():
+            init_kwargs["model"] = model
+        new_instance = type(self)(**init_kwargs)
+
+        new_instance.name = self.name
+        if self.description is not None:
+            new_instance.description = self.description
+        if self.aggregations is not None:
+            new_instance.aggregations = self.aggregations
+        if self._cached_dump is not None:
+            object.__setattr__(new_instance, "_cached_dump", dict(self._cached_dump))
+        return new_instance
 
     def _check_can_be_registered(self, error_message: str | None = None) -> None:
         from mlflow.genai.scorers.registry import DatabricksStore, _get_scorer_store
@@ -949,6 +1127,14 @@ class Scorer(BaseModel):
         if self.kind == ScorerKind.DECORATOR and not is_databricks_uri(get_tracking_uri()):
             raise MlflowException.invalid_parameter_value(
                 DECORATOR_SCORER_REGISTRATION_NOT_SUPPORTED_ERROR
+            )
+
+        # Third-party scorer wrappers (RAGAS / DeepEval / TruLens / Phoenix) can be
+        # registered against OSS MLflow backends but are not yet supported by the
+        # Databricks scorer hosting layer.
+        if self.kind == ScorerKind.THIRD_PARTY and is_databricks_uri(get_tracking_uri()):
+            raise MlflowException.invalid_parameter_value(
+                THIRD_PARTY_SCORER_REGISTRATION_NOT_SUPPORTED_ON_DATABRICKS_ERROR
             )
 
         store = _get_scorer_store()

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -1022,15 +1022,23 @@ class Scorer(BaseModel):
         )
 
         if self.kind == ScorerKind.THIRD_PARTY:
-            # Rebuild via `__init__` rather than `model_copy(deep=True)`: some
-            # third-party metric instances (notably RAGAS metrics, which hold an
-            # `instructor`-wrapped LLM client) contain objects whose `__getattr__`
-            # recurses into themselves when deepcopy walks them, overflowing the
-            # stack. Re-running `__init__` with the stored args produces a clean
-            # wrapper without touching the underlying metric's state.
+            # Rebuild via __init__ — some third-party metrics (e.g. RAGAS) hold
+            # `instructor`-wrapped clients whose __getattr__ recurses infinitely
+            # on deepcopy.
             init_kwargs = dict(self._metric_kwargs)
-            if getattr(type(self), "metric_name", None) != self._metric_name:
+            # Two shapes of third-party class: (a) base wrappers (`RagasScorer` etc.)
+            # have no `metric_name` ClassVar — pass it as a kwarg; (b) concrete
+            # subclasses (`ExactMatch`) pin it via ClassVar and forward to
+            # `super().__init__`, so re-passing raises "multiple values".
+            class_metric_name = getattr(type(self), "metric_name", None)
+            if class_metric_name is None:
                 init_kwargs["metric_name"] = self._metric_name
+            elif class_metric_name != self._metric_name:
+                raise MlflowException.invalid_parameter_value(
+                    f"Third-party scorer {type(self).__name__}: instance "
+                    f"`_metric_name='{self._metric_name}'` does not match class "
+                    f"ClassVar `metric_name='{class_metric_name}'`."
+                )
             if self._model is not None:
                 init_kwargs["model"] = self._model
             copy = type(self)(**init_kwargs)

--- a/mlflow/genai/scorers/deepeval/__init__.py
+++ b/mlflow/genai/scorers/deepeval/__init__.py
@@ -64,6 +64,7 @@ class DeepEvalScorer(Scorer):
     _metric: Any = PrivateAttr()
     _metric_kwargs: dict[str, Any] = PrivateAttr(default_factory=dict)
     _metric_name: str = PrivateAttr(default="")
+    _model: str | None = PrivateAttr(default=None)
 
     def __init__(
         self,
@@ -72,7 +73,6 @@ class DeepEvalScorer(Scorer):
         model_kwargs: dict[str, Any] | None = None,
         **metric_kwargs: Any,
     ):
-        # Use class attribute if metric_name not provided
         if metric_name is None:
             metric_name = self.metric_name
 
@@ -81,20 +81,15 @@ class DeepEvalScorer(Scorer):
         metric_class = get_metric_class(metric_name)
 
         self._is_deterministic = is_deterministic_metric(metric_name)
-        # Preserve the intrinsic DeepEval metric identifier separately from `self.name`,
-        # which users can rebind at register-time via `register(name=...)`.
         self._metric_name = metric_name
-        # Snapshot the user-supplied metric kwargs so we can round-trip them through
-        # register() -> serialize -> model_validate without re-wrapping the LLM.
         self._metric_kwargs = dict(metric_kwargs)
 
         if self._is_deterministic:
-            # Deterministic metrics don't need a model
             self._metric = metric_class(**metric_kwargs)
-            self._model_uri = None
+            self._model = None
         else:
             model = model or get_default_model()
-            self._model_uri = model
+            self._model = model
             deepeval_model = create_deepeval_model(model, model_kwargs=model_kwargs)
             self._metric = metric_class(
                 model=deepeval_model,
@@ -106,13 +101,6 @@ class DeepEvalScorer(Scorer):
     @property
     def kind(self) -> ScorerKind:
         return ScorerKind.THIRD_PARTY
-
-    def model_dump(self, **kwargs) -> dict[str, Any]:
-        return self._build_third_party_dump(
-            metric_name=self._metric_name,
-            model=self._model_uri,
-            metric_kwargs=self._metric_kwargs,
-        )
 
     def align(self, **kwargs):
         raise MlflowException.invalid_parameter_value(
@@ -153,7 +141,7 @@ class DeepEvalScorer(Scorer):
             source_id = None
         else:
             source_type = AssessmentSourceType.LLM_JUDGE
-            source_id = self._model_uri
+            source_id = self._model
 
         assessment_source = AssessmentSource(
             source_type=source_type,

--- a/mlflow/genai/scorers/deepeval/__init__.py
+++ b/mlflow/genai/scorers/deepeval/__init__.py
@@ -110,12 +110,9 @@ class DeepEvalScorer(Scorer):
     def model_dump(self, **kwargs) -> dict[str, Any]:
         return self._build_third_party_dump(
             metric_name=self._metric_name,
-            model=self._model_uri if self._third_party_accepts_model() else None,
+            model=self._model_uri,
             metric_kwargs=self._metric_kwargs,
         )
-
-    def _third_party_accepts_model(self) -> bool:
-        return not self._is_deterministic
 
     def align(self, **kwargs):
         raise MlflowException.invalid_parameter_value(

--- a/mlflow/genai/scorers/deepeval/__init__.py
+++ b/mlflow/genai/scorers/deepeval/__init__.py
@@ -73,6 +73,7 @@ class DeepEvalScorer(Scorer):
         model_kwargs: dict[str, Any] | None = None,
         **metric_kwargs: Any,
     ):
+        # Use class attribute if metric_name not provided
         if metric_name is None:
             metric_name = self.metric_name
 
@@ -85,6 +86,7 @@ class DeepEvalScorer(Scorer):
         self._metric_kwargs = dict(metric_kwargs)
 
         if self._is_deterministic:
+            # Deterministic metrics don't need a model
             self._metric = metric_class(**metric_kwargs)
             self._model = None
         else:

--- a/mlflow/genai/scorers/deepeval/__init__.py
+++ b/mlflow/genai/scorers/deepeval/__init__.py
@@ -62,6 +62,8 @@ class DeepEvalScorer(Scorer):
     """
 
     _metric: Any = PrivateAttr()
+    _metric_kwargs: dict[str, Any] = PrivateAttr(default_factory=dict)
+    _metric_name: str = PrivateAttr(default="")
 
     def __init__(
         self,
@@ -79,6 +81,12 @@ class DeepEvalScorer(Scorer):
         metric_class = get_metric_class(metric_name)
 
         self._is_deterministic = is_deterministic_metric(metric_name)
+        # Preserve the intrinsic DeepEval metric identifier separately from `self.name`,
+        # which users can rebind at register-time via `register(name=...)`.
+        self._metric_name = metric_name
+        # Snapshot the user-supplied metric kwargs so we can round-trip them through
+        # register() -> serialize -> model_validate without re-wrapping the LLM.
+        self._metric_kwargs = dict(metric_kwargs)
 
         if self._is_deterministic:
             # Deterministic metrics don't need a model
@@ -99,24 +107,15 @@ class DeepEvalScorer(Scorer):
     def kind(self) -> ScorerKind:
         return ScorerKind.THIRD_PARTY
 
-    def _raise_registration_not_supported(self, method_name: str):
-        raise MlflowException.invalid_parameter_value(
-            f"'{method_name}()' is not supported for third-party scorers like DeepEval. "
-            f"Third-party scorers cannot be registered, started, updated, or stopped. "
-            f"Use them directly in mlflow.genai.evaluate() instead."
+    def model_dump(self, **kwargs) -> dict[str, Any]:
+        return self._build_third_party_dump(
+            metric_name=self._metric_name,
+            model=self._model_uri if self._third_party_accepts_model() else None,
+            metric_kwargs=self._metric_kwargs,
         )
 
-    def register(self, **kwargs):
-        self._raise_registration_not_supported("register")
-
-    def start(self, **kwargs):
-        self._raise_registration_not_supported("start")
-
-    def update(self, **kwargs):
-        self._raise_registration_not_supported("update")
-
-    def stop(self, **kwargs):
-        self._raise_registration_not_supported("stop")
+    def _third_party_accepts_model(self) -> bool:
+        return not self._is_deterministic
 
     def align(self, **kwargs):
         raise MlflowException.invalid_parameter_value(

--- a/mlflow/genai/scorers/phoenix/__init__.py
+++ b/mlflow/genai/scorers/phoenix/__init__.py
@@ -27,7 +27,7 @@ from mlflow.entities.trace import Trace
 from mlflow.genai.judges.builtin import _MODEL_API_DOC
 from mlflow.genai.judges.utils import get_default_model
 from mlflow.genai.scorers import FRAMEWORK_METADATA_KEY
-from mlflow.genai.scorers.base import Scorer
+from mlflow.genai.scorers.base import Scorer, ScorerKind
 from mlflow.genai.scorers.phoenix.models import create_phoenix_model
 from mlflow.genai.scorers.phoenix.registry import get_evaluator_class
 from mlflow.genai.scorers.phoenix.utils import map_scorer_inputs_to_phoenix_record
@@ -50,6 +50,8 @@ class PhoenixScorer(Scorer):
 
     _evaluator: Any = PrivateAttr()
     _model: str = PrivateAttr()
+    _metric_kwargs: dict[str, Any] = PrivateAttr(default_factory=dict)
+    _metric_name: str = PrivateAttr(default="")
 
     def __init__(
         self,
@@ -62,9 +64,26 @@ class PhoenixScorer(Scorer):
         super().__init__(name=metric_name)
         model = model or get_default_model()
         self._model = model
+        # Preserve the intrinsic Phoenix metric identifier separately from `self.name`,
+        # which users can rebind at register-time via `register(name=...)`.
+        self._metric_name = metric_name
+        # Snapshot the user-supplied evaluator kwargs so we can round-trip them through
+        # register() -> serialize -> model_validate without re-wrapping the LLM.
+        self._metric_kwargs = dict(evaluator_kwargs)
         phoenix_model = create_phoenix_model(model)
         evaluator_class = get_evaluator_class(metric_name)
         self._evaluator = evaluator_class(model=phoenix_model, **evaluator_kwargs)
+
+    @property
+    def kind(self) -> ScorerKind:
+        return ScorerKind.THIRD_PARTY
+
+    def model_dump(self, **kwargs) -> dict[str, Any]:
+        return self._build_third_party_dump(
+            metric_name=self._metric_name,
+            model=self._model,
+            metric_kwargs=self._metric_kwargs,
+        )
 
     def __call__(
         self,
@@ -274,4 +293,5 @@ __all__ = [
     "Toxicity",
     "QA",
     "Summarization",
+    "ScorerKind",
 ]

--- a/mlflow/genai/scorers/phoenix/__init__.py
+++ b/mlflow/genai/scorers/phoenix/__init__.py
@@ -282,5 +282,4 @@ __all__ = [
     "Toxicity",
     "QA",
     "Summarization",
-    "ScorerKind",
 ]

--- a/mlflow/genai/scorers/phoenix/__init__.py
+++ b/mlflow/genai/scorers/phoenix/__init__.py
@@ -64,11 +64,7 @@ class PhoenixScorer(Scorer):
         super().__init__(name=metric_name)
         model = model or get_default_model()
         self._model = model
-        # Preserve the intrinsic Phoenix metric identifier separately from `self.name`,
-        # which users can rebind at register-time via `register(name=...)`.
         self._metric_name = metric_name
-        # Snapshot the user-supplied evaluator kwargs so we can round-trip them through
-        # register() -> serialize -> model_validate without re-wrapping the LLM.
         self._metric_kwargs = dict(evaluator_kwargs)
         phoenix_model = create_phoenix_model(model)
         evaluator_class = get_evaluator_class(metric_name)
@@ -77,13 +73,6 @@ class PhoenixScorer(Scorer):
     @property
     def kind(self) -> ScorerKind:
         return ScorerKind.THIRD_PARTY
-
-    def model_dump(self, **kwargs) -> dict[str, Any]:
-        return self._build_third_party_dump(
-            metric_name=self._metric_name,
-            model=self._model,
-            metric_kwargs=self._metric_kwargs,
-        )
 
     def __call__(
         self,

--- a/mlflow/genai/scorers/ragas/__init__.py
+++ b/mlflow/genai/scorers/ragas/__init__.py
@@ -86,16 +86,25 @@ class RagasScorer(Scorer):
 
         self._validate_args(metric_name, model)
         super().__init__(name=metric_name)
-        model = model or get_default_model()
-        self._model = model
         # Preserve the intrinsic RAGAS metric identifier separately from `self.name`,
         # which users can rebind at register-time via `register(name=...)`.
         self._metric_name = metric_name
         # Snapshot the user-supplied metric kwargs so we can round-trip them through
         # register() -> serialize -> model_validate without re-wrapping the LLM/embeddings.
         self._metric_kwargs = dict(metric_kwargs)
+        # Deterministic RAGAS metrics (e.g. `ExactMatch`) reject `model=` in their
+        # constructor via `_validate_args`; leave `_model` as None for them so
+        # serialization round-trips and `_create_copy` reconstruct cleanly.
+        metric_accepts_model = requires_llm_in_constructor(
+            metric_name
+        ) or requires_llm_at_score_time(metric_name)
+        if metric_accepts_model:
+            model = model or get_default_model()
+            self._model = model
+        else:
+            self._model = None
         metric_class = get_metric_class(metric_name)
-        ragas_llm = create_ragas_model(model)
+        ragas_llm = create_ragas_model(model) if metric_accepts_model else None
         constructor_kwargs = dict(metric_kwargs)
 
         if requires_llm_in_constructor(metric_name):
@@ -115,19 +124,10 @@ class RagasScorer(Scorer):
         return ScorerKind.THIRD_PARTY
 
     def model_dump(self, **kwargs) -> dict[str, Any]:
-        # Deterministic RAGAS metrics (e.g., ExactMatch) reject `model=` in their
-        # constructor via `_validate_args`. We still stash `self._model` for audit
-        # purposes, but only serialize it when the metric actually accepts one so
-        # round-trips reconstruct cleanly.
         return self._build_third_party_dump(
             metric_name=self._metric_name,
-            model=self._model if self._third_party_accepts_model() else None,
+            model=self._model,
             metric_kwargs=self._metric_kwargs,
-        )
-
-    def _third_party_accepts_model(self) -> bool:
-        return requires_llm_in_constructor(self._metric_name) or requires_llm_at_score_time(
-            self._metric_name
         )
 
     def align(self, **kwargs):

--- a/mlflow/genai/scorers/ragas/__init__.py
+++ b/mlflow/genai/scorers/ragas/__init__.py
@@ -72,6 +72,8 @@ class RagasScorer(Scorer):
     _is_deterministic: bool = PrivateAttr(default=False)
     _model: str = PrivateAttr()
     _llm: BaseRagasLLM | None = PrivateAttr(default=None)
+    _metric_kwargs: dict[str, Any] = PrivateAttr(default_factory=dict)
+    _metric_name: str = PrivateAttr(default="")
 
     def __init__(
         self,
@@ -86,6 +88,12 @@ class RagasScorer(Scorer):
         super().__init__(name=metric_name)
         model = model or get_default_model()
         self._model = model
+        # Preserve the intrinsic RAGAS metric identifier separately from `self.name`,
+        # which users can rebind at register-time via `register(name=...)`.
+        self._metric_name = metric_name
+        # Snapshot the user-supplied metric kwargs so we can round-trip them through
+        # register() -> serialize -> model_validate without re-wrapping the LLM/embeddings.
+        self._metric_kwargs = dict(metric_kwargs)
         metric_class = get_metric_class(metric_name)
         ragas_llm = create_ragas_model(model)
         constructor_kwargs = dict(metric_kwargs)
@@ -106,24 +114,21 @@ class RagasScorer(Scorer):
     def kind(self) -> ScorerKind:
         return ScorerKind.THIRD_PARTY
 
-    def _raise_registration_not_supported(self, method_name: str):
-        raise MlflowException.invalid_parameter_value(
-            f"'{method_name}()' is not supported for third-party scorers like RAGAS. "
-            f"Third-party scorers cannot be registered, started, updated, or stopped. "
-            f"Use them directly in mlflow.genai.evaluate() instead."
+    def model_dump(self, **kwargs) -> dict[str, Any]:
+        # Deterministic RAGAS metrics (e.g., ExactMatch) reject `model=` in their
+        # constructor via `_validate_args`. We still stash `self._model` for audit
+        # purposes, but only serialize it when the metric actually accepts one so
+        # round-trips reconstruct cleanly.
+        return self._build_third_party_dump(
+            metric_name=self._metric_name,
+            model=self._model if self._third_party_accepts_model() else None,
+            metric_kwargs=self._metric_kwargs,
         )
 
-    def register(self, **kwargs):
-        self._raise_registration_not_supported("register")
-
-    def start(self, **kwargs):
-        self._raise_registration_not_supported("start")
-
-    def update(self, **kwargs):
-        self._raise_registration_not_supported("update")
-
-    def stop(self, **kwargs):
-        self._raise_registration_not_supported("stop")
+    def _third_party_accepts_model(self) -> bool:
+        return requires_llm_in_constructor(self._metric_name) or requires_llm_at_score_time(
+            self._metric_name
+        )
 
     def align(self, **kwargs):
         raise MlflowException.invalid_parameter_value(

--- a/mlflow/genai/scorers/ragas/__init__.py
+++ b/mlflow/genai/scorers/ragas/__init__.py
@@ -86,25 +86,16 @@ class RagasScorer(Scorer):
 
         self._validate_args(metric_name, model)
         super().__init__(name=metric_name)
-        # Preserve the intrinsic RAGAS metric identifier separately from `self.name`,
-        # which users can rebind at register-time via `register(name=...)`.
         self._metric_name = metric_name
-        # Snapshot the user-supplied metric kwargs so we can round-trip them through
-        # register() -> serialize -> model_validate without re-wrapping the LLM/embeddings.
         self._metric_kwargs = dict(metric_kwargs)
-        # Deterministic RAGAS metrics (e.g. `ExactMatch`) reject `model=` in their
-        # constructor via `_validate_args`; leave `_model` as None for them so
-        # serialization round-trips and `_create_copy` reconstruct cleanly.
-        metric_accepts_model = requires_llm_in_constructor(
+        # Deterministic metrics reject `model=` via `_validate_args`; keep `_model`
+        # None for them so serialization and `_create_copy` round-trip.
+        accepts_model = requires_llm_in_constructor(metric_name) or requires_llm_at_score_time(
             metric_name
-        ) or requires_llm_at_score_time(metric_name)
-        if metric_accepts_model:
-            model = model or get_default_model()
-            self._model = model
-        else:
-            self._model = None
+        )
+        self._model = (model or get_default_model()) if accepts_model else None
         metric_class = get_metric_class(metric_name)
-        ragas_llm = create_ragas_model(model) if metric_accepts_model else None
+        ragas_llm = create_ragas_model(self._model) if accepts_model else None
         constructor_kwargs = dict(metric_kwargs)
 
         if requires_llm_in_constructor(metric_name):
@@ -122,13 +113,6 @@ class RagasScorer(Scorer):
     @property
     def kind(self) -> ScorerKind:
         return ScorerKind.THIRD_PARTY
-
-    def model_dump(self, **kwargs) -> dict[str, Any]:
-        return self._build_third_party_dump(
-            metric_name=self._metric_name,
-            model=self._model,
-            metric_kwargs=self._metric_kwargs,
-        )
 
     def align(self, **kwargs):
         raise MlflowException.invalid_parameter_value(

--- a/mlflow/genai/scorers/ragas/__init__.py
+++ b/mlflow/genai/scorers/ragas/__init__.py
@@ -88,8 +88,6 @@ class RagasScorer(Scorer):
         super().__init__(name=metric_name)
         self._metric_name = metric_name
         self._metric_kwargs = dict(metric_kwargs)
-        # Deterministic metrics reject `model=` via `_validate_args`; keep `_model`
-        # None for them so serialization and `_create_copy` round-trip.
         accepts_model = requires_llm_in_constructor(metric_name) or requires_llm_at_score_time(
             metric_name
         )

--- a/mlflow/genai/scorers/scorer_utils.py
+++ b/mlflow/genai/scorers/scorer_utils.py
@@ -33,6 +33,29 @@ DECORATOR_SCORER_REGISTRATION_NOT_SUPPORTED_ERROR = (
     "3. Use built-in scorers or make_judge() scorers instead."
 )
 
+# Error message used by Scorer._check_can_be_registered when a user attempts to register
+# a third-party scorer (RAGAS, DeepEval, TruLens, Phoenix) against a Databricks tracking
+# URI. Third-party scorers can be registered against OSS MLflow backends but are not yet
+# supported by the Databricks scorer hosting layer.
+THIRD_PARTY_SCORER_REGISTRATION_NOT_SUPPORTED_ON_DATABRICKS_ERROR = (
+    "Third-party scorer registration (e.g., RAGAS, DeepEval, TruLens, Phoenix) is not "
+    "supported when using a Databricks tracking URI. Third-party scorers are only "
+    "available for registration against OSS MLflow backends.\n\n"
+    "To use third-party scorers on Databricks, pass them directly to "
+    "`mlflow.genai.evaluate(..., scorers=[...])` without calling `.register()`."
+)
+
+# Known module paths for first-party third-party scorer integrations. Used by
+# `Scorer.model_validate` when deserializing a third-party scorer to restrict
+# dynamic imports to this closed set and avoid turning deserialization into an
+# arbitrary-import vector.
+THIRD_PARTY_SCORER_ALLOWED_MODULES = frozenset({
+    "mlflow.genai.scorers.ragas",
+    "mlflow.genai.scorers.deepeval",
+    "mlflow.genai.scorers.trulens",
+    "mlflow.genai.scorers.phoenix",
+})
+
 
 # FunctionBodyExtractor class is forked from https://github.com/unitycatalog/unitycatalog/blob/20dd3820be332ac04deec4e063099fb863eb3392/ai/core/src/unitycatalog/ai/core/utils/callable_utils.py
 class FunctionBodyExtractor(ast.NodeVisitor):
@@ -196,6 +219,8 @@ def extract_model_from_serialized_scorer(serialized_data: dict[str, Any]) -> str
     if mem_data := serialized_data.get("memory_augmented_judge_data"):
         base_judge = mem_data.get("base_judge", {})
         return extract_model_from_serialized_scorer(base_judge)
+    if tp_data := serialized_data.get("third_party_scorer_data"):
+        return tp_data.get("model")
     return None
 
 
@@ -214,6 +239,8 @@ def update_model_in_serialized_scorer(
                 mem_data.get("base_judge", {}), new_model
             ),
         }
+    elif tp_data := result.get("third_party_scorer_data"):
+        result["third_party_scorer_data"] = {**tp_data, "model": new_model}
     return result
 
 

--- a/mlflow/genai/scorers/scorer_utils.py
+++ b/mlflow/genai/scorers/scorer_utils.py
@@ -33,10 +33,6 @@ DECORATOR_SCORER_REGISTRATION_NOT_SUPPORTED_ERROR = (
     "3. Use built-in scorers or make_judge() scorers instead."
 )
 
-# Error message used by Scorer._check_can_be_registered when a user attempts to register
-# a third-party scorer (RAGAS, DeepEval, TruLens, Phoenix) against a Databricks tracking
-# URI. Third-party scorers can be registered against OSS MLflow backends but are not yet
-# supported by the Databricks scorer hosting layer.
 THIRD_PARTY_SCORER_REGISTRATION_NOT_SUPPORTED_ON_DATABRICKS_ERROR = (
     "Third-party scorer registration (e.g., RAGAS, DeepEval, TruLens, Phoenix) is not "
     "supported when using a Databricks tracking URI. Third-party scorers are only "
@@ -45,10 +41,8 @@ THIRD_PARTY_SCORER_REGISTRATION_NOT_SUPPORTED_ON_DATABRICKS_ERROR = (
     "`mlflow.genai.evaluate(..., scorers=[...])` without calling `.register()`."
 )
 
-# Known module paths for first-party third-party scorer integrations. Used by
-# `Scorer.model_validate` when deserializing a third-party scorer to restrict
-# dynamic imports to this closed set and avoid turning deserialization into an
-# arbitrary-import vector.
+# Restricts dynamic imports during third-party scorer deserialization to this
+# closed set so a malicious payload can't turn `model_validate` into arbitrary import.
 THIRD_PARTY_SCORER_ALLOWED_MODULES = frozenset({
     "mlflow.genai.scorers.ragas",
     "mlflow.genai.scorers.deepeval",

--- a/mlflow/genai/scorers/scorer_utils.py
+++ b/mlflow/genai/scorers/scorer_utils.py
@@ -234,9 +234,6 @@ def update_model_in_serialized_scorer(
             ),
         }
     elif tp_data := result.get("third_party_scorer_data"):
-        # Only overwrite when the scorer originally recorded a model — deterministic
-        # RAGAS/DeepEval metrics store None and their constructors reject `model=`,
-        # which would break deserialization.
         if tp_data.get("model") is not None:
             result["third_party_scorer_data"] = {**tp_data, "model": new_model}
     return result

--- a/mlflow/genai/scorers/scorer_utils.py
+++ b/mlflow/genai/scorers/scorer_utils.py
@@ -234,7 +234,11 @@ def update_model_in_serialized_scorer(
             ),
         }
     elif tp_data := result.get("third_party_scorer_data"):
-        result["third_party_scorer_data"] = {**tp_data, "model": new_model}
+        # Only overwrite when the scorer originally recorded a model — deterministic
+        # RAGAS/DeepEval metrics store None and their constructors reject `model=`,
+        # which would break deserialization.
+        if tp_data.get("model") is not None:
+            result["third_party_scorer_data"] = {**tp_data, "model": new_model}
     return result
 
 

--- a/mlflow/genai/scorers/trulens/__init__.py
+++ b/mlflow/genai/scorers/trulens/__init__.py
@@ -297,5 +297,4 @@ __all__ = [
     "PlanQuality",
     "ToolSelection",
     "ToolCalling",
-    "ScorerKind",
 ]

--- a/mlflow/genai/scorers/trulens/__init__.py
+++ b/mlflow/genai/scorers/trulens/__init__.py
@@ -27,7 +27,7 @@ from mlflow.entities.trace import Trace
 from mlflow.genai.judges.builtin import _MODEL_API_DOC
 from mlflow.genai.judges.utils import CategoricalRating, get_default_model
 from mlflow.genai.scorers import FRAMEWORK_METADATA_KEY
-from mlflow.genai.scorers.base import Scorer
+from mlflow.genai.scorers.base import Scorer, ScorerKind
 from mlflow.genai.scorers.trulens.models import create_trulens_provider
 from mlflow.genai.scorers.trulens.registry import get_feedback_method_name
 from mlflow.genai.scorers.trulens.utils import (
@@ -59,6 +59,8 @@ class TruLensScorer(Scorer):
     _model: str = PrivateAttr()
     _method_name: str = PrivateAttr()
     _threshold: float = PrivateAttr()
+    _metric_kwargs: dict[str, Any] = PrivateAttr(default_factory=dict)
+    _metric_name: str = PrivateAttr(default="")
 
     def __init__(
         self,
@@ -74,9 +76,26 @@ class TruLensScorer(Scorer):
         model = model or get_default_model()
         self._model = model
         self._threshold = threshold
+        # Preserve the intrinsic TruLens metric identifier separately from `self.name`,
+        # which users can rebind at register-time via `register(name=...)`.
+        self._metric_name = metric_name
+        # Snapshot the user-supplied construction kwargs so we can round-trip them through
+        # register() -> serialize -> model_validate. We stash `threshold` alongside them.
+        self._metric_kwargs = {"threshold": threshold, **kwargs}
 
         self._provider = create_trulens_provider(model, **kwargs)
         self._method_name = get_feedback_method_name(metric_name)
+
+    @property
+    def kind(self) -> ScorerKind:
+        return ScorerKind.THIRD_PARTY
+
+    def model_dump(self, **kwargs) -> dict[str, Any]:
+        return self._build_third_party_dump(
+            metric_name=self._metric_name,
+            model=self._model,
+            metric_kwargs=self._metric_kwargs,
+        )
 
     def __call__(
         self,
@@ -289,4 +308,5 @@ __all__ = [
     "PlanQuality",
     "ToolSelection",
     "ToolCalling",
+    "ScorerKind",
 ]

--- a/mlflow/genai/scorers/trulens/__init__.py
+++ b/mlflow/genai/scorers/trulens/__init__.py
@@ -76,11 +76,7 @@ class TruLensScorer(Scorer):
         model = model or get_default_model()
         self._model = model
         self._threshold = threshold
-        # Preserve the intrinsic TruLens metric identifier separately from `self.name`,
-        # which users can rebind at register-time via `register(name=...)`.
         self._metric_name = metric_name
-        # Snapshot the user-supplied construction kwargs so we can round-trip them through
-        # register() -> serialize -> model_validate. We stash `threshold` alongside them.
         self._metric_kwargs = {"threshold": threshold, **kwargs}
 
         self._provider = create_trulens_provider(model, **kwargs)
@@ -89,13 +85,6 @@ class TruLensScorer(Scorer):
     @property
     def kind(self) -> ScorerKind:
         return ScorerKind.THIRD_PARTY
-
-    def model_dump(self, **kwargs) -> dict[str, Any]:
-        return self._build_third_party_dump(
-            metric_name=self._metric_name,
-            model=self._model,
-            metric_kwargs=self._metric_kwargs,
-        )
 
     def __call__(
         self,

--- a/tests/genai/scorers/deepeval/test_deepeval_scorer.py
+++ b/tests/genai/scorers/deepeval/test_deepeval_scorer.py
@@ -6,9 +6,10 @@ import pytest
 import mlflow
 from mlflow.entities.assessment import Feedback
 from mlflow.entities.assessment_source import AssessmentSourceType
+from mlflow.exceptions import MlflowException
 from mlflow.genai.judges.utils import CategoricalRating
 from mlflow.genai.scorers import FRAMEWORK_METADATA_KEY
-from mlflow.genai.scorers.base import ScorerKind
+from mlflow.genai.scorers.base import Scorer, ScorerKind
 from mlflow.genai.scorers.deepeval import (
     AnswerRelevancy,
     ExactMatch,
@@ -259,8 +260,6 @@ def test_deepeval_scorer_kind_property():
 
 
 def test_deepeval_scorer_register_blocked_on_databricks():
-    from mlflow.exceptions import MlflowException
-
     scorer = get_scorer("ExactMatch")
     with patch(
         "mlflow.genai.scorers.base.is_databricks_uri",
@@ -272,8 +271,6 @@ def test_deepeval_scorer_register_blocked_on_databricks():
 
 
 def test_deepeval_scorer_serialization_round_trip():
-    from mlflow.genai.scorers.base import Scorer
-
     scorer = ExactMatch()
     dump = scorer.model_dump()
     assert dump["third_party_scorer_data"]["class"] == "ExactMatch"
@@ -287,8 +284,6 @@ def test_deepeval_scorer_serialization_round_trip():
 
 
 def test_deepeval_scorer_llm_metric_serialization_round_trip(mock_deepeval_model):
-    from mlflow.genai.scorers.base import Scorer
-
     with patch(
         "mlflow.genai.scorers.deepeval.create_deepeval_model", return_value=mock_deepeval_model
     ):

--- a/tests/genai/scorers/deepeval/test_deepeval_scorer.py
+++ b/tests/genai/scorers/deepeval/test_deepeval_scorer.py
@@ -286,6 +286,23 @@ def test_deepeval_scorer_serialization_round_trip():
     assert restored.kind == ScorerKind.THIRD_PARTY
 
 
+def test_deepeval_scorer_llm_metric_serialization_round_trip(mock_deepeval_model):
+    from mlflow.genai.scorers.base import Scorer
+
+    with patch(
+        "mlflow.genai.scorers.deepeval.create_deepeval_model", return_value=mock_deepeval_model
+    ):
+        scorer = AnswerRelevancy(model="openai:/gpt-4o")
+        dump = scorer.model_dump()
+        assert dump["third_party_scorer_data"]["class"] == "AnswerRelevancy"
+        assert dump["third_party_scorer_data"]["metric_name"] == "AnswerRelevancy"
+        assert dump["third_party_scorer_data"]["model"] == "openai:/gpt-4o"
+
+        restored = Scorer.model_validate(dump)
+        assert isinstance(restored, AnswerRelevancy)
+        assert restored._model == "openai:/gpt-4o"
+
+
 def test_deepeval_scorer_align_not_supported():
     from mlflow.exceptions import MlflowException
 

--- a/tests/genai/scorers/deepeval/test_deepeval_scorer.py
+++ b/tests/genai/scorers/deepeval/test_deepeval_scorer.py
@@ -258,15 +258,32 @@ def test_deepeval_scorer_kind_property():
     assert scorer.kind == ScorerKind.THIRD_PARTY
 
 
-@pytest.mark.parametrize("method_name", ["register", "start", "update", "stop"])
-def test_deepeval_scorer_registration_methods_not_supported(method_name):
+def test_deepeval_scorer_register_blocked_on_databricks():
     from mlflow.exceptions import MlflowException
 
     scorer = get_scorer("ExactMatch")
-    method = getattr(scorer, method_name)
+    with patch(
+        "mlflow.genai.scorers.base.is_databricks_uri",
+        return_value=True,
+    ) as mock_is_dbx:
+        with pytest.raises(MlflowException, match="Third-party scorer registration"):
+            scorer.register(name="exact_match")
+        mock_is_dbx.assert_called()
 
-    with pytest.raises(MlflowException, match=f"'{method_name}\\(\\)' is not supported"):
-        method()
+
+def test_deepeval_scorer_serialization_round_trip():
+    from mlflow.genai.scorers.base import Scorer
+
+    scorer = ExactMatch()
+    dump = scorer.model_dump()
+    assert dump["third_party_scorer_data"]["class"] == "ExactMatch"
+    assert dump["third_party_scorer_data"]["metric_name"] == "ExactMatch"
+    assert dump["third_party_scorer_data"]["model"] is None
+
+    restored = Scorer.model_validate(dump)
+    assert isinstance(restored, ExactMatch)
+    assert restored.name == "ExactMatch"
+    assert restored.kind == ScorerKind.THIRD_PARTY
 
 
 def test_deepeval_scorer_align_not_supported():

--- a/tests/genai/scorers/phoenix/test_phoenix.py
+++ b/tests/genai/scorers/phoenix/test_phoenix.py
@@ -159,25 +159,28 @@ def test_high_level_scorer_call_chain(monkeypatch):
     assert feedback.source.source_id == "openai:/gpt-4"
 
 
-def test_phoenix_scorer_kind_is_third_party():
-    assert Hallucination(model="openai:/gpt-4").kind == ScorerKind.THIRD_PARTY
+def test_phoenix_scorer_kind_is_third_party(mock_model):
+    with patch("mlflow.genai.scorers.phoenix.create_phoenix_model", return_value=mock_model):
+        assert Hallucination(model="openai:/gpt-4").kind == ScorerKind.THIRD_PARTY
 
 
-def test_phoenix_scorer_serialization_round_trip():
-    scorer = Hallucination(model="openai:/gpt-4")
-    dump = scorer.model_dump()
-    assert dump["third_party_scorer_data"]["class"] == "Hallucination"
-    assert dump["third_party_scorer_data"]["metric_name"] == "Hallucination"
-    assert dump["third_party_scorer_data"]["model"] == "openai:/gpt-4"
+def test_phoenix_scorer_serialization_round_trip(mock_model):
+    with patch("mlflow.genai.scorers.phoenix.create_phoenix_model", return_value=mock_model):
+        scorer = Hallucination(model="openai:/gpt-4")
+        dump = scorer.model_dump()
+        assert dump["third_party_scorer_data"]["class"] == "Hallucination"
+        assert dump["third_party_scorer_data"]["metric_name"] == "Hallucination"
+        assert dump["third_party_scorer_data"]["model"] == "openai:/gpt-4"
 
-    restored = Scorer.model_validate(dump)
-    assert isinstance(restored, Hallucination)
-    assert restored.kind == ScorerKind.THIRD_PARTY
-    assert restored._model == "openai:/gpt-4"
+        restored = Scorer.model_validate(dump)
+        assert isinstance(restored, Hallucination)
+        assert restored.kind == ScorerKind.THIRD_PARTY
+        assert restored._model == "openai:/gpt-4"
 
 
-def test_phoenix_scorer_register_blocked_on_databricks():
-    scorer = Hallucination(model="openai:/gpt-4")
-    with patch("mlflow.genai.scorers.base.is_databricks_uri", return_value=True):
-        with pytest.raises(MlflowException, match="Third-party scorer registration"):
-            scorer.register(name="hallucination")
+def test_phoenix_scorer_register_blocked_on_databricks(mock_model):
+    with patch("mlflow.genai.scorers.phoenix.create_phoenix_model", return_value=mock_model):
+        scorer = Hallucination(model="openai:/gpt-4")
+        with patch("mlflow.genai.scorers.base.is_databricks_uri", return_value=True):
+            with pytest.raises(MlflowException, match="Third-party scorer registration"):
+                scorer.register(name="hallucination")

--- a/tests/genai/scorers/phoenix/test_phoenix.py
+++ b/tests/genai/scorers/phoenix/test_phoenix.py
@@ -5,6 +5,9 @@ import pytest
 
 from mlflow.entities.assessment import Feedback
 from mlflow.entities.assessment_source import AssessmentSourceType
+from mlflow.exceptions import MlflowException
+from mlflow.genai.scorers.base import Scorer, ScorerKind
+from mlflow.genai.scorers.phoenix import Hallucination
 
 
 @pytest.fixture
@@ -157,16 +160,10 @@ def test_high_level_scorer_call_chain(monkeypatch):
 
 
 def test_phoenix_scorer_kind_is_third_party():
-    from mlflow.genai.scorers.base import ScorerKind
-    from mlflow.genai.scorers.phoenix import Hallucination
-
     assert Hallucination(model="openai:/gpt-4").kind == ScorerKind.THIRD_PARTY
 
 
 def test_phoenix_scorer_serialization_round_trip():
-    from mlflow.genai.scorers.base import Scorer, ScorerKind
-    from mlflow.genai.scorers.phoenix import Hallucination
-
     scorer = Hallucination(model="openai:/gpt-4")
     dump = scorer.model_dump()
     assert dump["third_party_scorer_data"]["class"] == "Hallucination"
@@ -180,9 +177,6 @@ def test_phoenix_scorer_serialization_round_trip():
 
 
 def test_phoenix_scorer_register_blocked_on_databricks():
-    from mlflow.exceptions import MlflowException
-    from mlflow.genai.scorers.phoenix import Hallucination
-
     scorer = Hallucination(model="openai:/gpt-4")
     with patch("mlflow.genai.scorers.base.is_databricks_uri", return_value=True):
         with pytest.raises(MlflowException, match="Third-party scorer registration"):

--- a/tests/genai/scorers/phoenix/test_phoenix.py
+++ b/tests/genai/scorers/phoenix/test_phoenix.py
@@ -154,3 +154,36 @@ def test_high_level_scorer_call_chain(monkeypatch):
     assert feedback.rationale == "Grounded."
     assert feedback.source.source_type == AssessmentSourceType.LLM_JUDGE
     assert feedback.source.source_id == "openai:/gpt-4"
+
+
+def test_phoenix_scorer_kind_is_third_party():
+    from mlflow.genai.scorers.base import ScorerKind
+    from mlflow.genai.scorers.phoenix import Hallucination
+
+    assert Hallucination(model="openai:/gpt-4").kind == ScorerKind.THIRD_PARTY
+
+
+def test_phoenix_scorer_serialization_round_trip():
+    from mlflow.genai.scorers.base import Scorer, ScorerKind
+    from mlflow.genai.scorers.phoenix import Hallucination
+
+    scorer = Hallucination(model="openai:/gpt-4")
+    dump = scorer.model_dump()
+    assert dump["third_party_scorer_data"]["class"] == "Hallucination"
+    assert dump["third_party_scorer_data"]["metric_name"] == "Hallucination"
+    assert dump["third_party_scorer_data"]["model"] == "openai:/gpt-4"
+
+    restored = Scorer.model_validate(dump)
+    assert isinstance(restored, Hallucination)
+    assert restored.kind == ScorerKind.THIRD_PARTY
+    assert restored._model == "openai:/gpt-4"
+
+
+def test_phoenix_scorer_register_blocked_on_databricks():
+    from mlflow.exceptions import MlflowException
+    from mlflow.genai.scorers.phoenix import Hallucination
+
+    scorer = Hallucination(model="openai:/gpt-4")
+    with patch("mlflow.genai.scorers.base.is_databricks_uri", return_value=True):
+        with pytest.raises(MlflowException, match="Third-party scorer registration"):
+            scorer.register(name="hallucination")

--- a/tests/genai/scorers/ragas/test_ragas_scorer.py
+++ b/tests/genai/scorers/ragas/test_ragas_scorer.py
@@ -10,7 +10,7 @@ from mlflow.entities.assessment_source import AssessmentSourceType
 from mlflow.exceptions import MlflowException
 from mlflow.genai.judges.utils import CategoricalRating
 from mlflow.genai.scorers import FRAMEWORK_METADATA_KEY
-from mlflow.genai.scorers.base import ScorerKind
+from mlflow.genai.scorers.base import Scorer, ScorerKind
 from mlflow.genai.scorers.ragas import (
     AgentGoalAccuracyWithoutReference,
     AgentGoalAccuracyWithReference,
@@ -245,8 +245,6 @@ def test_ragas_scorer_serialization_round_trip():
         "model": None,
         "kwargs": {},
     }
-    from mlflow.genai.scorers.base import Scorer
-
     restored = Scorer.model_validate(dump)
     assert isinstance(restored, ExactMatch)
     assert restored.name == "ExactMatch"
@@ -264,8 +262,6 @@ def test_ragas_scorer_serialization_round_trip_preserves_register_name():
     # metric_name stays bound to the RAGAS class, not the registered name.
     assert dump["third_party_scorer_data"]["metric_name"] == "ExactMatch"
 
-    from mlflow.genai.scorers.base import Scorer
-
     restored = Scorer.model_validate(dump)
     assert restored.name == "exact_match_v1"
     assert isinstance(restored, ExactMatch)
@@ -276,8 +272,6 @@ def test_ragas_scorer_llm_metric_serialization_round_trip():
     dump = scorer.model_dump()
     assert dump["third_party_scorer_data"]["metric_name"] == "Faithfulness"
     assert dump["third_party_scorer_data"]["model"] == "openai:/gpt-4o"
-
-    from mlflow.genai.scorers.base import Scorer
 
     restored = Scorer.model_validate(dump)
     assert isinstance(restored, Faithfulness)

--- a/tests/genai/scorers/ragas/test_ragas_scorer.py
+++ b/tests/genai/scorers/ragas/test_ragas_scorer.py
@@ -224,13 +224,65 @@ def test_ragas_scorer_kind_property():
     assert scorer.kind == ScorerKind.THIRD_PARTY
 
 
-@pytest.mark.parametrize("method_name", ["register", "start", "update", "stop"])
-def test_ragas_scorer_registration_methods_not_supported(method_name):
+def test_ragas_scorer_register_blocked_on_databricks(tmp_path):
     scorer = get_scorer("ExactMatch")
-    method = getattr(scorer, method_name)
+    with patch(
+        "mlflow.genai.scorers.base.is_databricks_uri",
+        return_value=True,
+    ) as mock_is_dbx:
+        with pytest.raises(MlflowException, match="Third-party scorer registration"):
+            scorer.register(name="exact_match")
+        mock_is_dbx.assert_called()
 
-    with pytest.raises(MlflowException, match=f"'{method_name}\\(\\)' is not supported"):
-        method()
+
+def test_ragas_scorer_serialization_round_trip():
+    scorer = ExactMatch()
+    dump = scorer.model_dump()
+    assert dump["third_party_scorer_data"] == {
+        "module": ExactMatch.__module__,
+        "class": "ExactMatch",
+        "metric_name": "ExactMatch",
+        "model": None,
+        "kwargs": {},
+    }
+    from mlflow.genai.scorers.base import Scorer
+
+    restored = Scorer.model_validate(dump)
+    assert isinstance(restored, ExactMatch)
+    assert restored.name == "ExactMatch"
+    assert restored.kind == ScorerKind.THIRD_PARTY
+
+    fb = restored(outputs="Paris", expectations={"expected_output": "Paris"})
+    assert fb.value == 1.0
+
+
+def test_ragas_scorer_serialization_round_trip_preserves_register_name():
+    scorer = ExactMatch()
+    # Simulate what `register(name=...)` does: renames before serialization.
+    renamed = scorer._rebuild_third_party_copy()
+    renamed.name = "exact_match_v1"
+    dump = renamed.model_dump()
+    # `metric_name` must remain the underlying RAGAS class name, not the rename.
+    assert dump["third_party_scorer_data"]["metric_name"] == "ExactMatch"
+
+    from mlflow.genai.scorers.base import Scorer
+
+    restored = Scorer.model_validate(dump)
+    assert restored.name == "exact_match_v1"
+    assert isinstance(restored, ExactMatch)
+
+
+def test_ragas_scorer_llm_metric_serialization_round_trip():
+    scorer = Faithfulness(model="openai:/gpt-4o")
+    dump = scorer.model_dump()
+    assert dump["third_party_scorer_data"]["metric_name"] == "Faithfulness"
+    assert dump["third_party_scorer_data"]["model"] == "openai:/gpt-4o"
+
+    from mlflow.genai.scorers.base import Scorer
+
+    restored = Scorer.model_validate(dump)
+    assert isinstance(restored, Faithfulness)
+    assert restored._model == "openai:/gpt-4o"
 
 
 def test_ragas_scorer_align_not_supported():

--- a/tests/genai/scorers/ragas/test_ragas_scorer.py
+++ b/tests/genai/scorers/ragas/test_ragas_scorer.py
@@ -258,11 +258,10 @@ def test_ragas_scorer_serialization_round_trip():
 
 def test_ragas_scorer_serialization_round_trip_preserves_register_name():
     scorer = ExactMatch()
-    # Simulate what `register(name=...)` does: renames before serialization.
-    renamed = scorer._rebuild_third_party_copy()
+    renamed = scorer._create_copy()
     renamed.name = "exact_match_v1"
     dump = renamed.model_dump()
-    # `metric_name` must remain the underlying RAGAS class name, not the rename.
+    # metric_name stays bound to the RAGAS class, not the registered name.
     assert dump["third_party_scorer_data"]["metric_name"] == "ExactMatch"
 
     from mlflow.genai.scorers.base import Scorer

--- a/tests/genai/scorers/test_scorer_utils.py
+++ b/tests/genai/scorers/test_scorer_utils.py
@@ -494,6 +494,63 @@ def test_update_model_in_serialized_scorer():
     assert data[INSTRUCTIONS_JUDGE_PYDANTIC_DATA]["model"] == "gateway:/old-endpoint"
 
 
+def test_extract_model_from_third_party_scorer():
+    llm_scorer = {
+        "name": "faithfulness",
+        "third_party_scorer_data": {
+            "module": "mlflow.genai.scorers.ragas.scorers.rag_metrics",
+            "class": "Faithfulness",
+            "metric_name": "Faithfulness",
+            "model": "openai:/gpt-4o",
+            "kwargs": {},
+        },
+    }
+    assert extract_model_from_serialized_scorer(llm_scorer) == "openai:/gpt-4o"
+
+    deterministic_scorer = {
+        "name": "exact_match",
+        "third_party_scorer_data": {
+            "module": "mlflow.genai.scorers.ragas.scorers.comparison_metrics",
+            "class": "ExactMatch",
+            "metric_name": "ExactMatch",
+            "model": None,
+            "kwargs": {},
+        },
+    }
+    assert extract_model_from_serialized_scorer(deterministic_scorer) is None
+
+
+def test_update_model_in_third_party_scorer():
+    llm_scorer = {
+        "name": "faithfulness",
+        "third_party_scorer_data": {
+            "module": "mlflow.genai.scorers.ragas.scorers.rag_metrics",
+            "class": "Faithfulness",
+            "metric_name": "Faithfulness",
+            "model": "openai:/old",
+            "kwargs": {},
+        },
+    }
+    result = update_model_in_serialized_scorer(llm_scorer, "openai:/new")
+    assert result["third_party_scorer_data"]["model"] == "openai:/new"
+    assert llm_scorer["third_party_scorer_data"]["model"] == "openai:/old"
+
+    # Deterministic scorer (model=None) must not gain a model — the wrapper
+    # constructor rejects `model=` and the round-trip would break.
+    deterministic_scorer = {
+        "name": "exact_match",
+        "third_party_scorer_data": {
+            "module": "mlflow.genai.scorers.ragas.scorers.comparison_metrics",
+            "class": "ExactMatch",
+            "metric_name": "ExactMatch",
+            "model": None,
+            "kwargs": {},
+        },
+    }
+    result = update_model_in_serialized_scorer(deterministic_scorer, "openai:/new")
+    assert result["third_party_scorer_data"]["model"] is None
+
+
 # ============================================================================
 # TOOL CALL HELPER FUNCTION TESTS
 # ============================================================================

--- a/tests/genai/scorers/test_serialization.py
+++ b/tests/genai/scorers/test_serialization.py
@@ -1,11 +1,12 @@
 import json
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
 from mlflow.entities import Feedback
 from mlflow.exceptions import MlflowException
 from mlflow.genai.scorers import Scorer, scorer
+from mlflow.genai.scorers.base import SerializedScorer
 from mlflow.genai.scorers.builtin_scorers import Guidelines
 
 
@@ -673,43 +674,124 @@ def test_builtin_scorer_instructions_preserved_through_serialization():
 # ============================================================================
 
 
-def test_third_party_scorer_module_allow_list_enforced():
-    from mlflow.genai.scorers.base import SerializedScorer
-
-    payload = SerializedScorer(
-        name="evil",
-        third_party_scorer_data={
-            "module": "os",
-            "class": "system",
-            "metric_name": "system",
-            "model": None,
-            "kwargs": {},
-        },
-    )
-    with pytest.raises(MlflowException, match="not in the allow-list"):
+@pytest.mark.parametrize(
+    ("third_party_data", "match"),
+    [
+        pytest.param(
+            {
+                "module": "os",
+                "class": "system",
+                "metric_name": "system",
+                "model": None,
+                "kwargs": {},
+            },
+            "not in the allow-list",
+            id="module_not_allow_listed",
+        ),
+        pytest.param(
+            {
+                "module": "mlflow.genai.scorers.ragas..evil",
+                "class": "X",
+                "metric_name": "X",
+                "model": None,
+                "kwargs": {},
+            },
+            "not in the allow-list",
+            id="module_with_dotdot_rejected",
+        ),
+        pytest.param(
+            {
+                "module": "mlflow.genai.scorers.ragas",
+                "class": "",
+                "metric_name": "Faithfulness",
+                "model": None,
+                "kwargs": {},
+            },
+            "missing required fields",
+            id="missing_class_name",
+        ),
+        pytest.param(
+            {
+                "module": "mlflow.genai.scorers.ragas",
+                "class": "ExactMatch",
+                "metric_name": "",
+                "model": None,
+                "kwargs": {},
+            },
+            "missing required fields",
+            id="missing_metric_name",
+        ),
+    ],
+)
+def test_third_party_scorer_invalid_payload_rejected(third_party_data, match):
+    payload = SerializedScorer(name="bad", third_party_scorer_data=third_party_data)
+    with pytest.raises(MlflowException, match=match):
         Scorer.model_validate(payload)
 
 
-def test_third_party_scorer_missing_required_fields_rejected():
-    from mlflow.genai.scorers.base import SerializedScorer
-
+def test_third_party_scorer_import_failure():
     payload = SerializedScorer(
-        name="nope",
+        name="x",
         third_party_scorer_data={
             "module": "mlflow.genai.scorers.ragas",
-            "class": "",
-            "metric_name": "",
+            "class": "ExactMatch",
+            "metric_name": "ExactMatch",
             "model": None,
             "kwargs": {},
         },
     )
-    with pytest.raises(MlflowException, match="missing required fields"):
-        Scorer.model_validate(payload)
+    with patch(
+        "mlflow.genai.scorers.base.importlib.import_module",
+        side_effect=ImportError("library not installed"),
+    ):
+        with pytest.raises(MlflowException, match="could not import"):
+            Scorer.model_validate(payload)
+
+
+def test_third_party_scorer_class_not_found():
+    payload = SerializedScorer(
+        name="x",
+        third_party_scorer_data={
+            "module": "mlflow.genai.scorers.ragas",
+            "class": "DoesNotExist",
+            "metric_name": "X",
+            "model": None,
+            "kwargs": {},
+        },
+    )
+    with patch(
+        "mlflow.genai.scorers.base.importlib.import_module",
+        return_value=Mock(spec=[]),
+    ):
+        with pytest.raises(MlflowException, match="not found in module"):
+            Scorer.model_validate(payload)
+
+
+def test_third_party_scorer_instantiation_failure():
+    class BoomScorer:
+        def __init__(self, **kwargs):
+            raise RuntimeError("boom")
+
+    fake_module = Mock(BoomScorer=BoomScorer)
+    payload = SerializedScorer(
+        name="x",
+        third_party_scorer_data={
+            "module": "mlflow.genai.scorers.ragas",
+            "class": "BoomScorer",
+            "metric_name": "X",
+            "model": None,
+            "kwargs": {},
+        },
+    )
+    with patch(
+        "mlflow.genai.scorers.base.importlib.import_module",
+        return_value=fake_module,
+    ):
+        with pytest.raises(MlflowException, match="failed to instantiate"):
+            Scorer.model_validate(payload)
 
 
 def test_serialized_scorer_rejects_multiple_scorer_field_types():
-    from mlflow.genai.scorers.base import SerializedScorer
-
     with pytest.raises(ValueError, match="cannot have multiple types"):
         SerializedScorer(
             name="oops",

--- a/tests/genai/scorers/test_serialization.py
+++ b/tests/genai/scorers/test_serialization.py
@@ -455,8 +455,19 @@ def test_direct_subclass_scorer_rejected():
     assert direct_scorer(outputs="hello world") is True
     assert direct_scorer(outputs="hi") is False
 
+    # But serialization should raise an error
     with pytest.raises(MlflowException, match="Unsupported scorer type: DirectSubclassScorer"):
         direct_scorer.model_dump()
+
+    # Verify the error message is informative
+    try:
+        direct_scorer.model_dump()
+    except MlflowException as e:
+        error_msg = str(e)
+        assert "Builtin scorers" in error_msg
+        assert "Decorator-created scorers" in error_msg
+        assert "@scorer decorator" in error_msg
+        assert "Direct subclassing of Scorer is not supported" in error_msg
 
 
 def test_builtin_scorer_with_aggregations_round_trip():

--- a/tests/genai/scorers/test_serialization.py
+++ b/tests/genai/scorers/test_serialization.py
@@ -690,17 +690,6 @@ def test_builtin_scorer_instructions_preserved_through_serialization():
         ),
         pytest.param(
             {
-                "module": "mlflow.genai.scorers.ragas..evil",
-                "class": "X",
-                "metric_name": "X",
-                "model": None,
-                "kwargs": {},
-            },
-            "not in the allow-list",
-            id="module_with_dotdot_rejected",
-        ),
-        pytest.param(
-            {
                 "module": "mlflow.genai.scorers.ragas",
                 "class": "",
                 "metric_name": "Faithfulness",

--- a/tests/genai/scorers/test_serialization.py
+++ b/tests/genai/scorers/test_serialization.py
@@ -666,3 +666,59 @@ def test_builtin_scorer_instructions_preserved_through_serialization():
     assert deserialized.instructions == original_instructions
     assert deserialized.name == "test_guidelines"
     assert deserialized.guidelines == ["Be helpful"]
+
+
+# ============================================================================
+# THIRD-PARTY SCORER (de)serialization
+# ============================================================================
+
+
+def test_third_party_scorer_module_allow_list_enforced():
+    from mlflow.genai.scorers.base import SerializedScorer
+
+    payload = SerializedScorer(
+        name="evil",
+        third_party_scorer_data={
+            "module": "os",
+            "class": "system",
+            "metric_name": "system",
+            "model": None,
+            "kwargs": {},
+        },
+    )
+    with pytest.raises(MlflowException, match="not in the allow-list"):
+        Scorer.model_validate(payload)
+
+
+def test_third_party_scorer_missing_required_fields_rejected():
+    from mlflow.genai.scorers.base import SerializedScorer
+
+    payload = SerializedScorer(
+        name="nope",
+        third_party_scorer_data={
+            "module": "mlflow.genai.scorers.ragas",
+            "class": "",
+            "metric_name": "",
+            "model": None,
+            "kwargs": {},
+        },
+    )
+    with pytest.raises(MlflowException, match="missing required fields"):
+        Scorer.model_validate(payload)
+
+
+def test_serialized_scorer_rejects_multiple_scorer_field_types():
+    from mlflow.genai.scorers.base import SerializedScorer
+
+    with pytest.raises(ValueError, match="cannot have multiple types"):
+        SerializedScorer(
+            name="oops",
+            builtin_scorer_class="Safety",
+            third_party_scorer_data={
+                "module": "mlflow.genai.scorers.ragas",
+                "class": "ExactMatch",
+                "metric_name": "ExactMatch",
+                "model": None,
+                "kwargs": {},
+            },
+        )

--- a/tests/genai/scorers/test_serialization.py
+++ b/tests/genai/scorers/test_serialization.py
@@ -455,19 +455,8 @@ def test_direct_subclass_scorer_rejected():
     assert direct_scorer(outputs="hello world") is True
     assert direct_scorer(outputs="hi") is False
 
-    # But serialization should raise an error
     with pytest.raises(MlflowException, match="Unsupported scorer type: DirectSubclassScorer"):
         direct_scorer.model_dump()
-
-    # Verify the error message is informative
-    try:
-        direct_scorer.model_dump()
-    except MlflowException as e:
-        error_msg = str(e)
-        assert "Builtin scorers" in error_msg
-        assert "Decorator-created scorers" in error_msg
-        assert "@scorer decorator" in error_msg
-        assert "Direct subclassing of Scorer is not supported" in error_msg
 
 
 def test_builtin_scorer_with_aggregations_round_trip():

--- a/tests/genai/scorers/test_serialization.py
+++ b/tests/genai/scorers/test_serialization.py
@@ -1,4 +1,5 @@
 import json
+from typing import ClassVar
 from unittest.mock import Mock, patch
 
 import pytest
@@ -753,6 +754,29 @@ def test_third_party_scorer_class_not_found():
         return_value=Mock(spec=[]),
     ):
         with pytest.raises(MlflowException, match="not found in module"):
+            Scorer.model_validate(payload)
+
+
+def test_third_party_scorer_metric_name_mismatch_with_classvar():
+    class RenamedScorer:
+        metric_name: ClassVar[str] = "NewName"
+
+    fake_module = Mock(RenamedScorer=RenamedScorer)
+    payload = SerializedScorer(
+        name="stale",
+        third_party_scorer_data={
+            "module": "mlflow.genai.scorers.ragas",
+            "class": "RenamedScorer",
+            "metric_name": "OldName",
+            "model": None,
+            "kwargs": {},
+        },
+    )
+    with patch(
+        "mlflow.genai.scorers.base.importlib.import_module",
+        return_value=fake_module,
+    ):
+        with pytest.raises(MlflowException, match="does not match class"):
             Scorer.model_validate(payload)
 
 

--- a/tests/genai/scorers/trulens/test_trulens.py
+++ b/tests/genai/scorers/trulens/test_trulens.py
@@ -234,3 +234,44 @@ def test_high_level_scorer_call_chain(mock_provider):
     assert feedback.value == CategoricalRating.YES
     assert feedback.source.source_type == AssessmentSourceType.LLM_JUDGE
     assert feedback.source.source_id == "openai:/gpt-4"
+
+
+def test_trulens_scorer_kind_is_third_party(mock_provider):
+    from mlflow.genai.scorers.base import ScorerKind
+
+    with patch("mlflow.genai.scorers.trulens.create_trulens_provider", return_value=mock_provider):
+        from mlflow.genai.scorers.trulens import Groundedness
+
+        assert Groundedness(model="openai:/gpt-4").kind == ScorerKind.THIRD_PARTY
+
+
+def test_trulens_scorer_serialization_round_trip(mock_provider):
+    from mlflow.genai.scorers.base import Scorer, ScorerKind
+
+    with patch("mlflow.genai.scorers.trulens.create_trulens_provider", return_value=mock_provider):
+        from mlflow.genai.scorers.trulens import Groundedness
+
+        scorer = Groundedness(model="openai:/gpt-4", threshold=0.7)
+        dump = scorer.model_dump()
+        assert dump["third_party_scorer_data"]["class"] == "Groundedness"
+        assert dump["third_party_scorer_data"]["metric_name"] == "Groundedness"
+        assert dump["third_party_scorer_data"]["model"] == "openai:/gpt-4"
+        assert dump["third_party_scorer_data"]["kwargs"]["threshold"] == 0.7
+
+        restored = Scorer.model_validate(dump)
+        assert isinstance(restored, Groundedness)
+        assert restored.kind == ScorerKind.THIRD_PARTY
+        assert restored._model == "openai:/gpt-4"
+        assert restored._threshold == 0.7
+
+
+def test_trulens_scorer_register_blocked_on_databricks(mock_provider):
+    from mlflow.exceptions import MlflowException
+
+    with patch("mlflow.genai.scorers.trulens.create_trulens_provider", return_value=mock_provider):
+        from mlflow.genai.scorers.trulens import Groundedness
+
+        scorer = Groundedness(model="openai:/gpt-4")
+        with patch("mlflow.genai.scorers.base.is_databricks_uri", return_value=True):
+            with pytest.raises(MlflowException, match="Third-party scorer registration"):
+                scorer.register(name="groundedness")

--- a/tests/genai/scorers/trulens/test_trulens.py
+++ b/tests/genai/scorers/trulens/test_trulens.py
@@ -5,7 +5,10 @@ import trulens  # noqa: F401
 
 from mlflow.entities.assessment import Feedback
 from mlflow.entities.assessment_source import AssessmentSourceType
+from mlflow.exceptions import MlflowException
 from mlflow.genai.judges.utils import CategoricalRating
+from mlflow.genai.scorers.base import Scorer, ScorerKind
+from mlflow.genai.scorers.trulens import Groundedness
 
 
 @pytest.fixture
@@ -237,20 +240,12 @@ def test_high_level_scorer_call_chain(mock_provider):
 
 
 def test_trulens_scorer_kind_is_third_party(mock_provider):
-    from mlflow.genai.scorers.base import ScorerKind
-
     with patch("mlflow.genai.scorers.trulens.create_trulens_provider", return_value=mock_provider):
-        from mlflow.genai.scorers.trulens import Groundedness
-
         assert Groundedness(model="openai:/gpt-4").kind == ScorerKind.THIRD_PARTY
 
 
 def test_trulens_scorer_serialization_round_trip(mock_provider):
-    from mlflow.genai.scorers.base import Scorer, ScorerKind
-
     with patch("mlflow.genai.scorers.trulens.create_trulens_provider", return_value=mock_provider):
-        from mlflow.genai.scorers.trulens import Groundedness
-
         scorer = Groundedness(model="openai:/gpt-4", threshold=0.7)
         dump = scorer.model_dump()
         assert dump["third_party_scorer_data"]["class"] == "Groundedness"
@@ -266,11 +261,7 @@ def test_trulens_scorer_serialization_round_trip(mock_provider):
 
 
 def test_trulens_scorer_register_blocked_on_databricks(mock_provider):
-    from mlflow.exceptions import MlflowException
-
     with patch("mlflow.genai.scorers.trulens.create_trulens_provider", return_value=mock_provider):
-        from mlflow.genai.scorers.trulens import Groundedness
-
         scorer = Groundedness(model="openai:/gpt-4")
         with patch("mlflow.genai.scorers.base.is_databricks_uri", return_value=True):
             with pytest.raises(MlflowException, match="Third-party scorer registration"):


### PR DESCRIPTION
### Related Issues/PRs

Relates to #

### What changes are proposed in this pull request?

Allow users to call `register()`, `start()`, `update()`, and `stop()` on third-party scorer wrappers (RAGAS, DeepEval, TruLens, Phoenix) against OSS MLflow backends. Previously these methods raised unconditionally in `RagasScorer` / `DeepEvalScorer` and silently failed via the `ScorerKind.CLASS` fallback in `TruLensScorer` / `PhoenixScorer`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Ran full scorer test suite locally:

```
uv run --with ragas --with deepeval --with arize-phoenix-evals --with trulens-core \\
    --with trulens-providers-litellm --with openai --with litellm \\
    pytest tests/genai/scorers/ragas tests/genai/scorers/deepeval \\
           tests/genai/scorers/trulens tests/genai/scorers/phoenix \\
           tests/genai/scorers/test_serialization.py tests/genai/scorers/test_scorer.py -q
# 316 passed, 17 skipped
```

Manual end-to-end script (register / list / get round-trip) against a local SQLite backend:

```
=== Deterministic RAGAS metric (ExactMatch) ===
before register: name=ExactMatch kind=ScorerKind.THIRD_PARTY status=ScorerStatus.UNREGISTERED
registered: name=exact_match_v1 backend=tracking
  listed: name=exact_match_v1 class=ExactMatch kind=ScorerKind.THIRD_PARTY
get_scorer: class=ExactMatch name=exact_match_v1
call after round-trip: value=1.0

=== LLM RAGAS metric (Faithfulness) register + round-trip ===
before register: name=Faithfulness kind=ScorerKind.THIRD_PARTY
registered: name=faithfulness_v1
  listed: name=faithfulness_v1 class=Faithfulness kind=ScorerKind.THIRD_PARTY
get_scorer: class=Faithfulness name=faithfulness_v1 model=openai:/gpt-4o
```

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

(Will follow up with docs updates in a separate PR — this PR is the code enablement.)

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Users of third-party scorer wrappers (RAGAS, DeepEval, TruLens, Phoenix) can now call \`register()\` / \`start()\` / \`update()\` / \`stop()\` against OSS MLflow backends. Registration remains blocked when the tracking URI points at Databricks.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request was AI-assisted by Isaac.