### PR TITLE
Fix ABFSS URI double-encoding in `_parse_abfss_uri`

### DIFF
--- a/mlflow/store/artifact/azure_data_lake_artifact_repo.py
+++ b/mlflow/store/artifact/azure_data_lake_artifact_repo.py
@@ -56,6 +56,10 @@ def _parse_abfss_uri(uri):
     domain_suffix = match.group(3)
     path = parsed.path
     path = path.removeprefix("/")
+    # Decode percent-encoded characters so the Azure SDK re-quotes exactly once.
+    # Without this, an encoded %20 becomes %2520 on the wire and any SAS signature
+    # minted over the decoded path fails validation with AuthenticationFailed.
+    path = urllib.parse.unquote(path)
     return filesystem, account_name, domain_suffix, path
 
 

--- a/mlflow/store/artifact/azure_data_lake_artifact_repo.py
+++ b/mlflow/store/artifact/azure_data_lake_artifact_repo.py
@@ -59,7 +59,9 @@ def _parse_abfss_uri(uri):
     # Decode percent-encoded characters so the Azure SDK re-quotes exactly once.
     # Without this, an encoded %20 becomes %2520 on the wire and any SAS signature
     # minted over the decoded path fails validation with AuthenticationFailed.
-    path = urllib.parse.unquote(path)
+    # lstrip("/") strips any leading slash re-introduced by decoding "%2F", so
+    # downstream ADLS calls always receive a relative path.
+    path = urllib.parse.unquote(path).lstrip("/")
     return filesystem, account_name, domain_suffix, path
 
 

--- a/tests/store/artifact/test_azure_data_lake_artifact_repo.py
+++ b/tests/store/artifact/test_azure_data_lake_artifact_repo.py
@@ -125,6 +125,13 @@ def mock_file_client(mock_directory_client):
             "dfs.core.usgovcloudapi.net",
             "a/b",
         ),
+        (
+            "abfss://filesystem@acct.dfs.core.windows.net/Pharma/Marketing%20Navigator",
+            "filesystem",
+            "acct",
+            "dfs.core.windows.net",
+            "Pharma/Marketing Navigator",
+        ),
     ],
 )
 def test_parse_valid_abfss_uri(uri, filesystem, account, region_suffix, path):
@@ -317,6 +324,54 @@ def test_download_file_artifact(mock_directory_client, mock_file_client, tmp_pat
     repo.download_artifacts("test.txt")
     assert os.path.exists(os.path.join(tmp_path, "test.txt"))
     mock_directory_client.get_file_client.assert_called_once_with("test.txt")
+
+
+TEST_ENCODED_ROOT_PATH = "Pharma/Commercial/Global/Marketing%20Navigator"
+TEST_DECODED_ROOT_PATH = "Pharma/Commercial/Global/Marketing Navigator"
+TEST_DATA_LAKE_URI_ENCODED = posixpath.join(TEST_DATA_LAKE_URI_BASE, TEST_ENCODED_ROOT_PATH)
+
+
+def test_log_artifact_decodes_percent_encoded_path(
+    mock_filesystem_client, mock_directory_client, tmp_path
+):
+    # Paths with %20 must be decoded before being handed to the Azure SDK,
+    # otherwise the SDK re-quotes them (%2520) and a SAS signature minted over
+    # the decoded path fails validation.
+    repo = AzureDataLakeArtifactRepository(TEST_DATA_LAKE_URI_ENCODED, credential=TEST_CREDENTIAL)
+
+    f = tmp_path.joinpath("b.txt")
+    f.write_text("B")
+    repo.log_artifact(f)
+
+    mock_filesystem_client.get_directory_client.assert_called_once_with(TEST_DECODED_ROOT_PATH)
+    assert "%20" not in mock_filesystem_client.get_directory_client.call_args[0][0]
+
+
+def test_list_artifacts_decodes_percent_encoded_path(mock_filesystem_client):
+    repo = AzureDataLakeArtifactRepository(TEST_DATA_LAKE_URI_ENCODED, credential=TEST_CREDENTIAL)
+    mock_filesystem_client.get_paths.return_value = MockPathList([])
+
+    repo.list_artifacts()
+
+    mock_filesystem_client.get_paths.assert_called_once_with(
+        path=TEST_DECODED_ROOT_PATH, recursive=False
+    )
+
+
+def test_download_decodes_percent_encoded_path(
+    mock_filesystem_client, mock_directory_client, mock_file_client, tmp_path
+):
+    repo = AzureDataLakeArtifactRepository(TEST_DATA_LAKE_URI_ENCODED, credential=TEST_CREDENTIAL)
+
+    def create_file(file):
+        tmp_path.joinpath(os.path.basename(file.name)).write_text("hello")
+
+    mock_file_client.download_file().readinto.side_effect = create_file
+    repo.download_artifacts("test.txt")
+
+    base_dir = mock_filesystem_client.get_directory_client.call_args[0][0]
+    assert base_dir == TEST_DECODED_ROOT_PATH
+    assert "%20" not in base_dir
 
 
 def test_download_directory_artifact(mock_filesystem_client, mock_file_client, tmp_path):

--- a/tests/store/artifact/test_azure_data_lake_artifact_repo.py
+++ b/tests/store/artifact/test_azure_data_lake_artifact_repo.py
@@ -132,6 +132,15 @@ def mock_file_client(mock_directory_client):
             "dfs.core.windows.net",
             "Pharma/Marketing Navigator",
         ),
