### PR TITLE
Add RBAC data model, migration, and store CRUD

### DIFF
--- a/mlflow/server/auth/db/migrations/versions/c3d4e5f6a7b8_add_rbac_tables.py
+++ b/mlflow/server/auth/db/migrations/versions/c3d4e5f6a7b8_add_rbac_tables.py
@@ -1,0 +1,66 @@
+"""Add RBAC tables (roles, role_permissions, user_role_assignments)
+
+Revision ID: c3d4e5f6a7b8
+Revises: 2ed73881770d
+Create Date: 2026-04-20 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c3d4e5f6a7b8"
+down_revision = "2ed73881770d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "roles",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("workspace", sa.String(length=63), nullable=False),
+        sa.Column("description", sa.String(length=1024), nullable=True),
+        sa.Column("is_workspace_admin", sa.Boolean(), server_default=sa.text("0")),
+        sa.UniqueConstraint("workspace", "name", name="unique_workspace_role_name"),
+    )
+    op.create_index("idx_roles_workspace", "roles", ["workspace"], unique=False)
+
+    op.create_table(
+        "role_permissions",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("role_id", sa.Integer(), sa.ForeignKey("roles.id"), nullable=False),
+        sa.Column("resource_type", sa.String(length=64), nullable=False),
+        sa.Column("resource_pattern", sa.String(length=255), nullable=False),
+        sa.Column("permission", sa.String(length=255), nullable=False),
+        sa.UniqueConstraint(
+            "role_id", "resource_type", "resource_pattern", name="unique_role_resource_perm"
+        ),
+    )
+    op.create_index("idx_role_permissions_role_id", "role_permissions", ["role_id"], unique=False)
+
+    op.create_table(
+        "user_role_assignments",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("role_id", sa.Integer(), sa.ForeignKey("roles.id"), nullable=False),
+        sa.UniqueConstraint("user_id", "role_id", name="unique_user_role"),
+    )
+    op.create_index(
+        "idx_user_role_assignments_user_id", "user_role_assignments", ["user_id"], unique=False
+    )
+    op.create_index(
+        "idx_user_role_assignments_role_id", "user_role_assignments", ["role_id"], unique=False
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_user_role_assignments_role_id", table_name="user_role_assignments")
+    op.drop_index("idx_user_role_assignments_user_id", table_name="user_role_assignments")
+    op.drop_table("user_role_assignments")
+    op.drop_index("idx_role_permissions_role_id", table_name="role_permissions")
+    op.drop_table("role_permissions")
+    op.drop_index("idx_roles_workspace", table_name="roles")
+    op.drop_table("roles")

--- a/mlflow/server/auth/db/models.py
+++ b/mlflow/server/auth/db/models.py
@@ -17,6 +17,8 @@ from mlflow.server.auth.entities import (
     GatewayModelDefinitionPermission,
     GatewaySecretPermission,
     RegisteredModelPermission,
+    Role,
+    RolePermission,
     ScorerPermission,
     User,
     WorkspacePermission,
@@ -179,3 +181,69 @@ class SqlWorkspacePermission(Base):
             user_id=self.user_id,
             permission=self.permission,
         )
+
+
+class SqlRole(Base):
+    __tablename__ = "roles"
+
+    id = Column(Integer(), primary_key=True)
+    name = Column(String(255), nullable=False)
+    workspace = Column(String(63), nullable=False)
+    description = Column(String(1024), nullable=True)
+    is_workspace_admin = Column(Boolean, default=False)
+    permissions = relationship("SqlRolePermission", backref="role", cascade="all, delete-orphan")
+    user_assignments = relationship(
+        "SqlUserRoleAssignment", backref="role", cascade="all, delete-orphan"
+    )
+    __table_args__ = (
+        UniqueConstraint("workspace", "name", name="unique_workspace_role_name"),
+        Index("idx_roles_workspace", "workspace"),
+    )
+
+    def to_mlflow_entity(self):
+        return Role(
+            id_=self.id,
+            name=self.name,
+            workspace=self.workspace,
+            description=self.description,
+            is_workspace_admin=self.is_workspace_admin,
+            permissions=[p.to_mlflow_entity() for p in self.permissions],
+        )
+
+
+class SqlRolePermission(Base):
+    __tablename__ = "role_permissions"
+
+    id = Column(Integer(), primary_key=True)
+    role_id = Column(Integer, ForeignKey("roles.id"), nullable=False)
+    resource_type = Column(String(64), nullable=False)
+    resource_pattern = Column(String(255), nullable=False)
+    permission = Column(String(255), nullable=False)
+    __table_args__ = (
+        UniqueConstraint(
+            "role_id", "resource_type", "resource_pattern", name="unique_role_resource_perm"
+        ),
+        Index("idx_role_permissions_role_id", "role_id"),
+    )
+
+    def to_mlflow_entity(self):
+        return RolePermission(
+            id_=self.id,
+            role_id=self.role_id,
+            resource_type=self.resource_type,
+            resource_pattern=self.resource_pattern,
+            permission=self.permission,
+        )
+
+
+class SqlUserRoleAssignment(Base):
+    __tablename__ = "user_role_assignments"
+
+    id = Column(Integer(), primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    role_id = Column(Integer, ForeignKey("roles.id"), nullable=False)
+    __table_args__ = (
+        UniqueConstraint("user_id", "role_id", name="unique_user_role"),
+        Index("idx_user_role_assignments_user_id", "user_id"),
+        Index("idx_user_role_assignments_role_id", "role_id"),
+    )

--- a/mlflow/server/auth/entities.py
+++ b/mlflow/server/auth/entities.py
@@ -1,6 +1,6 @@
 from mlflow.exceptions import MlflowException
 from mlflow.server.auth.permissions import get_permission
-from mlflow.utils.workspace_utils import resolve_entity_workspace_name
+from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME, resolve_entity_workspace_name
 
 
 class User:
@@ -354,6 +354,163 @@ class GatewayModelDefinitionPermission:
             model_definition_id=dictionary["model_definition_id"],
             user_id=dictionary["user_id"],
             permission=dictionary["permission"],
+        )
+
+
+class Role:
+    def __init__(
+        self,
+        id_,
+        name,
+        workspace,
+        description=None,
+        is_workspace_admin=False,
+        permissions=None,
+    ):
+        self._id = id_
+        self._name = name
+        self._workspace = workspace
+        self._description = description
+        self._is_workspace_admin = is_workspace_admin
+        self._permissions = permissions or []
+
+    @property
+    def id(self):
+        return self._id
+
+    @property
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        self._name = name
+
+    @property
+    def workspace(self):
+        return self._workspace
+
+    @property
+    def description(self):
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        self._description = description
+
+    @property
+    def is_workspace_admin(self):
+        return self._is_workspace_admin
+
+    @property
+    def permissions(self):
+        return self._permissions
+
+    def to_json(self):
+        return {
+            "id": self.id,
+            "name": self.name,
+            "workspace": self.workspace,
+            "description": self.description,
+            "is_workspace_admin": self.is_workspace_admin,
+            "permissions": [p.to_json() for p in self.permissions],
+        }
+
+    @classmethod
+    def from_json(cls, dictionary):
+        return cls(
+            id_=dictionary["id"],
+            name=dictionary["name"],
+            workspace=dictionary.get("workspace", DEFAULT_WORKSPACE_NAME),
+            description=dictionary.get("description"),
+            is_workspace_admin=dictionary.get("is_workspace_admin", False),
+            permissions=[RolePermission.from_json(p) for p in dictionary.get("permissions", [])],
+        )
+
+
+class RolePermission:
+    def __init__(self, id_, role_id, resource_type, resource_pattern, permission):
+        self._id = id_
+        self._role_id = role_id
+        self._resource_type = resource_type
+        self._resource_pattern = resource_pattern
+        self._permission = permission
+
+    @property
+    def id(self):
+        return self._id
+
+    @property
+    def role_id(self):
+        return self._role_id
+
+    @property
+    def resource_type(self):
+        return self._resource_type
+
+    @property
+    def resource_pattern(self):
+        return self._resource_pattern
+
+    @property
+    def permission(self):
+        return self._permission
+
+    @permission.setter
+    def permission(self, permission):
+        self._permission = permission
+
+    def to_json(self):
+        return {
+            "id": self.id,
+            "role_id": self.role_id,
+            "resource_type": self.resource_type,
+            "resource_pattern": self.resource_pattern,
+            "permission": self.permission,
+        }
+
+    @classmethod
+    def from_json(cls, dictionary):
+        return cls(
+            id_=dictionary["id"],
+            role_id=dictionary["role_id"],
+            resource_type=dictionary["resource_type"],
+            resource_pattern=dictionary["resource_pattern"],
+            permission=dictionary["permission"],
+        )
+
+
+class UserRoleAssignment:
+    def __init__(self, id_, user_id, role_id):
+        self._id = id_
+        self._user_id = user_id
+        self._role_id = role_id
+
+    @property
+    def id(self):
+        return self._id
+
+    @property
+    def user_id(self):
+        return self._user_id
+
+    @property
+    def role_id(self):
+        return self._role_id
+
+    def to_json(self):
+        return {
+            "id": self.id,
+            "user_id": self.user_id,
+            "role_id": self.role_id,
+        }
+
+    @classmethod
+    def from_json(cls, dictionary):
+        return cls(
+            id_=dictionary["id"],
+            user_id=dictionary["user_id"],
+            role_id=dictionary["role_id"],
         )
 
 

--- a/mlflow/server/auth/permissions.py
+++ b/mlflow/server/auth/permissions.py
@@ -72,9 +72,40 @@ def get_permission(permission: str) -> Permission:
     return ALL_PERMISSIONS[permission]
 
 
+PERMISSION_PRIORITY = {
+    NO_PERMISSIONS.name: 0,
+    READ.name: 1,
+    USE.name: 2,
+    EDIT.name: 3,
+    MANAGE.name: 4,
+}
+
+VALID_RESOURCE_TYPES = frozenset({
+    "experiment",
+    "registered_model",
+    "scorer",
+    "gateway_secret",
+    "gateway_endpoint",
+    "gateway_model_definition",
+})
+
+
 def _validate_permission(permission: str):
     if permission not in ALL_PERMISSIONS:
         raise MlflowException(
             f"Invalid permission '{permission}'. Valid permissions are: {tuple(ALL_PERMISSIONS)}",
             INVALID_PARAMETER_VALUE,
         )
+
+
+def _validate_resource_type(resource_type: str):
+    if resource_type not in VALID_RESOURCE_TYPES:
+        raise MlflowException(
+            f"Invalid resource type '{resource_type}'. "
+            f"Valid resource types are: {tuple(sorted(VALID_RESOURCE_TYPES))}",
+            INVALID_PARAMETER_VALUE,
+        )
+
+
+def max_permission(a: str, b: str) -> str:
+    return a if PERMISSION_PRIORITY.get(a, 0) >= PERMISSION_PRIORITY.get(b, 0) else b

--- a/mlflow/server/auth/sqlalchemy_store.py
+++ b/mlflow/server/auth/sqlalchemy_store.py
@@ -16,8 +16,11 @@ from mlflow.server.auth.db.models import (
     SqlGatewayModelDefinitionPermission,
     SqlGatewaySecretPermission,
     SqlRegisteredModelPermission,
+    SqlRole,
+    SqlRolePermission,
     SqlScorerPermission,
     SqlUser,
+    SqlUserRoleAssignment,
     SqlWorkspacePermission,
 )
 from mlflow.server.auth.entities import (
@@ -26,11 +29,21 @@ from mlflow.server.auth.entities import (
     GatewayModelDefinitionPermission,
     GatewaySecretPermission,
     RegisteredModelPermission,
+    Role,
+    RolePermission,
     ScorerPermission,
     User,
+    UserRoleAssignment,
     WorkspacePermission,
 )
-from mlflow.server.auth.permissions import Permission, _validate_permission, get_permission
+from mlflow.server.auth.permissions import (
+    MANAGE,
+    Permission,
+    _validate_permission,
+    _validate_resource_type,
+    get_permission,
+    max_permission,
+)
 from mlflow.store.db.utils import _get_managed_session_maker, create_sqlalchemy_engine_with_retry
 from mlflow.utils import workspace_context
 from mlflow.utils.uri import extract_db_type_from_uri
@@ -782,3 +795,305 @@ class SqlAlchemyStore:
             session.query(SqlGatewayModelDefinitionPermission).filter(
                 SqlGatewayModelDefinitionPermission.model_definition_id == model_definition_id,
             ).delete()
+
+    # ---- Role CRUD ----
+
+    def create_role(
+        self,
+        name: str,
+        workspace: str,
+        description: str | None = None,
+        is_workspace_admin: bool = False,
+    ) -> Role:
+        with self.ManagedSessionMaker() as session:
+            try:
+                role = SqlRole(
+                    name=name,
+                    workspace=workspace,
+                    description=description,
+                    is_workspace_admin=is_workspace_admin,
+                )
+                session.add(role)
+                session.flush()
+                return role.to_mlflow_entity()
+            except IntegrityError as e:
+                raise MlflowException(
+                    f"Role (name={name}, workspace={workspace}) already exists. Error: {e}",
+                    RESOURCE_ALREADY_EXISTS,
+                ) from e
+
+    @staticmethod
+    def _get_role(session, role_id: int) -> SqlRole:
+        try:
+            return session.query(SqlRole).filter(SqlRole.id == role_id).one()
+        except NoResultFound:
+            raise MlflowException(
+                f"Role with id={role_id} not found",
+                RESOURCE_DOES_NOT_EXIST,
+            )
+
+    @staticmethod
+    def _get_role_by_name(session, workspace: str, name: str) -> SqlRole:
+        try:
+            return (
+                session
+                .query(SqlRole)
+                .filter(SqlRole.workspace == workspace, SqlRole.name == name)
+                .one()
+            )
+        except NoResultFound:
+            raise MlflowException(
+                f"Role with name={name} in workspace={workspace} not found",
+                RESOURCE_DOES_NOT_EXIST,
+            )
+
+    def get_role(self, role_id: int) -> Role:
+        with self.ManagedSessionMaker() as session:
+            return self._get_role(session, role_id).to_mlflow_entity()
+
+    def get_role_by_name(self, workspace: str, name: str) -> Role:
+        with self.ManagedSessionMaker() as session:
+            return self._get_role_by_name(session, workspace, name).to_mlflow_entity()
+
+    def list_roles(self, workspace: str) -> list[Role]:
+        with self.ManagedSessionMaker() as session:
+            roles = session.query(SqlRole).filter(SqlRole.workspace == workspace).all()
+            return [r.to_mlflow_entity() for r in roles]
+
+    def list_all_roles(self) -> list[Role]:
+        with self.ManagedSessionMaker() as session:
+            roles = session.query(SqlRole).all()
+            return [r.to_mlflow_entity() for r in roles]
+
+    def update_role(
+        self,
+        role_id: int,
+        name: str | None = None,
+        description: str | None = None,
+    ) -> Role:
+        with self.ManagedSessionMaker() as session:
+            role = self._get_role(session, role_id)
+            if name is not None:
+                # Check for name conflicts before updating
+                existing = (
+                    session
+                    .query(SqlRole)
+                    .filter(
+                        SqlRole.workspace == role.workspace,
+                        SqlRole.name == name,
+                        SqlRole.id != role_id,
+                    )
+                    .first()
+                )
+                if existing is not None:
+                    raise MlflowException(
+                        f"Role with name={name} already exists in workspace={role.workspace}",
+                        RESOURCE_ALREADY_EXISTS,
+                    )
+                role.name = name
+            if description is not None:
+                role.description = description
+            return role.to_mlflow_entity()
+
+    def delete_role(self, role_id: int) -> None:
+        with self.ManagedSessionMaker() as session:
+            role = self._get_role(session, role_id)
+            session.delete(role)
+
+    def delete_roles_for_workspace(self, workspace_name: str) -> None:
+        with self.ManagedSessionMaker() as session:
+            session.query(SqlRole).filter(SqlRole.workspace == workspace_name).delete(
+                synchronize_session=False
+            )
+
+    # ---- RolePermission CRUD ----
+
+    def add_role_permission(
+        self,
+        role_id: int,
+        resource_type: str,
+        resource_pattern: str,
+        permission: str,
+    ) -> RolePermission:
+        _validate_permission(permission)
+        _validate_resource_type(resource_type)
+        with self.ManagedSessionMaker() as session:
+            self._get_role(session, role_id)
+            try:
+                rp = SqlRolePermission(
+                    role_id=role_id,
+                    resource_type=resource_type,
+                    resource_pattern=resource_pattern,
+                    permission=permission,
+                )
+                session.add(rp)
+                session.flush()
+                return rp.to_mlflow_entity()
+            except IntegrityError as e:
+                raise MlflowException(
+                    f"Role permission (role_id={role_id}, resource_type={resource_type}, "
+                    f"resource_pattern={resource_pattern}) already exists. Error: {e}",
+                    RESOURCE_ALREADY_EXISTS,
+                ) from e
+
+    def remove_role_permission(self, role_permission_id: int) -> None:
+        with self.ManagedSessionMaker() as session:
+            try:
+                rp = (
+                    session
+                    .query(SqlRolePermission)
+                    .filter(SqlRolePermission.id == role_permission_id)
+                    .one()
+                )
+            except NoResultFound:
+                raise MlflowException(
+                    f"Role permission with id={role_permission_id} not found",
+                    RESOURCE_DOES_NOT_EXIST,
+                )
+            session.delete(rp)
+
+    def list_role_permissions(self, role_id: int) -> list[RolePermission]:
+        with self.ManagedSessionMaker() as session:
+            self._get_role(session, role_id)
+            perms = (
+                session.query(SqlRolePermission).filter(SqlRolePermission.role_id == role_id).all()
+            )
+            return [p.to_mlflow_entity() for p in perms]
+
+    def update_role_permission(self, role_permission_id: int, permission: str) -> RolePermission:
+        _validate_permission(permission)
+        with self.ManagedSessionMaker() as session:
+            try:
+                rp = (
+                    session
+                    .query(SqlRolePermission)
+                    .filter(SqlRolePermission.id == role_permission_id)
+                    .one()
+                )
+            except NoResultFound:
+                raise MlflowException(
+                    f"Role permission with id={role_permission_id} not found",
+                    RESOURCE_DOES_NOT_EXIST,
+                )
+            rp.permission = permission
+            return rp.to_mlflow_entity()
+
+    # ---- UserRoleAssignment CRUD ----
+
+    def assign_role_to_user(self, user_id: int, role_id: int) -> UserRoleAssignment:
+        with self.ManagedSessionMaker() as session:
+            self._get_role(session, role_id)
+            try:
+                assignment = SqlUserRoleAssignment(user_id=user_id, role_id=role_id)
+                session.add(assignment)
+                session.flush()
+                return UserRoleAssignment(
+                    id_=assignment.id,
+                    user_id=assignment.user_id,
+                    role_id=assignment.role_id,
+                )
+            except IntegrityError as e:
+                raise MlflowException(
+                    f"User role assignment (user_id={user_id}, role_id={role_id}) "
+                    f"already exists. Error: {e}",
+                    RESOURCE_ALREADY_EXISTS,
+                ) from e
+
+    def unassign_role_from_user(self, user_id: int, role_id: int) -> None:
+        with self.ManagedSessionMaker() as session:
+            try:
+                assignment = (
+                    session
+                    .query(SqlUserRoleAssignment)
+                    .filter(
+                        SqlUserRoleAssignment.user_id == user_id,
+                        SqlUserRoleAssignment.role_id == role_id,
+                    )
+                    .one()
+                )
+            except NoResultFound:
+                raise MlflowException(
+                    f"User role assignment (user_id={user_id}, role_id={role_id}) not found",
+                    RESOURCE_DOES_NOT_EXIST,
+                )
+            session.delete(assignment)
+
+    def list_user_roles(self, user_id: int) -> list[Role]:
+        with self.ManagedSessionMaker() as session:
+            assignments = (
+                session
+                .query(SqlUserRoleAssignment)
+                .filter(SqlUserRoleAssignment.user_id == user_id)
+                .all()
+            )
+            role_ids = [a.role_id for a in assignments]
+            if not role_ids:
+                return []
+            roles = session.query(SqlRole).filter(SqlRole.id.in_(role_ids)).all()
+            return [r.to_mlflow_entity() for r in roles]
+
+    def list_user_roles_for_workspace(self, user_id: int, workspace: str) -> list[Role]:
+        with self.ManagedSessionMaker() as session:
+            roles = (
+                session
+                .query(SqlRole)
+                .join(SqlUserRoleAssignment, SqlRole.id == SqlUserRoleAssignment.role_id)
+                .filter(
+                    SqlUserRoleAssignment.user_id == user_id,
+                    SqlRole.workspace == workspace,
+                )
+                .all()
+            )
+            return [r.to_mlflow_entity() for r in roles]
+
+    def list_role_users(self, role_id: int) -> list[UserRoleAssignment]:
+        with self.ManagedSessionMaker() as session:
+            self._get_role(session, role_id)
+            assignments = (
+                session
+                .query(SqlUserRoleAssignment)
+                .filter(SqlUserRoleAssignment.role_id == role_id)
+                .all()
+            )
+            return [
+                UserRoleAssignment(id_=a.id, user_id=a.user_id, role_id=a.role_id)
+                for a in assignments
+            ]
+
+    # ---- Role-based permission resolution ----
+
+    def get_role_permission_for_resource(
+        self, user_id: int, resource_type: str, resource_id: str, workspace: str
+    ) -> Permission | None:
+        with self.ManagedSessionMaker() as session:
+            roles = (
+                session
+                .query(SqlRole)
+                .join(SqlUserRoleAssignment, SqlRole.id == SqlUserRoleAssignment.role_id)
+                .filter(
+                    SqlUserRoleAssignment.user_id == user_id,
+                    SqlRole.workspace == workspace,
+                )
+                .all()
+            )
+            if not roles:
+                return None
+
+            best_permission_name: str | None = None
+            for role in roles:
+                if role.is_workspace_admin:
+                    return MANAGE
+
+                for rp in role.permissions:
+                    if rp.resource_type != resource_type:
+                        continue
+                    if rp.resource_pattern in ("*", resource_id):
+                        best_permission_name = (
+                            max_permission(best_permission_name, rp.permission)
+                            if best_permission_name is not None
+                            else rp.permission
+                        )
+
+            if best_permission_name is None:
+                return None
+            return get_permission(best_permission_name)

--- a/tests/server/auth/test_sqlalchemy_store_rbac.py
+++ b/tests/server/auth/test_sqlalchemy_store_rbac.py
@@ -1,0 +1,410 @@
+import pytest
+
+from mlflow.exceptions import MlflowException
+from mlflow.server.auth.entities import Role, RolePermission, UserRoleAssignment
+from mlflow.server.auth.permissions import EDIT, MANAGE, READ, USE
+from mlflow.server.auth.sqlalchemy_store import SqlAlchemyStore
+
+from tests.helper_functions import random_str
+
+pytestmark = pytest.mark.notrackingurimock
+
+
+@pytest.fixture
+def store(tmp_sqlite_uri):
+    store = SqlAlchemyStore()
+    store.init_db(tmp_sqlite_uri)
+    return store
+
+
+@pytest.fixture
+def user(store):
+    return store.create_user(random_str(), random_str())
+
+
+@pytest.fixture
+def user2(store):
+    return store.create_user(random_str(), random_str())
+
+
+# ---- Role CRUD ----
+
+
+def test_create_role(store):
+    role = store.create_role(name="viewer", workspace="ws1", description="Read-only access")
+    assert isinstance(role, Role)
+    assert role.name == "viewer"
+    assert role.workspace == "ws1"
+    assert role.description == "Read-only access"
+    assert role.is_workspace_admin is False
+    assert role.permissions == []
+
+
+def test_create_role_duplicate(store):
+    store.create_role(name="viewer", workspace="ws1")
+    with pytest.raises(MlflowException, match="already exists"):
+        store.create_role(name="viewer", workspace="ws1")
+
+
+def test_create_role_same_name_different_workspace(store):
+    r1 = store.create_role(name="viewer", workspace="ws1")
+    r2 = store.create_role(name="viewer", workspace="ws2")
+    assert r1.id != r2.id
+
+
+def test_create_workspace_admin_role(store):
+    role = store.create_role(name="ws-admin", workspace="ws1", is_workspace_admin=True)
+    assert role.is_workspace_admin is True
+
+
+def test_get_role(store):
+    created = store.create_role(name="editor", workspace="ws1")
+    fetched = store.get_role(created.id)
+    assert fetched.id == created.id
+    assert fetched.name == "editor"
+    assert fetched.workspace == "ws1"
+
+
+def test_get_role_not_found(store):
+    with pytest.raises(MlflowException, match="not found"):
+        store.get_role(99999)
+
+
+def test_get_role_by_name(store):
+    created = store.create_role(name="editor", workspace="ws1")
+    fetched = store.get_role_by_name("ws1", "editor")
+    assert fetched.id == created.id
+
+
+def test_get_role_by_name_not_found(store):
+    with pytest.raises(MlflowException, match="not found"):
+        store.get_role_by_name("ws1", "nonexistent")
+
+
+def test_list_roles(store):
+    store.create_role(name="viewer", workspace="ws1")
+    store.create_role(name="editor", workspace="ws1")
+    store.create_role(name="viewer", workspace="ws2")
+
+    ws1_roles = store.list_roles("ws1")
+    assert len(ws1_roles) == 2
+    assert {r.name for r in ws1_roles} == {"viewer", "editor"}
+
+    ws2_roles = store.list_roles("ws2")
+    assert len(ws2_roles) == 1
+
+
+def test_list_all_roles(store):
+    store.create_role(name="viewer", workspace="ws1")
+    store.create_role(name="editor", workspace="ws2")
+    all_roles = store.list_all_roles()
+    assert len(all_roles) == 2
+
+
+def test_update_role(store):
+    role = store.create_role(name="old-name", workspace="ws1", description="old desc")
+    updated = store.update_role(role.id, name="new-name", description="new desc")
+    assert updated.name == "new-name"
+    assert updated.description == "new desc"
+
+
+def test_update_role_name_conflict(store):
+    store.create_role(name="existing", workspace="ws1")
+    role2 = store.create_role(name="other", workspace="ws1")
+    with pytest.raises(MlflowException, match="already exists"):
+        store.update_role(role2.id, name="existing")
+
+
+def test_delete_role(store):
+    role = store.create_role(name="doomed", workspace="ws1")
+    store.delete_role(role.id)
+    with pytest.raises(MlflowException, match="not found"):
+        store.get_role(role.id)
+
+
+def test_delete_role_cascades_permissions_and_assignments(store, user):
+    role = store.create_role(name="role1", workspace="ws1")
+    store.add_role_permission(role.id, "experiment", "*", "READ")
+    store.assign_role_to_user(user.id, role.id)
+
+    store.delete_role(role.id)
+
+    # Role no longer exists
+    with pytest.raises(MlflowException, match="not found"):
+        store.get_role(role.id)
+
+    # User no longer has the role
+    assert store.list_user_roles(user.id) == []
+
+
+def test_delete_roles_for_workspace(store):
+    store.create_role(name="r1", workspace="ws1")
+    store.create_role(name="r2", workspace="ws1")
+    store.create_role(name="r3", workspace="ws2")
+
+    store.delete_roles_for_workspace("ws1")
+    assert store.list_roles("ws1") == []
+    assert len(store.list_roles("ws2")) == 1
+
+
+# ---- RolePermission CRUD ----
+
+
+def test_add_role_permission(store):
+    role = store.create_role(name="viewer", workspace="ws1")
+    rp = store.add_role_permission(role.id, "experiment", "123", "READ")
+    assert isinstance(rp, RolePermission)
+    assert rp.role_id == role.id
+    assert rp.resource_type == "experiment"
+    assert rp.resource_pattern == "123"
+    assert rp.permission == "READ"
+
+
+def test_add_role_permission_wildcard(store):
+    role = store.create_role(name="viewer", workspace="ws1")
+    rp = store.add_role_permission(role.id, "experiment", "*", "READ")
+    assert rp.resource_pattern == "*"
+
+
+def test_add_role_permission_duplicate(store):
+    role = store.create_role(name="viewer", workspace="ws1")
+    store.add_role_permission(role.id, "experiment", "123", "READ")
+    with pytest.raises(MlflowException, match="already exists"):
+        store.add_role_permission(role.id, "experiment", "123", "EDIT")
+
+
+def test_add_role_permission_invalid_permission(store):
+    role = store.create_role(name="viewer", workspace="ws1")
+    with pytest.raises(MlflowException, match="Invalid permission"):
+        store.add_role_permission(role.id, "experiment", "123", "INVALID")
+
+
+def test_add_role_permission_invalid_resource_type(store):
+    role = store.create_role(name="viewer", workspace="ws1")
+    with pytest.raises(MlflowException, match="Invalid resource type"):
+        store.add_role_permission(role.id, "invalid_type", "123", "READ")
+
+
+def test_add_role_permission_nonexistent_role(store):
+    with pytest.raises(MlflowException, match="not found"):
+        store.add_role_permission(99999, "experiment", "123", "READ")
+
+
+def test_remove_role_permission(store):
+    role = store.create_role(name="viewer", workspace="ws1")
+    rp = store.add_role_permission(role.id, "experiment", "123", "READ")
+    store.remove_role_permission(rp.id)
+    assert store.list_role_permissions(role.id) == []
+
+
+def test_remove_role_permission_not_found(store):
+    with pytest.raises(MlflowException, match="not found"):
+        store.remove_role_permission(99999)
+
+
+def test_list_role_permissions(store):
+    role = store.create_role(name="viewer", workspace="ws1")
+    store.add_role_permission(role.id, "experiment", "1", "READ")
+    store.add_role_permission(role.id, "experiment", "2", "EDIT")
+    store.add_role_permission(role.id, "registered_model", "*", "READ")
+
+    perms = store.list_role_permissions(role.id)
+    assert len(perms) == 3
+
+
+def test_update_role_permission(store):
+    role = store.create_role(name="viewer", workspace="ws1")
+    rp = store.add_role_permission(role.id, "experiment", "123", "READ")
+    updated = store.update_role_permission(rp.id, "EDIT")
+    assert updated.permission == "EDIT"
+
+
+def test_update_role_permission_not_found(store):
+    with pytest.raises(MlflowException, match="not found"):
+        store.update_role_permission(99999, "READ")
+
+
+def test_update_role_permission_invalid_permission(store):
+    role = store.create_role(name="viewer", workspace="ws1")
+    rp = store.add_role_permission(role.id, "experiment", "123", "READ")
+    with pytest.raises(MlflowException, match="Invalid permission"):
+        store.update_role_permission(rp.id, "INVALID")
+
+
+# ---- UserRoleAssignment CRUD ----
+
+
+def test_assign_role_to_user(store, user):
+    role = store.create_role(name="viewer", workspace="ws1")
+    assignment = store.assign_role_to_user(user.id, role.id)
+    assert isinstance(assignment, UserRoleAssignment)
+    assert assignment.user_id == user.id
+    assert assignment.role_id == role.id
+
+
+def test_assign_role_duplicate(store, user):
+    role = store.create_role(name="viewer", workspace="ws1")
+    store.assign_role_to_user(user.id, role.id)
+    with pytest.raises(MlflowException, match="already exists"):
+        store.assign_role_to_user(user.id, role.id)
+
+
+def test_unassign_role_from_user(store, user):
+    role = store.create_role(name="viewer", workspace="ws1")
+    store.assign_role_to_user(user.id, role.id)
+    store.unassign_role_from_user(user.id, role.id)
+    assert store.list_user_roles(user.id) == []
+
+
+def test_unassign_role_not_found(store, user):
+    with pytest.raises(MlflowException, match="not found"):
+        store.unassign_role_from_user(user.id, 99999)
+
+
+def test_list_user_roles(store, user):
+    r1 = store.create_role(name="viewer", workspace="ws1")
+    r2 = store.create_role(name="editor", workspace="ws2")
+    store.assign_role_to_user(user.id, r1.id)
+    store.assign_role_to_user(user.id, r2.id)
+
+    roles = store.list_user_roles(user.id)
+    assert len(roles) == 2
+    assert {r.name for r in roles} == {"viewer", "editor"}
+
+
+def test_list_user_roles_for_workspace(store, user):
+    r1 = store.create_role(name="viewer", workspace="ws1")
+    r2 = store.create_role(name="editor", workspace="ws1")
+    r3 = store.create_role(name="viewer", workspace="ws2")
+    store.assign_role_to_user(user.id, r1.id)
+    store.assign_role_to_user(user.id, r2.id)
+    store.assign_role_to_user(user.id, r3.id)
+
+    ws1_roles = store.list_user_roles_for_workspace(user.id, "ws1")
+    assert len(ws1_roles) == 2
+
+    ws2_roles = store.list_user_roles_for_workspace(user.id, "ws2")
+    assert len(ws2_roles) == 1
+
+
+def test_list_role_users(store, user, user2):
+    role = store.create_role(name="viewer", workspace="ws1")
+    store.assign_role_to_user(user.id, role.id)
+    store.assign_role_to_user(user2.id, role.id)
+
+    users = store.list_role_users(role.id)
+    assert len(users) == 2
+    assert {u.user_id for u in users} == {user.id, user2.id}
+
+
+# ---- Role-based permission resolution ----
+
+
+def test_get_role_permission_no_roles(store, user):
+    result = store.get_role_permission_for_resource(user.id, "experiment", "1", "ws1")
+    assert result is None
+
+
+def test_get_role_permission_specific_match(store, user):
+    role = store.create_role(name="viewer", workspace="ws1")
+    store.add_role_permission(role.id, "experiment", "1", "READ")
+    store.assign_role_to_user(user.id, role.id)
+
+    result = store.get_role_permission_for_resource(user.id, "experiment", "1", "ws1")
+    assert result == READ
+
+
+def test_get_role_permission_no_match(store, user):
+    role = store.create_role(name="viewer", workspace="ws1")
+    store.add_role_permission(role.id, "experiment", "1", "READ")
+    store.assign_role_to_user(user.id, role.id)
+
+    result = store.get_role_permission_for_resource(user.id, "experiment", "999", "ws1")
+    assert result is None
+
+
+def test_get_role_permission_wildcard_match(store, user):
+    role = store.create_role(name="viewer", workspace="ws1")
+    store.add_role_permission(role.id, "experiment", "*", "EDIT")
+    store.assign_role_to_user(user.id, role.id)
+
+    result = store.get_role_permission_for_resource(user.id, "experiment", "any-id", "ws1")
+    assert result == EDIT
+
+
+def test_get_role_permission_union_of_multiple_roles(store, user):
+    r1 = store.create_role(name="viewer", workspace="ws1")
+    store.add_role_permission(r1.id, "experiment", "1", "READ")
+    store.assign_role_to_user(user.id, r1.id)
+
+    r2 = store.create_role(name="editor", workspace="ws1")
+    store.add_role_permission(r2.id, "experiment", "1", "EDIT")
+    store.assign_role_to_user(user.id, r2.id)
+
+    result = store.get_role_permission_for_resource(user.id, "experiment", "1", "ws1")
+    assert result == EDIT
+
+
+def test_get_role_permission_wildcard_and_specific_union(store, user):
+    role = store.create_role(name="mixed", workspace="ws1")
+    store.add_role_permission(role.id, "experiment", "*", "READ")
+    store.add_role_permission(role.id, "experiment", "1", "EDIT")
+    store.assign_role_to_user(user.id, role.id)
+
+    # Experiment 1 gets EDIT (higher of READ wildcard and EDIT specific)
+    result = store.get_role_permission_for_resource(user.id, "experiment", "1", "ws1")
+    assert result == EDIT
+
+    # Other experiments get READ from wildcard
+    result = store.get_role_permission_for_resource(user.id, "experiment", "999", "ws1")
+    assert result == READ
+
+
+def test_get_role_permission_workspace_admin(store, user):
+    role = store.create_role(name="ws-admin", workspace="ws1", is_workspace_admin=True)
+    store.assign_role_to_user(user.id, role.id)
+
+    result = store.get_role_permission_for_resource(user.id, "experiment", "any-id", "ws1")
+    assert result == MANAGE
+
+
+def test_get_role_permission_does_not_cross_workspace(store, user):
+    role = store.create_role(name="viewer", workspace="ws1")
+    store.add_role_permission(role.id, "experiment", "*", "READ")
+    store.assign_role_to_user(user.id, role.id)
+
+    # Should not apply in ws2
+    result = store.get_role_permission_for_resource(user.id, "experiment", "1", "ws2")
+    assert result is None
+
+
+def test_get_role_permission_different_resource_types(store, user):
+    role = store.create_role(name="viewer", workspace="ws1")
+    store.add_role_permission(role.id, "experiment", "*", "READ")
+    store.assign_role_to_user(user.id, role.id)
+
+    # Should not match registered_model
+    result = store.get_role_permission_for_resource(user.id, "registered_model", "m1", "ws1")
+    assert result is None
+
+    # Should match experiment
+    result = store.get_role_permission_for_resource(user.id, "experiment", "1", "ws1")
+    assert result == READ
+
+
+@pytest.mark.parametrize(
+    ("perms", "expected"),
+    [
+        ([("experiment", "1", "READ"), ("experiment", "1", "MANAGE")], MANAGE),
+        ([("experiment", "1", "USE"), ("experiment", "1", "EDIT")], EDIT),
+        ([("experiment", "*", "READ"), ("experiment", "1", "USE")], USE),
+    ],
+)
+def test_get_role_permission_picks_highest(store, user, perms, expected):
+    for i, (rtype, pattern, perm) in enumerate(perms):
+        role = store.create_role(name=f"role-{i}", workspace="ws1")
+        store.add_role_permission(role.id, rtype, pattern, perm)
+        store.assign_role_to_user(user.id, role.id)
+
+    result = store.get_role_permission_for_resource(user.id, "experiment", "1", "ws1")
+    assert result == expected


### PR DESCRIPTION
### Related Issues/PRs

Relates to user management & access control feature (RBAC milestone)

### What changes are proposed in this pull request?

This is **PR 1/2** in the RBAC stack. It adds the data layer for Role-Based Access Control:

- **New entity classes** (`Role`, `RolePermission`, `UserRoleAssignment`) in `entities.py`
- **New SQLAlchemy models** (`SqlRole`, `SqlRolePermission`, `SqlUserRoleAssignment`) in `db/models.py`
- **Alembic migration** creating 3 new tables: `roles`, `role_permissions`, `user_role_assignments`
- **Permission helpers** in `permissions.py`: `PERMISSION_PRIORITY`, `max_permission()`, `VALID_RESOURCE_TYPES`, `_validate_resource_type()`
- **Full CRUD** in `SqlAlchemyStore`: role/role_permission/user_role_assignment management
- **Role-based permission resolution**: `get_role_permission_for_resource()` — queries user's roles in a workspace, checks `is_workspace_admin` → MANAGE, matches specific or wildcard (`*`) resource patterns, returns highest permission via union

Key design decisions:
- Roles are **workspace-scoped** — a role belongs to exactly one workspace
- **Wildcard resource patterns**: `resource_pattern = "*"` grants access to all resources of that type in the workspace
- **WP admin** is modeled as `is_workspace_admin=True` on the role (not a separate flag on users)
- **Permission union**: multiple roles' permissions are combined, taking the highest

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

46 new unit tests in `tests/server/auth/test_sqlalchemy_store_rbac.py` covering:
- Role CRUD (create, get, list, update, delete, cascade)
- Role permission CRUD (add, remove, list, update, wildcards, validation)
- User-role assignment CRUD (assign, unassign, list by user/workspace/role)
- Permission resolution (specific match, wildcard, union of multiple roles, WP admin override, cross-workspace isolation)

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

Co-authored-by: Claude <noreply@anthropic.com>