### PR TITLE
[Trace UI Improvements][4/6] Minor alignment fixes

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionPage.tsx
@@ -231,6 +231,8 @@ const ExperimentSingleChatSessionPageImpl = () => {
             <div
               css={{
                 height: '100%',
+                display: 'flex',
+                flexDirection: 'column',
                 marginLeft: -theme.spacing.lg,
                 marginRight: -theme.spacing.lg,
                 marginBottom: -theme.spacing.lg,

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/GenAiEvaluationTracesReviewModal.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/GenAiEvaluationTracesReviewModal.tsx
@@ -240,7 +240,16 @@ export const GenAiEvaluationTracesReviewModal = React.memo(
           // Show ModelTraceExplorer only if there is no run to compare to and there's trace data.
           ((shouldFetchTraceBySearchParamId && traceBySearchParamQueryResult?.data) || isSingleTraceView) &&
           !isNil(currentTraceQueryResult.data) ? (
-            <div css={{ height: 'calc(100% - 34px)', marginLeft: -theme.spacing.lg, marginRight: -theme.spacing.lg }}>
+            <div
+              css={{
+                height: '100%',
+                marginLeft: -theme.spacing.lg,
+                marginRight: -theme.spacing.lg,
+                marginBottom: -theme.spacing.lg,
+                display: 'flex',
+                flexDirection: 'column',
+              }}
+            >
               {/* prettier-ignore */}
               <ModelTraceExplorerModalBody
                 traceData={currentTraceQueryResult.data}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerContent.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerContent.tsx
@@ -44,8 +44,8 @@ export const ModelTraceExplorerContent = ({
           flexShrink: 0,
         },
         display: 'flex',
+        flex: 1,
         flexDirection: 'column',
-        height: '100%',
         overflow: 'hidden',
       }}
     >

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessage.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessage.tsx
@@ -2,10 +2,8 @@ import { isNil } from 'lodash';
 import { useState } from 'react';
 
 import {
-  Button,
   ChevronDownIcon,
   ChevronRightIcon,
-  ChevronUpIcon,
   LightbulbIcon,
   Modal,
   Spinner,

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessageHeader.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessageHeader.tsx
@@ -1,10 +1,4 @@
-import {
-  ChevronRightIcon,
-  ChevronDownIcon,
-  Typography,
-  useDesignSystemTheme,
-  Tooltip,
-} from '@databricks/design-system';
+import { Typography, useDesignSystemTheme, Tooltip } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
 
 import type { ModelTraceChatMessage } from '../ModelTrace.types';

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerRightPaneTabs.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerRightPaneTabs.tsx
@@ -90,7 +90,7 @@ function ModelTraceExplorerRightPaneTabsImpl({
         <div
           css={{
             position: 'absolute',
-            right: theme.spacing.md,
+            right: theme.spacing.sm,
             top: theme.spacing.xs,
             zIndex: 1,
             backgroundColor: theme.colors.backgroundPrimary,

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/summary-view/ModelTraceExplorerSummarySpans.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/summary-view/ModelTraceExplorerSummarySpans.tsx
@@ -75,7 +75,7 @@ export const ModelTraceExplorerSummarySpans = ({
     >
       {!hideRenderModeSelector && (
         <div css={{ display: 'flex', flexDirection: 'row', justifyContent: 'flex-end', marginBlock: theme.spacing.sm }}>
-          <div css={{ display: 'flex', gap: theme.spacing.sm }}>
+          <div css={{ display: 'flex', gap: theme.spacing.sm, paddingInline: theme.spacing.sm }}>
             <SegmentedControlGroup
               name="render-mode"
               componentId="shared.model-trace-explorer.summary-view.render-mode"


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/22803/files) to review incremental changes.
- [**stack/simplify-trace-ui-4**](https://github.com/mlflow/mlflow/pull/22803) [[Files changed](https://github.com/mlflow/mlflow/pull/22803/files)]
  - [stack/simplify-trace-ui-5](https://github.com/mlflow/mlflow/pull/22804) [[Files changed](https://github.com/mlflow/mlflow/pull/22804/files/cc50023a9de2bb744b0c45e931bb47b235b2ba3d..e338821ea607949f94ce61a08281867d0de27dd1)]
    - [stack/simplify-trace-ui-6](https://github.com/mlflow/mlflow/pull/22805) [[Files changed](https://github.com/mlflow/mlflow/pull/22805/files/e338821ea607949f94ce61a08281867d0de27dd1..e9de437e2e7354879322b7298f93b517d25f6e9e)]

---------
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

1. I noticed somehow you can scroll the entire modal which is weird, seems to be caused by some padding changes in the modal? Fixed in this PR
2. Alignment of the assessment pane toggle is inconsistent, fixed in this PR


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Before (scrolling):


https://github.com/user-attachments/assets/027f4381-1da6-4277-a8b4-3d1ab7642102


After (fixed)


Before (alignment)

| | Summary | Detail
|---|---|----|
| Before | <img width="1115" height="359" alt="Screenshot 2026-04-23 at 10 30 30 AM" src="https://github.com/user-attachments/assets/9bf955e1-666b-4c52-b55a-14881dbe8420" /> | <img width="1114" height="415" alt="Screenshot 2026-04-23 at 10 30 37 AM" src="https://github.com/user-attachments/assets/c9f0a67f-0f6d-4ae3-a6f1-24b17eb23649" /> |
|---|---|---|
| After |  <img width="1115" height="439" alt="Screenshot 2026-04-23 at 10 30 11 AM" src="https://github.com/user-attachments/assets/05d6f1bf-1a9d-4d8b-b999-236c149cf035" /> | <img width="1114" height="400" alt="Screenshot 2026-04-23 at 10 30 16 AM" src="https://github.com/user-attachments/assets/1f109d9c-f399-4f0c-bc36-f95fbf48f1b7" /> |





### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
