### PR TITLE
Fix `ValueError: Circular reference detected` crash in `dump_span_attribute_value` (pydantic_ai autolog)

### DIFF
--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -130,14 +130,13 @@ def dump_span_attribute_value(value: Any) -> str:
     #   for the simplicity in deserialization process.
     try:
         return json.dumps(value, cls=TraceJSONEncoder, ensure_ascii=False)
-    except ValueError:
-        # `json.dumps` raises `ValueError: Circular reference detected` when a value
-        # contains self-referencing objects (e.g. pydantic_ai's `run_context`). Fall back
-        # to a repr-based dump so the span attribute is still set and tracing doesn't
-        # crash the user's workflow.
+    except (ValueError, TypeError, RecursionError):
+        # `json.dumps` raises `ValueError: Circular reference detected` for self-referencing
+        # objects (e.g. pydantic_ai's `run_context`), and can raise `TypeError` /
+        # `RecursionError` on other pathological inputs. Fall back to a repr-based dump so
+        # the span attribute is still set and tracing doesn't crash the user's workflow.
         _logger.debug(
-            "Failed to serialize span attribute value due to circular reference. "
-            "Falling back to repr.",
+            "Failed to serialize span attribute value. Falling back to repr.",
             exc_info=True,
         )
         return json.dumps(repr(value), ensure_ascii=False)

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -128,7 +128,19 @@ def dump_span_attribute_value(value: Any) -> str:
     # NB: OpenTelemetry attribute can store not only string but also a few primitives like
     #   int, float, bool, and list of them. However, we serialize all into JSON string here
     #   for the simplicity in deserialization process.
-    return json.dumps(value, cls=TraceJSONEncoder, ensure_ascii=False)
+    try:
+        return json.dumps(value, cls=TraceJSONEncoder, ensure_ascii=False)
+    except ValueError:
+        # `json.dumps` raises `ValueError: Circular reference detected` when a value
+        # contains self-referencing objects (e.g. pydantic_ai's `run_context`). Fall back
+        # to a repr-based dump so the span attribute is still set and tracing doesn't
+        # crash the user's workflow.
+        _logger.debug(
+            "Failed to serialize span attribute value due to circular reference. "
+            "Falling back to repr.",
+            exc_info=True,
+        )
+        return json.dumps(repr(value), ensure_ascii=False)
 
 
 def try_json_loads(value: Any) -> Any:

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -130,13 +130,13 @@ def dump_span_attribute_value(value: Any) -> str:
     #   for the simplicity in deserialization process.
     try:
         return json.dumps(value, cls=TraceJSONEncoder, ensure_ascii=False)
-    except (ValueError, TypeError, RecursionError):
+    except ValueError:
         # `json.dumps` raises `ValueError: Circular reference detected` for self-referencing
-        # objects (e.g. pydantic_ai's `run_context`), and can raise `TypeError` /
-        # `RecursionError` on other pathological inputs. Fall back to a repr-based dump so
-        # the span attribute is still set and tracing doesn't crash the user's workflow.
+        # objects (e.g. pydantic_ai's `run_context`). Fall back to a repr-based dump so the
+        # span attribute is still set and tracing doesn't crash the user's workflow.
         _logger.debug(
-            "Failed to serialize span attribute value. Falling back to repr.",
+            "Failed to serialize span attribute value due to circular reference. "
+            "Falling back to repr.",
             exc_info=True,
         )
         return json.dumps(repr(value), ensure_ascii=False)

--- a/tests/tracing/utils/test_utils.py
+++ b/tests/tracing/utils/test_utils.py
@@ -744,13 +744,11 @@ def test_litellm_provider_list_printed_when_debug_logging(capsys):
 
 
 def test_dump_span_attribute_value_handles_circular_reference():
-    """Values with circular references (e.g. pydantic_ai's `run_context` passed to
-    `LiveSpan.set_inputs`) must not crash tracing. `json.dumps` raises
-    `ValueError: Circular reference detected` for such values; the dump helper should
-    fall back to a repr-based string so the span attribute is still set.
-    """
     cyclic = {"name": "run_context"}
     cyclic["self"] = cyclic
+
+    with pytest.raises(ValueError, match="Circular reference detected"):
+        json.dumps(cyclic)
 
     # Must not raise; fall back result is a valid JSON string containing repr(value).
     result = dump_span_attribute_value(cyclic)

--- a/tests/tracing/utils/test_utils.py
+++ b/tests/tracing/utils/test_utils.py
@@ -30,6 +30,7 @@ from mlflow.tracing.utils import (
     calculate_cost_by_model_and_token_usage,
     capture_function_input_args,
     construct_full_inputs,
+    dump_span_attribute_value,
     encode_span_id,
     encode_trace_id,
     generate_trace_id_v4,
@@ -740,3 +741,19 @@ def test_litellm_provider_list_printed_when_debug_logging(capsys):
     # During the call to calculate cost, suppress was set to False
     # We are asserting that suppress is reset to the original value after
     assert litellm.suppress_debug_info is True
+
+
+def test_dump_span_attribute_value_handles_circular_reference():
+    """Values with circular references (e.g. pydantic_ai's `run_context` passed to
+    `LiveSpan.set_inputs`) must not crash tracing. `json.dumps` raises
+    `ValueError: Circular reference detected` for such values; the dump helper should
+    fall back to a repr-based string so the span attribute is still set.
+    """
+    cyclic = {"name": "run_context"}
+    cyclic["self"] = cyclic
+
+    # Must not raise; fall back result is a valid JSON string containing repr(value).
+    result = dump_span_attribute_value(cyclic)
+    loaded = json.loads(result)
+    assert isinstance(loaded, str)
+    assert "run_context" in loaded


### PR DESCRIPTION
### Related Issues/PRs

Closes #22604

### What changes are proposed in this pull request?

`dump_span_attribute_value` calls `json.dumps` unguarded, so cyclic values (e.g. pydantic_ai's `run_context`) raise `ValueError: Circular reference detected`, which propagates through `LiveSpan.set_inputs` and crashes callers such as `mlflow.pydantic_ai.autolog()` + `AGUIAdapter`.

Wrap the dump in `try/except ValueError` and fall back to `json.dumps(repr(value))` so tracing degrades gracefully.

### How is this PR tested?

- [x] New unit/integration tests

Added `test_dump_span_attribute_value_handles_circular_reference`: self-referencing dict must round-trip to a valid JSON string without raising.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fix `RUN_ERROR: Circular reference detected` when using `mlflow.pydantic_ai.autolog()` with PydanticAI's `AGUIAdapter`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release