### PR TITLE
Fix OPENAI_API_KEY requirement when guardrails use gateway:/ judge model

### DIFF
--- a/mlflow/gateway/guardrails.py
+++ b/mlflow/gateway/guardrails.py
@@ -414,15 +414,14 @@ class JudgeGuardrail(Guardrail):
 
         # Inside the server process MLFLOW_TRACKING_URI points to the backend store
         # (e.g. sqlite://), so _resolve_gateway_uri() would fail for gateway:/ URIs.
-        # Rewrite to openai:/ with an explicit base_url derived from the HTTP request
-        # URL so the judge calls the gateway directly without touching the tracking URI.
+        # Pass base_url explicitly so _get_provider_instance can skip _resolve_gateway_uri().
         if server_url and isinstance(scorer, InstructionsJudge) and scorer.model:
             provider, endpoint_name = _parse_model_uri(scorer.model)
             if provider == "gateway":
                 scorer = InstructionsJudge(
                     name=scorer.name,
                     instructions=scorer._instructions,
-                    model=f"openai:/{endpoint_name}",
+                    model=f"gateway:/{endpoint_name}",
                     base_url=f"{server_url.rstrip('/')}/gateway/mlflow/v1/chat/completions",
                     feedback_value_type=scorer._feedback_value_type,
                     inference_params=scorer._inference_params,

--- a/mlflow/genai/judges/adapters/gateway_adapter.py
+++ b/mlflow/genai/judges/adapters/gateway_adapter.py
@@ -517,7 +517,7 @@ class GatewayAdapter(BaseJudgeAdapter):
         # Resolve provider for config, URL, headers, and request/response transformation.
         # Each provider's get_endpoint_url() returns the full endpoint path
         # (e.g. OpenAI: .../chat/completions, Anthropic: .../messages).
-        provider_instance = _get_provider_instance(provider, model_name)
+        provider_instance = _get_provider_instance(provider, model_name, base_url=base_url)
         endpoint = base_url or provider_instance.get_endpoint_url("llm/v1/chat")
         headers = dict(provider_instance.headers or {})
         # Tag gateway requests so the server can attribute traffic to the judge

--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -224,7 +224,7 @@ def _call_llm_provider_api(
 
     eval_parameters = eval_parameters or {}
     extra_headers = extra_headers or {}
-    provider = _get_provider_instance(provider_name, model)
+    provider = _get_provider_instance(provider_name, model, base_url=proxy_url)
 
     if messages is not None:
         payload = {"messages": messages} | eval_parameters
@@ -315,8 +315,20 @@ class _MlflowGatewayProvider(OpenAIProvider):
         return {**(self._extra_headers or {})}
 
 
-def _get_provider_instance(provider: str, model: str) -> "BaseProvider":
-    """Get the provider instance for the given provider name and the model name."""
+def _get_provider_instance(
+    provider: str, model: str, base_url: str | None = None
+) -> "BaseProvider":
+    """Get the provider instance for the given provider name and the model name.
+
+    Args:
+        provider: The provider name (e.g. "openai", "anthropic").
+        model: The model name (e.g. "gpt-4").
+        base_url: When provided for the ``"gateway"`` provider, skips
+            ``_resolve_gateway_uri()`` and constructs the provider directly
+            from this URL. Used when the caller already knows the gateway URL
+            (e.g. inside the gateway server process where ``MLFLOW_TRACKING_URI``
+            points to the backend store, not an HTTP endpoint).
+    """
     from mlflow.gateway.config import Provider
 
     def _get_route_config(config):
@@ -413,10 +425,19 @@ def _get_provider_instance(provider: str, model: str) -> "BaseProvider":
         return TogetherAIProvider(_get_route_config(config))
 
     elif provider == "gateway":
-        gw_config = get_gateway_config(model)
+        if base_url is not None:
+            # Called from inside the gateway server process where MLFLOW_TRACKING_URI
+            # points to the backend store (e.g. sqlite://), so _resolve_gateway_uri()
+            # would fail. Use the caller-supplied URL directly.
+            api_base = base_url.rstrip("/")
+            extra_headers = None
+        else:
+            gw_config = get_gateway_config(model)
+            api_base = gw_config.api_base.rstrip("/")
+            extra_headers = gw_config.extra_headers
         openai_config = OpenAIConfig(
             openai_api_key="mlflow-gateway-auth",
-            openai_api_base=gw_config.api_base.rstrip("/"),
+            openai_api_base=api_base,
         )
         route_config = EndpointConfig(
             name="gateway",
@@ -427,7 +448,7 @@ def _get_provider_instance(provider: str, model: str) -> "BaseProvider":
                 "config": openai_config.model_dump(),
             },
         )
-        return _MlflowGatewayProvider(route_config, extra_headers=gw_config.extra_headers)
+        return _MlflowGatewayProvider(route_config, extra_headers=extra_headers)
 
     elif provider == Provider.GROQ:
         from mlflow.gateway.config import _OpenAICompatibleConfig

--- a/tests/gateway/test_guardrails.py
+++ b/tests/gateway/test_guardrails.py
@@ -429,9 +429,9 @@ def test_from_entity_with_action_endpoint():
 
 
 def test_from_entity_rewrites_gateway_model_uri():
-    """gateway:/ model URIs must be rewritten to openai:/ with an explicit base_url so
-    the judge doesn't hit _resolve_gateway_uri(), which fails when MLFLOW_TRACKING_URI
-    is the backend store URI (e.g. sqlite://) inside the server process.
+    """gateway:/ model URIs are kept as gateway:/ but given an explicit base_url so
+    _get_provider_instance can skip _resolve_gateway_uri(), which fails when
+    MLFLOW_TRACKING_URI is the backend store URI (e.g. sqlite://) inside the server process.
     """
     from mlflow.genai.judges.instructions_judge import InstructionsJudge
 
@@ -455,7 +455,7 @@ def test_from_entity_rewrites_gateway_model_uri():
         guard = JudgeGuardrail.from_entity(entity, server_url="http://localhost:5000")
 
     assert isinstance(guard.scorer, InstructionsJudge)
-    assert guard.scorer.model == "openai:/my-judge-ep"
+    assert guard.scorer.model == "gateway:/my-judge-ep"
     assert guard.scorer._base_url == "http://localhost:5000/gateway/mlflow/v1/chat/completions"
 
 

--- a/tests/genai/judges/adapters/test_gateway_adapter.py
+++ b/tests/genai/judges/adapters/test_gateway_adapter.py
@@ -615,6 +615,20 @@ def test_get_provider_instance_gateway():
     assert payload["model"] == "my-endpoint"
 
 
+def test_get_provider_instance_gateway_with_base_url():
+    with mock.patch(
+        "mlflow.metrics.genai.model_utils.get_gateway_config"
+    ) as mock_get_config:
+        provider = _get_provider_instance(
+            "gateway", "my-endpoint", base_url="http://localhost:5000/gateway/mlflow/v1/chat/completions"
+        )
+        mock_get_config.assert_not_called()
+
+    assert isinstance(provider, _MlflowGatewayProvider)
+    assert provider.config.model.name == "my-endpoint"
+    assert provider.headers == {}
+
+
 def test_get_provider_unsupported_raises():
     with pytest.raises(MlflowException, match="not supported"):
         _get_provider_instance("nonexistent-provider", "some-model")

--- a/tests/genai/judges/adapters/test_gateway_adapter.py
+++ b/tests/genai/judges/adapters/test_gateway_adapter.py
@@ -616,11 +616,11 @@ def test_get_provider_instance_gateway():
 
 
 def test_get_provider_instance_gateway_with_base_url():
-    with mock.patch(
-        "mlflow.metrics.genai.model_utils.get_gateway_config"
-    ) as mock_get_config:
+    with mock.patch("mlflow.metrics.genai.model_utils.get_gateway_config") as mock_get_config:
         provider = _get_provider_instance(
-            "gateway", "my-endpoint", base_url="http://localhost:5000/gateway/mlflow/v1/chat/completions"
+            "gateway",
+            "my-endpoint",
+            base_url="http://localhost:5000/gateway/mlflow/v1/chat/completions",
         )
         mock_get_config.assert_not_called()
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/22769/files) to review incremental changes.
- [**stack/fix-guardrail-openai-key**](https://github.com/mlflow/mlflow/pull/22769) [[Files changed](https://github.com/mlflow/mlflow/pull/22769/files)]

---------
### Related Issues/PRs

Relates to gateway guardrail functionality

### What changes are proposed in this pull request?

When a guardrail's `InstructionsJudge` uses a `gateway:/` model URI, the gateway server process cannot call `_resolve_gateway_uri()` because `MLFLOW_TRACKING_URI` points to the backend store (e.g. `sqlite://`), not an HTTP endpoint.

Previously, `from_entity()` worked around this by rewriting the scorer model from `gateway:/` to `openai:/` with an explicit `base_url`. This caused `_get_provider_instance("openai", ...)` to require `OPENAI_API_KEY` even though all requests go to the local gateway URL — producing the error:

> `OPENAI_API_KEY environment variable must be set to use the openai provider.`

**Fix:** Thread `base_url` into `_get_provider_instance` for the `gateway` provider branch. When `base_url` is provided, the `_MlflowGatewayProvider` is constructed directly from that URL, skipping `_resolve_gateway_uri()` entirely. `from_entity()` now preserves `gateway:/` semantics instead of rewriting to `openai:/`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

New test: `test_get_provider_instance_gateway_with_base_url` — verifies that `get_gateway_config` is not called when `base_url` is provided, and that the resulting provider has the correct model name and no spurious auth headers.

Updated test: `test_from_entity_rewrites_gateway_model_uri` — updated to assert `gateway:/` is preserved (not rewritten to `openai:/`).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix `OPENAI_API_KEY environment variable must be set` error when using guardrails with a `gateway:/` judge model. The gateway server no longer requires `OPENAI_API_KEY` to invoke internal judge endpoints.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release