### PR TITLE
fix(ui): paginate chart cards and sections, auto-collapse for high metric counts

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/hooks/useExperimentLoggedModelsChartsUIState.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/hooks/useExperimentLoggedModelsChartsUIState.tsx
@@ -41,9 +41,13 @@ const getExperimentLoggedModelsPageChartSetup = (metricsByDatasets: RunsChartsMe
     }),
   );
 
+  // Auto-collapse sections when there are many charts to prevent browser crashes
+  // with thousands of metrics
+  const collapseByDefault = compareRunCharts.length > 100;
+
   const compareRunSections: ChartSectionConfig[] = uniq(metricsByDatasets.map(({ datasetName }) => datasetName)).map(
     (datasetName) => ({
-      display: true,
+      display: !collapseByDefault,
       name: datasetName ?? 'Metrics',
       uuid: datasetName ? `autogen-${datasetName}` : 'default',
       isReordered: false,
@@ -52,7 +56,7 @@ const getExperimentLoggedModelsPageChartSetup = (metricsByDatasets: RunsChartsMe
 
   if (isEmpty(compareRunSections)) {
     compareRunSections.push({
-      display: true,
+      display: !collapseByDefault,
       name: 'Metrics',
       uuid: 'default',
       isReordered: false,

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/hooks/useExperimentLoggedModelsChartsUIState.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/hooks/useExperimentLoggedModelsChartsUIState.tsx
@@ -43,11 +43,11 @@ const getExperimentLoggedModelsPageChartSetup = (metricsByDatasets: RunsChartsMe
 
   // Auto-collapse sections when there are many charts to prevent browser crashes
   // with thousands of metrics
-  const collapseByDefault = compareRunCharts.length > 100;
+  const isCollapsed = compareRunCharts.length > 100;
 
   const compareRunSections: ChartSectionConfig[] = uniq(metricsByDatasets.map(({ datasetName }) => datasetName)).map(
     (datasetName) => ({
-      display: !collapseByDefault,
+      display: !isCollapsed,
       name: datasetName ?? 'Metrics',
       uuid: datasetName ? `autogen-${datasetName}` : 'default',
       isReordered: false,
@@ -56,7 +56,7 @@ const getExperimentLoggedModelsPageChartSetup = (metricsByDatasets: RunsChartsMe
 
   if (isEmpty(compareRunSections)) {
     compareRunSections.push({
-      display: !collapseByDefault,
+      display: !isCollapsed,
       name: 'Metrics',
       uuid: 'default',
       isReordered: false,

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsDraggableCardsGrid.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsDraggableCardsGrid.test.tsx
@@ -439,6 +439,158 @@ describe('RunsChartsDraggableCardsGrid', () => {
     });
   });
 
+  describe('pagination', () => {
+    const renderPaginatedSection = (cards: RunsChartsBarCardConfig[]) => {
+      const TestComponent = () => {
+        const [uiState, setUIState] = useState<ExperimentRunsChartsUIConfiguration>({
+          ...createExperimentPageUIState(),
+          compareRunCharts: cards,
+        });
+
+        return (
+          <RunsChartsUIConfigurationContextProvider updateChartsUIState={setUIState}>
+            <RunsChartsDraggableCardsGridContextProvider visibleChartCards={cards}>
+              <RunsChartsDraggableCardsGridSection
+                cardsConfig={uiState.compareRunCharts ?? []}
+                chartRunData={[]}
+                sectionId="abc"
+                setFullScreenChart={noop}
+                groupBy={null}
+                onRemoveChart={noop}
+                onStartEditChart={noop}
+                sectionConfig={{
+                  display: true,
+                  isReordered: false,
+                  name: 'section_1',
+                  uuid: 'section_1',
+                  cardHeight: 360,
+                  columns: 3,
+                }}
+              />
+            </RunsChartsDraggableCardsGridContextProvider>
+          </RunsChartsUIConfigurationContextProvider>
+        );
+      };
+
+      renderTestComponent(<TestComponent />);
+    };
+
+    const makeCards = (count: number, prefix = 'metric'): RunsChartsBarCardConfig[] =>
+      Array.from({ length: count }, (_, i) => ({
+        type: RunsChartType.BAR,
+        metricKey: `${prefix}_${i}`,
+        uuid: `${prefix}_card_${i}`,
+      })) as RunsChartsBarCardConfig[];
+
+    test('initial render caps at 50 cards and shows "Show more" button when there are more', async () => {
+      renderPaginatedSection(makeCards(60));
+
+      await waitFor(() => {
+        expect(screen.getAllByTestId('experiment-view-compare-runs-card-drag-handle')).toHaveLength(50);
+      });
+
+      // The "Show more charts" button should appear with the remaining count
+      expect(screen.getByRole('button', { name: /Show 10 more charts \(10 remaining\)/ })).toBeInTheDocument();
+    });
+
+    test('does not show "Show more" button when total cards fit in a single page', async () => {
+      renderPaginatedSection(makeCards(20));
+
+      await waitFor(() => {
+        expect(screen.getAllByTestId('experiment-view-compare-runs-card-drag-handle')).toHaveLength(20);
+      });
+
+      expect(screen.queryByRole('button', { name: /Show \d+ more charts/ })).not.toBeInTheDocument();
+    });
+
+    test('clicking "Show more" loads the next batch', async () => {
+      renderPaginatedSection(makeCards(120));
+
+      await waitFor(() => {
+        expect(screen.getAllByTestId('experiment-view-compare-runs-card-drag-handle')).toHaveLength(50);
+      });
+
+      // First batch shows 70 remaining, with the next click loading min(70, 50) = 50 more
+      await userEvent.click(screen.getByRole('button', { name: /Show 50 more charts \(70 remaining\)/ }));
+
+      await waitFor(() => {
+        expect(screen.getAllByTestId('experiment-view-compare-runs-card-drag-handle')).toHaveLength(100);
+      });
+
+      // After loading 50 more, 20 remain
+      await userEvent.click(screen.getByRole('button', { name: /Show 20 more charts \(20 remaining\)/ }));
+
+      await waitFor(() => {
+        expect(screen.getAllByTestId('experiment-view-compare-runs-card-drag-handle')).toHaveLength(120);
+      });
+
+      expect(screen.queryByRole('button', { name: /Show \d+ more charts/ })).not.toBeInTheDocument();
+    });
+
+    test('pagination resets when the card list changes (different cards, same length)', async () => {
+      const cardsA = makeCards(60, 'a');
+      const cardsB = makeCards(60, 'b');
+
+      const TestComponent = () => {
+        const [activeCards, setActiveCards] = useState(cardsA);
+        const [uiState, setUIState] = useState<ExperimentRunsChartsUIConfiguration>({
+          ...createExperimentPageUIState(),
+          compareRunCharts: activeCards,
+        });
+
+        return (
+          <>
+            <RunsChartsUIConfigurationContextProvider updateChartsUIState={setUIState}>
+              <RunsChartsDraggableCardsGridContextProvider visibleChartCards={activeCards}>
+                <RunsChartsDraggableCardsGridSection
+                  cardsConfig={activeCards}
+                  chartRunData={[]}
+                  sectionId="abc"
+                  setFullScreenChart={noop}
+                  groupBy={null}
+                  onRemoveChart={noop}
+                  onStartEditChart={noop}
+                  sectionConfig={{
+                    display: true,
+                    isReordered: false,
+                    name: 'section_1',
+                    uuid: 'section_1',
+                    cardHeight: 360,
+                    columns: 3,
+                  }}
+                />
+              </RunsChartsDraggableCardsGridContextProvider>
+            </RunsChartsUIConfigurationContextProvider>
+            <button type="button" onClick={() => setActiveCards(cardsB)}>
+              Switch
+            </button>
+          </>
+        );
+      };
+
+      renderTestComponent(<TestComponent />);
+
+      await waitFor(() => {
+        expect(screen.getAllByTestId('experiment-view-compare-runs-card-drag-handle')).toHaveLength(50);
+      });
+
+      // Expand pagination — load all 60 cards
+      await userEvent.click(screen.getByRole('button', { name: /Show 10 more charts/ }));
+      await waitFor(() => {
+        expect(screen.getAllByTestId('experiment-view-compare-runs-card-drag-handle')).toHaveLength(60);
+      });
+
+      // Switch to a different list (same length, different reference + UUIDs)
+      await userEvent.click(screen.getByRole('button', { name: 'Switch' }));
+
+      // Pagination must reset back to the initial page size of 50
+      await waitFor(() => {
+        expect(screen.getAllByTestId('experiment-view-compare-runs-card-drag-handle')).toHaveLength(50);
+        expect(screen.getByRole('button', { name: /Show 10 more charts \(10 remaining\)/ })).toBeInTheDocument();
+      });
+    });
+  });
+
   test('properly hide cards with no data', async () => {
     const cards = [
       { type: RunsChartType.BAR, metricKey: 'metric_1', uuid: 'card_1' } as RunsChartsBarCardConfig,

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsDraggableCardsGridSection.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsDraggableCardsGridSection.tsx
@@ -21,6 +21,12 @@ import type { RunsChartsGlobalLineChartConfig } from '../../experiment-page/mode
 const CHARTS_PER_PAGE = 50;
 const rowHeightSuggestions = [300, 330, 360, 400, 500];
 
+const showMoreWrapperStyles = (theme: { spacing: { md: number } }) => ({
+  display: 'flex',
+  justifyContent: 'center',
+  padding: theme.spacing.md,
+});
+
 const getColumnSuggestions = (containerWidth: number, gapSize = 8) =>
   [1, 2, 3, 4, 5].map((n) => ({
     cols: n,
@@ -126,14 +132,13 @@ export const RunsChartsDraggableCardsGridSection = memo(
     const [positionInSection, setPositionInSection] = useState<number | null>(null);
     const [resizePreview, setResizePreview] = useState<null | Partial<DOMRect>>(null);
 
-    lastElementCount.current = cardsConfig.length;
     const position = !draggedCardUuid ? null : positionInSection;
 
     // Helper function that calculates the x, y coordinates of a card based on its position in the grid
     const findCoords = useCallback(
       (position) => {
         const gap = theme.spacing.sm;
-        const rowCount = Math.ceil(cardsConfig.length / columns);
+        const rowCount = Math.ceil(lastElementCount.current / columns);
 
         const row = Math.floor(position / columns);
         const col = position % columns;
@@ -156,7 +161,7 @@ export const RunsChartsDraggableCardsGridSection = memo(
           y: row * cardHeight + passedRowGaps * gap,
         };
       },
-      [columns, cardHeight, theme, cardsConfig.length],
+      [columns, cardHeight, theme],
     );
 
     const allFilteredCards = useMemo(() => {
@@ -170,13 +175,16 @@ export const RunsChartsDraggableCardsGridSection = memo(
     }, [cardsConfig, chartRunData, hideEmptyCharts]);
 
     const [visibleCount, setVisibleCount] = useState(CHARTS_PER_PAGE);
-    // Reset pagination when the card list changes (e.g., switching experiments)
+    // Reset pagination when the filtered card list changes (e.g., switching experiments
+    // or filters). Keying off the array reference catches changes that preserve length,
+    // such as switching to a same-sized set of different metrics.
     useEffect(() => {
       setVisibleCount(CHARTS_PER_PAGE);
-    }, [allFilteredCards.length]);
+    }, [allFilteredCards]);
     const cardsToRender = useMemo(() => {
       return allFilteredCards.slice(0, visibleCount);
     }, [allFilteredCards, visibleCount]);
+    lastElementCount.current = cardsToRender.length;
     const hasMoreCards = allFilteredCards.length > visibleCount;
     const remainingCards = allFilteredCards.length - visibleCount;
 
@@ -371,7 +379,12 @@ export const RunsChartsDraggableCardsGridSection = memo(
               />
             </div>
           )}
-          {cardsToRender.map((cardConfig, index, array) => {
+          {cardsToRender.map((cardConfig, index) => {
+            // Reorder math is computed against the full filtered list (not the paginated slice)
+            // so "move down/to bottom" works across pages, not just within the visible page.
+            const fullIndex = allFilteredCards.indexOf(cardConfig);
+            const previousCard = fullIndex > 0 ? allFilteredCards[fullIndex - 1] : undefined;
+            const nextCard = fullIndex >= 0 ? allFilteredCards[fullIndex + 1] : undefined;
             return (
               <RunsChartsDraggableCard
                 key={cardConfig.uuid}
@@ -385,15 +398,15 @@ export const RunsChartsDraggableCardsGridSection = memo(
                 onReorderWith={onSwapCards}
                 index={index}
                 height={cardHeight}
-                canMoveDown={Boolean(array[index + 1])}
-                canMoveUp={Boolean(array[index - 1])}
-                canMoveToTop={index > 0}
-                canMoveToBottom={index < array.length - 1}
-                previousChartUuid={array[index - 1]?.uuid}
-                nextChartUuid={array[index + 1]?.uuid}
+                canMoveDown={Boolean(nextCard)}
+                canMoveUp={Boolean(previousCard)}
+                canMoveToTop={fullIndex > 0}
+                canMoveToBottom={fullIndex >= 0 && fullIndex < allFilteredCards.length - 1}
+                previousChartUuid={previousCard?.uuid}
+                nextChartUuid={nextCard?.uuid}
                 hideEmptyCharts={hideEmptyCharts}
-                firstChartUuid={array[0]?.uuid}
-                lastChartUuid={array[array.length - 1]?.uuid}
+                firstChartUuid={allFilteredCards[0]?.uuid}
+                lastChartUuid={allFilteredCards[allFilteredCards.length - 1]?.uuid}
                 {...cardProps}
               />
             );
@@ -402,12 +415,19 @@ export const RunsChartsDraggableCardsGridSection = memo(
           {resizePreview && <RunsChartsDraggablePreview {...resizePreview} />}
         </div>
         {hasMoreCards && (
-          <div css={{ display: 'flex', justifyContent: 'center', padding: theme.spacing.md }}>
+          <div css={showMoreWrapperStyles(theme)}>
             <Button
               componentId="mlflow_show_more_charts"
               onClick={() => setVisibleCount((prev) => prev + CHARTS_PER_PAGE)}
             >
-              Show {Math.min(remainingCards, CHARTS_PER_PAGE)} more charts ({remainingCards} remaining)
+              <FormattedMessage
+                defaultMessage="Show {count} more {count, plural, one {chart} other {charts}} ({remaining} remaining)"
+                description="Runs compare page > Charts tab > Show more charts button label"
+                values={{
+                  count: Math.min(remainingCards, CHARTS_PER_PAGE),
+                  remaining: remainingCards,
+                }}
+              />
             </Button>
           </div>
         )}

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsDraggableCardsGridSection.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsDraggableCardsGridSection.tsx
@@ -1,5 +1,5 @@
-import { Empty, useDesignSystemTheme } from '@databricks/design-system';
-import { memo, useCallback, useMemo, useRef, useState } from 'react';
+import { Button, Empty, useDesignSystemTheme } from '@databricks/design-system';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useUpdateRunsChartsUIConfiguration } from '../hooks/useRunsChartsUIConfiguration';
 import type { RunsChartsCardConfig } from '../runs-charts.types';
 import type { RunsChartsRunData } from './RunsCharts.common';
@@ -18,6 +18,7 @@ import { DRAGGABLE_CARD_TRANSITION_NAME, type RunsChartCardSetFullscreenFn } fro
 import type { RunsGroupByConfig } from '../../experiment-page/utils/experimentPage.group-row-utils';
 import type { RunsChartsGlobalLineChartConfig } from '../../experiment-page/models/ExperimentPageUIState';
 
+const CHARTS_PER_PAGE = 50;
 const rowHeightSuggestions = [300, 330, 360, 400, 500];
 
 const getColumnSuggestions = (containerWidth: number, gapSize = 8) =>
@@ -158,7 +159,7 @@ export const RunsChartsDraggableCardsGridSection = memo(
       [columns, cardHeight, theme, cardsConfig.length],
     );
 
-    const cardsToRender = useMemo(() => {
+    const allFilteredCards = useMemo(() => {
       const isEmptyChartCard = createEmptyChartCardPredicate(chartRunData);
       return cardsConfig.filter((cardConfig) => {
         if (!hideEmptyCharts) {
@@ -167,6 +168,17 @@ export const RunsChartsDraggableCardsGridSection = memo(
         return !isEmptyChartCard(cardConfig);
       });
     }, [cardsConfig, chartRunData, hideEmptyCharts]);
+
+    const [visibleCount, setVisibleCount] = useState(CHARTS_PER_PAGE);
+    // Reset pagination when the card list changes (e.g., switching experiments)
+    useEffect(() => {
+      setVisibleCount(CHARTS_PER_PAGE);
+    }, [allFilteredCards.length]);
+    const cardsToRender = useMemo(() => {
+      return allFilteredCards.slice(0, visibleCount);
+    }, [allFilteredCards, visibleCount]);
+    const hasMoreCards = allFilteredCards.length > visibleCount;
+    const remainingCards = allFilteredCards.length - visibleCount;
 
     // Calculate the transforms for each card based on the dragged card and its position.
     const cardTransforms = useMemo(() => {
@@ -310,84 +322,96 @@ export const RunsChartsDraggableCardsGridSection = memo(
     );
 
     return (
-      <div
-        ref={gridBoxRef}
-        css={[
-          { position: 'relative' },
-          cardsToRender.length > 0 && {
-            display: 'grid',
-            gap: theme.spacing.sm,
-          },
-        ]}
-        style={{
-          gridTemplateColumns: 'repeat(' + columns + ', 1fr)',
-          ...(draggedCardUuid && {
-            [DRAGGABLE_CARD_TRANSITION_NAME]: 'transform 0.1s',
-          }),
-        }}
-        data-testid="draggable-chart-cards-grid"
-        onMouseMove={mouseMove}
-        onMouseLeave={() => {
-          setPositionInSection(null);
-        }}
-      >
-        {(draggedCardUuid || resizePreview) && (
-          <Global
-            styles={{
-              'body, :host': {
-                userSelect: 'none',
-              },
-            }}
-          />
-        )}
-        {cardsToRender.length === 0 && (
-          <div css={{ display: 'flex', justifyContent: 'center', minHeight: 160 }}>
-            <Empty
-              title={
-                <FormattedMessage
-                  defaultMessage="No charts in this section"
-                  description="Runs compare page > Charts tab > No charts placeholder title"
-                />
-              }
-              description={
-                <FormattedMessage
-                  defaultMessage="Click 'Add chart' or drag and drop to add charts here."
-                  description="Runs compare page > Charts tab > No charts placeholder description"
-                />
-              }
+      <>
+        <div
+          ref={gridBoxRef}
+          css={[
+            { position: 'relative' },
+            cardsToRender.length > 0 && {
+              display: 'grid',
+              gap: theme.spacing.sm,
+            },
+          ]}
+          style={{
+            gridTemplateColumns: 'repeat(' + columns + ', 1fr)',
+            ...(draggedCardUuid && {
+              [DRAGGABLE_CARD_TRANSITION_NAME]: 'transform 0.1s',
+            }),
+          }}
+          data-testid="draggable-chart-cards-grid"
+          onMouseMove={mouseMove}
+          onMouseLeave={() => {
+            setPositionInSection(null);
+          }}
+        >
+          {(draggedCardUuid || resizePreview) && (
+            <Global
+              styles={{
+                'body, :host': {
+                  userSelect: 'none',
+                },
+              }}
             />
+          )}
+          {cardsToRender.length === 0 && (
+            <div css={{ display: 'flex', justifyContent: 'center', minHeight: 160 }}>
+              <Empty
+                title={
+                  <FormattedMessage
+                    defaultMessage="No charts in this section"
+                    description="Runs compare page > Charts tab > No charts placeholder title"
+                  />
+                }
+                description={
+                  <FormattedMessage
+                    defaultMessage="Click 'Add chart' or drag and drop to add charts here."
+                    description="Runs compare page > Charts tab > No charts placeholder description"
+                  />
+                }
+              />
+            </div>
+          )}
+          {cardsToRender.map((cardConfig, index, array) => {
+            return (
+              <RunsChartsDraggableCard
+                key={cardConfig.uuid}
+                uuid={cardConfig.uuid ?? ''}
+                translateBy={cardTransforms[cardConfig.uuid ?? '']}
+                onResizeStart={onResizeStart}
+                onResizeStop={onResizeStop}
+                onResize={onResize}
+                cardConfig={cardConfig}
+                chartRunData={chartRunData}
+                onReorderWith={onSwapCards}
+                index={index}
+                height={cardHeight}
+                canMoveDown={Boolean(array[index + 1])}
+                canMoveUp={Boolean(array[index - 1])}
+                canMoveToTop={index > 0}
+                canMoveToBottom={index < array.length - 1}
+                previousChartUuid={array[index - 1]?.uuid}
+                nextChartUuid={array[index + 1]?.uuid}
+                hideEmptyCharts={hideEmptyCharts}
+                firstChartUuid={array[0]?.uuid}
+                lastChartUuid={array[array.length - 1]?.uuid}
+                {...cardProps}
+              />
+            );
+          })}
+          {dragPreview && <RunsChartsDraggablePreview {...dragPreview} />}
+          {resizePreview && <RunsChartsDraggablePreview {...resizePreview} />}
+        </div>
+        {hasMoreCards && (
+          <div css={{ display: 'flex', justifyContent: 'center', padding: theme.spacing.md }}>
+            <Button
+              componentId="mlflow_show_more_charts"
+              onClick={() => setVisibleCount((prev) => prev + CHARTS_PER_PAGE)}
+            >
+              Show {Math.min(remainingCards, CHARTS_PER_PAGE)} more charts ({remainingCards} remaining)
+            </Button>
           </div>
         )}
-        {cardsToRender.map((cardConfig, index, array) => {
-          return (
-            <RunsChartsDraggableCard
-              key={cardConfig.uuid}
-              uuid={cardConfig.uuid ?? ''}
-              translateBy={cardTransforms[cardConfig.uuid ?? '']}
-              onResizeStart={onResizeStart}
-              onResizeStop={onResizeStop}
-              onResize={onResize}
-              cardConfig={cardConfig}
-              chartRunData={chartRunData}
-              onReorderWith={onSwapCards}
-              index={index}
-              height={cardHeight}
-              canMoveDown={Boolean(array[index + 1])}
-              canMoveUp={Boolean(array[index - 1])}
-              canMoveToTop={index > 0}
-              canMoveToBottom={index < array.length - 1}
-              previousChartUuid={array[index - 1]?.uuid}
-              nextChartUuid={array[index + 1]?.uuid}
-              hideEmptyCharts={hideEmptyCharts}
-              firstChartUuid={array[0]?.uuid}
-              lastChartUuid={array[array.length - 1]?.uuid}
-              {...cardProps}
-            />
-          );
-        })}
-        {dragPreview && <RunsChartsDraggablePreview {...dragPreview} />}
-        {resizePreview && <RunsChartsDraggablePreview {...resizePreview} />}
-      </div>
+      </>
     );
   },
 );

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/sections/RunsChartsSectionAccordion.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/sections/RunsChartsSectionAccordion.tsx
@@ -14,7 +14,7 @@ import { RunsChartType } from '../../runs-charts.types';
 import MetricChartsAccordion, { METRIC_CHART_SECTION_HEADER_SIZE } from '../../../MetricChartsAccordion';
 import { RunsChartsSectionHeader } from './RunsChartsSectionHeader';
 import { RunsChartsSection } from './RunsChartsSection';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { getUUID } from '@mlflow/mlflow/src/common/utils/ActionUtils';
 import { Button, PlusIcon } from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
@@ -317,6 +317,12 @@ export const RunsChartsSectionAccordion = ({
 
   const SECTIONS_PER_PAGE = 20;
   const [visibleSectionCount, setVisibleSectionCount] = useState(SECTIONS_PER_PAGE);
+  // Reset section pagination when the section list changes (e.g., switching experiments
+  // or applying a different search filter) so the user doesn't carry over a large visible
+  // count into a context where it negates the performance benefit.
+  useEffect(() => {
+    setVisibleSectionCount(SECTIONS_PER_PAGE);
+  }, [sectionsToRender]);
   const totalSections = (sectionsToRender || []).length;
   const paginatedSections = useMemo(
     () => (sectionsToRender || []).slice(0, visibleSectionCount),
@@ -429,8 +435,14 @@ export const RunsChartsSectionAccordion = ({
             componentId="mlflow_show_more_sections"
             onClick={() => setVisibleSectionCount((prev) => prev + SECTIONS_PER_PAGE)}
           >
-            Show {Math.min(totalSections - visibleSectionCount, SECTIONS_PER_PAGE)} more sections (
-            {totalSections - visibleSectionCount} remaining)
+            <FormattedMessage
+              defaultMessage="Show {count} more {count, plural, one {section} other {sections}} ({remaining} remaining)"
+              description="Experiment page > compare runs > chart section accordion > show more sections button"
+              values={{
+                count: Math.min(totalSections - visibleSectionCount, SECTIONS_PER_PAGE),
+                remaining: totalSections - visibleSectionCount,
+              }}
+            />
           </Button>
         </div>
       )}

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/sections/RunsChartsSectionAccordion.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/sections/RunsChartsSectionAccordion.tsx
@@ -14,9 +14,8 @@ import { RunsChartType } from '../../runs-charts.types';
 import MetricChartsAccordion, { METRIC_CHART_SECTION_HEADER_SIZE } from '../../../MetricChartsAccordion';
 import { RunsChartsSectionHeader } from './RunsChartsSectionHeader';
 import { RunsChartsSection } from './RunsChartsSection';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { getUUID } from '@mlflow/mlflow/src/common/utils/ActionUtils';
-import { useState } from 'react';
 import { Button, PlusIcon } from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
 import { Empty } from '@databricks/design-system';
@@ -316,6 +315,15 @@ export const RunsChartsSectionAccordion = ({
     return { sectionsToRender: compareRunSectionsFiltered, chartsToRender: compareRunChartsFiltered };
   }, [search, compareRunCharts, compareRunSections]);
 
+  const SECTIONS_PER_PAGE = 20;
+  const [visibleSectionCount, setVisibleSectionCount] = useState(SECTIONS_PER_PAGE);
+  const totalSections = (sectionsToRender || []).length;
+  const paginatedSections = useMemo(
+    () => (sectionsToRender || []).slice(0, visibleSectionCount),
+    [sectionsToRender, visibleSectionCount],
+  );
+  const hasMoreSections = totalSections > visibleSectionCount;
+
   const isSearching = search !== '';
 
   if (!compareRunSections || !compareRunCharts) {
@@ -365,7 +373,7 @@ export const RunsChartsSectionAccordion = ({
   return (
     <div>
       <MetricChartsAccordion activeKey={activeKey} onActiveKeyChange={onActivePanelChange}>
-        {(sectionsToRender || []).map((sectionConfig: ChartSectionConfig, index: number) => {
+        {paginatedSections.map((sectionConfig: ChartSectionConfig, index: number) => {
           const sectionCharts = (chartsToRender || []).filter((config: RunsChartsCardConfig) => {
             const section = (config as RunsChartsBarCardConfig).metricSectionId;
             return !config.deleted && section === sectionConfig.uuid;
@@ -415,6 +423,17 @@ export const RunsChartsSectionAccordion = ({
           );
         })}
       </MetricChartsAccordion>
+      {hasMoreSections && (
+        <div css={{ display: 'flex', justifyContent: 'center', padding: theme.spacing.md }}>
+          <Button
+            componentId="mlflow_show_more_sections"
+            onClick={() => setVisibleSectionCount((prev) => prev + SECTIONS_PER_PAGE)}
+          >
+            Show {Math.min(totalSections - visibleSectionCount, SECTIONS_PER_PAGE)} more sections (
+            {totalSections - visibleSectionCount} remaining)
+          </Button>
+        </div>
+      )}
       {!isSearching && (
         <div>
           <Button

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/runs-charts.types.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/runs-charts.types.ts
@@ -247,13 +247,13 @@ export abstract class RunsChartsCardConfig {
     ];
 
     // Auto-collapse sections when there are many charts to prevent browser performance issues
-    const collapseByDefault = resultChartSet.length > 100;
+    const isCollapsed = resultChartSet.length > 100;
 
     // Create section configs
     const resultSectionSet: ChartSectionConfig[] = sortedSectionNames.map((sectionName) => ({
       uuid: sectionName2Uuid[sectionName],
       name: sectionName,
-      display: !collapseByDefault,
+      display: !isCollapsed,
       isReordered: false,
       deleted: false,
       isGenerated: true,
@@ -423,7 +423,7 @@ export abstract class RunsChartsCardConfig {
 
     // Auto-collapse newly-discovered sections when chart count is high to avoid
     // rendering thousands of charts if new metrics stream in incrementally
-    const collapseNewSections = resultChartSet.length > 100;
+    const isCollapsed = resultChartSet.length > 100;
 
     Object.keys(sectionName2Uuid).forEach((sectionName) => {
       // Check if it is a new section
@@ -432,7 +432,7 @@ export abstract class RunsChartsCardConfig {
         resultSectionSet.push({
           uuid: sectionName2Uuid[sectionName],
           name: sectionName,
-          display: !collapseNewSections,
+          display: !isCollapsed,
           isReordered: false,
         });
       }

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/runs-charts.types.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/runs-charts.types.ts
@@ -421,6 +421,10 @@ export abstract class RunsChartsCardConfig {
       }
     });
 
+    // Auto-collapse newly-discovered sections when chart count is high to avoid
+    // rendering thousands of charts if new metrics stream in incrementally
+    const collapseNewSections = resultChartSet.length > 100;
+
     Object.keys(sectionName2Uuid).forEach((sectionName) => {
       // Check if it is a new section
       const doesSectionNameExist = resultSectionSet.findIndex((section) => section.name === sectionName) >= 0;
@@ -428,7 +432,7 @@ export abstract class RunsChartsCardConfig {
         resultSectionSet.push({
           uuid: sectionName2Uuid[sectionName],
           name: sectionName,
-          display: true,
+          display: !collapseNewSections,
           isReordered: false,
         });
       }

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/runs-charts.types.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/runs-charts.types.ts
@@ -246,11 +246,14 @@ export abstract class RunsChartsCardConfig {
       ...[MLFLOW_MODEL_METRIC_NAME, MLFLOW_SYSTEM_METRIC_NAME].filter((name) => enabledSectionNames.includes(name)),
     ];
 
+    // Auto-collapse sections when there are many charts to prevent browser performance issues
+    const collapseByDefault = resultChartSet.length > 100;
+
     // Create section configs
     const resultSectionSet: ChartSectionConfig[] = sortedSectionNames.map((sectionName) => ({
       uuid: sectionName2Uuid[sectionName],
       name: sectionName,
-      display: true,
+      display: !collapseByDefault,
       isReordered: false,
       deleted: false,
       isGenerated: true,

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/hooks/useExperimentEvaluationRunsChartsUIState.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/hooks/useExperimentEvaluationRunsChartsUIState.tsx
@@ -43,10 +43,10 @@ const getExperimentEvalRunsPageChartSetup = (allMetricKeys: string[]) => {
 
   // Auto-collapse sections when there are many charts to prevent browser crashes
   // (8000+ metrics would otherwise render 8000 BAR charts on mount)
-  const collapseByDefault = compareRunCharts.length > 100;
+  const isCollapsed = compareRunCharts.length > 100;
 
   const compareRunSections: ChartSectionConfig[] = firstNameSegments.map((segmentName) => ({
-    display: !collapseByDefault,
+    display: !isCollapsed,
     name: segmentName,
     uuid: `autogen-${segmentName}`,
     isReordered: false,
@@ -54,7 +54,7 @@ const getExperimentEvalRunsPageChartSetup = (allMetricKeys: string[]) => {
 
   if (isEmpty(compareRunSections)) {
     compareRunSections.push({
-      display: !collapseByDefault,
+      display: !isCollapsed,
       name: 'Metrics',
       uuid: 'default',
       isReordered: false,

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/hooks/useExperimentEvaluationRunsChartsUIState.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/hooks/useExperimentEvaluationRunsChartsUIState.tsx
@@ -41,8 +41,12 @@ const getExperimentEvalRunsPageChartSetup = (allMetricKeys: string[]) => {
     };
   });
 
+  // Auto-collapse sections when there are many charts to prevent browser crashes
+  // (8000+ metrics would otherwise render 8000 BAR charts on mount)
+  const collapseByDefault = compareRunCharts.length > 100;
+
   const compareRunSections: ChartSectionConfig[] = firstNameSegments.map((segmentName) => ({
-    display: true,
+    display: !collapseByDefault,
     name: segmentName,
     uuid: `autogen-${segmentName}`,
     isReordered: false,
@@ -50,7 +54,7 @@ const getExperimentEvalRunsPageChartSetup = (allMetricKeys: string[]) => {
 
   if (isEmpty(compareRunSections)) {
     compareRunSections.push({
-      display: true,
+      display: !collapseByDefault,
       name: 'Metrics',
       uuid: 'default',
       isReordered: false,

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -4405,6 +4405,10 @@
     "defaultMessage": "Group traces from the same chat session together",
     "description": "Empty state title for the chat sessions table"
   },
+  "QuKu0y": {
+    "defaultMessage": "Show {count} more {count, plural, one {section} other {sections}} ({remaining} remaining)",
+    "description": "Experiment page > compare runs > chart section accordion > show more sections button"
+  },
   "QuU1sl": {
     "defaultMessage": "Parallel Coordinates Plot",
     "description": "Tab text for parallel coordinates plot on the model comparison page"
@@ -6278,6 +6282,10 @@
   "cSSMIs": {
     "defaultMessage": "Copy artifact location",
     "description": "Copy tooltip to copy experiment artifact location from experiment runs table header"
+  },
+  "cSc3Ue": {
+    "defaultMessage": "Show {count} more {count, plural, one {chart} other {charts}} ({remaining} remaining)",
+    "description": "Runs compare page > Charts tab > Show more charts button label"
   },
   "cXhWaG": {
     "defaultMessage": "Select Model",


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22489

### What changes are proposed in this pull request?

All chart cards and accordion sections rendered simultaneously, causing multi-second layout/paint times and tab crashes with 1000+ metrics. On the `/experiments/<id>/evaluation-runs` page specifically, 8000+ metrics caused Chrome to consume 400% CPU and crash with "snap error 5" (renderer OOM).

Changes:
- Paginate chart cards at 50 per page with a "Show more" button in `RunsChartsDraggableCardsGridSection`
- Paginate accordion sections at 20 per page with a "Show more" button in `RunsChartsSectionAccordion`
- Auto-collapse all generated sections when chart count exceeds 100 in `getBaseChartAndSectionConfigs` (main chart page)
- Auto-collapse sections in `getExperimentEvalRunsPageChartSetup` (evaluation-runs page) — fixes the Chrome crash
- Auto-collapse sections in `getExperimentLoggedModelsPageChartSetup` (logged-models page) — same pattern
- Reset pagination when the card list changes (e.g., switching experiments)

This keeps the initial render fast while preserving full access to all charts and sections via progressive loading.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Tested with experiments logging 3000+ metrics — confirmed fast initial render with progressive loading. Tested `/experiments/<id>/evaluation-runs` with 8000+ metrics — page loads successfully instead of crashing.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Charts and sections are now paginated with "Show more" buttons, and sections auto-collapse when there are more than 100 charts on the main chart page, evaluation-runs page, and logged-models page. This prevents browser freezing and renderer crashes with high metric counts.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release