### PR TITLE
Pin `arize-phoenix-evals<3.0.0` to unblock GenAI CI

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -322,9 +322,11 @@ jobs:
       - name: Install dependencies
         run: |
           uv sync --extra genai
+          # TODO: migrate mlflow/genai/scorers/phoenix to arize-phoenix-evals 3.x API
+          # (removed HallucinationEvaluator/RelevanceEvaluator/etc. and LiteLLMModel)
           uv pip install \
             -r requirements/test-requirements.txt \
-            deepeval ragas arize-phoenix-evals trulens trulens-providers-litellm guardrails-ai
+            deepeval ragas 'arize-phoenix-evals<3.0.0' trulens trulens-providers-litellm guardrails-ai
       - uses: ./.github/actions/show-versions
       - uses: ./.github/actions/pipdeptree
       - name: Run GenAI Tests (OSS)


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

`arize-phoenix-evals` 3.0.0 (released 2026-04-07) removed the legacy `models/` wrappers and the pre-built evaluator classes (`HallucinationEvaluator`, `RelevanceEvaluator`, `ToxicityEvaluator`, `QAEvaluator`, `SummarizationEvaluator`) as well as `LiteLLMModel`, which `mlflow/genai/scorers/phoenix/registry.py` and `models.py` depend on.

This breaks the `genai` CI job with:

```
mlflow.exceptions.MlflowException: Unknown Phoenix metric: 'Hallucination'.
Could not find 'HallucinationEvaluator' in 'phoenix.evals'.
```

This PR pins `arize-phoenix-evals<3.0.0` in the `genai` workflow to unblock CI, and leaves a TODO to migrate the Phoenix scorer integration to the 3.x API (`Evaluator` / `LLMEvaluator` / `ClassificationEvaluator`) in a follow-up.

### How is this PR tested?

- [x] Existing unit/integration tests

Verified locally: `uv run --with 'arize-phoenix-evals<3.0.0' pytest tests/genai/scorers/phoenix/test_registry.py` passes (7/7).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release