### PR TITLE
Fix missing authorization for online scoring config endpoints

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -213,6 +213,8 @@ from mlflow.server.auth.routes import (
     GET_METRIC_HISTORY_BULK,
     GET_METRIC_HISTORY_BULK_INTERVAL,
     GET_MODEL_VERSION_ARTIFACT,
+    GET_ONLINE_SCORING_CONFIGS_AJAX,
+    GET_ONLINE_SCORING_CONFIGS_REST,
     GET_REGISTERED_MODEL_PERMISSION,
     GET_SCORER_PERMISSION,
     GET_TRACE_ARTIFACT,
@@ -233,6 +235,8 @@ from mlflow.server.auth.routes import (
     UPDATE_USER_ADMIN,
     UPDATE_USER_PASSWORD,
     UPLOAD_ARTIFACT,
+    UPSERT_ONLINE_SCORING_CONFIG_AJAX,
+    UPSERT_ONLINE_SCORING_CONFIG_REST,
 )
 from mlflow.server.auth.sqlalchemy_store import SqlAlchemyStore
 from mlflow.server.fastapi_app import create_fastapi_app
@@ -1016,6 +1020,15 @@ def validate_can_manage_scorer_permission():
     return _get_permission_from_scorer_permission_request().can_manage
 
 
+def validate_can_read_online_scoring_configs():
+    authenticate_request()
+    return True
+
+
+def validate_can_update_online_scoring_config():
+    return _get_permission_from_scorer_name().can_update
+
+
 def sender_is_admin():
     """Validate if the sender is admin"""
     username = authenticate_request().username
@@ -1567,7 +1580,6 @@ BEFORE_REQUEST_VALIDATORS = {
     (http_path, method): handler
     for http_path, handler, methods in get_endpoints(get_before_request_handler)
     for method in methods
-    if "/scorers/online-config" not in http_path
 }
 
 # Auth-related routes
@@ -1638,6 +1650,11 @@ BEFORE_REQUEST_VALIDATORS.update({
     (LIST_WORKSPACE_PERMISSIONS, "POST"): validate_can_modify_workspace_permission,
     (LIST_WORKSPACE_PERMISSIONS, "DELETE"): validate_can_modify_workspace_permission,
     (LIST_USER_WORKSPACE_PERMISSIONS, "GET"): sender_is_admin,
+    # Online scoring config endpoints
+    (GET_ONLINE_SCORING_CONFIGS_AJAX, "GET"): validate_can_read_online_scoring_configs,
+    (GET_ONLINE_SCORING_CONFIGS_REST, "GET"): validate_can_read_online_scoring_configs,
+    (UPSERT_ONLINE_SCORING_CONFIG_AJAX, "PUT"): validate_can_update_online_scoring_config,
+    (UPSERT_ONLINE_SCORING_CONFIG_REST, "PUT"): validate_can_update_online_scoring_config,
 })
 
 # Precompile workspace parameterized paths (e.g., workspace_name) for fast matching.
@@ -2294,7 +2311,6 @@ AFTER_REQUEST_HANDLERS = {
     for method in methods
     if handler is not None
     and "/graphql" not in http_path
-    and "/scorers/online-config" not in http_path
     and "/mlflow/server-info" not in http_path
     and http_path not in _AJAX_GATEWAY_PATHS
 }

--- a/mlflow/server/auth/routes.py
+++ b/mlflow/server/auth/routes.py
@@ -82,3 +82,8 @@ GATEWAY_SUPPORTED_MODELS = _get_ajax_path("/mlflow/gateway/supported-models", ve
 GATEWAY_PROVIDER_CONFIG = _get_ajax_path("/mlflow/gateway/provider-config", version=3)
 GATEWAY_SECRETS_CONFIG = _get_ajax_path("/mlflow/gateway/secrets/config", version=3)
 INVOKE_SCORER = _get_ajax_path("/mlflow/scorer/invoke", version=3)
+
+GET_ONLINE_SCORING_CONFIGS_AJAX = _get_ajax_path("/mlflow/scorers/online-configs", version=3)
+GET_ONLINE_SCORING_CONFIGS_REST = _get_rest_path("/mlflow/scorers/online-configs", version=3)
+UPSERT_ONLINE_SCORING_CONFIG_AJAX = _get_ajax_path("/mlflow/scorers/online-config", version=3)
+UPSERT_ONLINE_SCORING_CONFIG_REST = _get_rest_path("/mlflow/scorers/online-config", version=3)


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Relates to authorization bypass in online scoring config endpoints.

### What changes are proposed in this pull request?

The `/mlflow/scorers/online-config` and `/mlflow/scorers/online-configs` endpoints were explicitly excluded from auth validation in `BEFORE_REQUEST_VALIDATORS` and `AFTER_REQUEST_HANDLERS` in `mlflow/server/auth/__init__.py`, allowing any authenticated user to read and modify online scoring configurations without proper permission checks.

This PR:
- Removes the exclusion filters for `"/scorers/online-config"` in `BEFORE_REQUEST_VALIDATORS` and `AFTER_REQUEST_HANDLERS`
- Adds route constants in `routes.py` for all 4 endpoint variants (AJAX + REST × GET configs + PUT config)
- Adds `validate_can_read_online_scoring_configs()` — enforces authentication for GET
- Adds `validate_can_update_online_scoring_config()` — reuses `_get_permission_from_scorer_name()` to verify `can_update` permission (matches `experiment_id` + `name` params in PUT request body)
- Registers validators in `BEFORE_REQUEST_VALIDATORS` for all 4 endpoint variants

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Existing scorer auth tests cover the auth framework. Manual verification: unauthenticated request → 401; authenticated user without permission → 403; authenticated user with permission → 200.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed an authorization bypass where online scoring config endpoints (`/mlflow/scorers/online-config` and `/mlflow/scorers/online-configs`) were accessible to any authenticated user without proper permission checks. These endpoints now correctly require authentication for GET and update permission for PUT.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g., https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release