### PR TITLE
Fix AI Gateway provider dropdown by flattening OpenAI / Azure OpenAI

### DIFF
--- a/mlflow/server/js/src/common/components/navigable-combobox/NavigableCombobox.tsx
+++ b/mlflow/server/js/src/common/components/navigable-combobox/NavigableCombobox.tsx
@@ -448,19 +448,7 @@ export function NavigableCombobox<T = string>({
           index={index}
           comboboxState={comboboxState}
           data-testid={`${componentId}.option.${menuItem.key}`}
-          onMouseDown={(e) => {
-            // Prevent input blur but don't switch views yet, wait for onClick
-            // so the DOM element still exists during the full click cycle.
-            e.preventDefault();
-            e.stopPropagation();
-          }}
-          onClick={(e) => {
-            // Prevent downshift from processing this click as an item selection.
-            // downshift's callAllEventHandlers checks this flag on both the synthetic
-            // and native event to skip subsequent handlers (e.g. itemHandleClick).
-            (e as any).preventDownshiftDefault = true;
-            handleGroupClick(menuItem, e);
-          }}
+          onMouseDown={(e) => handleGroupClick(menuItem, e)}
         >
           {renderItem ? renderItem(menuItem, defaultContent) : defaultContent}
         </TypeaheadComboboxMenuItem>

--- a/mlflow/server/js/src/common/components/navigable-combobox/NavigableCombobox.tsx
+++ b/mlflow/server/js/src/common/components/navigable-combobox/NavigableCombobox.tsx
@@ -449,7 +449,7 @@ export function NavigableCombobox<T = string>({
           comboboxState={comboboxState}
           data-testid={`${componentId}.option.${menuItem.key}`}
           onMouseDown={(e) => {
-            // Prevent input blur but don't switch views yet — wait for onClick
+            // Prevent input blur but don't switch views yet, wait for onClick
             // so the DOM element still exists during the full click cycle.
             e.preventDefault();
             e.stopPropagation();

--- a/mlflow/server/js/src/common/components/navigable-combobox/NavigableCombobox.tsx
+++ b/mlflow/server/js/src/common/components/navigable-combobox/NavigableCombobox.tsx
@@ -456,7 +456,9 @@ export function NavigableCombobox<T = string>({
           }}
           onClick={(e) => {
             // Prevent downshift from processing this click as an item selection.
-            (e.nativeEvent as any).preventDownshiftDefault = true;
+            // downshift's callAllEventHandlers checks this flag on both the synthetic
+            // and native event to skip subsequent handlers (e.g. itemHandleClick).
+            (e as any).preventDownshiftDefault = true;
             handleGroupClick(menuItem, e);
           }}
         >

--- a/mlflow/server/js/src/common/components/navigable-combobox/NavigableCombobox.tsx
+++ b/mlflow/server/js/src/common/components/navigable-combobox/NavigableCombobox.tsx
@@ -448,7 +448,17 @@ export function NavigableCombobox<T = string>({
           index={index}
           comboboxState={comboboxState}
           data-testid={`${componentId}.option.${menuItem.key}`}
-          onMouseDown={(e) => handleGroupClick(menuItem, e)}
+          onMouseDown={(e) => {
+            // Prevent input blur but don't switch views yet — wait for onClick
+            // so the DOM element still exists during the full click cycle.
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+          onClick={(e) => {
+            // Prevent downshift from processing this click as an item selection.
+            (e.nativeEvent as any).preventDownshiftDefault = true;
+            handleGroupClick(menuItem, e);
+          }}
         >
           {renderItem ? renderItem(menuItem, defaultContent) : defaultContent}
         </TypeaheadComboboxMenuItem>

--- a/mlflow/server/js/src/gateway/components/create-endpoint/ProviderSelect.tsx
+++ b/mlflow/server/js/src/gateway/components/create-endpoint/ProviderSelect.tsx
@@ -5,7 +5,6 @@ import { NavigableCombobox } from '../../../common/components/navigable-combobox
 import type {
   NavigableComboboxConfig,
   ComboboxModalTriggerItem,
-  ComboboxGroupItem,
   ComboboxSelectableItem,
 } from '../../../common/components/navigable-combobox/types';
 import type { SelectorItem } from '../../../common/components/selector-modal/types';
@@ -45,44 +44,22 @@ export const ProviderSelect = ({
       };
     }
 
-    const { groups, ungroupedProviders } = buildProviderGroups(providers);
+    const { ungroupedProviders } = buildProviderGroups(providers);
     const commonSet = new Set<string>(COMMON_PROVIDERS);
 
-    const commonUngrouped: string[] = [];
+    const commonProviders: string[] = [];
     const otherUngrouped: string[] = [];
     for (const provider of ungroupedProviders) {
       if (commonSet.has(provider)) {
-        commonUngrouped.push(provider);
+        commonProviders.push(provider);
       } else {
         otherUngrouped.push(provider);
       }
     }
 
-    const items: (ComboboxSelectableItem<string> | ComboboxGroupItem<string> | ComboboxModalTriggerItem<string>)[] = [];
+    const items: (ComboboxSelectableItem<string> | ComboboxModalTriggerItem<string>)[] = [];
 
-    for (const group of groups) {
-      const isCommonGroup = group.groupId === 'openai_azure' || group.groupId === 'vertex_ai';
-      if (isCommonGroup) {
-        const groupItem: ComboboxGroupItem<string> = {
-          type: 'group',
-          key: `group-${group.groupId}`,
-          label: group.displayName,
-          backLabel: intl.formatMessage({
-            defaultMessage: 'Back to providers',
-            description: 'Navigation back to main provider list',
-          }),
-          children: group.providers.map((provider) => ({
-            type: 'item' as const,
-            key: provider,
-            label: formatProviderName(provider),
-            value: provider,
-          })),
-        };
-        items.push(groupItem);
-      }
-    }
-
-    for (const provider of commonUngrouped) {
+    for (const provider of commonProviders) {
       items.push({
         type: 'item',
         key: provider,
@@ -92,11 +69,10 @@ export const ProviderSelect = ({
     }
 
     const getCommonProviderIndex = (
-      item: ComboboxSelectableItem<string> | ComboboxGroupItem<string> | ComboboxModalTriggerItem<string>,
+      item: ComboboxSelectableItem<string> | ComboboxModalTriggerItem<string>,
     ): number => {
       if (item.type === 'modal-trigger') return Infinity;
-      const providerKey = item.type === 'group' ? item.children[0]?.value : item.value;
-      const index = COMMON_PROVIDERS.indexOf(providerKey as (typeof COMMON_PROVIDERS)[number]);
+      const index = COMMON_PROVIDERS.indexOf(item.value as (typeof COMMON_PROVIDERS)[number]);
       return index === -1 ? Infinity : index;
     };
     items.sort((a, b) => getCommonProviderIndex(a) - getCommonProviderIndex(b));

--- a/mlflow/server/js/src/gateway/components/create-endpoint/ProviderSelect.tsx
+++ b/mlflow/server/js/src/gateway/components/create-endpoint/ProviderSelect.tsx
@@ -9,7 +9,7 @@ import type {
 } from '../../../common/components/navigable-combobox/types';
 import type { SelectorItem } from '../../../common/components/selector-modal/types';
 import { useProvidersQuery } from '../../hooks/useProvidersQuery';
-import { formatProviderName, buildProviderGroups, COMMON_PROVIDERS } from '../../utils/providerUtils';
+import { formatProviderName, COMMON_PROVIDERS } from '../../utils/providerUtils';
 
 interface ProviderSelectProps {
   value: string;
@@ -44,12 +44,11 @@ export const ProviderSelect = ({
       };
     }
 
-    const { ungroupedProviders } = buildProviderGroups(providers);
     const commonSet = new Set<string>(COMMON_PROVIDERS);
 
     const commonProviders: string[] = [];
     const otherUngrouped: string[] = [];
-    for (const provider of ungroupedProviders) {
+    for (const provider of providers) {
       if (commonSet.has(provider)) {
         commonProviders.push(provider);
       } else {

--- a/mlflow/server/js/src/gateway/utils/providerUtils.ts
+++ b/mlflow/server/js/src/gateway/utils/providerUtils.ts
@@ -1,5 +1,6 @@
 export const COMMON_PROVIDERS = [
   'openai',
+  'azure',
   'anthropic',
   'databricks',
   'bedrock',
@@ -29,10 +30,7 @@ export const PROVIDER_GROUPS = {
   },
 };
 
-export function getProviderGroupId(provider: string): string | null {
-  if (provider === 'openai' || provider === 'azure') {
-    return 'openai_azure';
-  }
+export function getProviderGroupId(_provider: string): string | null {
   return null;
 }
 

--- a/mlflow/server/js/src/gateway/utils/providerUtils.ts
+++ b/mlflow/server/js/src/gateway/utils/providerUtils.ts
@@ -15,65 +15,6 @@ export const COMMON_PROVIDERS = [
   'together_ai',
 ] as const;
 
-export interface ProviderGroup {
-  groupId: string;
-  displayName: string;
-  defaultProvider: string;
-  providers: string[];
-}
-
-export const PROVIDER_GROUPS = {
-  openai_azure: {
-    groupId: 'openai_azure',
-    displayName: 'OpenAI / Azure OpenAI',
-    defaultProvider: 'openai',
-  },
-};
-
-export function getProviderGroupId(_provider: string): string | null {
-  return null;
-}
-
-export function buildProviderGroups(providers: string[]): {
-  groups: ProviderGroup[];
-  ungroupedProviders: string[];
-} {
-  const groupedProviders = new Map<keyof typeof PROVIDER_GROUPS, string[]>();
-  const ungroupedProviders: string[] = [];
-
-  for (const provider of providers) {
-    const groupId = getProviderGroupId(provider);
-    if (groupId) {
-      const existing = groupedProviders.get(groupId as keyof typeof PROVIDER_GROUPS) ?? [];
-      existing.push(provider);
-      groupedProviders.set(groupId as keyof typeof PROVIDER_GROUPS, existing);
-    } else {
-      ungroupedProviders.push(provider);
-    }
-  }
-
-  const groups: ProviderGroup[] = [];
-
-  const openaiAzureProviders = groupedProviders.get('openai_azure');
-  if (openaiAzureProviders && openaiAzureProviders.length > 0) {
-    const preferredOrder = ['openai', 'azure'];
-    openaiAzureProviders.sort((a, b) => {
-      const aIndex = preferredOrder.indexOf(a);
-      const bIndex = preferredOrder.indexOf(b);
-      if (aIndex !== -1 && bIndex !== -1) return aIndex - bIndex;
-      if (aIndex !== -1) return -1;
-      if (bIndex !== -1) return 1;
-      return a.localeCompare(b);
-    });
-    groups.push({
-      ...PROVIDER_GROUPS['openai_azure'],
-      providers: openaiAzureProviders,
-    });
-  }
-
-  return { groups, ungroupedProviders };
-}
-
 const PROVIDER_DISPLAY_NAMES = {
   openai: 'OpenAI',
   anthropic: 'Anthropic',

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -9231,10 +9231,6 @@
     "defaultMessage": "Evaluation criteria",
     "description": "Accordion section header for evaluation criteria (judge type, guidelines/instructions, and output type)"
   },
-  "trW0O+": {
-    "defaultMessage": "Back to providers",
-    "description": "Navigation back to main provider list"
-  },
   "tsYxhE": {
     "defaultMessage": "Search judges",
     "description": "Placeholder for scorer search input"


### PR DESCRIPTION
### Related Issues/PRs

Closes #22672

### What changes are proposed in this pull request?

Flatten OpenAI and Azure OpenAI as separate selectable items in the provider dropdown instead of grouping them behind a submenu. This avoids the dropdown closing issue at narrow viewports and simplifies the UX.


## Before

https://github.com/user-attachments/assets/b9cbaf89-2246-47f0-a7bc-0d104b378ca3

## After

https://github.com/user-attachments/assets/299cc29c-39d8-40a9-bc9a-100037e56137



### How is this PR tested?

- [x] Manual tests

https://github.com/user-attachments/assets/11bc55eb-4c41-4b32-9da6-de2641fecb61

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed the AI Gateway provider dropdown closing immediately when clicking "OpenAI / Azure OpenAI" at narrow viewport widths by flattening them as separate selectable items.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)