### PR TITLE
Bump demo generator versions and always refresh in ui-preview app

### DIFF
--- a/.github/ui-preview/app.py
+++ b/.github/ui-preview/app.py
@@ -20,10 +20,12 @@ def setup():
     _logger.info("Extracting UI assets to %s", target_dir)
     subprocess.check_call(["tar", "xzf", tar_path, "-C", target_dir])
 
-    # Generate demo data
+    # Generate demo data. Always refresh so the preview app reflects the latest
+    # demo content (e.g. new trace types) even if the SQLite database persisted
+    # from a previous deploy with stale demo data.
     os.environ["MLFLOW_TRACKING_URI"] = "sqlite:///mlflow.db"
     _logger.info("Generating demo data...")
-    generate_all_demos()
+    generate_all_demos(refresh=True)
     _logger.info("Demo data generated.")
 
 

--- a/mlflow/demo/generators/evaluation.py
+++ b/mlflow/demo/generators/evaluation.py
@@ -155,7 +155,7 @@ class EvaluationDemoGenerator(BaseDemoGenerator):
     """
 
     name = DemoFeature.EVALUATION
-    version = 1
+    version = 2
 
     def generate(self) -> DemoResult:
         traces_generator = TracesDemoGenerator()

--- a/mlflow/demo/generators/issues.py
+++ b/mlflow/demo/generators/issues.py
@@ -32,7 +32,7 @@ class IssuesDemoGenerator(BaseDemoGenerator):
     """
 
     name = DemoFeature.ISSUES
-    version = 3
+    version = 4
 
     def generate(self) -> DemoResult:
         store = _get_store()

--- a/mlflow/demo/generators/issues.py
+++ b/mlflow/demo/generators/issues.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import mlflow
@@ -17,6 +18,10 @@ from mlflow.entities.issue import IssueStatus
 from mlflow.store.tracking import MAX_TRACE_LINKS_PER_REQUEST
 from mlflow.tracking._tracking_service.utils import _get_store
 from mlflow.utils.mlflow_tags import MLFLOW_RUN_TYPE, MLFLOW_RUN_TYPE_ISSUE_DETECTION
+
+_logger = logging.getLogger(__name__)
+
+_DEMO_CREATED_BY = "demo"
 
 DEMO_ISSUE_DETECTION_RUN_NAME = "Demo Issue Detection"
 _MAX_TRACES_PER_ISSUE = 5
@@ -97,7 +102,7 @@ class IssuesDemoGenerator(BaseDemoGenerator):
                     severity=issue_config["severity"],
                     root_causes=issue_config["root_causes"],
                     categories=issue_config["categories"],
-                    created_by="demo",
+                    created_by=_DEMO_CREATED_BY,
                     source_run_id=run_id,
                 )
                 created_issue_ids.append(issue.issue_id)
@@ -210,5 +215,18 @@ class IssuesDemoGenerator(BaseDemoGenerator):
         for _, run in runs.iterrows():
             mlflow.delete_run(run.run_id)
 
-        # TODO: Delete issues explicitly once delete_issue API is available
+        # No delete_issue API exists yet. Without cleanup here, regeneration would
+        # pile new PENDING issues on top of the old ones (same names, same
+        # experiment) and the UI would show duplicates. Mark the old demo issues
+        # as REJECTED so they're hidden from the default "active issues" view —
+        # this is also semantically correct since these issues referenced traces
+        # that have just been deleted as part of the demo refresh.
+        try:
+            issues = store.search_issues(experiment_id=experiment.experiment_id)
+            for issue in issues:
+                if issue.created_by == _DEMO_CREATED_BY and issue.status == IssueStatus.PENDING:
+                    store.update_issue(issue_id=issue.issue_id, status=IssueStatus.REJECTED)
+        except Exception:
+            _logger.debug("Failed to reject old demo issues", exc_info=True)
+
         # Note: Issues are also automatically deleted when the experiment is deleted.

