### PR TITLE
Bulk-upsert trace metadata/metrics/tag rows in `log_spans` Phase 5

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -4751,7 +4751,28 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                     .all()
                 }
 
-            # --- Phase 5: Per-trace updates (UPDATE + merges) ---
+            trace_ids_with_user = [tid for tid in all_trace_ids if trace_aggregates[tid].user_id]
+            existing_user_ids: set[str] = set()
+            if trace_ids_with_user:
+                existing_user_ids = {
+                    request_id
+                    for (request_id,) in session
+                    .query(SqlTraceMetadata.request_id)
+                    .filter(
+                        SqlTraceMetadata.request_id.in_(trace_ids_with_user),
+                        SqlTraceMetadata.key == TraceMetadataKey.TRACE_USER,
+                    )
+                    .all()
+                }
+
+            # --- Phase 5: Per-trace UPDATE on SqlTraceInfo + collect metadata rows ---
+            # Metadata/metrics/tag rows are accumulated here and bulk-upserted in
+            # Phase 6, collapsing up to ~10 per-trace session.merge() calls (each
+            # costing a SELECT + INSERT/UPDATE round-trip) into three bulk upserts
+            # regardless of batch size.
+            metadata_rows: list[dict[str, Any]] = []
+            metric_rows: list[dict[str, Any]] = []
+            tag_rows: list[dict[str, Any]] = []
             for trace_id in all_trace_ids:
                 agg = trace_aggregates[trace_id]
                 sql_trace_info = existing_traces[trace_id]
@@ -4811,20 +4832,16 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                             existing_record.value if existing_record else {},
                             aggregated_token_usage,
                         )
