### PR TITLE
Preserve cache_read tokens in claude_code tracing for cache observability

### DIFF
--- a/mlflow/claude_code/tracing.py
+++ b/mlflow/claude_code/tracing.py
@@ -383,6 +383,31 @@ def _get_input_messages(transcript: list[dict[str, Any]], current_idx: int) -> l
     return messages
 
 
+def _build_usage_dict(usage: dict[str, Any]) -> dict[str, int]:
+    """Normalize a Claude Code usage payload into the CHAT_USAGE schema.
+
+    Stores fields as the Anthropic API reports them, matching
+    ``mlflow.anthropic.autolog``: ``input_tokens`` is the non-cached input,
+    cache tokens are exposed as separate optional keys so consumers can
+    compute cache hit rate, and ``total_tokens`` follows the
+    ``mlflow.anthropic`` convention of ``input_tokens + output_tokens``
+    (cache tokens excluded).
+    """
+    input_tokens = usage.get("input_tokens", 0)
+    output_tokens = usage.get("output_tokens", 0)
+
+    usage_dict: dict[str, int] = {
+        TokenUsageKey.INPUT_TOKENS: input_tokens,
+        TokenUsageKey.OUTPUT_TOKENS: output_tokens,
+        TokenUsageKey.TOTAL_TOKENS: input_tokens + output_tokens,
+    }
+    if (cached := usage.get("cache_read_input_tokens")) is not None:
+        usage_dict[TokenUsageKey.CACHE_READ_INPUT_TOKENS] = cached
+    if (created := usage.get("cache_creation_input_tokens")) is not None:
+        usage_dict[TokenUsageKey.CACHE_CREATION_INPUT_TOKENS] = created
+    return usage_dict
+
+
 def _set_token_usage_attribute(span, usage: dict[str, Any]) -> None:
     """Set token usage on a span using the standardized CHAT_USAGE attribute.
 
@@ -393,18 +418,7 @@ def _set_token_usage_attribute(span, usage: dict[str, Any]) -> None:
     if not usage:
         return
 
-    # Include cache_creation_input_tokens (similar cost to input tokens) but not
-    # cache_read_input_tokens (much cheaper, would inflate cost estimates)
-    input_tokens = usage.get("input_tokens", 0) + usage.get("cache_creation_input_tokens", 0)
-    output_tokens = usage.get("output_tokens", 0)
-
-    usage_dict = {
-        TokenUsageKey.INPUT_TOKENS: input_tokens,
-        TokenUsageKey.OUTPUT_TOKENS: output_tokens,
-        TokenUsageKey.TOTAL_TOKENS: input_tokens + output_tokens,
-    }
-
-    span.set_attribute(SpanAttributeKey.CHAT_USAGE, usage_dict)
+    span.set_attribute(SpanAttributeKey.CHAT_USAGE, _build_usage_dict(usage))
 
 
 def _create_llm_and_tool_spans(
@@ -517,15 +531,7 @@ def _finalize_trace(
             # Set token usage directly on trace metadata so it survives
             # even if span-level aggregation doesn't pick it up
             if usage:
-                input_tokens = usage.get("input_tokens", 0) + usage.get(
-                    "cache_creation_input_tokens", 0
-                )
-                output_tokens = usage.get("output_tokens", 0)
-                metadata[TraceMetadataKey.TOKEN_USAGE] = json.dumps({
-                    TokenUsageKey.INPUT_TOKENS: input_tokens,
-                    TokenUsageKey.OUTPUT_TOKENS: output_tokens,
-                    TokenUsageKey.TOTAL_TOKENS: input_tokens + output_tokens,
-                })
+                metadata[TraceMetadataKey.TOKEN_USAGE] = json.dumps(_build_usage_dict(usage))
 
             in_memory_trace.info.trace_metadata = {
                 **in_memory_trace.info.trace_metadata,

--- a/tests/claude_code/test_tracing.py
+++ b/tests/claude_code/test_tracing.py
@@ -345,6 +345,56 @@ def test_process_transcript_tracks_token_usage(mock_transcript_file_with_usage):
     assert trace.info.token_usage["total_tokens"] == 175
 
 
+def test_process_transcript_preserves_cache_tokens(tmp_path):
+    """Verify cache_read/cache_creation fields from Anthropic usage survive on the
+    CHAT_USAGE span attribute so prompt-cache hit rate is observable.
+    """
+    transcript_entries = [
+        {
+            "type": "user",
+            "message": {"role": "user", "content": "Cached prompt"},
+            "timestamp": "2025-01-15T10:00:00.000Z",
+            "sessionId": "cache-transcript-session",
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Answer using cache."}],
+                "model": "claude-sonnet-4-20250514",
+                "usage": {
+                    "input_tokens": 36,
+                    "cache_creation_input_tokens": 23554,
+                    "cache_read_input_tokens": 139035,
+                    "output_tokens": 3344,
+                },
+            },
+            "timestamp": "2025-01-15T10:00:01.000Z",
+        },
+    ]
+
+    transcript_path = tmp_path / "transcript_cache.jsonl"
+    with open(transcript_path, "w") as f:
+        for entry in transcript_entries:
+            f.write(json.dumps(entry) + "\n")
+
+    trace = process_transcript(str(transcript_path), "cache-transcript-session")
+
+    assert trace is not None
+    llm_spans = [s for s in trace.search_spans() if s.span_type == SpanType.LLM]
+    assert len(llm_spans) == 1
+
+    # input_tokens is the non-cached input the Anthropic API reports, matching
+    # mlflow.anthropic.autolog. Cache fields are exposed as separate keys so
+    # consumers can compute cache hit rate.
+    token_usage = llm_spans[0].get_attribute(SpanAttributeKey.CHAT_USAGE)
+    assert token_usage["input_tokens"] == 36
+    assert token_usage["output_tokens"] == 3344
+    assert token_usage["total_tokens"] == 36 + 3344
+    assert token_usage["cache_read_input_tokens"] == 139035
+    assert token_usage["cache_creation_input_tokens"] == 23554
+
+
 # ============================================================================
 # SDK MESSAGE PROCESSING TESTS
 # ============================================================================
@@ -497,14 +547,18 @@ def test_process_sdk_messages_cache_tokens():
     assert trace is not None
     root_span = trace.data.spans[0]
 
-    # input_tokens should include cache_creation but not cache_read: 36 + 23554 = 23590
+    # input_tokens is the non-cached input the Anthropic API reports, matching
+    # mlflow.anthropic.autolog. Cache fields are exposed as separate keys so
+    # consumers can compute cache hit rate without scraping transcripts.
     token_usage = root_span.get_attribute(SpanAttributeKey.CHAT_USAGE)
-    assert token_usage["input_tokens"] == 23590
+    assert token_usage["input_tokens"] == 36
     assert token_usage["output_tokens"] == 3344
-    assert token_usage["total_tokens"] == 23590 + 3344
+    assert token_usage["total_tokens"] == 36 + 3344
+    assert token_usage["cache_read_input_tokens"] == 139035
+    assert token_usage["cache_creation_input_tokens"] == 23554
 
     # Trace-level aggregation should match
-    assert trace.info.token_usage["input_tokens"] == 23590
+    assert trace.info.token_usage["input_tokens"] == 36
     assert trace.info.token_usage["output_tokens"] == 3344
 
 


### PR DESCRIPTION
### Related Issues/PRs

Closes #22679

### What changes are proposed in this pull request?

`mlflow.claude_code.tracing.process_transcript` reads `message.usage` from the Claude Code transcript — which contains all four Anthropic usage fields (`input_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`, `output_tokens`) — but previously folded `cache_creation_input_tokens` into `input_tokens` and dropped `cache_read_input_tokens` entirely. As a result, prompt-cache hit rate is unobservable from emitted traces, which is one of the most material cost/latency levers on the Anthropic API.

The `SpanAttributeKey.CHAT_USAGE` schema (see `mlflow/tracing/constant.py`) documents `cache_read_input_tokens` and `cache_creation_input_tokens` as optional top-level keys, and `mlflow.anthropic.autolog` already conforms to this shape — `mlflow.claude_code` was the outlier.

This PR aligns `mlflow.claude_code` with the `mlflow.anthropic.autolog` convention:

- Preserves `input_tokens` as the non-cached input the Anthropic API reports (no summing). `total_tokens` follows the same convention (`input_tokens + output_tokens`, cache excluded), matching `mlflow/anthropic/autolog.py::_parse_usage`.
- Exposes `cache_read_input_tokens` and `cache_creation_input_tokens` as separate optional keys on `CHAT_USAGE` and in trace-level `TOKEN_USAGE` metadata whenever the API reports them, using the same `is not None` check as `mlflow.anthropic.autolog` so explicit zeroes are preserved.
- Shares the normalisation between `_set_token_usage_attribute` and `_finalize_trace` via a new `_build_usage_dict` helper (previously the two call sites each duplicated the folding logic).
- Updates `test_process_sdk_messages_cache_tokens` to assert the corrected schema, and adds a new `test_process_transcript_preserves_cache_tokens` covering the transcript (CLI) path.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

All 28 tests in `tests/claude_code/test_tracing.py` pass locally (27 existing + 1 new). `ruff check` and `ruff format --check` clean against pinned MLflow ruff 0.15.5.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

The documented `CHAT_USAGE` schema at `SpanAttributeKey.CHAT_USAGE` already lists `cache_read_input_tokens` and `cache_creation_input_tokens` as optional keys — this PR brings the `mlflow.claude_code` implementation in line with existing documentation and the existing `mlflow.anthropic.autolog` convention.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

No user-facing API or skill guidance changes — only the internal trace-attribute shape emitted by `mlflow.claude_code`, now conforming to the documented schema and matching `mlflow.anthropic.autolog`.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Prompt-cache hit rate is now observable from `mlflow.claude_code` traces: `cache_read_input_tokens` and `cache_creation_input_tokens` are exposed on `CHAT_USAGE` as separate optional keys, matching the existing `mlflow.anthropic.autolog` convention.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release