### PR TITLE
Support \`X-Mlflow-Authorization\` as alternative auth header

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -1755,7 +1755,7 @@ def get_auth_func(authorization_function: str) -> Callable[[], Authorization | R
 def authenticate_request_basic_auth() -> Authorization | Response:
     """Authenticate the request using basic auth."""
     authorization = request.authorization
-    if authorization is None:
+    if authorization is None and not request.headers.get("Authorization"):
         if alt_auth := request.headers.get("X-Mlflow-Authorization"):
             try:
                 scheme, credentials = alt_auth.split(None, 1)

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -1754,13 +1754,27 @@ def get_auth_func(authorization_function: str) -> Callable[[], Authorization | R
 
 def authenticate_request_basic_auth() -> Authorization | Response:
     """Authenticate the request using basic auth."""
-    if request.authorization is None:
+    authorization = request.authorization
+    if authorization is None:
+        if alt_auth := request.headers.get("X-Mlflow-Authorization"):
+            try:
+                scheme, credentials = alt_auth.split(None, 1)
+                if scheme.lower() == "basic":
+                    decoded = base64.b64decode(credentials).decode("ascii")
+                    username, _, password = decoded.partition(":")
+                    authorization = Authorization(
+                        "basic", {"username": username, "password": password}
+                    )
+            except Exception:
+                pass
+
+    if authorization is None:
         return make_basic_auth_response()
 
-    username = request.authorization.username
-    password = request.authorization.password
+    username = authorization.username
+    password = authorization.password
     if store.authenticate_user(username, password):
-        return request.authorization
+        return authorization
     else:
         # let user attempt login again
         return make_basic_auth_response()
@@ -2953,10 +2967,10 @@ def _authenticate_fastapi_request(request: StarletteRequest) -> User | None:
     Returns:
         User object if authentication succeeds, None otherwise.
     """
-    if "Authorization" not in request.headers:
+    auth = request.headers.get("Authorization") or request.headers.get("X-Mlflow-Authorization")
+    if auth is None:
         return None
 
-    auth = request.headers["Authorization"]
     try:
         scheme, credentials = auth.split()
         if scheme.lower() != "basic":

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -1756,7 +1756,7 @@ def authenticate_request_basic_auth() -> Authorization | Response:
     """Authenticate the request using basic auth."""
     authorization = request.authorization
     if authorization is None and not request.headers.get("Authorization"):
-        if alt_auth := request.headers.get("X-Mlflow-Authorization"):
+        if alt_auth := request.headers.get("x-mlflow-authorization"):
             try:
                 scheme, credentials = alt_auth.split(None, 1)
                 if scheme.lower() == "basic":
@@ -2967,7 +2967,7 @@ def _authenticate_fastapi_request(request: StarletteRequest) -> User | None:
     Returns:
         User object if authentication succeeds, None otherwise.
     """
-    auth = request.headers.get("Authorization") or request.headers.get("X-Mlflow-Authorization")
+    auth = request.headers.get("Authorization") or request.headers.get("x-mlflow-authorization")
     if auth is None:
         return None
 

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -104,6 +104,17 @@ def test_authenticate(client, monkeypatch):
         client.search_experiments()
 
 
+def test_x_mlflow_authorization_header(client):
+    username, password = create_user(client.tracking_uri)
+    credentials = base64.b64encode(f"{username}:{password}".encode()).decode("ascii")
+    response = requests.post(
+        f"{client.tracking_uri}/api/2.0/mlflow/experiments/search",
+        headers={"X-Mlflow-Authorization": f"Basic {credentials}"},
+        json={"max_results": 100},
+    )
+    assert response.status_code == 200
+
+
 @pytest.mark.parametrize(
     ("username", "password"),
     [
@@ -3247,3 +3258,47 @@ def test_fastapi_malformed_authorization_header(mock_auth_store, mock_auth_confi
     user = _authenticate_fastapi_request(request)
 
     assert user is None
+
+
+# -- X-Mlflow-Authorization fallback header --
+
+
+def _make_request_with_mlflow_auth_header(path, mlflow_authorization):
+    request = mock.Mock()
+    request.url.path = path
+    request.headers = {"X-Mlflow-Authorization": mlflow_authorization}
+    return request
+
+
+def test_fastapi_x_mlflow_authorization_header_used_when_no_authorization(
+    mock_auth_store, mock_auth_config, monkeypatch
+):
+    monkeypatch.delenv(_MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN.name, raising=False)
+    credentials = base64.b64encode(b"alice:password123").decode("ascii")
+    request = _make_request_with_mlflow_auth_header(
+        "/api/3.0/mlflow/experiments/list", f"Basic {credentials}"
+    )
+
+    user = _authenticate_fastapi_request(request)
+
+    assert user.username == "alice"
+    mock_auth_store.authenticate_user.assert_called_once_with("alice", "password123")
+
+
+def test_fastapi_authorization_header_takes_precedence_over_x_mlflow_authorization(
+    mock_auth_store, mock_auth_config, monkeypatch
+):
+    monkeypatch.delenv(_MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN.name, raising=False)
+    credentials_alice = base64.b64encode(b"alice:password123").decode("ascii")
+    credentials_bob = base64.b64encode(b"bob:password456").decode("ascii")
+    request = mock.Mock()
+    request.url.path = "/api/3.0/mlflow/experiments/list"
+    request.headers = {
+        "Authorization": f"Basic {credentials_alice}",
+        "X-Mlflow-Authorization": f"Basic {credentials_bob}",
+    }
+
+    user = _authenticate_fastapi_request(request)
+
+    assert user.username == "alice"
+    mock_auth_store.authenticate_user.assert_called_once_with("alice", "password123")

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -109,7 +109,7 @@ def test_x_mlflow_authorization_header(client):
     credentials = base64.b64encode(f"{username}:{password}".encode()).decode("ascii")
     response = requests.post(
         f"{client.tracking_uri}/api/2.0/mlflow/experiments/search",
-        headers={"X-Mlflow-Authorization": f"Basic {credentials}"},
+        headers={"x-mlflow-authorization": f"Basic {credentials}"},
         json={"max_results": 100},
     )
     assert response.status_code == 200
@@ -122,7 +122,7 @@ def test_authorization_header_takes_precedence_over_x_mlflow_authorization(clien
         f"{client.tracking_uri}/api/2.0/mlflow/experiments/search",
         headers={
             "Authorization": "Bearer invalid-token",
-            "X-Mlflow-Authorization": f"Basic {credentials}",
+            "x-mlflow-authorization": f"Basic {credentials}",
         },
         json={"max_results": 100},
     )
@@ -3274,7 +3274,7 @@ def test_fastapi_malformed_authorization_header(mock_auth_store, mock_auth_confi
     assert user is None
 
 
-# -- X-Mlflow-Authorization fallback header --
+# -- x-mlflow-authorization fallback header --
 
 
 def test_fastapi_x_mlflow_authorization_header_used_when_no_authorization(
@@ -3283,7 +3283,7 @@ def test_fastapi_x_mlflow_authorization_header_used_when_no_authorization(
     monkeypatch.delenv(_MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN.name, raising=False)
     credentials = base64.b64encode(b"alice:password123").decode("ascii")
     request = _make_request("/api/3.0/mlflow/experiments/list")
-    request.headers = {"X-Mlflow-Authorization": f"Basic {credentials}"}
+    request.headers = {"x-mlflow-authorization": f"Basic {credentials}"}
 
     user = _authenticate_fastapi_request(request)
 
@@ -3301,7 +3301,7 @@ def test_fastapi_authorization_header_takes_precedence_over_x_mlflow_authorizati
     request.url.path = "/api/3.0/mlflow/experiments/list"
     request.headers = {
         "Authorization": f"Basic {credentials_alice}",
-        "X-Mlflow-Authorization": f"Basic {credentials_bob}",
+        "x-mlflow-authorization": f"Basic {credentials_bob}",
     }
 
     user = _authenticate_fastapi_request(request)

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -115,6 +115,20 @@ def test_x_mlflow_authorization_header(client):
     assert response.status_code == 200
 
 
+def test_authorization_header_takes_precedence_over_x_mlflow_authorization(client):
+    username, password = create_user(client.tracking_uri)
+    credentials = base64.b64encode(f"{username}:{password}".encode()).decode("ascii")
+    response = requests.post(
+        f"{client.tracking_uri}/api/2.0/mlflow/experiments/search",
+        headers={
+            "Authorization": "Bearer invalid-token",
+            "X-Mlflow-Authorization": f"Basic {credentials}",
+        },
+        json={"max_results": 100},
+    )
+    assert response.status_code == 401
+
+
 @pytest.mark.parametrize(
     ("username", "password"),
     [
@@ -3263,21 +3277,13 @@ def test_fastapi_malformed_authorization_header(mock_auth_store, mock_auth_confi
 # -- X-Mlflow-Authorization fallback header --
 
 
-def _make_request_with_mlflow_auth_header(path, mlflow_authorization):
-    request = mock.Mock()
-    request.url.path = path
-    request.headers = {"X-Mlflow-Authorization": mlflow_authorization}
-    return request
-
-
 def test_fastapi_x_mlflow_authorization_header_used_when_no_authorization(
     mock_auth_store, mock_auth_config, monkeypatch
 ):
     monkeypatch.delenv(_MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN.name, raising=False)
     credentials = base64.b64encode(b"alice:password123").decode("ascii")
-    request = _make_request_with_mlflow_auth_header(
-        "/api/3.0/mlflow/experiments/list", f"Basic {credentials}"
-    )
+    request = _make_request("/api/3.0/mlflow/experiments/list")
+    request.headers = {"X-Mlflow-Authorization": f"Basic {credentials}"}
 
     user = _authenticate_fastapi_request(request)
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/22785/files) to review incremental changes.
- [**stack/x-mlflow-authorization-header**](https://github.com/mlflow/mlflow/pull/22785) [[Files changed](https://github.com/mlflow/mlflow/pull/22785/files)]

---------
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

Adds support for `X-Mlflow-Authorization` as an alternative to the standard `Authorization` HTTP header in the MLflow auth app. This allows clients that cannot set the `Authorization` header (e.g., due to proxy stripping or framework restrictions) to authenticate using `X-Mlflow-Authorization` instead.

- In the Flask path (`authenticate_request_basic_auth`): falls back to `X-Mlflow-Authorization` when `Authorization` is absent, parses the Basic auth credentials, and constructs a Werkzeug `Authorization` object.
- In the FastAPI/Starlette path (`_authenticate_fastapi_request`): falls back to `X-Mlflow-Authorization` when `Authorization` is absent. The standard `Authorization` header takes precedence when both are present.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

New tests:
- `test_x_mlflow_authorization_header` — Flask integration test verifying the header authenticates successfully against a live server
- `test_fastapi_x_mlflow_authorization_header_used_when_no_authorization` — unit test for FastAPI path
- `test_fastapi_authorization_header_takes_precedence_over_x_mlflow_authorization` — unit test verifying `Authorization` wins when both headers are present

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Adds support for `X-Mlflow-Authorization` as an alternative to the `Authorization` header in the MLflow auth app, enabling clients that cannot set `Authorization` (e.g., due to proxy stripping) to authenticate.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none`
- [ ] `rn/breaking-change`
- [x] `rn/feature`
- [ ] `rn/bug-fix`
- [ ] `rn/documentation`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release