-                        session.merge(
-                            SqlTraceMetadata(
-                                request_id=trace_id,
-                                key=TraceMetadataKey.TOKEN_USAGE,
-                                value=json.dumps(trace_token_usage),
-                            )
+                        metadata_rows.append({
+                            "request_id": trace_id,
+                            "key": TraceMetadataKey.TOKEN_USAGE,
+                            "value": json.dumps(trace_token_usage),
+                        })
+                        metric_rows.extend(
+                            {"request_id": trace_id, "key": key, "value": float(value)}
+                            for key in TokenUsageKey.all_keys()
+                            if (value := trace_token_usage.get(key)) is not None
                         )
-                        for key in TokenUsageKey.all_keys():
-                            if (value := trace_token_usage.get(key)) is not None:
-                                session.merge(
-                                    SqlTraceMetrics(
-                                        request_id=trace_id, key=key, value=float(value)
-                                    )
-                                )
 
                 # Cost metadata — skip only if start_trace() has already written the
                 # authoritative value (flag set AND existing record present). If the flag
@@ -4835,13 +4852,11 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                         recorded_cost = update_cost(
                             existing_record.value if existing_record else {}, aggregated_cost
                         )
-                        session.merge(
-                            SqlTraceMetadata(
-                                request_id=trace_id,
-                                key=TraceMetadataKey.COST,
-                                value=json.dumps(recorded_cost),
-                            )
-                        )
+                        metadata_rows.append({
+                            "request_id": trace_id,
+                            "key": TraceMetadataKey.COST,
+                            "value": json.dumps(recorded_cost),
+                        })
 
                 # Session ID metadata
                 if (
@@ -4849,33 +4864,19 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                     and trace_id not in existing_sessions
                     and trace_id not in finalized_trace_ids
                 ):
-                    session.merge(
-                        SqlTraceMetadata(
-                            request_id=trace_id,
-                            key=TraceMetadataKey.TRACE_SESSION,
-                            value=agg.session_id,
-                        )
-                    )
+                    metadata_rows.append({
+                        "request_id": trace_id,
+                        "key": TraceMetadataKey.TRACE_SESSION,
+                        "value": agg.session_id,
+                    })
 
                 # User ID metadata
-                if agg.user_id:
-                    existing_user_id = (
-                        session
-                        .query(SqlTraceMetadata)
-                        .filter(
-                            SqlTraceMetadata.request_id == trace_id,
-                            SqlTraceMetadata.key == TraceMetadataKey.TRACE_USER,
-                        )
-                        .one_or_none()
-                    )
-                    if not existing_user_id:
-                        session.merge(
-                            SqlTraceMetadata(
-                                request_id=trace_id,
-                                key=TraceMetadataKey.TRACE_USER,
-                                value=agg.user_id,
-                            )
-                        )
+                if agg.user_id and trace_id not in existing_user_ids:
+                    metadata_rows.append({
+                        "request_id": trace_id,
+                        "key": TraceMetadataKey.TRACE_USER,
+                        "value": agg.user_id,
+                    })
 
                 if update_dict:
                     self._trace_query(session, for_update_or_delete=True).filter(
@@ -4888,13 +4889,16 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                     )
                 # Mark that spans are stored in the tracking store DB (required for
                 # concurrent calls that create or update the trace info).
-                session.merge(
-                    SqlTraceTag(
-                        request_id=trace_id,
-                        key=TraceTagKey.SPANS_LOCATION,
-                        value=SpansLocation.TRACKING_STORE.value,
-                    )
-                )
+                tag_rows.append({
+                    "request_id": trace_id,
+                    "key": TraceTagKey.SPANS_LOCATION,
+                    "value": SpansLocation.TRACKING_STORE.value,
+                })
+
+            # --- Phase 6: Bulk upsert all accumulated metadata/metrics/tag rows ---
+            _bulk_upsert(session, SqlTraceMetadata, metadata_rows)
+            _bulk_upsert(session, SqlTraceMetrics, metric_rows)
+            _bulk_upsert(session, SqlTraceTag, tag_rows)
 
         return spans
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #N/A

### What changes are proposed in this pull request?

Phase 5 of `SqlAlchemyStore.log_spans()` previously called `session.merge()` up to ~10 times per trace (one per `TokenUsageKey` metric plus `TOKEN_USAGE`, `COST`, `TRACE_SESSION`, `TRACE_USER`, and `SPANS_LOCATION` rows), each costing a `SELECT` + `INSERT`/`UPDATE` round-trip, and issued a separate per-trace `SELECT` to look up existing `TRACE_USER` rows.

This PR:

- Accumulates those rows into three lists during the existing per-trace loop and flushes them via three `_bulk_upsert` calls after the loop (new Phase 6).
- Hoists the `TRACE_USER` existence check into Phase 4 as a single batch query, mirroring the existing `TRACE_SESSION` batch fetch.
- Leaves the per-trace `SqlTraceInfo` `UPDATE` untouched — it relies on `case()` expressions for atomic `min`/`max` time-range merging across concurrent writers and is not trivially batchable.

Measured impact (full-metadata batches — spans carrying token usage, cost, session id, user id, and model attributes):

| DB         | N traces/batch | before   | after    | speedup | queries |
|-----------:|---------------:|---------:|---------:|--------:|--------:|
| Postgres 16 |            10 |   446 ms |    89 ms |   5.0x  | 247 → 41 |
| Postgres 16 |            50 |  2013 ms |   283 ms |   7.1x  | 1208 → 165 |
| Postgres 16 |           100 |  3632 ms |   532 ms |   6.8x  | 2409 → 320 |
| Postgres 16 |           200 |  7627 ms |  1080 ms |   7.1x  | 4813 → 634 |
| SQLite     |           100 |   374 ms |   140 ms |   2.7x  | 2415 → 425 |
| SQLite     |           200 |   744 ms |   272 ms |   2.7x  | 4819 → 839 |

Correctness was verified by running identical `log_spans` batches through the old and new code paths and comparing the resulting `trace_info`, `trace_tags`, `trace_request_metadata`, `trace_metrics`, and `spans` rows (identical in every field), and by running the full existing `log_spans`/tracing pytest suite (358 tests) plus the workspace-aware variants (165 tests).

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

`tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store.py` covers both the workspace-enabled and workspace-disabled paths for `log_spans`, including the token-usage, cost, session, user, trace-status, and time-range branches of Phase 5. All pass.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release