### PR TITLE
fix(ui): default runsHiddenMode to HIDEALL for performance

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/models/ExperimentPageUIState.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/models/ExperimentPageUIState.tsx
@@ -163,7 +163,7 @@ export const createExperimentPageUIState = (): ExperimentPageUIState => ({
   runsPinned: [],
   runsHidden: [],
   runsVisibilityMap: {},
-  runsHiddenMode: RUNS_VISIBILITY_MODE.FIRST_10_RUNS,
+  runsHiddenMode: RUNS_VISIBILITY_MODE.HIDEALL,
   compareRunCharts: undefined,
   compareRunSections: undefined,
   viewMaximized: false,


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22489

### What changes are proposed in this pull request?

With experiments logging 1000+ metrics, rendering even 10 runs on first load generates thousands of chart components and traces, causing the browser tab to freeze or crash.

Changes:
- Change the default `runsHiddenMode` from `FIRST_10_RUNS` to `HIDEALL` in `createExperimentPageUIState`

Users start with a fast page and explicitly select which runs to visualize. This is a one-line change in `ExperimentPageUIState.tsx`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Confirmed fast initial page load with high metric count experiments.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Experiment pages now default to hiding all runs instead of showing the first 10, preventing browser freezing with high metric count experiments. Users select which runs to view.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release