### PR TITLE
Phase 2 M1.5: dual-write workspace_permissions via resource_type='*'

### DIFF
--- a/mlflow/server/auth/permissions.py
+++ b/mlflow/server/auth/permissions.py
@@ -92,8 +92,8 @@ VALID_RESOURCE_TYPES = frozenset({
     # management capabilities within the workspace.
     "workspace",
     # Special: a "default" permission on every resource of every type in the role's
-    # workspace. resource_pattern must be "*". Used by the Phase 2 dual-write to mirror
-    # the legacy `workspace_permissions` table — semantically distinct from
+    # workspace. resource_pattern must be "*". Used by the dual-write mirror of the
+    # legacy `workspace_permissions` table — semantically distinct from
     # `resource_type="workspace"` which conveys workspace-admin capability over role/user
     # management.
     "*",

--- a/mlflow/server/auth/permissions.py
+++ b/mlflow/server/auth/permissions.py
@@ -91,6 +91,12 @@ VALID_RESOURCE_TYPES = frozenset({
     # resource_pattern must be "*". permission=MANAGE additionally grants role/user
     # management capabilities within the workspace.
     "workspace",
+    # Special: a "default" permission on every resource of every type in the role's
+    # workspace. resource_pattern must be "*". Used by the Phase 2 dual-write to mirror
+    # the legacy `workspace_permissions` table — semantically distinct from
+    # `resource_type="workspace"` which conveys workspace-admin capability over role/user
+    # management.
+    "*",
 })
 
 

--- a/mlflow/server/auth/sqlalchemy_store.py
+++ b/mlflow/server/auth/sqlalchemy_store.py
@@ -143,9 +143,9 @@ class SqlAlchemyStore:
     def delete_user(self, username: str):
         with self.ManagedSessionMaker() as session:
             user = self._get_user(session, username)
-            # Clean up synthetic per-user roles created by the Phase 2 M1 dual-write so their
-            # role_permissions / user_role_assignments rows don't leak (and don't hit FK errors
-            # on backends that enforce referential integrity).
+            # Clean up the user's synthetic per-user roles (see the synthetic role helpers
+            # section below) so their role_permissions / user_role_assignments rows don't
+            # leak and don't hit FK errors on backends that enforce referential integrity.
             synthetic_name = self._synthetic_user_role_name(user.id)
             synthetic_roles = session.query(SqlRole).filter(SqlRole.name == synthetic_name).all()
             for role in synthetic_roles:
@@ -153,13 +153,13 @@ class SqlAlchemyStore:
             session.flush()
             session.delete(user)
 
-    # ---- Synthetic user-role helpers (Phase 2 M1 dual-write) ----
+    # ---- Synthetic user-role helpers (dual-write into role_permissions) ----
     #
-    # Per-resource grants (experiment_permissions, registered_model_permissions, ...) are
-    # mirrored into `role_permissions` under a synthetic role named `__user_<user_id>__`
-    # scoped to the resource's workspace. Reads still go through the per-resource tables;
-    # the mirrored grants make `get_role_permission_for_resource` a valid source of truth
-    # in parallel so later phases can flip reads over.
+    # Every legacy per-resource grant (experiment_permissions, registered_model_permissions,
+    # ...) is mirrored into `role_permissions` under a synthetic role named
+    # `__user_<user_id>__` scoped to the grant's workspace. This keeps
+    # `role_permissions` in sync with the per-resource tables so it can serve as an
+    # authoritative permission source without a separate backfill.
     #
     # The synthetic namespace (``__user_<int>__``) is RESERVED: ``create_role`` and
     # ``update_role`` reject names matching the pattern so an API consumer can't hijack a
@@ -185,7 +185,8 @@ class SqlAlchemyStore:
         if cls._is_synthetic_role_name(name):
             raise MlflowException.invalid_parameter_value(
                 f"Role name {name!r} matches the reserved synthetic pattern "
-                f"'__user_<id>__' used by Phase 2 dual-write. Choose a different name."
+                f"'__user_<id>__' used by the role_permissions dual-write. "
+                "Choose a different name."
             )
 
     def _get_or_create_synthetic_user_role(self, session, user_id: int, workspace: str) -> SqlRole:

--- a/mlflow/server/auth/sqlalchemy_store.py
+++ b/mlflow/server/auth/sqlalchemy_store.py
@@ -1,3 +1,5 @@
+import re
+
 from sqlalchemy import and_, or_, select
 from sqlalchemy.exc import IntegrityError, MultipleResultsFound, NoResultFound
 from sqlalchemy.orm import selectinload, sessionmaker
@@ -158,14 +160,40 @@ class SqlAlchemyStore:
     # scoped to the resource's workspace. Reads still go through the per-resource tables;
     # the mirrored grants make `get_role_permission_for_resource` a valid source of truth
     # in parallel so later phases can flip reads over.
+    #
+    # The synthetic namespace (``__user_<int>__``) is RESERVED: ``create_role`` and
+    # ``update_role`` reject names matching the pattern so an API consumer can't hijack a
+    # synthetic role to receive another user's mirrored grants. Bulk cleanup / rename
+    # helpers (``_unmirror_resource``, ``_rename_mirrored_resource``) also restrict their
+    # scope to synthetic roles so they never touch admin-created roles that happen to
+    # hold overlapping grants.
     _SYNTHETIC_ROLE_PREFIX = "__user_"
     _SYNTHETIC_ROLE_SUFFIX = "__"
+    _SYNTHETIC_ROLE_NAME_RE = re.compile(r"^__user_\d+__$")
 
     @classmethod
     def _synthetic_user_role_name(cls, user_id: int) -> str:
         return f"{cls._SYNTHETIC_ROLE_PREFIX}{user_id}{cls._SYNTHETIC_ROLE_SUFFIX}"
 
+    @classmethod
+    def _is_synthetic_role_name(cls, name: str | None) -> bool:
+        return name is not None and cls._SYNTHETIC_ROLE_NAME_RE.match(name) is not None
+
+    @classmethod
+    def _reject_synthetic_role_name(cls, name: str) -> None:
+        """Guard user-facing role CRUD against the reserved synthetic pattern."""
+        if cls._is_synthetic_role_name(name):
+            raise MlflowException.invalid_parameter_value(
+                f"Role name {name!r} matches the reserved synthetic pattern "
+                f"'__user_<id>__' used by Phase 2 dual-write. Choose a different name."
+            )
+
     def _get_or_create_synthetic_user_role(self, session, user_id: int, workspace: str) -> SqlRole:
+        # Race-proof: two concurrent permission mutations for the same (user, workspace)
+        # can both see "role doesn't exist yet" and both try to INSERT. Wrap the INSERT
+        # in a SAVEPOINT so the UniqueConstraint violation rolls back only that nested
+        # scope and we can recover by re-querying the winner's row. Same pattern for
+        # the user->role assignment.
         name = self._synthetic_user_role_name(user_id)
         role = (
             session
@@ -174,9 +202,18 @@ class SqlAlchemyStore:
             .first()
         )
         if role is None:
-            role = SqlRole(name=name, workspace=workspace, description=None)
-            session.add(role)
-            session.flush()
+            try:
+                with session.begin_nested():
+                    role = SqlRole(name=name, workspace=workspace, description=None)
+                    session.add(role)
+                    session.flush()
+            except IntegrityError:
+                role = (
+                    session
+                    .query(SqlRole)
+                    .filter(SqlRole.workspace == workspace, SqlRole.name == name)
+                    .one()
+                )
         assignment = (
             session
             .query(SqlUserRoleAssignment)
@@ -187,8 +224,13 @@ class SqlAlchemyStore:
             .first()
         )
         if assignment is None:
-            session.add(SqlUserRoleAssignment(user_id=user_id, role_id=role.id))
-            session.flush()
+            try:
+                with session.begin_nested():
+                    session.add(SqlUserRoleAssignment(user_id=user_id, role_id=role.id))
+                    session.flush()
+            except IntegrityError:
+                # Another concurrent write already assigned the user.
+                pass
         return role
 
     def _mirror_user_grant(
@@ -253,6 +295,17 @@ class SqlAlchemyStore:
         )
         session.flush()
 
+    def _synthetic_role_ids(self, session, workspace: str | None = None) -> list[int]:
+        """
+        Return ids of synthetic ``__user_<id>__`` roles, optionally scoped to
+        ``workspace``. Callers of bulk cleanup/rename helpers route through this so they
+        never touch admin-created roles that happen to share a grant.
+        """
+        query = session.query(SqlRole.id, SqlRole.name)
+        if workspace is not None:
+            query = query.filter(SqlRole.workspace == workspace)
+        return [rid for (rid, name) in query.all() if self._is_synthetic_role_name(name)]
+
     def _unmirror_resource(
         self,
         session,
@@ -263,22 +316,16 @@ class SqlAlchemyStore:
         # Delete all mirrored role_permissions rows for one resource across users.
         # `workspace=None` is used when the underlying resource ID is globally unique
         # (scorer, gateway_*), so mirrored rows are removed regardless of which
-        # synthetic role holds them.
-        query = session.query(SqlRolePermission).filter(
+        # synthetic role holds them. Restricted to synthetic roles so admin-created
+        # roles with an overlapping grant are never touched.
+        role_ids = self._synthetic_role_ids(session, workspace=workspace)
+        if not role_ids:
+            return
+        session.query(SqlRolePermission).filter(
+            SqlRolePermission.role_id.in_(role_ids),
             SqlRolePermission.resource_type == resource_type,
             SqlRolePermission.resource_pattern == resource_pattern,
-        )
-        if workspace is not None:
-            role_ids = [
-                rid
-                for (rid,) in (
-                    session.query(SqlRole.id).filter(SqlRole.workspace == workspace).all()
-                )
-            ]
-            if not role_ids:
-                return
-            query = query.filter(SqlRolePermission.role_id.in_(role_ids))
-        query.delete(synchronize_session=False)
+        ).delete(synchronize_session=False)
         session.flush()
 
     def _rename_mirrored_resource(
@@ -289,10 +336,8 @@ class SqlAlchemyStore:
         old_pattern: str,
         new_pattern: str,
     ) -> None:
-        role_ids = [
-            rid
-            for (rid,) in (session.query(SqlRole.id).filter(SqlRole.workspace == workspace).all())
-        ]
+        # Synthetic-role-only, same rationale as _unmirror_resource above.
+        role_ids = self._synthetic_role_ids(session, workspace=workspace)
         if not role_ids:
             return
         (
@@ -1087,6 +1132,7 @@ class SqlAlchemyStore:
         workspace: str,
         description: str | None = None,
     ) -> Role:
+        self._reject_synthetic_role_name(name)
         with self.ManagedSessionMaker() as session:
             try:
                 role = SqlRole(
@@ -1168,6 +1214,8 @@ class SqlAlchemyStore:
         name: str | None = None,
         description: str | None = None,
     ) -> Role:
+        if name is not None:
+            self._reject_synthetic_role_name(name)
         with self.ManagedSessionMaker() as session:
             role = self._get_role(session, role_id)
             if name is not None:

--- a/mlflow/server/auth/sqlalchemy_store.py
+++ b/mlflow/server/auth/sqlalchemy_store.py
@@ -141,27 +141,196 @@ class SqlAlchemyStore:
     def delete_user(self, username: str):
         with self.ManagedSessionMaker() as session:
             user = self._get_user(session, username)
+            # Clean up synthetic per-user roles created by the Phase 2 M1 dual-write so their
+            # role_permissions / user_role_assignments rows don't leak (and don't hit FK errors
+            # on backends that enforce referential integrity).
+            synthetic_name = self._synthetic_user_role_name(user.id)
+            synthetic_roles = session.query(SqlRole).filter(SqlRole.name == synthetic_name).all()
+            for role in synthetic_roles:
+                session.delete(role)
+            session.flush()
             session.delete(user)
+
+    # ---- Synthetic user-role helpers (Phase 2 M1 dual-write) ----
+    #
+    # Per-resource grants (experiment_permissions, registered_model_permissions, ...) are
+    # mirrored into `role_permissions` under a synthetic role named `__user_<user_id>__`
+    # scoped to the resource's workspace. Reads still go through the per-resource tables;
+    # the mirrored grants make `get_role_permission_for_resource` a valid source of truth
+    # in parallel so later phases can flip reads over.
+    _SYNTHETIC_ROLE_PREFIX = "__user_"
+    _SYNTHETIC_ROLE_SUFFIX = "__"
+
+    @classmethod
+    def _synthetic_user_role_name(cls, user_id: int) -> str:
+        return f"{cls._SYNTHETIC_ROLE_PREFIX}{user_id}{cls._SYNTHETIC_ROLE_SUFFIX}"
+
+    def _get_or_create_synthetic_user_role(self, session, user_id: int, workspace: str) -> SqlRole:
+        name = self._synthetic_user_role_name(user_id)
+        role = (
+            session
+            .query(SqlRole)
+            .filter(SqlRole.workspace == workspace, SqlRole.name == name)
+            .first()
+        )
+        if role is None:
+            role = SqlRole(name=name, workspace=workspace, description=None)
+            session.add(role)
+            session.flush()
+        assignment = (
+            session
+            .query(SqlUserRoleAssignment)
+            .filter(
+                SqlUserRoleAssignment.user_id == user_id,
+                SqlUserRoleAssignment.role_id == role.id,
+            )
+            .first()
+        )
+        if assignment is None:
+            session.add(SqlUserRoleAssignment(user_id=user_id, role_id=role.id))
+            session.flush()
+        return role
+
+    def _mirror_user_grant(
+        self,
+        session,
+        user_id: int,
+        workspace: str,
+        resource_type: str,
+        resource_pattern: str,
+        permission: str,
+    ) -> None:
+        role = self._get_or_create_synthetic_user_role(session, user_id, workspace)
+        rp = (
+            session
+            .query(SqlRolePermission)
+            .filter(
+                SqlRolePermission.role_id == role.id,
+                SqlRolePermission.resource_type == resource_type,
+                SqlRolePermission.resource_pattern == resource_pattern,
+            )
+            .first()
+        )
+        if rp is None:
+            session.add(
+                SqlRolePermission(
+                    role_id=role.id,
+                    resource_type=resource_type,
+                    resource_pattern=resource_pattern,
+                    permission=permission,
+                )
+            )
+        else:
+            rp.permission = permission
+        session.flush()
+
+    def _unmirror_user_grant(
+        self,
+        session,
+        user_id: int,
+        workspace: str,
+        resource_type: str,
+        resource_pattern: str,
+    ) -> None:
+        name = self._synthetic_user_role_name(user_id)
+        role = (
+            session
+            .query(SqlRole)
+            .filter(SqlRole.workspace == workspace, SqlRole.name == name)
+            .first()
+        )
+        if role is None:
+            return
+        (
+            session
+            .query(SqlRolePermission)
+            .filter(
+                SqlRolePermission.role_id == role.id,
+                SqlRolePermission.resource_type == resource_type,
+                SqlRolePermission.resource_pattern == resource_pattern,
+            )
+            .delete(synchronize_session=False)
+        )
+        session.flush()
+
+    def _unmirror_resource(
+        self,
+        session,
+        resource_type: str,
+        resource_pattern: str,
+        workspace: str | None = None,
+    ) -> None:
+        # Delete all mirrored role_permissions rows for one resource across users.
+        # `workspace=None` is used when the underlying resource ID is globally unique
+        # (scorer, gateway_*), so mirrored rows are removed regardless of which
+        # synthetic role holds them.
+        query = session.query(SqlRolePermission).filter(
+            SqlRolePermission.resource_type == resource_type,
+            SqlRolePermission.resource_pattern == resource_pattern,
+        )
+        if workspace is not None:
+            role_ids = [
+                rid
+                for (rid,) in (
+                    session.query(SqlRole.id).filter(SqlRole.workspace == workspace).all()
+                )
+            ]
+            if not role_ids:
+                return
+            query = query.filter(SqlRolePermission.role_id.in_(role_ids))
+        query.delete(synchronize_session=False)
+        session.flush()
+
+    def _rename_mirrored_resource(
+        self,
+        session,
+        workspace: str,
+        resource_type: str,
+        old_pattern: str,
+        new_pattern: str,
+    ) -> None:
+        role_ids = [
+            rid
+            for (rid,) in (session.query(SqlRole.id).filter(SqlRole.workspace == workspace).all())
+        ]
+        if not role_ids:
+            return
+        (
+            session
+            .query(SqlRolePermission)
+            .filter(
+                SqlRolePermission.role_id.in_(role_ids),
+                SqlRolePermission.resource_type == resource_type,
+                SqlRolePermission.resource_pattern == old_pattern,
+            )
+            .update({SqlRolePermission.resource_pattern: new_pattern}, synchronize_session=False)
+        )
+        session.flush()
 
     def create_experiment_permission(
         self, experiment_id: str, username: str, permission: str
     ) -> ExperimentPermission:
         _validate_permission(permission)
         with self.ManagedSessionMaker() as session:
+            user = self._get_user(session, username=username)
+            workspace_name = self._get_active_workspace_name()
             try:
-                user = self._get_user(session, username=username)
                 perm = SqlExperimentPermission(
                     experiment_id=experiment_id, user_id=user.id, permission=permission
                 )
                 session.add(perm)
                 session.flush()
-                return perm.to_mlflow_entity()
+                entity = perm.to_mlflow_entity()
             except IntegrityError as e:
                 raise MlflowException(
                     f"Experiment permission (experiment_id={experiment_id}, username={username}) "
                     f"already exists. Error: {e}",
                     RESOURCE_ALREADY_EXISTS,
                 )
+            self._mirror_user_grant(
+                session, user.id, workspace_name, "experiment", experiment_id, permission
+            )
+            return entity
 
     def _get_experiment_permission(
         self, session, experiment_id: str, username: str
@@ -214,12 +383,20 @@ class SqlAlchemyStore:
         with self.ManagedSessionMaker() as session:
             perm = self._get_experiment_permission(session, experiment_id, username)
             perm.permission = permission
+            workspace_name = self._get_active_workspace_name()
+            self._mirror_user_grant(
+                session, perm.user_id, workspace_name, "experiment", experiment_id, permission
+            )
             return perm.to_mlflow_entity()
 
     def delete_experiment_permission(self, experiment_id: str, username: str):
         with self.ManagedSessionMaker() as session:
             perm = self._get_experiment_permission(session, experiment_id, username)
+            user_id = perm.user_id
+            workspace_name = self._get_active_workspace_name()
             session.delete(perm)
+            session.flush()
+            self._unmirror_user_grant(session, user_id, workspace_name, "experiment", experiment_id)
 
     def delete_workspace_permissions_for_workspace(self, workspace_name: str) -> None:
         with self.ManagedSessionMaker() as session:
@@ -232,9 +409,9 @@ class SqlAlchemyStore:
     ) -> RegisteredModelPermission:
         _validate_permission(permission)
         with self.ManagedSessionMaker() as session:
+            user = self._get_user(session, username=username)
+            workspace_name = self._get_active_workspace_name()
             try:
-                user = self._get_user(session, username=username)
-                workspace_name = self._get_active_workspace_name()
                 perm = SqlRegisteredModelPermission(
                     workspace=workspace_name,
                     name=name,
@@ -243,7 +420,7 @@ class SqlAlchemyStore:
                 )
                 session.add(perm)
                 session.flush()
-                return perm.to_mlflow_entity()
+                entity = perm.to_mlflow_entity()
             except IntegrityError as e:
                 raise MlflowException(
                     "Registered model permission "
@@ -251,6 +428,10 @@ class SqlAlchemyStore:
                     f"already exists. Error: {e}",
                     RESOURCE_ALREADY_EXISTS,
                 )
+            self._mirror_user_grant(
+                session, user.id, workspace_name, "registered_model", name, permission
+            )
+            return entity
 
     def _get_registered_model_permission(
         self, session, name: str, username: str
@@ -310,12 +491,19 @@ class SqlAlchemyStore:
         with self.ManagedSessionMaker() as session:
             perm = self._get_registered_model_permission(session, name, username)
             perm.permission = permission
+            self._mirror_user_grant(
+                session, perm.user_id, perm.workspace, "registered_model", name, permission
+            )
             return perm.to_mlflow_entity()
 
     def delete_registered_model_permission(self, name: str, username: str):
         with self.ManagedSessionMaker() as session:
             perm = self._get_registered_model_permission(session, name, username)
+            user_id = perm.user_id
+            workspace_name = perm.workspace
             session.delete(perm)
+            session.flush()
+            self._unmirror_user_grant(session, user_id, workspace_name, "registered_model", name)
 
     def delete_registered_model_permissions(self, name: str) -> None:
         """
@@ -332,6 +520,7 @@ class SqlAlchemyStore:
                 SqlRegisteredModelPermission.workspace == workspace_name,
                 SqlRegisteredModelPermission.name == name,
             ).delete(synchronize_session=False)
+            self._unmirror_resource(session, "registered_model", name, workspace=workspace_name)
 
     def rename_registered_model_permissions(self, old_name: str, new_name: str):
         with self.ManagedSessionMaker() as session:
@@ -347,6 +536,9 @@ class SqlAlchemyStore:
             )
             for perm in perms:
                 perm.name = new_name
+            self._rename_mirrored_resource(
+                session, workspace_name, "registered_model", old_name, new_name
+            )
 
     def list_workspace_permissions(self, workspace_name: str) -> list[WorkspacePermission]:
         with self.ManagedSessionMaker() as session:
@@ -444,8 +636,9 @@ class SqlAlchemyStore:
     ) -> ScorerPermission:
         _validate_permission(permission)
         with self.ManagedSessionMaker() as session:
+            user = self._get_user(session, username=username)
+            workspace_name = self._get_active_workspace_name()
             try:
-                user = self._get_user(session, username=username)
                 perm = SqlScorerPermission(
                     experiment_id=experiment_id,
                     scorer_name=scorer_name,
@@ -454,13 +647,22 @@ class SqlAlchemyStore:
                 )
                 session.add(perm)
                 session.flush()
-                return perm.to_mlflow_entity()
+                entity = perm.to_mlflow_entity()
             except IntegrityError as e:
                 raise MlflowException(
                     f"Scorer permission (experiment_id={experiment_id}, scorer_name={scorer_name}, "
                     f"username={username}) already exists. Error: {e}",
                     RESOURCE_ALREADY_EXISTS,
                 ) from e
+            self._mirror_user_grant(
+                session,
+                user.id,
+                workspace_name,
+                "scorer",
+                f"{experiment_id}/{scorer_name}",
+                permission,
+            )
+            return entity
 
     def _get_scorer_permission(
         self, session, experiment_id: str, scorer_name: str, username: str
@@ -516,12 +718,31 @@ class SqlAlchemyStore:
         with self.ManagedSessionMaker() as session:
             perm = self._get_scorer_permission(session, experiment_id, scorer_name, username)
             perm.permission = permission
+            workspace_name = self._get_active_workspace_name()
+            self._mirror_user_grant(
+                session,
+                perm.user_id,
+                workspace_name,
+                "scorer",
+                f"{experiment_id}/{scorer_name}",
+                permission,
+            )
             return perm.to_mlflow_entity()
 
     def delete_scorer_permission(self, experiment_id: str, scorer_name: str, username: str):
         with self.ManagedSessionMaker() as session:
             perm = self._get_scorer_permission(session, experiment_id, scorer_name, username)
+            user_id = perm.user_id
+            workspace_name = self._get_active_workspace_name()
             session.delete(perm)
+            session.flush()
+            self._unmirror_user_grant(
+                session,
+                user_id,
+                workspace_name,
+                "scorer",
+                f"{experiment_id}/{scorer_name}",
+            )
 
     def delete_scorer_permissions_for_scorer(self, experiment_id: str, scorer_name: str):
         with self.ManagedSessionMaker() as session:
@@ -529,26 +750,32 @@ class SqlAlchemyStore:
                 SqlScorerPermission.experiment_id == experiment_id,
                 SqlScorerPermission.scorer_name == scorer_name,
             ).delete()
+            self._unmirror_resource(session, "scorer", f"{experiment_id}/{scorer_name}")
 
     def create_gateway_secret_permission(
         self, secret_id: str, username: str, permission: str
     ) -> GatewaySecretPermission:
         _validate_permission(permission)
         with self.ManagedSessionMaker() as session:
+            user = self._get_user(session, username=username)
+            workspace_name = self._get_active_workspace_name()
             try:
-                user = self._get_user(session, username=username)
                 perm = SqlGatewaySecretPermission(
                     secret_id=secret_id, user_id=user.id, permission=permission
                 )
                 session.add(perm)
                 session.flush()
-                return perm.to_mlflow_entity()
+                entity = perm.to_mlflow_entity()
             except IntegrityError as e:
                 raise MlflowException(
                     f"Gateway secret permission (secret_id={secret_id}, username={username}) "
                     f"already exists. Error: {e}",
                     RESOURCE_ALREADY_EXISTS,
                 ) from e
+            self._mirror_user_grant(
+                session, user.id, workspace_name, "gateway_secret", secret_id, permission
+            )
+            return entity
 
     def _get_gateway_secret_permission(
         self, session, secret_id: str, username: str
@@ -603,38 +830,52 @@ class SqlAlchemyStore:
         with self.ManagedSessionMaker() as session:
             perm = self._get_gateway_secret_permission(session, secret_id, username)
             perm.permission = permission
+            workspace_name = self._get_active_workspace_name()
+            self._mirror_user_grant(
+                session, perm.user_id, workspace_name, "gateway_secret", secret_id, permission
+            )
             return perm.to_mlflow_entity()
 
     def delete_gateway_secret_permission(self, secret_id: str, username: str):
         with self.ManagedSessionMaker() as session:
             perm = self._get_gateway_secret_permission(session, secret_id, username)
+            user_id = perm.user_id
+            workspace_name = self._get_active_workspace_name()
             session.delete(perm)
+            session.flush()
+            self._unmirror_user_grant(session, user_id, workspace_name, "gateway_secret", secret_id)
 
     def delete_gateway_secret_permissions_for_secret(self, secret_id: str):
         with self.ManagedSessionMaker() as session:
             session.query(SqlGatewaySecretPermission).filter(
                 SqlGatewaySecretPermission.secret_id == secret_id,
             ).delete()
+            self._unmirror_resource(session, "gateway_secret", secret_id)
 
     def create_gateway_endpoint_permission(
         self, endpoint_id: str, username: str, permission: str
     ) -> GatewayEndpointPermission:
         _validate_permission(permission)
         with self.ManagedSessionMaker() as session:
+            user = self._get_user(session, username=username)
+            workspace_name = self._get_active_workspace_name()
             try:
-                user = self._get_user(session, username=username)
                 perm = SqlGatewayEndpointPermission(
                     endpoint_id=endpoint_id, user_id=user.id, permission=permission
                 )
                 session.add(perm)
                 session.flush()
-                return perm.to_mlflow_entity()
+                entity = perm.to_mlflow_entity()
             except IntegrityError as e:
                 raise MlflowException(
                     f"Gateway endpoint permission (endpoint_id={endpoint_id}, username={username}) "
                     f"already exists. Error: {e}",
                     RESOURCE_ALREADY_EXISTS,
                 ) from e
+            self._mirror_user_grant(
+                session, user.id, workspace_name, "gateway_endpoint", endpoint_id, permission
+            )
+            return entity
 
     def _get_gateway_endpoint_permission(
         self, session, endpoint_id: str, username: str
@@ -689,32 +930,44 @@ class SqlAlchemyStore:
         with self.ManagedSessionMaker() as session:
             perm = self._get_gateway_endpoint_permission(session, endpoint_id, username)
             perm.permission = permission
+            workspace_name = self._get_active_workspace_name()
+            self._mirror_user_grant(
+                session, perm.user_id, workspace_name, "gateway_endpoint", endpoint_id, permission
+            )
             return perm.to_mlflow_entity()
 
     def delete_gateway_endpoint_permission(self, endpoint_id: str, username: str):
         with self.ManagedSessionMaker() as session:
             perm = self._get_gateway_endpoint_permission(session, endpoint_id, username)
+            user_id = perm.user_id
+            workspace_name = self._get_active_workspace_name()
             session.delete(perm)
+            session.flush()
+            self._unmirror_user_grant(
+                session, user_id, workspace_name, "gateway_endpoint", endpoint_id
+            )
 
     def delete_gateway_endpoint_permissions_for_endpoint(self, endpoint_id: str):
         with self.ManagedSessionMaker() as session:
             session.query(SqlGatewayEndpointPermission).filter(
                 SqlGatewayEndpointPermission.endpoint_id == endpoint_id,
             ).delete()
+            self._unmirror_resource(session, "gateway_endpoint", endpoint_id)
 
     def create_gateway_model_definition_permission(
         self, model_definition_id: str, username: str, permission: str
     ) -> GatewayModelDefinitionPermission:
         _validate_permission(permission)
         with self.ManagedSessionMaker() as session:
+            user = self._get_user(session, username=username)
+            workspace_name = self._get_active_workspace_name()
             try:
-                user = self._get_user(session, username=username)
                 perm = SqlGatewayModelDefinitionPermission(
                     model_definition_id=model_definition_id, user_id=user.id, permission=permission
                 )
                 session.add(perm)
                 session.flush()
-                return perm.to_mlflow_entity()
+                entity = perm.to_mlflow_entity()
             except IntegrityError as e:
                 raise MlflowException(
                     f"Gateway model definition permission "
@@ -722,6 +975,15 @@ class SqlAlchemyStore:
                     f"already exists. Error: {e}",
                     RESOURCE_ALREADY_EXISTS,
                 ) from e
+            self._mirror_user_grant(
+                session,
+                user.id,
+                workspace_name,
+                "gateway_model_definition",
+                model_definition_id,
+                permission,
+            )
+            return entity
 
     def _get_gateway_model_definition_permission(
         self, session, model_definition_id: str, username: str
@@ -780,6 +1042,15 @@ class SqlAlchemyStore:
                 session, model_definition_id, username
             )
             perm.permission = permission
+            workspace_name = self._get_active_workspace_name()
+            self._mirror_user_grant(
+                session,
+                perm.user_id,
+                workspace_name,
+                "gateway_model_definition",
+                model_definition_id,
+                permission,
+            )
             return perm.to_mlflow_entity()
 
     def delete_gateway_model_definition_permission(self, model_definition_id: str, username: str):
@@ -787,7 +1058,17 @@ class SqlAlchemyStore:
             perm = self._get_gateway_model_definition_permission(
                 session, model_definition_id, username
             )
+            user_id = perm.user_id
+            workspace_name = self._get_active_workspace_name()
             session.delete(perm)
+            session.flush()
+            self._unmirror_user_grant(
+                session,
+                user_id,
+                workspace_name,
+                "gateway_model_definition",
+                model_definition_id,
+            )
 
     def delete_gateway_model_definition_permissions_for_model_definition(
         self, model_definition_id: str
@@ -796,6 +1077,7 @@ class SqlAlchemyStore:
             session.query(SqlGatewayModelDefinitionPermission).filter(
                 SqlGatewayModelDefinitionPermission.model_definition_id == model_definition_id,
             ).delete()
+            self._unmirror_resource(session, "gateway_model_definition", model_definition_id)
 
     # ---- Role CRUD ----
 

--- a/mlflow/server/auth/sqlalchemy_store.py
+++ b/mlflow/server/auth/sqlalchemy_store.py
@@ -449,6 +449,7 @@ class SqlAlchemyStore:
             session.query(SqlWorkspacePermission).filter(
                 SqlWorkspacePermission.workspace == workspace_name
             ).delete(synchronize_session=False)
+            self._unmirror_resource(session, "*", "*", workspace=workspace_name)
 
     def create_registered_model_permission(
         self, name: str, username: str, permission: str
@@ -628,6 +629,7 @@ class SqlAlchemyStore:
             else:
                 entity.permission = permission
             session.flush()
+            self._mirror_user_grant(session, user.id, workspace_name, "*", "*", permission)
             return entity.to_mlflow_entity()
 
     def delete_workspace_permission(self, workspace_name: str, username: str) -> None:
@@ -646,6 +648,8 @@ class SqlAlchemyStore:
                     RESOURCE_DOES_NOT_EXIST,
                 )
             session.delete(entity)
+            session.flush()
+            self._unmirror_user_grant(session, user.id, workspace_name, "*", "*")
 
     def list_accessible_workspace_names(self, username: str | None) -> set[str]:
         if username is None:
@@ -1276,12 +1280,11 @@ class SqlAlchemyStore:
     ) -> RolePermission:
         _validate_permission(permission)
         _validate_resource_type(resource_type)
-        # Workspace-scope grants only support the "*" pattern (apply to every resource in
-        # the role's workspace). Any other pattern would be silently ignored by the
-        # resolver, so reject it up front.
-        if resource_type == "workspace" and resource_pattern != "*":
+        # Workspace-scope and type-wildcard grants only support the "*" pattern. Any other
+        # pattern would be silently ignored by the resolver, so reject it up front.
+        if resource_type in ("workspace", "*") and resource_pattern != "*":
             raise MlflowException.invalid_parameter_value(
-                "resource_type='workspace' requires resource_pattern='*'. "
+                f"resource_type='{resource_type}' requires resource_pattern='*'. "
                 f"Got resource_pattern='{resource_pattern}'."
             )
         with self.ManagedSessionMaker() as session:
@@ -1478,8 +1481,11 @@ class SqlAlchemyStore:
             best_permission_name: str | None = None
             for role in roles:
                 for rp in role.permissions:
-                    # Workspace-wide permission — applies to every resource type.
-                    if rp.resource_type == "workspace" and rp.resource_pattern == "*":
+                    # Workspace-wide permission — applies to every resource type. Both
+                    # ``resource_type='workspace'`` (workspace admin) and ``resource_type='*'``
+                    # (type-wildcard, mirrors the legacy workspace_permissions table) match
+                    # every resource in the role's workspace.
+                    if rp.resource_type in ("workspace", "*") and rp.resource_pattern == "*":
                         best_permission_name = (
                             max_permission(best_permission_name, rp.permission)
                             if best_permission_name is not None
@@ -1584,9 +1590,10 @@ class SqlAlchemyStore:
         ``filter_experiment_ids``, which unions the result of this query with
         ``list_experiment_permissions`` from the legacy table).
 
-        Includes both grants on the specific resource_type and workspace-wide grants
-        (``resource_type='workspace'``, ``resource_pattern='*'``) since those apply to
-        every resource type.
+        Includes grants on the specific resource_type plus workspace-wide grants that
+        match every resource type: ``resource_type='workspace'`` (workspace admin) and
+        ``resource_type='*'`` (type-wildcard mirroring the legacy
+        ``workspace_permissions`` table).
 
         Returns a list of ``(resource_pattern, permission)`` tuples.
         """
@@ -1603,7 +1610,7 @@ class SqlAlchemyStore:
                     or_(
                         SqlRolePermission.resource_type == resource_type,
                         and_(
-                            SqlRolePermission.resource_type == "workspace",
+                            SqlRolePermission.resource_type.in_(("workspace", "*")),
                             SqlRolePermission.resource_pattern == "*",
                         ),
                     ),

--- a/tests/server/auth/test_rbac_dual_write.py
+++ b/tests/server/auth/test_rbac_dual_write.py
@@ -1,5 +1,6 @@
 import pytest
 
+from mlflow.exceptions import MlflowException
 from mlflow.server.auth.permissions import EDIT, MANAGE, READ, get_permission
 from mlflow.server.auth.sqlalchemy_store import SqlAlchemyStore
 from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
@@ -217,3 +218,80 @@ def test_legacy_and_role_views_agree(store, user):
             store.create_experiment_permission("exp1", user.username, permission_name)
         legacy = store.get_experiment_permission("exp1", user.username).permission
         _assert_role_permission(store, user.id, "experiment", "exp1", get_permission(legacy))
+
+
+# ---- Synthetic-role scoping invariants ----
+#
+# The synthetic `__user_<id>__` namespace is reserved. Bulk cleanup/rename helpers must
+# never touch admin-created roles even when the (resource_type, resource_pattern) match.
+
+
+def test_bulk_delete_does_not_touch_admin_created_roles(store, user):
+    # Admin creates a regular role with a registered_model grant; user also has a
+    # mirrored registered_model permission. Bulk delete must only remove the mirror.
+    admin_role = store.create_role(name="team-editor", workspace=DEFAULT_WORKSPACE_NAME)
+    store.add_role_permission(admin_role.id, "registered_model", "model_a", EDIT.name)
+    store.create_registered_model_permission("model_a", user.username, READ.name)
+
+    store.delete_registered_model_permissions("model_a")
+
+    _assert_role_permission(store, user.id, "registered_model", "model_a", None)
+    admin_perms = store.list_role_permissions(admin_role.id)
+    assert len(admin_perms) == 1
+    assert admin_perms[0].resource_pattern == "model_a"
+    assert admin_perms[0].permission == EDIT.name
+
+
+def test_bulk_rename_does_not_touch_admin_created_roles(store, user):
+    admin_role = store.create_role(name="team-editor", workspace=DEFAULT_WORKSPACE_NAME)
+    store.add_role_permission(admin_role.id, "registered_model", "old_name", EDIT.name)
+    store.create_registered_model_permission("old_name", user.username, READ.name)
+
+    store.rename_registered_model_permissions("old_name", "new_name")
+
+    # User's mirror was renamed.
+    _assert_role_permission(store, user.id, "registered_model", "new_name", READ)
+    _assert_role_permission(store, user.id, "registered_model", "old_name", None)
+    # Admin-created role's permission pattern unchanged.
+    admin_perms = store.list_role_permissions(admin_role.id)
+    assert len(admin_perms) == 1
+    assert admin_perms[0].resource_pattern == "old_name"
+
+
+def test_scorer_bulk_delete_does_not_touch_admin_created_roles(store, user):
+    # Workspace=None bulk path (used by scorer/gateway_*) must also be synthetic-only.
+    admin_role = store.create_role(name="scorer-admin", workspace=DEFAULT_WORKSPACE_NAME)
+    store.add_role_permission(admin_role.id, "scorer", "exp1/judge", EDIT.name)
+    store.create_scorer_permission("exp1", "judge", user.username, READ.name)
+
+    store.delete_scorer_permissions_for_scorer("exp1", "judge")
+
+    _assert_role_permission(store, user.id, "scorer", "exp1/judge", None)
+    admin_perms = store.list_role_permissions(admin_role.id)
+    assert len(admin_perms) == 1
+    assert admin_perms[0].permission == EDIT.name
+
+
+def test_create_role_rejects_synthetic_name_pattern(store):
+    with pytest.raises(MlflowException, match="reserved synthetic pattern"):
+        store.create_role(name="__user_42__", workspace=DEFAULT_WORKSPACE_NAME)
+    # Non-integer suffix is allowed — only the exact pattern is reserved.
+    store.create_role(name="__user_foo__", workspace=DEFAULT_WORKSPACE_NAME)
+
+
+def test_update_role_rejects_synthetic_name_pattern(store):
+    role = store.create_role(name="normal", workspace=DEFAULT_WORKSPACE_NAME)
+    with pytest.raises(MlflowException, match="reserved synthetic pattern"):
+        store.update_role(role.id, name="__user_7__")
+
+
+def test_is_synthetic_role_name_rejects_edge_cases():
+    assert SqlAlchemyStore._is_synthetic_role_name("__user_1__") is True
+    assert SqlAlchemyStore._is_synthetic_role_name("__user_99999__") is True
+    # Wrong surroundings or missing id:
+    assert SqlAlchemyStore._is_synthetic_role_name("__user__") is False
+    assert SqlAlchemyStore._is_synthetic_role_name("__user_abc__") is False
+    assert SqlAlchemyStore._is_synthetic_role_name("user_1") is False
+    assert SqlAlchemyStore._is_synthetic_role_name("_user_1__") is False
+    assert SqlAlchemyStore._is_synthetic_role_name("__user_1_") is False
+    assert SqlAlchemyStore._is_synthetic_role_name(None) is False

--- a/tests/server/auth/test_rbac_dual_write.py
+++ b/tests/server/auth/test_rbac_dual_write.py
@@ -193,8 +193,8 @@ def test_delete_user_removes_synthetic_role(store, user):
     # Create a grant to force the synthetic role into existence, then remove the grant so
     # only the (now empty) synthetic role + assignment remain. This avoids tripping a
     # pre-existing FK issue on the legacy permission tables when a user is deleted while
-    # still holding direct grants — that issue exists independent of Phase 2 and will be
-    # addressed in its own fix.
+    # still holding direct grants — that issue is orthogonal to the dual-write cleanup and
+    # will be addressed in its own fix.
     store.create_experiment_permission("exp1", user.username, READ.name)
     store.delete_experiment_permission("exp1", user.username)
     user_id = user.id

--- a/tests/server/auth/test_rbac_dual_write.py
+++ b/tests/server/auth/test_rbac_dual_write.py
@@ -295,3 +295,76 @@ def test_is_synthetic_role_name_rejects_edge_cases():
     assert SqlAlchemyStore._is_synthetic_role_name("_user_1__") is False
     assert SqlAlchemyStore._is_synthetic_role_name("__user_1_") is False
     assert SqlAlchemyStore._is_synthetic_role_name(None) is False
+
+
+# ---- workspace_permissions dual-write (resource_type='*') ----
+#
+# The legacy ``workspace_permissions`` table expresses "user has permission X on every
+# resource of every type in this workspace." We mirror those grants as
+# ``(resource_type='*', resource_pattern='*', permission)`` rows on the synthetic role,
+# and the resolver treats type-wildcard rows as a match for any resource_type.
+
+
+def test_workspace_permission_dual_write_applies_to_every_type(store, user):
+    store.set_workspace_permission(DEFAULT_WORKSPACE_NAME, user.username, READ.name)
+
+    # A type-wildcard grant matches every resource type.
+    for resource_type in (
+        "experiment",
+        "registered_model",
+        "scorer",
+        "gateway_secret",
+        "gateway_endpoint",
+        "gateway_model_definition",
+    ):
+        _assert_role_permission(store, user.id, resource_type, "any-id", READ)
+
+
+def test_workspace_permission_dual_write_update_and_delete(store, user):
+    store.set_workspace_permission(DEFAULT_WORKSPACE_NAME, user.username, READ.name)
+    _assert_role_permission(store, user.id, "experiment", "exp1", READ)
+
+    store.set_workspace_permission(DEFAULT_WORKSPACE_NAME, user.username, EDIT.name)
+    _assert_role_permission(store, user.id, "experiment", "exp1", EDIT)
+
+    store.delete_workspace_permission(DEFAULT_WORKSPACE_NAME, user.username)
+    _assert_role_permission(store, user.id, "experiment", "exp1", None)
+
+
+def test_workspace_permissions_bulk_delete_unmirrors(store, user, user2):
+    store.set_workspace_permission(DEFAULT_WORKSPACE_NAME, user.username, READ.name)
+    store.set_workspace_permission(DEFAULT_WORKSPACE_NAME, user2.username, EDIT.name)
+
+    store.delete_workspace_permissions_for_workspace(DEFAULT_WORKSPACE_NAME)
+
+    _assert_role_permission(store, user.id, "experiment", "exp1", None)
+    _assert_role_permission(store, user2.id, "experiment", "exp1", None)
+
+
+def test_type_wildcard_unions_with_specific_grant(store, user):
+    # A type-wildcard READ on the workspace + a specific experiment MANAGE grant should
+    # resolve to MANAGE (higher of the two).
+    store.set_workspace_permission(DEFAULT_WORKSPACE_NAME, user.username, READ.name)
+    store.create_experiment_permission("exp1", user.username, MANAGE.name)
+
+    _assert_role_permission(store, user.id, "experiment", "exp1", MANAGE)
+    # Other experiments still see only the type-wildcard grant.
+    _assert_role_permission(store, user.id, "experiment", "exp2", READ)
+
+
+def test_type_wildcard_and_workspace_admin_coexist(store, user):
+    # A user can hold both a workspace-admin grant (role/user management) and a separate
+    # type-wildcard permission. Both rows apply and the resolver unions them.
+    admin_role = store.create_role(name="ws-admin", workspace=DEFAULT_WORKSPACE_NAME)
+    store.add_role_permission(admin_role.id, "workspace", "*", MANAGE.name)
+    store.assign_role_to_user(user.id, admin_role.id)
+
+    store.set_workspace_permission(DEFAULT_WORKSPACE_NAME, user.username, READ.name)
+
+    _assert_role_permission(store, user.id, "experiment", "exp1", MANAGE)
+
+
+def test_add_role_permission_type_wildcard_requires_pattern_wildcard(store):
+    role = store.create_role(name="r", workspace=DEFAULT_WORKSPACE_NAME)
+    with pytest.raises(MlflowException, match=r"resource_type='\*' requires"):
+        store.add_role_permission(role.id, "*", "exp1", READ.name)

--- a/tests/server/auth/test_rbac_dual_write.py
+++ b/tests/server/auth/test_rbac_dual_write.py
@@ -1,0 +1,219 @@
+import pytest
+
+from mlflow.server.auth.permissions import EDIT, MANAGE, READ, get_permission
+from mlflow.server.auth.sqlalchemy_store import SqlAlchemyStore
+from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
+
+from tests.helper_functions import random_str
+
+pytestmark = pytest.mark.notrackingurimock
+
+
+@pytest.fixture
+def store(tmp_sqlite_uri):
+    store = SqlAlchemyStore()
+    store.init_db(tmp_sqlite_uri)
+    return store
+
+
+@pytest.fixture
+def user(store):
+    return store.create_user(random_str(), random_str())
+
+
+@pytest.fixture
+def user2(store):
+    return store.create_user(random_str(), random_str())
+
+
+def _assert_role_permission(store, user_id, resource_type, resource_id, expected):
+    resolved = store.get_role_permission_for_resource(
+        user_id, resource_type, resource_id, DEFAULT_WORKSPACE_NAME
+    )
+    if expected is None:
+        assert resolved is None
+    else:
+        assert resolved == expected
+
+
+# ---- Per-resource dual-write invariants ----
+#
+# For each of the six per-resource permission tables, creating / updating / deleting a grant
+# via the legacy API must keep `get_role_permission_for_resource` in sync with the direct
+# lookup so later phases can flip reads over without changing semantics.
+
+
+def test_experiment_permission_dual_write(store, user):
+    store.create_experiment_permission("exp1", user.username, READ.name)
+    _assert_role_permission(store, user.id, "experiment", "exp1", READ)
+
+    store.update_experiment_permission("exp1", user.username, EDIT.name)
+    _assert_role_permission(store, user.id, "experiment", "exp1", EDIT)
+
+    store.delete_experiment_permission("exp1", user.username)
+    _assert_role_permission(store, user.id, "experiment", "exp1", None)
+
+
+def test_registered_model_permission_dual_write(store, user):
+    store.create_registered_model_permission("model_a", user.username, READ.name)
+    _assert_role_permission(store, user.id, "registered_model", "model_a", READ)
+
+    store.update_registered_model_permission("model_a", user.username, MANAGE.name)
+    _assert_role_permission(store, user.id, "registered_model", "model_a", MANAGE)
+
+    store.delete_registered_model_permission("model_a", user.username)
+    _assert_role_permission(store, user.id, "registered_model", "model_a", None)
+
+
+def test_registered_model_bulk_delete_unmirrors(store, user, user2):
+    store.create_registered_model_permission("model_a", user.username, READ.name)
+    store.create_registered_model_permission("model_a", user2.username, EDIT.name)
+    _assert_role_permission(store, user.id, "registered_model", "model_a", READ)
+    _assert_role_permission(store, user2.id, "registered_model", "model_a", EDIT)
+
+    store.delete_registered_model_permissions("model_a")
+
+    _assert_role_permission(store, user.id, "registered_model", "model_a", None)
+    _assert_role_permission(store, user2.id, "registered_model", "model_a", None)
+
+
+def test_registered_model_rename_updates_mirror(store, user):
+    store.create_registered_model_permission("old_name", user.username, EDIT.name)
+    _assert_role_permission(store, user.id, "registered_model", "old_name", EDIT)
+
+    store.rename_registered_model_permissions("old_name", "new_name")
+
+    _assert_role_permission(store, user.id, "registered_model", "old_name", None)
+    _assert_role_permission(store, user.id, "registered_model", "new_name", EDIT)
+
+
+def test_scorer_permission_dual_write(store, user):
+    store.create_scorer_permission("exp1", "scorer_a", user.username, READ.name)
+    _assert_role_permission(store, user.id, "scorer", "exp1/scorer_a", READ)
+
+    store.update_scorer_permission("exp1", "scorer_a", user.username, EDIT.name)
+    _assert_role_permission(store, user.id, "scorer", "exp1/scorer_a", EDIT)
+
+    store.delete_scorer_permission("exp1", "scorer_a", user.username)
+    _assert_role_permission(store, user.id, "scorer", "exp1/scorer_a", None)
+
+
+def test_scorer_bulk_delete_unmirrors(store, user, user2):
+    store.create_scorer_permission("exp1", "scorer_a", user.username, READ.name)
+    store.create_scorer_permission("exp1", "scorer_a", user2.username, EDIT.name)
+    store.delete_scorer_permissions_for_scorer("exp1", "scorer_a")
+    _assert_role_permission(store, user.id, "scorer", "exp1/scorer_a", None)
+    _assert_role_permission(store, user2.id, "scorer", "exp1/scorer_a", None)
+
+
+def test_gateway_secret_permission_dual_write(store, user):
+    store.create_gateway_secret_permission("secret1", user.username, READ.name)
+    _assert_role_permission(store, user.id, "gateway_secret", "secret1", READ)
+
+    store.update_gateway_secret_permission("secret1", user.username, MANAGE.name)
+    _assert_role_permission(store, user.id, "gateway_secret", "secret1", MANAGE)
+
+    store.delete_gateway_secret_permission("secret1", user.username)
+    _assert_role_permission(store, user.id, "gateway_secret", "secret1", None)
+
+
+def test_gateway_secret_bulk_delete_unmirrors(store, user, user2):
+    store.create_gateway_secret_permission("secret1", user.username, READ.name)
+    store.create_gateway_secret_permission("secret1", user2.username, EDIT.name)
+    store.delete_gateway_secret_permissions_for_secret("secret1")
+    _assert_role_permission(store, user.id, "gateway_secret", "secret1", None)
+    _assert_role_permission(store, user2.id, "gateway_secret", "secret1", None)
+
+
+def test_gateway_endpoint_permission_dual_write(store, user):
+    store.create_gateway_endpoint_permission("endpoint1", user.username, READ.name)
+    _assert_role_permission(store, user.id, "gateway_endpoint", "endpoint1", READ)
+
+    store.update_gateway_endpoint_permission("endpoint1", user.username, EDIT.name)
+    _assert_role_permission(store, user.id, "gateway_endpoint", "endpoint1", EDIT)
+
+    store.delete_gateway_endpoint_permission("endpoint1", user.username)
+    _assert_role_permission(store, user.id, "gateway_endpoint", "endpoint1", None)
+
+
+def test_gateway_endpoint_bulk_delete_unmirrors(store, user, user2):
+    store.create_gateway_endpoint_permission("endpoint1", user.username, READ.name)
+    store.create_gateway_endpoint_permission("endpoint1", user2.username, EDIT.name)
+    store.delete_gateway_endpoint_permissions_for_endpoint("endpoint1")
+    _assert_role_permission(store, user.id, "gateway_endpoint", "endpoint1", None)
+    _assert_role_permission(store, user2.id, "gateway_endpoint", "endpoint1", None)
+
+
+def test_gateway_model_definition_permission_dual_write(store, user):
+    store.create_gateway_model_definition_permission("model1", user.username, READ.name)
+    _assert_role_permission(store, user.id, "gateway_model_definition", "model1", READ)
+
+    store.update_gateway_model_definition_permission("model1", user.username, MANAGE.name)
+    _assert_role_permission(store, user.id, "gateway_model_definition", "model1", MANAGE)
+
+    store.delete_gateway_model_definition_permission("model1", user.username)
+    _assert_role_permission(store, user.id, "gateway_model_definition", "model1", None)
+
+
+def test_gateway_model_definition_bulk_delete_unmirrors(store, user, user2):
+    store.create_gateway_model_definition_permission("model1", user.username, READ.name)
+    store.create_gateway_model_definition_permission("model1", user2.username, EDIT.name)
+    store.delete_gateway_model_definition_permissions_for_model_definition("model1")
+    _assert_role_permission(store, user.id, "gateway_model_definition", "model1", None)
+    _assert_role_permission(store, user2.id, "gateway_model_definition", "model1", None)
+
+
+# ---- Synthetic role bookkeeping ----
+
+
+def test_synthetic_role_is_created_and_reused(store, user):
+    store.create_experiment_permission("exp1", user.username, READ.name)
+    store.create_registered_model_permission("model1", user.username, EDIT.name)
+
+    # A single synthetic role per (user, workspace) holds all mirrored grants.
+    roles = store.list_roles(DEFAULT_WORKSPACE_NAME)
+    synthetic = [r for r in roles if r.name == f"__user_{user.id}__"]
+    assert len(synthetic) == 1
+    patterns = {(p.resource_type, p.resource_pattern) for p in synthetic[0].permissions}
+    assert ("experiment", "exp1") in patterns
+    assert ("registered_model", "model1") in patterns
+
+
+def test_synthetic_role_is_user_scoped(store, user, user2):
+    store.create_experiment_permission("exp1", user.username, READ.name)
+    store.create_experiment_permission("exp1", user2.username, EDIT.name)
+
+    # Each user gets their own synthetic role — grants don't bleed across users.
+    _assert_role_permission(store, user.id, "experiment", "exp1", READ)
+    _assert_role_permission(store, user2.id, "experiment", "exp1", EDIT)
+
+
+def test_delete_user_removes_synthetic_role(store, user):
+    # Create a grant to force the synthetic role into existence, then remove the grant so
+    # only the (now empty) synthetic role + assignment remain. This avoids tripping a
+    # pre-existing FK issue on the legacy permission tables when a user is deleted while
+    # still holding direct grants — that issue exists independent of Phase 2 and will be
+    # addressed in its own fix.
+    store.create_experiment_permission("exp1", user.username, READ.name)
+    store.delete_experiment_permission("exp1", user.username)
+    user_id = user.id
+    assert any(r.name == f"__user_{user_id}__" for r in store.list_roles(DEFAULT_WORKSPACE_NAME))
+
+    store.delete_user(user.username)
+
+    assert not any(
+        r.name == f"__user_{user_id}__" for r in store.list_roles(DEFAULT_WORKSPACE_NAME)
+    )
+
+
+def test_legacy_and_role_views_agree(store, user):
+    # The goal of dual-write is that whatever the legacy read returns, the role-based
+    # resolution returns the same Permission object. Exercise that directly across a
+    # sequence of grant mutations.
+    for permission_name in (READ.name, EDIT.name, MANAGE.name):
+        if store.list_experiment_permissions(user.username):
+            store.update_experiment_permission("exp1", user.username, permission_name)
+        else:
+            store.create_experiment_permission("exp1", user.username, permission_name)
+        legacy = store.get_experiment_permission("exp1", user.username).permission
+        _assert_role_permission(store, user.id, "experiment", "exp1", get_permission(legacy))


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/22809/files/d34a20e7578eb5ecfe6b81eb6a6d69c672b4baa3..a619e25030e2a3201d94e069acdad2a5995998e3) to review incremental changes.
- [stack/rbac/data-model](https://github.com/mlflow/mlflow/pull/22721) [[Files changed](https://github.com/mlflow/mlflow/pull/22721/files)] [MERGED]
  - [stack/rbac/rest-api](https://github.com/mlflow/mlflow/pull/22722) [[Files changed](https://github.com/mlflow/mlflow/pull/22722/files)] [MERGED]
    - [stack/rbac/phase2-dual-write](https://github.com/mlflow/mlflow/pull/22806) [[Files changed](https://github.com/mlflow/mlflow/pull/22806/files)]
      - [**stack/rbac/phase2-workspace-perms**](https://github.com/mlflow/mlflow/pull/22809) [[Files changed](https://github.com/mlflow/mlflow/pull/22809/files/d34a20e7578eb5ecfe6b81eb6a6d69c672b4baa3..a619e25030e2a3201d94e069acdad2a5995998e3)]
        - [stack/rbac/phase2-backfill](https://github.com/mlflow/mlflow/pull/22810) [[Files changed](https://github.com/mlflow/mlflow/pull/22810/files/a619e25030e2a3201d94e069acdad2a5995998e3..be4d18f78944a4e774af3a887149b3ee58baf230)]
          - [stack/rbac/phase2-unified-reads](https://github.com/mlflow/mlflow/pull/22813) [[Files changed](https://github.com/mlflow/mlflow/pull/22813/files/be4d18f78944a4e774af3a887149b3ee58baf230..47b65c5825ba3352700651a5a0beb666f671578b)]

---------
### Related Issues/PRs

Part of the RBAC stack. Depends on #22806.

### What changes are proposed in this pull request?

**Phase 2 M1.5: dual-write \`workspace_permissions\` via \`resource_type='*'\`.**

The legacy \`workspace_permissions\` table expresses "user has permission X on every resource of every type in this workspace." M1 (#22806) mirrored the six per-resource tables into \`role_permissions\` but left workspace-scope grants out of scope because they need a new \`resource_type='*'\` semantic. This PR adds that semantic and wires the dual-write.

**What changes:**
- \`VALID_RESOURCE_TYPES\` now includes \`"*"\` with the invariant that \`resource_pattern\` must also be \`"*"\`. Distinct from \`resource_type='workspace'\` (workspace admin / role-and-user management) — type-wildcard grants match every resource type but don't convey admin capabilities.
- \`get_role_permission_for_resource\` and \`list_role_grants_for_user_in_workspace\` treat \`resource_type='*'\` rows as a match for any \`resource_type\`.
- \`set_workspace_permission\` / \`delete_workspace_permission\` / \`delete_workspace_permissions_for_workspace\` mirror/unmirror into \`role_permissions\` as \`(resource_type='*', resource_pattern='*', permission)\` rows on the synthetic \`__user_<id>__\` role.

**What doesn't change:**
- Reads still go through \`workspace_permissions\`; the mirror is parallel source of truth for later migration phases.
- \`list_workspace_admin_workspaces\` intentionally still filters on \`resource_type='workspace'\` (not \`'*'\`), since a type-wildcard \`MANAGE\` is NOT the same as WP admin.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Extended \`tests/server/auth/test_rbac_dual_write.py\` with 6 new tests covering workspace_permission dual-write, bulk-delete, union with specific grants, and coexistence with workspace-admin. Full auth suite (291 tests) passes.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] \`area/server-infra\`: MLflow Tracking server backend, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