+        (
+            # %2F decodes to "/", which lstrip("/") removes so downstream ADLS
+            # calls receive a relative path.
+            "abfss://filesystem@acct.dfs.core.windows.net/%2Ffoo/bar",
+            "filesystem",
+            "acct",
+            "dfs.core.windows.net",
+            "foo/bar",
+        ),
     ],
 )
 def test_parse_valid_abfss_uri(uri, filesystem, account, region_suffix, path):


### PR DESCRIPTION
### Related Issues/PRs

Relates to #

### What changes are proposed in this pull request?

`_parse_abfss_uri` currently returns the `path` segment of an `abfss://` URI
with its percent-encoding intact (via `urllib.parse.urlparse(uri).path`).
That path is then handed directly to the Azure Data Lake SDK
(`FileSystemClient.get_paths`, `FileSystemClient.get_directory_client`,
etc.), whose internal helper re-quotes the string with
`quote(path, safe="~/")`. Because `%` is not in the safe set, an encoded
`%20` becomes `%2520` on the wire.

When the caller authenticates with a SAS token that was signed over the
decoded path (the normal case when the token is minted by a server that
percent-decodes the URI before signing), the path Azure reconstructs from
the double-encoded request does not match what was signed and the request
fails with `AuthenticationFailed: Server failed to authenticate the request`.

Paths without percent-encoded characters are unaffected because the
re-encoding is a no-op.

The fix is a one-liner in `_parse_abfss_uri`: `urllib.parse.unquote` the
path after stripping the leading `/`, so the Azure SDK re-quotes exactly
once. Nothing downstream depends on the percent-encoded form —
`posixpath.join` and relative-path math in `list_artifacts` already operate
on decoded strings.

### How is this PR tested?

- [x] New unit/integration tests
- [x] Existing unit/integration tests
- [x] Manual tests
  - Manual verification of fix in workspace 

Adds one parametrize case to `test_parse_valid_abfss_uri` and three
integration-style tests that construct an `AzureDataLakeArtifactRepository`
with a URI containing `%20`, drive `log_artifact` / `list_artifacts` /
`download_artifacts` through mocked Azure SDK clients, and assert that the
decoded string is what reaches the SDK.

Before the fix the three new integration tests fail; after the fix they
pass.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fix `AuthenticationFailed` when using
  `AzureDataLakeArtifactRepository` with `abfss://` URIs whose path contains
  percent-encoded characters (e.g. spaces encoded as `%20`).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
