### PR TITLE
Fix artifact downloads against older MLflow servers

### DIFF
--- a/mlflow/store/artifact/runs_artifact_repo.py
+++ b/mlflow/store/artifact/runs_artifact_repo.py
@@ -1,13 +1,16 @@
 import logging
 import os
 import urllib.parse
-from typing import Iterator
 
 import mlflow
 from mlflow.entities.file_info import FileInfo
-from mlflow.entities.logged_model import LoggedModel
 from mlflow.exceptions import MlflowException
-from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
+from mlflow.protos.databricks_pb2 import (
+    ENDPOINT_NOT_FOUND,
+    NOT_IMPLEMENTED,
+    RESOURCE_DOES_NOT_EXIST,
+    ErrorCode,
+)
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
 from mlflow.utils.file_utils import create_tmp_dir
 from mlflow.utils.uri import (
@@ -145,24 +148,38 @@ class RunsArtifactRepository(ArtifactRepository):
         client = mlflow.tracking.MlflowClient(self.tracking_uri)
         experiment_id = client.get_run(run_id).info.experiment_id
 
-        def iter_models() -> Iterator[LoggedModel]:
-            page_token: str | None = None
-            while True:
+        page_token: str | None = None
+        while True:
+            try:
                 page = client.search_logged_models(
                     experiment_ids=[experiment_id],
                     # TODO: Filter by 'source_run_id' once Databricks backend supports it
                     filter_string=f"name = '{name}'",
                     page_token=page_token,
                 )
-                yield from page
-                if not page.token:
-                    break
-                page_token = page.token
+            except MlflowException as e:
+                # Older tracking servers (e.g. MLflow 2.x) don't have the logged models APIs.
+                # In such cases, treat the run as having no associated logged model artifacts.
+                if e.error_code in {
+                    ErrorCode.Name(ENDPOINT_NOT_FOUND),
+                    ErrorCode.Name(NOT_IMPLEMENTED),
+                }:
+                    _logger.debug(
+                        "Logged models APIs are unavailable on the tracking server; skipping "
+                        "logged model artifact lookup.",
+                        exc_info=True,
+                    )
+                    return None
+                raise
 
-        if matched := next((m for m in iter_models() if m.source_run_id == run_id), None):
-            return get_artifact_repository(
-                matched.artifact_location, tracking_uri=self.tracking_uri
-            )
+            if matched := next((m for m in page if m.source_run_id == run_id), None):
+                return get_artifact_repository(
+                    matched.artifact_location, tracking_uri=self.tracking_uri
+                )
+
+            if not page.token:
+                break
+            page_token = page.token
 
         return None
 

--- a/tests/store/artifact/test_runs_artifact_repo.py
+++ b/tests/store/artifact/test_runs_artifact_repo.py
@@ -4,7 +4,8 @@ from unittest.mock import Mock
 import pytest
 
 import mlflow
-from mlflow.exceptions import MlflowException
+from mlflow.exceptions import MlflowException, RestException
+from mlflow.store.artifact.artifact_repo import ArtifactRepository
 from mlflow.store.artifact.runs_artifact_repo import RunsArtifactRepository
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 
@@ -124,3 +125,35 @@ def test_runs_artifact_repo_tracking_uri_passed_as_keyword():
         )
         assert isinstance(runs_repo.repo, S3ArtifactRepository)
         mock_get_artifact_uri.assert_called_once()
+
+
+def test_get_logged_model_artifact_repo_returns_none_when_logged_models_api_missing():
+    runs_repo = RunsArtifactRepository.__new__(RunsArtifactRepository)
+    ArtifactRepository.__init__(runs_repo, artifact_uri="runs:/some-run-id/foo", tracking_uri="http://x")
+
+    mock_client = Mock()
+    mock_client.get_run.return_value = Mock(info=Mock(experiment_id="0"))
+    mock_client.search_logged_models.side_effect = RestException(
+        {"error_code": "ENDPOINT_NOT_FOUND", "message": "endpoint does not exist"}
+    )
+
+    with mock.patch("mlflow.tracking.MlflowClient", return_value=mock_client), mock.patch(
+        "mlflow.store.artifact.artifact_repository_registry.get_artifact_repository"
+    ) as get_artifact_repo_mock:
+        assert runs_repo._get_logged_model_artifact_repo(run_id="some-run-id", name="foo") is None
+        get_artifact_repo_mock.assert_not_called()
+
+
+def test_list_model_artifacts_returns_empty_when_logged_models_api_missing():
+    runs_repo = RunsArtifactRepository.__new__(RunsArtifactRepository)
+    ArtifactRepository.__init__(runs_repo, artifact_uri="runs:/some-run-id/foo", tracking_uri="http://x")
+    runs_repo.repo = Mock()
+
+    mock_client = Mock()
+    mock_client.get_run.return_value = Mock(info=Mock(experiment_id="0"))
+    mock_client.search_logged_models.side_effect = RestException(
+        {"error_code": "ENDPOINT_NOT_FOUND", "message": "endpoint does not exist"}
+    )
+
+    with mock.patch("mlflow.tracking.MlflowClient", return_value=mock_client):
+        assert runs_repo._list_model_artifacts(path=None) == []


### PR DESCRIPTION
### Related Issues/PRs

Closes #16215

### What changes are proposed in this pull request?

This PR makes artifact downloads compatible with older MLflow tracking servers that do not implement the logged model search API introduced in newer clients. When `RunsArtifactRepository` attempts a logged-model lookup and the server responds with `ENDPOINT_NOT_FOUND` or `NOT_IMPLEMENTED`, the client now falls back to the legacy artifact path behavior instead of failing the download.

The PR also adds regression coverage for both listing and downloading artifacts when talking to an older server.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

- `env UV_CACHE_DIR=/Users/garion/Work/.uv-cache /Users/garion/Library/Python/3.14/bin/uv run pytest tests/store/artifact/test_runs_artifact_repo.py -q`
- `env UV_CACHE_DIR=/Users/garion/Work/.uv-cache /Users/garion/Library/Python/3.14/bin/uv run ruff check mlflow/store/artifact/runs_artifact_repo.py tests/store/artifact/test_runs_artifact_repo.py`

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

MLflow clients can now continue downloading run artifacts from older tracking servers that do not support the logged model search API, instead of failing with a 404 or not-implemented error.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release