### PR TITLE
Disable Create button when experiment name is empty

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/modals/CreateExperimentForm.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/CreateExperimentForm.tsx
@@ -20,6 +20,7 @@ type Props = {
     formatMessage: (...args: any[]) => any;
   };
   innerRef: any;
+  onValuesChange?: (changedValues: any, allValues: any) => void;
 };
 
 /**
@@ -31,7 +32,7 @@ class CreateExperimentFormComponent extends Component<Props> {
 
     return (
       // @ts-expect-error TS(2322): Type '{ children: Element[]; ref: any; layout: "ve... Remove this comment to see the full error message
-      <LegacyForm ref={this.props.innerRef} layout="vertical">
+      <LegacyForm ref={this.props.innerRef} layout="vertical" onValuesChange={this.props.onValuesChange}>
         <LegacyForm.Item
           label={this.props.intl.formatMessage({
             defaultMessage: 'Experiment Name',

--- a/mlflow/server/js/src/experiment-tracking/components/modals/CreateExperimentModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/CreateExperimentModal.tsx
@@ -28,7 +28,26 @@ type CreateExperimentModalImplProps = {
   navigate: NavigateFunction;
 };
 
-export class CreateExperimentModalImpl extends Component<CreateExperimentModalImplProps> {
+type CreateExperimentModalImplState = {
+  experimentName: string;
+};
+
+export class CreateExperimentModalImpl extends Component<CreateExperimentModalImplProps, CreateExperimentModalImplState> {
+  state: CreateExperimentModalImplState = {
+    experimentName: '',
+  };
+
+  handleValuesChange = (changedValues: any) => {
+    if (EXP_NAME_FIELD in changedValues) {
+      this.setState({ experimentName: changedValues[EXP_NAME_FIELD] });
+    }
+  };
+
+  handleClose = () => {
+    this.setState({ experimentName: '' });
+    this.props.onClose();
+  };
+
   handleCreateExperiment = async (values: any) => {
     // get values of input fields
     const experimentName = values[EXP_NAME_FIELD];
@@ -55,16 +74,21 @@ export class CreateExperimentModalImpl extends Component<CreateExperimentModalIm
 
   render() {
     const { isOpen } = this.props;
+    const { experimentName } = this.state;
     return (
       <GenericInputModal
         title="Create Experiment"
         okText="Create"
         isOpen={isOpen}
         handleSubmit={this.handleCreateExperiment}
-        onClose={this.props.onClose}
+        onClose={this.handleClose}
+        okButtonProps={{ disabled: !experimentName.trim() }}
       >
         {/* @ts-expect-error TS(2322): Type '{ validator: ((rule: any, value: any, callba... Remove this comment to see the full error message */}
-        <CreateExperimentForm validator={this.debouncedExperimentNameValidator} />
+        <CreateExperimentForm
+          validator={this.debouncedExperimentNameValidator}
+          onValuesChange={this.handleValuesChange}
+        />
       </GenericInputModal>
     );
   }

--- a/mlflow/server/js/src/experiment-tracking/components/modals/GenericInputModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/GenericInputModal.tsx
@@ -20,6 +20,7 @@ type Props = {
   footer?: React.ReactNode;
   handleSubmit: (...args: any[]) => any;
   title: React.ReactNode;
+  okButtonProps?: Record<string, any>;
 };
 
 type State = {
@@ -71,7 +72,7 @@ export class GenericInputModal extends Component<Props, State> {
 
   render() {
     const { isSubmitting } = this.state;
-    const { okText, cancelText, isOpen, footer, children } = this.props;
+    const { okText, cancelText, isOpen, footer, children, okButtonProps } = this.props;
 
     // add props (ref) to passed component
     const displayForm = React.Children.map(children, (child) => {
@@ -95,6 +96,7 @@ export class GenericInputModal extends Component<Props, State> {
         okText={okText}
         cancelText={cancelText}
         confirmLoading={isSubmitting}
+        okButtonProps={okButtonProps}
         onCancel={this.handleCancel}
         footer={footer}
         centered


### PR DESCRIPTION
### Related Issues/PRs

Closes #22609

### What changes are proposed in this pull request?

The Create button in the experiment creation dialog was always enabled on open, even before typing anything in the name field. This tracks the experiment name input value and keeps the Create button disabled until there's actual text entered.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The Create button in the Create Experiment dialog is now disabled until the user types an experiment name.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
