### PR TITLE
Update ML package versions

### DIFF
--- a/libs/skinny/pyproject.toml
+++ b/libs/skinny/pyproject.toml
@@ -98,7 +98,7 @@ sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]
 jfrog = ["mlflow-jfrog-plugin"]
 kubernetes = ["kubernetes"]
-langchain = ["langchain>=0.3.21,<=1.2.12"]
+langchain = ["langchain>=0.3.24,<=1.2.15"]
 auth = ["Flask-WTF<2"]
 
 [project.urls]

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -6,13 +6,13 @@ sklearn:
       uv pip install --system git+https://github.com/scikit-learn/scikit-learn.git
 
   models:
-    minimum: "1.4.2"
+    minimum: "1.5.0"
     maximum: "1.8.0"
     run: |
       pytest tests/sklearn/test_sklearn_model_export.py
 
   autologging:
-    minimum: "1.4.2"
+    minimum: "1.5.0"
     maximum: "1.8.0"
     requirements:
       ">= 0.0.0": ["matplotlib", "polars"]
@@ -32,8 +32,8 @@ pytorch:
       uv pip install --system --upgrade --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 
   models:
-    minimum: "2.2.2"
-    maximum: "2.10.0"
+    minimum: "2.3.0"
+    maximum: "2.11.0"
     requirements:
       ">= 0.0.0": ["torchvision", "scikit-learn"]
       ">= 1.8": ["transformers"]
@@ -43,8 +43,8 @@ pytorch:
       pytest tests/pytorch/test_pytorch_model_export.py tests/pytorch/test_pytorch_metric_value_conversion_utils.py
 
   autologging:
-    minimum: "2.2.2"
-    maximum: "2.10.0"
+    minimum: "2.3.0"
+    maximum: "2.11.0"
     requirements:
       ">= 0.0.0": ["tensorboard"]
     run: |
@@ -60,7 +60,7 @@ pytorch-lightning:
       uv pip install --system git+https://github.com/PytorchLightning/pytorch-lightning.git
 
   autologging:
-    minimum: "2.2.2"
+    minimum: "2.2.3"
     maximum: "2.6.1"
     requirements:
       ">= 0.0.0":
@@ -76,7 +76,7 @@ pytorch-lightning:
       pytest tests/pytorch/test_pytorch_autolog.py
 
   models:
-    minimum: "2.2.2"
+    minimum: "2.2.3"
     maximum: "2.6.1"
     requirements:
       ">= 0.0.0": ["pytorch-forecasting"]
@@ -91,8 +91,8 @@ keras:
       uv pip install --system --upgrade git+https://github.com/keras-team/keras.git
 
   models:
-    minimum: "3.1.0"
-    maximum: "3.13.2"
+    minimum: "3.3.0"
+    maximum: "3.14.0"
     requirements:
       ">= 3.0.0": ["jax[cpu]>0.4"]
       "< 3.10.0": ["jax[cpu]<0.6"]
@@ -101,8 +101,8 @@ keras:
       pytest tests/keras/test_callback.py
 
   autologging:
-    minimum: "3.1.0"
-    maximum: "3.13.2"
+    minimum: "3.3.0"
+    maximum: "3.14.0"
     requirements:
       ">= 3.0.0": ["jax[cpu]>0.4"]
       "< 3.10.0": ["jax[cpu]<0.6"]
@@ -193,7 +193,7 @@ catboost:
     pip_release: "catboost"
 
   models:
-    minimum: "1.2.5"
+    minimum: "1.2.6"
     maximum: "1.2.10"
     requirements:
       ">= 0.0.0": ["scikit-learn"]
@@ -222,7 +222,7 @@ onnx:
 
   models:
     minimum: "1.17.0"
-    maximum: "1.20.1"
+    maximum: "1.21.0"
     requirements:
       ">= 0.0.0": ["onnxruntime", "onnxscript", "torch", "scikit-learn"]
     run: |
@@ -238,7 +238,7 @@ semantic_kernel:
 
   autologging:
     minimum: "1.34.0"
