### PR TITLE
jobs: add configurable Huey storage URL for Redis

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1363,6 +1363,13 @@ MLFLOW_SERVER_ENABLE_JOB_EXECUTION = _BooleanEnvironmentVariable(
     "MLFLOW_SERVER_ENABLE_JOB_EXECUTION", True
 )
 
+#: Specifies optional Huey storage backend URL for MLflow server job execution.
+#: When set, MLflow uses Redis-backed Huey storage instead of local SQLite files.
+#: (default: ``None``)
+MLFLOW_SERVER_JOB_HUEY_STORAGE_URL = _EnvironmentVariable(
+    "MLFLOW_SERVER_JOB_HUEY_STORAGE_URL", str, None
+)
+
 #: Specifies MLflow server job maximum allowed retries for transient errors.
 #: (default: ``3``)
 MLFLOW_SERVER_JOB_TRANSIENT_ERROR_MAX_RETRIES = _EnvironmentVariable(

--- a/mlflow/server/jobs/utils.py
+++ b/mlflow/server/jobs/utils.py
@@ -22,6 +22,7 @@ from mlflow.entities._job_status import JobStatus
 from mlflow.environment_variables import (
     MLFLOW_ENABLE_WORKSPACES,
     MLFLOW_LOGGING_LEVEL,
+    MLFLOW_SERVER_JOB_HUEY_STORAGE_URL,
     MLFLOW_SERVER_JOB_TRANSIENT_ERROR_RETRY_BASE_DELAY,
     MLFLOW_SERVER_JOB_TRANSIENT_ERROR_RETRY_MAX_DELAY,
     MLFLOW_WORKSPACE,
@@ -35,8 +36,6 @@ from mlflow.utils.workspace_context import WorkspaceContext
 from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
 
 if TYPE_CHECKING:
-    import huey
-
     from mlflow.store.jobs.abstract_store import AbstractJobStore
 
 _logger = logging.getLogger(__name__)
@@ -422,7 +421,7 @@ def _exec_job(
 
 @dataclass
 class HueyInstance:
-    instance: "huey.SqliteHuey"
+    instance: Any
     submit_task: Callable[..., Any]
 
 
@@ -435,7 +434,7 @@ _huey_instance_map_lock = threading.RLock()
 
 
 def _get_or_init_huey_instance(instance_key: str):
-    from huey import SqliteHuey
+    from huey import RedisHuey, SqliteHuey
     from huey.serializer import Serializer
 
     class CustomJSONEncoder(json.JSONEncoder):
@@ -473,17 +472,33 @@ def _get_or_init_huey_instance(instance_key: str):
             else:
                 return decoded
 
+    def _get_huey_storage_config(key: str) -> tuple[str, dict[str, str]]:
+        storage_url = MLFLOW_SERVER_JOB_HUEY_STORAGE_URL.get()
+        if storage_url:
+            return "redis", {"url": storage_url}
+
+        huey_store_file = os.path.join(
+            os.environ[HUEY_STORAGE_PATH_ENV_VAR],
+            f"{key}.mlflow-huey-store",
+        )
+        return "sqlite", {"filename": huey_store_file}
+
     with _huey_instance_map_lock:
         if instance_key not in _huey_instance_map:
             _logger.debug(f"Creating huey instance for {instance_key}")
-            huey_store_file = os.path.join(
-                os.environ[HUEY_STORAGE_PATH_ENV_VAR], f"{instance_key}.mlflow-huey-store"
-            )
-            huey_instance = SqliteHuey(
-                filename=huey_store_file,
-                results=False,
-                serializer=JsonSerializer(),
-            )
+            storage_type, storage_kwargs = _get_huey_storage_config(instance_key)
+            if storage_type == "redis":
+                huey_instance = RedisHuey(
+                    results=False,
+                    serializer=JsonSerializer(),
+                    **storage_kwargs,
+                )
+            else:
+                huey_instance = SqliteHuey(
+                    results=False,
+                    serializer=JsonSerializer(),
+                    **storage_kwargs,
+                )
             huey_submit_task_fn = huey_instance.task(retries=0)(_exec_job)
             _huey_instance_map[instance_key] = HueyInstance(
                 instance=huey_instance,

--- a/tests/server/jobs/test_utils.py
+++ b/tests/server/jobs/test_utils.py
@@ -1,8 +1,10 @@
 import os
+from unittest import mock
 
 import pytest
 
 from mlflow.exceptions import MlflowException
+from mlflow.server.constants import HUEY_STORAGE_PATH_ENV_VAR
 from mlflow.server.jobs.utils import _load_function, _validate_function_parameters
 
 pytestmark = pytest.mark.skipif(
@@ -134,3 +136,43 @@ def test_compute_exclusive_lock_key():
     # Key format is job_name:hash
     assert key1.startswith("job_name:")
     assert key5.startswith("other_job:")
+
+
+def test_get_or_init_huey_instance_uses_sqlite_backend_by_default(monkeypatch, tmp_path):
+    from mlflow.server.jobs import utils as job_utils
+
+    job_utils._huey_instance_map.clear()
+    monkeypatch.delenv("MLFLOW_SERVER_JOB_HUEY_STORAGE_URL", raising=False)
+    monkeypatch.setenv(HUEY_STORAGE_PATH_ENV_VAR, str(tmp_path))
+
+    with mock.patch("huey.SqliteHuey") as mock_sqlite_huey, mock.patch("huey.RedisHuey"):
+        mock_huey_instance = mock.Mock()
+        mock_huey_instance.task.return_value = lambda fn: fn
+        mock_sqlite_huey.return_value = mock_huey_instance
+
+        job_utils._get_or_init_huey_instance("test.instance")
+
+        assert mock_sqlite_huey.call_count == 1
+        sqlite_kwargs = mock_sqlite_huey.call_args.kwargs
+        assert sqlite_kwargs["filename"] == str(tmp_path / "test.instance.mlflow-huey-store")
+        assert sqlite_kwargs["results"] is False
+
+
+def test_get_or_init_huey_instance_uses_redis_backend_when_configured(monkeypatch):
+    from mlflow.server.jobs import utils as job_utils
+
+    job_utils._huey_instance_map.clear()
+    monkeypatch.setenv("MLFLOW_SERVER_JOB_HUEY_STORAGE_URL", "redis://localhost:6379/0")
+    monkeypatch.delenv(HUEY_STORAGE_PATH_ENV_VAR, raising=False)
+
+    with mock.patch("huey.RedisHuey") as mock_redis_huey, mock.patch("huey.SqliteHuey"):
+        mock_huey_instance = mock.Mock()
+        mock_huey_instance.task.return_value = lambda fn: fn
+        mock_redis_huey.return_value = mock_huey_instance
+
+        job_utils._get_or_init_huey_instance("test.instance")
+
+        assert mock_redis_huey.call_count == 1
+        redis_kwargs = mock_redis_huey.call_args.kwargs
+        assert redis_kwargs["url"] == "redis://localhost:6379/0"
+        assert redis_kwargs["results"] is False


### PR DESCRIPTION
### Related Issues/PRs

Closes #22597

### What changes are proposed in this pull request?

- Add a new environment variable `MLFLOW_SERVER_JOB_HUEY_STORAGE_URL` for server job execution.
- Update Huey initialization in `mlflow/server/jobs/utils.py` to select `RedisHuey` when this URL is set.
- Keep the existing SQLite behavior as the default fallback when the URL is not set.
- Add unit tests covering backend selection for both default SQLite and configured Redis.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Commands run:
- `source .venv/bin/activate && python -m ruff check mlflow/server/jobs/utils.py tests/server/jobs/test_utils.py mlflow/environment_variables.py`
- `source .venv/bin/activate && python -m pytest tests/server/jobs/test_utils.py -k "huey_instance_uses_sqlite_backend_by_default or huey_instance_uses_redis_backend_when_configured"`

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I have updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release