### PR TITLE
fix(ui): move gateway experiment filter from IS NULL to client-side

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useExperimentListQuery.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useExperimentListQuery.test.tsx
@@ -390,8 +390,57 @@ describe('useExperimentListQuery', () => {
   });
 
   describe('gateway experiment filtering', () => {
-    it('includes gateway exclusion filter in API call', async () => {
-      mockSearchExperiments.mockResolvedValueOnce(createMockResponse(['1', '2'], undefined));
+    it('filters out gateway experiments client-side', async () => {
+      // Create response with a gateway experiment mixed in
+      const response: SearchExperimentsApiResponse = {
+        experiments: [
+          {
+            experimentId: '1',
+            name: 'Normal experiment',
+            artifactLocation: '/artifacts/1',
+            lifecycleStage: 'active',
+            lastUpdateTime: Date.now(),
+            creationTime: Date.now(),
+            tags: [],
+            allowedActions: [],
+          },
+          {
+            experimentId: '2',
+            name: 'Gateway experiment',
+            artifactLocation: '/artifacts/2',
+            lifecycleStage: 'active',
+            lastUpdateTime: Date.now(),
+            creationTime: Date.now(),
+            tags: [{ key: 'mlflow.experiment.isGateway', value: 'true' }],
+            allowedActions: [],
+          },
+          {
+            experimentId: '3',
+            name: 'Another normal experiment',
+            artifactLocation: '/artifacts/3',
+            lifecycleStage: 'active',
+            lastUpdateTime: Date.now(),
+            creationTime: Date.now(),
+            tags: [],
+            allowedActions: [],
+          },
+        ],
+      };
+      mockSearchExperiments.mockResolvedValueOnce(response);
+
+      const { result } = renderHook(() => useExperimentListQuery(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      // Gateway experiment should be filtered out client-side
+      expect(result.current.data).toHaveLength(2);
+      expect(result.current.data?.map((e) => e.experimentId)).toEqual(['1', '3']);
+    });
+
+    it('does not send IS NULL filter to the API', async () => {
+      mockSearchExperiments.mockResolvedValueOnce(createMockResponse(['1'], undefined));
 
       renderHook(() => useExperimentListQuery(), {
         wrapper: createWrapper(),
@@ -402,8 +451,8 @@ describe('useExperimentListQuery', () => {
       const apiCallData = mockSearchExperiments.mock.calls[0][0];
       const filterParam = apiCallData.find((param: [string, string]) => param?.[0] === 'filter');
 
-      expect(filterParam).toBeDefined();
-      expect(filterParam?.[1]).toContain('tags.`mlflow.experiment.isGateway` IS NULL');
+      // No filter should be sent when there are no user-specified filters
+      expect(filterParam).toBeUndefined();
     });
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useExperimentListQuery.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useExperimentListQuery.ts
@@ -52,9 +52,13 @@ function getFilters({ searchFilter, tagsFilter }: Pick<ExperimentListQueryKey['1
     filters.push(tagFilterToSql(tagFilter));
   }
 
-  // Exclude gateway experiments server-side to ensure consistent page sizes
-  filters.push(`tags.\`${EXPERIMENT_IS_GATEWAY_TAG}\` IS NULL`);
+  // Note: we previously tried to exclude gateway experiments server-side with
+  // `tags.mlflow.experiment.isGateway IS NULL`, but IS NULL is not supported
+  // by all backends (e.g., Databricks). Filter client-side instead.
 
+  if (filters.length === 0) {
+    return undefined;
+  }
   return ['filter', filters.join(' AND ')];
 }
 
@@ -66,7 +70,7 @@ const queryFn = ({ queryKey }: QueryFunctionContext<ExperimentListQueryKey>) => 
 
   const data: (string[] | undefined)[] = [['max_results', String(pageSize)], ...orderBy];
 
-  // NOTE: undefined values are fine, they're filtered out by the request helpers inside `MlflowService`
+  // NOTE: undefined values are fine, they're filtered out by `getBigIntJson` inside `MlflowService`
   data.push(getFilters({ searchFilter, tagsFilter }));
 
   if (pageToken) {
@@ -134,8 +138,10 @@ export const useExperimentListQuery = ({
   const sortedExperiments = useMemo(() => {
     const experiments = queryResult.data?.experiments;
     if (!experiments) return undefined;
-    const demo = experiments.filter(isDemoExperiment);
-    const nonDemo = experiments.filter((e) => !isDemoExperiment(e));
+    // Filter out gateway experiments client-side (IS NULL not supported by all backends)
+    const nonGateway = experiments.filter((e) => !e.tags?.some((tag) => tag.key === EXPERIMENT_IS_GATEWAY_TAG));
+    const demo = nonGateway.filter(isDemoExperiment);
+    const nonDemo = nonGateway.filter((e) => !isDemoExperiment(e));
     return [...demo, ...nonDemo];
   }, [queryResult.data?.experiments]);
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22489

### What changes are proposed in this pull request?

The server-side filter `tags.mlflow.experiment.isGateway IS NULL` is not supported by all backends (e.g. Databricks), causing errors when listing experiments.

Changes:
- Remove the `IS NULL` filter from the API call in `getFilters`
- Add client-side filtering of gateway experiments in the `sortedExperiments` useMemo
- Return `undefined` from `getFilters` when no user-specified filters exist (avoids sending empty filter param)

Gateway experiments are rare, so filtering post-fetch has negligible impact on page sizes.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Updated unit tests in `useExperimentListQuery.test.tsx`: new test verifies gateway experiments are filtered out client-side, updated test verifies no `IS NULL` filter is sent to the API.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixes experiment listing errors on backends that don't support `IS NULL` tag filters by moving gateway experiment filtering to client-side.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release