-    maximum: "1.41.0"
+    maximum: "1.41.1"
     requirements:
       ">= 1.34.0": [
           "pydantic>=2.0,<2.12",
@@ -261,7 +261,7 @@ spacy:
 
   models:
     minimum: "3.7.5"
-    maximum: "3.8.11"
+    maximum: "3.8.14"
     requirements:
       "< 3.8": ["numpy<2"]
     run: |
@@ -275,13 +275,13 @@ statsmodels:
       uv pip install --system git+https://github.com/statsmodels/statsmodels.git
 
   models:
-    minimum: "0.14.2"
+    minimum: "0.14.3"
     maximum: "0.14.6"
     run: |
       pytest tests/statsmodels/test_statsmodels_model_export.py
 
   autologging:
-    minimum: "0.14.2"
+    minimum: "0.14.3"
     maximum: "0.14.6"
     run: |
       pytest tests/statsmodels/test_statsmodels_autolog.py
@@ -429,13 +429,13 @@ paddle:
     pip_release: "paddlepaddle"
   models:
     minimum: "2.6.2"
-    maximum: "3.3.0"
+    maximum: "3.3.1"
     requirements:
     run: |
       pytest tests/paddle/test_paddle_model_export.py
   autologging:
     minimum: "2.6.2"
-    maximum: "3.3.0"
+    maximum: "3.3.1"
     requirements:
     run: |
       pytest tests/paddle/test_paddle_autolog.py
@@ -447,8 +447,8 @@ transformers:
     install_dev: |
       uv pip install --system git+https://github.com/huggingface/transformers
   models:
-    minimum: "4.39.0"
-    maximum: "5.3.0"
+    minimum: "4.40.1"
+    maximum: "5.5.0"
     test_every_n_versions: 4
     unsupported: [
         # Avoid this patch: https://github.com/huggingface/transformers/pull/29032
@@ -493,8 +493,8 @@ transformers:
       pip uninstall -y accelerate
       pytest tests/transformers/test_transformers_model_export.py -k "test_transformers_pt_model_save_dependencies_without_accelerate"
   autologging:
-    minimum: "4.39.0"
-    maximum: "5.3.0"
+    minimum: "4.40.1"
+    maximum: "5.5.0"
     test_every_n_versions: 4
     unsupported: [
         # https://github.com/huggingface/transformers/issues/38269
@@ -553,8 +553,8 @@ openai:
     install_dev: |
       uv pip install --system git+https://github.com/openai/openai-python
   models:
-    minimum: "1.66.5"
-    maximum: "2.28.0"
+    minimum: "1.76.0"
+    maximum: "2.30.0"
     requirements:
       ">= 0.0.0": [
           "pyspark",
@@ -571,8 +571,8 @@ openai:
     # many test tasks for openai. Reducing the number of testing only for every 10 version.
     test_every_n_versions: 10
   autologging:
-    minimum: "1.66.5"
-    maximum: "2.28.0"
+    minimum: "1.76.0"
+    maximum: "2.30.0"
     requirements:
       ">= 0.0.0": [
           "tiktoken",
@@ -596,14 +596,14 @@ dspy:
     install_dev: |
       uv pip install --system git+https://github.com/stanfordnlp/dspy.git
   models:
-    minimum: "2.6.13"
+    minimum: "2.6.19"
     maximum: "3.1.3"
     requirements:
       ">= 0.0.0": ["openai"]
     run: |
       pytest tests/dspy --ignore tests/dspy/test_dspy_autolog.py
   autologging:
-    minimum: "2.6.13"
+    minimum: "2.6.19"
     maximum: "3.1.3"
     requirements:
       ">= 0.0.0": ["openai"]
@@ -620,8 +620,8 @@ langchain:
       uv pip install --system git+https://github.com/langchain-ai/langchain#subdirectory=libs/langchain_v1
   models:
     # Where the large package update was made (langchain-core, community, ...)
-    minimum: "0.3.21"
-    maximum: "1.2.12"
+    minimum: "0.3.24"
+    maximum: "1.2.15"
     unsupported: [
         # Chain.save() broken in 0.3.28 due to model_dump() regression: https://github.com/langchain-ai/langchain/issues/35665
         "== 0.3.28",
@@ -671,8 +671,8 @@ langchain:
       # Run all langchain tests except autologging
       pytest tests/langchain --ignore tests/langchain/test_langchain_autolog.py
   autologging:
-    minimum: "0.3.21"
-    maximum: "1.2.12"
+    minimum: "0.3.24"
+    maximum: "1.2.15"
     requirements:
       ">= 0.0.0": [
           "openai",
@@ -712,8 +712,8 @@ langgraph:
       uv pip install --system --force-reinstall --no-deps git+https://github.com/langchain-ai/langgraph#subdirectory=libs/prebuilt
 
   models:
-    minimum: "0.3.12"
-    maximum: "1.1.2"
+    minimum: "0.3.32"
+    maximum: "1.1.6"
     requirements:
       ">= 0.0.0": [
           "langchain",
@@ -732,8 +732,8 @@ langgraph:
       pytest tests/langgraph --ignore tests/langgraph/test_langgraph_autolog.py
 
   autologging:
-    minimum: "0.3.12"
-    maximum: "1.1.2"
+    minimum: "0.3.32"
+    maximum: "1.1.6"
     requirements:
       ">= 0.0.0": [
           "langchain",
@@ -762,7 +762,7 @@ llama_index:
       uv pip install --system git+https://github.com/run-llama/llama_index.git
   models:
     # New event/span framework is fully implemented in 0.10.44
-    minimum: "0.12.25"
+    minimum: "0.12.32"
     maximum: "0.14.16"
     requirements:
       ">= 0.0.0": [
@@ -783,7 +783,7 @@ llama_index:
         ]
     run: pytest tests/llama_index --ignore tests/llama_index/test_llama_index_autolog.py --ignore tests/llama_index/test_llama_index_tracer.py
   autologging:
-    minimum: "0.12.25"
+    minimum: "0.12.32"
     maximum: "0.14.16"
     requirements:
       ">= 0.0.0": [
@@ -803,8 +803,8 @@ ag2:
     pip_release: "ag2"
     module_name: "autogen"
   autologging:
-    minimum: "0.8.2"
-    maximum: "0.11.2"
+    minimum: "0.9"
+    maximum: "0.11.5"
     requirements:
       ">= 0.0.0": [
           # Required to run tests/openai/mock_openai.py
@@ -825,7 +825,7 @@ autogen:
     pip_release: "autogen-agentchat"
     module_name: "autogen_agentchat"
   autologging:
-    minimum: "0.4.9.3"
+    minimum: "0.5.4"
     maximum: "0.7.5"
     requirements:
       ">= 0.0.0": [
@@ -848,8 +848,8 @@ gemini:
     install_dev: |
       uv pip install --system git+https://github.com/googleapis/python-genai
   autologging:
-    minimum: "1.7.0"
-    maximum: "1.67.0"
+    minimum: "1.12.1"
+    maximum: "1.70.0"
     requirements:
     run: |
       # Install legacy gemini SDK to ensure the integration works for the legacy SDK
@@ -867,7 +867,7 @@ anthropic:
       uv pip install --system git+https://github.com/anthropics/anthropic-sdk-python
   autologging:
     minimum: "0.50.0"
-    maximum: "0.84.0"
+    maximum: "0.89.0"
     requirements:
     run: pytest tests/anthropic
     # Our CI runs tests for every minor version of the library by default, which results in
@@ -884,8 +884,8 @@ crewai:
     install_dev: |
       uv pip install --system git+https://github.com/crewAIInc/crewAI#subdirectory=lib/crewai
   autologging:
-    minimum: "0.108.0"
-    maximum: "1.10.3"
+    minimum: "0.117.0"
+    maximum: "1.13.0"
     unsupported: ["==0.114.0"]
     requirements:
     run: pytest tests/crewai
@@ -902,7 +902,7 @@ agno:
       uv pip install --system git+https://github.com/agno-agi/agno.git#subdirectory=libs/agno
   autologging:
     minimum: "1.7.0"
-    maximum: "2.5.9"
+    maximum: "2.5.14"
     requirements:
       ">= 0.0.0": ["anthropic", "yfinance"]
       ">= 2.0.0": ["opentelemetry-exporter-otlp", "openinference-instrumentation-agno"]
@@ -933,7 +933,7 @@ pydantic_ai:
         "git+https://github.com/pydantic/pydantic-ai.git#egg=pydantic-ai"
   autologging:
     minimum: "0.1.9"
-    maximum: "1.68.0"
+    maximum: "1.77.0"
     requirements:
       ">= 0.0.0": ["mcp"]
     run: pytest tests/pydantic_ai
@@ -949,7 +949,7 @@ smolagents:
     install_dev: |
       uv pip install --system "git+https://github.com/huggingface/smolagents"
   autologging:
-    minimum: "1.14.0"
+    minimum: "1.15.0"
     maximum: "1.24.0"
     requirements:
       "< 1.21.0": ["duckduckgo-search"]
@@ -969,7 +969,7 @@ strands:
       uv pip install --system "git+https://github.com/strands-agents/sdk-python"
   autologging:
     minimum: "1.4.0"
-    maximum: "1.30.0"
+    maximum: "1.34.1"
     run: pytest tests/strands
     test_tracing_sdk: true
 
@@ -981,8 +981,8 @@ haystack:
     install_dev: |
       uv pip install --system git+https://github.com/deepset-ai/haystack
   autologging:
-    minimum: "2.0.1"
-    maximum: "2.25.2"
+    minimum: "2.1.0"
+    maximum: "2.27.0"
     requirements:
     run: pytest tests/haystack
     test_tracing_sdk: true
@@ -1002,8 +1002,8 @@ mistral:
       uv pip install --system .
       rm -rf $TMP_DIR
   autologging:
-    minimum: "1.5.2"
-    maximum: "2.0.2"
+    minimum: "1.7.1"
+    maximum: "2.3.0"
     requirements:
     run: pytest tests/mistral
     test_tracing_sdk: true
@@ -1016,7 +1016,7 @@ sentence_transformers:
     install_dev: |
       uv pip install --system git+https://github.com/UKPLab/sentence-transformers#egg=sentence-transformers
   models:
-    minimum: "2.6.0"
+    minimum: "3.0.0"
     maximum: "5.3.0"
     requirements:
       ">= 0.0.0": [
@@ -1038,7 +1038,7 @@ johnsnowlabs:
   package_info:
     pip_release: "johnsnowlabs"
   models:
-    minimum: "5.3.3"
+    minimum: "5.3.5"
     maximum: "6.3.0"
     requirements:
       ">= 0.0.0": ["pandas<=1.5.3"]
@@ -1057,8 +1057,8 @@ groq:
     install_dev: |
       uv pip install --system git+https://github.com/groq/groq-python
   autologging:
-    minimum: "0.20.0"
-    maximum: "1.1.1"
+    minimum: "0.23.0"
+    maximum: "1.1.2"
     requirements:
     run: pytest tests/groq
     test_tracing_sdk: true
@@ -1071,7 +1071,7 @@ bedrock:
     module_name: "boto3"
   autologging:
     # BedrockRuntime client is added in boto3 1.33
-    minimum: "1.37.14"
-    maximum: "1.42.68"
+    minimum: "1.37.38"
+    maximum: "1.42.84"
     run: pytest tests/bedrock
     test_tracing_sdk: true

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -38,7 +38,6 @@ pytorch:
       ">= 0.0.0": ["torchvision", "scikit-learn"]
       ">= 1.8": ["transformers"]
       "== 2.3.*": ["transformers<5"]
-      "< 2.3": ["numpy<2", "transformers<=4.49.0", "safetensors<0.6.0"]
     run: |
       pytest tests/pytorch/test_pytorch_model_export.py tests/pytorch/test_pytorch_metric_value_conversion_utils.py
 
@@ -813,10 +812,6 @@ ag2:
           "openai",
           "numpy<2",
         ]
-      # see https://github.com/ag2ai/ag2/issues/2046, this release
-      # used simple string comparison for packages and does not
-      # recognize that version 1.100 is greater than 1.66
-      "== 0.8.7": ["openai<1.99.9"]
     run: pytest tests/ag2
 
 autogen:

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -8,7 +8,7 @@ _ML_PACKAGE_VERSIONS = {
         },
         "autologging": {
             "minimum": "1.34.0",
-            "maximum": "1.41.0"
+            "maximum": "1.41.1"
         }
     },
     "openai": {
@@ -16,12 +16,12 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "openai"
         },
         "models": {
-            "minimum": "1.66.5",
-            "maximum": "2.28.0"
+            "minimum": "1.76.0",
+            "maximum": "2.30.0"
         },
         "autologging": {
-            "minimum": "1.66.5",
-            "maximum": "2.28.0"
+            "minimum": "1.76.0",
+            "maximum": "2.30.0"
         }
     },
     "dspy": {
@@ -29,11 +29,11 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "dspy"
         },
         "models": {
-            "minimum": "2.6.13",
+            "minimum": "2.6.19",
             "maximum": "3.1.3"
         },
         "autologging": {
-            "minimum": "2.6.13",
+            "minimum": "2.6.19",
             "maximum": "3.1.3"
         }
     },
@@ -42,12 +42,12 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "langchain"
         },
         "models": {
-            "minimum": "0.3.21",
-            "maximum": "1.2.12"
+            "minimum": "0.3.24",
+            "maximum": "1.2.15"
         },
         "autologging": {
-            "minimum": "0.3.21",
-            "maximum": "1.2.12"
+            "minimum": "0.3.24",
+            "maximum": "1.2.15"
         }
     },
     "langgraph": {
@@ -55,12 +55,12 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "langgraph"
         },
         "models": {
-            "minimum": "0.3.12",
-            "maximum": "1.1.2"
+            "minimum": "0.3.32",
+            "maximum": "1.1.6"
         },
         "autologging": {
-            "minimum": "0.3.12",
-            "maximum": "1.1.2"
+            "minimum": "0.3.32",
+            "maximum": "1.1.6"
         }
     },
     "llama_index": {
@@ -69,11 +69,11 @@ _ML_PACKAGE_VERSIONS = {
             "module_name": "llama_index.core"
         },
         "models": {
-            "minimum": "0.12.25",
+            "minimum": "0.12.32",
             "maximum": "0.14.16"
         },
         "autologging": {
-            "minimum": "0.12.25",
+            "minimum": "0.12.32",
             "maximum": "0.14.16"
         }
     },
@@ -83,8 +83,8 @@ _ML_PACKAGE_VERSIONS = {
             "module_name": "autogen"
         },
         "autologging": {
-            "minimum": "0.8.2",
-            "maximum": "0.11.2"
+            "minimum": "0.9",
+            "maximum": "0.11.5"
         }
     },
     "autogen": {
@@ -93,7 +93,7 @@ _ML_PACKAGE_VERSIONS = {
             "module_name": "autogen_agentchat"
         },
         "autologging": {
-            "minimum": "0.4.9.3",
+            "minimum": "0.5.4",
             "maximum": "0.7.5"
         }
     },
@@ -103,8 +103,8 @@ _ML_PACKAGE_VERSIONS = {
             "module_name": "google.genai"
         },
         "autologging": {
-            "minimum": "1.7.0",
-            "maximum": "1.67.0"
+            "minimum": "1.12.1",
+            "maximum": "1.70.0"
         }
     },
     "anthropic": {
@@ -113,7 +113,7 @@ _ML_PACKAGE_VERSIONS = {
         },
         "autologging": {
             "minimum": "0.50.0",
-            "maximum": "0.84.0"
+            "maximum": "0.89.0"
         }
     },
     "crewai": {
@@ -122,8 +122,8 @@ _ML_PACKAGE_VERSIONS = {
             "module_name": "crewai"
         },
         "autologging": {
-            "minimum": "0.108.0",
-            "maximum": "1.10.3"
+            "minimum": "0.117.0",
+            "maximum": "1.13.0"
         }
     },
     "agno": {
@@ -133,7 +133,7 @@ _ML_PACKAGE_VERSIONS = {
         },
         "autologging": {
             "minimum": "1.7.0",
-            "maximum": "2.5.9"
+            "maximum": "2.5.14"
         }
     },
     "pydantic_ai": {
@@ -143,7 +143,7 @@ _ML_PACKAGE_VERSIONS = {
         },
         "autologging": {
             "minimum": "0.1.9",
-            "maximum": "1.68.0"
+            "maximum": "1.77.0"
         }
     },
     "smolagents": {
@@ -152,7 +152,7 @@ _ML_PACKAGE_VERSIONS = {
             "module_name": "smolagents"
         },
         "autologging": {
-            "minimum": "1.14.0",
+            "minimum": "1.15.0",
             "maximum": "1.24.0"
         }
     },
@@ -163,7 +163,7 @@ _ML_PACKAGE_VERSIONS = {
         },
         "autologging": {
             "minimum": "1.4.0",
-            "maximum": "1.30.0"
+            "maximum": "1.34.1"
         }
     },
     "mistral": {
@@ -172,8 +172,8 @@ _ML_PACKAGE_VERSIONS = {
             "module_name": "mistralai"
         },
         "autologging": {
-            "minimum": "1.5.2",
-            "maximum": "2.0.2"
+            "minimum": "1.7.1",
+            "maximum": "2.3.0"
         }
     },
     "groq": {
@@ -181,8 +181,8 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "groq"
         },
         "autologging": {
-            "minimum": "0.20.0",
-            "maximum": "1.1.1"
+            "minimum": "0.23.0",
+            "maximum": "1.1.2"
         }
     },
     "bedrock": {
@@ -191,8 +191,8 @@ _ML_PACKAGE_VERSIONS = {
             "module_name": "boto3"
         },
         "autologging": {
-            "minimum": "1.37.14",
-            "maximum": "1.42.68"
+            "minimum": "1.37.38",
+            "maximum": "1.42.84"
         }
     },
     "sklearn": {
@@ -200,11 +200,11 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "scikit-learn"
         },
         "models": {
-            "minimum": "1.4.2",
+            "minimum": "1.5.0",
             "maximum": "1.8.0"
         },
         "autologging": {
-            "minimum": "1.4.2",
+            "minimum": "1.5.0",
             "maximum": "1.8.0"
         }
     },
@@ -214,12 +214,12 @@ _ML_PACKAGE_VERSIONS = {
             "module_name": "torch"
         },
         "models": {
-            "minimum": "2.2.2",
-            "maximum": "2.10.0"
+            "minimum": "2.3.0",
+            "maximum": "2.11.0"
         },
         "autologging": {
-            "minimum": "2.2.2",
-            "maximum": "2.10.0"
+            "minimum": "2.3.0",
+            "maximum": "2.11.0"
         }
     },
     "pytorch-lightning": {
@@ -228,11 +228,11 @@ _ML_PACKAGE_VERSIONS = {
             "module_name": "lightning"
         },
         "models": {
-            "minimum": "2.2.2",
+            "minimum": "2.2.3",
             "maximum": "2.6.1"
         },
         "autologging": {
-            "minimum": "2.2.2",
+            "minimum": "2.2.3",
             "maximum": "2.6.1"
         }
     },
