### PR TITLE
Add RBAC REST API, permission resolution, and client

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -183,13 +183,16 @@ from mlflow.server.auth.permissions import (
     get_permission,
 )
 from mlflow.server.auth.routes import (
+    ADD_ROLE_PERMISSION,
     AJAX_LIST_USERS,
+    ASSIGN_ROLE,
     CREATE_EXPERIMENT_PERMISSION,
     CREATE_GATEWAY_ENDPOINT_PERMISSION,
     CREATE_GATEWAY_MODEL_DEFINITION_PERMISSION,
     CREATE_GATEWAY_SECRET_PERMISSION,
     CREATE_PROMPTLAB_RUN,
     CREATE_REGISTERED_MODEL_PERMISSION,
+    CREATE_ROLE,
     CREATE_SCORER_PERMISSION,
     CREATE_USER,
     CREATE_USER_UI,
@@ -198,6 +201,7 @@ from mlflow.server.auth.routes import (
     DELETE_GATEWAY_MODEL_DEFINITION_PERMISSION,
     DELETE_GATEWAY_SECRET_PERMISSION,
     DELETE_REGISTERED_MODEL_PERMISSION,
+    DELETE_ROLE,
     DELETE_SCORER_PERMISSION,
     DELETE_USER,
     GATEWAY_PROVIDER_CONFIG,
@@ -214,21 +218,31 @@ from mlflow.server.auth.routes import (
     GET_METRIC_HISTORY_BULK_INTERVAL,
     GET_MODEL_VERSION_ARTIFACT,
     GET_REGISTERED_MODEL_PERMISSION,
+    GET_ROLE,
     GET_SCORER_PERMISSION,
     GET_TRACE_ARTIFACT,
     GET_USER,
     HOME,
     INVOKE_SCORER,
+    LIST_ALL_ROLES,
+    LIST_ROLE_PERMISSIONS,
+    LIST_ROLE_USERS,
+    LIST_ROLES,
+    LIST_USER_ROLES,
     LIST_USER_WORKSPACE_PERMISSIONS,
     LIST_USERS,
     LIST_WORKSPACE_PERMISSIONS,
+    REMOVE_ROLE_PERMISSION,
     SEARCH_DATASETS,
     SIGNUP,
+    UNASSIGN_ROLE,
     UPDATE_EXPERIMENT_PERMISSION,
     UPDATE_GATEWAY_ENDPOINT_PERMISSION,
     UPDATE_GATEWAY_MODEL_DEFINITION_PERMISSION,
     UPDATE_GATEWAY_SECRET_PERMISSION,
     UPDATE_REGISTERED_MODEL_PERMISSION,
+    UPDATE_ROLE,
+    UPDATE_ROLE_PERMISSION,
     UPDATE_SCORER_PERMISSION,
     UPDATE_USER_ADMIN,
     UPDATE_USER_PASSWORD,
@@ -323,38 +337,62 @@ def _get_request_param(param: str) -> str:
     return args[param]
 
 
+def _higher_permission(a: Permission, b: Permission) -> Permission:
+    from mlflow.server.auth.permissions import PERMISSION_PRIORITY
+
+    a_priority = PERMISSION_PRIORITY.get(a.name, 0)
+    b_priority = PERMISSION_PRIORITY.get(b.name, 0)
+    return a if a_priority >= b_priority else b
+
+
 def _get_permission_from_store_or_default(
     store_permission_func: Callable[[], str],
     workspace_level_permission_func: Callable[[], Permission | None] | None = None,
+    role_permission_func: Callable[[], Permission | None] | None = None,
 ) -> Permission:
     """
-    Resolve a permission from the auth store, with an optional workspace-aware fallback.
+    Resolve a permission from the auth store, with optional role-based and workspace fallbacks.
 
-    Behavior:
-    - If a direct (resource-level) permission exists, it is returned.
-    - If no direct permission exists and workspaces are enabled, callers provide
-      ``workspace_level_permission_func`` to check workspace-level permissions for the resource's
-      workspace. This fallback should default to ``NO_PERMISSIONS`` to preserve workspace isolation.
-    - If workspace permissions are not applicable (e.g. workspaces are disabled and the func
-      returns ``None``), fall back to ``auth_config.default_permission``.
-    - Unexpected errors are propagated rather than granting access.
+    Resolution order:
+    1. If role_permission_func is provided and returns a non-None/non-NO_PERMISSIONS result,
+       combine it with any direct resource permission (take the higher of the two).
+    2. If a direct (resource-level) permission exists, it is returned.
+    3. If no direct permission exists and workspaces are enabled, check workspace-level permission.
+    4. Fall back to auth_config.default_permission.
     """
+    # Check role-based permissions
+    role_perm = None
+    if role_permission_func is not None:
+        role_perm = role_permission_func()
+
+    # Check direct resource permission
+    direct_perm = None
     try:
-        perm = store_permission_func()
+        direct_perm = get_permission(store_permission_func())
     except MlflowException as e:
-        if e.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST):
-            if workspace_level_permission_func is not None:
-                workspace_permission = workspace_level_permission_func()
-                # workspace_permission is only None when workspaces are not enabled.
-                # workspace_permission defaults to NO_PERMISSIONS. In effect, this means that
-                # auth_config.default_permission is not supported when workspaces are enabled
-                # to keep workspace isolation.
-                if workspace_permission is not None:
-                    return workspace_permission
-            perm = auth_config.default_permission
-        else:
+        if e.error_code != ErrorCode.Name(RESOURCE_DOES_NOT_EXIST):
             raise
-    return get_permission(perm)
+
+    # If we have both, take the higher
+    if role_perm is not None and role_perm != NO_PERMISSIONS and direct_perm is not None:
+        return _higher_permission(role_perm, direct_perm)
+
+    # If only role permission, use it
+    if role_perm is not None and role_perm != NO_PERMISSIONS:
+        return role_perm
+
+    # If only direct permission, use it
+    if direct_perm is not None:
+        return direct_perm
+
+    # Fall back to workspace permission
+    if workspace_level_permission_func is not None:
+        workspace_permission = workspace_level_permission_func()
+        if workspace_permission is not None:
+            return workspace_permission
+
+    # Final fallback to default
+    return get_permission(auth_config.default_permission)
 
 
 def _workspace_permission(
@@ -572,11 +610,23 @@ def _get_permission_from_experiment_id() -> Permission:
 
 
 def _get_experiment_permission(experiment_id: str, username: str) -> Permission:
+    def _role_perm():
+        user = store.get_user(username)
+        workspace_name = _get_resource_workspace(
+            experiment_id, _get_tracking_store().get_experiment, "experiment"
+        )
+        if workspace_name is None:
+            return None
+        return store.get_role_permission_for_resource(
+            user.id, "experiment", experiment_id, workspace_name
+        )
+
     return _get_permission_from_store_or_default(
         lambda: store.get_experiment_permission(experiment_id, username).permission,
         workspace_level_permission_func=lambda: _workspace_permission_for_experiment(
             username, experiment_id
         ),
+        role_permission_func=_role_perm,
     )
 
 
@@ -678,11 +728,24 @@ def _get_permission_from_prompt_optimization_job_id() -> Permission:
 def _get_permission_from_registered_model_name() -> Permission:
     name = _get_request_param("name")
     username = authenticate_request().username
+
+    def _role_perm():
+        user = store.get_user(username)
+        workspace_name = _get_resource_workspace(
+            name, _get_model_registry_store().get_registered_model, "registered model"
+        )
+        if workspace_name is None:
+            return None
+        return store.get_role_permission_for_resource(
+            user.id, "registered_model", name, workspace_name
+        )
+
     return _get_permission_from_store_or_default(
         lambda: store.get_registered_model_permission(name, username).permission,
         workspace_level_permission_func=lambda: _workspace_permission_for_registered_model(
             username, name
         ),
+        role_permission_func=_role_perm,
     )
 
 
@@ -690,11 +753,24 @@ def _get_permission_from_scorer_name() -> Permission:
     experiment_id = _get_request_param("experiment_id")
     name = _get_request_param("name")
     username = authenticate_request().username
+
+    def _role_perm():
+        user = store.get_user(username)
+        workspace_name = _get_resource_workspace(
+            experiment_id, _get_tracking_store().get_experiment, "experiment"
+        )
+        if workspace_name is None:
+            return None
+        return store.get_role_permission_for_resource(
+            user.id, "scorer", f"{experiment_id}/{name}", workspace_name
+        )
+
     return _get_permission_from_store_or_default(
         lambda: store.get_scorer_permission(experiment_id, name, username).permission,
         workspace_level_permission_func=lambda: _workspace_permission_for_experiment(
             username, experiment_id
         ),
+        role_permission_func=_role_perm,
     )
 
 
@@ -702,11 +778,24 @@ def _get_permission_from_scorer_permission_request() -> Permission:
     experiment_id = _get_request_param("experiment_id")
     scorer_name = _get_request_param("scorer_name")
     username = authenticate_request().username
+
+    def _role_perm():
+        user = store.get_user(username)
+        workspace_name = _get_resource_workspace(
+            experiment_id, _get_tracking_store().get_experiment, "experiment"
+        )
+        if workspace_name is None:
+            return None
+        return store.get_role_permission_for_resource(
+            user.id, "scorer", f"{experiment_id}/{scorer_name}", workspace_name
+        )
+
     return _get_permission_from_store_or_default(
         lambda: store.get_scorer_permission(experiment_id, scorer_name, username).permission,
         workspace_level_permission_func=lambda: _workspace_permission_for_experiment(
             username, experiment_id
         ),
+        role_permission_func=_role_perm,
     )
 
 
@@ -770,28 +859,74 @@ def _workspace_permission_for_gateway_model_definition(
 def _get_permission_from_gateway_secret_id() -> Permission:
     secret_id = _get_request_param("secret_id")
     username = authenticate_request().username
+
+    def _role_perm():
+        user = store.get_user(username)
+        workspace_name = _get_resource_workspace(
+            secret_id,
+            lambda sid: _get_tracking_store().get_secret_info(secret_id=sid),
+            "gateway secret",
+        )
+        if workspace_name is None:
+            return None
+        return store.get_role_permission_for_resource(
+            user.id, "gateway_secret", secret_id, workspace_name
+        )
+
     return _get_permission_from_store_or_default(
         lambda: store.get_gateway_secret_permission(secret_id, username).permission,
         workspace_level_permission_func=lambda: _workspace_permission_for_gateway_secret(
             username, secret_id
         ),
+        role_permission_func=_role_perm,
     )
 
 
 def _get_permission_from_gateway_endpoint_id() -> Permission:
     endpoint_id = _get_request_param("endpoint_id")
     username = authenticate_request().username
+
+    def _role_perm():
+        user = store.get_user(username)
+        workspace_name = _get_resource_workspace(
+            endpoint_id,
+            lambda eid: _get_tracking_store().get_gateway_endpoint(endpoint_id=eid),
+            "gateway endpoint",
+        )
+        if workspace_name is None:
+            return None
+        return store.get_role_permission_for_resource(
+            user.id, "gateway_endpoint", endpoint_id, workspace_name
+        )
+
     return _get_permission_from_store_or_default(
         lambda: store.get_gateway_endpoint_permission(endpoint_id, username).permission,
         workspace_level_permission_func=lambda: _workspace_permission_for_gateway_endpoint(
             username, endpoint_id
         ),
+        role_permission_func=_role_perm,
     )
 
 
 def _get_permission_from_gateway_model_definition_id() -> Permission:
     model_definition_id = _get_request_param("model_definition_id")
     username = authenticate_request().username
+
+    def _role_perm():
+        user = store.get_user(username)
+        workspace_name = _get_resource_workspace(
+            model_definition_id,
+            lambda mdid: _get_tracking_store().get_gateway_model_definition(
+                model_definition_id=mdid
+            ),
+            "gateway model definition",
+        )
+        if workspace_name is None:
+            return None
+        return store.get_role_permission_for_resource(
+            user.id, "gateway_model_definition", model_definition_id, workspace_name
+        )
+
     return _get_permission_from_store_or_default(
         lambda: (
             store.get_gateway_model_definition_permission(model_definition_id, username).permission
@@ -799,6 +934,7 @@ def _get_permission_from_gateway_model_definition_id() -> Permission:
         workspace_level_permission_func=lambda: _workspace_permission_for_gateway_model_definition(
             username, model_definition_id
         ),
+        role_permission_func=_role_perm,
     )
 
 
@@ -1022,6 +1158,53 @@ def sender_is_admin():
     return store.get_user(username).is_admin
 
 
+def _is_workspace_admin(username: str, workspace: str) -> bool:
+    user = store.get_user(username)
+    roles = store.list_user_roles_for_workspace(user.id, workspace)
+    return any(r.is_workspace_admin for r in roles)
+
+
+def _get_role_workspace_from_request() -> str:
+    if role_id := _get_request_param("role_id"):
+        role = store.get_role(int(role_id))
+        return role.workspace
+    return _get_request_param("workspace")
+
+
+def validate_can_manage_roles():
+    username = authenticate_request().username
+    if store.get_user(username).is_admin:
+        return True
+    workspace = _get_role_workspace_from_request()
+    return _is_workspace_admin(username, workspace)
+
+
+def validate_can_view_roles():
+    username = authenticate_request().username
+    user = store.get_user(username)
+    if user.is_admin:
+        return True
+    workspace = _get_role_workspace_from_request()
+    roles = store.list_user_roles_for_workspace(user.id, workspace)
+    return len(roles) > 0
+
+
+def validate_can_view_user_roles():
+    username = authenticate_request().username
+    user = store.get_user(username)
+    if user.is_admin:
+        return True
+    target_username = _get_request_param("username")
+    if username == target_username:
+        return True
+    # WP admins can view user roles for users in their workspaces
+    all_target_roles = store.list_user_roles(store.get_user(target_username).id)
+    for role in all_target_roles:
+        if _is_workspace_admin(username, role.workspace):
+            return True
+    return False
+
+
 def filter_experiment_ids(experiment_ids: list[str]) -> list[str]:
     """
     Filter experiment IDs to only include those the user has read access to.
@@ -1046,6 +1229,7 @@ def filter_experiment_ids(experiment_ids: list[str]) -> list[str]:
             return experiment_ids
 
         username = authenticate_request().username
+        user = store.get_user(username)
         perms = store.list_experiment_permissions(username)
         can_read = {p.experiment_id: get_permission(p.permission).can_read for p in perms}
         default_can_read = get_permission(auth_config.default_permission).can_read
@@ -1060,6 +1244,14 @@ def filter_experiment_ids(experiment_ids: list[str]) -> list[str]:
         workspace_perm = (
             _workspace_permission(username, workspace_name) if workspace_name else NO_PERMISSIONS
         )
+
+        # Check if user has a wildcard experiment role in the active workspace
+        if workspace_name:
+            role_perm = store.get_role_permission_for_resource(
+                user.id, "experiment", "*", workspace_name
+            )
+            if role_perm is not None and role_perm.can_read:
+                return experiment_ids
 
         return [
             exp_id for exp_id in experiment_ids if can_read.get(exp_id, workspace_perm.can_read)
@@ -1621,6 +1813,24 @@ BEFORE_REQUEST_VALIDATORS.update({
     ): validate_can_manage_gateway_model_definition,
 })
 
+# Role management routes (RBAC)
+BEFORE_REQUEST_VALIDATORS.update({
+    (CREATE_ROLE, "POST"): validate_can_manage_roles,
+    (GET_ROLE, "GET"): validate_can_view_roles,
+    (LIST_ROLES, "GET"): validate_can_view_roles,
+    (UPDATE_ROLE, "PATCH"): validate_can_manage_roles,
+    (DELETE_ROLE, "DELETE"): validate_can_manage_roles,
+    (ADD_ROLE_PERMISSION, "POST"): validate_can_manage_roles,
+    (REMOVE_ROLE_PERMISSION, "DELETE"): validate_can_manage_roles,
+    (LIST_ROLE_PERMISSIONS, "GET"): validate_can_view_roles,
+    (UPDATE_ROLE_PERMISSION, "PATCH"): validate_can_manage_roles,
+    (ASSIGN_ROLE, "POST"): validate_can_manage_roles,
+    (UNASSIGN_ROLE, "DELETE"): validate_can_manage_roles,
+    (LIST_USER_ROLES, "GET"): validate_can_view_user_roles,
+    (LIST_ROLE_USERS, "GET"): validate_can_manage_roles,
+    (LIST_ALL_ROLES, "GET"): sender_is_admin,
+})
+
 # Flask routes (no proto mapping)
 BEFORE_REQUEST_VALIDATORS.update({
     (GET_ARTIFACT, "GET"): validate_can_read_run_artifact,
@@ -1934,6 +2144,122 @@ def list_user_workspace_permissions():
     return jsonify({"permissions": [perm.to_json() for perm in permissions]})
 
 
+# ---- Role management handlers (RBAC) ----
+
+
+@catch_mlflow_exception
+def create_role():
+    name = _get_request_param("name")
+    workspace = _get_request_param("workspace")
+    body = request.json or {}
+    description = body.get("description")
+    is_workspace_admin = body.get("is_workspace_admin", False)
+    role = store.create_role(name, workspace, description, is_workspace_admin)
+    return jsonify({"role": role.to_json()})
+
+
+@catch_mlflow_exception
+def get_role():
+    role_id = int(_get_request_param("role_id"))
+    role = store.get_role(role_id)
+    return jsonify({"role": role.to_json()})
+
+
+@catch_mlflow_exception
+def list_roles():
+    workspace = _get_request_param("workspace")
+    roles = store.list_roles(workspace)
+    return jsonify({"roles": [r.to_json() for r in roles]})
+
+
+@catch_mlflow_exception
+def update_role():
+    role_id = int(_get_request_param("role_id"))
+    body = request.json or {}
+    name = body.get("name")
+    description = body.get("description")
+    role = store.update_role(role_id, name=name, description=description)
+    return jsonify({"role": role.to_json()})
+
+
+@catch_mlflow_exception
+def delete_role():
+    role_id = int(_get_request_param("role_id"))
+    store.delete_role(role_id)
+    return make_response({})
+
+
+@catch_mlflow_exception
+def add_role_permission():
+    role_id = int(_get_request_param("role_id"))
+    resource_type = _get_request_param("resource_type")
+    resource_pattern = _get_request_param("resource_pattern")
+    permission = _get_request_param("permission")
+    rp = store.add_role_permission(role_id, resource_type, resource_pattern, permission)
+    return jsonify({"role_permission": rp.to_json()})
+
+
+@catch_mlflow_exception
+def remove_role_permission():
+    role_permission_id = int(_get_request_param("role_permission_id"))
+    store.remove_role_permission(role_permission_id)
+    return make_response({})
+
+
+@catch_mlflow_exception
+def list_role_permissions():
+    role_id = int(_get_request_param("role_id"))
+    perms = store.list_role_permissions(role_id)
+    return jsonify({"role_permissions": [p.to_json() for p in perms]})
+
+
+@catch_mlflow_exception
+def update_role_permission():
+    role_permission_id = int(_get_request_param("role_permission_id"))
+    permission = _get_request_param("permission")
+    rp = store.update_role_permission(role_permission_id, permission)
+    return jsonify({"role_permission": rp.to_json()})
+
+
+@catch_mlflow_exception
+def assign_role():
+    username = _get_request_param("username")
+    role_id = int(_get_request_param("role_id"))
+    user = store.get_user(username)
+    assignment = store.assign_role_to_user(user.id, role_id)
+    return jsonify({"assignment": assignment.to_json()})
+
+
+@catch_mlflow_exception
+def unassign_role():
+    username = _get_request_param("username")
+    role_id = int(_get_request_param("role_id"))
+    user = store.get_user(username)
+    store.unassign_role_from_user(user.id, role_id)
+    return make_response({})
+
+
+@catch_mlflow_exception
+def list_user_roles():
+    username = _get_request_param("username")
+    user = store.get_user(username)
+    roles = store.list_user_roles(user.id)
+    return jsonify({"roles": [r.to_json() for r in roles]})
+
+
+@catch_mlflow_exception
+def list_role_users():
+    role_id = int(_get_request_param("role_id"))
+    assignments = store.list_role_users(role_id)
+    return jsonify({"assignments": [a.to_json() for a in assignments]})
+
+
+@catch_mlflow_exception
+def list_all_roles():
+    roles = store.list_all_roles()
+    return jsonify({"roles": [r.to_json() for r in roles]})
+
+
 def filter_list_workspaces(resp: Response) -> None:
     if sender_is_admin():
         return
@@ -1969,6 +2295,15 @@ def _cleanup_workspace_permissions(resp: Response) -> None:
     except MlflowException as e:
         _logger.error(
             "Failed to delete workspace permissions for workspace '%s': %s",
+            workspace_name,
+            e,
+        )
+
+    try:
+        store.delete_roles_for_workspace(workspace_name)
+    except MlflowException as e:
+        _logger.error(
+            "Failed to delete roles for workspace '%s': %s",
             workspace_name,
             e,
         )
@@ -3426,6 +3761,25 @@ def create_app(app: Flask = app):
         view_func=list_user_workspace_permissions,
         methods=["GET"],
     )
+    # Role management routes (RBAC)
+    app.add_url_rule(rule=CREATE_ROLE, view_func=create_role, methods=["POST"])
+    app.add_url_rule(rule=GET_ROLE, view_func=get_role, methods=["GET"])
+    app.add_url_rule(rule=LIST_ROLES, view_func=list_roles, methods=["GET"])
+    app.add_url_rule(rule=UPDATE_ROLE, view_func=update_role, methods=["PATCH"])
+    app.add_url_rule(rule=DELETE_ROLE, view_func=delete_role, methods=["DELETE"])
+    app.add_url_rule(rule=ADD_ROLE_PERMISSION, view_func=add_role_permission, methods=["POST"])
+    app.add_url_rule(
+        rule=REMOVE_ROLE_PERMISSION, view_func=remove_role_permission, methods=["DELETE"]
+    )
+    app.add_url_rule(rule=LIST_ROLE_PERMISSIONS, view_func=list_role_permissions, methods=["GET"])
+    app.add_url_rule(
+        rule=UPDATE_ROLE_PERMISSION, view_func=update_role_permission, methods=["PATCH"]
+    )
+    app.add_url_rule(rule=ASSIGN_ROLE, view_func=assign_role, methods=["POST"])
+    app.add_url_rule(rule=UNASSIGN_ROLE, view_func=unassign_role, methods=["DELETE"])
+    app.add_url_rule(rule=LIST_USER_ROLES, view_func=list_user_roles, methods=["GET"])
+    app.add_url_rule(rule=LIST_ROLE_USERS, view_func=list_role_users, methods=["GET"])
+    app.add_url_rule(rule=LIST_ALL_ROLES, view_func=list_all_roles, methods=["GET"])
 
     app.before_request(_before_request)
     app.after_request(_after_request)

--- a/mlflow/server/auth/client.py
+++ b/mlflow/server/auth/client.py
@@ -6,16 +6,22 @@ from mlflow.server.auth.entities import (
     GatewayModelDefinitionPermission,
     GatewaySecretPermission,
     RegisteredModelPermission,
+    Role,
+    RolePermission,
     ScorerPermission,
     User,
+    UserRoleAssignment,
     WorkspacePermission,
 )
 from mlflow.server.auth.routes import (
+    ADD_ROLE_PERMISSION,
+    ASSIGN_ROLE,
     CREATE_EXPERIMENT_PERMISSION,
     CREATE_GATEWAY_ENDPOINT_PERMISSION,
     CREATE_GATEWAY_MODEL_DEFINITION_PERMISSION,
     CREATE_GATEWAY_SECRET_PERMISSION,
     CREATE_REGISTERED_MODEL_PERMISSION,
+    CREATE_ROLE,
     CREATE_SCORER_PERMISSION,
     CREATE_USER,
     DELETE_EXPERIMENT_PERMISSION,
@@ -23,6 +29,7 @@ from mlflow.server.auth.routes import (
     DELETE_GATEWAY_MODEL_DEFINITION_PERMISSION,
     DELETE_GATEWAY_SECRET_PERMISSION,
     DELETE_REGISTERED_MODEL_PERMISSION,
+    DELETE_ROLE,
     DELETE_SCORER_PERMISSION,
     DELETE_USER,
     GET_EXPERIMENT_PERMISSION,
@@ -30,15 +37,25 @@ from mlflow.server.auth.routes import (
     GET_GATEWAY_MODEL_DEFINITION_PERMISSION,
     GET_GATEWAY_SECRET_PERMISSION,
     GET_REGISTERED_MODEL_PERMISSION,
+    GET_ROLE,
     GET_SCORER_PERMISSION,
     GET_USER,
+    LIST_ALL_ROLES,
+    LIST_ROLE_PERMISSIONS,
+    LIST_ROLE_USERS,
+    LIST_ROLES,
+    LIST_USER_ROLES,
     LIST_USER_WORKSPACE_PERMISSIONS,
     LIST_WORKSPACE_PERMISSIONS,
+    REMOVE_ROLE_PERMISSION,
+    UNASSIGN_ROLE,
     UPDATE_EXPERIMENT_PERMISSION,
     UPDATE_GATEWAY_ENDPOINT_PERMISSION,
     UPDATE_GATEWAY_MODEL_DEFINITION_PERMISSION,
     UPDATE_GATEWAY_SECRET_PERMISSION,
     UPDATE_REGISTERED_MODEL_PERMISSION,
+    UPDATE_ROLE,
+    UPDATE_ROLE_PERMISSION,
     UPDATE_SCORER_PERMISSION,
     UPDATE_USER_ADMIN,
     UPDATE_USER_PASSWORD,
@@ -990,3 +1007,91 @@ class AuthServiceClient:
             params={"username": username},
         )
         return [WorkspacePermission.from_json(p) for p in resp["permissions"]]
+
+    # ---- Role management (RBAC) ----
+
+    def create_role(
+        self,
+        workspace: str,
+        name: str,
+        description: str | None = None,
+        is_workspace_admin: bool = False,
+    ) -> Role:
+        payload = {"workspace": workspace, "name": name, "is_workspace_admin": is_workspace_admin}
+        if description is not None:
+            payload["description"] = description
+        resp = self._request(CREATE_ROLE, "POST", json=payload)
+        return Role.from_json(resp["role"])
+
+    def get_role(self, role_id: int) -> Role:
+        resp = self._request(GET_ROLE, "GET", params={"role_id": str(role_id)})
+        return Role.from_json(resp["role"])
+
+    def list_roles(self, workspace: str) -> list[Role]:
+        resp = self._request(LIST_ROLES, "GET", params={"workspace": workspace})
+        return [Role.from_json(r) for r in resp["roles"]]
+
+    def update_role(
+        self, role_id: int, name: str | None = None, description: str | None = None
+    ) -> Role:
+        payload: dict[str, object] = {"role_id": role_id}
+        if name is not None:
+            payload["name"] = name
+        if description is not None:
+            payload["description"] = description
+        resp = self._request(UPDATE_ROLE, "PATCH", json=payload)
+        return Role.from_json(resp["role"])
+
+    def delete_role(self, role_id: int) -> None:
+        self._request(DELETE_ROLE, "DELETE", json={"role_id": role_id})
+
+    def add_role_permission(
+        self, role_id: int, resource_type: str, resource_pattern: str, permission: str
+    ) -> RolePermission:
+        resp = self._request(
+            ADD_ROLE_PERMISSION,
+            "POST",
+            json={
+                "role_id": role_id,
+                "resource_type": resource_type,
+                "resource_pattern": resource_pattern,
+                "permission": permission,
+            },
+        )
+        return RolePermission.from_json(resp["role_permission"])
+
+    def remove_role_permission(self, role_permission_id: int) -> None:
+        self._request(
+            REMOVE_ROLE_PERMISSION, "DELETE", json={"role_permission_id": role_permission_id}
+        )
+
+    def list_role_permissions(self, role_id: int) -> list[RolePermission]:
+        resp = self._request(LIST_ROLE_PERMISSIONS, "GET", params={"role_id": str(role_id)})
+        return [RolePermission.from_json(p) for p in resp["role_permissions"]]
+
+    def update_role_permission(self, role_permission_id: int, permission: str) -> RolePermission:
+        resp = self._request(
+            UPDATE_ROLE_PERMISSION,
+            "PATCH",
+            json={"role_permission_id": role_permission_id, "permission": permission},
+        )
+        return RolePermission.from_json(resp["role_permission"])
+
+    def assign_role(self, username: str, role_id: int) -> UserRoleAssignment:
+        resp = self._request(ASSIGN_ROLE, "POST", json={"username": username, "role_id": role_id})
+        return UserRoleAssignment.from_json(resp["assignment"])
+
+    def unassign_role(self, username: str, role_id: int) -> None:
+        self._request(UNASSIGN_ROLE, "DELETE", json={"username": username, "role_id": role_id})
+
+    def list_user_roles(self, username: str) -> list[Role]:
+        resp = self._request(LIST_USER_ROLES, "GET", params={"username": username})
+        return [Role.from_json(r) for r in resp["roles"]]
+
+    def list_role_users(self, role_id: int) -> list[UserRoleAssignment]:
+        resp = self._request(LIST_ROLE_USERS, "GET", params={"role_id": str(role_id)})
+        return [UserRoleAssignment.from_json(a) for a in resp["assignments"]]
+
+    def list_all_roles(self) -> list[Role]:
+        resp = self._request(LIST_ALL_ROLES, "GET")
+        return [Role.from_json(r) for r in resp["roles"]]

--- a/mlflow/server/auth/db/migrations/versions/c3d4e5f6a7b8_add_rbac_tables.py
+++ b/mlflow/server/auth/db/migrations/versions/c3d4e5f6a7b8_add_rbac_tables.py
@@ -1,0 +1,66 @@
+"""Add RBAC tables (roles, role_permissions, user_role_assignments)
+
+Revision ID: c3d4e5f6a7b8
+Revises: 2ed73881770d
+Create Date: 2026-04-20 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c3d4e5f6a7b8"
+down_revision = "2ed73881770d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "roles",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("workspace", sa.String(length=63), nullable=False),
+        sa.Column("description", sa.String(length=1024), nullable=True),
+        sa.Column("is_workspace_admin", sa.Boolean(), server_default=sa.text("0")),
+        sa.UniqueConstraint("workspace", "name", name="unique_workspace_role_name"),
+    )
+    op.create_index("idx_roles_workspace", "roles", ["workspace"], unique=False)
+
+    op.create_table(
+        "role_permissions",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("role_id", sa.Integer(), sa.ForeignKey("roles.id"), nullable=False),
+        sa.Column("resource_type", sa.String(length=64), nullable=False),
+        sa.Column("resource_pattern", sa.String(length=255), nullable=False),
+        sa.Column("permission", sa.String(length=255), nullable=False),
+        sa.UniqueConstraint(
+            "role_id", "resource_type", "resource_pattern", name="unique_role_resource_perm"
+        ),
+    )
+    op.create_index("idx_role_permissions_role_id", "role_permissions", ["role_id"], unique=False)
+
+    op.create_table(
+        "user_role_assignments",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("role_id", sa.Integer(), sa.ForeignKey("roles.id"), nullable=False),
+        sa.UniqueConstraint("user_id", "role_id", name="unique_user_role"),
+    )
+    op.create_index(
+        "idx_user_role_assignments_user_id", "user_role_assignments", ["user_id"], unique=False
+    )
+    op.create_index(
+        "idx_user_role_assignments_role_id", "user_role_assignments", ["role_id"], unique=False
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_user_role_assignments_role_id", table_name="user_role_assignments")
+    op.drop_index("idx_user_role_assignments_user_id", table_name="user_role_assignments")
+    op.drop_table("user_role_assignments")
+    op.drop_index("idx_role_permissions_role_id", table_name="role_permissions")
+    op.drop_table("role_permissions")
+    op.drop_index("idx_roles_workspace", table_name="roles")
+    op.drop_table("roles")

--- a/mlflow/server/auth/db/models.py
+++ b/mlflow/server/auth/db/models.py
@@ -17,6 +17,8 @@ from mlflow.server.auth.entities import (
     GatewayModelDefinitionPermission,
     GatewaySecretPermission,
     RegisteredModelPermission,
+    Role,
+    RolePermission,
     ScorerPermission,
     User,
     WorkspacePermission,
@@ -179,3 +181,69 @@ class SqlWorkspacePermission(Base):
             user_id=self.user_id,
             permission=self.permission,
         )
+
+
+class SqlRole(Base):
+    __tablename__ = "roles"
+
+    id = Column(Integer(), primary_key=True)
+    name = Column(String(255), nullable=False)
+    workspace = Column(String(63), nullable=False)
+    description = Column(String(1024), nullable=True)
+    is_workspace_admin = Column(Boolean, default=False)
+    permissions = relationship("SqlRolePermission", backref="role", cascade="all, delete-orphan")
+    user_assignments = relationship(
+        "SqlUserRoleAssignment", backref="role", cascade="all, delete-orphan"
+    )
+    __table_args__ = (
+        UniqueConstraint("workspace", "name", name="unique_workspace_role_name"),
+        Index("idx_roles_workspace", "workspace"),
+    )
+
+    def to_mlflow_entity(self):
+        return Role(
+            id_=self.id,
+            name=self.name,
+            workspace=self.workspace,
+            description=self.description,
+            is_workspace_admin=self.is_workspace_admin,
+            permissions=[p.to_mlflow_entity() for p in self.permissions],
+        )
+
+
+class SqlRolePermission(Base):
+    __tablename__ = "role_permissions"
+
+    id = Column(Integer(), primary_key=True)
+    role_id = Column(Integer, ForeignKey("roles.id"), nullable=False)
+    resource_type = Column(String(64), nullable=False)
+    resource_pattern = Column(String(255), nullable=False)
+    permission = Column(String(255), nullable=False)
+    __table_args__ = (
+        UniqueConstraint(
+            "role_id", "resource_type", "resource_pattern", name="unique_role_resource_perm"
+        ),
+        Index("idx_role_permissions_role_id", "role_id"),
+    )
+
+    def to_mlflow_entity(self):
+        return RolePermission(
+            id_=self.id,
+            role_id=self.role_id,
+            resource_type=self.resource_type,
+            resource_pattern=self.resource_pattern,
+            permission=self.permission,
+        )
+
+
+class SqlUserRoleAssignment(Base):
+    __tablename__ = "user_role_assignments"
+
+    id = Column(Integer(), primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    role_id = Column(Integer, ForeignKey("roles.id"), nullable=False)
+    __table_args__ = (
+        UniqueConstraint("user_id", "role_id", name="unique_user_role"),
+        Index("idx_user_role_assignments_user_id", "user_id"),
+        Index("idx_user_role_assignments_role_id", "role_id"),
+    )

--- a/mlflow/server/auth/entities.py
+++ b/mlflow/server/auth/entities.py
@@ -1,6 +1,6 @@
 from mlflow.exceptions import MlflowException
 from mlflow.server.auth.permissions import get_permission
-from mlflow.utils.workspace_utils import resolve_entity_workspace_name
+from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME, resolve_entity_workspace_name
 
 
 class User:
@@ -354,6 +354,163 @@ class GatewayModelDefinitionPermission:
             model_definition_id=dictionary["model_definition_id"],
             user_id=dictionary["user_id"],
             permission=dictionary["permission"],
+        )
+
+
+class Role:
+    def __init__(
+        self,
+        id_,
+        name,
+        workspace,
+        description=None,
+        is_workspace_admin=False,
+        permissions=None,
+    ):
+        self._id = id_
+        self._name = name
+        self._workspace = workspace
+        self._description = description
+        self._is_workspace_admin = is_workspace_admin
+        self._permissions = permissions or []
+
+    @property
+    def id(self):
+        return self._id
+
+    @property
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        self._name = name
+
+    @property
+    def workspace(self):
+        return self._workspace
+
+    @property
+    def description(self):
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        self._description = description
+
+    @property
+    def is_workspace_admin(self):
+        return self._is_workspace_admin
+
+    @property
+    def permissions(self):
+        return self._permissions
+
+    def to_json(self):
+        return {
+            "id": self.id,
+            "name": self.name,
+            "workspace": self.workspace,
+            "description": self.description,
+            "is_workspace_admin": self.is_workspace_admin,
+            "permissions": [p.to_json() for p in self.permissions],
+        }
+
+    @classmethod
+    def from_json(cls, dictionary):
+        return cls(
+            id_=dictionary["id"],
+            name=dictionary["name"],
+            workspace=dictionary.get("workspace", DEFAULT_WORKSPACE_NAME),
+            description=dictionary.get("description"),
+            is_workspace_admin=dictionary.get("is_workspace_admin", False),
+            permissions=[RolePermission.from_json(p) for p in dictionary.get("permissions", [])],
+        )
+
+
+class RolePermission:
+    def __init__(self, id_, role_id, resource_type, resource_pattern, permission):
+        self._id = id_
+        self._role_id = role_id
+        self._resource_type = resource_type
+        self._resource_pattern = resource_pattern
+        self._permission = permission
+
+    @property
+    def id(self):
+        return self._id
+
+    @property
+    def role_id(self):
+        return self._role_id
+
+    @property
+    def resource_type(self):
+        return self._resource_type
+
+    @property
+    def resource_pattern(self):
+        return self._resource_pattern
+
+    @property
+    def permission(self):
+        return self._permission
+
+    @permission.setter
+    def permission(self, permission):
+        self._permission = permission
+
+    def to_json(self):
+        return {
+            "id": self.id,
+            "role_id": self.role_id,
+            "resource_type": self.resource_type,
+            "resource_pattern": self.resource_pattern,
+            "permission": self.permission,
+        }
+
+    @classmethod
+    def from_json(cls, dictionary):
+        return cls(
+            id_=dictionary["id"],
+            role_id=dictionary["role_id"],
+            resource_type=dictionary["resource_type"],
+            resource_pattern=dictionary["resource_pattern"],
+            permission=dictionary["permission"],
+        )
+
+
+class UserRoleAssignment:
+    def __init__(self, id_, user_id, role_id):
+        self._id = id_
+        self._user_id = user_id
+        self._role_id = role_id
+
+    @property
+    def id(self):
+        return self._id
+
+    @property
+    def user_id(self):
+        return self._user_id
+
+    @property
+    def role_id(self):
+        return self._role_id
+
+    def to_json(self):
+        return {
+            "id": self.id,
+            "user_id": self.user_id,
+            "role_id": self.role_id,
+        }
+
+    @classmethod
+    def from_json(cls, dictionary):
+        return cls(
+            id_=dictionary["id"],
+            user_id=dictionary["user_id"],
+            role_id=dictionary["role_id"],
         )
 
 

--- a/mlflow/server/auth/permissions.py
+++ b/mlflow/server/auth/permissions.py
@@ -72,9 +72,40 @@ def get_permission(permission: str) -> Permission:
     return ALL_PERMISSIONS[permission]
 
 
+PERMISSION_PRIORITY = {
+    NO_PERMISSIONS.name: 0,
+    READ.name: 1,
+    USE.name: 2,
+    EDIT.name: 3,
+    MANAGE.name: 4,
+}
+
+VALID_RESOURCE_TYPES = frozenset({
+    "experiment",
+    "registered_model",
+    "scorer",
+    "gateway_secret",
+    "gateway_endpoint",
+    "gateway_model_definition",
+})
+
+
 def _validate_permission(permission: str):
     if permission not in ALL_PERMISSIONS:
         raise MlflowException(
             f"Invalid permission '{permission}'. Valid permissions are: {tuple(ALL_PERMISSIONS)}",
             INVALID_PARAMETER_VALUE,
         )
+
+
+def _validate_resource_type(resource_type: str):
+    if resource_type not in VALID_RESOURCE_TYPES:
+        raise MlflowException(
+            f"Invalid resource type '{resource_type}'. "
+            f"Valid resource types are: {tuple(sorted(VALID_RESOURCE_TYPES))}",
+            INVALID_PARAMETER_VALUE,
+        )
+
+
+def max_permission(a: str, b: str) -> str:
+    return a if PERMISSION_PRIORITY.get(a, 0) >= PERMISSION_PRIORITY.get(b, 0) else b

--- a/mlflow/server/auth/routes.py
+++ b/mlflow/server/auth/routes.py
@@ -76,6 +76,22 @@ DELETE_GATEWAY_MODEL_DEFINITION_PERMISSION = _get_rest_path(
     "/mlflow/gateway/model-definitions/permissions/delete", version=3
 )
 
+# Role management routes (RBAC)
+CREATE_ROLE = _get_rest_path("/mlflow/roles/create", version=3)
+GET_ROLE = _get_rest_path("/mlflow/roles/get", version=3)
+LIST_ROLES = _get_rest_path("/mlflow/roles/list", version=3)
+UPDATE_ROLE = _get_rest_path("/mlflow/roles/update", version=3)
+DELETE_ROLE = _get_rest_path("/mlflow/roles/delete", version=3)
+ADD_ROLE_PERMISSION = _get_rest_path("/mlflow/roles/permissions/add", version=3)
+REMOVE_ROLE_PERMISSION = _get_rest_path("/mlflow/roles/permissions/remove", version=3)
+LIST_ROLE_PERMISSIONS = _get_rest_path("/mlflow/roles/permissions/list", version=3)
+UPDATE_ROLE_PERMISSION = _get_rest_path("/mlflow/roles/permissions/update", version=3)
+ASSIGN_ROLE = _get_rest_path("/mlflow/roles/assign", version=3)
+UNASSIGN_ROLE = _get_rest_path("/mlflow/roles/unassign", version=3)
+LIST_USER_ROLES = _get_rest_path("/mlflow/users/roles/list", version=3)
+LIST_ROLE_USERS = _get_rest_path("/mlflow/roles/users/list", version=3)
+LIST_ALL_ROLES = _get_rest_path("/mlflow/admin/roles/list", version=3)
+
 # Gateway AJAX-only routes
 GATEWAY_SUPPORTED_PROVIDERS = _get_ajax_path("/mlflow/gateway/supported-providers", version=3)
 GATEWAY_SUPPORTED_MODELS = _get_ajax_path("/mlflow/gateway/supported-models", version=3)

--- a/mlflow/server/auth/sqlalchemy_store.py
+++ b/mlflow/server/auth/sqlalchemy_store.py
@@ -16,8 +16,11 @@ from mlflow.server.auth.db.models import (
     SqlGatewayModelDefinitionPermission,
     SqlGatewaySecretPermission,
     SqlRegisteredModelPermission,
+    SqlRole,
+    SqlRolePermission,
     SqlScorerPermission,
     SqlUser,
+    SqlUserRoleAssignment,
     SqlWorkspacePermission,
 )
 from mlflow.server.auth.entities import (
@@ -26,11 +29,21 @@ from mlflow.server.auth.entities import (
     GatewayModelDefinitionPermission,
     GatewaySecretPermission,
     RegisteredModelPermission,
+    Role,
+    RolePermission,
     ScorerPermission,
     User,
+    UserRoleAssignment,
     WorkspacePermission,
 )
-from mlflow.server.auth.permissions import Permission, _validate_permission, get_permission
+from mlflow.server.auth.permissions import (
+    MANAGE,
+    Permission,
+    _validate_permission,
+    _validate_resource_type,
+    get_permission,
+    max_permission,
+)
 from mlflow.store.db.utils import _get_managed_session_maker, create_sqlalchemy_engine_with_retry
 from mlflow.utils import workspace_context
 from mlflow.utils.uri import extract_db_type_from_uri
@@ -782,3 +795,305 @@ class SqlAlchemyStore:
             session.query(SqlGatewayModelDefinitionPermission).filter(
                 SqlGatewayModelDefinitionPermission.model_definition_id == model_definition_id,
             ).delete()
+
+    # ---- Role CRUD ----
+
+    def create_role(
+        self,
+        name: str,
+        workspace: str,
+        description: str | None = None,
+        is_workspace_admin: bool = False,
+    ) -> Role:
+        with self.ManagedSessionMaker() as session:
+            try:
+                role = SqlRole(
+                    name=name,
+                    workspace=workspace,
+                    description=description,
+                    is_workspace_admin=is_workspace_admin,
+                )
+                session.add(role)
+                session.flush()
+                return role.to_mlflow_entity()
+            except IntegrityError as e:
+                raise MlflowException(
+                    f"Role (name={name}, workspace={workspace}) already exists. Error: {e}",
+                    RESOURCE_ALREADY_EXISTS,
+                ) from e
+
+    @staticmethod
+    def _get_role(session, role_id: int) -> SqlRole:
+        try:
+            return session.query(SqlRole).filter(SqlRole.id == role_id).one()
+        except NoResultFound:
+            raise MlflowException(
+                f"Role with id={role_id} not found",
+                RESOURCE_DOES_NOT_EXIST,
+            )
+
+    @staticmethod
+    def _get_role_by_name(session, workspace: str, name: str) -> SqlRole:
+        try:
+            return (
+                session
+                .query(SqlRole)
+                .filter(SqlRole.workspace == workspace, SqlRole.name == name)
+                .one()
+            )
+        except NoResultFound:
+            raise MlflowException(
+                f"Role with name={name} in workspace={workspace} not found",
+                RESOURCE_DOES_NOT_EXIST,
+            )
+
+    def get_role(self, role_id: int) -> Role:
+        with self.ManagedSessionMaker() as session:
+            return self._get_role(session, role_id).to_mlflow_entity()
+
+    def get_role_by_name(self, workspace: str, name: str) -> Role:
+        with self.ManagedSessionMaker() as session:
+            return self._get_role_by_name(session, workspace, name).to_mlflow_entity()
+
+    def list_roles(self, workspace: str) -> list[Role]:
+        with self.ManagedSessionMaker() as session:
+            roles = session.query(SqlRole).filter(SqlRole.workspace == workspace).all()
+            return [r.to_mlflow_entity() for r in roles]
+
+    def list_all_roles(self) -> list[Role]:
+        with self.ManagedSessionMaker() as session:
+            roles = session.query(SqlRole).all()
+            return [r.to_mlflow_entity() for r in roles]
+
+    def update_role(
+        self,
+        role_id: int,
+        name: str | None = None,
+        description: str | None = None,
+    ) -> Role:
+        with self.ManagedSessionMaker() as session:
+            role = self._get_role(session, role_id)
+            if name is not None:
+                # Check for name conflicts before updating
+                existing = (
+                    session
+                    .query(SqlRole)
+                    .filter(
+                        SqlRole.workspace == role.workspace,
+                        SqlRole.name == name,
+                        SqlRole.id != role_id,
+                    )
+                    .first()
+                )
+                if existing is not None:
+                    raise MlflowException(
+                        f"Role with name={name} already exists in workspace={role.workspace}",
+                        RESOURCE_ALREADY_EXISTS,
+                    )
+                role.name = name
+            if description is not None:
+                role.description = description
+            return role.to_mlflow_entity()
+
+    def delete_role(self, role_id: int) -> None:
+        with self.ManagedSessionMaker() as session:
+            role = self._get_role(session, role_id)
+            session.delete(role)
+
+    def delete_roles_for_workspace(self, workspace_name: str) -> None:
+        with self.ManagedSessionMaker() as session:
+            session.query(SqlRole).filter(SqlRole.workspace == workspace_name).delete(
+                synchronize_session=False
+            )
+
+    # ---- RolePermission CRUD ----
+
+    def add_role_permission(
+        self,
+        role_id: int,
+        resource_type: str,
+        resource_pattern: str,
+        permission: str,
+    ) -> RolePermission:
+        _validate_permission(permission)
+        _validate_resource_type(resource_type)
+        with self.ManagedSessionMaker() as session:
+            self._get_role(session, role_id)
+            try:
+                rp = SqlRolePermission(
+                    role_id=role_id,
+                    resource_type=resource_type,
+                    resource_pattern=resource_pattern,
+                    permission=permission,
+                )
+                session.add(rp)
+                session.flush()
+                return rp.to_mlflow_entity()
+            except IntegrityError as e:
+                raise MlflowException(
+                    f"Role permission (role_id={role_id}, resource_type={resource_type}, "
+                    f"resource_pattern={resource_pattern}) already exists. Error: {e}",
+                    RESOURCE_ALREADY_EXISTS,
+                ) from e
+
+    def remove_role_permission(self, role_permission_id: int) -> None:
+        with self.ManagedSessionMaker() as session:
+            try:
+                rp = (
+                    session
+                    .query(SqlRolePermission)
+                    .filter(SqlRolePermission.id == role_permission_id)
+                    .one()
+                )
+            except NoResultFound:
+                raise MlflowException(
+                    f"Role permission with id={role_permission_id} not found",
+                    RESOURCE_DOES_NOT_EXIST,
+                )
+            session.delete(rp)
+
+    def list_role_permissions(self, role_id: int) -> list[RolePermission]:
+        with self.ManagedSessionMaker() as session:
+            self._get_role(session, role_id)
+            perms = (
+                session.query(SqlRolePermission).filter(SqlRolePermission.role_id == role_id).all()
+            )
+            return [p.to_mlflow_entity() for p in perms]
+
+    def update_role_permission(self, role_permission_id: int, permission: str) -> RolePermission:
+        _validate_permission(permission)
+        with self.ManagedSessionMaker() as session:
+            try:
+                rp = (
+                    session
+                    .query(SqlRolePermission)
+                    .filter(SqlRolePermission.id == role_permission_id)
+                    .one()
+                )
+            except NoResultFound:
+                raise MlflowException(
+                    f"Role permission with id={role_permission_id} not found",
+                    RESOURCE_DOES_NOT_EXIST,
+                )
+            rp.permission = permission
+            return rp.to_mlflow_entity()
+
+    # ---- UserRoleAssignment CRUD ----
+
+    def assign_role_to_user(self, user_id: int, role_id: int) -> UserRoleAssignment:
+        with self.ManagedSessionMaker() as session:
+            self._get_role(session, role_id)
+            try:
+                assignment = SqlUserRoleAssignment(user_id=user_id, role_id=role_id)
+                session.add(assignment)
+                session.flush()
+                return UserRoleAssignment(
+                    id_=assignment.id,
+                    user_id=assignment.user_id,
+                    role_id=assignment.role_id,
+                )
+            except IntegrityError as e:
+                raise MlflowException(
+                    f"User role assignment (user_id={user_id}, role_id={role_id}) "
+                    f"already exists. Error: {e}",
+                    RESOURCE_ALREADY_EXISTS,
+                ) from e
+
+    def unassign_role_from_user(self, user_id: int, role_id: int) -> None:
+        with self.ManagedSessionMaker() as session:
+            try:
+                assignment = (
+                    session
+                    .query(SqlUserRoleAssignment)
+                    .filter(
+                        SqlUserRoleAssignment.user_id == user_id,
+                        SqlUserRoleAssignment.role_id == role_id,
+                    )
+                    .one()
+                )
+            except NoResultFound:
+                raise MlflowException(
+                    f"User role assignment (user_id={user_id}, role_id={role_id}) not found",
+                    RESOURCE_DOES_NOT_EXIST,
+                )
+            session.delete(assignment)
+
+    def list_user_roles(self, user_id: int) -> list[Role]:
+        with self.ManagedSessionMaker() as session:
+            assignments = (
+                session
+                .query(SqlUserRoleAssignment)
+                .filter(SqlUserRoleAssignment.user_id == user_id)
+                .all()
+            )
+            role_ids = [a.role_id for a in assignments]
+            if not role_ids:
+                return []
+            roles = session.query(SqlRole).filter(SqlRole.id.in_(role_ids)).all()
+            return [r.to_mlflow_entity() for r in roles]
+
+    def list_user_roles_for_workspace(self, user_id: int, workspace: str) -> list[Role]:
+        with self.ManagedSessionMaker() as session:
+            roles = (
+                session
+                .query(SqlRole)
+                .join(SqlUserRoleAssignment, SqlRole.id == SqlUserRoleAssignment.role_id)
+                .filter(
+                    SqlUserRoleAssignment.user_id == user_id,
+                    SqlRole.workspace == workspace,
+                )
+                .all()
+            )
+            return [r.to_mlflow_entity() for r in roles]
+
+    def list_role_users(self, role_id: int) -> list[UserRoleAssignment]:
+        with self.ManagedSessionMaker() as session:
+            self._get_role(session, role_id)
+            assignments = (
+                session
+                .query(SqlUserRoleAssignment)
+                .filter(SqlUserRoleAssignment.role_id == role_id)
+                .all()
+            )
+            return [
+                UserRoleAssignment(id_=a.id, user_id=a.user_id, role_id=a.role_id)
+                for a in assignments
+            ]
+
+    # ---- Role-based permission resolution ----
+
+    def get_role_permission_for_resource(
+        self, user_id: int, resource_type: str, resource_id: str, workspace: str
+    ) -> Permission | None:
+        with self.ManagedSessionMaker() as session:
+            roles = (
+                session
+                .query(SqlRole)
+                .join(SqlUserRoleAssignment, SqlRole.id == SqlUserRoleAssignment.role_id)
+                .filter(
+                    SqlUserRoleAssignment.user_id == user_id,
+                    SqlRole.workspace == workspace,
+                )
+                .all()
+            )
+            if not roles:
+                return None
+
+            best_permission_name: str | None = None
+            for role in roles:
+                if role.is_workspace_admin:
+                    return MANAGE
+
+                for rp in role.permissions:
+                    if rp.resource_type != resource_type:
+                        continue
+                    if rp.resource_pattern in ("*", resource_id):
+                        best_permission_name = (
+                            max_permission(best_permission_name, rp.permission)
+                            if best_permission_name is not None
+                            else rp.permission
+                        )
+
+            if best_permission_name is None:
+                return None
+            return get_permission(best_permission_name)

--- a/tests/server/auth/test_sqlalchemy_store_rbac.py
+++ b/tests/server/auth/test_sqlalchemy_store_rbac.py
@@ -1,0 +1,410 @@
+import pytest
+
+from mlflow.exceptions import MlflowException
+from mlflow.server.auth.entities import Role, RolePermission, UserRoleAssignment
+from mlflow.server.auth.permissions import EDIT, MANAGE, READ, USE
+from mlflow.server.auth.sqlalchemy_store import SqlAlchemyStore
+
+from tests.helper_functions import random_str
+
+pytestmark = pytest.mark.notrackingurimock
+
+
+@pytest.fixture
+def store(tmp_sqlite_uri):
+    store = SqlAlchemyStore()
+    store.init_db(tmp_sqlite_uri)
+    return store
+
+
+@pytest.fixture
+def user(store):
+    return store.create_user(random_str(), random_str())
+
+
+@pytest.fixture
+def user2(store):
+    return store.create_user(random_str(), random_str())
+
+
+# ---- Role CRUD ----
+
+
+def test_create_role(store):
+    role = store.create_role(name="viewer", workspace="ws1", description="Read-only access")
+    assert isinstance(role, Role)
+    assert role.name == "viewer"
+    assert role.workspace == "ws1"
+    assert role.description == "Read-only access"
+    assert role.is_workspace_admin is False
+    assert role.permissions == []
+
+
+def test_create_role_duplicate(store):
+    store.create_role(name="viewer", workspace="ws1")
+    with pytest.raises(MlflowException, match="already exists"):
+        store.create_role(name="viewer", workspace="ws1")
+
+
+def test_create_role_same_name_different_workspace(store):
+    r1 = store.create_role(name="viewer", workspace="ws1")
+    r2 = store.create_role(name="viewer", workspace="ws2")
+    assert r1.id != r2.id
+
+
+def test_create_workspace_admin_role(store):
+    role = store.create_role(name="ws-admin", workspace="ws1", is_workspace_admin=True)
+    assert role.is_workspace_admin is True
+
+
+def test_get_role(store):
+    created = store.create_role(name="editor", workspace="ws1")
+    fetched = store.get_role(created.id)
+    assert fetched.id == created.id
+    assert fetched.name == "editor"
+    assert fetched.workspace == "ws1"
+
+
+def test_get_role_not_found(store):
+    with pytest.raises(MlflowException, match="not found"):
+        store.get_role(99999)
+
+
+def test_get_role_by_name(store):
+    created = store.create_role(name="editor", workspace="ws1")
+    fetched = store.get_role_by_name("ws1", "editor")
+    assert fetched.id == created.id
+
+
+def test_get_role_by_name_not_found(store):
+    with pytest.raises(MlflowException, match="not found"):
+        store.get_role_by_name("ws1", "nonexistent")
+
+
+def test_list_roles(store):
+    store.create_role(name="viewer", workspace="ws1")
+    store.create_role(name="editor", workspace="ws1")
+    store.create_role(name="viewer", workspace="ws2")
+
+    ws1_roles = store.list_roles("ws1")
+    assert len(ws1_roles) == 2
+    assert {r.name for r in ws1_roles} == {"viewer", "editor"}
+
+    ws2_roles = store.list_roles("ws2")
+    assert len(ws2_roles) == 1
+
+
+def test_list_all_roles(store):
+    store.create_role(name="viewer", workspace="ws1")
+    store.create_role(name="editor", workspace="ws2")
+    all_roles = store.list_all_roles()
+    assert len(all_roles) == 2
+
+
+def test_update_role(store):
+    role = store.create_role(name="old-name", workspace="ws1", description="old desc")
+    updated = store.update_role(role.id, name="new-name", description="new desc")
+    assert updated.name == "new-name"
+    assert updated.description == "new desc"
+
+
+def test_update_role_name_conflict(store):
+    store.create_role(name="existing", workspace="ws1")
+    role2 = store.create_role(name="other", workspace="ws1")
+    with pytest.raises(MlflowException, match="already exists"):
+        store.update_role(role2.id, name="existing")
+
+
+def test_delete_role(store):
+    role = store.create_role(name="doomed", workspace="ws1")
+    store.delete_role(role.id)
+    with pytest.raises(MlflowException, match="not found"):
+        store.get_role(role.id)
+
+
+def test_delete_role_cascades_permissions_and_assignments(store, user):
+    role = store.create_role(name="role1", workspace="ws1")
+    store.add_role_permission(role.id, "experiment", "*", "READ")
+    store.assign_role_to_user(user.id, role.id)
+
+    store.delete_role(role.id)
+
+    # Role no longer exists
+    with pytest.raises(MlflowException, match="not found"):
+        store.get_role(role.id)
+
+    # User no longer has the role
+    assert store.list_user_roles(user.id) == []
+
+
+def test_delete_roles_for_workspace(store):
+    store.create_role(name="r1", workspace="ws1")
+    store.create_role(name="r2", workspace="ws1")
+    store.create_role(name="r3", workspace="ws2")
+
+    store.delete_roles_for_workspace("ws1")
+    assert store.list_roles("ws1") == []
+    assert len(store.list_roles("ws2")) == 1
+
+
+# ---- RolePermission CRUD ----
+
+
+def test_add_role_permission(store):
+    role = store.create_role(name="viewer", workspace="ws1")
+    rp = store.add_role_permission(role.id, "experiment", "123", "READ")
+    assert isinstance(rp, RolePermission)
+    assert rp.role_id == role.id
+    assert rp.resource_type == "experiment"
+    assert rp.resource_pattern == "123"
+    assert rp.permission == "READ"
+
+
+def test_add_role_permission_wildcard(store):
+    role = store.create_role(name="viewer", workspace="ws1")
+    rp = store.add_role_permission(role.id, "experiment", "*", "READ")
+    assert rp.resource_pattern == "*"
+
+
+def test_add_role_permission_duplicate(store):
+    role = store.create_role(name="viewer", workspace="ws1")
+    store.add_role_permission(role.id, "experiment", "123", "READ")
+    with pytest.raises(MlflowException, match="already exists"):
+        store.add_role_permission(role.id, "experiment", "123", "EDIT")
+
+
+def test_add_role_permission_invalid_permission(store):
+    role = store.create_role(name="viewer", workspace="ws1")
+    with pytest.raises(MlflowException, match="Invalid permission"):
+        store.add_role_permission(role.id, "experiment", "123", "INVALID")
+
+
+def test_add_role_permission_invalid_resource_type(store):
+    role = store.create_role(name="viewer", workspace="ws1")
+    with pytest.raises(MlflowException, match="Invalid resource type"):
+        store.add_role_permission(role.id, "invalid_type", "123", "READ")
+
+
+def test_add_role_permission_nonexistent_role(store):
+    with pytest.raises(MlflowException, match="not found"):
+        store.add_role_permission(99999, "experiment", "123", "READ")
+
+
+def test_remove_role_permission(store):
+    role = store.create_role(name="viewer", workspace="ws1")
+    rp = store.add_role_permission(role.id, "experiment", "123", "READ")
+    store.remove_role_permission(rp.id)
+    assert store.list_role_permissions(role.id) == []
+
+
+def test_remove_role_permission_not_found(store):
+    with pytest.raises(MlflowException, match="not found"):
+        store.remove_role_permission(99999)
+
+
+def test_list_role_permissions(store):
+    role = store.create_role(name="viewer", workspace="ws1")
+    store.add_role_permission(role.id, "experiment", "1", "READ")
+    store.add_role_permission(role.id, "experiment", "2", "EDIT")
+    store.add_role_permission(role.id, "registered_model", "*", "READ")
+
+    perms = store.list_role_permissions(role.id)
+    assert len(perms) == 3
+
+
+def test_update_role_permission(store):
+    role = store.create_role(name="viewer", workspace="ws1")
+    rp = store.add_role_permission(role.id, "experiment", "123", "READ")
+    updated = store.update_role_permission(rp.id, "EDIT")
+    assert updated.permission == "EDIT"
+
+
+def test_update_role_permission_not_found(store):
+    with pytest.raises(MlflowException, match="not found"):
+        store.update_role_permission(99999, "READ")
+
+
+def test_update_role_permission_invalid_permission(store):
+    role = store.create_role(name="viewer", workspace="ws1")
+    rp = store.add_role_permission(role.id, "experiment", "123", "READ")
+    with pytest.raises(MlflowException, match="Invalid permission"):
+        store.update_role_permission(rp.id, "INVALID")
+
+
+# ---- UserRoleAssignment CRUD ----
+
+
+def test_assign_role_to_user(store, user):
+    role = store.create_role(name="viewer", workspace="ws1")
+    assignment = store.assign_role_to_user(user.id, role.id)
+    assert isinstance(assignment, UserRoleAssignment)
+    assert assignment.user_id == user.id
+    assert assignment.role_id == role.id
+
+
+def test_assign_role_duplicate(store, user):
+    role = store.create_role(name="viewer", workspace="ws1")
+    store.assign_role_to_user(user.id, role.id)
+    with pytest.raises(MlflowException, match="already exists"):
+        store.assign_role_to_user(user.id, role.id)
+
+
+def test_unassign_role_from_user(store, user):
+    role = store.create_role(name="viewer", workspace="ws1")
+    store.assign_role_to_user(user.id, role.id)
+    store.unassign_role_from_user(user.id, role.id)
+    assert store.list_user_roles(user.id) == []
+
+
+def test_unassign_role_not_found(store, user):
+    with pytest.raises(MlflowException, match="not found"):
+        store.unassign_role_from_user(user.id, 99999)
+
+
+def test_list_user_roles(store, user):
+    r1 = store.create_role(name="viewer", workspace="ws1")
+    r2 = store.create_role(name="editor", workspace="ws2")
+    store.assign_role_to_user(user.id, r1.id)
+    store.assign_role_to_user(user.id, r2.id)
+
+    roles = store.list_user_roles(user.id)
+    assert len(roles) == 2
+    assert {r.name for r in roles} == {"viewer", "editor"}
+
+
+def test_list_user_roles_for_workspace(store, user):
+    r1 = store.create_role(name="viewer", workspace="ws1")
+    r2 = store.create_role(name="editor", workspace="ws1")
+    r3 = store.create_role(name="viewer", workspace="ws2")
+    store.assign_role_to_user(user.id, r1.id)
+    store.assign_role_to_user(user.id, r2.id)
+    store.assign_role_to_user(user.id, r3.id)
+
+    ws1_roles = store.list_user_roles_for_workspace(user.id, "ws1")
+    assert len(ws1_roles) == 2
+
+    ws2_roles = store.list_user_roles_for_workspace(user.id, "ws2")
+    assert len(ws2_roles) == 1
+
+
+def test_list_role_users(store, user, user2):
+    role = store.create_role(name="viewer", workspace="ws1")
+    store.assign_role_to_user(user.id, role.id)
+    store.assign_role_to_user(user2.id, role.id)
+
+    users = store.list_role_users(role.id)
+    assert len(users) == 2
+    assert {u.user_id for u in users} == {user.id, user2.id}
+
+
+# ---- Role-based permission resolution ----
+
+
+def test_get_role_permission_no_roles(store, user):
+    result = store.get_role_permission_for_resource(user.id, "experiment", "1", "ws1")
+    assert result is None
+
+
+def test_get_role_permission_specific_match(store, user):
+    role = store.create_role(name="viewer", workspace="ws1")
+    store.add_role_permission(role.id, "experiment", "1", "READ")
+    store.assign_role_to_user(user.id, role.id)
+
+    result = store.get_role_permission_for_resource(user.id, "experiment", "1", "ws1")
+    assert result == READ
+
+
+def test_get_role_permission_no_match(store, user):
+    role = store.create_role(name="viewer", workspace="ws1")
+    store.add_role_permission(role.id, "experiment", "1", "READ")
+    store.assign_role_to_user(user.id, role.id)
+
+    result = store.get_role_permission_for_resource(user.id, "experiment", "999", "ws1")
+    assert result is None
+
+
+def test_get_role_permission_wildcard_match(store, user):
+    role = store.create_role(name="viewer", workspace="ws1")
+    store.add_role_permission(role.id, "experiment", "*", "EDIT")
+    store.assign_role_to_user(user.id, role.id)
+
+    result = store.get_role_permission_for_resource(user.id, "experiment", "any-id", "ws1")
+    assert result == EDIT
+
+
+def test_get_role_permission_union_of_multiple_roles(store, user):
+    r1 = store.create_role(name="viewer", workspace="ws1")
+    store.add_role_permission(r1.id, "experiment", "1", "READ")
+    store.assign_role_to_user(user.id, r1.id)
+
+    r2 = store.create_role(name="editor", workspace="ws1")
+    store.add_role_permission(r2.id, "experiment", "1", "EDIT")
+    store.assign_role_to_user(user.id, r2.id)
+
+    result = store.get_role_permission_for_resource(user.id, "experiment", "1", "ws1")
+    assert result == EDIT
+
+
+def test_get_role_permission_wildcard_and_specific_union(store, user):
+    role = store.create_role(name="mixed", workspace="ws1")
+    store.add_role_permission(role.id, "experiment", "*", "READ")
+    store.add_role_permission(role.id, "experiment", "1", "EDIT")
+    store.assign_role_to_user(user.id, role.id)
+
+    # Experiment 1 gets EDIT (higher of READ wildcard and EDIT specific)
+    result = store.get_role_permission_for_resource(user.id, "experiment", "1", "ws1")
+    assert result == EDIT
+
+    # Other experiments get READ from wildcard
+    result = store.get_role_permission_for_resource(user.id, "experiment", "999", "ws1")
+    assert result == READ
+
+
+def test_get_role_permission_workspace_admin(store, user):
+    role = store.create_role(name="ws-admin", workspace="ws1", is_workspace_admin=True)
+    store.assign_role_to_user(user.id, role.id)
+
+    result = store.get_role_permission_for_resource(user.id, "experiment", "any-id", "ws1")
+    assert result == MANAGE
+
+
+def test_get_role_permission_does_not_cross_workspace(store, user):
+    role = store.create_role(name="viewer", workspace="ws1")
+    store.add_role_permission(role.id, "experiment", "*", "READ")
+    store.assign_role_to_user(user.id, role.id)
+
+    # Should not apply in ws2
+    result = store.get_role_permission_for_resource(user.id, "experiment", "1", "ws2")
+    assert result is None
+
+
+def test_get_role_permission_different_resource_types(store, user):
+    role = store.create_role(name="viewer", workspace="ws1")
+    store.add_role_permission(role.id, "experiment", "*", "READ")
+    store.assign_role_to_user(user.id, role.id)
+
+    # Should not match registered_model
+    result = store.get_role_permission_for_resource(user.id, "registered_model", "m1", "ws1")
+    assert result is None
+
+    # Should match experiment
+    result = store.get_role_permission_for_resource(user.id, "experiment", "1", "ws1")
+    assert result == READ
+
+
+@pytest.mark.parametrize(
+    ("perms", "expected"),
+    [
+        ([("experiment", "1", "READ"), ("experiment", "1", "MANAGE")], MANAGE),
+        ([("experiment", "1", "USE"), ("experiment", "1", "EDIT")], EDIT),
+        ([("experiment", "*", "READ"), ("experiment", "1", "USE")], USE),
+    ],
+)
+def test_get_role_permission_picks_highest(store, user, perms, expected):
+    for i, (rtype, pattern, perm) in enumerate(perms):
+        role = store.create_role(name=f"role-{i}", workspace="ws1")
+        store.add_role_permission(role.id, rtype, pattern, perm)
+        store.assign_role_to_user(user.id, role.id)
+
+    result = store.get_role_permission_for_resource(user.id, "experiment", "1", "ws1")
+    assert result == expected


### PR DESCRIPTION
### Related Issues/PRs

Relates to user management & access control feature (RBAC milestone)
Stacked on #22719 — merge that PR first

### What changes are proposed in this pull request?

This is **PR 2/2** in the RBAC stack. It wires up the data layer from #22719 to the HTTP layer and auth middleware:

**14 new REST API endpoints** (all v3):
- Role CRUD: `create/get/list/update/delete`
- Role permissions: `add/remove/list/update`
- User-role assignments: `assign/unassign/list-user-roles/list-role-users`
- Cross-workspace admin: `list-all-roles` (super admin only)

**Permission resolution integration:**
- Extended `_get_permission_from_store_or_default` with `role_permission_func` parameter
- Updated all `_get_*_permission` functions (experiment, registered model, scorer, gateway secret/endpoint/model_definition) to check role-based grants
- Added wildcard `experiment(*)` support in `filter_experiment_ids`
- Roles are cleaned up on workspace deletion

**Authorization:**
- WP admins (`is_workspace_admin` role) can manage roles within their workspace
- Super admins (`is_admin` flag) can manage roles across all workspaces
- Users with any role in a workspace can view that workspace's roles
- WP admins cannot delete users (super admin only)

**Client library:**
- Added all 14 role management methods to `AuthServiceClient`

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

All 69 existing auth integration tests (`test_auth.py`) pass, confirming 100% backwards compatibility when no roles exist.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

Co-authored-by: Claude <noreply@anthropic.com>