### PR TITLE
Add Application Default Credentials auth mode for Vertex AI gateway

### DIFF
--- a/mlflow/utils/providers.py
+++ b/mlflow/utils/providers.py
@@ -563,6 +563,27 @@ _PROVIDER_AUTH_MODES: dict[str, dict[str, AuthModeDict]] = {
                 },
             ],
         },
+        "default_chain": {
+            "display_name": "Application Default Credentials",
+            "description": "Use the server's Application Default Credentials "
+            "(GOOGLE_APPLICATION_CREDENTIALS, gcloud auth application-default login, "
+            "or attached GCE/GKE/Cloud Run service account)",
+            "fields": [
+                {
+                    "name": "vertex_project",
+                    "description": "GCP Project ID",
+                    "secret": False,
+                    "required": True,
+                },
+                {
+                    "name": "vertex_location",
+                    "description": "GCP Region (e.g., us-central1)",
+                    "secret": False,
+                    "required": False,
+                    "default": "us-central1",
+                },
+            ],
+        },
     },
     "databricks": {
         "pat_token": {

--- a/tests/utils/test_providers.py
+++ b/tests/utils/test_providers.py
@@ -238,6 +238,18 @@ def test_get_provider_config_sagemaker_has_default_chain():
     assert "default_chain" in modes
 
 
+def test_get_provider_config_vertex_ai_has_default_chain():
+    config = get_provider_config_response("vertex_ai")
+    modes = {m["mode"] for m in config["auth_modes"]}
+    assert "default_chain" in modes
+
+    default_chain = next(m for m in config["auth_modes"] if m["mode"] == "default_chain")
+    assert default_chain["display_name"] == "Application Default Credentials"
+    assert default_chain["secret_fields"] == []
+    project_field = next(f for f in default_chain["config_fields"] if f["name"] == "vertex_project")
+    assert project_field["required"] is True
+
+
 _MOCK_PROVIDER_DATA = {
     "test_provider": {
         "test-model": {


### PR DESCRIPTION
### Related Issues/PRs

Closes #22644

### What changes are proposed in this pull request?

Add a `default_chain` (Application Default Credentials) auth mode for the Vertex AI provider in the AI Gateway, alongside the existing `service_account_json` mode.

The Vertex AI provider (`mlflow/gateway/providers/vertex_ai.py:73-75`) already falls back to ADC via `google.auth.default()` when no service account JSON is configured, and `VertexAIConfig.vertex_credentials` is already `str | None`. The gap was purely in the UI schema (`mlflow/utils/providers.py`), which only exposed the `service_account_json` mode and therefore forced users to paste a JSON key even when running on GCE/GKE/Cloud Run with an attached service account, or with `GOOGLE_APPLICATION_CREDENTIALS` / `gcloud auth application-default login` configured.

This mirrors the existing `default_chain` pattern already used by the `bedrock` and `sagemaker` providers. The gateway UI renders auth modes dynamically from this schema, so no frontend change is required.

https://github.com/user-attachments/assets/e5b2a0c1-d396-4343-a4d7-9fa67fb8d939

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added `test_get_provider_config_vertex_ai_has_default_chain` in `tests/utils/test_providers.py`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The AI Gateway UI now offers an "Application Default Credentials" auth mode for Vertex AI endpoints, letting users rely on ambient GCP credentials instead of pasting a service account JSON key.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release