### PR TITLE
Fix Bedrock tool-use chat response parsing

### DIFF
--- a/mlflow/gateway/providers/bedrock.py
+++ b/mlflow/gateway/providers/bedrock.py
@@ -412,7 +412,7 @@ class AmazonBedrockProvider(BaseProvider):
                     chat.ToolCall(
                         id=tool_use.get("toolUseId", ""),
                         type="function",
-                        function=chat.ToolCallFunction(
+                        function=chat.Function(
                             name=tool_use.get("name", ""),
                             arguments=json.dumps(tool_use.get("input", {})),
                         ),

--- a/tests/gateway/providers/test_bedrock.py
+++ b/tests/gateway/providers/test_bedrock.py
@@ -464,6 +464,31 @@ def _converse_response():
     }
 
 
+def _converse_response_with_tool_use():
+    return {
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "toolUse": {
+                            "toolUseId": "tool_abc123",
+                            "name": "add",
+                            "input": {"a": 17, "b": 25},
+                        }
+                    }
+                ],
+            }
+        },
+        "stopReason": "tool_use",
+        "usage": {
+            "inputTokens": 30,
+            "outputTokens": 10,
+            "totalTokens": 40,
+        },
+    }
+
+
 def _converse_stream_response():
     return {
         "stream": iter([
@@ -568,3 +593,19 @@ async def test_bedrock_converse_with_system_message():
     call_kwargs = mock_client.converse.call_args.kwargs
     assert call_kwargs["system"] == [{"text": "You are helpful"}]
     assert len(call_kwargs["messages"]) == 1  # only user message
+
+
+@pytest.mark.asyncio
+async def test_bedrock_converse_chat_with_tool_call():
+
+    provider = _make_converse_provider()
+    mock_client = mock.Mock()
+    mock_client.converse.return_value = _converse_response_with_tool_use()
+
+    with mock.patch.object(provider, "get_bedrock_client", return_value=mock_client):
+        payload = chat.RequestPayload(messages=[{"role": "user", "content": "add 17 and 25"}])
+        response = await provider.chat(payload)
+
+    result = jsonable_encoder(response)
+    tool_calls = result["choices"][0]["message"]["tool_calls"]
+    assert tool_calls[0]["function"]["name"] == "add"


### PR DESCRIPTION
### Related Issues/PRs

Closes #22636

### What changes are proposed in this pull request?

This PR fixes the Bedrock Gateway provider's non-streaming Converse response handling for `toolUse` outputs. The current code tries to instantiate `chat.ToolCallFunction`, which does not exist, and raises an `AttributeError` instead of returning the tool call to the client.

The fix switches that path to the existing `chat.Function` type and adds a regression test that covers non-streaming Bedrock tool-use responses.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

- `env UV_CACHE_DIR=/Users/garion/Work/.uv-cache /Users/garion/Library/Python/3.14/bin/uv run --extra gateway --with sentence-transformers pytest tests/gateway/providers/test_bedrock.py -q`
- `env UV_CACHE_DIR=/Users/garion/Work/.uv-cache /Users/garion/Library/Python/3.14/bin/uv run ruff check mlflow/gateway/providers/bedrock.py tests/gateway/providers/test_bedrock.py`

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Bedrock Gateway clients can now receive non-streaming `toolUse` responses correctly instead of hitting an `AttributeError` when the provider returns a tool call.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release