--- a/mlflow/demo/generators/traces.py
+++ b/mlflow/demo/generators/traces.py
@@ -144,7 +144,7 @@ class TracesDemoGenerator(BaseDemoGenerator):
     """
 
     name = DemoFeature.TRACES
-    version = 1
+    version = 2
 
     def generate(self) -> DemoResult:
         self._restore_experiment_if_deleted()

--- a/tests/demo/test_demo_integration.py
+++ b/tests/demo/test_demo_integration.py
@@ -32,6 +32,7 @@ from mlflow.demo.generators.traces import (
     TracesDemoGenerator,
 )
 from mlflow.demo.registry import demo_registry
+from mlflow.entities.issue import IssueStatus
 from mlflow.genai.datasets import search_datasets
 from mlflow.genai.prompts import load_prompt, search_prompts
 from mlflow.genai.scorers.registry import list_scorers
@@ -576,3 +577,26 @@ def test_issues_delete_removes_all(client, issues_prerequisites, issues_generato
         max_results=100,
     )
     assert len(runs_after) == 0
+
+
+def test_issues_delete_rejects_pending_demo_issues(client, issues_prerequisites, issues_generator):
+    # No delete_issue API exists, so delete_demo() must mark previously created
+    # demo issues as REJECTED to prevent duplicates on regeneration.
+    issues_generator.generate()
+    issues_generator.store_version()
+
+    store = _get_store()
+    experiment = client.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+
+    issues_before = store.search_issues(experiment_id=experiment.experiment_id, max_results=1000)
+    demo_issues_before = [i for i in issues_before if i.created_by == "demo"]
+    assert len(demo_issues_before) > 0
+    assert all(i.status == IssueStatus.PENDING for i in demo_issues_before)
+
+    issues_generator.delete_demo()
+
+    issues_after = store.search_issues(experiment_id=experiment.experiment_id, max_results=1000)
+    demo_issues_after = [i for i in issues_after if i.created_by == "demo"]
+    # Same issue records (no delete API), but all now REJECTED.
+    assert len(demo_issues_after) == len(demo_issues_before)
+    assert all(i.status == IssueStatus.REJECTED for i in demo_issues_after)

--- a/tests/demo/test_evaluation_generator.py
+++ b/tests/demo/test_evaluation_generator.py
@@ -22,7 +22,7 @@ def traces_generator():
 
 def test_generator_attributes(evaluation_generator):
     assert evaluation_generator.name == DemoFeature.EVALUATION
-    assert evaluation_generator.version == 1
+    assert evaluation_generator.version == 2
 
 
 def test_data_exists_false_when_no_experiment(evaluation_generator):

--- a/tests/demo/test_traces_generator.py
+++ b/tests/demo/test_traces_generator.py
@@ -20,7 +20,7 @@ def traces_generator():
 def test_generator_attributes():
     generator = TracesDemoGenerator()
     assert generator.name == DemoFeature.TRACES
-    assert generator.version == 1
+    assert generator.version == 2
 
 
 def test_data_exists_false_when_no_experiment():


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22465 (added multimodal demo traces)

### What changes are proposed in this pull request?

Three complementary changes to ensure the multimodal demo traces added in #22465 actually appear on existing deploys:

**1. Bump demo generator versions** to trigger automatic regeneration on existing deploys:

- `TracesDemoGenerator.version`: 1 → 2
- `EvaluationDemoGenerator.version`: 1 → 2
- `IssuesDemoGenerator.version`: 3 → 4

**2. Mark old demo issues as REJECTED in `IssuesDemoGenerator.delete_demo()`** so bumping the issues version does not leave duplicate issues behind (no `delete_issue` API exists yet).

**3. Pass `refresh=True` in `.github/ui-preview/app.py`** so the ui-preview app always reflects the latest demo content, even when its SQLite database persists across deploys (which happens for `mlflow-ui-preview-dev`, the persistent app reused on every master push).

### Why this is needed

PR #22465 added four multimodal trace types (vision, image generation, audio input, audio output) to `TracesDemoGenerator` but did **not** bump `TracesDemoGenerator.version`. This means:

- For **fresh** MLflow deploys with no prior demo data, multimodal traces appear correctly on first generation.
- For **existing** deploys that ran demo generation before #22465 landed, the demo experiment shows the pre-#22465 traces without the multimodal ones, and will continue to do so indefinitely.

The reason: `generate_all_demos()` calls `generator.is_generated()` on each generator, which compares the version stored on the experiment tag (`mlflow.demo.version.{name}`) against the generator's current class `version`. If they match, regeneration is skipped. Since the version never changed, existing deploys think the demo is up-to-date and never regenerate.

This is particularly important for staging/production environments (e.g. the Databricks app) where end users hit `POST /ajax-api/3.0/mlflow/demo/generate` via the UI. That endpoint has no `refresh` parameter, so the only way to force regeneration without a version bump is direct CLI access (`mlflow demo --refresh`), which most users don't have.

### Why three generators and not just traces?

Only traces actually got new content, but bumping just `TracesDemoGenerator.version` would leave the demo in an inconsistent state on existing deploys:

- `EvaluationDemoGenerator` creates datasets and runs that reference specific trace IDs. When traces regenerate, those IDs change, and the evaluation datasets/runs reference stale IDs.
- `IssuesDemoGenerator` creates issue records linked to specific trace IDs (via `client.link_traces_to_run`) and analyzes traces filtered by `DEMO_VERSION_TAG`. Linked trace IDs become stale on trace regeneration.

Bumping evaluation and issues forces them to regenerate alongside traces, keeping the three cross-referencing feature sets consistent.

`PromptsDemoGenerator` and `JudgesDemoGenerator` don't reference trace IDs (prompts are standalone templates; judges are scorer definitions registered against the experiment ID, not traces), so their versions are untouched.

### Why mark old issues as REJECTED?

`IssuesDemoGenerator.delete_demo()` was only deleting the issue-detection runs, not the issues themselves (there's even a TODO comment about needing a `delete_issue` API that doesn't exist yet). On a naive version bump, regeneration would create brand-new PENDING issues on top of the existing ones — duplicates in the UI.

The fix: in `delete_demo()`, find all demo-created issues (`created_by == "demo"`) that are still PENDING and update their status to REJECTED via the existing `update_issue` API. This is:
- **Semantically correct** — those issues pointed at traces that are about to be deleted, so they are no longer relevant.
- **Idempotent** — filters on `status == PENDING` so repeated calls are no-ops.
- **Safe** — `created_by` filter ensures we never touch non-demo issues.
- **UI-appropriate** — REJECTED issues drop out of the default "active issues" view, so users just see the freshly created ones.

### Why also change the ui-preview app?

The `.github/ui-preview/app.py` is a separate code path from the version bump — it calls `generate_all_demos()` directly at app startup before the MLflow server is up. Databricks Apps keep the working-directory filesystem across redeploys, so `sqlite:///mlflow.db` persists across app restarts. The persistent `mlflow-ui-preview-dev` app (reused for every master push) was first deployed before #22465, so every subsequent deploy's `generate_all_demos()` call sees `is_generated() == True` and does nothing.

Passing `refresh=True` guarantees the ui-preview app always has fresh demo state regardless of database persistence or version numbers. A few seconds of startup regeneration on redeploy is acceptable — the app exists specifically to preview UI features, so always-fresh demo data matches its purpose. This change is also a belt-and-suspenders against future demo content additions that forget to bump versions.

### Regeneration flow on existing deploys

On the next call to `generate_all_demos()` after this merges:

1. `PromptsDemoGenerator`: stored=1, current=1 → skip (unchanged)
2. `TracesDemoGenerator`: stored=1, current=2 → `delete_demo()` then `generate()` → new trace IDs, now including the 4 multimodal traces
3. `EvaluationDemoGenerator`: stored=1, current=2 → `delete_demo()` (deletes eval runs + datasets, not traces) then `generate()` → recreates datasets referencing the new trace IDs
4. `JudgesDemoGenerator`: stored=1, current=1 → skip (unchanged, no trace refs)
5. `IssuesDemoGenerator`: stored=3, current=4 → `delete_demo()` (deletes detection runs + marks old demo issues REJECTED) then `generate()` → fresh issue detection against the new traces

One-time cost per existing deploy. Fresh deploys pay nothing (first-time generation runs everything anyway).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Updated existing `test_generator_attributes` assertions in `test_traces_generator.py` and `test_evaluation_generator.py` to reflect the new versions. The integration test `test_version_mismatch_triggers_cleanup_and_regeneration` uses relative version arithmetic (`version + 1`) and continues to work unchanged. Added `test_issues_delete_rejects_pending_demo_issues` to cover the new REJECTED-marking behavior (verifies demo issues are PENDING before `delete_demo()` and REJECTED after). Full demo test suite (116 tests) passes.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
