### PR TITLE
Fix `EvaluationDataset` type references in GenAI datasets docs

### DIFF
--- a/docs/docs/genai/concepts/evaluation-datasets.mdx
+++ b/docs/docs/genai/concepts/evaluation-datasets.mdx
@@ -56,22 +56,23 @@ Evaluation datasets are composed of several key elements that work together to p
 
 ## Dataset Object Schema
 
-The <APILink fn="mlflow.entities.EvaluationDataset" text="EvaluationDataset" /> object contains the following fields:
+The <APILink fn="mlflow.genai.datasets.EvaluationDataset" text="EvaluationDataset" /> object returned by <APILink fn="mlflow.genai.datasets.create_dataset" text="create_dataset()" /> and <APILink fn="mlflow.genai.datasets.get_dataset" text="get_dataset()" /> exposes the following fields:
 
-| Field              | Type                  | Description                                                              |
-| ------------------ | --------------------- | ------------------------------------------------------------------------ |
-| `dataset_id`       | `str`                 | Unique identifier for the dataset (format: `d-{32 hex chars}`)           |
-| `name`             | `str`                 | Human-readable name for the dataset                                      |
-| `digest`           | `str`                 | Content hash for data integrity verification                             |
-| `records`          | `list[DatasetRecord]` | The actual test data records containing inputs and expectations          |
-| `schema`           | `Optional[str]`       | JSON string describing the structure of records (automatically computed) |
-| `profile`          | `Optional[str]`       | JSON string containing statistical information about the dataset         |
-| `tags`             | `dict[str, str]`      | Key-value pairs for organizing and categorizing datasets                 |
-| `experiment_ids`   | `list[str]`           | List of MLflow experiment IDs this dataset is associated with            |
-| `created_time`     | `int`                 | Timestamp when the dataset was created (milliseconds)                    |
-| `last_update_time` | `int`                 | Timestamp of the last modification (milliseconds)                        |
-| `created_by`       | `Optional[str]`       | User who created the dataset (auto-detected from tags)                   |
-| `last_updated_by`  | `Optional[str]`       | User who last modified the dataset                                       |
+| Field              | Type             | Description                                                              |
+| ------------------ | ---------------- | ------------------------------------------------------------------------ |
+| `dataset_id`       | `str`            | Unique identifier for the dataset (format: `d-{32 hex chars}`)           |
+| `name`             | `str`            | Human-readable name for the dataset                                      |
+| `digest`           | `str`            | Content hash for data integrity verification                             |
+| `schema`           | `Optional[str]`  | JSON string describing the structure of records (automatically computed) |
+| `profile`          | `Optional[str]`  | JSON string containing statistical information about the dataset         |
+| `tags`             | `dict[str, str]` | Key-value pairs for organizing and categorizing datasets                 |
+| `experiment_ids`   | `list[str]`      | List of MLflow experiment IDs this dataset is associated with            |
+| `created_time`     | `int`            | Timestamp when the dataset was created (milliseconds)                    |
+| `last_update_time` | `int`            | Timestamp of the last modification (milliseconds)                        |
+| `created_by`       | `Optional[str]`  | User who created the dataset (auto-detected from tags)                   |
+| `last_updated_by`  | `Optional[str]`  | User who last modified the dataset                                       |
+
+Records are fetched lazily — call <APILink fn="mlflow.genai.datasets.EvaluationDataset.to_df" text="to_df()" /> to load them into a pandas `DataFrame`.
 
 ## Record Structure
 
@@ -116,7 +117,7 @@ Each record in an evaluation dataset represents a single test case with the foll
 
 ### Record Identity and Deduplication
 
-Records are uniquely identified by a **hash of their inputs**. When merging records with <APILink fn="mlflow.entities.EvaluationDataset.merge_records" text="merge_records()" />, if a record with identical inputs already exists, its expectations and tags are merged rather than creating a duplicate. This enables iterative refinement of test cases without data duplication.
+Records are uniquely identified by a **hash of their inputs**. When merging records with <APILink fn="mlflow.genai.datasets.EvaluationDataset.merge_records" text="merge_records()" />, if a record with identical inputs already exists, its expectations and tags are merged rather than creating a duplicate. This enables iterative refinement of test cases without data duplication.
 
 ## Schema Evolution
 

--- a/docs/docs/genai/datasets/end-to-end-workflow.mdx
+++ b/docs/docs/genai/datasets/end-to-end-workflow.mdx
@@ -132,7 +132,7 @@ for trace in traces:
 
 ## Step 4: Create an Evaluation Dataset
 
