### PR TITLE
Support `PYPI_URL` env var for PyPI proxy in dev scripts

### DIFF
--- a/dev/tests/test_update_ml_package_versions.py
+++ b/dev/tests/test_update_ml_package_versions.py
@@ -62,8 +62,8 @@ def change_working_directory(tmp_path, monkeypatch):
 
 
 def run_test(src, src_expected, mock_responses):
-    def patch_urlopen(url):
-        package_name = re.search(r"https://pypi.python.org/pypi/(.+)/json", url).group(1)
+    def patch_urlopen(url, **kwargs):
+        package_name = re.search(r"/pypi/(.+)/json", url).group(1)
         return mock_responses[package_name]
 
     versions_yaml = Path("mlflow/ml-package-versions.yml")

--- a/dev/tests/test_update_ml_package_versions.py
+++ b/dev/tests/test_update_ml_package_versions.py
@@ -63,8 +63,10 @@ def change_working_directory(tmp_path, monkeypatch):
 
 def run_test(src, src_expected, mock_responses):
     def patch_urlopen(url, **kwargs):
-        package_name = re.search(r"/pypi/(.+)/json", url).group(1)
-        return mock_responses[package_name]
+        match = re.search(r"/pypi/(.+)/json", url)
+        if not match:
+            return MockResponse({"status": "ok"})
+        return mock_responses[match.group(1)]
 
     versions_yaml = Path("mlflow/ml-package-versions.yml")
     versions_yaml.parent.mkdir()

--- a/dev/update_ml_package_versions.py
+++ b/dev/update_ml_package_versions.py
@@ -10,9 +10,11 @@ $ python dev/update_ml_package_versions.py
 
 import argparse
 import json
+import os
 import re
 import sys
 import time
+import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -33,6 +35,17 @@ def save_file(src, path):
 
 
 RELEASE_CUTOFF_DAYS = 14
+PYPI_URL = os.environ.get("PYPI_URL", "https://pypi.org")
+
+
+def check_pypi_accessibility() -> None:
+    try:
+        urllib.request.urlopen(PYPI_URL, timeout=5)
+    except (urllib.error.URLError, OSError):
+        raise SystemExit(
+            f"Error: Cannot connect to {PYPI_URL}. "
+            "If it's not accessible, set the PYPI_URL environment variable to a PyPI proxy URL."
+        )
 
 
 @dataclass
@@ -42,7 +55,7 @@ class VersionInfo:
 
 
 def get_package_version_infos(package_name: str) -> list[VersionInfo]:
-    url = f"https://pypi.python.org/pypi/{package_name}/json"
+    url = f"{PYPI_URL}/pypi/{package_name}/json"
     for _ in range(5):  # Retry up to 5 times
         try:
             with urllib.request.urlopen(url) as res:
@@ -265,6 +278,8 @@ def get_min_supported_version(versions_infos: list[VersionInfo], genai: bool = F
 
 
 def update(skip_yml=False):
+    if not skip_yml:
+        check_pypi_accessibility()
     yml_path = "mlflow/ml-package-versions.yml"
 
     if not skip_yml:

--- a/dev/update_ml_package_versions.py
+++ b/dev/update_ml_package_versions.py
@@ -35,12 +35,13 @@ def save_file(src, path):
 
 
 RELEASE_CUTOFF_DAYS = 14
-PYPI_URL = os.environ.get("PYPI_URL", "https://pypi.org")
+PYPI_URL = os.environ.get("PYPI_URL", "https://pypi.org").rstrip("/")
 
 
 def check_pypi_accessibility() -> None:
     try:
-        urllib.request.urlopen(PYPI_URL, timeout=5)
+        with urllib.request.urlopen(PYPI_URL, timeout=5):
+            pass
     except (urllib.error.URLError, OSError):
         raise SystemExit(
             f"Error: Cannot connect to {PYPI_URL}. "

--- a/dev/update_requirements.py
+++ b/dev/update_requirements.py
@@ -13,10 +13,21 @@ from packaging.version import InvalidVersion, Version
 
 PACKAGE_NAMES = ["tracing", "skinny", "core", "gateway"]
 RELEASE_CUTOFF_DAYS = 14
+PYPI_URL = os.environ.get("PYPI_URL", "https://pypi.org")
+
+
+def check_pypi_accessibility() -> None:
+    try:
+        requests.head(PYPI_URL, timeout=5)
+    except requests.exceptions.ConnectionError:
+        raise SystemExit(
+            f"Error: Cannot connect to {PYPI_URL}. "
+            "If it's not accessible, set the PYPI_URL environment variable to a PyPI proxy URL."
+        )
 
 
 def get_latest_major_version(package_name: str) -> int | None:
-    url = f"https://pypi.org/pypi/{package_name}/json"
+    url = f"{PYPI_URL}/pypi/{package_name}/json"
     response = requests.get(url)
     response.raise_for_status()
     data = response.json()
@@ -68,6 +79,7 @@ def update_max_major_version(raw: str, key: str, old_value: int, new_value: int)
 
 
 def main() -> None:
+    check_pypi_accessibility()
     for package_name in PACKAGE_NAMES:
         req_file_path = os.path.join("requirements", package_name + "-requirements.yaml")
         with open(req_file_path) as f:

--- a/dev/update_requirements.py
+++ b/dev/update_requirements.py
@@ -13,13 +13,14 @@ from packaging.version import InvalidVersion, Version
 
 PACKAGE_NAMES = ["tracing", "skinny", "core", "gateway"]
 RELEASE_CUTOFF_DAYS = 14
-PYPI_URL = os.environ.get("PYPI_URL", "https://pypi.org")
+PYPI_URL = os.environ.get("PYPI_URL", "https://pypi.org").rstrip("/")
 
 
 def check_pypi_accessibility() -> None:
     try:
-        requests.head(PYPI_URL, timeout=5)
-    except requests.exceptions.ConnectionError:
+        response = requests.head(PYPI_URL, timeout=5)
+        response.raise_for_status()
+    except requests.exceptions.RequestException:
         raise SystemExit(
             f"Error: Cannot connect to {PYPI_URL}. "
             "If it's not accessible, set the PYPI_URL environment variable to a PyPI proxy URL."


### PR DESCRIPTION
### Related Issues/PRs

Relates to #N/A

### What changes are proposed in this pull request?

Allow overriding the PyPI base URL via the `PYPI_URL` environment variable in `dev/update_requirements.py` and `dev/update_ml_package_versions.py`. This is useful when `https://pypi.org` is not directly accessible and a proxy is needed.

Both scripts now perform an upfront accessibility check and fail fast with a helpful message suggesting the env var if the configured URL is unreachable.

### How is this PR tested?

- [x] Manual tests

Tested with default URL (blocked), custom proxy URL (success), and invalid URL (expected error).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)