### PR TITLE
Fix Vertex AI gateway `global` location handling for Gemini 3 models

### DIFF
--- a/mlflow/gateway/providers/vertex_ai.py
+++ b/mlflow/gateway/providers/vertex_ai.py
@@ -87,15 +87,10 @@ class VertexAIProvider(GeminiProvider):
     @property
     def base_url(self) -> str:
         project = self.vertex_config.vertex_project
-        location = self.vertex_config.vertex_location
-        if location and location != "global":
-            host = f"https://{location}-aiplatform.googleapis.com"
-            path = f"/v1/projects/{project}/locations/{location}/publishers/google/models"
-        else:
-            # When no location is specified or location is "global", use the global
-            # endpoint. Models only available on the global endpoint (e.g., Gemini 3
-            # family) require `locations/global` in the path.
-            # See: https://cloud.google.com/vertex-ai/generative-ai/docs/learn/locations
-            host = "https://aiplatform.googleapis.com"
-            path = f"/v1/projects/{project}/locations/global/publishers/google/models"
+        location = self.vertex_config.vertex_location or "global"
+        # Regional endpoints use a "{location}-" prefix; the global endpoint has no prefix.
+        # https://docs.cloud.google.com/vertex-ai/docs/general/googleapi-access-methods#regional-global-endpoints
+        prefix = "" if location == "global" else f"{location}-"
+        host = f"https://{prefix}aiplatform.googleapis.com"
+        path = f"/v1/projects/{project}/locations/{location}/publishers/google/models"
         return f"{host}{path}"

--- a/mlflow/gateway/providers/vertex_ai.py
+++ b/mlflow/gateway/providers/vertex_ai.py
@@ -84,11 +84,24 @@ class VertexAIProvider(GeminiProvider):
         credentials = self._get_credentials()
         return {"Authorization": f"Bearer {credentials.token}"}
 
+    def _requires_global_endpoint(self) -> bool:
+        """Check if the model requires the global endpoint.
+
+        Some models (e.g., Gemini 3 family) are only available via the
+        global endpoint and cannot be accessed through regional endpoints.
+        See: https://cloud.google.com/vertex-ai/generative-ai/docs/learn/locations
+        """
+        return self.config.model.name.startswith("gemini-3")
+
     @property
     def base_url(self) -> str:
-        location = self.vertex_config.vertex_location
         project = self.vertex_config.vertex_project
-        if location:
+        if self._requires_global_endpoint():
+            return (
+                "https://aiplatform.googleapis.com"
+                f"/v1/projects/{project}/locations/global/publishers/google/models"
+            )
+        if location := self.vertex_config.vertex_location:
             host = f"https://{location}-aiplatform.googleapis.com"
             path = f"/v1/projects/{project}/locations/{location}/publishers/google/models"
         else:

--- a/mlflow/gateway/providers/vertex_ai.py
+++ b/mlflow/gateway/providers/vertex_ai.py
@@ -88,16 +88,14 @@ class VertexAIProvider(GeminiProvider):
     def base_url(self) -> str:
         project = self.vertex_config.vertex_project
         location = self.vertex_config.vertex_location
-        if location == "global":
-            # Models only available on the global endpoint (e.g., Gemini 3 family)
-            # must use the un-prefixed host with `locations/global` in the path.
-            # See: https://cloud.google.com/vertex-ai/generative-ai/docs/learn/locations
-            host = "https://aiplatform.googleapis.com"
-            path = f"/v1/projects/{project}/locations/global/publishers/google/models"
-        elif location:
+        if location and location != "global":
             host = f"https://{location}-aiplatform.googleapis.com"
             path = f"/v1/projects/{project}/locations/{location}/publishers/google/models"
         else:
+            # When no location is specified or location is "global", use the global
+            # endpoint. Models only available on the global endpoint (e.g., Gemini 3
+            # family) require `locations/global` in the path.
+            # See: https://cloud.google.com/vertex-ai/generative-ai/docs/learn/locations
             host = "https://aiplatform.googleapis.com"
-            path = f"/v1/projects/{project}/publishers/google/models"
+            path = f"/v1/projects/{project}/locations/global/publishers/google/models"
         return f"{host}{path}"

--- a/mlflow/gateway/providers/vertex_ai.py
+++ b/mlflow/gateway/providers/vertex_ai.py
@@ -84,24 +84,17 @@ class VertexAIProvider(GeminiProvider):
         credentials = self._get_credentials()
         return {"Authorization": f"Bearer {credentials.token}"}
 
-    def _requires_global_endpoint(self) -> bool:
-        """Check if the model requires the global endpoint.
-
-        Some models (e.g., Gemini 3 family) are only available via the
-        global endpoint and cannot be accessed through regional endpoints.
-        See: https://cloud.google.com/vertex-ai/generative-ai/docs/learn/locations
-        """
-        return self.config.model.name.startswith("gemini-3")
-
     @property
     def base_url(self) -> str:
         project = self.vertex_config.vertex_project
