### PR TITLE
[Trace UI Improvements][6/6] Move llm span cost badge into the pane

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerAttributesTab.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerAttributesTab.tsx
@@ -6,6 +6,7 @@ import { FormattedMessage } from '@databricks/i18n';
 import { CodeSnippetRenderMode, type ModelTraceSpanNode, type SearchMatch } from '../ModelTrace.types';
 import { ModelTraceExplorerCodeSnippet } from '../ModelTraceExplorerCodeSnippet';
 import { useModelTraceExplorerPreferences } from '../ModelTraceExplorerPreferencesContext';
+import { SpanModelCostBadge } from './SpanModelCostBadge';
 
 export function ModelTraceExplorerAttributesTab({
   activeSpan,
@@ -30,15 +31,18 @@ export function ModelTraceExplorerAttributesTab({
 
   if (!containsAttributes || isNil(attributes)) {
     return (
-      <div css={{ marginTop: theme.spacing.md }}>
-        <Empty
-          description={
-            <FormattedMessage
-              defaultMessage="No attributes found"
-              description="Empty state for the attributes tab in the model trace explorer. Attributes are properties of a span that the user defines."
-            />
-          }
-        />
+      <div css={{ marginTop: theme.spacing.sm }}>
+        <SpanModelCostBadge css={{ marginLeft: theme.spacing.sm }} activeSpan={activeSpan} />
+        <div css={{ marginTop: theme.spacing.sm }}>
+          <Empty
+            description={
+              <FormattedMessage
+                defaultMessage="No attributes found"
+                description="Empty state for the attributes tab in the model trace explorer. Attributes are properties of a span that the user defines."
+              />
+            }
+          />
+        </div>
       </div>
     );
   }
@@ -52,6 +56,7 @@ export function ModelTraceExplorerAttributesTab({
         padding: theme.spacing.sm,
       }}
     >
+      <SpanModelCostBadge activeSpan={activeSpan} />
       {Object.entries(attributes).map(([key, value]) => (
         <ModelTraceExplorerCodeSnippet
           key={key}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatTab.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatTab.tsx
@@ -3,17 +3,13 @@ import { FormattedMessage } from '@databricks/i18n';
 
 import { ModelTraceExplorerChatTool } from './ModelTraceExplorerChatTool';
 import { ModelTraceExplorerConversation } from './ModelTraceExplorerConversation';
-import type { ModelTraceChatMessage, ModelTraceChatTool } from '../ModelTrace.types';
+import type { ModelTraceSpanNode } from '../ModelTrace.types';
 import { ModelTraceExplorerCollapsibleSection } from '../ModelTraceExplorerCollapsibleSection';
+import { SpanModelCostBadge } from './SpanModelCostBadge';
 
-export function ModelTraceExplorerChatTab({
-  chatMessages,
-  chatTools,
-}: {
-  chatMessages: ModelTraceChatMessage[];
-  chatTools?: ModelTraceChatTool[];
-}) {
+export function ModelTraceExplorerChatTab({ activeSpan }: { activeSpan: ModelTraceSpanNode }) {
   const { theme } = useDesignSystemTheme();
+  const { chatMessages, chatTools } = activeSpan;
 
   return (
     <div
@@ -22,6 +18,10 @@ export function ModelTraceExplorerChatTab({
       }}
       data-testid="model-trace-explorer-chat-tab"
     >
+      <SpanModelCostBadge
+        css={{ marginBlock: theme.spacing.sm, marginLeft: theme.spacing.sm }}
+        activeSpan={activeSpan}
+      />
       {chatTools && (
         <ModelTraceExplorerCollapsibleSection
           withBorder
@@ -52,7 +52,7 @@ export function ModelTraceExplorerChatTab({
         sectionKey="messages"
         withBorder
       >
-        <ModelTraceExplorerConversation messages={chatMessages} />
+        <ModelTraceExplorerConversation messages={chatMessages ?? []} />
       </ModelTraceExplorerCollapsibleSection>
     </div>
   );

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerContentTab.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerContentTab.tsx
@@ -48,7 +48,7 @@ export function ModelTraceExplorerContentTab({
           paddingInline: theme.spacing.sm,
         }}
       >
-        <SpanModelCostBadge css={{ justifySelf: 'flex-start' }} activeSpan={activeSpan} />
+        <SpanModelCostBadge css={{ marginRight: 'auto' }} activeSpan={activeSpan} />
         <SegmentedControlGroup
           name="content-tab-render-mode"
           componentId="shared.model-trace-explorer.content-tab.render-mode"

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerContentTab.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerContentTab.tsx
@@ -7,6 +7,7 @@ import { FormattedMessage } from '@databricks/i18n';
 import { ModelTraceExplorerDefaultSpanView } from './ModelTraceExplorerDefaultSpanView';
 import type { ModelTraceExplorerRenderMode, ModelTraceSpanNode, SearchMatch } from '../ModelTrace.types';
 import { useModelTraceExplorerPreferences } from '../ModelTraceExplorerPreferencesContext';
+import { SpanModelCostBadge } from './SpanModelCostBadge';
 
 export function ModelTraceExplorerContentTab({
   activeSpan,
@@ -43,9 +44,11 @@ export function ModelTraceExplorerContentTab({
           display: 'flex',
           justifyContent: 'flex-end',
           marginBottom: theme.spacing.sm,
+          marginRight: 'auto',
           paddingInline: theme.spacing.sm,
         }}
       >
+        <SpanModelCostBadge css={{ justifySelf: 'flex-start' }} activeSpan={activeSpan} />
         <SegmentedControlGroup
           name="content-tab-render-mode"
           componentId="shared.model-trace-explorer.content-tab.render-mode"

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerEventsTab.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerEventsTab.tsx
@@ -7,6 +7,7 @@ import { CodeSnippetRenderMode, type ModelTraceSpanNode, type SearchMatch } from
 import { getEventAttributeKey } from '../ModelTraceExplorer.utils';
 import { ModelTraceExplorerCodeSnippet } from '../ModelTraceExplorerCodeSnippet';
 import { ModelTraceExplorerCollapsibleSection } from '../ModelTraceExplorerCollapsibleSection';
+import { SpanModelCostBadge } from './SpanModelCostBadge';
 
 export function ModelTraceExplorerEventsTab({
   activeSpan,
@@ -23,21 +24,28 @@ export function ModelTraceExplorerEventsTab({
 
   if (!Array.isArray(events) || events.length === 0) {
     return (
-      <div css={{ marginTop: theme.spacing.md }}>
-        <Empty
-          description={
-            <FormattedMessage
-              defaultMessage="No events found"
-              description="Empty state for the events tab in the model trace explorer. Events are logs of arbitrary things (e.g. exceptions) that occur during the execution of a span, and can be user-defined."
-            />
-          }
-        />
+      <div css={{ marginTop: theme.spacing.sm }}>
+        <SpanModelCostBadge css={{ marginLeft: theme.spacing.sm }} activeSpan={activeSpan} />
+        <div css={{ marginTop: theme.spacing.sm }}>
+          <Empty
+            description={
+              <FormattedMessage
+                defaultMessage="No events found"
+                description="Empty state for the events tab in the model trace explorer. Events are logs of arbitrary things (e.g. exceptions) that occur during the execution of a span, and can be user-defined."
+              />
+            }
+          />
+        </div>
       </div>
     );
   }
 
   return (
     <div>
+      <SpanModelCostBadge
+        css={{ marginLeft: theme.spacing.sm, marginBlock: theme.spacing.sm }}
+        activeSpan={activeSpan}
+      />
       {events.map((event, index) => {
         const attributes = event.attributes;
         const title =

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerRightPane.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerRightPane.test.tsx
@@ -7,7 +7,7 @@ import { IntlProvider } from '@databricks/i18n';
 
 import { ModelTraceExplorerChatTab } from './ModelTraceExplorerChatTab';
 import { ModelTraceExplorerContentTab } from './ModelTraceExplorerContentTab';
-import type { ModelTraceSpan } from '../ModelTrace.types';
+import type { ModelTraceSpan, ModelTraceSpanNode } from '../ModelTrace.types';
 import {
   mockSpans,
   MOCK_RETRIEVER_SPAN,
@@ -55,7 +55,17 @@ describe('ModelTraceExplorerRightPane', () => {
   });
 
   it('should render conversations if possible', async () => {
-    render(<ModelTraceExplorerChatTab chatMessages={MOCK_CHAT_MESSAGES} chatTools={MOCK_CHAT_TOOLS} />, {
+    const MOCK_SPAN: ModelTraceSpanNode = {
+      ...DEFAULT_SPAN,
+      start: DEFAULT_SPAN.start_time,
+      end: DEFAULT_SPAN.end_time,
+      key: DEFAULT_SPAN.context.span_id,
+      assessments: [],
+      traceId: DEFAULT_SPAN.context.trace_id,
+      chatMessages: MOCK_CHAT_MESSAGES,
+      chatTools: MOCK_CHAT_TOOLS,
+    };
+    render(<ModelTraceExplorerChatTab activeSpan={MOCK_SPAN} />, {
       wrapper: Wrapper,
     });
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerRightPaneTabs.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerRightPaneTabs.tsx
@@ -85,7 +85,6 @@ function ModelTraceExplorerRightPaneTabsImpl({
       value={activeTab}
       onValueChange={(tab: string) => setActiveTab(tab as ModelTraceExplorerTab)}
     >
-      <SpanModelCostBadge activeSpan={activeSpan} />
       {!displayReadOnlyAssessments && !assessmentsPaneExpanded && (
         <div
           css={{
@@ -141,7 +140,7 @@ function ModelTraceExplorerRightPaneTabsImpl({
       </Tabs.List>
       {activeSpan.chatMessages && (
         <Tabs.Content css={contentStyle} value="chat">
-          <ModelTraceExplorerChatTab chatMessages={activeSpan.chatMessages} chatTools={activeSpan.chatTools} />
+          <ModelTraceExplorerChatTab activeSpan={activeSpan} />
         </Tabs.Content>
       )}
       <Tabs.Content css={contentStyle} value="content">

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/SpanModelCostBadge.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/SpanModelCostBadge.tsx
@@ -109,8 +109,18 @@ const SpanCostHoverCard = ({ cost }: { cost: SpanCostInfo }) => {
   );
 };
 
-export const SpanModelCostBadge = ({ activeSpan }: { activeSpan: ModelTraceSpanNode }) => {
+export const SpanModelCostBadge = ({
+  activeSpan,
+  className,
+}: {
+  activeSpan: ModelTraceSpanNode | undefined;
+  className?: string;
+}) => {
   const { theme } = useDesignSystemTheme();
+
+  if (!activeSpan) {
+    return null;
+  }
 
   const { modelName, cost } = activeSpan;
 
@@ -125,11 +135,11 @@ export const SpanModelCostBadge = ({ activeSpan }: { activeSpan: ModelTraceSpanN
         display: 'flex',
         flexDirection: 'row',
         alignItems: 'center',
-        gap: theme.spacing.md,
-        paddingLeft: theme.spacing.md,
-        paddingBottom: theme.spacing.sm,
+        gap: theme.spacing.sm,
+        paddingLeft: theme.spacing.xs,
         flexWrap: 'wrap',
       }}
+      className={className}
     >
       {modelName && (
         <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/22805/files) to review incremental changes.
- [**stack/simplify-trace-ui-6**](https://github.com/mlflow/mlflow/pull/22805) [[Files changed](https://github.com/mlflow/mlflow/pull/22805/files)]

---------
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

The position + alignment of the LLM model + span cost is a little weird to me. It renders above the tabs, but I feel it should be inside the panel so the tab bar doesn't jump around when navigating between spans.

Also it's way too close to the top.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

Before:

<img width="1392" height="964" alt="Screenshot 2026-04-23 at 9 46 40 AM" src="https://github.com/user-attachments/assets/92d53694-3f89-44ee-b769-0c0379f2f18e" />

After:

<img width="1393" height="962" alt="Screenshot 2026-04-23 at 10 12 19 AM" src="https://github.com/user-attachments/assets/ec03e181-1f72-4933-b6ac-4423ff8e879c" />

<img width="1393" height="963" alt="Screenshot 2026-04-23 at 10 13 18 AM" src="https://github.com/user-attachments/assets/9c1678ae-9bcb-465b-b74c-98d302daa395" />


<img width="1724" height="962" alt="Screenshot 2026-04-23 at 11 15 39 AM" src="https://github.com/user-attachments/assets/34d349e6-2d1c-4cd1-942d-691c73651a25" />

<img width="1724" height="961" alt="Screenshot 2026-04-23 at 11 15 44 AM" src="https://github.com/user-attachments/assets/da5cf10d-7886-4616-81f3-a70aa1b1bcd4" />



### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
