### PR TITLE
[Trace UI Improvements][5/6] Beautify json renderer

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/CollapsibleJsonViewer.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/CollapsibleJsonViewer.test.tsx
@@ -229,8 +229,8 @@ describe('CollapsibleJsonViewer', () => {
 
       expect(screen.getByText('"a"')).toBeInTheDocument();
 
-      const itemsKey = screen.getByText('"items"');
-      await user.click(itemsKey.closest('div')!);
+      // Click the first collapse button
+      await user.click(screen.getAllByRole('button')[0]);
 
       expect(screen.queryByText('"a"')).not.toBeInTheDocument();
     });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/CollapsibleJsonViewer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/CollapsibleJsonViewer.tsx
@@ -139,6 +139,7 @@ function calculateLineNumbers(
 interface JsonNodeProps {
   nodeKey?: string;
   value: unknown;
+  endLine: number;
   depth: number;
   isLast: boolean;
   initialExpanded?: boolean;
@@ -152,6 +153,7 @@ function JsonNode({
   nodeKey,
   value,
   depth,
+  endLine,
   isLast,
   initialExpanded = false,
   colors,
@@ -169,6 +171,7 @@ function JsonNode({
 
   const lineInfo = lineMap.get(path) || { lineNumber: 1, startLine: 1, endLine: 1 };
   const displayLine = collapsed && lineInfo.endLine !== lineInfo.startLine ? lineInfo.endLine : lineInfo.lineNumber;
+  const maxLineNumberDigits = Math.floor(Math.log10(endLine)) + 1;
 
   const monoTextStyle: CSSObject = {
     fontFamily: 'monospace',
@@ -177,8 +180,9 @@ function JsonNode({
   };
 
   const lineNumberStyle: CSSObject = {
-    minWidth: 40,
-    paddingRight: theme.spacing.sm,
+    minWidth: 11 * maxLineNumberDigits + theme.spacing.xs,
+    paddingLeft: theme.spacing.sm,
+    paddingRight: theme.spacing.xs,
     textAlign: 'right' as const,
     color: theme.colors.textSecondary,
     userSelect: 'none' as const,
@@ -187,17 +191,27 @@ function JsonNode({
 
   const lineWrapperStyle: CSSObject = {
     display: 'flex',
-    paddingTop: 2,
-    paddingBottom: 2,
+    alignItems: 'center',
+    minHeight: theme.typography.lineHeightLg,
+  };
+
+  const expandStyle: CSSObject = {
+    minWidth: 20,
+    borderRight: `1px solid ${theme.colors.actionDisabledBorder}`,
+    display: 'inline-flex',
+    alignSelf: 'stretch',
+    alignItems: 'center',
+    cursor: isExpandable ? 'pointer' : 'default',
   };
 
   if (depth > MAX_DEPTH) {
     return (
       <div css={lineWrapperStyle}>
         <span css={lineNumberStyle}>{displayLine}</span>
+        <span css={expandStyle} />
         <div
           css={{
-            paddingLeft: depth * indentSize,
+            paddingLeft: depth * indentSize + theme.spacing.sm,
             color: theme.colors.textSecondary,
             fontStyle: 'italic',
             ...monoTextStyle,
@@ -226,19 +240,14 @@ function JsonNode({
 
   if (isPrimitive) {
     return (
-      <div
-        css={{
-          display: 'flex',
-          paddingTop: 2,
-          paddingBottom: 2,
-        }}
-      >
+      <div css={lineWrapperStyle}>
         <span css={lineNumberStyle}>{displayLine}</span>
+        <span css={expandStyle} />
         <div
           css={{
             display: 'flex',
             alignItems: 'flex-start',
-            paddingLeft: depth * indentSize,
+            paddingLeft: depth * indentSize + theme.spacing.sm,
             ...monoTextStyle,
           }}
         >
@@ -259,35 +268,12 @@ function JsonNode({
 
   return (
     <div>
-      <div
-        css={{
-          display: 'flex',
-          paddingTop: 2,
-          paddingBottom: 2,
-        }}
-      >
+      <div css={lineWrapperStyle}>
         <span css={lineNumberStyle}>{displayLine}</span>
-        <div
-          css={{
-            display: 'flex',
-            alignItems: 'center',
-            paddingLeft: depth * indentSize,
-            cursor: isExpandable ? 'pointer' : 'default',
-            borderRadius: theme.borders.borderRadiusSm,
-            marginLeft: -theme.spacing.xs,
-            marginRight: -theme.spacing.xs,
-            paddingRight: theme.spacing.xs,
-            ...monoTextStyle,
-          }}
-          onClick={() => isExpandable && setCollapsed(!collapsed)}
-        >
-          {isExpandable ? (
+        <span css={expandStyle} onClick={() => isExpandable && setCollapsed(!collapsed)}>
+          {isExpandable && (
             <span
               css={{
-                marginRight: 4,
-                marginLeft: theme.spacing.xs,
-                display: 'flex',
-                alignItems: 'center',
                 color: theme.colors.textSecondary,
               }}
             >
@@ -297,9 +283,18 @@ function JsonNode({
                 <ChevronDownIcon css={{ fontSize: theme.spacing.mid }} />
               )}
             </span>
-          ) : (
-            <span css={{ marginLeft: theme.spacing.xs }} />
           )}
+        </span>
+        <div
+          css={{
+            display: 'flex',
+            alignItems: 'center',
+            paddingLeft: depth * indentSize + theme.spacing.sm,
+            borderRadius: theme.borders.borderRadiusSm,
+            paddingRight: theme.spacing.xs,
+            ...monoTextStyle,
+          }}
+        >
           {nodeKey !== undefined && (
             <>
               <span css={{ color: colors.key }}>"{nodeKey}"</span>
@@ -342,6 +337,7 @@ function JsonNode({
                   nodeKey={isArrayValue ? undefined : String(key)}
                   value={val}
                   depth={depth + 1}
+                  endLine={endLine}
                   isLast={index === entries.length - 1}
                   initialExpanded={depth < INITIAL_EXPAND_DEPTH}
                   colors={colors}
@@ -352,17 +348,12 @@ function JsonNode({
               </Fragment>
             );
           })}
-          <div
-            css={{
-              display: 'flex',
-              paddingTop: 2,
-              paddingBottom: 2,
-            }}
-          >
+          <div css={lineWrapperStyle}>
             <span css={lineNumberStyle}>{lineInfo.endLine}</span>
+            <span css={expandStyle} />
             <div
               css={{
-                paddingLeft: depth * indentSize,
+                paddingLeft: depth * indentSize + theme.spacing.sm,
                 color: colors.punctuation,
                 ...monoTextStyle,
               }}
@@ -385,13 +376,14 @@ interface IdeJsonViewerProps {
 }
 
 function IdeJsonViewer({ parsedData, initialExpanded, colors, theme }: IdeJsonViewerProps) {
-  const { lineMap } = useMemo(() => calculateLineNumbers(parsedData), [parsedData]);
+  const { lineMap, endLine } = useMemo(() => calculateLineNumbers(parsedData), [parsedData]);
 
   return (
     <div css={{ paddingRight: theme.spacing.md * 2 }}>
       <JsonNode
         value={parsedData}
         depth={0}
+        endLine={endLine}
         isLast
         initialExpanded={initialExpanded}
         colors={colors}
@@ -558,7 +550,7 @@ function JsonTable({ rows, colors, theme, initialExpanded }: JsonTableProps) {
         <Fragment key={row.id}>
           <tr
             css={{
-              borderBottom: `1px solid ${theme.isDarkMode ? theme.colors.grey650 : theme.colors.grey200}`,
+              borderBottom: `1px solid ${theme.colors.actionDisabledBorder}`,
             }}
           >
             <td css={pathCellStyle}>
@@ -613,7 +605,7 @@ function JsonTable({ rows, colors, theme, initialExpanded }: JsonTableProps) {
         <thead>
           <tr
             css={{
-              borderBottom: `1px solid ${theme.isDarkMode ? theme.colors.grey650 : theme.colors.grey200}`,
+              borderBottom: `1px solid ${theme.colors.actionDisabledBorder}`,
               backgroundColor: theme.colors.backgroundSecondary,
             }}
           >
@@ -779,7 +771,6 @@ export function CollapsibleJsonViewer({
     <div
       css={{
         backgroundColor: theme.colors.backgroundSecondary,
-        padding: theme.spacing.sm,
         position: 'relative',
         borderRadius: theme.borders.borderRadiusSm,
       }}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/CollapsibleJsonViewer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/CollapsibleJsonViewer.tsx
@@ -183,9 +183,11 @@ function JsonNode({
     minWidth: 11 * maxLineNumberDigits + theme.spacing.xs,
     paddingLeft: theme.spacing.sm,
     paddingRight: theme.spacing.xs,
+    paddingTop: 2,
     textAlign: 'right' as const,
     color: theme.colors.textSecondary,
     userSelect: 'none' as const,
+    alignSelf: 'flex-start' as const,
     flexShrink: 0,
     ...monoTextStyle,
   };

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/CollapsibleJsonViewer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/CollapsibleJsonViewer.tsx
@@ -273,7 +273,7 @@ function JsonNode({
     <div>
       <div css={lineWrapperStyle}>
         <span css={lineNumberStyle}>{displayLine}</span>
-        <span css={expandStyle} onClick={() => isExpandable && setCollapsed(!collapsed)}>
+        <span css={expandStyle} role="button" onClick={() => isExpandable && setCollapsed(!collapsed)}>
           {isExpandable && (
             <span
               css={{

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/CollapsibleJsonViewer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/CollapsibleJsonViewer.tsx
@@ -186,6 +186,7 @@ function JsonNode({
     textAlign: 'right' as const,
     color: theme.colors.textSecondary,
     userSelect: 'none' as const,
+    flexShrink: 0,
     ...monoTextStyle,
   };
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerCodeSnippetBody.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerCodeSnippetBody.tsx
@@ -124,9 +124,14 @@ export function ModelTraceExplorerCodeSnippetBody({
           )}
         </div>
         {expandable && (
-          <div css={{ backgroundColor: theme.colors.backgroundSecondary }}>
+          <div
+            css={{ backgroundColor: theme.colors.backgroundSecondary, borderTop: `1px solid ${theme.colors.border}` }}
+          >
             <Button
-              css={{ width: '100%', padding: 0 }}
+              css={{
+                width: '100%',
+                padding: 0,
+              }}
               componentId={
                 expanded
                   ? 'shared.model-trace-explorer.snippet-see-less'


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/22804/files) to review incremental changes.
- [**stack/simplify-trace-ui-5**](https://github.com/mlflow/mlflow/pull/22804) [[Files changed](https://github.com/mlflow/mlflow/pull/22804/files)]
  - [stack/simplify-trace-ui-6](https://github.com/mlflow/mlflow/pull/22805) [[Files changed](https://github.com/mlflow/mlflow/pull/22805/files/94d9c4748183518b4557e2703927f24b23794f3c..2aa72e53ccf48187f7841a58e22fc09fc4694687)]

---------
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

UI sync included a change which improves the JSON renderer, implenting features like collapsible objects & arrays.

However it has some problems:

1. Line number width is static, so it only works for < 10k lines of code, and is too wide for < 100 lines
2. Collapse button being next to the brackets feels not as natural, in VSCode, the collapse is next to the line number so you can directly move your cursor down rather than jumping around.

This PR fixes these two issues

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Before:

https://github.com/user-attachments/assets/3fc44b34-cb8c-42f3-9547-a82b7899418a

After:


https://github.com/user-attachments/assets/4570f5d1-5a73-4c97-ae50-3b853a9c3831





### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
