### PR TITLE
Gate PR auto-approval on author role

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -74,17 +74,17 @@ For each issue found, use the `add-review-comment` skill to post review comments
 
 ### 6. Approve the PR
 
-Approve the PR when there are no issues or only minor issues, but **only if the PR author is a maintainer or admin**.
+Approve the PR when there are no issues or only minor issues, but **only if the PR author has the `admin` or `maintain` role**.
 
 First, check the PR author's role:
 
 ```bash
-gh api repos/<owner>/<repo>/pulls/<PR_NUMBER> --jq '.user.login'
-gh api repos/<owner>/<repo>/collaborators/<author>/permission --jq '.role_name'
+author=$(gh api repos/<owner>/<repo>/pulls/<PR_NUMBER> --jq '.user.login')
+gh api repos/<owner>/<repo>/collaborators/"$author"/permission --jq '.role_name'
 ```
 
 - If the role is `admin` or `maintain` -> approve the PR:
   ```bash
   gh pr review <PR_NUMBER> --repo <owner/repo> --approve
   ```
-- Otherwise -> do NOT approve. Do not mention the reason for not approving in the review.
+- Otherwise (including API errors, e.g., 404 for non-collaborators) -> do NOT approve. Do not mention the reason for not approving in the review.

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -74,8 +74,17 @@ For each issue found, use the `add-review-comment` skill to post review comments
 
 ### 6. Approve the PR
 
-Approve the PR when there are no issues or only minor issues.
+Approve the PR when there are no issues or only minor issues, but **only if the PR author is a maintainer or admin**.
+
+First, check the PR author's role:
 
 ```bash
-gh pr review <PR_NUMBER> --repo <owner/repo> --approve
+gh api repos/<owner>/<repo>/pulls/<PR_NUMBER> --jq '.user.login'
+gh api repos/<owner>/<repo>/collaborators/<author>/permission --jq '.role_name'
 ```
+
+- If the role is `admin` or `maintain` -> approve the PR:
+  ```bash
+  gh pr review <PR_NUMBER> --repo <owner/repo> --approve
+  ```
+- Otherwise -> do NOT approve. Do not mention the reason for not approving in the review.


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Update the PR review skill to only auto-approve PRs authored by maintainers or admins, determined by checking the author's `role_name` via the GitHub collaborators API.

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)