### PR TITLE
Add aggregate_openai_responses_stream_chunks for streaming trace output

### DIFF
--- a/mlflow/gateway/tracing_utils.py
+++ b/mlflow/gateway/tracing_utils.py
@@ -501,12 +501,25 @@ def aggregate_openai_responses_stream_chunks(
     if not chunks:
         return None
 
-    # Concatenate before parsing: aiohttp yields arbitrary-sized byte chunks that
-    # can split a single SSE "data:" line across multiple pieces.
-    combined = b"".join(chunks)
+    # Scan chunks incrementally to avoid materializing a second full copy of the
+    # stream bytes.  aiohttp yields arbitrary-sized byte chunks that can bisect a
+    # ``data:`` line, so we carry any trailing incomplete line into the next
+    # iteration rather than joining everything up front.
+    leftover = b""
+    for chunk in chunks:
+        data = leftover + chunk
+        # Split on newlines, keeping the last (potentially incomplete) segment.
+        lines = data.split(b"\n")
+        leftover = lines[-1]
+        complete = b"\n".join(lines[:-1]) + b"\n"
+        for event in parse_sse_lines(complete):
+            if event.get("type") == "response.completed":
+                return event.get("response")
 
-    for event in parse_sse_lines(combined):
-        if event.get("type") == "response.completed":
-            return event.get("response")
+    # Flush any remaining bytes that were not followed by a newline.
+    if leftover:
+        for event in parse_sse_lines(leftover):
+            if event.get("type") == "response.completed":
+                return event.get("response")
 
     return None

--- a/mlflow/gateway/tracing_utils.py
+++ b/mlflow/gateway/tracing_utils.py
@@ -468,3 +468,45 @@ def aggregate_anthropic_messages_stream_chunks(
         result["usage"] = usage
 
     return result
+
+
+def aggregate_openai_responses_stream_chunks(
+    chunks: list[bytes],
+) -> dict[str, Any] | None:
+    """
+    Aggregate raw OpenAI Responses API SSE streaming chunks into a single response object.
+
+    The OpenAI Responses streaming API emits a ``response.completed`` event that contains
+    the fully-assembled response object — including all output items, content parts, and
+    token usage. This function locates that event and returns its ``response`` field,
+    giving the same shape as a non-streaming Responses API call::
+
+        {
+            "id": "resp_...",
+            "object": "response",
+            "status": "completed",
+            "output": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "..."}],
+                }
+            ],
+            "usage": {"input_tokens": N, "output_tokens": M, "total_tokens": T},
+            ...
+        }
+
+    Returns ``None`` if *chunks* is empty or contains no ``response.completed`` event.
+    """
+    if not chunks:
+        return None
+
+    # Concatenate before parsing: aiohttp yields arbitrary-sized byte chunks that
+    # can split a single SSE "data:" line across multiple pieces.
+    combined = b"".join(chunks)
+
+    for event in parse_sse_lines(combined):
+        if event.get("type") == "response.completed":
+            return event.get("response")
+
+    return None

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -59,6 +59,7 @@ from mlflow.gateway.schemas import chat, embeddings
 from mlflow.gateway.tracing_utils import (
     aggregate_anthropic_messages_stream_chunks,
     aggregate_chat_stream_chunks,
+    aggregate_openai_responses_stream_chunks,
     maybe_traced_gateway_call,
 )
 from mlflow.gateway.utils import safe_stream, to_sse_chunk, translate_http_exception
@@ -947,6 +948,7 @@ async def openai_passthrough_responses(request: Request):
             yield_stream,
             endpoint_config,
             user_metadata,
+            output_reducer=aggregate_openai_responses_stream_chunks,
             request_headers=headers,
             request_type=GatewayRequestType.PASSTHROUGH_MODEL_OPENAI_RESPONSES,
             on_complete=make_budget_on_complete(store, workspace),

--- a/tests/gateway/test_tracing_utils.py
+++ b/tests/gateway/test_tracing_utils.py
@@ -10,6 +10,7 @@ from mlflow.gateway.tracing_utils import (
     _get_model_span_info,
     aggregate_anthropic_messages_stream_chunks,
     aggregate_chat_stream_chunks,
+    aggregate_openai_responses_stream_chunks,
     maybe_traced_gateway_call,
 )
 from mlflow.store.tracking.gateway.entities import GatewayEndpointConfig
@@ -842,3 +843,80 @@ def test_aggregate_anthropic_messages_stream_chunks_cache_tokens():
         "cache_creation_input_tokens": 2,
         "output_tokens": 8,
     }
+
+
+# ---------------------------------------------------------------------------
+# Tests for aggregate_openai_responses_stream_chunks
+# ---------------------------------------------------------------------------
+
+_RESPONSES_CREATED = (
+    b'data: {"type":"response.created","response":{"id":"resp_1","object":"response",'
+    b'"created_at":1741290958,"status":"in_progress","output":[],"usage":null}}\n'
+)
+_RESPONSES_TEXT_DELTA = (
+    b'data: {"type":"response.output_text.delta","item_id":"msg_1",'
+    b'"output_index":0,"content_index":0,"delta":"Hi"}\n'
+)
+_RESPONSES_TEXT_DONE = (
+    b'data: {"type":"response.output_text.done","item_id":"msg_1",'
+    b'"output_index":0,"content_index":0,"text":"Hi there!"}\n'
+)
+_RESPONSES_COMPLETED = (
+    b'data: {"type":"response.completed","response":{"id":"resp_1","object":"response",'
+    b'"created_at":1741290958,"status":"completed",'
+    b'"output":[{"id":"msg_1","type":"message","status":"completed","role":"assistant",'
+    b'"content":[{"type":"output_text","text":"Hi there!","annotations":[]}]}],'
+    b'"usage":{"input_tokens":37,"output_tokens":11,"total_tokens":48}}}\n'
+)
+
+
+def test_aggregate_openai_responses_stream_chunks_empty():
+    assert aggregate_openai_responses_stream_chunks([]) is None
+
+
+def test_aggregate_openai_responses_stream_chunks_no_completed_event():
+    chunks = [_RESPONSES_CREATED, _RESPONSES_TEXT_DELTA]
+    assert aggregate_openai_responses_stream_chunks(chunks) is None
+
+
+def test_aggregate_openai_responses_stream_chunks_basic():
+    chunks = [
+        _RESPONSES_CREATED,
+        _RESPONSES_TEXT_DELTA,
+        _RESPONSES_TEXT_DONE,
+        _RESPONSES_COMPLETED,
+    ]
+    result = aggregate_openai_responses_stream_chunks(chunks)
+
+    assert result["id"] == "resp_1"
+    assert result["object"] == "response"
+    assert result["status"] == "completed"
+    assert len(result["output"]) == 1
+    assert result["output"][0]["role"] == "assistant"
+    assert result["output"][0]["content"][0]["text"] == "Hi there!"
+    assert result["usage"] == {"input_tokens": 37, "output_tokens": 11, "total_tokens": 48}
+
+
+def test_aggregate_openai_responses_stream_chunks_split_sse_lines():
+    # Simulate aiohttp yielding a chunk that splits the data: line mid-way.
+    mid = len(_RESPONSES_COMPLETED) // 2
+    chunks = [
+        _RESPONSES_CREATED,
+        _RESPONSES_COMPLETED[:mid],
+        _RESPONSES_COMPLETED[mid:],
+    ]
+    result = aggregate_openai_responses_stream_chunks(chunks)
+
+    assert result is not None
+    assert result["id"] == "resp_1"
+    assert result["status"] == "completed"
+
+
+def test_aggregate_openai_responses_stream_chunks_returns_completed_response():
+    # When multiple events are packed into a single bytes chunk, the
+    # completed response is still extracted correctly.
+    combined = _RESPONSES_CREATED + _RESPONSES_TEXT_DELTA + _RESPONSES_COMPLETED
+    result = aggregate_openai_responses_stream_chunks([combined])
+
+    assert result["status"] == "completed"
+    assert result["usage"]["total_tokens"] == 48


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/22764/files) to review incremental changes.
- [**stack/aggregate-openai-responses-stream**](https://github.com/mlflow/mlflow/pull/22764) [[Files changed](https://github.com/mlflow/mlflow/pull/22764/files)]
  - [stack/aggregate-gemini-stream](https://github.com/mlflow/mlflow/pull/22775) [[Files changed](https://github.com/mlflow/mlflow/pull/22775/files/f2591594e94725e1e6072c9a9bbab2d6ef393b94..dde8290e826da467a688c3b0734677b844a59645)]

---------
### Related Issues/PRs

Relates to #22763

### What changes are proposed in this pull request?

Adds `aggregate_openai_responses_stream_chunks` to `mlflow/gateway/tracing_utils.py`, a streaming output reducer for the OpenAI Responses API — parallel to `aggregate_chat_stream_chunks` (unified chat) and `aggregate_anthropic_messages_stream_chunks` (#22763).

The OpenAI Responses streaming API emits a `response.completed` SSE event that already contains the fully-assembled response object. The function locates that event and returns its `response` field, giving traces the same shape as a non-streaming Responses API call. All raw bytes are concatenated before parsing to handle aiohttp's arbitrary-sized chunks that can split a `data:` line mid-way.

The reducer is wired as `output_reducer` in the OpenAI Responses passthrough streaming path in `gateway_api.py`.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New tests in `tests/gateway/test_tracing_utils.py`:
- Empty input returns `None`
- No `response.completed` event returns `None`
- Basic aggregation returns correct id, status, output content, and usage
- Split `data:` line across chunks is handled correctly
- Multiple events packed into one bytes chunk still works

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release