### PR TITLE
[Trace UI Improvement][1/6] Condense chat messages

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessage.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessage.tsx
@@ -343,8 +343,6 @@ export function ModelTraceExplorerChatMessage({
         display: 'flex',
         flexDirection: 'column',
         width: '100%',
-        borderRadius: theme.borders.borderRadiusSm,
-        border: `1px solid ${theme.colors.border}`,
         backgroundColor: theme.colors.backgroundPrimary,
         overflow: 'hidden',
       }}
@@ -375,20 +373,17 @@ export function ModelTraceExplorerChatMessage({
         )}
       </div>
       {isExpandable && (
-        <Button
+        <Typography.Link
           componentId={
             expanded
               ? 'shared.model-trace-explorer.chat-message-see-less'
               : 'shared.model-trace-explorer.chat-message-see-more'
           }
-          icon={expanded ? <ChevronUpIcon /> : <ChevronDownIcon />}
-          type="tertiary"
           onClick={() => setExpanded(!expanded)}
           css={{
+            padding: theme.spacing.sm,
             display: 'flex',
-            width: '100%',
-            padding: theme.spacing.md,
-            borderRadius: '0px !important',
+            alignItems: 'center',
           }}
         >
           {expanded ? (
@@ -402,7 +397,7 @@ export function ModelTraceExplorerChatMessage({
               description="A button label in a message renderer that expands truncated content when clicked."
             />
           )}
-        </Button>
+        </Typography.Link>
       )}
     </div>
   );

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessageHeader.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessageHeader.tsx
@@ -104,7 +104,6 @@ export const ModelTraceExplorerChatMessageHeader = ({
       }}
       onClick={() => setExpanded(!expanded)}
     >
-      {isExpandable && (expanded ? <ChevronDownIcon /> : <ChevronRightIcon />)}
       {getRoleIcon(message.role)}
       {message.tool_call_id ? (
         <Typography.Text

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerConversation.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerConversation.tsx
@@ -17,11 +17,23 @@ export function ModelTraceExplorerConversation({ messages }: { messages: ModelTr
       css={{
         display: 'flex',
         flexDirection: 'column',
-        gap: theme.spacing.sm,
+        border: `1px solid ${theme.colors.border}`,
+        borderRadius: theme.borders.borderRadiusSm,
       }}
     >
       {messages.map((message, index) => (
-        <ModelTraceExplorerChatMessage key={index} message={message} />
+        <ModelTraceExplorerChatMessage
+          css={{
+            borderTop: index > 0 ? `1px solid ${theme.colors.border}` : undefined,
+            // need to set radius for first and last message, otherwise the border will be cut off
+            borderTopLeftRadius: index > 0 ? undefined : theme.borders.borderRadiusSm,
+            borderTopRightRadius: index > 0 ? undefined : theme.borders.borderRadiusSm,
+            borderBottomLeftRadius: index === messages.length - 1 ? theme.borders.borderRadiusSm : undefined,
+            borderBottomRightRadius: index === messages.length - 1 ? theme.borders.borderRadiusSm : undefined,
+          }}
+          key={index}
+          message={message}
+        />
       ))}
     </div>
   );


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/22800/files) to review incremental changes.
- [**stack/simplify-trace-ui-1**](https://github.com/mlflow/mlflow/pull/22800) [[Files changed](https://github.com/mlflow/mlflow/pull/22800/files)]
  - [stack/simplify-trace-ui-2](https://github.com/mlflow/mlflow/pull/22801) [[Files changed](https://github.com/mlflow/mlflow/pull/22801/files/bf6dcb4f1c491e721a58a3ee54bab820df259d63..337a214388b4924ed2954211a8648ffe79f2991a)]
    - [stack/simplify-trace-ui-3](https://github.com/mlflow/mlflow/pull/22802) [[Files changed](https://github.com/mlflow/mlflow/pull/22802/files/337a214388b4924ed2954211a8648ffe79f2991a..58cc68ffa8ebf823ba131374d14b81393f66a743)]
      - [stack/simplify-trace-ui-4](https://github.com/mlflow/mlflow/pull/22803) [[Files changed](https://github.com/mlflow/mlflow/pull/22803/files/58cc68ffa8ebf823ba131374d14b81393f66a743..d2f4db459fb6cd6414bbc5e613975e68575daea0)]
        - [stack/simplify-trace-ui-5](https://github.com/mlflow/mlflow/pull/22804) [[Files changed](https://github.com/mlflow/mlflow/pull/22804/files/d2f4db459fb6cd6414bbc5e613975e68575daea0..a817976bf6dd1c097c6eeb4da09c5a97e869135e)]
          - [stack/simplify-trace-ui-6](https://github.com/mlflow/mlflow/pull/22805) [[Files changed](https://github.com/mlflow/mlflow/pull/22805/files/a817976bf6dd1c097c6eeb4da09c5a97e869135e..7bdf1ad7e4b4e46585fbf8b42c73fe7d368271b1)]

---------
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

This PR stack is aimed at reducing the boxiness of the trace UI, making it feel less overwhelming.

This PR condenses the rendering for chat messages, so they are in one block rather than separated bubbles. By itself it does not help much but take a look at the next PRs to see the end state.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Before:

<img width="1392" height="963" alt="Screenshot 2026-04-23 at 9 48 32 AM" src="https://github.com/user-attachments/assets/e9fb075a-89ab-4d8d-a240-592b0711f3ff" />

After

<img width="1392" height="962" alt="Screenshot 2026-04-23 at 9 46 55 AM" src="https://github.com/user-attachments/assets/18a939f6-f7bb-4c7e-9877-5433e80d4a46" />


### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
