### PR TITLE
Clarify yes/no semantics and stage picker wording in guardrail modal

### DIFF
--- a/docs/docs/genai/governance/ai-gateway/guardrails.mdx
+++ b/docs/docs/genai/governance/ai-gateway/guardrails.mdx
@@ -70,13 +70,15 @@ When you switch between stages, the editor automatically swaps `{{ inputs }}` â†
 
 #### Instructions
 
-Write natural-language instructions for the LLM judge. Instructions describe what the guardrail should look for and how it should respond. The hint text below the label shows an example for the currently selected stage.
+Write natural-language instructions for the LLM judge. Instructions describe what the guardrail should look for and how it should respond.
+
+The judge must reply **yes** to pass the content through, or **no** to trigger the configured action (block or sanitize). The hint text below the label in the UI shows a stage-specific example.
 
 Instructions must contain at least one content variable so the judge receives the actual content to evaluate. Use `{{ inputs }}` to reference the request and `{{ outputs }}` to reference the LLM response â€” Before guardrails typically use `{{ inputs }}`, while After guardrails can use `{{ outputs }}`, `{{ inputs }}`, or both.
 
 Example instructions for a custom toxicity guardrail on the After stage:
 
-```
+```text
 You are a toxicity detector. Review the LLM response below for any harmful,
 offensive, or hateful language. Reply with a JSON object:
 

