### PR TITLE
ui: disable Create Experiment until name is provided

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/modals/CreateExperimentForm.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/CreateExperimentForm.tsx
@@ -16,6 +16,7 @@ export const ARTIFACT_LOCATION = 'artifactLocation';
 
 type Props = {
   validator?: (...args: any[]) => any;
+  onValuesChange?: (...args: any[]) => any;
   intl: {
     formatMessage: (...args: any[]) => any;
   };
@@ -31,7 +32,7 @@ class CreateExperimentFormComponent extends Component<Props> {
 
     return (
       // @ts-expect-error TS(2322): Type '{ children: Element[]; ref: any; layout: "ve... Remove this comment to see the full error message
-      <LegacyForm ref={this.props.innerRef} layout="vertical">
+      <LegacyForm ref={this.props.innerRef} layout="vertical" onValuesChange={this.props.onValuesChange}>
         <LegacyForm.Item
           label={this.props.intl.formatMessage({
             defaultMessage: 'Experiment Name',

--- a/mlflow/server/js/src/experiment-tracking/components/modals/CreateExperimentModal.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/CreateExperimentModal.enzyme.test.tsx
@@ -39,7 +39,15 @@ describe('CreateExperimentModal', () => {
   test('should render with minimal props without exploding', () => {
     wrapper = shallow(<CreateExperimentModalImpl {...minimalProps} />);
     expect(wrapper.find(GenericInputModal).length).toBe(1);
+    expect(wrapper.find(GenericInputModal).prop('okButtonProps')).toEqual({ disabled: true });
     expect(wrapper.length).toBe(1);
+  });
+
+  test('enables create button when experiment name is provided', () => {
+    instance = wrapper.instance();
+    instance.handleValuesChange({}, { experimentName: 'new-exp' });
+    wrapper.update();
+    expect(wrapper.find(GenericInputModal).prop('okButtonProps')).toEqual({ disabled: false });
   });
   test('handleCreateExperiment redirects user to newly-created experiment page', async () => {
     instance = wrapper.instance();

--- a/mlflow/server/js/src/experiment-tracking/components/modals/CreateExperimentModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/CreateExperimentModal.tsx
@@ -29,6 +29,10 @@ type CreateExperimentModalImplProps = {
 };
 
 export class CreateExperimentModalImpl extends Component<CreateExperimentModalImplProps> {
+  state = {
+    isCreateDisabled: true,
+  };
+
   handleCreateExperiment = async (values: any) => {
     // get values of input fields
     const experimentName = values[EXP_NAME_FIELD];
@@ -53,6 +57,11 @@ export class CreateExperimentModalImpl extends Component<CreateExperimentModalIm
     400,
   );
 
+  handleValuesChange = (_: any, allValues: any) => {
+    const experimentName = allValues?.[EXP_NAME_FIELD];
+    this.setState({ isCreateDisabled: !experimentName?.trim() });
+  };
+
   render() {
     const { isOpen } = this.props;
     return (
@@ -61,10 +70,14 @@ export class CreateExperimentModalImpl extends Component<CreateExperimentModalIm
         okText="Create"
         isOpen={isOpen}
         handleSubmit={this.handleCreateExperiment}
+        okButtonProps={{ disabled: this.state.isCreateDisabled }}
         onClose={this.props.onClose}
       >
         {/* @ts-expect-error TS(2322): Type '{ validator: ((rule: any, value: any, callba... Remove this comment to see the full error message */}
-        <CreateExperimentForm validator={this.debouncedExperimentNameValidator} />
+        <CreateExperimentForm
+          validator={this.debouncedExperimentNameValidator}
+          onValuesChange={this.handleValuesChange}
+        />
       </GenericInputModal>
     );
   }

--- a/mlflow/server/js/src/experiment-tracking/components/modals/GenericInputModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/GenericInputModal.tsx
@@ -18,6 +18,7 @@ type Props = {
   onCancel?: () => void;
   className?: string;
   footer?: React.ReactNode;
+  okButtonProps?: Record<string, unknown>;
   handleSubmit: (...args: any[]) => any;
   title: React.ReactNode;
 };
@@ -71,7 +72,7 @@ export class GenericInputModal extends Component<Props, State> {
 
   render() {
     const { isSubmitting } = this.state;
-    const { okText, cancelText, isOpen, footer, children } = this.props;
+    const { okText, cancelText, isOpen, footer, okButtonProps, children } = this.props;
 
     // add props (ref) to passed component
     const displayForm = React.Children.map(children, (child) => {
@@ -93,6 +94,7 @@ export class GenericInputModal extends Component<Props, State> {
         visible={isOpen}
         onOk={this.onSubmit}
         okText={okText}
+        okButtonProps={okButtonProps}
         cancelText={cancelText}
         confirmLoading={isSubmitting}
         onCancel={this.handleCancel}


### PR DESCRIPTION
## What changes are included?
- add `okButtonProps` support in `GenericInputModal` so submit buttons can be disabled when needed
- wire `CreateExperimentModal` to keep the Create button disabled until `experimentName` has non-whitespace content
- pass form value change callbacks through `CreateExperimentForm` to update button state in real time
- extend modal tests to verify the button is disabled initially and enabled after entering an experiment name

Fixes #22609.

## Verification
- `cd mlflow/server/js && npx yarn test CreateExperimentModal.enzyme.test.tsx GenericInputModal.enzyme.test.tsx CreateExperimentForm.test.tsx`
- Result: `3 passed`