### PR TITLE
Fix JSON parsing failure for judge model responses containing newlines

### DIFF
--- a/mlflow/genai/judges/adapters/gateway_adapter.py
+++ b/mlflow/genai/judges/adapters/gateway_adapter.py
@@ -387,7 +387,7 @@ class GatewayAdapter(BaseJudgeAdapter):
         cleaned_response = _strip_markdown_code_blocks(response)
 
         try:
-            response_dict = json.loads(cleaned_response)
+            response_dict = json.loads(cleaned_response, strict=False)
         except json.JSONDecodeError as e:
             raise MlflowException(
                 f"Failed to parse response from judge model. Response: {response}",
@@ -429,7 +429,7 @@ class GatewayAdapter(BaseJudgeAdapter):
 
         cleaned_response = _strip_markdown_code_blocks(output.response)
         try:
-            response_dict = json.loads(cleaned_response)
+            response_dict = json.loads(cleaned_response, strict=False)
         except json.JSONDecodeError as e:
             raise MlflowException(
                 f"Failed to parse response from judge model. Response: {output.response}",
@@ -463,7 +463,7 @@ class GatewayAdapter(BaseJudgeAdapter):
         cleaned_response = _strip_markdown_code_blocks(output.response)
 
         try:
-            response_dict = json.loads(cleaned_response)
+            response_dict = json.loads(cleaned_response, strict=False)
         except json.JSONDecodeError as e:
             raise MlflowException(
                 f"Failed to parse response from judge model. Response: {output.response}",

--- a/mlflow/genai/judges/adapters/litellm_adapter.py
+++ b/mlflow/genai/judges/adapters/litellm_adapter.py
@@ -590,7 +590,7 @@ class LiteLLMAdapter(BaseJudgeAdapter):
         cleaned_response = _strip_markdown_code_blocks(output.response)
 
         try:
-            response_dict = json.loads(cleaned_response)
+            response_dict = json.loads(cleaned_response, strict=False)
         except json.JSONDecodeError as e:
             raise MlflowException(
                 f"Failed to parse response from judge model. Response: {output.response}"

--- a/mlflow/genai/judges/utils/invocation_utils.py
+++ b/mlflow/genai/judges/utils/invocation_utils.py
@@ -148,7 +148,7 @@ def _invoke_databricks_structured_output(
             raise MlflowException("Empty content in final response from Databricks judge")
         try:
             cleaned = _strip_markdown_code_blocks(content)
-            response_dict = json.loads(cleaned)
+            response_dict = json.loads(cleaned, strict=False)
             return output_schema(**response_dict)
         except json.JSONDecodeError as e:
             raise MlflowException(
@@ -264,7 +264,7 @@ def get_chat_completions_with_structured_output(
     )
     cleaned_response = _strip_markdown_code_blocks(output.response)
     try:
-        response_dict = json.loads(cleaned_response)
+        response_dict = json.loads(cleaned_response, strict=False)
     except json.JSONDecodeError as e:
         raise MlflowException(
             f"Failed to parse response from judge model. Response: {output.response}",

--- a/tests/genai/judges/adapters/test_gateway_adapter.py
+++ b/tests/genai/judges/adapters/test_gateway_adapter.py
@@ -172,6 +172,31 @@ def test_invoke_without_trace_uses_gateway():
     assert result.feedback.value == "yes"
 
 
+def test_invoke_parses_response_with_newlines_in_json_strings():
+    adapter = GatewayAdapter()
+    input_params = AdapterInvocationInput(
+        model_uri="ollama:/llama3.2:3b",
+        prompt=[ChatMessage(role="user", content="test")],
+        assessment_name="test_metric",
+    )
+
+    # Simulate LLM response with literal newlines inside JSON string values
+    response_with_newlines = (
+        '{\n  "rationale": "Let\'s think step by step.\n'
+        'The response is clear.",\n  "result": "yes"\n}'
+    )
+
+    with mock.patch(
+        "mlflow.genai.judges.adapters.gateway_adapter._invoke_via_gateway",
+        return_value=response_with_newlines,
+    ) as mock_invoke:
+        result = adapter.invoke(input_params)
+
+    mock_invoke.assert_called_once()
+    assert result.feedback.value == "yes"
+    assert "step by step" in result.feedback.rationale
+
+
 # --- invoke_with_structured_output tests ---
 
 

--- a/tests/genai/judges/adapters/test_gateway_adapter.py
+++ b/tests/genai/judges/adapters/test_gateway_adapter.py
@@ -198,7 +198,7 @@ def test_invoke_parses_response_with_newlines_in_json_strings():
 
     mock_invoke.assert_called_once()
     assert result.feedback.value == "yes"
-    assert "step by step" in result.feedback.rationale
+    assert "\nThe response is clear." in result.feedback.rationale
 
 
 # --- invoke_with_structured_output tests ---

--- a/tests/genai/judges/adapters/test_gateway_adapter.py
+++ b/tests/genai/judges/adapters/test_gateway_adapter.py
@@ -186,6 +186,10 @@ def test_invoke_parses_response_with_newlines_in_json_strings():
         'The response is clear.",\n  "result": "yes"\n}'
     )
 
+    # Verify this response is indeed invalid under strict JSON parsing
+    with pytest.raises(json.JSONDecodeError, match="Invalid control character"):
+        json.loads(response_with_newlines)
+
     with mock.patch(
         "mlflow.genai.judges.adapters.gateway_adapter._invoke_via_gateway",
         return_value=response_with_newlines,


### PR DESCRIPTION
### Related Issues/PRs

Closes #22674

### What changes are proposed in this pull request?

Use `json.loads(strict=False)` when parsing LLM judge responses to tolerate control characters (e.g., literal newlines) inside JSON string values. Smaller/local models (e.g., Ollama's llama3.2) commonly produce JSON with unescaped newlines in string values, causing `JSONDecodeError: Invalid control character` failures.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed JSON parsing errors when using local LLM models (e.g., Ollama) as custom judges in evaluation scorers. Models that produce newlines inside JSON string values no longer cause `SCORER_ERROR`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)