### PR TITLE
Serialize SQL trace archival with concurrent span writes

### DIFF
--- a/mlflow/store/db_migrations/versions/da6fb0208061_add_workspaces_trace_archival_location.py
+++ b/mlflow/store/db_migrations/versions/da6fb0208061_add_workspaces_trace_archival_location.py
@@ -18,14 +18,14 @@ depends_on = None
 
 
 def upgrade():
-    trace_version_column = sa.Column(
-        "trace_version", sa.Integer(), nullable=False, server_default="0"
+    db_payload_generation_column = sa.Column(
+        "db_payload_generation", sa.Integer(), nullable=False, server_default="0"
     )
     if op.get_bind().dialect.name == "sqlite":
         with op.batch_alter_table("trace_info", schema=None) as batch_op:
-            batch_op.add_column(trace_version_column)
+            batch_op.add_column(db_payload_generation_column)
     else:
-        op.add_column("trace_info", trace_version_column)
+        op.add_column("trace_info", db_payload_generation_column)
 
     with op.batch_alter_table("workspaces", schema=None) as batch_op:
         batch_op.add_column(sa.Column("trace_archival_location", sa.Text(), nullable=True))
@@ -37,9 +37,9 @@ def upgrade():
 def downgrade():
     if op.get_bind().dialect.name == "sqlite":
         with op.batch_alter_table("trace_info", schema=None) as batch_op:
-            batch_op.drop_column("trace_version")
+            batch_op.drop_column("db_payload_generation")
     else:
-        op.drop_column("trace_info", "trace_version")
+        op.drop_column("trace_info", "db_payload_generation")
 
     with op.batch_alter_table("workspaces", schema=None) as batch_op:
         batch_op.drop_column("trace_archival_retention")

--- a/mlflow/store/db_migrations/versions/da6fb0208061_add_workspaces_trace_archival_location.py
+++ b/mlflow/store/db_migrations/versions/da6fb0208061_add_workspaces_trace_archival_location.py
@@ -18,6 +18,15 @@ depends_on = None
 
 
 def upgrade():
+    trace_version_column = sa.Column(
+        "trace_version", sa.Integer(), nullable=False, server_default="0"
+    )
+    if op.get_bind().dialect.name == "sqlite":
+        with op.batch_alter_table("trace_info", schema=None) as batch_op:
+            batch_op.add_column(trace_version_column)
+    else:
+        op.add_column("trace_info", trace_version_column)
+
     with op.batch_alter_table("workspaces", schema=None) as batch_op:
         batch_op.add_column(sa.Column("trace_archival_location", sa.Text(), nullable=True))
         batch_op.add_column(
@@ -26,6 +35,12 @@ def upgrade():
 
 
 def downgrade():
+    if op.get_bind().dialect.name == "sqlite":
+        with op.batch_alter_table("trace_info", schema=None) as batch_op:
+            batch_op.drop_column("trace_version")
+    else:
+        op.drop_column("trace_info", "trace_version")
+
     with op.batch_alter_table("workspaces", schema=None) as batch_op:
         batch_op.drop_column("trace_archival_retention")
         batch_op.drop_column("trace_archival_location")

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -755,6 +755,11 @@ class SqlTraceInfo(Base):
     """
     Response preview: `String` (limit 1000 characters). Could be *null*. Newly added in V3 format.
     """
+    trace_version = Column(Integer, nullable=False, server_default="0")
+    """
+    DB-backed trace payload generation used for concurrency coordination.
+    Defaults to 0.
+    """
 
     __table_args__ = (
         PrimaryKeyConstraint("request_id", name="trace_info_pk"),

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -755,7 +755,7 @@ class SqlTraceInfo(Base):
     """
     Response preview: `String` (limit 1000 characters). Could be *null*. Newly added in V3 format.
     """
-    trace_version = Column(Integer, nullable=False, server_default="0")
+    db_payload_generation = Column(Integer, nullable=False, server_default="0")
     """
     DB-backed trace payload generation used for concurrency coordination.
     Defaults to 0.

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -14,7 +14,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from functools import reduce
 from pathlib import PurePath
-from typing import Any, TypedDict, TypeVar
+from typing import Any, Iterable, TypedDict, TypeVar
 from urllib.parse import urlparse
 
 import sqlalchemy
@@ -355,6 +355,15 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
     @property
     def supports_workspaces(self) -> bool:
         return False
+
+    def _get_active_workspace(self) -> str:
+        """
+        Get the active workspace name.
+
+        In single-tenant mode, always returns DEFAULT_WORKSPACE_NAME.
+        Workspace-aware subclasses override this to enforce isolation.
+        """
+        return DEFAULT_WORKSPACE_NAME
 
     def _get_query(self, session, model):
         """
@@ -875,8 +884,20 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
 
         return runs[0]
 
-    def _trace_query(self, session, for_update_or_delete=False):
-        return self._get_query(session, SqlTraceInfo)
+    def _trace_query(self, session, for_update_or_delete=False, workspace=None):
+        query = self._get_query(session, SqlTraceInfo)
+        if for_update_or_delete:
+            return self._apply_trace_row_lock(query)
+        return query
+
+    def _apply_trace_row_lock(self, query):
+        if self.db_type == MSSQL:
+            return query.with_hint(
+                SqlTraceInfo,
+                "WITH (UPDLOCK, ROWLOCK)",
+                dialect_name="mssql",
+            )
+        return query.with_for_update()
 
     def _dataset_query(self, session):
         return self._get_query(session, SqlEvaluationDataset)
@@ -3352,65 +3373,66 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 session.flush()
             except IntegrityError:
                 # Trace already exists (likely created by log_spans() racing with
-                # start_trace()). Rollback the failed INSERT and use merge (upsert)
-                # to update the trace with the complete data from start_trace().
+                # start_trace()). Roll back the failed INSERT, lock and reread the
+                # persistent row, then merge child rows additively so we never
+                # mutate trace state from a stale snapshot or drop assessments
+                # that were already attached to the trace.
                 session.rollback()
-
-                # Re-create sql_trace_info without metadata/metrics relationships
-                # to avoid cascade INSERT conflicts during merge.
-                sql_trace_info = SqlTraceInfo(
-                    request_id=trace_id,
-                    experiment_id=trace_info.experiment_id,
-                    timestamp_ms=trace_info.request_time,
-                    execution_time_ms=trace_info.execution_duration,
-                    status=trace_info.state.value,
-                    client_request_id=trace_info.client_request_id,
-                    request_preview=sql_trace_info.request_preview,
-                    response_preview=sql_trace_info.response_preview,
-                )
-                sql_trace_info.tags = tags
-                sql_trace_info.assessments = sql_assessments
-
-                # Preserve the spans_location tag if it was set by log_spans
+                session.expunge_all()
+                # Rebuild child rows after expunging the failed parent tree so later
+                # per-row merges cannot drag its stale trace_info state back in.
+                tags = [
+                    SqlTraceTag(request_id=trace_id, key=tag.key, value=tag.value) for tag in tags
+                ]
+                sql_assessments = []
+                for a in trace_info.assessments:
+                    sql_assessment = SqlAssessments.from_mlflow_entity(a)
+                    if a.trace_id is None:
+                        sql_assessment.trace_id = trace_id
+                    sql_assessments.append(sql_assessment)
+                trace_write_workspace = self._get_active_workspace()
+                # Lock the reread because this is the read half of a read-modify-write
+                # merge on trace_info, not a passive lookup. The trace_version bump below
+                # coordinates DB-backed payload generation, but this row lock also prevents
+                # us from preserving top-level trace fields from a stale snapshot.
                 db_sql_trace_info = (
                     self
-                    ._trace_query(session)
+                    ._trace_query(
+                        session,
+                        for_update_or_delete=True,
+                        workspace=trace_write_workspace,
+                    )
                     .filter(SqlTraceInfo.request_id == trace_id)
                     .one_or_none()
                 )
-                new_tag_keys = {t.key for t in tags}
-                if db_sql_trace_info:
-                    # Duplicate start_trace() calls must keep any store-managed tags already
-                    # attached to the trace, including archival state written after log_spans().
-                    for tag in db_sql_trace_info.tags:
-                        if tag.key not in new_tag_keys:
-                            sql_trace_info.tags.append(
-                                SqlTraceTag(request_id=trace_id, key=tag.key, value=tag.value)
-                            )
+                if db_sql_trace_info is None:
+                    raise MlflowException(
+                        f"Trace with ID '{trace_id}' no longer exists.",
+                        error_code=RESOURCE_DOES_NOT_EXIST,
+                    )
+                if not self._is_sql_trace_db_backed(db_sql_trace_info):
+                    raise MlflowException(
+                        f"Cannot update traces that are no longer DB-backed: '{trace_id}'.",
+                        error_code=INVALID_STATE,
+                    )
+                # Advance the version before staging ORM writes so a concurrent archival
+                # finalization cannot be hidden by autoflush re-publishing TRACKING_STORE.
+                self._advance_trace_versions_for_db_span_writes(session, [trace_id])
 
-                    new_metric_keys = {m.key for m in sql_trace_info.metrics}
-                    for metric in db_sql_trace_info.metrics:
-                        if metric.key not in new_metric_keys:
-                            sql_trace_info.metrics.append(
-                                SqlTraceMetrics(
-                                    request_id=trace_id, key=metric.key, value=metric.value
-                                )
-                            )
+                db_sql_trace_info.experiment_id = trace_info.experiment_id
+                db_sql_trace_info.timestamp_ms = trace_info.request_time
+                db_sql_trace_info.execution_time_ms = trace_info.execution_duration
+                db_sql_trace_info.status = trace_info.state.value
+                db_sql_trace_info.client_request_id = trace_info.client_request_id
+                if trace_info.request_preview is not None:
+                    db_sql_trace_info.request_preview = trace_info.request_preview
+                if trace_info.response_preview is not None:
+                    db_sql_trace_info.response_preview = trace_info.response_preview
 
-                    # Preserve request/response previews computed by log_spans()
-                    if (
-                        sql_trace_info.request_preview is None
-                        and db_sql_trace_info.request_preview is not None
-                    ):
-                        sql_trace_info.request_preview = db_sql_trace_info.request_preview
-                    if (
-                        sql_trace_info.response_preview is None
-                        and db_sql_trace_info.response_preview is not None
-                    ):
-                        sql_trace_info.response_preview = db_sql_trace_info.response_preview
-
-                session.merge(sql_trace_info)
-                session.flush()
+                for tag in tags:
+                    session.merge(tag)
+                for assessment in sql_assessments:
+                    session.merge(assessment)
 
                 # Upsert metadata and metrics individually so the complete data
                 # from start_trace() overwrites any partial values from log_spans().
@@ -3418,6 +3440,12 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                     session.merge(SqlTraceMetadata(request_id=trace_id, key=k, value=v))
                 for k, v in trace_metrics.items():
                     session.merge(SqlTraceMetrics(request_id=trace_id, key=k, value=v))
+                session.flush()
+                sql_trace_info = self._get_sql_trace_info(
+                    session,
+                    trace_id,
+                    workspace=trace_write_workspace,
+                )
 
             return sql_trace_info.to_mlflow_entity()
 
@@ -3435,9 +3463,12 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             sql_trace_info = self._get_sql_trace_info(session, trace_id)
             return sql_trace_info.to_mlflow_entity()
 
-    def _get_sql_trace_info(self, session, trace_id) -> SqlTraceInfo:
+    def _get_sql_trace_info(self, session, trace_id, workspace=None) -> SqlTraceInfo:
         sql_trace_info = (
-            self._trace_query(session).filter(SqlTraceInfo.request_id == trace_id).one_or_none()
+            self
+            ._trace_query(session, workspace=workspace)
+            .filter(SqlTraceInfo.request_id == trace_id)
+            .one_or_none()
         )
         if sql_trace_info is None:
             raise MlflowException(
@@ -4656,27 +4687,6 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 .all()
             }
 
-            if existing_traces:
-                archived_trace_ids = sorted(
-                    request_id
-                    for (request_id,) in session
-                    .query(SqlTraceTag.request_id)
-                    .filter(
-                        SqlTraceTag.request_id.in_(list(existing_traces)),
-                        SqlTraceTag.key == TraceTagKey.SPANS_LOCATION,
-                        SqlTraceTag.value == SpansLocation.ARCHIVE_REPO.value,
-                    )
-                    .all()
-                )
-                if archived_trace_ids:
-                    archived_trace_list = ", ".join(
-                        f"'{trace_id}'" for trace_id in archived_trace_ids
-                    )
-                    raise MlflowException(
-                        f"Cannot log spans to archived traces: {archived_trace_list}.",
-                        error_code=INVALID_STATE,
-                    )
-
             # --- Phase 2: Create missing traces ---
             # On IntegrityError (concurrent start_trace race), roll back and retry so that
             # previously flushed trace_infos (which session.rollback() would undo) are
@@ -4739,6 +4749,9 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 all_metric_rows = [
                     r for r in all_metric_rows if r["trace_id"] not in missing_trace_ids
                 ]
+
+            # Keep downstream per-trace updates aligned with the surviving span/metric rows.
+            all_trace_ids = [trace_id for trace_id in all_trace_ids if trace_id in existing_traces]
 
             # Fill in experiment_id on span rows now that we have trace infos
             for row in all_span_rows:
@@ -4927,16 +4940,29 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                         )
 
                 if update_dict:
-                    self._trace_query(session, for_update_or_delete=True).filter(
-                        SqlTraceInfo.request_id == trace_id
-                    ).update(
-                        update_dict,
-                        # Skip session synchronization for performance — we don't
-                        # use the ORM object afterward.
-                        synchronize_session=False,
+                    # `trace_id` was selected through workspace-scoped reads earlier in this
+                    # call, so we can update by PK here without paying for another workspace
+                    # filter on the hot path.
+                    (
+                        session
+                        .query(SqlTraceInfo)
+                        .filter(SqlTraceInfo.request_id == trace_id)
+                        .update(
+                            update_dict,
+                            # Skip session synchronization for performance — we don't
+                            # use the ORM object afterward.
+                            synchronize_session=False,
+                        )
                     )
-                # Mark that spans are stored in the tracking store DB (required for
-                # concurrent calls that create or update the trace info).
+            # Keep the authoritative archived/non-DB-backed check after the writes so the version
+            # bump closes the TOCTOU window; if it fails, the surrounding transaction rolls back
+            # the earlier span/metric/tag flushes.
+            self._advance_trace_versions_for_db_span_writes(session, all_trace_ids)
+
+            # Re-publish TRACKING_STORE only after the conditional trace_version bump succeeds so
+            # span writes, including span-only changes that did not update trace_info, commit
+            # atomically with the new DB-backed trace version.
+            for trace_id in all_trace_ids:
                 session.merge(
                     SqlTraceTag(
                         request_id=trace_id,
@@ -5139,6 +5165,138 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
 
             return [sql_trace_info.to_mlflow_entity() for sql_trace_info in sql_trace_infos]
 
+    def _get_trace_ids_outside_tracking_store(
+        self, session: Session, trace_ids: Iterable[str]
+    ) -> dict[str, str]:
+        trace_ids = list(dict.fromkeys(trace_ids))
+        if not trace_ids:
+            return {}
+
+        blocked_rows = (
+            session
+            .query(SqlTraceTag.request_id, SqlTraceTag.value)
+            .filter(
+                SqlTraceTag.request_id.in_(trace_ids),
+                SqlTraceTag.key == TraceTagKey.SPANS_LOCATION,
+                SqlTraceTag.value != SpansLocation.TRACKING_STORE.value,
+            )
+            .all()
+        )
+        return dict(blocked_rows)
+
+    def _get_existing_trace_ids(self, session: Session, trace_ids: Iterable[str]) -> set[str]:
+        trace_ids = list(dict.fromkeys(trace_ids))
+        if not trace_ids:
+            return set()
+        return {
+            request_id
+            for (request_id,) in session
+            .query(SqlTraceInfo.request_id)
+            .filter(SqlTraceInfo.request_id.in_(trace_ids))
+            .all()
+        }
+
+    def _raise_log_spans_trace_write_conflict_error(
+        self,
+        *,
+        blocked_trace_ids: dict[str, str],
+        missing_trace_ids: list[str],
+    ) -> None:
+        archived_trace_ids = sorted(
+            trace_id
+            for trace_id, spans_location in blocked_trace_ids.items()
+            if spans_location == SpansLocation.ARCHIVE_REPO.value
+        )
+        other_non_db_backed_trace_ids = sorted(
+            trace_id
+            for trace_id, spans_location in blocked_trace_ids.items()
+            if spans_location != SpansLocation.ARCHIVE_REPO.value
+        )
+
+        if archived_trace_ids and not other_non_db_backed_trace_ids and not missing_trace_ids:
+            archived_trace_list = ", ".join(f"'{trace_id}'" for trace_id in archived_trace_ids)
+            raise MlflowException(
+                f"Cannot log spans to archived traces: {archived_trace_list}.",
+                error_code=INVALID_STATE,
+            )
+
+        if missing_trace_ids and not archived_trace_ids and not other_non_db_backed_trace_ids:
+            missing_trace_list = ", ".join(f"'{trace_id}'" for trace_id in missing_trace_ids)
+            raise MlflowException(
+                f"Cannot log spans to traces that no longer exist: {missing_trace_list}.",
+                error_code=RESOURCE_DOES_NOT_EXIST,
+            )
+
+        detail_groups = []
+        if archived_trace_ids:
+            detail_groups.append(
+                "archived=" + ", ".join(f"'{trace_id}'" for trace_id in archived_trace_ids)
+            )
+        if other_non_db_backed_trace_ids:
+            detail_groups.append(
+                "other=" + ", ".join(f"'{trace_id}'" for trace_id in other_non_db_backed_trace_ids)
+            )
+        if missing_trace_ids:
+            detail_groups.append(
+                "missing=" + ", ".join(f"'{trace_id}'" for trace_id in missing_trace_ids)
+            )
+
+        detail_suffix = f": {'; '.join(detail_groups)}" if detail_groups else "."
+        raise MlflowException(
+            "Cannot log spans because one or more traces are unavailable for DB-backed span "
+            f"writes{detail_suffix}",
+            error_code=INVALID_STATE,
+        )
+
+    def _advance_trace_versions_for_db_span_writes(
+        self, session: Session, trace_ids: Iterable[str]
+    ) -> None:
+        """
+        Atomically advance the DB-backed trace version for each touched trace.
+
+        The version bump is the writer-side guard against archival finalization: if a trace is
+        no longer DB-backed at commit time, the conditional UPDATE affects fewer rows than
+        expected and the whole write transaction must roll back.
+        """
+        trace_ids = list(dict.fromkeys(trace_ids))
+        if not trace_ids:
+            return
+
+        spans_outside_tracking_store = exists().where(
+            and_(
+                SqlTraceTag.request_id == SqlTraceInfo.request_id,
+                SqlTraceTag.key == TraceTagKey.SPANS_LOCATION,
+                SqlTraceTag.value != SpansLocation.TRACKING_STORE.value,
+            )
+        )
+        updated_rows = (
+            session
+            .query(SqlTraceInfo)
+            .filter(
+                SqlTraceInfo.request_id.in_(trace_ids),
+                ~spans_outside_tracking_store,
+            )
+            .update(
+                {SqlTraceInfo.trace_version: SqlTraceInfo.trace_version + 1},
+                synchronize_session=False,
+            )
+        )
+        if updated_rows == len(trace_ids):
+            return
+
+        # We intentionally pay for this reread only on the failure path because
+        # archival races are rare, and we still need this post-UPDATE check to
+        # distinguish archived traces from other non-DB-backed states.
+        blocked_trace_ids = self._get_trace_ids_outside_tracking_store(session, trace_ids)
+        existing_trace_ids = self._get_existing_trace_ids(session, trace_ids)
+        missing_trace_ids = [
+            trace_id for trace_id in trace_ids if trace_id not in existing_trace_ids
+        ]
+        self._raise_log_spans_trace_write_conflict_error(
+            blocked_trace_ids=blocked_trace_ids,
+            missing_trace_ids=missing_trace_ids,
+        )
+
     def archive_traces(
         self,
         *,
@@ -5310,7 +5468,19 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                     ):
                         archived_count += 1
                 except MlflowNotImplementedException:
-                    raise
+                    # TODO: The orchestration follow-up should treat unsupported archival
+                    # destinations as a scope-level signal (for example per workspace /
+                    # resolved archival location) and isolate the rest of that scope for the
+                    # current pass. Keep this retryable for now so traces remain eligible once
+                    # the workspace configuration is fixed.
+                    _logger.warning(
+                        "Failed to archive trace %s because the archive destination is "
+                        "unsupported; leaving it eligible for retry.",
+                        candidate.trace_id,
+                        exc_info=True,
+                    )
+                    if candidate.experiment_id in archive_now_experiment_ids:
+                        retryable_failure_experiment_ids.add(candidate.experiment_id)
                 except (MlflowException, SQLAlchemyError):
                     _logger.warning(
                         "Failed to archive trace %s; leaving it eligible for retry.",
@@ -5553,18 +5723,19 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         trace_id: str,
         trace_archival_config: ResolvedTraceArchivalConfig,
     ) -> bool:
-        snapshot = self._load_trace_archival_snapshot(trace_id)
-        if snapshot is None:
+        archival_data = self._load_trace_archival_data(trace_id)
+        if archival_data is None:
             return False
+        trace_info, trace_version, span_rows = archival_data
 
-        trace_info, snapshot_rows = snapshot
         try:
-            archived_pb = self._serialize_trace_archival_snapshot_to_pb(snapshot_rows)
+            archived_pb = self._serialize_trace_archival_span_rows_to_pb(span_rows)
         except MlflowTraceArchivalMalformedTrace:
             _logger.warning("Marking trace %s as MALFORMED_TRACE during archival.", trace_id)
             self._mark_trace_archival_failure(
                 trace_id=trace_id,
                 failure_reason=TraceArchivalFailureReason.MALFORMED_TRACE.value,
+                trace_version=trace_version,
             )
             return False
 
@@ -5578,23 +5749,24 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             artifact_repo.upload_archived_trace_data_bytes(archived_pb)
         except MlflowNotImplementedException:
             _logger.warning(
-                "Marking trace %s as UNSUPPORTED_ARCHIVE_REPOSITORY during archival.",
+                "Archive repository upload is unsupported for trace %s; leaving it retryable.",
                 trace_id,
             )
-            self._mark_trace_archival_failure(
-                trace_id=trace_id,
-                failure_reason=TraceArchivalFailureReason.UNSUPPORTED_ARCHIVE_REPOSITORY.value,
-            )
-            return False
+            raise
         except Exception as e:
+            self._delete_unreferenced_archived_trace_payload(
+                trace_id=trace_id,
+                artifact_uri=artifact_uri,
+                artifact_repo=artifact_repo,
+            )
             # Normalize backend-specific upload errors so the outer archival loop
             # can treat them as retryable without depending on repository internals.
             raise MlflowException("Trace archival upload failed.") from e
         try:
             finalized = self._finalize_archived_trace(
                 trace_id=trace_id,
-                snapshot_rows=snapshot_rows,
                 artifact_uri=artifact_uri,
+                trace_version=trace_version,
             )
         except Exception as e:
             self._delete_unreferenced_archived_trace_payload(
@@ -5616,9 +5788,9 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             )
         return finalized
 
-    def _load_trace_archival_snapshot(
+    def _load_trace_archival_data(
         self, trace_id: str
-    ) -> tuple[TraceInfo, list[tuple[str, str]]] | None:
+    ) -> tuple[TraceInfo, int, list[tuple[str, str]]] | None:
         with self.ManagedSessionMaker() as session:
             sql_trace_info = (
                 self
@@ -5634,16 +5806,14 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             if not self._is_trace_actionable_for_archival(trace_info, sql_trace_info.spans):
                 return None
 
-            snapshot_rows = sorted((span.span_id, span.content) for span in sql_trace_info.spans)
-            return trace_info, snapshot_rows
+            span_rows = sorted((span.span_id, span.content) for span in sql_trace_info.spans)
+            return trace_info, sql_trace_info.trace_version, span_rows
 
-    def _serialize_trace_archival_snapshot_to_pb(
-        self, snapshot_rows: list[tuple[str, str]]
-    ) -> bytes:
+    def _serialize_trace_archival_span_rows_to_pb(self, span_rows: list[tuple[str, str]]) -> bytes:
         try:
             spans = [
                 Span.from_dict(translate_loaded_span(json.loads(content)))
-                for _, content in snapshot_rows
+                for _, content in span_rows
             ]
             return spans_to_traces_data_pb(spans)
         except (MlflowException, TypeError, ValueError, AttributeError) as e:
@@ -5653,13 +5823,48 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         self, trace_info: TraceInfo, spans: list[SqlSpan]
     ) -> bool:
         spans_location = trace_info.tags.get(TraceTagKey.SPANS_LOCATION)
-        if spans_location not in (None, SpansLocation.TRACKING_STORE.value):
+        if not self._is_db_backed_spans_location(spans_location):
             return False
         if TraceTagKey.ARCHIVAL_FAILURE in trace_info.tags:
             return False
         if trace_info.state == TraceState.IN_PROGRESS:
             return False
         return any(span.content != "" for span in spans)
+
+    @staticmethod
+    def _is_db_backed_spans_location(spans_location: str | None) -> bool:
+        return spans_location in (None, SpansLocation.TRACKING_STORE.value)
+
+    def _is_sql_trace_db_backed(self, sql_trace_info: SqlTraceInfo) -> bool:
+        spans_location = next(
+            (tag.value for tag in sql_trace_info.tags if tag.key == TraceTagKey.SPANS_LOCATION),
+            None,
+        )
+        return self._is_db_backed_spans_location(spans_location)
+
+    def _is_trace_metadata_actionable_for_archival(self, sql_trace_info: SqlTraceInfo) -> bool:
+        if not self._is_sql_trace_db_backed(sql_trace_info):
+            return False
+        if any(tag.key == TraceTagKey.ARCHIVAL_FAILURE for tag in sql_trace_info.tags):
+            return False
+        return sql_trace_info.status in {
+            TraceState.OK.value,
+            TraceState.ERROR.value,
+            TraceState.STATE_UNSPECIFIED.value,
+        }
+
+    def _trace_has_non_empty_span_content(self, session: Session, trace_id: str) -> bool:
+        # Use .first() instead of a top-level EXISTS query for MSSQL compatibility.
+        return (
+            session
+            .query(SqlSpan.span_id)
+            .filter(
+                SqlSpan.trace_id == trace_id,
+                SqlSpan.content != "",
+            )
+            .first()
+            is not None
+        )
 
     def _get_archival_repository_artifact_uri(
         self,
@@ -5725,37 +5930,28 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         self,
         *,
         trace_id: str,
-        snapshot_rows: list[tuple[str, str]],
         artifact_uri: str,
+        trace_version: int,
     ) -> bool:
         with self.ManagedSessionMaker() as session:
             sql_trace_info = (
                 self
                 ._trace_query(session, for_update_or_delete=True)
-                .options(joinedload(SqlTraceInfo.tags), joinedload(SqlTraceInfo.spans))
+                .options(selectinload(SqlTraceInfo.tags))
                 .filter(SqlTraceInfo.request_id == trace_id)
                 .one_or_none()
             )
             if sql_trace_info is None:
                 return False
 
-            trace_info = sql_trace_info.to_mlflow_entity()
-            if not self._is_trace_actionable_for_archival(trace_info, sql_trace_info.spans):
+            if sql_trace_info.trace_version != trace_version:
                 return False
-
-            # Do a snapshot comparison as defense in depth for non-cooperating writers
-            # or backend-specific lock gaps.
-            current_snapshot_rows = sorted(
-                (span.span_id, span.content) for span in sql_trace_info.spans
-            )
-            if current_snapshot_rows != snapshot_rows:
-                _logger.info(
-                    (
-                        "Skipping archival finalization for trace %s because its DB-backed spans "
-                        "changed."
-                    ),
-                    trace_id,
-                )
+            if not self._is_trace_metadata_actionable_for_archival(sql_trace_info):
+                return False
+            # The trace_version check is the primary race guard; this cheap EXISTS probe is
+            # defense in depth that confirms DB-backed span content still exists without
+            # triggering a second full load of potentially large span payloads.
+            if not self._trace_has_non_empty_span_content(session, trace_id):
                 return False
 
             (
@@ -5789,23 +5985,25 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             )
             return True
 
-    def _mark_trace_archival_failure(self, *, trace_id: str, failure_reason: str) -> None:
+    def _mark_trace_archival_failure(
+        self, *, trace_id: str, failure_reason: str, trace_version: int | None = None
+    ) -> None:
         with self.ManagedSessionMaker() as session:
             sql_trace_info = (
                 self
                 ._trace_query(session, for_update_or_delete=True)
-                .options(joinedload(SqlTraceInfo.tags))
+                # Keep tags out of the locking SELECT: PostgreSQL rejects FOR UPDATE on
+                # LEFT OUTER JOIN-loaded collections from the nullable side of the join.
+                .options(selectinload(SqlTraceInfo.tags))
                 .filter(SqlTraceInfo.request_id == trace_id)
                 .one_or_none()
             )
             if sql_trace_info is None:
                 return
 
-            spans_location = next(
-                (tag.value for tag in sql_trace_info.tags if tag.key == TraceTagKey.SPANS_LOCATION),
-                None,
-            )
-            if spans_location not in (None, SpansLocation.TRACKING_STORE.value):
+            if not self._is_sql_trace_db_backed(sql_trace_info):
+                return
+            if trace_version is not None and sql_trace_info.trace_version != trace_version:
                 return
 
             session.merge(

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -3392,7 +3392,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                     sql_assessments.append(sql_assessment)
                 trace_write_workspace = self._get_active_workspace()
                 # Lock the reread because this is the read half of a read-modify-write
-                # merge on trace_info, not a passive lookup. The trace_version bump below
+                # merge on trace_info, not a passive lookup. The db_payload_generation bump below
                 # coordinates DB-backed payload generation, but this row lock also prevents
                 # us from preserving top-level trace fields from a stale snapshot.
                 db_sql_trace_info = (
@@ -3415,9 +3415,9 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                         f"Cannot update traces that are no longer DB-backed: '{trace_id}'.",
                         error_code=INVALID_STATE,
                     )
-                # Advance the version before staging ORM writes so a concurrent archival
+                # Advance the payload generation before staging ORM writes so a concurrent archival
                 # finalization cannot be hidden by autoflush re-publishing TRACKING_STORE.
-                self._advance_trace_versions_for_db_span_writes(session, [trace_id])
+                self._advance_db_payload_generations_for_db_span_writes(session, [trace_id])
 
                 db_sql_trace_info.experiment_id = trace_info.experiment_id
                 db_sql_trace_info.timestamp_ms = trace_info.request_time
@@ -4954,14 +4954,16 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                             synchronize_session=False,
                         )
                     )
-            # Keep the authoritative archived/non-DB-backed check after the writes so the version
-            # bump closes the TOCTOU window; if it fails, the surrounding transaction rolls back
+            # Keep the authoritative archived/non-DB-backed check after the writes so the
+            # generation bump closes the TOCTOU window; if it fails, the surrounding transaction
+            # rolls back
             # the earlier span/metric/tag flushes.
-            self._advance_trace_versions_for_db_span_writes(session, all_trace_ids)
+            self._advance_db_payload_generations_for_db_span_writes(session, all_trace_ids)
 
-            # Re-publish TRACKING_STORE only after the conditional trace_version bump succeeds so
+            # Re-publish TRACKING_STORE only after the conditional db_payload_generation bump
+            # succeeds so
             # span writes, including span-only changes that did not update trace_info, commit
-            # atomically with the new DB-backed trace version.
+            # atomically with the new DB-backed payload generation.
             for trace_id in all_trace_ids:
                 session.merge(
                     SqlTraceTag(
@@ -5248,13 +5250,13 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             error_code=INVALID_STATE,
         )
 
-    def _advance_trace_versions_for_db_span_writes(
+    def _advance_db_payload_generations_for_db_span_writes(
         self, session: Session, trace_ids: Iterable[str]
     ) -> None:
         """
-        Atomically advance the DB-backed trace version for each touched trace.
+        Atomically advance the DB-backed payload generation for each touched trace.
 
-        The version bump is the writer-side guard against archival finalization: if a trace is
+        The generation bump is the writer-side guard against archival finalization: if a trace is
         no longer DB-backed at commit time, the conditional UPDATE affects fewer rows than
         expected and the whole write transaction must roll back.
         """
@@ -5277,7 +5279,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 ~spans_outside_tracking_store,
             )
             .update(
-                {SqlTraceInfo.trace_version: SqlTraceInfo.trace_version + 1},
+                {SqlTraceInfo.db_payload_generation: SqlTraceInfo.db_payload_generation + 1},
                 synchronize_session=False,
             )
         )
@@ -5726,7 +5728,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         archival_data = self._load_trace_archival_data(trace_id)
         if archival_data is None:
             return False
-        trace_info, trace_version, span_rows = archival_data
+        trace_info, db_payload_generation, span_rows = archival_data
 
         try:
             archived_pb = self._serialize_trace_archival_span_rows_to_pb(span_rows)
@@ -5735,7 +5737,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             self._mark_trace_archival_failure(
                 trace_id=trace_id,
                 failure_reason=TraceArchivalFailureReason.MALFORMED_TRACE.value,
-                trace_version=trace_version,
+                db_payload_generation=db_payload_generation,
             )
             return False
 
@@ -5766,7 +5768,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             finalized = self._finalize_archived_trace(
                 trace_id=trace_id,
                 artifact_uri=artifact_uri,
-                trace_version=trace_version,
+                db_payload_generation=db_payload_generation,
             )
         except Exception as e:
             self._delete_unreferenced_archived_trace_payload(
@@ -5807,7 +5809,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 return None
 
             span_rows = sorted((span.span_id, span.content) for span in sql_trace_info.spans)
-            return trace_info, sql_trace_info.trace_version, span_rows
+            return trace_info, sql_trace_info.db_payload_generation, span_rows
 
     def _serialize_trace_archival_span_rows_to_pb(self, span_rows: list[tuple[str, str]]) -> bytes:
         try:
@@ -5931,7 +5933,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         *,
         trace_id: str,
         artifact_uri: str,
-        trace_version: int,
+        db_payload_generation: int,
     ) -> bool:
         with self.ManagedSessionMaker() as session:
             sql_trace_info = (
@@ -5944,11 +5946,11 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             if sql_trace_info is None:
                 return False
 
-            if sql_trace_info.trace_version != trace_version:
+            if sql_trace_info.db_payload_generation != db_payload_generation:
                 return False
             if not self._is_trace_metadata_actionable_for_archival(sql_trace_info):
                 return False
-            # The trace_version check is the primary race guard; this cheap EXISTS probe is
+            # The db_payload_generation check is the primary race guard; this cheap EXISTS probe is
             # defense in depth that confirms DB-backed span content still exists without
             # triggering a second full load of potentially large span payloads.
             if not self._trace_has_non_empty_span_content(session, trace_id):
@@ -5986,7 +5988,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             return True
 
     def _mark_trace_archival_failure(
-        self, *, trace_id: str, failure_reason: str, trace_version: int | None = None
+        self, *, trace_id: str, failure_reason: str, db_payload_generation: int | None = None
     ) -> None:
         with self.ManagedSessionMaker() as session:
             sql_trace_info = (
@@ -6003,7 +6005,10 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
 
             if not self._is_sql_trace_db_backed(sql_trace_info):
                 return
-            if trace_version is not None and sql_trace_info.trace_version != trace_version:
+            if (
+                db_payload_generation is not None
+                and sql_trace_info.db_payload_generation != db_payload_generation
+            ):
                 return
 
             session.merge(

--- a/mlflow/store/tracking/sqlalchemy_workspace_store.py
+++ b/mlflow/store/tracking/sqlalchemy_workspace_store.py
@@ -154,19 +154,31 @@ class WorkspaceAwareSqlAlchemyStore(WorkspaceAwareMixin, SqlAlchemyStore):
                 error_code=INVALID_STATE,
             )
 
-    def _trace_query(self, session, for_update_or_delete=False):
+    def _trace_query(self, session, for_update_or_delete=False, workspace=None):
+        """
+        Return a workspace-scoped trace query.
+
+        Both plain reads and locking reads target `trace_info` directly via
+        `SqlAlchemyStore._get_query(..., SqlTraceInfo)` and scope results with an
+        `experiment_id IN (...)` subquery over experiments in the selected workspace. This keeps
+        the query shape anchored on trace rows rather than relying on a workspace-aware join
+        through experiments, which is especially important when applying row locks so the lock
+        lands directly on `trace_info` rows. Callers may pass an explicit workspace snapshot when
+        a multi-step write needs stable scoping across several queries.
+        """
+        workspace = workspace or self._get_active_workspace()
+        workspace_experiment_ids = (
+            session
+            .query(SqlExperiment.experiment_id)
+            .filter(SqlExperiment.workspace == workspace)
+            .subquery()
+        )
+        query = SqlAlchemyStore._get_query(self, session, SqlTraceInfo).filter(
+            SqlTraceInfo.experiment_id.in_(select(workspace_experiment_ids.c.experiment_id))
+        )
         if for_update_or_delete:
-            workspace = self._get_active_workspace()
-            workspace_experiment_ids = (
-                session
-                .query(SqlExperiment.experiment_id)
-                .filter(SqlExperiment.workspace == workspace)
-                .subquery()
-            )
-            return SqlAlchemyStore._get_query(self, session, SqlTraceInfo).filter(
-                SqlTraceInfo.experiment_id.in_(select(workspace_experiment_ids.c.experiment_id))
-            )
-        return super()._trace_query(session, for_update_or_delete=False)
+            return self._apply_trace_row_lock(query)
+        return query
 
     def _experiment_where_clauses(self):
         return [SqlExperiment.workspace == self._get_active_workspace()]

--- a/tests/db/schemas/mssql.sql
+++ b/tests/db/schemas/mssql.sql
@@ -333,6 +333,7 @@ CREATE TABLE trace_info (
 	client_request_id VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	request_preview VARCHAR(1000) COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	response_preview VARCHAR(1000) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	trace_version INTEGER DEFAULT '0' NOT NULL,
 	CONSTRAINT trace_info_pk PRIMARY KEY (request_id),
 	CONSTRAINT fk_trace_info_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
 )

--- a/tests/db/schemas/mssql.sql
+++ b/tests/db/schemas/mssql.sql
@@ -333,7 +333,7 @@ CREATE TABLE trace_info (
 	client_request_id VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	request_preview VARCHAR(1000) COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	response_preview VARCHAR(1000) COLLATE "SQL_Latin1_General_CP1_CI_AS",
-	trace_version INTEGER DEFAULT '0' NOT NULL,
+	db_payload_generation INTEGER DEFAULT '0' NOT NULL,
 	CONSTRAINT trace_info_pk PRIMARY KEY (request_id),
 	CONSTRAINT fk_trace_info_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
 )

--- a/tests/db/schemas/mysql.sql
+++ b/tests/db/schemas/mysql.sql
@@ -338,7 +338,7 @@ CREATE TABLE trace_info (
 	client_request_id VARCHAR(50),
 	request_preview VARCHAR(1000),
 	response_preview VARCHAR(1000),
-	trace_version INTEGER DEFAULT '0' NOT NULL,
+	db_payload_generation INTEGER DEFAULT '0' NOT NULL,
 	PRIMARY KEY (request_id),
 	CONSTRAINT fk_trace_info_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
 )

--- a/tests/db/schemas/mysql.sql
+++ b/tests/db/schemas/mysql.sql
@@ -338,6 +338,7 @@ CREATE TABLE trace_info (
 	client_request_id VARCHAR(50),
 	request_preview VARCHAR(1000),
 	response_preview VARCHAR(1000),
+	trace_version INTEGER DEFAULT '0' NOT NULL,
 	PRIMARY KEY (request_id),
 	CONSTRAINT fk_trace_info_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
 )

--- a/tests/db/schemas/postgresql.sql
+++ b/tests/db/schemas/postgresql.sql
@@ -339,7 +339,7 @@ CREATE TABLE trace_info (
 	client_request_id VARCHAR(50),
 	request_preview VARCHAR(1000),
 	response_preview VARCHAR(1000),
-	trace_version INTEGER DEFAULT '0' NOT NULL,
+	db_payload_generation INTEGER DEFAULT '0' NOT NULL,
 	CONSTRAINT trace_info_pk PRIMARY KEY (request_id),
 	CONSTRAINT fk_trace_info_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
 )

--- a/tests/db/schemas/postgresql.sql
+++ b/tests/db/schemas/postgresql.sql
@@ -339,6 +339,7 @@ CREATE TABLE trace_info (
 	client_request_id VARCHAR(50),
 	request_preview VARCHAR(1000),
 	response_preview VARCHAR(1000),
+	trace_version INTEGER DEFAULT '0' NOT NULL,
 	CONSTRAINT trace_info_pk PRIMARY KEY (request_id),
 	CONSTRAINT fk_trace_info_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
 )

--- a/tests/db/schemas/sqlite.sql
+++ b/tests/db/schemas/sqlite.sql
@@ -339,7 +339,7 @@ CREATE TABLE trace_info (
 	client_request_id VARCHAR(50),
 	request_preview VARCHAR(1000),
 	response_preview VARCHAR(1000),
-	trace_version INTEGER DEFAULT '0' NOT NULL,
+	db_payload_generation INTEGER DEFAULT '0' NOT NULL,
 	CONSTRAINT trace_info_pk PRIMARY KEY (request_id),
 	CONSTRAINT fk_trace_info_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
 )

--- a/tests/db/schemas/sqlite.sql
+++ b/tests/db/schemas/sqlite.sql
@@ -339,6 +339,7 @@ CREATE TABLE trace_info (
 	client_request_id VARCHAR(50),
 	request_preview VARCHAR(1000),
 	response_preview VARCHAR(1000),
+	trace_version INTEGER DEFAULT '0' NOT NULL,
 	CONSTRAINT trace_info_pk PRIMARY KEY (request_id),
 	CONSTRAINT fk_trace_info_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
 )

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -339,7 +339,7 @@ CREATE TABLE trace_info (
 	client_request_id VARCHAR(50),
 	request_preview VARCHAR(1000),
 	response_preview VARCHAR(1000),
-	trace_version INTEGER DEFAULT '0' NOT NULL,
+	db_payload_generation INTEGER DEFAULT '0' NOT NULL,
 	CONSTRAINT trace_info_pk PRIMARY KEY (request_id),
 	CONSTRAINT fk_trace_info_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
 )

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -339,6 +339,7 @@ CREATE TABLE trace_info (
 	client_request_id VARCHAR(50),
 	request_preview VARCHAR(1000),
 	response_preview VARCHAR(1000),
+	trace_version INTEGER DEFAULT '0' NOT NULL,
 	CONSTRAINT trace_info_pk PRIMARY KEY (request_id),
 	CONSTRAINT fk_trace_info_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
 )

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store.py
@@ -18,6 +18,7 @@ from opentelemetry import trace as trace_api
 from opentelemetry.sdk.resources import Resource as _OTelResource
 from opentelemetry.sdk.trace import ReadableSpan as OTelReadableSpan
 from packaging.version import Version
+from sqlalchemy.dialects import mssql, mysql, postgresql
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
 import mlflow
@@ -13825,7 +13826,57 @@ def test_log_spans_then_start_trace_preserves_tag(store: SqlAlchemyStore):
     assert trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.TRACKING_STORE.value
 
 
-def test_log_spans_then_start_trace_preserves_archived_trace_tags(store: SqlAlchemyStore):
+def test_log_spans_then_start_trace_advances_trace_version(store: SqlAlchemyStore):
+    """
+    A stale archival snapshot taken after log_spans() must lose once start_trace() updates the
+    same DB-backed trace and advances its trace_version.
+    """
+    experiment_id = store.create_experiment("test_log_spans_then_start_trace_trace_version")
+    trace_id = f"tr-{uuid.uuid4().hex}"
+
+    span = create_test_span(
+        trace_id=trace_id,
+        name="test_span",
+        span_id=111,
+        status=trace_api.StatusCode.OK,
+        start_ns=1_000_000_000,
+        end_ns=2_000_000_000,
+        trace_num=12345,
+    )
+    store.log_spans(experiment_id, [span])
+    snapshot = store._load_trace_archival_data(trace_id)
+    assert snapshot is not None
+    _, trace_version, _ = snapshot
+    assert trace_version == 1
+
+    trace_info_for_start = TraceInfo(
+        trace_id=trace_id,
+        trace_location=trace_location.TraceLocation.from_experiment_id(experiment_id),
+        request_time=1000,
+        execution_duration=1000,
+        state=TraceState.OK,
+        tags={"custom_tag": "value"},
+        trace_metadata={"source": "test"},
+    )
+    store.start_trace(trace_info_for_start)
+
+    with store.ManagedSessionMaker() as session:
+        sql_trace_info = (
+            session.query(SqlTraceInfo).filter(SqlTraceInfo.request_id == trace_id).one()
+        )
+        assert sql_trace_info.trace_version == 2
+
+    assert not store._finalize_archived_trace(
+        trace_id=trace_id,
+        artifact_uri="file:///unused-archive-root",
+        trace_version=trace_version,
+    )
+    assert store.get_trace_info(trace_id).tags[TraceTagKey.SPANS_LOCATION] == (
+        SpansLocation.TRACKING_STORE.value
+    )
+
+
+def test_log_spans_then_start_trace_rejects_archived_trace(store: SqlAlchemyStore):
     experiment_id = store.create_experiment("test_preserve_archived_trace_tags")
     trace_id = f"tr-{uuid.uuid4().hex}"
     archive_location = "s3://bucket/archive/traces.pb"
@@ -13852,11 +13903,92 @@ def test_log_spans_then_start_trace_preserves_archived_trace_tags(store: SqlAlch
         tags={"custom_tag": "value"},
         trace_metadata={"source": "test"},
     )
-    store.start_trace(trace_info_for_start)
+    with pytest.raises(
+        MlflowException, match=f"Cannot update traces that are no longer DB-backed: '{trace_id}'"
+    ) as exc_info:
+        store.start_trace(trace_info_for_start)
 
+    assert exc_info.value.error_code == ErrorCode.Name(INVALID_STATE)
     trace_info = store.get_trace_info(trace_id)
     assert trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.ARCHIVE_REPO.value
     assert trace_info.tags[TraceTagKey.ARCHIVE_LOCATION] == archive_location
+
+
+def test_advance_trace_versions_reports_deleted_traces(store: SqlAlchemyStore):
+    experiment_id = store.create_experiment("test_deleted_trace_version_bump")
+    trace_id = f"tr-{uuid.uuid4().hex}"
+
+    _create_trace(store, trace_id, experiment_id, request_time=1_000)
+    store.delete_traces(experiment_id=experiment_id, trace_ids=[trace_id])
+
+    with store.ManagedSessionMaker() as session:
+        with pytest.raises(
+            MlflowException,
+            match=f"Cannot log spans to traces that no longer exist: '{trace_id}'",
+        ) as exc_info:
+            store._advance_trace_versions_for_db_span_writes(session, [trace_id])
+
+    assert exc_info.value.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
+
+
+def test_log_spans_then_start_trace_reports_deleted_conflicting_trace(store: SqlAlchemyStore):
+    experiment_id = store.create_experiment("test_start_trace_deleted_conflicting_trace")
+    trace_id = f"tr-{uuid.uuid4().hex}"
+
+    span = create_test_span(
+        trace_id=trace_id,
+        name="test_span",
+        span_id=111,
+        status=trace_api.StatusCode.OK,
+        start_ns=1_000_000_000,
+        end_ns=2_000_000_000,
+        trace_num=12345,
+    )
+    store.log_spans(experiment_id, [span])
+
+    trace_info_for_start = TraceInfo(
+        trace_id=trace_id,
+        trace_location=trace_location.TraceLocation.from_experiment_id(experiment_id),
+        request_time=1000,
+        execution_duration=1000,
+        state=TraceState.OK,
+        tags={"custom_tag": "value"},
+        trace_metadata={"source": "test"},
+    )
+
+    original_trace_query = store._trace_query
+
+    class DeletingQuery:
+        def __init__(self, query):
+            self._query = query
+
+        def filter(self, *args, **kwargs):
+            self._query = self._query.filter(*args, **kwargs)
+            return self
+
+        def one_or_none(self):
+            with mock.patch.object(store, "_trace_query", original_trace_query):
+                store.delete_traces(experiment_id=experiment_id, trace_ids=[trace_id])
+            return self._query.one_or_none()
+
+    def deleting_trace_query(session, for_update_or_delete=False, workspace=None):
+        query = original_trace_query(
+            session,
+            for_update_or_delete=for_update_or_delete,
+            workspace=workspace,
+        )
+        if for_update_or_delete:
+            return DeletingQuery(query)
+        return query
+
+    with mock.patch.object(store, "_trace_query", side_effect=deleting_trace_query):
+        with pytest.raises(
+            MlflowException,
+            match=f"Trace with ID '{trace_id}' no longer exists.",
+        ) as exc_info:
+            store.start_trace(trace_info_for_start)
+
+    assert exc_info.value.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
 
 
 def test_log_spans_then_start_trace_preserves_archival_failure_tag(store: SqlAlchemyStore):
@@ -13933,6 +14065,52 @@ def test_log_spans_then_start_trace_preserves_preview(store: SqlAlchemyStore):
     assert trace_info.response_preview is not None
     assert "Hello" in trace_info.request_preview
     assert "Hi" in trace_info.response_preview
+
+
+def test_log_spans_then_start_trace_uses_locking_reread(store: SqlAlchemyStore):
+    experiment_id = store.create_experiment("test_start_trace_locking_reread")
+    trace_id = f"tr-{uuid.uuid4().hex}"
+
+    store.log_spans(
+        experiment_id,
+        [
+            create_test_span(
+                trace_id=trace_id,
+                name="llm_call",
+                span_id=111,
+                status=trace_api.StatusCode.OK,
+                start_ns=1_000_000_000,
+                end_ns=2_000_000_000,
+                trace_num=12345,
+            )
+        ],
+    )
+
+    trace_info_for_start = TraceInfo(
+        trace_id=trace_id,
+        trace_location=trace_location.TraceLocation.from_experiment_id(experiment_id),
+        request_time=1000,
+        execution_duration=1000,
+        state=TraceState.OK,
+        tags={"custom_tag": "value"},
+        trace_metadata={"source": "test"},
+    )
+
+    original_trace_query = store._trace_query
+    seen_locking_calls = []
+
+    def tracked_trace_query(session, for_update_or_delete=False, workspace=None):
+        seen_locking_calls.append(for_update_or_delete)
+        return original_trace_query(
+            session,
+            for_update_or_delete=for_update_or_delete,
+            workspace=workspace,
+        )
+
+    with mock.patch.object(store, "_trace_query", side_effect=tracked_trace_query):
+        store.start_trace(trace_info_for_start)
+
+    assert True in seen_locking_calls
 
 
 @pytest.mark.skipif(
@@ -15501,8 +15679,8 @@ def test_archive_traces_respects_workspace_trace_archival_location_overrides(
             "tr-workspace-old",
             SqlAlchemyStore.ARTIFACTS_FOLDER_NAME,
         )
-        assert archived_trace_info.tags[TraceTagKey.ARCHIVE_LOCATION] == (
-            expected_workspace_archive_uri
+        assert (
+            archived_trace_info.tags[TraceTagKey.ARCHIVE_LOCATION] == expected_workspace_archive_uri
         )
         assert (
             workspace_archive_root
@@ -15670,32 +15848,130 @@ def test_archive_traces_respects_workspace_retention_long_retention_allowlist(
     )
 
 
-def test_archive_traces_noops_when_candidate_becomes_stale(store: SqlAlchemyStore):
-    exp_id = store.create_experiment("archive-stale-candidate")
-    trace_id = "tr-stale-candidate"
-    now_millis = 40 * 24 * 60 * 60 * 1000
-    _create_trace(store, trace_id, exp_id, request_time=now_millis - 2 * 24 * 60 * 60 * 1000)
-    store.log_spans(exp_id, [create_test_span(trace_id, span_id=411)])
+def test_finalize_archived_trace_rejects_stale_snapshot_version(store: SqlAlchemyStore):
+    """
+    Finalization must reject an archival snapshot when a later DB-backed write advances the same
+    trace_version before finalize runs.
+    """
+    exp_id = store.create_experiment("archive-stale-version")
+    trace_id = "tr-stale-version"
+    request_time = 40 * 24 * 60 * 60 * 1000
+
+    _create_trace(store, trace_id, exp_id, request_time=request_time)
+    with store.ManagedSessionMaker() as session:
+        sql_trace_info = (
+            session.query(SqlTraceInfo).filter(SqlTraceInfo.request_id == trace_id).one()
+        )
+        assert sql_trace_info.trace_version == 0
+
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                trace_id,
+                span_id=411,
+                start_ns=request_time * 1_000_000,
+                end_ns=(request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+    with store.ManagedSessionMaker() as session:
+        (
+            session
+            .query(SqlTraceInfo)
+            .filter(SqlTraceInfo.request_id == trace_id)
+            .update({SqlTraceInfo.trace_version: 0}, synchronize_session=False)
+        )
+
+    snapshot = store._load_trace_archival_data(trace_id)
+    assert snapshot is not None
+    _, trace_version, _ = snapshot
+    assert trace_version == 0
+
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                trace_id,
+                span_id=412,
+                start_ns=(request_time + 2_000) * 1_000_000,
+                end_ns=(request_time + 3_000) * 1_000_000,
+            )
+        ],
+    )
+
+    assert not store._finalize_archived_trace(
+        trace_id=trace_id,
+        artifact_uri="file:///unused-archive-root",
+        trace_version=trace_version,
+    )
+    trace_info = store.get_trace_info(trace_id)
+    assert trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.TRACKING_STORE.value
+    assert TraceTagKey.ARCHIVE_LOCATION not in trace_info.tags
+    with store.ManagedSessionMaker() as session:
+        sql_trace_info = (
+            session.query(SqlTraceInfo).filter(SqlTraceInfo.request_id == trace_id).one()
+        )
+        assert sql_trace_info.trace_version == 1
+        contents = (
+            session
+            .query(SqlSpan.content)
+            .filter(SqlSpan.trace_id == trace_id)
+            .order_by(SqlSpan.span_id.asc())
+            .all()
+        )
+        assert len(contents) == 2
+        assert all(content != "" for (content,) in contents)
+
+
+def test_archive_traces_upload_race_cleans_payload_and_retries_safely(store: SqlAlchemyStore):
+    """
+    If archival uploads a payload and then loses the finalize race to a later DB-backed write, the
+    pass must delete the uploaded payload, leave the trace in TRACKING_STORE, and succeed on retry.
+    """
+    exp_id = store.create_experiment("archive-upload-race")
+    trace_id = "tr-upload-race"
+    now_millis = 41 * 24 * 60 * 60 * 1000
+    request_time = now_millis - 2 * 24 * 60 * 60 * 1000
+
+    _create_trace(store, trace_id, exp_id, request_time=request_time)
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                trace_id,
+                span_id=420,
+                start_ns=request_time * 1_000_000,
+                end_ns=(request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
 
     from mlflow.store.artifact.artifact_repo import ArtifactRepository
+    from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
+    from mlflow.tracing.otel.otel_archival import TRACE_ARCHIVAL_FILENAME
 
     original_upload_archived_trace_data_bytes = ArtifactRepository.upload_archived_trace_data_bytes
+    uploaded_uris = []
 
     def upload_bytes_and_mutate(self, data):
+        uploaded_uris.append(self.artifact_uri)
         original_upload_archived_trace_data_bytes(self, data)
-        store.log_spans(exp_id, [create_test_span(trace_id, span_id=412)])
+        store.log_spans(
+            exp_id,
+            [
+                create_test_span(
+                    trace_id,
+                    span_id=421,
+                    start_ns=(request_time + 2_000) * 1_000_000,
+                    end_ns=(request_time + 3_000) * 1_000_000,
+                )
+            ],
+        )
 
     with TempDir() as tmp:
         archive_root = Path(tmp.path("archive"))
         archive_root.mkdir()
-        archive_payload_path = (
-            archive_root
-            / exp_id
-            / SqlAlchemyStore.TRACE_FOLDER_NAME
-            / trace_id
-            / SqlAlchemyStore.ARTIFACTS_FOLDER_NAME
-            / "traces.pb"
-        )
         with mock.patch.object(
             ArtifactRepository, "upload_archived_trace_data_bytes", new=upload_bytes_and_mutate
         ):
@@ -15705,21 +15981,221 @@ def test_archive_traces_noops_when_candidate_becomes_stale(store: SqlAlchemyStor
                 default_retention="1d",
                 now_millis=now_millis,
             )
-        assert not archive_payload_path.exists()
 
-    assert archived == 0
-    assert store.get_trace_info(trace_id).tags[TraceTagKey.SPANS_LOCATION] == (
-        SpansLocation.TRACKING_STORE.value
-    )
+        assert archived == 0
+        trace_info = store.get_trace_info(trace_id)
+        assert trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.TRACKING_STORE.value
+        assert TraceTagKey.ARCHIVE_LOCATION not in trace_info.tags
+        assert len(uploaded_uris) == 1
+        staged_payload_path = (
+            Path(local_file_uri_to_path(uploaded_uris[0])) / TRACE_ARCHIVAL_FILENAME
+        )
+        assert not staged_payload_path.exists()
+        assert len(store.get_trace(trace_id).data.spans) == 2
+
+        archived_retry = _archive_traces(
+            store,
+            default_trace_archival_location=archive_root.as_uri(),
+            default_retention="1d",
+            now_millis=now_millis,
+        )
+
+        assert archived_retry == 1
+        archived_trace_info = store.get_trace_info(trace_id)
+        assert (
+            archived_trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.ARCHIVE_REPO.value
+        )
+        assert archived_trace_info.tags[TraceTagKey.ARCHIVE_LOCATION]
+        assert archived_trace_info.tags[TraceTagKey.ARCHIVE_LOCATION] == uploaded_uris[0]
+        archived_trace_data = get_artifact_repository(
+            archived_trace_info.tags[TraceTagKey.ARCHIVE_LOCATION]
+        ).download_archived_trace_data()
+        assert len(archived_trace_data.spans) == 2
+
+
+def test_trace_query_for_update_uses_backend_specific_lock_clause(store: SqlAlchemyStore):
+    """
+    Locking trace queries should compile to the backend-specific row-lock clause used by the
+    archival finalize/failure paths.
+    """
+    exp_id = store.create_experiment("archive-trace-query-lock")
+    trace_id = "tr-archive-trace-query-lock"
+    _create_trace(store, trace_id, exp_id, request_time=42 * 24 * 60 * 60 * 1000)
+
     with store.ManagedSessionMaker() as session:
-        contents = (
+        with mock.patch.object(store, "db_type", POSTGRES):
+            postgres_sql = str(
+                store
+                ._trace_query(session, for_update_or_delete=True)
+                .filter(SqlTraceInfo.request_id == trace_id)
+                .statement.compile(
+                    dialect=postgresql.dialect(),
+                    compile_kwargs={"literal_binds": True},
+                )
+            )
+
+        with mock.patch.object(store, "db_type", MYSQL):
+            mysql_sql = str(
+                store
+                ._trace_query(session, for_update_or_delete=True)
+                .filter(SqlTraceInfo.request_id == trace_id)
+                .statement.compile(
+                    dialect=mysql.dialect(),
+                    compile_kwargs={"literal_binds": True},
+                )
+            )
+
+        with mock.patch.object(store, "db_type", MSSQL):
+            mssql_sql = str(
+                store
+                ._trace_query(session, for_update_or_delete=True)
+                .filter(SqlTraceInfo.request_id == trace_id)
+                .statement.compile(
+                    dialect=mssql.dialect(),
+                    compile_kwargs={"literal_binds": True},
+                )
+            )
+
+    assert "FOR UPDATE" in postgres_sql
+    assert "FOR UPDATE" in mysql_sql
+    assert "WITH (UPDLOCK, ROWLOCK)" in mssql_sql
+
+
+def test_mark_trace_archival_failure_keeps_joined_tags_out_of_postgres_lock_query(
+    store: SqlAlchemyStore,
+):
+    """
+    The archival-failure locking query must avoid a joined tag load so PostgreSQL can apply
+    FOR UPDATE without rejecting a LEFT OUTER JOIN on the nullable collection side.
+    """
+    exp_id = store.create_experiment("archive-trace-failure-lock")
+    trace_id = "tr-archive-trace-failure-lock"
+    _create_trace(store, trace_id, exp_id, request_time=45 * 24 * 60 * 60 * 1000)
+
+    with store.ManagedSessionMaker() as session:
+        with mock.patch.object(store, "db_type", POSTGRES):
+            postgres_sql = str(
+                store
+                ._trace_query(session, for_update_or_delete=True)
+                .options(sqlalchemy.orm.selectinload(SqlTraceInfo.tags))
+                .filter(SqlTraceInfo.request_id == trace_id)
+                .statement.compile(
+                    dialect=postgresql.dialect(),
+                    compile_kwargs={"literal_binds": True},
+                )
+            )
+
+    assert "FOR UPDATE" in postgres_sql
+    assert "LEFT OUTER JOIN" not in postgres_sql
+
+
+def test_log_spans_advances_trace_version_for_multi_trace_batch(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("archive-log-spans-version-batch")
+    first_trace_id = "tr-version-batch-1"
+    second_trace_id = "tr-version-batch-2"
+    request_time = 44 * 24 * 60 * 60 * 1000
+
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                first_trace_id,
+                span_id=432,
+                start_ns=request_time * 1_000_000,
+                end_ns=(request_time + 1_000) * 1_000_000,
+            ),
+            create_test_span(
+                second_trace_id,
+                span_id=433,
+                start_ns=(request_time + 1_000) * 1_000_000,
+                end_ns=(request_time + 2_000) * 1_000_000,
+            ),
+        ],
+    )
+
+    with store.ManagedSessionMaker() as session:
+        versions = dict(
             session
-            .query(SqlSpan.content)
-            .filter(SqlSpan.trace_id == trace_id)
-            .order_by(SqlSpan.span_id.asc())
+            .query(SqlTraceInfo.request_id, SqlTraceInfo.trace_version)
+            .filter(SqlTraceInfo.request_id.in_([first_trace_id, second_trace_id]))
             .all()
         )
-        assert all(content for (content,) in contents)
+    assert versions == {first_trace_id: 1, second_trace_id: 1}
+
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                first_trace_id,
+                span_id=434,
+                start_ns=(request_time + 2_000) * 1_000_000,
+                end_ns=(request_time + 3_000) * 1_000_000,
+            ),
+            create_test_span(
+                second_trace_id,
+                span_id=435,
+                start_ns=(request_time + 3_000) * 1_000_000,
+                end_ns=(request_time + 4_000) * 1_000_000,
+            ),
+        ],
+    )
+
+    with store.ManagedSessionMaker() as session:
+        versions = dict(
+            session
+            .query(SqlTraceInfo.request_id, SqlTraceInfo.trace_version)
+            .filter(SqlTraceInfo.request_id.in_([first_trace_id, second_trace_id]))
+            .all()
+        )
+    assert versions == {first_trace_id: 2, second_trace_id: 2}
+
+
+def test_finalize_archived_trace_rejects_writer_after_finalization(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("archive-reject-log-spans-after-finalize")
+    trace_id = "tr-archive-reject-log-spans-after-finalize"
+    request_time = 43 * 24 * 60 * 60 * 1000
+
+    _create_trace(store, trace_id, exp_id, request_time=request_time)
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                trace_id,
+                span_id=430,
+                start_ns=request_time * 1_000_000,
+                end_ns=(request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+
+    snapshot = store._load_trace_archival_data(trace_id)
+    assert snapshot is not None
+    _, trace_version, _ = snapshot
+    assert store._finalize_archived_trace(
+        trace_id=trace_id,
+        artifact_uri="file:///unused-archive-root",
+        trace_version=trace_version,
+    )
+
+    with pytest.raises(
+        MlflowException, match=f"Cannot log spans to archived traces: '{trace_id}'"
+    ) as exc_info:
+        store.log_spans(
+            exp_id,
+            [
+                create_test_span(
+                    trace_id,
+                    span_id=431,
+                    start_ns=(request_time + 2_000) * 1_000_000,
+                    end_ns=(request_time + 3_000) * 1_000_000,
+                )
+            ],
+        )
+
+    assert exc_info.value.error_code == ErrorCode.Name(INVALID_STATE)
+    trace_info = store.get_trace_info(trace_id)
+    assert trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.ARCHIVE_REPO.value
+    assert trace_info.tags[TraceTagKey.ARCHIVE_LOCATION] == "file:///unused-archive-root"
 
 
 def test_log_spans_rejects_archived_trace(store: SqlAlchemyStore):
@@ -15858,7 +16334,7 @@ def test_archive_traces_continues_after_upload_failure_and_cleans_up_completed_a
             archived = _archive_traces(
                 store,
                 default_trace_archival_location=archive_root.as_uri(),
-                default_retention="365d",
+                default_retention="1d",
                 now_millis=now_millis,
             )
 
@@ -15969,10 +16445,84 @@ def test_archive_traces_marks_malformed_traces_and_excludes_retries(
     assert archived_again == 0
     trace_info = store.get_trace_info(trace_id)
     assert trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.TRACKING_STORE.value
+    assert TraceTagKey.ARCHIVE_LOCATION not in trace_info.tags
     assert trace_info.tags[TraceTagKey.ARCHIVAL_FAILURE] == (
         TraceArchivalFailureReason.MALFORMED_TRACE.value
     )
     assert TraceExperimentTagKey.ARCHIVE_NOW not in store.get_experiment(exp_id).tags
+
+
+def test_archive_traces_stale_malformed_snapshot_does_not_mark_new_generation_terminal(
+    store: SqlAlchemyStore,
+):
+    """
+    A malformed archival snapshot must not mark the trace terminal once a later DB-backed write
+    repairs the trace and advances its trace_version before failure marking runs.
+    """
+    exp_id = store.create_experiment("archive-stale-malformed-snapshot")
+    trace_id = "tr-stale-malformed-snapshot"
+    now_millis = 51 * 24 * 60 * 60 * 1000
+    request_time = now_millis - 2 * 24 * 60 * 60 * 1000
+
+    _create_trace(store, trace_id, exp_id, request_time=request_time)
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                trace_id,
+                span_id=531,
+                start_ns=request_time * 1_000_000,
+                end_ns=(request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+
+    with store.ManagedSessionMaker() as session:
+        (
+            session
+            .query(SqlSpan)
+            .filter(SqlSpan.trace_id == trace_id, SqlSpan.span_id == "0000000000000213")
+            .update({SqlSpan.content: "not-json"}, synchronize_session=False)
+        )
+
+    original_serialize = store._serialize_trace_archival_span_rows_to_pb
+
+    def serialize_after_repair(span_rows):
+        store.log_spans(
+            exp_id,
+            [
+                create_test_span(
+                    trace_id,
+                    span_id=531,
+                    start_ns=request_time * 1_000_000,
+                    end_ns=(request_time + 2_000) * 1_000_000,
+                )
+            ],
+        )
+        return original_serialize(span_rows)
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        with mock.patch.object(
+            store, "_serialize_trace_archival_span_rows_to_pb", side_effect=serialize_after_repair
+        ):
+            archived = _archive_traces(
+                store,
+                default_trace_archival_location=archive_root.as_uri(),
+                default_retention="1d",
+                now_millis=now_millis,
+            )
+
+    assert archived == 0
+    trace_info = store.get_trace_info(trace_id)
+    assert trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.TRACKING_STORE.value
+    assert TraceTagKey.ARCHIVAL_FAILURE not in trace_info.tags
+    with store.ManagedSessionMaker() as session:
+        sql_trace_info = (
+            session.query(SqlTraceInfo).filter(SqlTraceInfo.request_id == trace_id).one()
+        )
+        assert sql_trace_info.trace_version == 2
 
 
 def test_archive_traces_marks_serializer_failures_as_malformed_and_excludes_retries(
@@ -16012,13 +16562,14 @@ def test_archive_traces_marks_serializer_failures_as_malformed_and_excludes_retr
     assert archived_again == 0
     trace_info = store.get_trace_info(trace_id)
     assert trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.TRACKING_STORE.value
+    assert TraceTagKey.ARCHIVE_LOCATION not in trace_info.tags
     assert trace_info.tags[TraceTagKey.ARCHIVAL_FAILURE] == (
         TraceArchivalFailureReason.MALFORMED_TRACE.value
     )
     assert TraceExperimentTagKey.ARCHIVE_NOW not in store.get_experiment(exp_id).tags
 
 
-def test_archive_traces_marks_unsupported_archive_repository_as_terminal_failure(
+def test_archive_traces_keeps_unsupported_archive_repository_retryable(
     store: SqlAlchemyStore,
 ):
     exp_fail = store.create_experiment("archive-unsupported-repository")
@@ -16068,12 +16619,10 @@ def test_archive_traces_marks_unsupported_archive_repository_as_terminal_failure
     assert archived == 1
     fail_trace_info = store.get_trace_info(fail_trace_id)
     assert fail_trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.TRACKING_STORE.value
-    assert fail_trace_info.tags[TraceTagKey.ARCHIVAL_FAILURE] == (
-        TraceArchivalFailureReason.UNSUPPORTED_ARCHIVE_REPOSITORY.value
-    )
+    assert TraceTagKey.ARCHIVAL_FAILURE not in fail_trace_info.tags
     success_trace_info = store.get_trace_info(success_trace_id)
     assert success_trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.ARCHIVE_REPO.value
-    assert TraceExperimentTagKey.ARCHIVE_NOW not in store.get_experiment(exp_fail).tags
+    assert TraceExperimentTagKey.ARCHIVE_NOW in store.get_experiment(exp_fail).tags
     assert TraceExperimentTagKey.ARCHIVE_NOW not in store.get_experiment(exp_success).tags
 
 
@@ -16135,7 +16684,7 @@ def test_archive_traces_raises_unexpected_deserialization_errors(
         archive_root.mkdir()
         with mock.patch.object(
             store,
-            "_serialize_trace_archival_snapshot_to_pb",
+            "_serialize_trace_archival_span_rows_to_pb",
             side_effect=RuntimeError("simulated unexpected serialize failure"),
         ):
             with pytest.raises(RuntimeError, match="simulated unexpected serialize failure"):
@@ -16245,7 +16794,7 @@ def test_archive_traces_leaves_sqlalchemy_errors_retryable(
         archive_root.mkdir()
         with mock.patch.object(
             store,
-            "_load_trace_archival_snapshot",
+            "_load_trace_archival_data",
             side_effect=SQLAlchemyError("simulated retryable db failure"),
         ):
             archived = _archive_traces(

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store.py
@@ -13826,12 +13826,12 @@ def test_log_spans_then_start_trace_preserves_tag(store: SqlAlchemyStore):
     assert trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.TRACKING_STORE.value
 
 
-def test_log_spans_then_start_trace_advances_trace_version(store: SqlAlchemyStore):
+def test_log_spans_then_start_trace_advances_db_payload_generation(store: SqlAlchemyStore):
     """
     A stale archival snapshot taken after log_spans() must lose once start_trace() updates the
-    same DB-backed trace and advances its trace_version.
+    same DB-backed trace and advances its db_payload_generation.
     """
-    experiment_id = store.create_experiment("test_log_spans_then_start_trace_trace_version")
+    experiment_id = store.create_experiment("test_log_spans_then_start_trace_db_payload_generation")
     trace_id = f"tr-{uuid.uuid4().hex}"
 
     span = create_test_span(
@@ -13846,8 +13846,8 @@ def test_log_spans_then_start_trace_advances_trace_version(store: SqlAlchemyStor
     store.log_spans(experiment_id, [span])
     snapshot = store._load_trace_archival_data(trace_id)
     assert snapshot is not None
-    _, trace_version, _ = snapshot
-    assert trace_version == 1
+    _, db_payload_generation, _ = snapshot
+    assert db_payload_generation == 1
 
     trace_info_for_start = TraceInfo(
         trace_id=trace_id,
@@ -13864,12 +13864,12 @@ def test_log_spans_then_start_trace_advances_trace_version(store: SqlAlchemyStor
         sql_trace_info = (
             session.query(SqlTraceInfo).filter(SqlTraceInfo.request_id == trace_id).one()
         )
-        assert sql_trace_info.trace_version == 2
+        assert sql_trace_info.db_payload_generation == 2
 
     assert not store._finalize_archived_trace(
         trace_id=trace_id,
         artifact_uri="file:///unused-archive-root",
-        trace_version=trace_version,
+        db_payload_generation=db_payload_generation,
     )
     assert store.get_trace_info(trace_id).tags[TraceTagKey.SPANS_LOCATION] == (
         SpansLocation.TRACKING_STORE.value
@@ -13914,8 +13914,8 @@ def test_log_spans_then_start_trace_rejects_archived_trace(store: SqlAlchemyStor
     assert trace_info.tags[TraceTagKey.ARCHIVE_LOCATION] == archive_location
 
 
-def test_advance_trace_versions_reports_deleted_traces(store: SqlAlchemyStore):
-    experiment_id = store.create_experiment("test_deleted_trace_version_bump")
+def test_advance_db_payload_generations_reports_deleted_traces(store: SqlAlchemyStore):
+    experiment_id = store.create_experiment("test_deleted_db_payload_generation_bump")
     trace_id = f"tr-{uuid.uuid4().hex}"
 
     _create_trace(store, trace_id, experiment_id, request_time=1_000)
@@ -13926,7 +13926,7 @@ def test_advance_trace_versions_reports_deleted_traces(store: SqlAlchemyStore):
             MlflowException,
             match=f"Cannot log spans to traces that no longer exist: '{trace_id}'",
         ) as exc_info:
-            store._advance_trace_versions_for_db_span_writes(session, [trace_id])
+            store._advance_db_payload_generations_for_db_span_writes(session, [trace_id])
 
     assert exc_info.value.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
 
@@ -15848,13 +15848,13 @@ def test_archive_traces_respects_workspace_retention_long_retention_allowlist(
     )
 
 
-def test_finalize_archived_trace_rejects_stale_snapshot_version(store: SqlAlchemyStore):
+def test_finalize_archived_trace_rejects_stale_snapshot_generation(store: SqlAlchemyStore):
     """
     Finalization must reject an archival snapshot when a later DB-backed write advances the same
-    trace_version before finalize runs.
+    db_payload_generation before finalize runs.
     """
-    exp_id = store.create_experiment("archive-stale-version")
-    trace_id = "tr-stale-version"
+    exp_id = store.create_experiment("archive-stale-generation")
+    trace_id = "tr-stale-generation"
     request_time = 40 * 24 * 60 * 60 * 1000
 
     _create_trace(store, trace_id, exp_id, request_time=request_time)
@@ -15862,7 +15862,7 @@ def test_finalize_archived_trace_rejects_stale_snapshot_version(store: SqlAlchem
         sql_trace_info = (
             session.query(SqlTraceInfo).filter(SqlTraceInfo.request_id == trace_id).one()
         )
-        assert sql_trace_info.trace_version == 0
+        assert sql_trace_info.db_payload_generation == 0
 
     store.log_spans(
         exp_id,
@@ -15880,13 +15880,13 @@ def test_finalize_archived_trace_rejects_stale_snapshot_version(store: SqlAlchem
             session
             .query(SqlTraceInfo)
             .filter(SqlTraceInfo.request_id == trace_id)
-            .update({SqlTraceInfo.trace_version: 0}, synchronize_session=False)
+            .update({SqlTraceInfo.db_payload_generation: 0}, synchronize_session=False)
         )
 
     snapshot = store._load_trace_archival_data(trace_id)
     assert snapshot is not None
-    _, trace_version, _ = snapshot
-    assert trace_version == 0
+    _, db_payload_generation, _ = snapshot
+    assert db_payload_generation == 0
 
     store.log_spans(
         exp_id,
@@ -15903,7 +15903,7 @@ def test_finalize_archived_trace_rejects_stale_snapshot_version(store: SqlAlchem
     assert not store._finalize_archived_trace(
         trace_id=trace_id,
         artifact_uri="file:///unused-archive-root",
-        trace_version=trace_version,
+        db_payload_generation=db_payload_generation,
     )
     trace_info = store.get_trace_info(trace_id)
     assert trace_info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.TRACKING_STORE.value
@@ -15912,7 +15912,7 @@ def test_finalize_archived_trace_rejects_stale_snapshot_version(store: SqlAlchem
         sql_trace_info = (
             session.query(SqlTraceInfo).filter(SqlTraceInfo.request_id == trace_id).one()
         )
-        assert sql_trace_info.trace_version == 1
+        assert sql_trace_info.db_payload_generation == 1
         contents = (
             session
             .query(SqlSpan.content)
@@ -16089,10 +16089,12 @@ def test_mark_trace_archival_failure_keeps_joined_tags_out_of_postgres_lock_quer
     assert "LEFT OUTER JOIN" not in postgres_sql
 
 
-def test_log_spans_advances_trace_version_for_multi_trace_batch(store: SqlAlchemyStore):
-    exp_id = store.create_experiment("archive-log-spans-version-batch")
-    first_trace_id = "tr-version-batch-1"
-    second_trace_id = "tr-version-batch-2"
+def test_log_spans_advances_db_payload_generation_for_multi_trace_batch(
+    store: SqlAlchemyStore,
+):
+    exp_id = store.create_experiment("archive-log-spans-generation-batch")
+    first_trace_id = "tr-generation-batch-1"
+    second_trace_id = "tr-generation-batch-2"
     request_time = 44 * 24 * 60 * 60 * 1000
 
     store.log_spans(
@@ -16114,13 +16116,13 @@ def test_log_spans_advances_trace_version_for_multi_trace_batch(store: SqlAlchem
     )
 
     with store.ManagedSessionMaker() as session:
-        versions = dict(
+        db_payload_generations = dict(
             session
-            .query(SqlTraceInfo.request_id, SqlTraceInfo.trace_version)
+            .query(SqlTraceInfo.request_id, SqlTraceInfo.db_payload_generation)
             .filter(SqlTraceInfo.request_id.in_([first_trace_id, second_trace_id]))
             .all()
         )
-    assert versions == {first_trace_id: 1, second_trace_id: 1}
+    assert db_payload_generations == {first_trace_id: 1, second_trace_id: 1}
 
     store.log_spans(
         exp_id,
@@ -16141,13 +16143,13 @@ def test_log_spans_advances_trace_version_for_multi_trace_batch(store: SqlAlchem
     )
 
     with store.ManagedSessionMaker() as session:
-        versions = dict(
+        db_payload_generations = dict(
             session
-            .query(SqlTraceInfo.request_id, SqlTraceInfo.trace_version)
+            .query(SqlTraceInfo.request_id, SqlTraceInfo.db_payload_generation)
             .filter(SqlTraceInfo.request_id.in_([first_trace_id, second_trace_id]))
             .all()
         )
-    assert versions == {first_trace_id: 2, second_trace_id: 2}
+    assert db_payload_generations == {first_trace_id: 2, second_trace_id: 2}
 
 
 def test_finalize_archived_trace_rejects_writer_after_finalization(store: SqlAlchemyStore):
@@ -16170,11 +16172,11 @@ def test_finalize_archived_trace_rejects_writer_after_finalization(store: SqlAlc
 
     snapshot = store._load_trace_archival_data(trace_id)
     assert snapshot is not None
-    _, trace_version, _ = snapshot
+    _, db_payload_generation, _ = snapshot
     assert store._finalize_archived_trace(
         trace_id=trace_id,
         artifact_uri="file:///unused-archive-root",
-        trace_version=trace_version,
+        db_payload_generation=db_payload_generation,
     )
 
     with pytest.raises(
@@ -16457,7 +16459,7 @@ def test_archive_traces_stale_malformed_snapshot_does_not_mark_new_generation_te
 ):
     """
     A malformed archival snapshot must not mark the trace terminal once a later DB-backed write
-    repairs the trace and advances its trace_version before failure marking runs.
+    repairs the trace and advances its db_payload_generation before failure marking runs.
     """
     exp_id = store.create_experiment("archive-stale-malformed-snapshot")
     trace_id = "tr-stale-malformed-snapshot"
@@ -16522,7 +16524,7 @@ def test_archive_traces_stale_malformed_snapshot_does_not_mark_new_generation_te
         sql_trace_info = (
             session.query(SqlTraceInfo).filter(SqlTraceInfo.request_id == trace_id).one()
         )
-        assert sql_trace_info.trace_version == 2
+        assert sql_trace_info.db_payload_generation == 2
 
 
 def test_archive_traces_marks_serializer_failures_as_malformed_and_excludes_retries(

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_workspace_store.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_workspace_store.py
@@ -26,10 +26,13 @@ from mlflow.entities import (
     Param,
     RunStatus,
     RunTag,
+    TraceInfo,
     ViewType,
 )
 from mlflow.entities.entity_type import EntityAssociationType
 from mlflow.entities.lifecycle_stage import LifecycleStage
+from mlflow.entities.trace_location import TraceLocation
+from mlflow.entities.trace_state import TraceState
 from mlflow.entities.workspace import TraceArchivalConfig
 from mlflow.environment_variables import MLFLOW_ENABLE_WORKSPACES
 from mlflow.exceptions import MlflowException
@@ -804,42 +807,47 @@ def test_get_trace_is_workspace_scoped(workspace_tracking_store):
         assert excinfo.value.error_code == "RESOURCE_DOES_NOT_EXIST"
 
 
-def test_log_spans_update_is_workspace_scoped(workspace_tracking_store):
+def test_start_trace_conflict_update_is_workspace_scoped(workspace_tracking_store):
     trace_id = f"tr-{uuid.uuid4().hex}"
     initial_span = create_test_span(
         trace_id=trace_id,
         start_ns=2_000_000_000,
         end_ns=3_000_000_000,
     )
-    earlier_span = create_test_span(
-        trace_id=trace_id,
-        span_id=222,
-        start_ns=1_000_000_000,
-        end_ns=4_000_000_000,
-    )
 
     with WorkspaceContext("team-a"):
-        exp_id = workspace_tracking_store.create_experiment("trace-exp-workspace-guard")
+        exp_id = workspace_tracking_store.create_experiment("trace-exp-start-trace-workspace-guard")
         workspace_tracking_store.log_spans(exp_id, [initial_span])
-        original_trace = workspace_tracking_store.get_trace(trace_id)
+
+        trace_info = TraceInfo(
+            trace_id=trace_id,
+            trace_location=TraceLocation.from_experiment_id(exp_id),
+            request_time=1_000,
+            execution_duration=2_000,
+            state=TraceState.OK,
+            tags={"custom_tag": "value"},
+            trace_metadata={"source": "test"},
+        )
 
         call_state = {"count": 0}
 
         def workspace_side_effect(*_args, **_kwargs):
             call_state["count"] += 1
-            return "team-a" if call_state["count"] == 1 else "team-b"
+            return "team-a" if call_state["count"] <= 2 else "team-b"
 
         with mock.patch.object(
             WorkspaceAwareSqlAlchemyStore,
             "_get_active_workspace",
             side_effect=workspace_side_effect,
         ):
-            workspace_tracking_store.log_spans(exp_id, [earlier_span])
+            updated_trace = workspace_tracking_store.start_trace(trace_info)
 
-        updated_trace = workspace_tracking_store.get_trace(trace_id)
-        assert updated_trace.info.request_time == original_trace.info.request_time
-        assert updated_trace.info.execution_duration == original_trace.info.execution_duration
-        assert len(updated_trace.data.spans) == 2
+        assert call_state["count"] == 2
+        fetched_trace = workspace_tracking_store.get_trace_info(trace_id)
+        assert updated_trace.trace_id == trace_id
+        assert fetched_trace.request_time == 1_000
+        assert fetched_trace.execution_duration == 2_000
+        assert fetched_trace.tags["custom_tag"] == "value"
 
 
 def test_validate_artifact_root_allows_missing_global_root(workspace_tracking_store):


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/mlflow/rfcs/blob/main/rfcs/0001-trace-archival/0001-trace-archival.md

Depends on: https://github.com/mlflow/mlflow/pull/22605

Please also see complementary RFC update PR here: https://github.com/mlflow/rfcs/pull/9 (commit: https://github.com/mlflow/rfcs/pull/9/changes/01df0dbe14a7112b4343460a217979b95868e917)

### What changes are proposed in this pull request?

Replace the remaining archival barrier flow with trace_version-based coordination so DB-backed writes, archival finalization, and malformed-archive recovery all validate the generation they observed before mutating trace state. This keeps duplicate start_trace() calls from writing stale rows, rejects updates once a trace is no longer DB-backed, and prevents losing archival passes from publishing or deleting another attempt's payload.

Also align archival upload and cleanup paths with the RFC's canonical per-version layout, and add regression coverage for stale snapshots, upload retries, malformed archives, and backend-specific locking behavior.



### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests


### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
