### PR TITLE
Fix `AsyncHttpxClientWrapper` `AttributeError` by avoiding `deepcopy` in `TraceJSONEncoder`

### DIFF
--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -7,7 +7,7 @@ import logging
 import uuid
 from collections import defaultdict
 from contextlib import contextmanager
-from dataclasses import asdict, fields, is_dataclass
+from dataclasses import fields, is_dataclass
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Generator
 
@@ -80,13 +80,11 @@ class TraceJSONEncoder(json.JSONEncoder):
         # representation, so we use dict representation instead.
         # E.g. https://github.com/run-llama/llama_index/blob/29ece9b058f6b9a1cf29bc723ed4aa3a39879ad5/llama-index-core/llama_index/core/chat_engine/types.py#L63-L64
         if is_dataclass(obj):
-            try:
-                return asdict(obj)
-            except Exception:
-                pass
-            # asdict() calls copy.deepcopy() on non-dataclass fields, which can fail for
-            # objects with asyncio internals (e.g. HTTP clients). Fall back to shallow
-            # field extraction via getattr() to avoid partially-constructed copies.
+            # Use shallow field extraction instead of asdict() to avoid copy.deepcopy(),
+            # which can leave partially-constructed objects (e.g. AsyncHttpxClientWrapper
+            # missing _state) that crash during garbage collection.
+            # json.dumps will recursively call default() on nested values, so we still
+            # get full recursive serialization without the deepcopy hazard.
             try:
                 return {f.name: getattr(obj, f.name) for f in fields(obj)}
             except Exception:


### PR DESCRIPTION
### Related Issues/PRs

Closes #22723

### What changes are proposed in this pull request?

PR #21454 fixed one specific code path by excluding `run_config` from serialized attributes, but the root cause remained: `TraceJSONEncoder.default()` called `dataclasses.asdict()` which internally uses `copy.deepcopy()`. When deepcopy fails partway through on objects like `AsyncHttpxClientWrapper` (with asyncio locks), it leaves partially-constructed objects in memory whose `__del__` crashes because `_state` was never initialized.

This PR removes the `asdict()` call entirely and uses only the shallow field extraction approach (`getattr` per field). `json.dumps` recursively calls `default()` on each nested non-serializable value, so we still get full recursive serialization without the `deepcopy` hazard.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fix `AttributeError: 'AsyncHttpxClientWrapper' object has no attribute '_state'` when using MLflow tracing with OpenAI Agent SDK by avoiding `copy.deepcopy()` in dataclass serialization.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)