### PR TITLE
Reduce memory creep from `online_scoring_scheduler` periodic task

### DIFF
--- a/mlflow/server/jobs/utils.py
+++ b/mlflow/server/jobs/utils.py
@@ -767,11 +767,11 @@ def register_periodic_tasks(huey_instance) -> None:
     """
     from huey import crontab
 
-    @huey_instance.periodic_task(crontab(minute="*/1"))
-    # Prevent concurrent execution if scheduler takes longer than 1 minute.
+    @huey_instance.periodic_task(crontab(minute="*/5"))
+    # Prevent concurrent execution if scheduler takes longer than the interval.
     @huey_instance.lock_task("online-scoring-scheduler-lock")
     def online_scoring_scheduler():
-        """Runs every minute to fetch active scorer configs and submit scoring jobs."""
+        """Runs every 5 minutes to fetch active scorer configs and submit scoring jobs."""
         from mlflow.genai.scorers.job import run_online_scoring_scheduler
 
         try:
@@ -779,4 +779,4 @@ def register_periodic_tasks(huey_instance) -> None:
         except Exception as e:
             _logger.exception(f"Online scoring scheduler failed: {e!r}")
 
-    _logger.info("Registered online_scoring_scheduler periodic task (runs every 1 minute)")
+    _logger.info("Registered online_scoring_scheduler periodic task (runs every 5 minutes)")


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22792

### What changes are proposed in this pull request?

The dedicated Huey consumer for periodic tasks writes ~32 KB of frames to `periodic_tasks.mlflow-huey-store-wal` every minute — even when no online scorers are configured — from the lock put/pop + task enqueue/dequeue path around `online_scoring_scheduler`. Over a long-running tracking server this produces steady WAL churn in `/dev/shm` and a slow Python-heap creep in the consumer process, as reported in #22792.

Lower the `online_scoring_scheduler` cron from `*/1` to `*/5` in `mlflow/server/jobs/utils.py`. The scheduler only enqueues scoring jobs whose own cadence is governed by their config, so a 5-minute pickup window is acceptable and cuts WAL churn and scheduler-driven heap churn by ~5×.

An earlier revision of this PR also set `cache_mb=1` on the `SqliteHuey` instances, but a 45-minute side-by-side Docker run with stock vs `cache_mb=1` (both at `*/1`) showed the knob was a no-op: WAL grew at an identical rate in both, and VmData drift was statistically indistinguishable. SQLite's `cache_size` is a cap, not a preallocation, and huey's tiny queue tables never fill the default 8 MB. Dropped to keep the fix minimal.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Reproduced the Docker setup from #22792 on `ghcr.io/mlflow/mlflow:v3.11.1` with the same env vars, running stock v3.11.1 and a patched image side-by-side. The `*/5` cron is the lever that moves both WAL churn and periodic-consumer heap drift; see the commit message for details.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Reduce slow memory growth in the MLflow tracking server when server-side jobs are enabled. The `online_scoring_scheduler` now runs every 5 minutes (previously every minute).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
