### PR TITLE
Add `--auth` flag to gateway benchmark for measuring basic-auth overhead

### DIFF
--- a/dev/benchmarks/gateway/README.md
+++ b/dev/benchmarks/gateway/README.md
@@ -29,6 +29,10 @@ uv run run.py --instances 8 --workers 8
 # Benchmark an existing endpoint directly (skips all setup)
 uv run run.py --url http://your-server/gateway/my-endpoint/mlflow/invocations
 
+# Basic-auth enabled (starts MLflow with --app-name=basic-auth,
+# sends Authorization: Basic on every request)
+uv run run.py --instances 1 --auth
+
 ```
 
 ## What is measured
@@ -40,12 +44,12 @@ Connection pooling and HTTP keep-alive are enabled, so TCP handshake cost is amo
 
 ### What is NOT measured
 
-| Factor             | In this benchmark                          | In production               |
-| ------------------ | ------------------------------------------ | --------------------------- |
-| Network latency    | ~0 ms (loopback)                           | 1–100 ms per hop            |
-| TLS/SSL            | None (plain HTTP)                          | ~5–20 ms per new connection |
-| Provider inference | Fixed fake delay (`--fake-delay-ms`)       | Variable (50 ms – 60 s+)    |
-| Authentication     | Disabled (`--disable-security-middleware`) | Token validation, RBAC      |
+| Factor             | In this benchmark                              | In production               |
+| ------------------ | ---------------------------------------------- | --------------------------- |
+| Network latency    | ~0 ms (loopback)                               | 1–100 ms per hop            |
+| TLS/SSL            | None (plain HTTP)                              | ~5–20 ms per new connection |
+| Provider inference | Fixed fake delay (`--fake-delay-ms`)           | Variable (50 ms – 60 s+)    |
+| Authentication     | Off by default; basic-auth opt-in via `--auth` | Token validation, RBAC      |
 
 ## What MLflow does per request
 
@@ -89,27 +93,31 @@ DB schema before the others join. All instances share one PostgreSQL database.
 
 ## Options
 
-| Flag                          | Default  | Description                                                             |
-| ----------------------------- | -------- | ----------------------------------------------------------------------- |
-| `--url URL`                   | —        | Benchmark this URL directly, skip all setup                             |
-| `--instances N`               | 4        | MLflow instances. Use 1 for single-instance (no nginx, optional SQLite) |
-| `--workers N`                 | 4        | MLflow worker processes per instance                                    |
-| `--database sqlite\|postgres` | `sqlite` | Database to use — only applies when `--instances 1`                     |
-| `--no-usage-tracking`         | —        | Disable usage tracking (tracing) on the endpoint                        |
-| `--port N`                    | 5731     | Port to benchmark (MLflow port for single, nginx LB port for multi)     |
-| `--base-port N`               | 5800     | First MLflow instance port in multi mode (rest are +1, +2, …)           |
-| `--fake-server-port N`        | 9137     | Fake OpenAI server port                                                 |
-| `--requests N`                | 2000     | Requests per run                                                        |
-| `--max-concurrent N`          | 50       | Max concurrent requests                                                 |
-| `--runs N`                    | 3        | Number of benchmark runs                                                |
-| `--fake-delay-ms N`           | 50       | Simulated provider latency in ms                                        |
-| `--min-rps N`                 | —        | Fail (exit 1) if average throughput falls below N req/s                 |
-| `--max-p50-ms N`              | —        | Fail (exit 1) if average P50 latency exceeds N ms (CI threshold)        |
-| `--max-p99-ms N`              | —        | Fail (exit 1) if average P99 latency exceeds N ms (CI threshold)        |
+| Flag                          | Default        | Description                                                             |
+| ----------------------------- | -------------- | ----------------------------------------------------------------------- |
+| `--url URL`                   | —              | Benchmark this URL directly, skip all setup                             |
+| `--instances N`               | 4              | MLflow instances. Use 1 for single-instance (no nginx, optional SQLite) |
+| `--workers N`                 | 4              | MLflow worker processes per instance                                    |
+| `--database sqlite\|postgres` | `sqlite`       | Database to use — only applies when `--instances 1`                     |
+| `--no-usage-tracking`         | —              | Disable usage tracking (tracing) on the endpoint                        |
+| `--port N`                    | 5731           | Port to benchmark (MLflow port for single, nginx LB port for multi)     |
+| `--base-port N`               | 5800           | First MLflow instance port in multi mode (rest are +1, +2, …)           |
+| `--fake-server-port N`        | 9137           | Fake OpenAI server port                                                 |
+| `--requests N`                | 2000           | Requests per run                                                        |
+| `--max-concurrent N`          | 50             | Max concurrent requests                                                 |
+| `--runs N`                    | 3              | Number of benchmark runs                                                |
+| `--fake-delay-ms N`           | 50             | Simulated provider latency in ms                                        |
+| `--min-rps N`                 | —              | Fail (exit 1) if average throughput falls below N req/s                 |
+| `--max-p50-ms N`              | —              | Fail (exit 1) if average P50 latency exceeds N ms (CI threshold)        |
+| `--max-p99-ms N`              | —              | Fail (exit 1) if average P99 latency exceeds N ms (CI threshold)        |
+| `--auth`                      | off            | Start MLflow with `--app-name=basic-auth`; send Basic auth on requests  |
+| `--auth-username USER`        | `admin`        | Basic-auth username (matches `mlflow/server/auth/basic_auth.ini`)       |
+| `--auth-password PASS`        | `password1234` | Basic-auth password (matches `mlflow/server/auth/basic_auth.ini`)       |
 
 All flags can also be set via environment variables (same name, uppercased):
 `INSTANCES`, `WORKERS_PER_INSTANCE`, `REQUESTS`, `MAX_CONCURRENT`, `RUNS`,
-`FAKE_RESPONSE_DELAY_MS`, `MLFLOW_PORT`, `BASE_PORT`, `FAKE_SERVER_PORT`.
+`FAKE_RESPONSE_DELAY_MS`, `MLFLOW_PORT`, `BASE_PORT`, `FAKE_SERVER_PORT`,
+`AUTH`, `AUTH_USERNAME`, `AUTH_PASSWORD`.
 
 To avoid conflicts with a local PostgreSQL instance, override the port via `GATEWAY_BENCH_POSTGRES_PORT` (default: 5432).
 
@@ -121,8 +129,9 @@ To avoid conflicts with a local PostgreSQL instance, override the port via `GATE
   add TLS termination overhead.
 - **Fixed provider latency** — `fake_server.py` always responds in exactly `--fake-delay-ms`.
   Real providers have high variance (P99 often 5–10× P50).