@@ -241,12 +241,12 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "keras"
         },
         "models": {
-            "minimum": "3.1.0",
-            "maximum": "3.13.2"
+            "minimum": "3.3.0",
+            "maximum": "3.14.0"
         },
         "autologging": {
-            "minimum": "3.1.0",
-            "maximum": "3.13.2"
+            "minimum": "3.3.0",
+            "maximum": "3.14.0"
         }
     },
     "tensorflow": {
@@ -293,7 +293,7 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "catboost"
         },
         "models": {
-            "minimum": "1.2.5",
+            "minimum": "1.2.6",
             "maximum": "1.2.10"
         }
     },
@@ -303,7 +303,7 @@ _ML_PACKAGE_VERSIONS = {
         },
         "models": {
             "minimum": "1.17.0",
-            "maximum": "1.20.1"
+            "maximum": "1.21.0"
         }
     },
     "spacy": {
@@ -312,7 +312,7 @@ _ML_PACKAGE_VERSIONS = {
         },
         "models": {
             "minimum": "3.7.5",
-            "maximum": "3.8.11"
+            "maximum": "3.8.14"
         }
     },
     "statsmodels": {
@@ -320,11 +320,11 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "statsmodels"
         },
         "models": {
-            "minimum": "0.14.2",
+            "minimum": "0.14.3",
             "maximum": "0.14.6"
         },
         "autologging": {
-            "minimum": "0.14.2",
+            "minimum": "0.14.3",
             "maximum": "0.14.6"
         }
     },