-Transform your annotated traces into a reusable evaluation dataset. Use <APILink fn="mlflow.genai.datasets.create_dataset">create_dataset()</APILink> to initialize your dataset and <APILink fn="mlflow.entities.EvaluationDataset.merge_records">merge_records()</APILink> to add test cases from multiple sources.
+Transform your annotated traces into a reusable evaluation dataset. Use <APILink fn="mlflow.genai.datasets.create_dataset">create_dataset()</APILink> to initialize your dataset and <APILink fn="mlflow.genai.datasets.EvaluationDataset.merge_records">merge_records()</APILink> to add test cases from multiple sources.
 
 ```python
 from mlflow.genai.datasets import create_dataset

--- a/docs/docs/genai/datasets/sdk-guide.mdx
+++ b/docs/docs/genai/datasets/sdk-guide.mdx
@@ -51,7 +51,7 @@ dataset = client.create_dataset(
 
 ## Adding Records to a Dataset
 
-Use the <APILink fn="mlflow.entities.EvaluationDataset.merge_records" text="merge_records()" /> method to add new records to your dataset. Records can be added from dictionaries, DataFrames, or traces:
+Use the <APILink fn="mlflow.genai.datasets.EvaluationDataset.merge_records" text="merge_records()" /> method to add new records to your dataset. Records can be added from dictionaries, DataFrames, or traces:
 
 <TabsWrapper>
   <Tabs>
@@ -80,7 +80,7 @@ new_records = [
 ]
 
 dataset.merge_records(new_records)
-print(f"Dataset now has {len(dataset.records)} records")
+print(f"Dataset now has {len(dataset.to_df())} records")
 ```
 
     </TabItem>
@@ -224,7 +224,7 @@ The `source` field tracks where a dataset record came from. Each record can have
 
 ## Updating Existing Records
 
-The <APILink fn="mlflow.entities.EvaluationDataset.merge_records" text="merge_records()" /> method intelligently handles updates. **Records are matched based on a hash of their inputs** - if a record with identical inputs already exists, its expectations and tags are merged rather than creating a duplicate:
+The <APILink fn="mlflow.genai.datasets.EvaluationDataset.merge_records" text="merge_records()" /> method intelligently handles updates. **Records are matched based on a hash of their inputs** - if a record with identical inputs already exists, its expectations and tags are merged rather than creating a duplicate:
 
 ```python
 # Initial record
@@ -272,7 +272,7 @@ dataset = get_dataset(dataset_id="d-7f2e3a9b8c1d4e5f")
 
 # Access dataset properties
 print(f"Name: {dataset.name}")
-print(f"Records: {len(dataset.records)}")
+print(f"Records: {len(dataset.to_df())}")
 print(f"Schema: {dataset.schema}")
 print(f"Tags: {dataset.tags}")
 ```
@@ -292,7 +292,7 @@ datasets = search_datasets(
 )
 
 for ds in datasets:
-    print(f"{ds.name} ({ds.dataset_id}): {len(ds.records)} records")
+    print(f"{ds.name} ({ds.dataset_id}): {len(ds.to_df())} records")
 ```
 
 See [Search Filter Reference](#search-filter-reference) for filter syntax details.
@@ -361,13 +361,10 @@ Deleting records updates the dataset's profile (record count) automatically.
 
 ## Working with Dataset Records
 
-The <APILink fn="mlflow.entities.EvaluationDataset" text="EvaluationDataset" /> object provides several ways to access and analyze records:
+The <APILink fn="mlflow.genai.datasets.EvaluationDataset" text="EvaluationDataset" /> object provides several ways to access and analyze records:
 
 ```python
-# Access all records
-all_records = dataset.records
-
-# Convert to DataFrame for analysis
+# Convert to DataFrame for analysis (records are loaded lazily on first call)
 df = dataset.to_df()
 print(df.head())
 
@@ -381,7 +378,7 @@ print(dataset.schema)
 print(dataset.profile)
 
 # Get record count
-print(f"Total number of records: {len(dataset.records)}")
+print(f"Total number of records: {len(df)}")
 ```
 
 To recreate a dataset from a serialized dictionary:


### PR DESCRIPTION
### Related Issues/PRs

Closes #22712

### What changes are proposed in this pull request?

`create_dataset()` returns `mlflow.genai.datasets.EvaluationDataset` (a wrapper), not `mlflow.entities.EvaluationDataset`. The wrapper blocks `records` access, so examples using `dataset.records` would raise `AttributeError`. Updated `APILink` targets and replaced `dataset.records` with `dataset.to_df()`.

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Examples
  - [x] API references

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix incorrect `EvaluationDataset` type references in GenAI datasets docs.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/documentation`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release