### PR TITLE
Fix `_get_token_usage` dropping cache tokens and zero values from OTLP GenAI spans

### DIFF
--- a/mlflow/tracing/otel/translation/__init__.py
+++ b/mlflow/tracing/otel/translation/__init__.py
@@ -173,7 +173,7 @@ def _parse_int_attribute(value: Any) -> int | None:
     return None
 
 
-def _get_token_usage(attributes: dict[str, Any]) -> dict[str, Any]:
+def _get_token_usage(attributes: dict[str, Any]) -> dict[str, Any] | None:
     """
     Get token usage from various OTEL semantic conventions.
     """
@@ -182,16 +182,31 @@ def _get_token_usage(attributes: dict[str, Any]) -> dict[str, Any]:
         output_tokens = _parse_int_attribute(translator.get_output_tokens(attributes))
         total_tokens = _parse_int_attribute(translator.get_total_tokens(attributes))
 
-        # Calculate total tokens if not provided but input/output are available
-        if input_tokens and output_tokens and (total_tokens is None):
+        # Derive total_tokens when the semantic convention does not surface it
+        # (OTel GenAI, for example, defines input and output but not total).
+        if input_tokens is not None and output_tokens is not None and total_tokens is None:
             total_tokens = input_tokens + output_tokens
 
-        if input_tokens and output_tokens and total_tokens:
-            return {
+        # Zero is a legitimate value (safety-filtered prompts, streaming fragments,
+        # cache-only responses). Use `is not None` rather than truthy checks so zero-
+        # valued tokens still produce a usage dict. `total_tokens` is guaranteed to
+        # be populated by the derivation above whenever input and output are set.
+        if input_tokens is not None and output_tokens is not None:
+            usage = {
                 TokenUsageKey.INPUT_TOKENS: input_tokens,
                 TokenUsageKey.OUTPUT_TOKENS: output_tokens,
                 TokenUsageKey.TOTAL_TOKENS: total_tokens,
             }
+            cache_read = _parse_int_attribute(translator.get_cache_read_input_tokens(attributes))
+            cache_creation = _parse_int_attribute(
+                translator.get_cache_creation_input_tokens(attributes)
+            )
+            if cache_read is not None:
+                usage[TokenUsageKey.CACHE_READ_INPUT_TOKENS] = cache_read
+            if cache_creation is not None:
+                usage[TokenUsageKey.CACHE_CREATION_INPUT_TOKENS] = cache_creation
+            return usage
+    return None
 
 
 def _get_input_value(attributes: dict[str, Any], events: list[dict[str, Any]] | None = None) -> Any:

--- a/mlflow/tracing/otel/translation/base.py
+++ b/mlflow/tracing/otel/translation/base.py
@@ -25,6 +25,8 @@ class OtelSchemaTranslator:
     INPUT_TOKEN_KEY: str | None = None
     OUTPUT_TOKEN_KEY: str | None = None
     TOTAL_TOKEN_KEY: str | None = None
+    CACHE_READ_INPUT_TOKEN_KEY: str | None = None
+    CACHE_CREATION_INPUT_TOKEN_KEY: str | None = None
     INPUT_VALUE_KEYS: list[str] | None = None
     OUTPUT_VALUE_KEYS: list[str] | None = None
     MODEL_NAME_KEYS: list[str] | None = None
@@ -111,6 +113,32 @@ class OtelSchemaTranslator:
         """
         if self.TOTAL_TOKEN_KEY:
             return attributes.get(self.TOTAL_TOKEN_KEY)
+
+    def get_cache_read_input_tokens(self, attributes: dict[str, Any]) -> int | None:
+        """
+        Get cache-read input token count from OTEL attributes.
+
+        Args:
+            attributes: Dictionary of span attributes
+
+        Returns:
+            Cache-read input token count or None if not found
+        """
+        if self.CACHE_READ_INPUT_TOKEN_KEY:
+            return attributes.get(self.CACHE_READ_INPUT_TOKEN_KEY)
+
+    def get_cache_creation_input_tokens(self, attributes: dict[str, Any]) -> int | None:
+        """
+        Get cache-creation input token count from OTEL attributes.
+
+        Args:
+            attributes: Dictionary of span attributes
+
+        Returns:
+            Cache-creation input token count or None if not found
+        """
+        if self.CACHE_CREATION_INPUT_TOKEN_KEY:
+            return attributes.get(self.CACHE_CREATION_INPUT_TOKEN_KEY)
 
     def get_model_name(self, attributes: dict[str, Any]) -> str | None:
         """

--- a/mlflow/tracing/otel/translation/genai_semconv.py
+++ b/mlflow/tracing/otel/translation/genai_semconv.py
@@ -41,6 +41,8 @@ class GenAiTranslator(OtelSchemaTranslator):
     # Reference: https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/#genai-attributes
     INPUT_TOKEN_KEY = "gen_ai.usage.input_tokens"
     OUTPUT_TOKEN_KEY = "gen_ai.usage.output_tokens"
+    CACHE_READ_INPUT_TOKEN_KEY = "gen_ai.usage.cache_read.input_tokens"
+    CACHE_CREATION_INPUT_TOKEN_KEY = "gen_ai.usage.cache_creation.input_tokens"
 
     # Input/Output attribute keys from OTEL GenAI semantic conventions
     # Reference: https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/#gen-ai-input-messages

--- a/tests/tracing/otel/test_span_translation.py
+++ b/tests/tracing/otel/test_span_translation.py
@@ -233,6 +233,122 @@ def test_translate_token_usage_edge_cases(
     assert usage[TokenUsageKey.TOTAL_TOKENS] == expected_total
 
 
+def test_translate_token_usage_from_otel_genai_with_cache():
+    """GenAI cache tokens surface in mlflow.chat.tokenUsage when OTLP spans set them."""
+    span = mock.Mock(spec=Span)
+    span.parent_id = "parent_123"
+    span_dict = {
+        "attributes": {
+            GenAiTranslator.INPUT_TOKEN_KEY: 100,
+            GenAiTranslator.OUTPUT_TOKEN_KEY: 50,
+            GenAiTranslator.CACHE_READ_INPUT_TOKEN_KEY: 80,
+            GenAiTranslator.CACHE_CREATION_INPUT_TOKEN_KEY: 20,
+        }
+    }
+    span.to_dict.return_value = span_dict
+
+    result = translate_span_when_storing(span)
+
+    assert SpanAttributeKey.CHAT_USAGE in result["attributes"]
+    usage = json.loads(result["attributes"][SpanAttributeKey.CHAT_USAGE])
+    assert usage[TokenUsageKey.INPUT_TOKENS] == 100
+    assert usage[TokenUsageKey.OUTPUT_TOKENS] == 50
+    assert usage[TokenUsageKey.TOTAL_TOKENS] == 150
+    assert usage[TokenUsageKey.CACHE_READ_INPUT_TOKENS] == 80
+    assert usage[TokenUsageKey.CACHE_CREATION_INPUT_TOKENS] == 20
+
+
+def test_translate_token_usage_from_otel_genai_without_cache_unchanged():
+    """GenAI spans without cache attrs produce the legacy 3-key usage dict."""
+    span = mock.Mock(spec=Span)
+    span.parent_id = "parent_123"
+    span_dict = {
+        "attributes": {
+            GenAiTranslator.INPUT_TOKEN_KEY: 100,
+            GenAiTranslator.OUTPUT_TOKEN_KEY: 50,
+        }
+    }
+    span.to_dict.return_value = span_dict
+
+    result = translate_span_when_storing(span)
+
+    usage = json.loads(result["attributes"][SpanAttributeKey.CHAT_USAGE])
+    assert usage == {
+        TokenUsageKey.INPUT_TOKENS: 100,
+        TokenUsageKey.OUTPUT_TOKENS: 50,
+        TokenUsageKey.TOTAL_TOKENS: 150,
+    }
+    assert TokenUsageKey.CACHE_READ_INPUT_TOKENS not in usage
+    assert TokenUsageKey.CACHE_CREATION_INPUT_TOKENS not in usage
+
+
+def test_translate_token_usage_preserves_zero_values():
+    """Zero-valued tokens survive rather than being silently dropped.
+
+    Guards two bundled gate fixes: the pre-existing truthy check at
+    _get_token_usage that dropped the whole usage dict when any of
+    input/output/total was 0 (safety-filtered refusals, streaming fragments),
+    and the matching cache-field guard that dropped cache_read_input_tokens=0.
+    Both are addressed by `is not None` checks.
+    """
+    span = mock.Mock(spec=Span)
+    span.parent_id = "parent_123"
+    span_dict = {
+        "attributes": {
+            GenAiTranslator.INPUT_TOKEN_KEY: 0,
+            GenAiTranslator.OUTPUT_TOKEN_KEY: 20,
+            GenAiTranslator.CACHE_READ_INPUT_TOKEN_KEY: 0,
+        }
+    }
+    span.to_dict.return_value = span_dict
+
+    result = translate_span_when_storing(span)
+
+    assert SpanAttributeKey.CHAT_USAGE in result["attributes"]
+    usage = json.loads(result["attributes"][SpanAttributeKey.CHAT_USAGE])
+    assert usage[TokenUsageKey.INPUT_TOKENS] == 0
+    assert usage[TokenUsageKey.OUTPUT_TOKENS] == 20
+    assert usage[TokenUsageKey.TOTAL_TOKENS] == 20
+    assert usage[TokenUsageKey.CACHE_READ_INPUT_TOKENS] == 0
+
+
+@pytest.mark.parametrize(
+    ("cache_read", "cache_creation"),
+    [
+        (80, None),
+        (None, 40),
+    ],
+)
+def test_translate_token_usage_handles_partial_cache_fields(
+    cache_read: int | None, cache_creation: int | None
+):
+    """Cache fields are independent — either one may appear without the other."""
+    span = mock.Mock(spec=Span)
+    span.parent_id = "parent_123"
+    attributes = {
+        GenAiTranslator.INPUT_TOKEN_KEY: 100,
+        GenAiTranslator.OUTPUT_TOKEN_KEY: 50,
+    }
+    if cache_read is not None:
+        attributes[GenAiTranslator.CACHE_READ_INPUT_TOKEN_KEY] = cache_read
+    if cache_creation is not None:
+        attributes[GenAiTranslator.CACHE_CREATION_INPUT_TOKEN_KEY] = cache_creation
+    span_dict = {"attributes": attributes}
+    span.to_dict.return_value = span_dict
+
+    result = translate_span_when_storing(span)
+
+    usage = json.loads(result["attributes"][SpanAttributeKey.CHAT_USAGE])
+    if cache_read is not None:
+        assert usage[TokenUsageKey.CACHE_READ_INPUT_TOKENS] == cache_read
+    else:
+        assert TokenUsageKey.CACHE_READ_INPUT_TOKENS not in usage
+    if cache_creation is not None:
+        assert usage[TokenUsageKey.CACHE_CREATION_INPUT_TOKENS] == cache_creation
+    else:
+        assert TokenUsageKey.CACHE_CREATION_INPUT_TOKENS not in usage
+
+
 @pytest.mark.parametrize(
     "translator",
     [

--- a/tests/tracing/utils/test_utils.py
+++ b/tests/tracing/utils/test_utils.py
@@ -677,6 +677,36 @@ def test_builtin_cost_fallback_with_cache_tokens():
     assert result["input_cost"] == pytest.approx(0.00225)
 
 
+def test_cost_applies_cache_discount_when_cache_read_present():
+    """Cost calculator applies the cache-read discount: given identical
+    input/output token counts, a usage dict that includes
+    cache_read_input_tokens yields a strictly lower input_cost (and total_cost)
+    than one without. Output cost is unaffected.
+    """
+    with mock.patch.dict("sys.modules", {"litellm": None}):
+        uncached = calculate_cost_by_model_and_token_usage(
+            "gpt-4o",
+            {
+                TokenUsageKey.INPUT_TOKENS: 1000,
+                TokenUsageKey.OUTPUT_TOKENS: 500,
+            },
+        )
+        cached = calculate_cost_by_model_and_token_usage(
+            "gpt-4o",
+            {
+                TokenUsageKey.INPUT_TOKENS: 1000,
+                TokenUsageKey.OUTPUT_TOKENS: 500,
+                TokenUsageKey.CACHE_READ_INPUT_TOKENS: 500,
+            },
+        )
+    assert uncached is not None
+    assert cached is not None
+    assert cached["input_cost"] < uncached["input_cost"]
+    assert cached["total_cost"] < uncached["total_cost"]
+    # Discount applies to input only; output cost is unchanged.
+    assert cached["output_cost"] == uncached["output_cost"]
+
+
 def test_builtin_cost_fallback_with_provider():
     with mock.patch.dict("sys.modules", {"litellm": None}):
         result = calculate_cost_by_model_and_token_usage(


### PR DESCRIPTION

> **Note to reviewers:** I filed #22745 this morning and pushed this branch to my fork before noticing that #22748 (Copilot SWE agent, opened ~25 min after the issue was filed) was already open for the same issue. The scopes overlap. I'm submitting this for comparison — if #22748 is preferred, please close this as duplicate. If any of the additional test coverage here is useful (cost-calculator roundtrip test, partial-cache-fields test, parametrized zero-value preservation), feel free to cherry-pick.

### Related Issues/PRs

Closes #22745. (The SQLAlchemy rollup sibling bug is tracked independently as #22746 and is out of scope for this PR.)

Relates to #22606 (umbrella cache-aware cost tracking; closed 2026-04-20 by #22620, which is scoped to `mlflow/openai/autolog.py` and does not touch the OTel GenAI ingest path fixed here) and #22683 (same schema-alignment argument applied to the `claude_code` transcript ingest path; open on GitHub as of 2026-04-21).

### What changes are proposed in this pull request?

Fix two defects in the OTLP GenAI ingest path that both live inside the same gate in `mlflow.tracing.otel.translation._get_token_usage`:

**1. Cache token fields dropped.** The function never reads `gen_ai.usage.cache_read.input_tokens` or `gen_ai.usage.cache_creation.input_tokens` from OTLP spans. Producers following the OTel GenAI semantic conventions (e.g. the community-maintained `opentelemetry-instrumentation-openai-v2` package) lose the cache breakdown at ingest. Experiment-level Token Usage charts show zero cache reads and per-trace cost is over-billed because `calculate_cost_by_model_and_token_usage` never sees the cache fields it needs for the cached-input price tier.

**2. Zero-valued token fields dropped.** The gate uses truthy checks (`if input_tokens and output_tokens and total_tokens`), silently dropping the whole usage dict whenever any of input/output/total is 0. Legitimate scenarios: safety-filtered refusals (output=0), streaming intermediate fragments (input=0).

Both defects sit inside the same 3-line gate; the cache additions would inherit the truthy bug, so they are fixed together.

**Files touched (~200 lines incl. tests):**

- `mlflow/tracing/otel/translation/base.py` — add `CACHE_READ_INPUT_TOKEN_KEY`, `CACHE_CREATION_INPUT_TOKEN_KEY` class attributes + matching getters. Mirrors the existing three-getter INPUT/OUTPUT/TOTAL trio.
- `mlflow/tracing/otel/translation/genai_semconv.py` — populate the two new keys with OTel GenAI semantic convention attribute names.
- `mlflow/tracing/otel/translation/__init__.py` — replace truthy gate with `is not None`, collect cache fields onto the usage dict.

Other translators (OpenInference, Traceloop, Spring AI, Google ADK, Vercel AI, VoltAgent, Laminar, Langfuse) have no cache-token schema to map today, so the base-class default (`None`) leaves them unaffected. `LiveKitTranslator` inherits from `GenAiTranslator` (`mlflow/tracing/otel/translation/livekit.py:19`), so the new cache-token keys flow through LiveKit spans automatically — this is the intended behavior since LiveKit uses the GenAI semantic conventions for token usage.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

**New tests:**
- `tests/tracing/otel/test_span_translation.py` — four translator tests (`_with_cache`, `_without_cache_unchanged`, `_preserves_zero_values`, `_handles_partial_cache_fields`).
- `tests/tracing/utils/test_utils.py` — one cost-calculator test confirming the cache_read discount vs. an uncached baseline.

**Regression surface:** `tests/tracing/otel/` and `tests/tracing/utils/` run clean (392 passed locally; 4 docker-dependent tests error on infrastructure unavailability, pre-existing).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Traces ingested via OTLP from producers following the OTel GenAI semantic conventions now expose `cache_read_input_tokens` and `cache_creation_input_tokens` on `mlflow.chat.tokenUsage`, enabling per-trace cache-discount cost calculation and correct cache-read rollup on the Token Usage chart. Additionally, spans with legitimate zero-valued token counts now produce a usage dict rather than being silently dropped.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`
- [ ] `area/models`
- [ ] `area/model-registry`
- [ ] `area/scoring`
- [ ] `area/evaluation`
- [ ] `area/gateway`
- [ ] `area/prompts`
- [x] `area/tracing`
- [ ] `area/projects`
- [ ] `area/uiux`
- [ ] `area/build`
- [ ] `area/docs`

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none`
- [ ] `rn/breaking-change`
- [ ] `rn/feature`
- [x] `rn/bug-fix`
- [ ] `rn/documentation`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

---

### Follow-up (out of scope for this PR)

- `VoltAgentTranslator.get_input_tokens` / `get_output_tokens` / `get_total_tokens` at `mlflow/tracing/otel/translation/voltagent.py:109-121` override the base getters with truthy `or` chains that still drop zero values. Can be fixed in a follow-up with the same `is not None` treatment.
- Sibling bug report: #22746 (`[BUG] SQLAlchemy trace-rollup double-counts token usage across parent and child CHAT_USAGE spans`). Independent from this PR — different layer, different owner.