-- **No auth** — token validation and RBAC are disabled. Auth middleware adds latency
-  proportional to token lookup strategy.
+- **Basic-auth is opt-in, no RBAC** — `--auth` enables `basic-auth` with the default
+  admin user (full permissions), which measures the cost of HTTP Basic authentication
+  and user lookup but not fine-grained RBAC checks against non-admin users.
 - **Single machine resource contention** — with multiple instances, all MLflow instances, nginx,
   PostgreSQL, and the benchmark client share CPU/memory. On a server with dedicated resources
   per instance, throughput will be higher.

--- a/dev/benchmarks/gateway/benchmark.py
+++ b/dev/benchmarks/gateway/benchmark.py
@@ -66,12 +66,15 @@ class RunResult:
 
 
 async def _send(
-    session: aiohttp.ClientSession, url: str, sem: asyncio.Semaphore
+    session: aiohttp.ClientSession,
+    url: str,
+    sem: asyncio.Semaphore,
+    auth: aiohttp.BasicAuth | None = None,
 ) -> tuple[float, str | None]:
     async with sem:
         t0 = time.perf_counter()
         try:
-            async with session.post(url, json=_BODY) as resp:
+            async with session.post(url, json=_BODY, auth=auth) as resp:
                 await resp.read()
                 ms = (time.perf_counter() - t0) * 1000
                 if resp.status == 200:
