### PR TITLE
Fix non-ASCII characters being escaped in judge template variables

### DIFF
--- a/mlflow/genai/judges/instructions_judge/__init__.py
+++ b/mlflow/genai/judges/instructions_judge/__init__.py
@@ -476,7 +476,7 @@ class InstructionsJudge(Judge):
     def _safe_json_dumps(self, value: Any) -> str:
         """Safely serialize a value to JSON, falling back to str() if JSON serialization fails."""
         try:
-            return json.dumps(value, default=str, indent=2)
+            return json.dumps(value, default=str, indent=2, ensure_ascii=False)
         except Exception:
             return str(value)
 

--- a/mlflow/genai/judges/tools/get_span.py
+++ b/mlflow/genai/judges/tools/get_span.py
@@ -116,7 +116,7 @@ class GetSpanTool(JudgeTool):
                     filtered_attributes[attr] = span_dict["attributes"][attr]
             span_dict["attributes"] = filtered_attributes
 
-        full_content = json.dumps(span_dict, default=str, indent=2)
+        full_content = json.dumps(span_dict, default=str, indent=2, ensure_ascii=False)
         total_size = len(full_content.encode("utf-8"))
         start_offset = parse_page_token(page_token)
         end_offset = min(start_offset + max_content_length, total_size)

--- a/mlflow/genai/judges/tools/get_span.py
+++ b/mlflow/genai/judges/tools/get_span.py
@@ -116,7 +116,7 @@ class GetSpanTool(JudgeTool):
                     filtered_attributes[attr] = span_dict["attributes"][attr]
             span_dict["attributes"] = filtered_attributes
 
-        full_content = json.dumps(span_dict, default=str, indent=2, ensure_ascii=False)
+        full_content = json.dumps(span_dict, default=str, indent=2)
         total_size = len(full_content.encode("utf-8"))
         start_offset = parse_page_token(page_token)
         end_offset = min(start_offset + max_content_length, total_size)

--- a/mlflow/genai/judges/utils/tool_calling_utils.py
+++ b/mlflow/genai/judges/utils/tool_calling_utils.py
@@ -66,7 +66,11 @@ def _process_tool_calls(
         else:
             if is_dataclass(result):
                 result = asdict(result)
-            result_json = json.dumps(result, default=str) if not isinstance(result, str) else result
+            result_json = (
+                json.dumps(result, default=str, ensure_ascii=False)
+                if not isinstance(result, str)
+                else result
+            )
             tool_response_messages.append(
                 _create_tool_response_message(
                     tool_call_id=tool_call.id,

--- a/tests/genai/judges/test_make_judge.py
+++ b/tests/genai/judges/test_make_judge.py
@@ -4118,3 +4118,24 @@ def test_conversation_with_timing_parameter(mock_invoke_judge_model, include_tim
 
     assert ("Response duration:" in conversation_content) is include_timing
     assert ("slowest spans:" in conversation_content) is include_timing
+
+
+def test_make_judge_preserves_non_ascii_in_template_variables():
+    judge = make_judge(
+        name="unicode_judge",
+        instructions="Evaluate: {{ inputs }} {{ outputs }} {{ expectations }}",
+        feedback_value_type=int,
+        model="openai:/gpt-4",
+    )
+
+    user_message = judge._build_user_message(
+        inputs={"query": "café résumé"},
+        outputs={"text": "éÉàç"},
+        expectations={"expected": "日本語テスト"},
+        conversation=None,
+    )
+
+    assert "éÉàç" in user_message
+    assert "\\u00e9" not in user_message
+    assert "café résumé" in user_message
+    assert "日本語テスト" in user_message


### PR DESCRIPTION
### Related Issues/PRs

Closes #22622

### What changes are proposed in this pull request?

`json.dumps` defaults to `ensure_ascii=True`, which escapes non-ASCII characters (e.g., `"éÉàç"` becomes `"\u00e9\u00c9\u00e0\u00e7"`) when building prompts for LLM-as-a-judge evaluation via `_safe_json_dumps`. This can degrade judge quality for non-English text.

This PR adds `ensure_ascii=False` to `json.dumps` calls in the judges module that serialize content sent to LLMs:

- `InstructionsJudge._safe_json_dumps` — template variable serialization (primary fix)
- `_process_tool_calls` — tool call result serialization

**Note:** `GetSpanTool.invoke` in `get_span.py` also uses `json.dumps` without `ensure_ascii=False`, but was intentionally left unchanged. Its pagination logic computes `total_size` in bytes (`len(full_content.encode("utf-8"))`) but slices the string by character index (`full_content[start_offset:end_offset]`). With `ensure_ascii=True`, byte count == character count, so the offsets are interchangeable. Adding `ensure_ascii=False` would break pagination for multi-byte characters. Fixing that requires reworking the pagination to use consistent units, which is out of scope for this PR.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added `test_make_judge_preserves_non_ascii_in_template_variables` covering inputs, outputs, and expectations with French, German, Japanese, and accented characters.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fix non-ASCII characters (e.g., accented letters, CJK characters) being escaped as `\uXXXX` sequences when passed as template variables to LLM-as-a-judge evaluation.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)