### PR TITLE
fix(ui): pre-compute section-to-charts map to avoid O(n²) filtering

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/sections/RunsChartsSectionAccordion.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/sections/RunsChartsSectionAccordion.tsx
@@ -321,7 +321,7 @@ export const RunsChartsSectionAccordion = ({
     const map: Record<string, RunsChartsCardConfig[]> = {};
     for (const config of chartsToRender || []) {
       if (config.deleted) continue;
-      const sectionId = (config as RunsChartsBarCardConfig).metricSectionId;
+      const sectionId = config.metricSectionId;
       if (sectionId) {
         if (!map[sectionId]) map[sectionId] = [];
         map[sectionId].push(config);

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/sections/RunsChartsSectionAccordion.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/sections/RunsChartsSectionAccordion.tsx
@@ -316,6 +316,20 @@ export const RunsChartsSectionAccordion = ({
     return { sectionsToRender: compareRunSectionsFiltered, chartsToRender: compareRunChartsFiltered };
   }, [search, compareRunCharts, compareRunSections]);
 
+  // Pre-compute section→charts mapping to avoid O(n²) filtering
+  const chartsBySectionId = useMemo(() => {
+    const map: Record<string, RunsChartsCardConfig[]> = {};
+    for (const config of chartsToRender || []) {
+      if (config.deleted) continue;
+      const sectionId = (config as RunsChartsBarCardConfig).metricSectionId;
+      if (sectionId) {
+        if (!map[sectionId]) map[sectionId] = [];
+        map[sectionId].push(config);
+      }
+    }
+    return map;
+  }, [chartsToRender]);
+
   const isSearching = search !== '';
 
   if (!compareRunSections || !compareRunCharts) {
@@ -366,10 +380,7 @@ export const RunsChartsSectionAccordion = ({
     <div>
       <MetricChartsAccordion activeKey={activeKey} onActiveKeyChange={onActivePanelChange}>
         {(sectionsToRender || []).map((sectionConfig: ChartSectionConfig, index: number) => {
-          const sectionCharts = (chartsToRender || []).filter((config: RunsChartsCardConfig) => {
-            const section = (config as RunsChartsBarCardConfig).metricSectionId;
-            return !config.deleted && section === sectionConfig.uuid;
-          });
+          const sectionCharts = chartsBySectionId[sectionConfig.uuid] || [];
 
           return (
             <Accordion.Panel


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22489

### What changes are proposed in this pull request?

`RunsChartsSectionAccordion` re-scanned the entire chart array for every section to find its children. At 3000 charts × 50 sections this caused a visible rendering bottleneck.

This PR builds a `Record<sectionId, cards[]>` once in `useMemo` and looks up by section UUID — O(n) total instead of O(n×m).

Changes:
- Add `chartsBySectionId` useMemo that pre-computes a section→charts mapping
- Replace the per-section inline `.filter()` with a direct map lookup

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Tested with experiments logging 3000+ metrics — confirmed faster section rendering.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Faster chart section rendering for experiments with many metrics by replacing O(n²) filtering with a pre-computed lookup map.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release