@@ -384,11 +384,11 @@ _ML_PACKAGE_VERSIONS = {
         },
         "models": {
             "minimum": "2.6.2",
-            "maximum": "3.3.0"
+            "maximum": "3.3.1"
         },
         "autologging": {
             "minimum": "2.6.2",
-            "maximum": "3.3.0"
+            "maximum": "3.3.1"
         }
     },
     "transformers": {
@@ -396,12 +396,12 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "transformers"
         },
         "models": {
-            "minimum": "4.39.0",
-            "maximum": "5.3.0"
+            "minimum": "4.40.1",
+            "maximum": "5.5.0"
         },
         "autologging": {
-            "minimum": "4.39.0",
-            "maximum": "5.3.0"
+            "minimum": "4.40.1",
+            "maximum": "5.5.0"
         }
     },
     "diffusers": {
@@ -419,8 +419,8 @@ _ML_PACKAGE_VERSIONS = {
             "module_name": "haystack"
         },
         "autologging": {
-            "minimum": "2.0.1",
-            "maximum": "2.25.2"
+            "minimum": "2.1.0",
+            "maximum": "2.27.0"
         }
     },
     "sentence_transformers": {
@@ -428,7 +428,7 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "sentence-transformers"
         },
         "models": {
-            "minimum": "2.6.0",
+            "minimum": "3.0.0",
             "maximum": "5.3.0"
         }
     },
