### PR TITLE
[Trace UI Improvements][3/6] Unnest one layer of boxes from messages

### DIFF
--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -4187,6 +4187,10 @@
     "defaultMessage": "View chat session",
     "description": "Tooltip for the session id tag"
   },
+  "OW3pF8": {
+    "defaultMessage": "Show {count} more intermediate {count, plural, =1 {step} other {steps}}",
+    "description": "Link that expands a collapsed list of intermediate function execution steps when clicked"
+  },
   "OWCfFp": {
     "defaultMessage": "Promote {sourceModelName} version {sourceModelVersion}",
     "description": "Modal title to promote the model to a different registered model"
@@ -7038,10 +7042,6 @@
   "g+YDB/": {
     "defaultMessage": "Group by",
     "description": "Label for the grouping selector button in the logged model list page when no grouping is selected"
-  },
-  "g/6rnt": {
-    "defaultMessage": "Show {count} more intermediate steps",
-    "description": "Link that expands a collapsed list of intermediate function execution steps when clicked"
   },
   "g0tloS": {
     "defaultMessage": "Context sufficiency assessment is missing. This is likely because your agent is not returning retrieved_context.",

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerCodeSnippet.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerCodeSnippet.tsx
@@ -78,18 +78,8 @@ export function ModelTraceExplorerCodeSnippet({
   }, [dataIsString, initialRenderMode]);
 
   return (
-    <div
-      css={{
-        position: 'relative',
-      }}
-    >
-      <div
-        css={{
-          borderRadius: theme.borders.borderRadiusSm,
-          border: `1px solid ${theme.colors.border}`,
-          overflow: 'hidden',
-        }}
-      >
+    <div css={{ position: 'relative' }}>
+      <div css={{ overflow: 'hidden' }}>
         {(title || shouldShowRenderModeDropdown) && (
           <div
             css={{
@@ -97,7 +87,8 @@ export function ModelTraceExplorerCodeSnippet({
               flexDirection: 'row',
               justifyContent: 'space-between',
               alignItems: 'center',
-              padding: theme.spacing.sm,
+              paddingInline: theme.spacing.sm,
+              paddingBlock: theme.spacing.xs,
             }}
           >
             {/* TODO: support other types of formatting, e.g. markdown */}
@@ -107,6 +98,7 @@ export function ModelTraceExplorerCodeSnippet({
                 overflow: 'hidden',
                 textOverflow: 'ellipsis',
                 whiteSpace: 'nowrap',
+                marginLeft: theme.spacing.xs,
               }}
               level={4}
               color="secondary"
@@ -163,14 +155,23 @@ export function ModelTraceExplorerCodeSnippet({
             </div>
           </div>
         )}
-        <ModelTraceExplorerCodeSnippetBody
-          data={data}
-          searchFilter={searchFilter}
-          activeMatch={activeMatch}
-          containsActiveMatch={containsActiveMatch}
-          renderMode={renderMode}
-          initialExpanded={initialExpanded}
-        />
+        <div
+          css={{
+            overflow: 'hidden',
+            border: `1px solid ${theme.colors.border}`,
+            borderRadius: theme.borders.borderRadiusSm,
+            marginInline: theme.spacing.sm,
+          }}
+        >
+          <ModelTraceExplorerCodeSnippetBody
+            data={data}
+            searchFilter={searchFilter}
+            activeMatch={activeMatch}
+            containsActiveMatch={containsActiveMatch}
+            renderMode={renderMode}
+            initialExpanded={initialExpanded}
+          />
+        </div>
       </div>
     </div>
   );

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerFieldRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerFieldRenderer.tsx
@@ -94,9 +94,8 @@ export const ModelTraceExplorerFieldRenderer = ({
         css={{
           display: 'flex',
           flexDirection: 'column',
-          gap: theme.spacing.sm,
+          gap: theme.spacing.xs,
           padding: theme.spacing.sm,
-          border: `1px solid ${theme.colors.border}`,
           borderRadius: theme.borders.borderRadiusSm,
         }}
       >

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerRetrieverFieldRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerRetrieverFieldRenderer.tsx
@@ -27,6 +27,7 @@ export const ModelTraceExplorerRetrieverFieldRenderer = ({
         backgroundColor: theme.colors.backgroundPrimary,
         borderRadius: theme.borders.borderRadiusSm,
         border: `1px solid ${theme.colors.border}`,
+        marginInline: theme.spacing.sm,
       }}
     >
       {title && (

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerTextFieldRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerTextFieldRenderer.tsx
@@ -14,14 +14,9 @@ export const ModelTraceExplorerTextFieldRenderer = ({ title, value }: { title: s
   const displayValue =
     !expanded && value.length > STRING_TRUNCATION_LIMIT ? value.slice(0, STRING_TRUNCATION_LIMIT) + '...' : value;
 
-  const hoverStyles = isExpandable
-    ? { ':hover': { backgroundColor: theme.colors.actionIconBackgroundHover, cursor: 'pointer' } }
-    : {};
-
   return (
     <div
       css={{
-        border: `1px solid ${theme.colors.border}`,
         borderRadius: theme.borders.borderRadiusSm,
       }}
     >
@@ -32,15 +27,13 @@ export const ModelTraceExplorerTextFieldRenderer = ({ title, value }: { title: s
             display: 'flex',
             justifyContent: 'space-between',
             alignItems: 'center',
-            padding: `${theme.spacing.sm}px ${theme.spacing.sm + theme.spacing.xs}px`,
-            ...hoverStyles,
+            paddingInline: theme.spacing.sm,
+            marginBottom: theme.spacing.xs,
           }}
-          onClick={() => setExpanded(!expanded)}
         >
-          <Typography.Title level={4} color="secondary" withoutMargins>
+          <Typography.Title css={{ marginLeft: theme.spacing.xs }} level={4} color="secondary" withoutMargins>
             {title}
           </Typography.Title>
-          {isExpandable && (expanded ? <ChevronDownIcon /> : <ChevronRightIcon />)}
         </div>
       )}
       <div
@@ -48,10 +41,11 @@ export const ModelTraceExplorerTextFieldRenderer = ({ title, value }: { title: s
           display: 'flex',
           flexDirection: 'column',
           gap: theme.spacing.sm,
-          paddingLeft: theme.spacing.sm + theme.spacing.xs,
-          paddingRight: theme.spacing.sm + theme.spacing.xs,
-          paddingTop: title ? 0 : theme.spacing.sm,
-          paddingBottom: theme.spacing.sm,
+          marginInline: theme.spacing.sm,
+          paddingInline: theme.spacing.sm,
+          paddingBlock: theme.spacing.sm,
+          border: `1px solid ${theme.colors.border}`,
+          borderRadius: theme.borders.borderRadiusSm,
           // get rid of last margin in markdown renderer
           '& > div:last-of-type': {
             marginBottom: 0,

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/summary-view/ModelTraceExplorerSummarySpans.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/summary-view/ModelTraceExplorerSummarySpans.tsx
@@ -157,7 +157,7 @@ export const ModelTraceExplorerSummarySpans = ({
               onClick={() => setIntermediateNodesExpanded(true)}
             >
               <FormattedMessage
-                defaultMessage="Show {count} more intermediate steps"
+                defaultMessage="Show {count} more intermediate {count, plural, =1 {step} other {steps}}"
                 description="Link that expands a collapsed list of intermediate function execution steps when clicked"
                 values={{
                   count: intermediateNodes.length - INTERMEDIATE_NODES_TRUNCATION_LIMIT,


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/22802/files) to review incremental changes.
- [**stack/simplify-trace-ui-3**](https://github.com/mlflow/mlflow/pull/22802) [[Files changed](https://github.com/mlflow/mlflow/pull/22802/files)]
  - [stack/simplify-trace-ui-4](https://github.com/mlflow/mlflow/pull/22803) [[Files changed](https://github.com/mlflow/mlflow/pull/22803/files/bb2ae3c3be96f7a2055a21ee87cc7ab93b6222bc..690cb72c0f4981b87b599cb642f99a9d870e22d9)]
    - [stack/simplify-trace-ui-5](https://github.com/mlflow/mlflow/pull/22804) [[Files changed](https://github.com/mlflow/mlflow/pull/22804/files/690cb72c0f4981b87b599cb642f99a9d870e22d9..914419f19aecc49a56a236e01970856411048ff4)]
      - [stack/simplify-trace-ui-6](https://github.com/mlflow/mlflow/pull/22805) [[Files changed](https://github.com/mlflow/mlflow/pull/22805/files/914419f19aecc49a56a236e01970856411048ff4..8cd9af8fa8f8295bd51218590c50c89df140dcf3)]

---------
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

This PR reduces one more layer of nesting by removing the box around input/output items


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Before:

<img width="1392" height="963" alt="Screenshot 2026-04-23 at 9 48 53 AM" src="https://github.com/user-attachments/assets/b22ea3ff-1abd-45fc-bd37-c3a033549ab4" />

After:

<img width="1389" height="962" alt="Screenshot 2026-04-23 at 9 51 02 AM" src="https://github.com/user-attachments/assets/e09b67cc-0a8a-402a-a21c-6bcca0775bad" />


### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