-        if self._requires_global_endpoint():
-            return (
-                "https://aiplatform.googleapis.com"
-                f"/v1/projects/{project}/locations/global/publishers/google/models"
-            )
-        if location := self.vertex_config.vertex_location:
+        location = self.vertex_config.vertex_location
+        if location == "global":
+            # Models only available on the global endpoint (e.g., Gemini 3 family)
+            # must use the un-prefixed host with `locations/global` in the path.
+            # See: https://cloud.google.com/vertex-ai/generative-ai/docs/learn/locations
+            host = "https://aiplatform.googleapis.com"
+            path = f"/v1/projects/{project}/locations/global/publishers/google/models"
+        elif location:
             host = f"https://{location}-aiplatform.googleapis.com"
             path = f"/v1/projects/{project}/locations/{location}/publishers/google/models"
         else:

--- a/tests/gateway/providers/test_vertex_ai.py
+++ b/tests/gateway/providers/test_vertex_ai.py
@@ -123,25 +123,16 @@ def test_global_endpoint_when_no_location():
     )
 
 
-@pytest.mark.parametrize(
-    "model_name",
-    [
-        "gemini-3-flash-preview",
-        "gemini-3-pro-preview",
-        "gemini-3-pro-image-preview",
-        "gemini-3.1-pro-preview",
-    ],
-)
-def test_gemini3_uses_global_endpoint(model_name: str):
+def test_global_location_uses_global_endpoint():
     endpoint_config = EndpointConfig(
         name="vertex-endpoint",
         endpoint_type="llm/v1/chat",
         model={
             "provider": "vertex_ai",
-            "name": model_name,
+            "name": "gemini-3-pro-preview",
             "config": {
                 "vertex_project": "my-gcp-project",
-                "vertex_location": "us-central1",
+                "vertex_location": "global",
             },
         },
     )

--- a/tests/gateway/providers/test_vertex_ai.py
+++ b/tests/gateway/providers/test_vertex_ai.py
@@ -123,6 +123,36 @@ def test_global_endpoint_when_no_location():
     )
 
 
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "gemini-3-flash-preview",
+        "gemini-3-pro-preview",
+        "gemini-3-pro-image-preview",
+        "gemini-3.1-pro-preview",
+    ],
+)
+def test_gemini3_uses_global_endpoint(model_name: str):
+    endpoint_config = EndpointConfig(
+        name="vertex-endpoint",
+        endpoint_type="llm/v1/chat",
+        model={
+            "provider": "vertex_ai",
+            "name": model_name,
+            "config": {
+                "vertex_project": "my-gcp-project",
+                "vertex_location": "us-central1",
+            },
+        },
+    )
+    provider = VertexAIProvider(endpoint_config)
+    provider._cached_credentials = _mock_credentials()
+    assert provider.base_url == (
+        "https://aiplatform.googleapis.com"
+        "/v1/projects/my-gcp-project/locations/global/publishers/google/models"
+    )
+
+
 def test_with_credentials():
     creds_json = json.dumps({"type": "service_account", "project_id": "test"})
     config = VertexAIConfig(vertex_project="my-project", vertex_credentials=creds_json)

--- a/tests/gateway/providers/test_vertex_ai.py
+++ b/tests/gateway/providers/test_vertex_ai.py
@@ -119,7 +119,8 @@ def test_global_endpoint_when_no_location():
     provider = VertexAIProvider(endpoint_config)
     provider._cached_credentials = _mock_credentials()
     assert provider.base_url == (
-        "https://aiplatform.googleapis.com/v1/projects/my-project/publishers/google/models"
+        "https://aiplatform.googleapis.com"
+        "/v1/projects/my-project/locations/global/publishers/google/models"
     )
 
 


### PR DESCRIPTION
### Related Issues/PRs

Closes #22645

### What changes are proposed in this pull request?

Gemini 3 models on Vertex AI are [only available via the global endpoint](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/locations). Users can opt in with `vertex_location: "global"`, but the resulting URL was wrong (`https://global-aiplatform.googleapis.com/...`, which doesn't exist). Fix `VertexAIProvider.base_url` to emit `https://aiplatform.googleapis.com/v1/projects/{project}/locations/global/...` when `vertex_location == "global"`.

```yaml
endpoints:
  - name: gemini-3
    endpoint_type: llm/v1/chat
    model:
      provider: vertex_ai
      name: gemini-3-pro-preview
      config:
        vertex_project: my-gcp-project
        vertex_location: global
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed the Vertex AI gateway provider to produce the correct URL when `vertex_location` is set to `"global"`, enabling Gemini 3 family models that are only available on the global endpoint.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)