@@ -437,7 +437,7 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "johnsnowlabs"
         },
         "models": {
-            "minimum": "5.3.3",
+            "minimum": "5.3.5",
             "maximum": "6.3.0"
         }
     }

--- a/pyproject.release.toml
+++ b/pyproject.release.toml
@@ -101,7 +101,7 @@ sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]
 jfrog = ["mlflow-jfrog-plugin"]
 kubernetes = ["kubernetes"]
-langchain = ["langchain>=0.3.21,<=1.2.12"]
+langchain = ["langchain>=0.3.24,<=1.2.15"]
 auth = ["Flask-WTF<2"]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]
 jfrog = ["mlflow-jfrog-plugin"]
 kubernetes = ["kubernetes"]
-langchain = ["langchain>=0.3.21,<=1.2.12"]
+langchain = ["langchain>=0.3.24,<=1.2.15"]
 auth = ["Flask-WTF<2"]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-06T01:40:41.024349926Z"
+exclude-newer = "2026-04-07T08:23:28.730639Z"
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
@@ -4515,7 +4515,7 @@ requires-dist = [
     { name = "importlib-metadata", specifier = ">=3.7.0,!=4.7.0,<9" },
     { name = "kubernetes", marker = "extra == 'extras'" },
     { name = "kubernetes", marker = "extra == 'kubernetes'" },
-    { name = "langchain", marker = "extra == 'langchain'", specifier = ">=0.3.21,<=1.2.12" },
+    { name = "langchain", marker = "extra == 'langchain'", specifier = ">=0.3.24,<=1.2.15" },
     { name = "matplotlib", specifier = "<4" },
     { name = "mlflow-dbstore", marker = "extra == 'sqlserver'" },
     { name = "mlflow-jfrog-plugin", marker = "extra == 'jfrog'" },


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Run `dev/update_ml_package_versions.py` to bump min/max versions for supported ML packages.

For `llama_index`, the script bumped the max to `0.14.20`, but versions `0.14.18+` pull a `llama-index-llms-databricks` constraint that conflicts with `llama-index-llms-openai>=0.7`, breaking the `models` install. Capped the max at `0.14.16` (the newest version where install resolves) for both `models` and `autologging`.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release