### PR TITLE
ui: disable Create Experiment until name is provided

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/modals/CreateExperimentForm.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/CreateExperimentForm.tsx
@@ -16,6 +16,7 @@ export const ARTIFACT_LOCATION = 'artifactLocation';
 
 type Props = {
   validator?: (...args: any[]) => any;
+  onValuesChange?: (...args: any[]) => any;
   intl: {
     formatMessage: (...args: any[]) => any;
   };
@@ -31,7 +32,7 @@ class CreateExperimentFormComponent extends Component<Props> {
 
     return (
       // @ts-expect-error TS(2322): Type '{ children: Element[]; ref: any; layout: "ve... Remove this comment to see the full error message
-      <LegacyForm ref={this.props.innerRef} layout="vertical">
+      <LegacyForm ref={this.props.innerRef} layout="vertical" onValuesChange={this.props.onValuesChange}>
         <LegacyForm.Item
           label={this.props.intl.formatMessage({
             defaultMessage: 'Experiment Name',

--- a/mlflow/server/js/src/experiment-tracking/components/modals/CreateExperimentModal.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/CreateExperimentModal.enzyme.test.tsx
@@ -39,7 +39,15 @@ describe('CreateExperimentModal', () => {
   test('should render with minimal props without exploding', () => {
     wrapper = shallow(<CreateExperimentModalImpl {...minimalProps} />);
     expect(wrapper.find(GenericInputModal).length).toBe(1);
+    expect(wrapper.find(GenericInputModal).prop('okButtonProps')).toEqual({ disabled: true });
     expect(wrapper.length).toBe(1);
+  });
+
+  test('enables create button when experiment name is provided', () => {
+    instance = wrapper.instance();
+    instance.handleValuesChange({}, { experimentName: 'new-exp' });
+    wrapper.update();
+    expect(wrapper.find(GenericInputModal).prop('okButtonProps')).toEqual({ disabled: false });
   });
   test('handleCreateExperiment redirects user to newly-created experiment page', async () => {
     instance = wrapper.instance();

--- a/mlflow/server/js/src/experiment-tracking/components/modals/CreateExperimentModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/CreateExperimentModal.tsx
@@ -29,6 +29,10 @@ type CreateExperimentModalImplProps = {
 };
 
 export class CreateExperimentModalImpl extends Component<CreateExperimentModalImplProps> {
+  state = {
+    isCreateDisabled: true,
+  };
+
   handleCreateExperiment = async (values: any) => {
     // get values of input fields
     const experimentName = values[EXP_NAME_FIELD];
@@ -53,6 +57,11 @@ export class CreateExperimentModalImpl extends Component<CreateExperimentModalIm
     400,
   );
 
+  handleValuesChange = (_: any, allValues: any) => {
+    const experimentName = allValues?.[EXP_NAME_FIELD];
+    this.setState({ isCreateDisabled: !experimentName?.trim() });
+  };
+
   render() {
     const { isOpen } = this.props;
     return (
@@ -61,10 +70,14 @@ export class CreateExperimentModalImpl extends Component<CreateExperimentModalIm
         okText="Create"
         isOpen={isOpen}
         handleSubmit={this.handleCreateExperiment}
+        okButtonProps={{ disabled: this.state.isCreateDisabled }}
         onClose={this.props.onClose}
       >
         {/* @ts-expect-error TS(2322): Type '{ validator: ((rule: any, value: any, callba... Remove this comment to see the full error message */}
-        <CreateExperimentForm validator={this.debouncedExperimentNameValidator} />
+        <CreateExperimentForm
+          validator={this.debouncedExperimentNameValidator}
+          onValuesChange={this.handleValuesChange}
+        />
       </GenericInputModal>
     );
   }

--- a/mlflow/server/js/src/experiment-tracking/components/modals/GenericInputModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/GenericInputModal.tsx
@@ -18,6 +18,7 @@ type Props = {
   onCancel?: () => void;
   className?: string;
   footer?: React.ReactNode;
+  okButtonProps?: Record<string, unknown>;
   handleSubmit: (...args: any[]) => any;
   title: React.ReactNode;
 };
@@ -71,7 +72,7 @@ export class GenericInputModal extends Component<Props, State> {
 
   render() {
     const { isSubmitting } = this.state;
-    const { okText, cancelText, isOpen, footer, children } = this.props;
+    const { okText, cancelText, isOpen, footer, okButtonProps, children } = this.props;
 
     // add props (ref) to passed component
     const displayForm = React.Children.map(children, (child) => {
@@ -93,6 +94,7 @@ export class GenericInputModal extends Component<Props, State> {
         visible={isOpen}
         onOk={this.onSubmit}
         okText={okText}
+        okButtonProps={okButtonProps}
         cancelText={cancelText}
         confirmLoading={isSubmitting}
         onCancel={this.handleCancel}


### PR DESCRIPTION
### Related Issues/PRs

Closes #22609

### What changes are proposed in this pull request?

- Add `okButtonProps` passthrough support in `GenericInputModal`.
- Keep the Create button disabled in `CreateExperimentModal` until `experimentName` has non-whitespace content.
- Wire form value change callbacks through `CreateExperimentForm` so button state updates in real time.
- Extend modal tests to verify initial disabled state and enabled state after entering a valid name.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Commands run:
- `cd mlflow/server/js && npx yarn test CreateExperimentModal.enzyme.test.tsx GenericInputModal.enzyme.test.tsx CreateExperimentForm.test.tsx`

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I have updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The Create Experiment action is now disabled until a valid experiment name is entered, preventing accidental empty submissions.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release