### PR TITLE
Reorganize Settings into section-based routing with sub-sidebar navigation

### DIFF
--- a/mlflow/server/js/src/MlflowRouter.tsx
+++ b/mlflow/server/js/src/MlflowRouter.tsx
@@ -28,7 +28,6 @@ import { useInitializeExperimentRunColors } from './experiment-tracking/componen
 import { MlflowSidebar } from './common/components/MlflowSidebar';
 import { AssistantProvider, AssistantRouteContextProvider } from './assistant';
 import { RootAssistantLayout } from './common/components/RootAssistantLayout';
-import type { To } from './common/utils/RoutingUtils';
 import {
   extractWorkspaceFromSearchParams,
   getActiveWorkspace,
@@ -179,14 +178,10 @@ export const WorkspaceRouterSync = ({ workspacesEnabled }: { workspacesEnabled: 
     const lastUsedWorkspace = getLastUsedWorkspace();
     if (!lastUsedWorkspace) {
       setActiveWorkspace(null);
-      navigate('/', { replace: true, state: location.state });
+      navigate('/', { replace: true });
       return;
     } else {
-      const to: To = {
-        pathname: location.pathname,
-        search: `?${WORKSPACE_QUERY_PARAM}=${encodeURIComponent(lastUsedWorkspace)}`,
-      };
-      navigate(to, { replace: true, state: location.state });
+      navigate(location.pathname + '?' + WORKSPACE_QUERY_PARAM + '=' + lastUsedWorkspace, { replace: true });
     }
   }, [location, navigate, workspacesEnabled, searchParams]);
 

--- a/mlflow/server/js/src/MlflowRouter.tsx
+++ b/mlflow/server/js/src/MlflowRouter.tsx
@@ -28,6 +28,7 @@ import { useInitializeExperimentRunColors } from './experiment-tracking/componen
 import { MlflowSidebar } from './common/components/MlflowSidebar';
 import { AssistantProvider, AssistantRouteContextProvider } from './assistant';
 import { RootAssistantLayout } from './common/components/RootAssistantLayout';
+import type { To } from './common/utils/RoutingUtils';
 import {
   extractWorkspaceFromSearchParams,
   getActiveWorkspace,
@@ -35,6 +36,7 @@ import {
   isGlobalRoute,
   setActiveWorkspace,
   setLastUsedWorkspace,
+  WORKSPACE_QUERY_PARAM,
 } from './workspaces/utils/WorkspaceUtils';
 import { useWorkspaces } from './workspaces/hooks/useWorkspaces';
 
@@ -177,10 +179,14 @@ export const WorkspaceRouterSync = ({ workspacesEnabled }: { workspacesEnabled: 
     const lastUsedWorkspace = getLastUsedWorkspace();
     if (!lastUsedWorkspace) {
       setActiveWorkspace(null);
-      navigate('/', { replace: true });
+      navigate('/', { replace: true, state: location.state });
       return;
     } else {
-      navigate(location.pathname + '?workspace=' + lastUsedWorkspace, { replace: true });
+      const to: To = {
+        pathname: location.pathname,
+        search: `?${WORKSPACE_QUERY_PARAM}=${encodeURIComponent(lastUsedWorkspace)}`,
+      };
+      navigate(to, { replace: true, state: location.state });
     }
   }, [location, navigate, workspacesEnabled, searchParams]);
 

--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -32,12 +32,14 @@ import { shouldEnableWorkflowBasedNavigation, shouldEnableWorkspaces } from '../
 import { AssistantSparkleIcon } from '../../assistant/AssistantIconButton';
 import { useAssistant } from '../../assistant/AssistantContext';
 import { extractWorkspaceFromSearchParams } from '../../workspaces/utils/WorkspaceUtils';
+import { SETTINGS_RETURN_TO_PARAM } from '../../settings/settingsSectionConstants';
 import { MlflowSidebarLink } from './MlflowSidebarLink';
 import { MlflowLogo } from './MlflowLogo';
 import { DOCS_ROOT, GenAIDocsUrl, MLDocsUrl, Version } from '../constants';
 import { WorkspaceSelector } from '../../workspaces/components/WorkspaceSelector';
 import { MlflowSidebarExperimentItems } from './MlflowSidebarExperimentItems';
 import { MlflowSidebarGatewayItems } from './MlflowSidebarGatewayItems';
+import { MlflowSidebarSettingsItems } from './MlflowSidebarSettingsItems';
 import { MlflowSidebarWorkflowSwitch } from './MlflowSidebarWorkflowSwitch';
 
 const isInsideExperiment = (location: Location) =>
@@ -51,7 +53,11 @@ const isExperimentsActive = (location: Location) =>
 const isModelsActive = (location: Location) => Boolean(matchPath('/models/*', location.pathname));
 const isPromptsActive = (location: Location) => Boolean(matchPath('/prompts/*', location.pathname));
 const isGatewayActive = (location: Location) => Boolean(matchPath('/gateway/*', location.pathname));
-const isSettingsActive = (location: Location) => Boolean(matchPath('/settings/*', location.pathname));
+const isSettingsActive = (location: Location) =>
+  Boolean(
+    matchPath({ path: '/settings', end: true }, location.pathname) ||
+    matchPath('/settings/:section', location.pathname),
+  );
 
 type MlFlowSidebarMenuDropdownComponentId =
   | 'mlflow_sidebar.create_experiment_button'
@@ -115,6 +121,7 @@ export function MlflowSidebar({
   // Use the current experimentId if inside an experiment, otherwise use the persisted one
   const activeExperimentId = isInsideExperiment(location) ? experimentId : lastSelectedExperimentIdRef.current;
   const showNestedExperimentItems = Boolean(activeExperimentId) && shouldEnableWorkflowBasedNavigation();
+  const showNestedSettingsItems = isSettingsActive(location);
 
   const { openPanel, closePanel, isPanelOpen, isLocalServer } = useAssistant();
   const [isAssistantHovered, setIsAssistantHovered] = useState(false);
@@ -318,21 +325,25 @@ export function MlflowSidebar({
           }}
         >
           {showWorkspaceMenuItems &&
-            menuItems.map(
-              ({ key, icon, linkProps, componentId, nestedItems }) =>
-                nestedItems ?? (
-                  <MlflowSidebarLink
-                    key={componentId}
-                    to={linkProps.to}
-                    componentId={componentId}
-                    isActive={linkProps.isActive}
-                    icon={icon}
-                    collapsed={!showSidebar}
-                  >
-                    {linkProps.children}
-                  </MlflowSidebarLink>
-                ),
-            )}
+            (showNestedSettingsItems ? (
+              <MlflowSidebarSettingsItems collapsed={!showSidebar} />
+            ) : (
+              menuItems.map(
+                ({ icon, linkProps, componentId, nestedItems }) =>
+                  nestedItems ?? (
+                    <MlflowSidebarLink
+                      key={componentId}
+                      to={linkProps.to}
+                      componentId={componentId}
+                      isActive={linkProps.isActive}
+                      icon={icon}
+                      collapsed={!showSidebar}
+                    >
+                      {linkProps.children}
+                    </MlflowSidebarLink>
+                  ),
+              )
+            ))}
         </ul>
         <div>
           {isLocalServer && (
@@ -400,16 +411,18 @@ export function MlflowSidebar({
               <NewWindowIcon css={{ fontSize: theme.typography.fontSizeBase }} />
             </span>
           </MlflowSidebarLink>
-          <MlflowSidebarLink
-            css={{ paddingBlock: theme.spacing.sm }}
-            to={ExperimentTrackingRoutes.settingsPageRoute}
-            componentId="mlflow.sidebar.settings_tab_link"
-            isActive={isSettingsActive}
-            icon={<GearIcon />}
-            collapsed={!showSidebar}
-          >
-            <FormattedMessage defaultMessage="Settings" description="Sidebar link for settings page" />
-          </MlflowSidebarLink>
+          {showWorkspaceMenuItems && !showNestedSettingsItems && (
+            <MlflowSidebarLink
+              css={{ paddingBlock: theme.spacing.sm }}
+              to={`${ExperimentTrackingRoutes.getSettingsSectionRoute('general')}?${SETTINGS_RETURN_TO_PARAM}=${encodeURIComponent(location.pathname + location.search)}`}
+              componentId="mlflow.sidebar.settings_tab_link"
+              isActive={isSettingsActive}
+              icon={<GearIcon />}
+              collapsed={!showSidebar}
+            >
+              <FormattedMessage defaultMessage="Settings" description="Sidebar link for settings page" />
+            </MlflowSidebarLink>
+          )}
         </div>
       </nav>
     </aside>

--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -32,7 +32,7 @@ import { shouldEnableWorkflowBasedNavigation, shouldEnableWorkspaces } from '../
 import { AssistantSparkleIcon } from '../../assistant/AssistantIconButton';
 import { useAssistant } from '../../assistant/AssistantContext';
 import { extractWorkspaceFromSearchParams } from '../../workspaces/utils/WorkspaceUtils';
-import { SETTINGS_RETURN_TO_PARAM } from '../../settings/settingsSectionConstants';
+import { SETTINGS_RETURN_TO_PARAM, SETTINGS_SECTION_GENERAL } from '../../settings/settingsSectionConstants';
 import { MlflowSidebarLink } from './MlflowSidebarLink';
 import { MlflowLogo } from './MlflowLogo';
 import { DOCS_ROOT, GenAIDocsUrl, MLDocsUrl, Version } from '../constants';
@@ -414,7 +414,7 @@ export function MlflowSidebar({
           {showWorkspaceMenuItems && !showNestedSettingsItems && (
             <MlflowSidebarLink
               css={{ paddingBlock: theme.spacing.sm }}
-              to={`${ExperimentTrackingRoutes.getSettingsSectionRoute('general')}?${SETTINGS_RETURN_TO_PARAM}=${encodeURIComponent(location.pathname + location.search)}`}
+              to={`${ExperimentTrackingRoutes.getSettingsSectionRoute(SETTINGS_SECTION_GENERAL)}?${SETTINGS_RETURN_TO_PARAM}=${encodeURIComponent(location.pathname + location.search)}`}
               componentId="mlflow.sidebar.settings_tab_link"
               isActive={isSettingsActive}
               icon={<GearIcon />}

--- a/mlflow/server/js/src/common/components/MlflowSidebarGatewayItems.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebarGatewayItems.tsx
@@ -3,7 +3,6 @@ import {
   ChartLineIcon,
   CloudModelIcon,
   CreditCardIcon,
-  KeyIcon,
   useDesignSystemTheme,
 } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
@@ -16,7 +15,6 @@ import { MlflowSidebarLink } from './MlflowSidebarLink';
 const isEndpointsActive = (location: Location) =>
   Boolean(matchPath('/gateway', location.pathname)) || Boolean(matchPath('/gateway/endpoints/*', location.pathname));
 const isUsageActive = (location: Location) => Boolean(matchPath('/gateway/usage', location.pathname));
-const isApiKeysActive = (location: Location) => Boolean(matchPath('/gateway/api-keys', location.pathname));
 const isBudgetsActive = (location: Location) => Boolean(matchPath('/gateway/budgets', location.pathname));
 
 export const MlflowSidebarGatewayItems = ({ collapsed }: { collapsed: boolean }) => {
@@ -75,16 +73,6 @@ export const MlflowSidebarGatewayItems = ({ collapsed }: { collapsed: boolean })
         collapsed={collapsed}
       >
         <FormattedMessage defaultMessage="Budgets" description="Sidebar link for gateway budgets" />
-      </MlflowSidebarLink>
-      <MlflowSidebarLink
-        css={{ paddingLeft: collapsed ? undefined : theme.spacing.lg }}
-        to={GatewayRoutes.apiKeysPageRoute}
-        componentId="mlflow.sidebar.gateway_api_keys_tab_link"
-        isActive={isApiKeysActive}
-        icon={<KeyIcon />}
-        collapsed={collapsed}
-      >
-        <FormattedMessage defaultMessage="API Keys" description="Sidebar link for gateway API keys" />
       </MlflowSidebarLink>
     </div>
   );

--- a/mlflow/server/js/src/common/components/MlflowSidebarSettingsItems.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebarSettingsItems.tsx
@@ -5,9 +5,10 @@ import { matchPath, useSearchParams } from '../utils/RoutingUtils';
 import type { Location } from '../utils/RoutingUtils';
 import { MlflowSidebarLink } from './MlflowSidebarLink';
 import {
-  sanitizeSettingsReturnPath,
   SETTINGS_RETURN_TO_PARAM,
+  SETTINGS_SECTION_GENERAL,
   SETTINGS_SECTION_LLM_CONNECTIONS,
+  SETTINGS_SECTION_WEBHOOKS,
 } from '../../settings/settingsSectionConstants';
 
 const matchSettingsSection =
@@ -24,7 +25,7 @@ export const MlflowSidebarSettingsItems = ({ collapsed }: { collapsed: boolean }
   const [searchParams] = useSearchParams();
 
   const returnToParam = searchParams.get(SETTINGS_RETURN_TO_PARAM) ?? undefined;
-  const exitTo = sanitizeSettingsReturnPath(returnToParam, ExperimentTrackingRoutes.rootRoute);
+  const exitTo = returnToParam ?? ExperimentTrackingRoutes.rootRoute;
 
   const sectionTo = (section: string) => {
     const path = ExperimentTrackingRoutes.getSettingsSectionRoute(section);
@@ -60,9 +61,9 @@ export const MlflowSidebarSettingsItems = ({ collapsed }: { collapsed: boolean }
       </MlflowSidebarLink>
       <MlflowSidebarLink
         css={{ paddingLeft: collapsed ? undefined : theme.spacing.lg }}
-        to={sectionTo('general')}
+        to={sectionTo(SETTINGS_SECTION_GENERAL)}
         componentId="mlflow.sidebar.settings_general_link"
-        isActive={matchSettingsSection('general')}
+        isActive={matchSettingsSection(SETTINGS_SECTION_GENERAL)}
         collapsed={collapsed}
       >
         <FormattedMessage defaultMessage="General" description="Sidebar link: Settings > General" />
@@ -78,9 +79,9 @@ export const MlflowSidebarSettingsItems = ({ collapsed }: { collapsed: boolean }
       </MlflowSidebarLink>
       <MlflowSidebarLink
         css={{ paddingLeft: collapsed ? undefined : theme.spacing.lg }}
-        to={sectionTo('webhooks')}
+        to={sectionTo(SETTINGS_SECTION_WEBHOOKS)}
         componentId="mlflow.sidebar.settings_webhooks_link"
-        isActive={matchSettingsSection('webhooks')}
+        isActive={matchSettingsSection(SETTINGS_SECTION_WEBHOOKS)}
         collapsed={collapsed}
       >
         <FormattedMessage defaultMessage="Webhooks" description="Sidebar link: Settings > Webhooks" />

--- a/mlflow/server/js/src/common/components/MlflowSidebarSettingsItems.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebarSettingsItems.tsx
@@ -1,0 +1,90 @@
+import { ArrowLeftIcon, GearIcon, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage } from 'react-intl';
+import ExperimentTrackingRoutes from '../../experiment-tracking/routes';
+import { matchPath, useSearchParams } from '../utils/RoutingUtils';
+import type { Location } from '../utils/RoutingUtils';
+import { MlflowSidebarLink } from './MlflowSidebarLink';
+import {
+  sanitizeSettingsReturnPath,
+  SETTINGS_RETURN_TO_PARAM,
+  SETTINGS_SECTION_LLM_CONNECTIONS,
+} from '../../settings/settingsSectionConstants';
+
+const matchSettingsSection =
+  (section: string) =>
+  (location: Location): boolean =>
+    Boolean(
+      matchPath({ path: ExperimentTrackingRoutes.getSettingsSectionRoute(section), end: true }, location.pathname),
+    );
+
+const isSettingsExitLinkActive = () => false;
+
+export const MlflowSidebarSettingsItems = ({ collapsed }: { collapsed: boolean }) => {
+  const { theme } = useDesignSystemTheme();
+  const [searchParams] = useSearchParams();
+
+  const returnToParam = searchParams.get(SETTINGS_RETURN_TO_PARAM) ?? undefined;
+  const exitTo = sanitizeSettingsReturnPath(returnToParam, ExperimentTrackingRoutes.rootRoute);
+
+  const sectionTo = (section: string) => {
+    const path = ExperimentTrackingRoutes.getSettingsSectionRoute(section);
+    return returnToParam ? `${path}?${SETTINGS_RETURN_TO_PARAM}=${encodeURIComponent(returnToParam)}` : path;
+  };
+
+  return (
+    <>
+      <MlflowSidebarLink
+        css={{
+          border: `1px solid ${theme.colors.actionDefaultBorderDefault}`,
+          marginBottom: theme.spacing.sm,
+        }}
+        to={exitTo}
+        componentId="mlflow.sidebar.settings_back_link"
+        isActive={isSettingsExitLinkActive}
+        icon={<ArrowLeftIcon />}
+        collapsed={collapsed}
+        tooltipContent={
+          <FormattedMessage
+            defaultMessage="Return to main navigation"
+            description="Tooltip for leaving Settings sub-sidebar to Home and other items"
+          />
+        }
+      >
+        <span css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
+          <GearIcon />
+          <FormattedMessage
+            defaultMessage="Settings"
+            description="Settings sub-sidebar: return to main nav (same label as main Settings)"
+          />
+        </span>
+      </MlflowSidebarLink>
+      <MlflowSidebarLink
+        css={{ paddingLeft: collapsed ? undefined : theme.spacing.lg }}
+        to={sectionTo('general')}
+        componentId="mlflow.sidebar.settings_general_link"
+        isActive={matchSettingsSection('general')}
+        collapsed={collapsed}
+      >
+        <FormattedMessage defaultMessage="General" description="Sidebar link: Settings > General" />
+      </MlflowSidebarLink>
+      <MlflowSidebarLink
+        css={{ paddingLeft: collapsed ? undefined : theme.spacing.lg }}
+        to={sectionTo(SETTINGS_SECTION_LLM_CONNECTIONS)}
+        componentId="mlflow.sidebar.settings_llm_connections_link"
+        isActive={matchSettingsSection(SETTINGS_SECTION_LLM_CONNECTIONS)}
+        collapsed={collapsed}
+      >
+        <FormattedMessage defaultMessage="LLM Connections" description="Sidebar link: Settings > LLM Connections" />
+      </MlflowSidebarLink>
+      <MlflowSidebarLink
+        css={{ paddingLeft: collapsed ? undefined : theme.spacing.lg }}
+        to={sectionTo('webhooks')}
+        componentId="mlflow.sidebar.settings_webhooks_link"
+        isActive={matchSettingsSection('webhooks')}
+        collapsed={collapsed}
+      >
+        <FormattedMessage defaultMessage="Webhooks" description="Sidebar link: Settings > Webhooks" />
+      </MlflowSidebarLink>
+    </>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/IssueDetectionModelSelection.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/IssueDetectionModelSelection.tsx
@@ -451,8 +451,9 @@ export const IssueDetectionModelSelection = forwardRef<
                     <Tooltip
                       componentId="mlflow.traces.issue-detection-modal.save-key-tooltip"
                       content={intl.formatMessage({
-                        defaultMessage: 'Saved API keys can be managed from the API Keys page',
-                        description: 'Tooltip explaining where saved API keys can be found',
+                        defaultMessage: 'Saved API keys can be managed in LLM Connections under Settings.',
+                        description:
+                          'Tooltip explaining where saved API keys can be found (LLM Connections section under Settings)',
                       })}
                     >
                       <span>

--- a/mlflow/server/js/src/experiment-tracking/route-defs.ts
+++ b/mlflow/server/js/src/experiment-tracking/route-defs.ts
@@ -235,8 +235,28 @@ export const getRouteDefs = () => [
     } satisfies RouteHandle,
   },
   {
-    path: RoutePaths.settingsPage,
+    path: RoutePaths.settingsSectionPage,
     element: createLazyRouteElement(() => import('../settings/SettingsPage')),
+    pageId: PageId.settingsPage,
+    handle: {
+      getPageTitle: (params) => {
+        const section = params['section'];
+        switch (section) {
+          case 'general':
+            return 'Settings – General';
+          case 'llm-connections':
+            return 'Settings – LLM Connections';
+          case 'webhooks':
+            return 'Settings – Webhooks';
+          default:
+            return 'Settings';
+        }
+      },
+    } satisfies RouteHandle,
+  },
+  {
+    path: RoutePaths.settingsPage,
+    element: createLazyRouteElement(() => import('../settings/SettingsEntryRedirect')),
     pageId: PageId.settingsPage,
     handle: { getPageTitle: () => 'Settings' } satisfies RouteHandle,
   },

--- a/mlflow/server/js/src/experiment-tracking/routes.ts
+++ b/mlflow/server/js/src/experiment-tracking/routes.ts
@@ -147,6 +147,9 @@ export class RoutePaths {
   static get settingsPage() {
     return createMLflowRoutePath('/settings');
   }
+  static get settingsSectionPage() {
+    return createMLflowRoutePath('/settings/:section');
+  }
 }
 
 // Concrete routes and functions for generating parametrized paths
@@ -170,6 +173,10 @@ class Routes {
 
   static get settingsPageRoute() {
     return RoutePaths.settingsPage;
+  }
+
+  static getSettingsSectionRoute(section: string) {
+    return generatePath(RoutePaths.settingsSectionPage, { section });
   }
 
   static getExperimentPageRoute(experimentId: string, isComparingRuns = false, shareState?: string) {

--- a/mlflow/server/js/src/gateway/components/edit-endpoint/EditEndpointFormRenderer.tsx
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/EditEndpointFormRenderer.tsx
@@ -16,6 +16,8 @@ import type { UseFormReturn } from 'react-hook-form';
 import { Controller } from 'react-hook-form';
 import { useMemo } from 'react';
 import GatewayRoutes from '../../routes';
+import Routes from '../../../experiment-tracking/routes';
+import { SETTINGS_SECTION_LLM_CONNECTIONS } from '../../../settings/settingsSectionConstants';
 import { GatewayLabel } from '../../../common/components/GatewayNewTag';
 import { LongFormSummary } from '../../../common/components/long-form/LongFormSummary';
 import type { EditEndpointFormData } from '../../hooks/useEditEndpointForm';
@@ -438,7 +440,7 @@ export const EditEndpointFormRenderer = ({
                         <Link
                           key={secretName}
                           componentId="mlflow.gateway.edit-endpoint.api-key-link"
-                          to={GatewayRoutes.apiKeysPageRoute}
+                          to={Routes.getSettingsSectionRoute(SETTINGS_SECTION_LLM_CONNECTIONS)}
                           css={{
                             fontSize: theme.typography.fontSizeSm,
                             color: theme.colors.actionPrimaryBackgroundDefault,

--- a/mlflow/server/js/src/gateway/components/side-nav/GatewaySideNav.tsx
+++ b/mlflow/server/js/src/gateway/components/side-nav/GatewaySideNav.tsx
@@ -2,7 +2,6 @@ import {
   ChainIcon,
   ChartLineIcon,
   CreditCardIcon,
-  KeyIcon,
   Tooltip,
   Typography,
   useDesignSystemTheme,
@@ -16,11 +15,10 @@ const SIDE_NAV_COLLAPSED_WIDTH = 32;
 const COLLAPSED_CLASS_NAME = 'gateway-side-nav-collapsed';
 const FULL_WIDTH_CLASS_NAME = 'gateway-side-nav-full-width';
 
-export type GatewayTab = 'endpoints' | 'usage' | 'api-keys' | 'budgets';
+export type GatewayTab = 'endpoints' | 'usage' | 'budgets';
 
 type GatewaySideNavComponentId =
   | 'mlflow.gateway.side-nav.endpoints.tooltip'
-  | 'mlflow.gateway.side-nav.api-keys.tooltip'
   | 'mlflow.gateway.side-nav.usage.tooltip'
   | 'mlflow.gateway.side-nav.budgets.tooltip';
 
@@ -55,13 +53,6 @@ const navItems: Array<{
     icon: <CreditCardIcon />,
     to: GatewayRoutes.budgetsPageRoute,
     componentId: 'mlflow.gateway.side-nav.budgets.tooltip',
-  },
-  {
-    tab: 'api-keys',
-    label: <FormattedMessage defaultMessage="API Keys" description="Gateway side nav > API Keys tab" />,
-    icon: <KeyIcon />,
-    to: GatewayRoutes.apiKeysPageRoute,
-    componentId: 'mlflow.gateway.side-nav.api-keys.tooltip',
   },
 ];
 

--- a/mlflow/server/js/src/gateway/pages/ApiKeysPage.tsx
+++ b/mlflow/server/js/src/gateway/pages/ApiKeysPage.tsx
@@ -1,8 +1,4 @@
-import { Breadcrumb, KeyIcon, Typography, useDesignSystemTheme } from '@databricks/design-system';
-import { FormattedMessage } from 'react-intl';
-import { Link } from '../../common/utils/RoutingUtils';
-import { GatewayLabel } from '../../common/components/GatewayNewTag';
-import GatewayRoutes from '../routes';
+import { useDesignSystemTheme } from '@databricks/design-system';
 import { withErrorBoundary } from '../../common/utils/withErrorBoundary';
 import ErrorUtils from '../../common/utils/ErrorUtils';
 import { ApiKeysList } from '../components/api-keys/ApiKeysList';
@@ -12,13 +8,7 @@ import { EndpointsUsingKeyDrawer } from '../components/api-keys/EndpointsUsingKe
 import { BindingsUsingKeyDrawer } from '../components/api-keys/BindingsUsingKeyDrawer';
 import { useApiKeysPage } from '../hooks/useApiKeysPage';
 
-/**
- * Container component for the API Keys page.
- * Uses the container/renderer pattern:
- * - useApiKeysPage: Contains all business logic (state, data fetching, handlers)
- * - This component: Handles page layout and renders child components
- */
-const ApiKeysPage = () => {
+export function ApiKeysPageInner() {
   const { theme } = useDesignSystemTheme();
 
   const {
@@ -61,45 +51,17 @@ const ApiKeysPage = () => {
   } = useApiKeysPage();
 
   return (
-    <div css={{ display: 'flex', flexDirection: 'column', flex: 1, overflow: 'hidden' }}>
-      {/* Header */}
-      <div
-        css={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          padding: theme.spacing.md,
-          borderBottom: `1px solid ${theme.colors.borderDecorative}`,
-        }}
-      >
-        <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
-          <Breadcrumb includeTrailingCaret>
-            <Breadcrumb.Item>
-              <Link componentId="mlflow.gateway.api-keys.breadcrumb_gateway_link" to={GatewayRoutes.gatewayPageRoute}>
-                <GatewayLabel />
-              </Link>
-            </Breadcrumb.Item>
-          </Breadcrumb>
-          <div css={{ display: 'flex', gap: theme.spacing.sm, alignItems: 'center' }}>
-            <div
-              css={{
-                borderRadius: theme.borders.borderRadiusSm,
-                backgroundColor: theme.colors.backgroundSecondary,
-                padding: theme.spacing.sm,
-                display: 'flex',
-              }}
-            >
-              <KeyIcon />
-            </div>
-            <Typography.Title withoutMargins level={2}>
-              <FormattedMessage defaultMessage="API Keys" description="API Keys page title" />
-            </Typography.Title>
-          </div>
-        </div>
-      </div>
-
-      {/* Content */}
-      <div css={{ flex: 1, overflow: 'auto', padding: theme.spacing.md }}>
+    <div
+      css={{
+        display: 'flex',
+        flexDirection: 'column',
+        flex: 1,
+        minHeight: 0,
+        overflow: 'hidden',
+        width: '100%',
+      }}
+    >
+      <div css={{ flex: 1, overflow: 'auto' }}>
         <ApiKeysList
           onCreateClick={handleCreateClick}
           onKeyClick={handleKeyClick}
@@ -137,6 +99,6 @@ const ApiKeysPage = () => {
       />
     </div>
   );
-};
+}
 
-export default withErrorBoundary(ErrorUtils.mlflowServices.EXPERIMENTS, ApiKeysPage);
+export default withErrorBoundary(ErrorUtils.mlflowServices.EXPERIMENTS, ApiKeysPageInner);

--- a/mlflow/server/js/src/gateway/pages/ApiKeysPage.tsx
+++ b/mlflow/server/js/src/gateway/pages/ApiKeysPage.tsx
@@ -1,4 +1,3 @@
-import { useDesignSystemTheme } from '@databricks/design-system';
 import { withErrorBoundary } from '../../common/utils/withErrorBoundary';
 import ErrorUtils from '../../common/utils/ErrorUtils';
 import { ApiKeysList } from '../components/api-keys/ApiKeysList';
@@ -9,8 +8,6 @@ import { BindingsUsingKeyDrawer } from '../components/api-keys/BindingsUsingKeyD
 import { useApiKeysPage } from '../hooks/useApiKeysPage';
 
 export function ApiKeysPageInner() {
-  const { theme } = useDesignSystemTheme();
-
   const {
     // Data
     allEndpoints,

--- a/mlflow/server/js/src/gateway/pages/GatewayPage.tsx
+++ b/mlflow/server/js/src/gateway/pages/GatewayPage.tsx
@@ -10,7 +10,6 @@ import { GatewaySideNav, type GatewayTab } from '../components/side-nav';
 import { GatewayLabel } from '../../common/components/GatewayNewTag';
 import { GatewaySetupGuide } from '../components/SecretsSetupGuide';
 import { useSecretsConfigQuery } from '../hooks/useSecretsConfigQuery';
-import ApiKeysPage from './ApiKeysPage';
 import BudgetsPage from './BudgetsPage';
 import GatewayUsagePage from './GatewayUsagePage';
 import GatewayRoutes from '../routes';
@@ -22,9 +21,6 @@ const GatewayPage = () => {
   const { data: secretsConfig, isLoading: isLoadingConfig } = useSecretsConfigQuery();
 
   const activeTab: GatewayTab = useMemo(() => {
-    if (location.pathname.includes('/api-keys')) {
-      return 'api-keys';
-    }
     if (location.pathname.includes('/usage')) {
       return 'usage';
     }
@@ -35,10 +31,9 @@ const GatewayPage = () => {
   }, [location.pathname]);
 
   const isIndexRoute = location.pathname === '/gateway' || location.pathname === '/gateway/';
-  const isApiKeysRoute = location.pathname.includes('/api-keys');
   const isUsageRoute = location.pathname.includes('/usage');
   const isBudgetsRoute = location.pathname.includes('/budgets');
-  const isNestedRoute = !isIndexRoute && !isApiKeysRoute && !isUsageRoute && !isBudgetsRoute;
+  const isNestedRoute = !isIndexRoute && !isUsageRoute && !isBudgetsRoute;
 
   if (isLoadingConfig) {
     return (
@@ -130,7 +125,6 @@ const GatewayPage = () => {
                   </div>
                 </div>
               )}
-              {isApiKeysRoute && <ApiKeysPage />}
               {isUsageRoute && <GatewayUsagePage />}
               {isBudgetsRoute && <BudgetsPage />}
             </>

--- a/mlflow/server/js/src/gateway/pages/RedirectApiKeysToSettings.tsx
+++ b/mlflow/server/js/src/gateway/pages/RedirectApiKeysToSettings.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+import { useNavigate } from '../../common/utils/RoutingUtils';
+import Routes from '../../experiment-tracking/routes';
+import { SETTINGS_SECTION_LLM_CONNECTIONS } from '../../settings/settingsSectionConstants';
+
+/**
+ * Legacy `/gateway/api-keys` route: API keys live under Settings > LLM Connections.
+ */
+const RedirectApiKeysToSettings = () => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    navigate(Routes.getSettingsSectionRoute(SETTINGS_SECTION_LLM_CONNECTIONS), { replace: true });
+  }, [navigate]);
+
+  return null;
+};
+
+export default RedirectApiKeysToSettings;

--- a/mlflow/server/js/src/gateway/pages/RedirectApiKeysToSettings.tsx
+++ b/mlflow/server/js/src/gateway/pages/RedirectApiKeysToSettings.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useNavigate } from '../../common/utils/RoutingUtils';
 import Routes from '../../experiment-tracking/routes';
-import { SETTINGS_SECTION_LLM_CONNECTIONS } from '../../settings/settingsSectionConstants';
+import { SETTINGS_RETURN_TO_PARAM, SETTINGS_SECTION_LLM_CONNECTIONS } from '../../settings/settingsSectionConstants';
 
 /**
  * Legacy `/gateway/api-keys` route: API keys live under Settings > LLM Connections.
@@ -10,7 +10,8 @@ const RedirectApiKeysToSettings = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    navigate(Routes.getSettingsSectionRoute(SETTINGS_SECTION_LLM_CONNECTIONS), { replace: true });
+    const settingsRoute = Routes.getSettingsSectionRoute(SETTINGS_SECTION_LLM_CONNECTIONS);
+    navigate(`${settingsRoute}?${SETTINGS_RETURN_TO_PARAM}=${encodeURIComponent('/gateway')}`, { replace: true });
   }, [navigate]);
 
   return null;

--- a/mlflow/server/js/src/gateway/route-defs.ts
+++ b/mlflow/server/js/src/gateway/route-defs.ts
@@ -12,7 +12,7 @@ export const getGatewayRouteDefs = () => {
       children: [
         {
           path: 'api-keys',
-          element: createLazyRouteElement(() => import('./pages/ApiKeysPage')),
+          element: createLazyRouteElement(() => import('./pages/RedirectApiKeysToSettings')),
           pageId: GatewayPageId.apiKeysPage,
           handle: { getPageTitle: () => 'API Keys' } satisfies DocumentTitleHandle,
         },

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -711,10 +711,6 @@
     "defaultMessage": "Created at",
     "description": "Column header for created timestamp in the evaluation runs table"
   },
-  "2PCNVS": {
-    "defaultMessage": "API Keys",
-    "description": "API Keys page title"
-  },
   "2RgAyy": {
     "defaultMessage": "Search",
     "description": "Search placeholder"
@@ -846,6 +842,10 @@
   "3N1zOb": {
     "defaultMessage": "Disabled",
     "description": "Webhook disabled label"
+  },
+  "3PBIB8": {
+    "defaultMessage": "Appearance, product feedback, telemetry, and workspace demo data.",
+    "description": "Settings content section subtitle for general preferences including demo data"
   },
   "3Rb4sG": {
     "defaultMessage": "Delete",
@@ -1843,10 +1843,6 @@
     "defaultMessage": "MLflow runs:",
     "description": "A label for the associated MLflow runs in the prompt details page"
   },
-  "9ZzOhu": {
-    "defaultMessage": "API Keys",
-    "description": "Sidebar link for gateway API keys"
-  },
   "9cTaBs": {
     "defaultMessage": "Fail",
     "description": "Failing assessment label"
@@ -1874,6 +1870,10 @@
   "9kTEoo": {
     "defaultMessage": "Is the app's response grounded in retrieved information?",
     "description": "Hint for RetrievalGroundedness template"
+  },
+  "9lo9Zg": {
+    "defaultMessage": "LLM Connections",
+    "description": "Settings content section title: LLM connections"
   },
   "9mAGv0": {
     "defaultMessage": "Model name",
@@ -2194,6 +2194,10 @@
   "BZLX5c": {
     "defaultMessage": "Track experiments, parameters, and metrics throughout training.",
     "description": "Home page quick action description for training models"
+  },
+  "BaNRkH": {
+    "defaultMessage": "Webhooks",
+    "description": "Settings content section title: webhooks"
   },
   "Bbm59f": {
     "defaultMessage": "100",
@@ -2726,6 +2730,10 @@
   "F16DNA": {
     "defaultMessage": "Version {versionNum}",
     "description": "Title text for model version page"
+  },
+  "F39ONm": {
+    "defaultMessage": "LLM Connections",
+    "description": "Sidebar link: Settings > LLM Connections"
   },
   "F4K195": {
     "defaultMessage": "No evaluation datasets found",
@@ -3579,6 +3587,10 @@
     "defaultMessage": "X-axis:",
     "description": "Label for the radio button to toggle the control on the X-axis of the metric graph for the experiment"
   },
+  "L3sJpt": {
+    "defaultMessage": "Settings",
+    "description": "Settings sub-sidebar: return to main nav (same label as main Settings)"
+  },
   "L3szkg": {
     "defaultMessage": "Failed to create assessment. Error: {error}",
     "description": "Error message when creating an assessment fails"
@@ -4226,6 +4238,10 @@
   "PGbCZD": {
     "defaultMessage": "Production",
     "description": "Column title for production phase version in the registered model page"
+  },
+  "PIPzZY": {
+    "defaultMessage": "General",
+    "description": "Sidebar link: Settings > General"
   },
   "PIsgM0": {
     "defaultMessage": "Experiments",
@@ -6207,10 +6223,6 @@
     "defaultMessage": "Ungrouped",
     "description": "Label for the group of logged models that are not grouped by any source run"
   },
-  "bZgVna": {
-    "defaultMessage": "Saved API keys can be managed from the API Keys page",
-    "description": "Tooltip explaining where saved API keys can be found"
-  },
   "ba7/ni": {
     "defaultMessage": "A demo experiment to quickly explore MLflow's core features with sample pre-generated data. You can clean up demo resources from Settings.",
     "description": "Tooltip explaining the demo experiment in the experiments list"
@@ -6554,6 +6566,10 @@
   "dSaI6E": {
     "defaultMessage": "Failed to load audio attachment",
     "description": "Error message when trace audio attachment fails to load"
+  },
+  "dTHmzd": {
+    "defaultMessage": "Saved API keys can be managed in LLM Connections under Settings.",
+    "description": "Tooltip explaining where saved API keys can be found (LLM Connections section under Settings)"
   },
   "dTLq6E": {
     "defaultMessage": "expand {title}",
@@ -6979,6 +6995,10 @@
     "defaultMessage": "Delete {count, plural, one { # trace } other { # traces }}",
     "description": "Experiment page > traces view controls > Delete traces modal > Delete button"
   },
+  "g5myH8": {
+    "defaultMessage": "Webhooks",
+    "description": "Sidebar link: Settings > Webhooks"
+  },
   "g7xNvF": {
     "defaultMessage": "Display points",
     "description": "Runs charts > line chart > display points > label"
@@ -7186,6 +7206,10 @@
   "hN4qL/": {
     "defaultMessage": "Create workspace",
     "description": "Home page workspaces empty state CTA"
+  },
+  "hNmwSr": {
+    "defaultMessage": "General",
+    "description": "Settings content section title: general"
   },
   "hP8kyS": {
     "defaultMessage": "Delete ({count})",
@@ -7911,6 +7935,10 @@
     "defaultMessage": "Hide charts with no data",
     "description": "Experiment page > control bar > label for a checkbox toggle button that hides chart cards with no corresponding data"
   },
+  "leXUJw": {
+    "defaultMessage": "Create and manage API keys for authenticating to external LLM providers.",
+    "description": "Settings content section subtitle for LLM connections (API keys)"
+  },
   "lf2ttL": {
     "defaultMessage": "Sample rate",
     "description": "Section header for sample rate"
@@ -8583,6 +8611,10 @@
     "defaultMessage": "via endpoint:",
     "description": "Gateway > Bindings using key drawer > Via endpoint label"
   },
+  "pdhbzZ": {
+    "defaultMessage": "Return to main navigation",
+    "description": "Tooltip for leaving Settings sub-sidebar to Home and other items"
+  },
   "peyOdH": {
     "defaultMessage": "Cancel",
     "description": "Text for canceling changes on rows in editable form table in MLflow"
@@ -8938,10 +8970,6 @@
   "rdrvCs": {
     "defaultMessage": "Created",
     "description": "Secret created label"
-  },
-  "retpTK": {
-    "defaultMessage": "API Keys",
-    "description": "Gateway side nav > API Keys tab"
   },
   "rgSaFx": {
     "defaultMessage": "Span type",
@@ -9407,6 +9435,10 @@
     "defaultMessage": "Overall",
     "description": "Evaluation results > known type of evaluation result assessment > overall assessment."
   },
+  "up3hbr": {
+    "defaultMessage": "Receive HTTP notifications when events occur in MLflow.",
+    "description": "Settings content section subtitle for webhooks"
+  },
   "uq6CTI": {
     "defaultMessage": "No profile available",
     "description": "Text for no profile available in the experiment run dataset drawer"
@@ -9646,10 +9678,6 @@
   "wOmMb1": {
     "defaultMessage": "Budget exceeded: {spend} of {limit} spent",
     "description": "Tooltip shown when current spend exceeds the budget limit"
-  },
-  "wRV8PN": {
-    "defaultMessage": "Settings",
-    "description": "Settings page title"
   },
   "wY58OE": {
     "defaultMessage": "Retrieval groundedness",

--- a/mlflow/server/js/src/settings/SettingsEntryRedirect.tsx
+++ b/mlflow/server/js/src/settings/SettingsEntryRedirect.tsx
@@ -1,13 +1,14 @@
 import { useEffect } from 'react';
 import { useNavigate } from '../common/utils/RoutingUtils';
 import Routes from '../experiment-tracking/routes';
+import { SETTINGS_SECTION_GENERAL } from './settingsSectionConstants';
 
 /** `/settings` without a section segment redirects to `/settings/general`. */
 const SettingsEntryRedirect = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    navigate(Routes.getSettingsSectionRoute('general'), { replace: true });
+    navigate(Routes.getSettingsSectionRoute(SETTINGS_SECTION_GENERAL), { replace: true });
   }, [navigate]);
 
   return null;

--- a/mlflow/server/js/src/settings/SettingsEntryRedirect.tsx
+++ b/mlflow/server/js/src/settings/SettingsEntryRedirect.tsx
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+import { useNavigate } from '../common/utils/RoutingUtils';
+import Routes from '../experiment-tracking/routes';
+
+/** `/settings` without a section segment redirects to `/settings/general`. */
+const SettingsEntryRedirect = () => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    navigate(Routes.getSettingsSectionRoute('general'), { replace: true });
+  }, [navigate]);
+
+  return null;
+};
+
+export default SettingsEntryRedirect;

--- a/mlflow/server/js/src/settings/SettingsPage.test.tsx
+++ b/mlflow/server/js/src/settings/SettingsPage.test.tsx
@@ -54,7 +54,7 @@ describe('SettingsPage', () => {
     jest.clearAllMocks();
   });
 
-  it('shows demo data controls under General (legacy /settings/data deep links redirect to general)', async () => {
+  it('shows demo data controls under General section', async () => {
     renderComponent('/settings/general');
 
     expect(await screen.findByText('Clear all demo data')).toBeInTheDocument();

--- a/mlflow/server/js/src/settings/SettingsPage.test.tsx
+++ b/mlflow/server/js/src/settings/SettingsPage.test.tsx
@@ -5,6 +5,7 @@ import { renderWithIntl } from '../common/utils/TestUtils.react18';
 import SettingsPage from './SettingsPage';
 import { DesignSystemProvider } from '@databricks/design-system';
 import { DarkThemeProvider } from '../common/contexts/DarkThemeContext';
+import { MemoryRouter, Route, Routes } from '../common/utils/RoutingUtils';
 
 import { fetchEndpointRaw } from '../common/utils/FetchUtils';
 
@@ -22,24 +23,51 @@ jest.mock('./webhooksApi', () => ({
     testWebhook: jest.fn(() => Promise.resolve({ result: { success: true } })),
   },
 }));
+
+jest.mock('../gateway/pages/ApiKeysPage', () => ({
+  __esModule: true,
+  ApiKeysPageInner: () => <div data-testid="api-keys-settings-embed" />,
+  default: () => null,
+}));
 const mockFetchEndpointRaw = jest.mocked(fetchEndpointRaw);
 
 describe('SettingsPage', () => {
-  const renderComponent = () =>
+  const renderComponent = (initialEntry = '/settings/general') =>
     renderWithIntl(
-      <DesignSystemProvider>
-        <DarkThemeProvider setIsDarkTheme={() => {}}>
-          <SettingsPage />
-        </DarkThemeProvider>
-      </DesignSystemProvider>,
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route
+            path="/settings/:section"
+            element={
+              <DesignSystemProvider>
+                <DarkThemeProvider setIsDarkTheme={() => {}}>
+                  <SettingsPage />
+                </DarkThemeProvider>
+              </DesignSystemProvider>
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
     );
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
+  it('shows demo data controls under General (legacy /settings/data deep links redirect to general)', async () => {
+    renderComponent('/settings/general');
+
+    expect(await screen.findByText('Clear all demo data')).toBeInTheDocument();
+  });
+
+  it('opens LLM Connections from the URL path and embeds API keys', async () => {
+    renderComponent('/settings/llm-connections');
+
+    expect(await screen.findByTestId('api-keys-settings-embed')).toBeInTheDocument();
+  });
+
   it('calls fetchEndpointRaw with the demo delete endpoint when clearing demo data', async () => {
-    renderComponent();
+    renderComponent('/settings/general');
 
     // Open the confirmation modal
     await userEvent.click(screen.getByText('Clear all demo data'));

--- a/mlflow/server/js/src/settings/SettingsPage.tsx
+++ b/mlflow/server/js/src/settings/SettingsPage.tsx
@@ -13,6 +13,7 @@ import WebhooksSettings from './WebhooksSettings';
 import {
   isSettingsPathSegment,
   SETTINGS_RETURN_TO_PARAM,
+  SETTINGS_SECTION_GENERAL,
   SETTINGS_SECTION_LLM_CONNECTIONS,
   type SettingsPathSegment,
 } from './settingsSectionConstants';
@@ -91,7 +92,7 @@ const SettingsPage = () => {
   useEffect(() => {
     if (sectionParam && !isSettingsPathSegment(sectionParam)) {
       const returnTo = new URLSearchParams(location.search).get(SETTINGS_RETURN_TO_PARAM);
-      const target = Routes.getSettingsSectionRoute('general');
+      const target = Routes.getSettingsSectionRoute(SETTINGS_SECTION_GENERAL);
       navigate(returnTo ? `${target}?${SETTINGS_RETURN_TO_PARAM}=${encodeURIComponent(returnTo)}` : target, {
         replace: true,
         state: location.state,

--- a/mlflow/server/js/src/settings/SettingsPage.tsx
+++ b/mlflow/server/js/src/settings/SettingsPage.tsx
@@ -1,20 +1,97 @@
-import { Button, Modal, Spinner, Switch, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { Button, Card, Modal, Spinner, Switch, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage, useIntl } from '@databricks/i18n';
 import { useLocalStorage } from '@databricks/web-shared/hooks';
 import { TELEMETRY_ENABLED_STORAGE_KEY, TELEMETRY_ENABLED_STORAGE_VERSION } from '../telemetry/utils';
 import { telemetryClient } from '../telemetry';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { fetchEndpointRaw, HTTPMethods } from '../common/utils/FetchUtils';
+import { useLocation, useNavigate, useParams } from '../common/utils/RoutingUtils';
 import { useDarkThemeContext } from '../common/contexts/DarkThemeContext';
+import { ApiKeysPageInner } from '../gateway/pages/ApiKeysPage';
+import Routes from '../experiment-tracking/routes';
 import WebhooksSettings from './WebhooksSettings';
+import {
+  isSettingsPathSegment,
+  SETTINGS_SECTION_LLM_CONNECTIONS,
+  type SettingsPathSegment,
+} from './settingsSectionConstants';
+
+type SettingsSectionHeaderProps = {
+  title: ReactNode;
+  subtitle: ReactNode;
+};
+
+const SettingsSectionHeader = ({ title, subtitle }: SettingsSectionHeaderProps) => {
+  const { theme } = useDesignSystemTheme();
+  return (
+    <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs, width: '100%' }}>
+      <Typography.Title level={3} withoutMargins>
+        {title}
+      </Typography.Title>
+      <Typography.Text color="secondary">{subtitle}</Typography.Text>
+    </div>
+  );
+};
+
+type SettingsRowProps = {
+  children: ReactNode;
+  trailing: ReactNode;
+  isFirst?: boolean;
+};
+
+const SettingsRow = ({ children, trailing, isFirst }: SettingsRowProps) => {
+  const { theme } = useDesignSystemTheme();
+  return (
+    <div
+      css={{
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'flex-start',
+        gap: theme.spacing.md,
+        padding: theme.spacing.md,
+        borderTop: isFirst ? undefined : `1px solid ${theme.colors.borderDecorative}`,
+      }}
+    >
+      <div
+        css={{
+          flex: 1,
+          minWidth: 0,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: theme.spacing.xs,
+          textAlign: 'left',
+        }}
+      >
+        {children}
+      </div>
+      <div css={{ flexShrink: 0, paddingTop: theme.spacing.xs }}>{trailing}</div>
+    </div>
+  );
+};
 
 const SettingsPage = () => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { section: sectionParam } = useParams();
   const [isCleaningDemo, setIsCleaningDemo] = useState(false);
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
   const { setIsDarkTheme } = useDarkThemeContext();
   const isDarkTheme = theme.isDarkMode;
+
+  const activeSection: SettingsPathSegment = useMemo(() => {
+    if (sectionParam && isSettingsPathSegment(sectionParam)) {
+      return sectionParam;
+    }
+    return 'general';
+  }, [sectionParam]);
+
+  useEffect(() => {
+    if (sectionParam && !isSettingsPathSegment(sectionParam)) {
+      navigate(Routes.getSettingsSectionRoute('general'), { replace: true, state: location.state });
+    }
+  }, [sectionParam, navigate, location.state]);
 
   const [isTelemetryEnabled, setIsTelemetryEnabled] = useLocalStorage({
     key: TELEMETRY_ENABLED_STORAGE_KEY,
@@ -54,108 +131,173 @@ const SettingsPage = () => {
   }, []);
 
   return (
-    <div css={{ padding: theme.spacing.md, display: 'flex', flexDirection: 'column', gap: theme.spacing.lg }}>
-      <Typography.Title level={2} withoutMargins>
-        <FormattedMessage defaultMessage="Settings" description="Settings page title" />
-      </Typography.Title>
-
-      <div css={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', maxWidth: 600 }}>
-        <div css={{ display: 'flex', flexDirection: 'column', marginRight: theme.spacing.lg }}>
-          <Typography.Title level={4}>
-            <FormattedMessage defaultMessage="Theme preference" description="Theme settings title" />
-          </Typography.Title>
-          <Typography.Text>
-            <FormattedMessage
-              defaultMessage="Select your theme preference between light and dark."
-              description="Description for the theme setting in the settings page"
-            />
-          </Typography.Text>
-        </div>
-        <Switch
-          componentId="mlflow.settings.theme.toggle-switch"
-          checked={isDarkTheme}
-          onChange={handleThemeToggle}
-          label={
-            isDarkTheme
-              ? intl.formatMessage({ defaultMessage: 'Dark', description: 'Dark theme label' })
-              : intl.formatMessage({ defaultMessage: 'Light', description: 'Light theme label' })
-          }
-          activeLabel={intl.formatMessage({ defaultMessage: 'Dark', description: 'Dark theme label' })}
-          inactiveLabel={intl.formatMessage({ defaultMessage: 'Light', description: 'Light theme label' })}
-        />
-      </div>
-
-      <div css={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', maxWidth: 600 }}>
-        <div css={{ display: 'flex', flexDirection: 'column', marginRight: theme.spacing.lg }}>
-          <Typography.Title level={4}>
-            <FormattedMessage defaultMessage="Enable telemetry" description="Enable telemetry settings title" />
-          </Typography.Title>
-          <Typography.Text>
-            <FormattedMessage
-              defaultMessage="This setting enables UI telemetry data collection. Learn more about what types of data are collected in our {documentation}."
-              description="Enable telemetry settings description"
-              values={{
-                documentation: (
-                  <Typography.Link
-                    componentId="mlflow.settings.telemetry.documentation-link"
-                    href="https://mlflow.org/docs/latest/community/usage-tracking.html"
-                    openInNewTab
-                  >
-                    <FormattedMessage defaultMessage="documentation" description="Documentation link text" />
-                  </Typography.Link>
-                ),
-              }}
-            />
-          </Typography.Text>
-        </div>
-        <Switch
-          componentId="mlflow.settings.telemetry.toggle-switch"
-          checked={isTelemetryEnabled}
-          onChange={handleTelemetryToggle}
-          label={
-            isTelemetryEnabled
-              ? intl.formatMessage({ defaultMessage: 'On', description: 'Telemetry enabled label' })
-              : intl.formatMessage({ defaultMessage: 'Off', description: 'Telemetry disabled label' })
-          }
-          activeLabel={intl.formatMessage({ defaultMessage: 'On', description: 'Telemetry enabled label' })}
-          inactiveLabel={intl.formatMessage({ defaultMessage: 'Off', description: 'Telemetry disabled label' })}
-        />
-      </div>
-
+    <div
+      css={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'flex-start',
+        minHeight: '100%',
+        padding: theme.spacing.md,
+        gap: theme.spacing.lg,
+        textAlign: 'left',
+      }}
+    >
       <div
         css={{
+          width: '100%',
+          maxWidth: theme.responsive.breakpoints.lg,
           display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          maxWidth: 600,
+          flexDirection: 'column',
+          gap: theme.spacing.lg,
+          textAlign: 'left',
         }}
       >
-        <div css={{ display: 'flex', flexDirection: 'column', marginRight: theme.spacing.lg }}>
-          <Typography.Title level={4}>
-            <FormattedMessage defaultMessage="Demo data" description="Demo data settings title" />
-          </Typography.Title>
-          <Typography.Text>
-            <FormattedMessage
-              defaultMessage="Clear all demo data generated from the home page. This removes demo experiments, traces, evaluations, and prompts."
-              description="Demo data settings description"
+        {activeSection === 'general' && (
+          <>
+            <SettingsSectionHeader
+              title={
+                <FormattedMessage defaultMessage="General" description="Settings content section title: general" />
+              }
+              subtitle={
+                <FormattedMessage
+                  defaultMessage="Appearance, product feedback, telemetry, and workspace demo data."
+                  description="Settings content section subtitle for general preferences including demo data"
+                />
+              }
             />
-          </Typography.Text>
-        </div>
-        <Button
-          componentId="mlflow.settings.demo.clear-all-button"
-          onClick={() => setIsConfirmModalOpen(true)}
-          disabled={isCleaningDemo}
-        >
-          {isCleaningDemo ? (
-            <Spinner size="small" />
-          ) : (
-            <FormattedMessage defaultMessage="Clear all demo data" description="Clear demo data button" />
-          )}
-        </Button>
-      </div>
+            <Card componentId="mlflow.settings.general.preferences-card" css={{ padding: 0, overflow: 'hidden' }}>
+              <SettingsRow
+                isFirst
+                trailing={
+                  <Switch
+                    componentId="mlflow.settings.theme.toggle-switch"
+                    checked={isDarkTheme}
+                    onChange={handleThemeToggle}
+                    label={
+                      isDarkTheme
+                        ? intl.formatMessage({ defaultMessage: 'Dark', description: 'Dark theme label' })
+                        : intl.formatMessage({ defaultMessage: 'Light', description: 'Light theme label' })
+                    }
+                    activeLabel={intl.formatMessage({ defaultMessage: 'Dark', description: 'Dark theme label' })}
+                    inactiveLabel={intl.formatMessage({ defaultMessage: 'Light', description: 'Light theme label' })}
+                  />
+                }
+              >
+                <Typography.Title level={4} withoutMargins>
+                  <FormattedMessage defaultMessage="Theme preference" description="Theme settings title" />
+                </Typography.Title>
+                <Typography.Text>
+                  <FormattedMessage
+                    defaultMessage="Select your theme preference between light and dark."
+                    description="Description for the theme setting in the settings page"
+                  />
+                </Typography.Text>
+              </SettingsRow>
+              <SettingsRow
+                trailing={
+                  <Switch
+                    componentId="mlflow.settings.telemetry.toggle-switch"
+                    checked={isTelemetryEnabled}
+                    onChange={handleTelemetryToggle}
+                    label={
+                      isTelemetryEnabled
+                        ? intl.formatMessage({ defaultMessage: 'On', description: 'Telemetry enabled label' })
+                        : intl.formatMessage({ defaultMessage: 'Off', description: 'Telemetry disabled label' })
+                    }
+                    activeLabel={intl.formatMessage({ defaultMessage: 'On', description: 'Telemetry enabled label' })}
+                    inactiveLabel={intl.formatMessage({
+                      defaultMessage: 'Off',
+                      description: 'Telemetry disabled label',
+                    })}
+                  />
+                }
+              >
+                <Typography.Title level={4} withoutMargins>
+                  <FormattedMessage defaultMessage="Enable telemetry" description="Enable telemetry settings title" />
+                </Typography.Title>
+                <Typography.Text>
+                  <FormattedMessage
+                    defaultMessage="This setting enables UI telemetry data collection. Learn more about what types of data are collected in our {documentation}."
+                    description="Enable telemetry settings description"
+                    values={{
+                      documentation: (
+                        <Typography.Link
+                          componentId="mlflow.settings.telemetry.documentation-link"
+                          href="https://mlflow.org/docs/latest/community/usage-tracking.html"
+                          openInNewTab
+                        >
+                          <FormattedMessage defaultMessage="documentation" description="Documentation link text" />
+                        </Typography.Link>
+                      ),
+                    }}
+                  />
+                </Typography.Text>
+              </SettingsRow>
+              <SettingsRow
+                trailing={
+                  <Button
+                    componentId="mlflow.settings.demo.clear-all-button"
+                    onClick={() => setIsConfirmModalOpen(true)}
+                    disabled={isCleaningDemo}
+                  >
+                    {isCleaningDemo ? (
+                      <Spinner size="small" />
+                    ) : (
+                      <FormattedMessage defaultMessage="Clear all demo data" description="Clear demo data button" />
+                    )}
+                  </Button>
+                }
+              >
+                <Typography.Title level={4} withoutMargins>
+                  <FormattedMessage defaultMessage="Demo data" description="Demo data settings title" />
+                </Typography.Title>
+                <Typography.Text>
+                  <FormattedMessage
+                    defaultMessage="Clear all demo data generated from the home page. This removes demo experiments, traces, evaluations, and prompts."
+                    description="Demo data settings description"
+                  />
+                </Typography.Text>
+              </SettingsRow>
+            </Card>
+          </>
+        )}
 
-      <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md, maxWidth: 800 }}>
-        <WebhooksSettings />
+        {activeSection === SETTINGS_SECTION_LLM_CONNECTIONS && (
+          <>
+            <SettingsSectionHeader
+              title={
+                <FormattedMessage
+                  defaultMessage="LLM Connections"
+                  description="Settings content section title: LLM connections"
+                />
+              }
+              subtitle={
+                <FormattedMessage
+                  defaultMessage="Create and manage API keys for authenticating to external LLM providers."
+                  description="Settings content section subtitle for LLM connections (API keys)"
+                />
+              }
+            />
+            <ApiKeysPageInner />
+          </>
+        )}
+
+        {activeSection === 'webhooks' && (
+          <>
+            <SettingsSectionHeader
+              title={
+                <FormattedMessage defaultMessage="Webhooks" description="Settings content section title: webhooks" />
+              }
+              subtitle={
+                <FormattedMessage
+                  defaultMessage="Receive HTTP notifications when events occur in MLflow."
+                  description="Settings content section subtitle for webhooks"
+                />
+              }
+            />
+            <WebhooksSettings showTitle={false} showDescription={false} />
+          </>
+        )}
       </div>
 
       <Modal

--- a/mlflow/server/js/src/settings/SettingsPage.tsx
+++ b/mlflow/server/js/src/settings/SettingsPage.tsx
@@ -12,6 +12,7 @@ import Routes from '../experiment-tracking/routes';
 import WebhooksSettings from './WebhooksSettings';
 import {
   isSettingsPathSegment,
+  SETTINGS_RETURN_TO_PARAM,
   SETTINGS_SECTION_LLM_CONNECTIONS,
   type SettingsPathSegment,
 } from './settingsSectionConstants';
@@ -89,9 +90,14 @@ const SettingsPage = () => {
 
   useEffect(() => {
     if (sectionParam && !isSettingsPathSegment(sectionParam)) {
-      navigate(Routes.getSettingsSectionRoute('general'), { replace: true, state: location.state });
+      const returnTo = new URLSearchParams(location.search).get(SETTINGS_RETURN_TO_PARAM);
+      const target = Routes.getSettingsSectionRoute('general');
+      navigate(returnTo ? `${target}?${SETTINGS_RETURN_TO_PARAM}=${encodeURIComponent(returnTo)}` : target, {
+        replace: true,
+        state: location.state,
+      });
     }
-  }, [sectionParam, navigate, location.state]);
+  }, [sectionParam, navigate, location.search, location.state]);
 
   const [isTelemetryEnabled, setIsTelemetryEnabled] = useLocalStorage({
     key: TELEMETRY_ENABLED_STORAGE_KEY,

--- a/mlflow/server/js/src/settings/WebhooksSettings.tsx
+++ b/mlflow/server/js/src/settings/WebhooksSettings.tsx
@@ -169,32 +169,27 @@ const WebhooksSettings = ({
 
   return (
     <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
-      <div css={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        {(showTitle || showDescription) && (
-          <div>
-            {showTitle && (
-              <Typography.Title level={4} withoutMargins>
-                {title ?? <FormattedMessage defaultMessage="Webhooks" description="Webhooks settings section title" />}
-              </Typography.Title>
-            )}
-            {showDescription && (
-              <Typography.Text color="secondary">
-                {description ?? (
-                  <FormattedMessage
-                    defaultMessage="Manage webhooks to receive HTTP notifications when events occur in MLflow."
-                    description="Webhooks settings section description"
-                  />
-                )}
-              </Typography.Text>
-            )}
-          </div>
-        )}
-        <Button
-          componentId="mlflow.settings.webhooks.create-button"
-          type="primary"
-          onClick={openCreateModal}
-          css={!showTitle && !showDescription ? { marginLeft: 'auto' } : undefined}
-        >
+      {(showTitle || showDescription) && (
+        <div>
+          {showTitle && (
+            <Typography.Title level={4} withoutMargins>
+              {title ?? <FormattedMessage defaultMessage="Webhooks" description="Webhooks settings section title" />}
+            </Typography.Title>
+          )}
+          {showDescription && (
+            <Typography.Text color="secondary">
+              {description ?? (
+                <FormattedMessage
+                  defaultMessage="Manage webhooks to receive HTTP notifications when events occur in MLflow."
+                  description="Webhooks settings section description"
+                />
+              )}
+            </Typography.Text>
+          )}
+        </div>
+      )}
+      <div css={{ display: 'flex', justifyContent: 'flex-start', width: '100%' }}>
+        <Button componentId="mlflow.settings.webhooks.create-button" type="primary" onClick={openCreateModal}>
           <FormattedMessage defaultMessage="Create webhook" description="Create webhook button" />
         </Button>
       </div>

--- a/mlflow/server/js/src/settings/settingsSectionConstants.ts
+++ b/mlflow/server/js/src/settings/settingsSectionConstants.ts
@@ -1,0 +1,28 @@
+/** URL path segment for Settings > LLM Connections (`/settings/llm-connections`). */
+export const SETTINGS_SECTION_LLM_CONNECTIONS = 'llm-connections';
+
+/** Allowed path segments for `/settings/:section`. */
+export const SETTINGS_PATH_SEGMENTS = ['general', SETTINGS_SECTION_LLM_CONNECTIONS, 'webhooks'] as const;
+
+export type SettingsPathSegment = (typeof SETTINGS_PATH_SEGMENTS)[number];
+
+export function isSettingsPathSegment(value: string): value is SettingsPathSegment {
+  return (SETTINGS_PATH_SEGMENTS as readonly string[]).includes(value);
+}
+
+/** Query param carrying the path to return to when leaving the Settings sub-sidebar. */
+export const SETTINGS_RETURN_TO_PARAM = 'returnTo';
+
+/** Returns a safe in-app location string; invalid or settings URLs fall back to `fallback`. */
+export function sanitizeSettingsReturnPath(value: string | undefined, fallback: string): string {
+  if (!value || typeof value !== 'string') {
+    return fallback;
+  }
+  if (!value.startsWith('/') || value.startsWith('//')) {
+    return fallback;
+  }
+  if (value === '/settings' || value.startsWith('/settings/')) {
+    return fallback;
+  }
+  return value;
+}

--- a/mlflow/server/js/src/settings/settingsSectionConstants.ts
+++ b/mlflow/server/js/src/settings/settingsSectionConstants.ts
@@ -21,7 +21,13 @@ export function sanitizeSettingsReturnPath(value: string | undefined, fallback: 
   if (!value.startsWith('/') || value.startsWith('//')) {
     return fallback;
   }
-  if (value === '/settings' || value.startsWith('/settings/')) {
+  // Parse to get just the pathname, so /settings?workspace=... and /settings#hash are also rejected.
+  try {
+    const { pathname } = new URL(value, 'http://localhost');
+    if (pathname === '/settings' || pathname.startsWith('/settings/')) {
+      return fallback;
+    }
+  } catch {
     return fallback;
   }
   return value;

--- a/mlflow/server/js/src/settings/settingsSectionConstants.ts
+++ b/mlflow/server/js/src/settings/settingsSectionConstants.ts
@@ -1,8 +1,18 @@
+/** URL path segment for Settings > General (`/settings/general`). */
+export const SETTINGS_SECTION_GENERAL = 'general';
+
 /** URL path segment for Settings > LLM Connections (`/settings/llm-connections`). */
 export const SETTINGS_SECTION_LLM_CONNECTIONS = 'llm-connections';
 
+/** URL path segment for Settings > Webhooks (`/settings/webhooks`). */
+export const SETTINGS_SECTION_WEBHOOKS = 'webhooks';
+
 /** Allowed path segments for `/settings/:section`. */
-export const SETTINGS_PATH_SEGMENTS = ['general', SETTINGS_SECTION_LLM_CONNECTIONS, 'webhooks'] as const;
+export const SETTINGS_PATH_SEGMENTS = [
+  SETTINGS_SECTION_GENERAL,
+  SETTINGS_SECTION_LLM_CONNECTIONS,
+  SETTINGS_SECTION_WEBHOOKS,
+] as const;
 
 export type SettingsPathSegment = (typeof SETTINGS_PATH_SEGMENTS)[number];
 
@@ -12,23 +22,3 @@ export function isSettingsPathSegment(value: string): value is SettingsPathSegme
 
 /** Query param carrying the path to return to when leaving the Settings sub-sidebar. */
 export const SETTINGS_RETURN_TO_PARAM = 'returnTo';
-
-/** Returns a safe in-app location string; invalid or settings URLs fall back to `fallback`. */
-export function sanitizeSettingsReturnPath(value: string | undefined, fallback: string): string {
-  if (!value || typeof value !== 'string') {
-    return fallback;
-  }
-  if (!value.startsWith('/') || value.startsWith('//')) {
-    return fallback;
-  }
-  // Parse to get just the pathname, so /settings?workspace=... and /settings#hash are also rejected.
-  try {
-    const { pathname } = new URL(value, 'http://localhost');
-    if (pathname === '/settings' || pathname.startsWith('/settings/')) {
-      return fallback;
-    }
-  } catch {
-    return fallback;
-  }
-  return value;
-}


### PR DESCRIPTION
### Related Issues/PRs

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

- Replaces the single `/settings` page with `/settings/:section` routes (`general`, `llm-connections`, `webhooks`), each rendered by `SettingsPage` which switches content based on the `section` param.
- Adds a Settings sub-sidebar (`MlflowSidebarSettingsItems`) that replaces the main nav while inside Settings, with a back link that returns to the originating page via a `?returnTo=` URL param.
- Moves API Keys from `/gateway/api-keys` into **Settings > LLM Connections**; the old route now redirects and the entry is removed from the Gateway side-nav.
- Adds `/settings` → `/settings/general` redirect via `SettingsEntryRedirect`.
- Updates tooltip text in `IssueDetectionModelSelection` to reference the new location of API Keys.

https://github.com/user-attachments/assets/c3640b64-052a-4a97-9bb3-126a4db70124

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [ ] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [ ] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The Settings page now uses section-based routing (`/settings/general`, `/settings/llm-connections`, `/settings/webhooks`) with a dedicated sub-sidebar for navigation. API Keys have moved from the Gateway section into Settings > LLM Connections.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Claude.