--- a/mlflow/server/js/src/gateway/components/guardrails/AddGuardrailModal.tsx
+++ b/mlflow/server/js/src/gateway/components/guardrails/AddGuardrailModal.tsx
@@ -378,7 +378,12 @@ export const AddGuardrailModal = ({ open, onClose, onSuccess, endpointId, experi
               </Typography.Text>
               <Typography.Text
                 color="secondary"
-                css={{ display: 'block', marginBottom: theme.spacing.xs, fontSize: theme.typography.fontSizeSm }}
+                css={{
+                  display: 'block',
+                  marginBottom: theme.spacing.xs,
+                  fontSize: theme.typography.fontSizeSm,
+                  whiteSpace: 'pre-line',
+                }}
               >
                 {STAGE_HINTS[stage]}
               </Typography.Text>

--- a/mlflow/server/js/src/gateway/components/guardrails/GuardrailDetailModal.tsx
+++ b/mlflow/server/js/src/gateway/components/guardrails/GuardrailDetailModal.tsx
@@ -273,7 +273,12 @@ export const GuardrailDetailModal = ({
             </Typography.Text>
             <Typography.Text
               color="secondary"
-              css={{ display: 'block', marginBottom: theme.spacing.xs, fontSize: theme.typography.fontSizeSm }}
+              css={{
+                display: 'block',
+                marginBottom: theme.spacing.xs,
+                fontSize: theme.typography.fontSizeSm,
+                whiteSpace: 'pre-line',
+              }}
             >
               {STAGE_HINTS[stage]}
             </Typography.Text>

--- a/mlflow/server/js/src/gateway/components/guardrails/PipelineStagePicker.tsx
+++ b/mlflow/server/js/src/gateway/components/guardrails/PipelineStagePicker.tsx
@@ -24,7 +24,7 @@ export const PipelineStagePicker = ({
         css={{ display: 'block', marginBottom: theme.spacing.sm, fontSize: theme.typography.fontSizeSm }}
       >
         <FormattedMessage
-          defaultMessage="Click on a stage to choose where this guardrail runs."
+          defaultMessage="Click on a stage to choose when this guardrail runs."
           description="Stage help text"
         />
       </Typography.Text>

--- a/mlflow/server/js/src/gateway/components/guardrails/guardrailValidation.ts
+++ b/mlflow/server/js/src/gateway/components/guardrails/guardrailValidation.ts
@@ -1,9 +1,10 @@
 import type { GuardrailStage } from '../../types';
 
 export const STAGE_HINTS: Record<GuardrailStage, string> = {
-  BEFORE: 'Receives {{ inputs }} (the incoming request). Example: "Is {{ inputs }} free of profanity?"',
+  BEFORE:
+    'Receives {{ inputs }} (the incoming request). Answer yes to pass, no to block/sanitize. Example: "Is {{ inputs }} free of profanity? Answer yes if it is safe, no if it contains profanity."',
   AFTER:
-    'Receives {{ inputs }} (the request) and {{ outputs }} (the response). Example: "Does {{ outputs }} correctly answer {{ inputs }}?"',
+    'Receives {{ inputs }} (the request) and {{ outputs }} (the response). Answer yes to pass, no to block/sanitize. Example: "Does {{ outputs }} correctly answer {{ inputs }}? Answer yes if it does, no if it is off-topic or incorrect."',
 };
 
 /** Returns an error message if instructions are incompatible with the stage, or null if valid. */

--- a/mlflow/server/js/src/gateway/components/guardrails/guardrailValidation.ts
+++ b/mlflow/server/js/src/gateway/components/guardrails/guardrailValidation.ts
@@ -2,9 +2,9 @@ import type { GuardrailStage } from '../../types';
 
 export const STAGE_HINTS: Record<GuardrailStage, string> = {
   BEFORE:
-    'Receives {{ inputs }} (the incoming request). Answer yes to pass, no to block/sanitize. Example: "Is {{ inputs }} free of profanity? Answer yes if it is safe, no if it contains profanity."',
+    'Receives {{ inputs }} (the incoming request). Answer yes to pass, no to block/sanitize.\nExample: "Is {{ inputs }} free of profanity? Answer yes if it is safe, no if it contains profanity."',
   AFTER:
-    'Receives {{ inputs }} (the request) and {{ outputs }} (the response). Answer yes to pass, no to block/sanitize. Example: "Does {{ outputs }} correctly answer {{ inputs }}? Answer yes if it does, no if it is off-topic or incorrect."',
+    'Receives {{ inputs }} (the request) and {{ outputs }} (the response). Answer yes to pass, no to block/sanitize.\nExample: "Does {{ outputs }} correctly answer {{ inputs }}? Answer yes if it does, no if it is off-topic or incorrect."',
 };
 
 /** Returns an error message if instructions are incompatible with the stage, or null if valid. */

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -3939,6 +3939,10 @@
     "defaultMessage": "Create custom code judge",
     "description": "Title for new custom code judge modal"
   },
+  "N5IyPh": {
+    "defaultMessage": "Click on a stage to choose when this guardrail runs.",
+    "description": "Stage help text"
+  },
   "N79Rdb": {
     "defaultMessage": "{count, plural, =1 {1 month} other {# months}} ago",
     "description": "Time duration in months"
@@ -7766,10 +7770,6 @@
   "kCsAho": {
     "defaultMessage": "Correctness",
     "description": "LLM template option"
-  },
-  "kDCMl+": {
-    "defaultMessage": "Click on a stage to choose where this guardrail runs.",
-    "description": "Stage help text"
   },
   "kHDQiE": {
     "defaultMessage": "Analyze the '{{ conversation }}' and determine if the agent maintains a polite and professional tone throughout all interactions.{br}Rate as 'consistently_polite', 'mostly_polite', or 'impolite'.",


### PR DESCRIPTION
### Related Issues/PRs

Relates to #

### What changes are proposed in this pull request?

- Updated the stage hint text in the create guardrail modal to explicitly state that **yes means pass** and **no means block/sanitize**, so users understand the expected answer format when writing guardrail instructions.
- Updated the example instructions in both BEFORE and AFTER stage hints to show explicit yes/no answers (e.g., `"Is {{ inputs }} free of profanity? Answer yes if it is safe, no if it contains profanity."`).
- Changed "Click on a stage to choose **where** this guardrail runs." → "Click on a stage to choose **when** this guardrail runs." in the pipeline stage picker help text.

### How is this PR tested?

- [x] Manual tests

<img width="878" height="753" alt="image" src="https://github.com/user-attachments/assets/2ead6a54-879e-4f23-85c1-a89d2733eb8b" />

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Clarified yes/no semantics in the create guardrail modal so users understand that answering "yes" passes the request/response and "no" triggers the block/sanitize action. Also improved stage picker help text wording.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release