@@ -82,7 +85,12 @@ async def _send(
 
 
 async def _run_once(
-    url: str, n: int, max_concurrent: int, progress: Progress, task_id: TaskID
+    url: str,
+    n: int,
+    max_concurrent: int,
+    progress: Progress,
+    task_id: TaskID,
+    auth: aiohttp.BasicAuth | None = None,
 ) -> RunResult:
     sem = asyncio.Semaphore(max_concurrent)
     connector = aiohttp.TCPConnector(
@@ -97,7 +105,7 @@ async def _run_once(
 
     async with aiohttp.ClientSession(connector=connector) as session:
         t0 = time.perf_counter()
-        for coro in asyncio.as_completed([_send(session, url, sem) for _ in range(n)]):
+        for coro in asyncio.as_completed([_send(session, url, sem, auth) for _ in range(n)]):
             ms, error = await coro
             if error:
                 result.failures[error] = result.failures.get(error, 0) + 1
@@ -118,19 +126,25 @@ async def _run_once(
     return result
 
 
-async def _warmup(url: str, n: int, max_concurrent: int) -> None:
+async def _warmup(
+    url: str, n: int, max_concurrent: int, auth: aiohttp.BasicAuth | None = None
+) -> None:
     sem = asyncio.Semaphore(max_concurrent)
     connector = aiohttp.TCPConnector(limit=max(max_concurrent * 2, 200))
     async with aiohttp.ClientSession(connector=connector) as session:
-        await asyncio.gather(*[_send(session, url, sem) for _ in range(n)])
+        await asyncio.gather(*[_send(session, url, sem, auth) for _ in range(n)])
 
 
 def run_benchmark(
-    url: str, n_requests: int = 2000, max_concurrent: int = 50, runs: int = 3
+    url: str,
+    n_requests: int = 2000,
+    max_concurrent: int = 50,
+    runs: int = 3,
+    auth: aiohttp.BasicAuth | None = None,
 ) -> list[RunResult]:
     warmup_n = min(max(50, max_concurrent), n_requests)
     console.print(f"  [dim]Warming up ({warmup_n} requests)...[/dim]")
-    asyncio.run(_warmup(url, warmup_n, max_concurrent))
+    asyncio.run(_warmup(url, warmup_n, max_concurrent, auth))
 
     results = []
     with Progress(
@@ -145,7 +159,7 @@ def run_benchmark(
         for i in range(runs):
             task_id = progress.add_task(f"  Run {i + 1}/{runs}", total=n_requests, live="")
             results.append(
-                asyncio.run(_run_once(url, n_requests, max_concurrent, progress, task_id))
+                asyncio.run(_run_once(url, n_requests, max_concurrent, progress, task_id, auth))
             )
     return results
 
@@ -313,13 +327,29 @@ def main() -> None:
         metavar="N",
         help="Fail (exit 1) if average P99 latency exceeds N ms",
     )
+    parser.add_argument(
+        "--auth-username",
+        default=None,
+        help="Basic auth username. If set together with --auth-password, sent on every request.",
+    )
+    parser.add_argument(
+        "--auth-password",
+        default=None,
+        help="Basic auth password. If set together with --auth-username, sent on every request.",
+    )
     args = parser.parse_args()
+
+    auth = (
+        aiohttp.BasicAuth(args.auth_username, args.auth_password)
+        if args.auth_username and args.auth_password
+        else None
+    )
 
     console.print(f"\n[bold]Benchmarking[/bold] {args.url}")
     console.print(
         f"  {args.requests} requests · {args.max_concurrent} concurrent · {args.runs} runs\n"
     )
-    results = run_benchmark(args.url, args.requests, args.max_concurrent, args.runs)
+    results = run_benchmark(args.url, args.requests, args.max_concurrent, args.runs, auth)
     print_results(results)
 
     if not check_thresholds(

--- a/dev/benchmarks/gateway/run.py
+++ b/dev/benchmarks/gateway/run.py
@@ -174,7 +174,7 @@ def _start_mlflow(
         cmd += ["--app-name", "basic-auth"]
     with (
         log_file.open("w") as f,
-        subprocess.Popen(cmd, stdout=f, stderr=f, env=_subprocess_env()) as proc,
+        subprocess.Popen(cmd, cwd=SCRIPT_DIR, stdout=f, stderr=f, env=_subprocess_env()) as proc,
     ):
         _wait_for_port(port, label, log_file)
         try:

--- a/dev/benchmarks/gateway/run.py
+++ b/dev/benchmarks/gateway/run.py
@@ -16,6 +16,7 @@ Usage:
 """
 
 import argparse
+import base64
 import contextlib
 import json
 import os
@@ -31,6 +32,7 @@ from pathlib import Path
 from typing import Any
 
 sys.path.insert(0, str(Path(__file__).parent))
+import aiohttp  # type: ignore[import-not-found]
 import benchmark as bm  # local module; path inserted above
 from rich.console import Console  # type: ignore[import-not-found]
 from rich.panel import Panel  # type: ignore[import-not-found]
@@ -144,30 +146,35 @@ def _start_mlflow(
     backend_uri: str,
     label: str = "MLflow server",
     host: str = "127.0.0.1",
+    auth: bool = False,
 ) -> Generator[None, None, None]:
     prefix = _uv_prefix()
+    # basic-auth requires the `auth` extra (Flask-WTF) at runtime.
+    if auth and prefix:
+        prefix = [*prefix, "--extra", "auth"]
+    # psycopg2-binary lives in the `db` extra.
+    if backend_uri.startswith("postgresql") and prefix:
+        prefix = [*prefix, "--extra", "db"]
     log_file = Path(work_dir) / f"mlflow-{port}.log"
+    cmd = [
+        *prefix,
+        "mlflow",
+        "server",
+        "--backend-store-uri",
+        backend_uri,
+        "--host",
+        host,
+        "--port",
+        str(port),
+        "--workers",
+        str(workers),
+        "--disable-security-middleware",
+    ]
+    if auth:
+        cmd += ["--app-name", "basic-auth"]
     with (
         log_file.open("w") as f,
-        subprocess.Popen(
-            [
-                *prefix,
-                "mlflow",
-                "server",
-                "--backend-store-uri",
-                backend_uri,
-                "--host",
-                host,
-                "--port",
-                str(port),
-                "--workers",
-                str(workers),
-                "--disable-security-middleware",
-            ],
-            stdout=f,
-            stderr=f,
-            env=_subprocess_env(),
-        ) as proc,
+        subprocess.Popen(cmd, stdout=f, stderr=f, env=_subprocess_env()) as proc,
     ):
         _wait_for_port(port, label, log_file)
         try:
@@ -244,11 +251,22 @@ def _start_postgres(container_name: str = "benchmark-postgres") -> Generator[str
             subprocess.run(["docker", "kill", container_name], capture_output=True)
 
 
-def _api_post(tracking_uri: str, path: str, body: dict[str, Any]) -> Any:
+def _basic_auth_header(creds: tuple[str, str] | None) -> dict[str, str]:
+    if creds is None:
+        return {}
+    token = base64.b64encode(f"{creds[0]}:{creds[1]}".encode()).decode()
+    return {"Authorization": f"Basic {token}"}
+
+
+def _api_post(
+    tracking_uri: str,
+    path: str,
+    body: dict[str, Any],
+    creds: tuple[str, str] | None = None,
+) -> Any:
     url = f"{tracking_uri.rstrip('/')}/api/3.0/mlflow/{path}"
-    req = urllib.request.Request(
-        url, data=json.dumps(body).encode(), headers={"Content-Type": "application/json"}
-    )
+    headers = {"Content-Type": "application/json", **_basic_auth_header(creds)}
+    req = urllib.request.Request(url, data=json.dumps(body).encode(), headers=headers)
     try:
         with urllib.request.urlopen(req, timeout=10) as resp:
             return json.loads(resp.read())
@@ -261,7 +279,11 @@ def _api_post(tracking_uri: str, path: str, body: dict[str, Any]) -> Any:
 
 
 def _setup_endpoint(
-    tracking_uri: str, fake_server_url: str, endpoint_name: str, usage_tracking: bool
+    tracking_uri: str,
+    fake_server_url: str,
+    endpoint_name: str,
+    usage_tracking: bool,
+    creds: tuple[str, str] | None = None,
 ) -> str:
     """Create secret → model definition → endpoint. Returns the invocation URL."""
     console.print("  Creating secret...")
@@ -274,6 +296,7 @@ def _setup_endpoint(
             "provider": "openai",
             "auth_config": {"api_base": fake_server_url},
         },
+        creds,
     )["secret"]["secret_id"]
 
     console.print("  Creating model definition...")
@@ -286,6 +309,7 @@ def _setup_endpoint(
             "provider": "openai",
             "model_name": "gpt-4o-mini",
         },
+        creds,
     )["model_definition"]["model_definition_id"]
 
     console.print(f"  Creating endpoint '{endpoint_name}' (usage_tracking={usage_tracking})...")
@@ -299,6 +323,7 @@ def _setup_endpoint(
             ],
             "usage_tracking": usage_tracking,
         },
+        creds,
     )
 
     invoke_url = f"{tracking_uri.rstrip('/')}/gateway/{endpoint_name}/mlflow/invocations"
@@ -306,10 +331,11 @@ def _setup_endpoint(
     return invoke_url
 
 
-def _sanity_check(url: str) -> None:
+def _sanity_check(url: str, creds: tuple[str, str] | None = None) -> None:
     console.print("  Sending sanity-check request...")
     body = json.dumps({"messages": [{"role": "user", "content": "test"}]}).encode()
-    req = urllib.request.Request(url, data=body, headers={"Content-Type": "application/json"})
+    headers = {"Content-Type": "application/json", **_basic_auth_header(creds)}
+    req = urllib.request.Request(url, data=body, headers=headers)
     try:
         with urllib.request.urlopen(req, timeout=10) as resp:
             if resp.status != 200:
@@ -330,8 +356,10 @@ def _run_benchmark(
     max_p50_ms: float | None = None,
     max_p99_ms: float | None = None,
     output: Path | None = None,
+    creds: tuple[str, str] | None = None,
 ) -> None:
-    results = bm.run_benchmark(url, n_requests, max_concurrent, runs)
+    auth = aiohttp.BasicAuth(*creds) if creds else None
+    results = bm.run_benchmark(url, n_requests, max_concurrent, runs, auth)
     bm.print_results(results)
     if output is not None:
         output.write_text(json.dumps(bm.results_to_dict(results), indent=2))
@@ -446,12 +474,14 @@ def _start_nginx(
 def cmd_bench(args: argparse.Namespace) -> None:
     instances = args.instances
     mode = "1 instance" if instances == 1 else f"{instances} instances, nginx LB"
+    creds = (args.auth_username, args.auth_password) if args.auth else None
 
     if args.url:
         console.print(
             Panel.fit(
                 f"[bold]Gateway Benchmark[/bold] ({mode})\n"
                 f"URL: [cyan]{args.url}[/cyan]\n"
+                f"Auth: {'basic-auth as ' + args.auth_username if creds else 'disabled'}\n"
                 f"Requests: {args.requests}  ·  Concurrency: {args.max_concurrent}"
                 f"  ·  Runs: {args.runs}",
                 border_style="cyan",
@@ -467,6 +497,7 @@ def cmd_bench(args: argparse.Namespace) -> None:
             args.max_p50_ms,
             args.max_p99_ms,
             args.output,
+            creds,
         )
         return
 
@@ -479,11 +510,12 @@ def cmd_bench(args: argparse.Namespace) -> None:
         fake_port = args.fake_server_port
         instance_ports = [args.base_port + i for i in range(instances)]
 
+        auth_line = f"basic-auth as {args.auth_username}" if creds else "disabled"
         if instances == 1:
             panel = (
                 f"[bold]Gateway Benchmark[/bold] ({mode})\n"
                 f"Workers: {args.workers}  ·  DB: {args.database.upper()}  ·  "
-                f"Usage tracking: {args.usage_tracking}\n"
+                f"Usage tracking: {args.usage_tracking}  ·  Auth: {auth_line}\n"
                 f"Requests: {args.requests}  ·  Concurrency: {args.max_concurrent}  ·  "
                 f"Runs: {args.runs}  ·  Fake delay: {args.fake_delay_ms}ms\n"
                 f"Ports: MLflow :{port}  ·  Fake server :{fake_port}"
@@ -493,7 +525,7 @@ def cmd_bench(args: argparse.Namespace) -> None:
                 f"[bold]Gateway Benchmark[/bold] ({mode})\n"
                 f"Workers/instance: {args.workers}  ·  "
                 f"Total workers: {instances * args.workers}  ·  "
-                f"Usage tracking: {args.usage_tracking}\n"
+                f"Usage tracking: {args.usage_tracking}  ·  Auth: {auth_line}\n"
                 f"Requests: {args.requests}  ·  Concurrency: {args.max_concurrent}  ·  "
                 f"Runs: {args.runs}  ·  Fake delay: {args.fake_delay_ms}ms\n"
                 f"Ports: instances {instance_ports[0]}–{instance_ports[-1]}"
@@ -520,7 +552,9 @@ def cmd_bench(args: argparse.Namespace) -> None:
             )
 
             if instances == 1:
-                stack.enter_context(_start_mlflow(work_dir, port, args.workers, backend_uri))
+                stack.enter_context(
+                    _start_mlflow(work_dir, port, args.workers, backend_uri, auth=args.auth)
+                )
 
                 console.print("\n[bold]Setting up gateway endpoint[/bold]")
                 invoke_url = _setup_endpoint(
@@ -528,8 +562,9 @@ def cmd_bench(args: argparse.Namespace) -> None:
                     f"http://127.0.0.1:{fake_port}/v1",
                     ENDPOINT_NAME,
                     usage_tracking=args.usage_tracking,
+                    creds=creds,
                 )
-                _sanity_check(invoke_url)
+                _sanity_check(invoke_url, creds)
             else:
                 # Start instance 0 first — it initializes the DB schema.
                 # All instances share the same PostgreSQL DB, so starting concurrently
@@ -542,6 +577,7 @@ def cmd_bench(args: argparse.Namespace) -> None:
                         backend_uri,
                         "MLflow instance 0",
                         host="0.0.0.0",
+                        auth=args.auth,
                     )
                 )
                 for i, p in enumerate(instance_ports[1:], start=1):
@@ -553,6 +589,7 @@ def cmd_bench(args: argparse.Namespace) -> None:
                             backend_uri,
                             f"MLflow instance {i}",
                             host="0.0.0.0",
+                            auth=args.auth,
                         )
                     )
 
@@ -562,6 +599,7 @@ def cmd_bench(args: argparse.Namespace) -> None:
                     f"http://127.0.0.1:{fake_port}/v1",
                     ENDPOINT_NAME,
                     usage_tracking=args.usage_tracking,
+                    creds=creds,
                 )
 
                 console.print("\n[bold]Starting nginx load balancer[/bold]")
@@ -578,7 +616,7 @@ def cmd_bench(args: argparse.Namespace) -> None:
                 time.sleep(1)
 
                 invoke_url = f"http://127.0.0.1:{port}/gateway/{ENDPOINT_NAME}/mlflow/invocations"
-                _sanity_check(invoke_url)
+                _sanity_check(invoke_url, creds)
 
             console.print("\n[bold]Running benchmark[/bold]")
             _run_benchmark(
@@ -590,6 +628,7 @@ def cmd_bench(args: argparse.Namespace) -> None:
                 args.max_p50_ms,
                 args.max_p99_ms,
                 args.output,
+                creds,
             )
 
 
@@ -724,6 +763,25 @@ def main() -> None:
         default=None,
         metavar="N",
         help="Exit 1 if average P99 latency across runs exceeds N ms (CI threshold)",
+    )
+    parser.add_argument(
+        "--auth",
+        action="store_true",
+        default=os.environ.get("AUTH", "").lower() in ("1", "true"),
+        help=(
+            "Start MLflow with --app-name=basic-auth and authenticate every setup + "
+            "benchmark request using --auth-username/--auth-password."
+        ),
+    )
+    parser.add_argument(
+        "--auth-username",
+        default=os.environ.get("AUTH_USERNAME", "admin"),
+        help="Basic auth username (default: admin, from basic_auth.ini)",
+    )
+    parser.add_argument(
+        "--auth-password",
+        default=os.environ.get("AUTH_PASSWORD", "password1234"),
+        help="Basic auth password (default: password1234, from basic_auth.ini)",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

Adds an opt-in `--auth` flag to `dev/benchmarks/gateway/run.py` so the gateway benchmark can measure the cost of running with `basic-auth` enabled. Previously the benchmark always ran against an unauthenticated MLflow server, so there was no easy way to quantify the overhead of HTTP Basic authentication and per-request user lookup that real deployments pay on every gateway invocation.

When `--auth` is set the runner:

- launches MLflow with `--app-name=basic-auth`,
- adds the `auth` (`Flask-WTF`) uv extra to the mlflow subprocess so the auth app can actually start,
- attaches `Authorization: Basic …` to the gateway setup API calls, the sanity-check request, and every benchmark + warmup request (via `aiohttp.BasicAuth`).

Credentials default to the admin user from `mlflow/server/auth/basic_auth.ini` (`admin` / `password1234`) and can be overridden with `--auth-username` / `--auth-password` or the corresponding `AUTH_*` env vars.

While wiring this up I also hit a separate papercut: running `--database postgres` fails inside an otherwise-clean repo checkout because the mlflow subprocess is launched with only the `gateway` extra and psycopg2 lives in the `db` extra. The runner now auto-adds `--extra db` when the backend URI is PostgreSQL, so `--database postgres` works out of the box.

The `benchmark.py` standalone CLI grew matching `--auth-username` / `--auth-password` flags so you can point it at an already-running auth-enabled endpoint via `--url`.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Manual:

- `uv run run.py --instances 1 --auth` — completes a full 3-run benchmark against a single sqlite-backed instance with basic-auth; setup API calls, sanity check, warmup, and timed runs all succeed with `Authorization: Basic`.
- `uv run run.py --instances 1 --database postgres --auth` — same, against a Docker Postgres container. Confirmed the auto `--extra db` fix: command previously failed with `ModuleNotFoundError: No module named 'psycopg2'`; now succeeds.
- `uv run run.py --instances 1` (no `--auth`) — unchanged behavior, no auth headers sent, server still started with `--disable-security-middleware`.
- `uv run ruff check dev/benchmarks/gateway/` / `ruff format` / `clint` — clean.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [x] Instructions

`dev/benchmarks/gateway/README.md` documents the new `--auth` / `--auth-username` / `--auth-password` flags, the matching `AUTH` / `AUTH_USERNAME` / `AUTH_PASSWORD` env vars, a quickstart example, and updates the "What is NOT measured" / "Known limitations" sections to reflect that basic-auth is now opt-in.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

No user-facing product change — this only touches the gateway benchmark harness under `dev/benchmarks/gateway/`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release