### PR TITLE
Phase 2 M3: flip auth reads to role_permissions under MLFLOW_RBAC_UNIFIED_READS

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -115,6 +115,12 @@ MLFLOW_WORKSPACE_STORE_URI = _EnvironmentVariable("MLFLOW_WORKSPACE_STORE_URI", 
 #: (default: ``False``)
 MLFLOW_ENABLE_WORKSPACES = _BooleanEnvironmentVariable("MLFLOW_ENABLE_WORKSPACES", False)
 
+#: When ``True``, MLflow's auth layer resolves permissions solely from the unified
+#: ``role_permissions`` table instead of the legacy per-resource permission tables.
+#: Requires Alembic revision ``d4e5f6a7b8c9`` (the Phase 2 M2 backfill) to be applied.
+#: (default: ``False``)
+MLFLOW_RBAC_UNIFIED_READS = _BooleanEnvironmentVariable("MLFLOW_RBAC_UNIFIED_READS", False)
+
 #: Specifies the active workspace for client operations.
 #: (default: ``None``)
 MLFLOW_WORKSPACE = _EnvironmentVariable("MLFLOW_WORKSPACE", str, None)

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -118,8 +118,10 @@ MLFLOW_ENABLE_WORKSPACES = _BooleanEnvironmentVariable("MLFLOW_ENABLE_WORKSPACES
 #: When ``True``, MLflow's auth layer resolves permissions solely from the unified
 #: ``role_permissions`` table instead of the legacy per-resource permission tables.
 #: Requires Alembic revision ``d4e5f6a7b8c9`` (the Phase 2 M2 backfill) to be applied.
-#: (default: ``False``)
-MLFLOW_RBAC_UNIFIED_READS = _BooleanEnvironmentVariable("MLFLOW_RBAC_UNIFIED_READS", False)
+#: Set to ``False`` to revert to the hybrid resolver that consults both legacy tables
+#: and ``role_permissions`` (useful as an emergency rollback).
+#: (default: ``True``)
+MLFLOW_RBAC_UNIFIED_READS = _BooleanEnvironmentVariable("MLFLOW_RBAC_UNIFIED_READS", True)
 
 #: Specifies the active workspace for client operations.
 #: (default: ``None``)

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -117,7 +117,8 @@ MLFLOW_ENABLE_WORKSPACES = _BooleanEnvironmentVariable("MLFLOW_ENABLE_WORKSPACES
 
 #: When ``True``, MLflow's auth layer resolves permissions solely from the unified
 #: ``role_permissions`` table instead of the legacy per-resource permission tables.
-#: Requires Alembic revision ``d4e5f6a7b8c9`` (the Phase 2 M2 backfill) to be applied.
+#: Requires the role_permissions backfill migration (Alembic revision
+#: ``d4e5f6a7b8c9``) to be applied.
 #: Set to ``False`` to revert to the hybrid resolver that consults both legacy tables
 #: and ``role_permissions`` (useful as an emergency rollback).
 #: (default: ``True``)

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -45,6 +45,7 @@ from mlflow.environment_variables import (
     _MLFLOW_SGI_NAME,
     MLFLOW_ENABLE_WORKSPACES,
     MLFLOW_FLASK_SERVER_SECRET_KEY,
+    MLFLOW_RBAC_UNIFIED_READS,
     MLFLOW_SERVER_ENABLE_GRAPHQL_AUTH,
 )
 from mlflow.protos.databricks_pb2 import (
@@ -281,6 +282,7 @@ from mlflow.utils import workspace_context
 from mlflow.utils.proto_json_utils import message_to_json, parse_dict
 from mlflow.utils.rest_utils import _REST_API_PATH_PREFIX
 from mlflow.utils.search_utils import SearchUtils
+from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
 
 try:
     from flask_wtf.csrf import CSRFProtect
@@ -383,16 +385,43 @@ def _get_permission_from_store_or_default(
     """
     Resolve a permission from the auth store, with optional role-based and workspace fallbacks.
 
-    Resolution order:
+    Resolution order (legacy mode):
     1. If role_permission_func is provided and returns a non-None/non-NO_PERMISSIONS result,
        combine it with any direct resource permission (take the higher of the two).
     2. If a direct (resource-level) permission exists, it is returned.
     3. If no direct permission exists and workspaces are enabled, check workspace-level permission.
     4. Fall back to auth_config.default_permission.
+
+    When ``MLFLOW_RBAC_UNIFIED_READS`` is enabled, ``role_permission_func`` is the sole
+    source of truth: the direct and workspace-level callbacks are skipped. This requires
+    the Phase 2 M2 backfill (Alembic revision ``d4e5f6a7b8c9``) — otherwise legacy grants
+    exist only in the per-resource tables and would not be visible.
     """
-    # Check the direct resource permission first. A direct MANAGE grant is already the
-    # ceiling — a role grant can't raise it — so we can skip the role lookup (one DB
-    # query) in the common admin/owner case. For any lower permission we still need to
+    if MLFLOW_RBAC_UNIFIED_READS.get():
+        if role_permission_func is not None:
+            role_perm = role_permission_func()
+            # Under unified reads, `role_permissions` is the sole source of truth. Any
+            # non-None result — including NO_PERMISSIONS — is the authoritative answer.
+            # Explicit NO_PERMISSIONS represents a denial that the dual-write mirrored
+            # from the legacy table; in legacy mode this case fell through to the direct
+            # permission (which held NO_PERMISSIONS) to reach the same outcome.
+            if role_perm is not None:
+                return role_perm
+        # Workspace fallback still applies when the user has no role in the resource's
+        # workspace. Under the unified-reads flag, ``_workspace_permission`` routes to
+        # ``get_workspace_permission_via_roles`` so it still consults ``role_permissions``.
+        # Crucially, when workspaces are enabled this returns ``NO_PERMISSIONS`` (not
+        # ``None``) for a user with no grant in the workspace — preserving the
+        # "deny by default" cross-workspace isolation.
+        if workspace_level_permission_func is not None:
+            workspace_permission = workspace_level_permission_func()
+            if workspace_permission is not None:
+                return workspace_permission
+        return get_permission(auth_config.default_permission)
+
+    # Legacy mode. Check the direct resource permission first — a direct MANAGE grant
+    # is already the ceiling (a role grant can't raise it) so we can skip the role
+    # lookup in the common admin/owner case. For any lower permission we still need to
     # consult roles so the `max(direct, role)` semantics below hold.
     direct_perm = None
     try:
@@ -455,7 +484,10 @@ def _workspace_permission(
         return NO_PERMISSIONS
 
     try:
-        permission = store.get_workspace_permission(workspace_name, username)
+        if MLFLOW_RBAC_UNIFIED_READS.get():
+            permission = store.get_workspace_permission_via_roles(username, workspace_name)
+        else:
+            permission = store.get_workspace_permission(workspace_name, username)
         if permission is not None:
             return permission
 
@@ -588,6 +620,39 @@ def _workspace_permission_for_registered_model(
     )
 
 
+def _active_role_workspace_for_filters() -> str | None:
+    """
+    Workspace to scope role-grant queries for the search/filter code paths. With
+    workspaces disabled, grants live under ``DEFAULT_WORKSPACE_NAME``; with workspaces
+    enabled, use the request's active workspace (which may still be None if unset).
+    """
+    if MLFLOW_ENABLE_WORKSPACES.get():
+        return workspace_context.get_request_workspace()
+    return DEFAULT_WORKSPACE_NAME
+
+
+def _role_can_read_map(user_id: int, resource_type: str) -> tuple[dict[str, bool], bool]:
+    """
+    Build a ``{resource_pattern: can_read}`` map from the user's role grants in the active
+    workspace plus a ``wildcard_allows_all`` flag (True when any matching wildcard grant
+    has ``can_read``). Callers that hit the wildcard flag should skip per-resource filtering.
+    """
+    workspace = _active_role_workspace_for_filters()
+    if not workspace:
+        return {}, False
+    grants = store.list_role_grants_for_user_in_workspace(user_id, workspace, resource_type)
+    can_read: dict[str, bool] = {}
+    wildcard_allows_all = False
+    for pattern, permission in grants:
+        if pattern == "*":
+            if get_permission(permission).can_read:
+                wildcard_allows_all = True
+            continue
+        existing = can_read.get(pattern, False)
+        can_read[pattern] = existing or get_permission(permission).can_read
+    return can_read, wildcard_allows_all
+
+
 def _has_resource_read_access(
     resource_id: str,
     username: str | None,
@@ -710,12 +775,7 @@ def _get_permission_from_experiment_id_artifact_proxy() -> Permission:
     username = authenticate_request().username
 
     if experiment_id := _get_experiment_id_from_view_args():
-        return _get_permission_from_store_or_default(
-            lambda: store.get_experiment_permission(experiment_id, username).permission,
-            workspace_level_permission_func=lambda: _workspace_permission_for_experiment(
-                username, experiment_id
-            ),
-        )
+        return _get_experiment_permission(experiment_id, username)
 
     if MLFLOW_ENABLE_WORKSPACES.get():
         if workspace_name := workspace_context.get_request_workspace():
@@ -736,42 +796,23 @@ def _get_permission_from_experiment_name() -> Permission:
             error_code=RESOURCE_DOES_NOT_EXIST,
         )
     username = authenticate_request().username
-
-    return _get_permission_from_store_or_default(
-        lambda: store.get_experiment_permission(store_exp.experiment_id, username).permission,
-        workspace_level_permission_func=lambda: _workspace_permission_for_experiment(
-            username, store_exp.experiment_id
-        ),
-    )
+    return _get_experiment_permission(store_exp.experiment_id, username)
 
 
 def _get_permission_from_run_id() -> Permission:
     # run permissions inherit from parent resource (experiment)
-    # so we just get the experiment permission
     run_id = _get_request_param("run_id")
     run = _get_tracking_store().get_run(run_id)
-    experiment_id = run.info.experiment_id
     username = authenticate_request().username
-    return _get_permission_from_store_or_default(
-        lambda: store.get_experiment_permission(experiment_id, username).permission,
-        workspace_level_permission_func=lambda: _workspace_permission_for_experiment(
-            username, experiment_id
-        ),
-    )
+    return _get_experiment_permission(run.info.experiment_id, username)
 
 
 def _get_permission_from_model_id() -> Permission:
     # logged model permissions inherit from parent resource (experiment)
     model_id = _get_request_param("model_id")
     model = _get_tracking_store().get_logged_model(model_id)
-    experiment_id = model.experiment_id
     username = authenticate_request().username
-    return _get_permission_from_store_or_default(
-        lambda: store.get_experiment_permission(experiment_id, username).permission,
-        workspace_level_permission_func=lambda: _workspace_permission_for_experiment(
-            username, experiment_id
-        ),
-    )
+    return _get_experiment_permission(model.experiment_id, username)
 
 
 def _get_permission_from_prompt_optimization_job_id() -> Permission:
@@ -781,17 +822,10 @@ def _get_permission_from_prompt_optimization_job_id() -> Permission:
     params = json.loads(job_entity.params)
     experiment_id = params.get("experiment_id")
     username = authenticate_request().username
-    return _get_permission_from_store_or_default(
-        lambda: store.get_experiment_permission(experiment_id, username).permission,
-        workspace_level_permission_func=lambda: _workspace_permission_for_experiment(
-            username, experiment_id
-        ),
-    )
+    return _get_experiment_permission(experiment_id, username)
 
 
-def _get_permission_from_registered_model_name() -> Permission:
-    name = _get_request_param("name")
-    username = authenticate_request().username
+def _get_registered_model_permission(name: str, username: str) -> Permission:
     return _get_permission_from_store_or_default(
         lambda: store.get_registered_model_permission(name, username).permission,
         workspace_level_permission_func=lambda: _workspace_permission_for_registered_model(
@@ -806,6 +840,12 @@ def _get_permission_from_registered_model_name() -> Permission:
             workspace_label="registered model",
         ),
     )
+
+
+def _get_permission_from_registered_model_name() -> Permission:
+    name = _get_request_param("name")
+    username = authenticate_request().username
+    return _get_registered_model_permission(name, username)
 
 
 def _get_permission_from_scorer_name() -> Permission:
@@ -1112,7 +1152,10 @@ def validate_can_view_workspace() -> bool:
         if default_workspace and workspace_name == default_workspace.name:
             return True
 
-    names = set(store.list_accessible_workspace_names(username))
+    if MLFLOW_RBAC_UNIFIED_READS.get():
+        names = store.list_accessible_workspace_names_via_roles(username)
+    else:
+        names = set(store.list_accessible_workspace_names(username))
 
     return workspace_name in names
 
@@ -1321,9 +1364,40 @@ def filter_experiment_ids(experiment_ids: list[str]) -> list[str]:
             return experiment_ids
 
         username = authenticate_request().username
+        default_can_read = get_permission(auth_config.default_permission).can_read
+
+        # Workspace to scope role grants against. With workspaces disabled, grants
+        # live under DEFAULT_WORKSPACE_NAME.
+        workspace_name = (
+            workspace_context.get_request_workspace()
+            if MLFLOW_ENABLE_WORKSPACES.get()
+            else DEFAULT_WORKSPACE_NAME
+        )
+
+        if MLFLOW_RBAC_UNIFIED_READS.get():
+            # Unified reads: role_permissions is the sole source of truth. Includes mirrored
+            # direct grants plus any wildcard / workspace-wide grants.
+            if not workspace_name:
+                return [exp_id for exp_id in experiment_ids if default_can_read]
+            user = store.get_user(username)
+            role_grants = store.list_role_grants_for_user_in_workspace(
+                user.id, workspace_name, "experiment"
+            )
+            role_can_read: dict[str, bool] = {}
+            for resource_pattern, permission in role_grants:
+                if resource_pattern == "*":
+                    if get_permission(permission).can_read:
+                        return experiment_ids
+                    continue
+                existing = role_can_read.get(resource_pattern, False)
+                role_can_read[resource_pattern] = existing or get_permission(permission).can_read
+            return [
+                exp_id for exp_id in experiment_ids if role_can_read.get(exp_id, default_can_read)
+            ]
+
+        # Legacy mode: consult direct per-resource table plus role-based grants.
         perms = store.list_experiment_permissions(username)
         can_read = {p.experiment_id: get_permission(p.permission).can_read for p in perms}
-        default_can_read = get_permission(auth_config.default_permission).can_read
 
         if not MLFLOW_ENABLE_WORKSPACES.get():
             return [exp_id for exp_id in experiment_ids if can_read.get(exp_id, default_can_read)]
@@ -1331,7 +1405,6 @@ def filter_experiment_ids(experiment_ids: list[str]) -> list[str]:
         # With workspaces enabled, the tracking store will filter to the active workspace
         # after this function returns. Since experiments outside the active workspace
         # will be excluded anyway, we only need ONE workspace permission check here.
-        workspace_name = workspace_context.get_request_workspace()
         workspace_perm = (
             _workspace_permission(username, workspace_name) if workspace_name else NO_PERMISSIONS
         )
@@ -1345,7 +1418,7 @@ def filter_experiment_ids(experiment_ids: list[str]) -> list[str]:
             role_grants = store.list_role_grants_for_user_in_workspace(
                 user.id, workspace_name, "experiment"
             )
-            role_can_read: dict[str, bool] = {}
+            role_can_read = {}
             for resource_pattern, permission in role_grants:
                 if resource_pattern == "*":
                     if get_permission(permission).can_read:
@@ -1462,6 +1535,14 @@ def validate_can_create_gateway_model_definition():
         workspace_level_permission_func=lambda: _workspace_permission_for_gateway_secret(
             username, secret_id
         ),
+        role_permission_func=_role_permission_for(
+            username,
+            "gateway_secret",
+            secret_id,
+            secret_id,
+            lambda sid: _get_tracking_store().get_secret_info(secret_id=sid),
+            "gateway secret",
+        ),
     )
     return permission.can_use
 
@@ -1489,6 +1570,14 @@ def validate_can_update_gateway_model_definition():
         workspace_level_permission_func=lambda: _workspace_permission_for_gateway_secret(
             username, secret_id
         ),
+        role_permission_func=_role_permission_for(
+            username,
+            "gateway_secret",
+            secret_id,
+            secret_id,
+            lambda sid: _get_tracking_store().get_secret_info(secret_id=sid),
+            "gateway secret",
+        ),
     )
     return permission.can_use
 
@@ -1513,12 +1602,24 @@ def _validate_can_use_model_definitions(model_configs: list[dict[str, Any]]) -> 
     username = authenticate_request().username
     # Reassign to a shorter name for line length limits
     ws_func = _workspace_permission_for_gateway_model_definition
+
+    def md_getter(mdid):
+        return _get_tracking_store().get_gateway_model_definition(model_definition_id=mdid)
+
     for model_def_id in model_def_ids:
         permission = _get_permission_from_store_or_default(
             lambda md_id=model_def_id: (
                 store.get_gateway_model_definition_permission(md_id, username).permission
             ),
             workspace_level_permission_func=lambda md_id=model_def_id: ws_func(username, md_id),
+            role_permission_func=_role_permission_for(
+                username,
+                "gateway_model_definition",
+                model_def_id,
+                model_def_id,
+                md_getter,
+                "gateway model definition",
+            ),
         )
         if not permission.can_use:
             return False
@@ -1579,14 +1680,8 @@ def _get_permission_from_run_id_or_uuid() -> Permission:
             INVALID_PARAMETER_VALUE,
         )
     run = _get_tracking_store().get_run(run_id)
-    experiment_id = run.info.experiment_id
     username = authenticate_request().username
-    return _get_permission_from_store_or_default(
-        lambda: store.get_experiment_permission(experiment_id, username).permission,
-        workspace_level_permission_func=lambda: _workspace_permission_for_experiment(
-            username, experiment_id
-        ),
-    )
+    return _get_experiment_permission(run.info.experiment_id, username)
 
 
 def validate_can_read_run_artifact():
@@ -1611,12 +1706,7 @@ def _get_permission_from_model_version() -> Permission:
             INVALID_PARAMETER_VALUE,
         )
     username = authenticate_request().username
-    return _get_permission_from_store_or_default(
-        lambda: store.get_registered_model_permission(name, username).permission,
-        workspace_level_permission_func=lambda: _workspace_permission_for_registered_model(
-            username, name
-        ),
-    )
+    return _get_registered_model_permission(name, username)
 
 
 def validate_can_read_model_version_artifact():
@@ -1637,14 +1727,8 @@ def _get_permission_from_trace_request_id() -> Permission:
         )
     # Get the trace to find its experiment
     trace = _get_tracking_store().get_trace_info(request_id)
-    experiment_id = trace.experiment_id
     username = authenticate_request().username
-    return _get_permission_from_store_or_default(
-        lambda: store.get_experiment_permission(experiment_id, username).permission,
-        workspace_level_permission_func=lambda: _workspace_permission_for_experiment(
-            username, experiment_id
-        ),
-    )
+    return _get_experiment_permission(trace.experiment_id, username)
 
 
 def validate_can_read_trace_artifact():
@@ -1672,16 +1756,7 @@ def validate_can_read_metric_history_bulk(run_ids=None):
 
     for run_id in run_ids:
         run = tracking_store.get_run(run_id)
-        experiment_id = run.info.experiment_id
-
-        def get_workspace_perm(eid=experiment_id):
-            return _workspace_permission_for_experiment(username, eid)
-
-        permission = _get_permission_from_store_or_default(
-            lambda eid=experiment_id: store.get_experiment_permission(eid, username).permission,
-            workspace_level_permission_func=get_workspace_perm,
-        )
-        if not permission.can_read:
+        if not _get_experiment_permission(run.info.experiment_id, username).can_read:
             return False
 
     return True
@@ -1714,17 +1789,8 @@ def validate_can_search_datasets():
 
     username = authenticate_request().username
 
-    # Check permission for each experiment
     for experiment_id in experiment_ids:
-
-        def get_workspace_perm(eid=experiment_id):
-            return _workspace_permission_for_experiment(username, eid)
-
-        permission = _get_permission_from_store_or_default(
-            lambda eid=experiment_id: store.get_experiment_permission(eid, username).permission,
-            workspace_level_permission_func=get_workspace_perm,
-        )
-        if not permission.can_read:
+        if not _get_experiment_permission(experiment_id, username).can_read:
             return False
 
     return True
@@ -1741,13 +1807,7 @@ def validate_can_create_promptlab_run():
         )
 
     username = authenticate_request().username
-    permission = _get_permission_from_store_or_default(
-        lambda: store.get_experiment_permission(experiment_id, username).permission,
-        workspace_level_permission_func=lambda: _workspace_permission_for_experiment(
-            username, experiment_id
-        ),
-    )
-    return permission.can_update
+    return _get_experiment_permission(experiment_id, username).can_update
 
 
 def validate_gateway_proxy():
@@ -2420,7 +2480,10 @@ def filter_list_workspaces(resp: Response) -> None:
 
     allowed: set[str] = set()
     if username is not None:
-        allowed = set(store.list_accessible_workspace_names(username))
+        if MLFLOW_RBAC_UNIFIED_READS.get():
+            allowed = store.list_accessible_workspace_names_via_roles(username)
+        else:
+            allowed = set(store.list_accessible_workspace_names(username))
         if auth_config.grant_default_workspace_access:
             default_workspace, _ = get_default_workspace_optional(_get_workspace_store())
             if default_workspace:
@@ -2468,9 +2531,16 @@ def filter_search_experiments(resp: Response):
 
     # fetch permissions
     username = authenticate_request().username
-    perms = store.list_experiment_permissions(username)
-    can_read = {p.experiment_id: get_permission(p.permission).can_read for p in perms}
     default_can_read = get_permission(auth_config.default_permission).can_read
+    if MLFLOW_RBAC_UNIFIED_READS.get():
+        user = store.get_user(username)
+        can_read, wildcard_allows_all = _role_can_read_map(user.id, "experiment")
+        if wildcard_allows_all:
+            resp.data = message_to_json(response_message)
+            return
+    else:
+        perms = store.list_experiment_permissions(username)
+        can_read = {p.experiment_id: get_permission(p.permission).can_read for p in perms}
     # filter out unreadable
     for e in list(response_message.experiments):
         if not _has_experiment_read_access(username, e.experiment_id, can_read, default_can_read):
@@ -2525,9 +2595,16 @@ def filter_search_logged_models(resp: Response) -> None:
 
     # fetch permissions
     username = authenticate_request().username
-    perms = store.list_experiment_permissions(username)
-    can_read = {p.experiment_id: get_permission(p.permission).can_read for p in perms}
     default_can_read = get_permission(auth_config.default_permission).can_read
+    if MLFLOW_RBAC_UNIFIED_READS.get():
+        user = store.get_user(username)
+        can_read, wildcard_allows_all = _role_can_read_map(user.id, "experiment")
+        if wildcard_allows_all:
+            resp.data = message_to_json(response_proto)
+            return
+    else:
+        perms = store.list_experiment_permissions(username)
+        can_read = {p.experiment_id: get_permission(p.permission).can_read for p in perms}
     # Remove unreadable models
     for m in list(response_proto.models):
         if not _has_experiment_read_access(
@@ -2597,9 +2674,16 @@ def filter_search_registered_models(resp: Response):
 
     # fetch permissions
     username = authenticate_request().username
-    perms = store.list_registered_model_permissions(username)
-    can_read = {p.name: get_permission(p.permission).can_read for p in perms}
     default_can_read = get_permission(auth_config.default_permission).can_read
+    if MLFLOW_RBAC_UNIFIED_READS.get():
+        user = store.get_user(username)
+        can_read, wildcard_allows_all = _role_can_read_map(user.id, "registered_model")
+        if wildcard_allows_all:
+            resp.data = message_to_json(response_message)
+            return
+    else:
+        perms = store.list_registered_model_permissions(username)
+        can_read = {p.name: get_permission(p.permission).can_read for p in perms}
     # filter out unreadable
     for rm in list(response_message.registered_models):
         if not _has_registered_model_read_access(username, rm.name, can_read, default_can_read):
@@ -2652,9 +2736,16 @@ def filter_search_model_versions(resp: Response):
 
     # fetch permissions
     username = authenticate_request().username
-    perms = store.list_registered_model_permissions(username)
-    can_read = {p.name: get_permission(p.permission).can_read for p in perms}
     default_can_read = get_permission(auth_config.default_permission).can_read
+    if MLFLOW_RBAC_UNIFIED_READS.get():
+        user = store.get_user(username)
+        can_read, wildcard_allows_all = _role_can_read_map(user.id, "registered_model")
+        if wildcard_allows_all:
+            resp.data = message_to_json(response_message)
+            return
+    else:
+        perms = store.list_registered_model_permissions(username)
+        can_read = {p.name: get_permission(p.permission).can_read for p in perms}
     # filter out model versions whose parent model is unreadable
     for mv in list(response_message.model_versions):
         if not _has_registered_model_read_access(username, mv.name, can_read, default_can_read):
@@ -3229,32 +3320,16 @@ def is_auth_enabled() -> bool:
 
 
 def _graphql_get_permission_for_experiment(experiment_id: str, username: str) -> Permission:
-    return _get_permission_from_store_or_default(
-        lambda: store.get_experiment_permission(experiment_id, username).permission,
-        workspace_level_permission_func=lambda: _workspace_permission_for_experiment(
-            username, experiment_id
-        ),
-    )
+    return _get_experiment_permission(experiment_id, username)
 
 
 def _graphql_get_permission_for_run(run_id: str, username: str) -> Permission:
     run = _get_tracking_store().get_run(run_id)
-    experiment_id = run.info.experiment_id
-    return _get_permission_from_store_or_default(
-        lambda: store.get_experiment_permission(experiment_id, username).permission,
-        workspace_level_permission_func=lambda: _workspace_permission_for_experiment(
-            username, experiment_id
-        ),
-    )
+    return _get_experiment_permission(run.info.experiment_id, username)
 
 
 def _graphql_get_permission_for_model(model_name: str, username: str) -> Permission:
-    return _get_permission_from_store_or_default(
-        lambda: store.get_registered_model_permission(model_name, username).permission,
-        workspace_level_permission_func=lambda: _workspace_permission_for_registered_model(
-            username, model_name
-        ),
-    )
+    return _get_registered_model_permission(model_name, username)
 
 
 def _graphql_can_read_experiment(experiment_id: str, username: str) -> bool:
@@ -3508,6 +3583,14 @@ def _validate_gateway_use_permission(endpoint_name: str, username: str) -> bool:
             workspace_level_permission_func=lambda: _workspace_permission_for_gateway_endpoint(
                 username, endpoint_id
             ),
+            role_permission_func=_role_permission_for(
+                username,
+                "gateway_endpoint",
+                endpoint_id,
+                endpoint_id,
+                lambda eid: tracking_store.get_gateway_endpoint(endpoint_id=eid),
+                "gateway endpoint",
+            ),
         )
         return permission.can_use
     except MlflowException:
@@ -3703,6 +3786,51 @@ _RBAC_ROUTES: list[tuple[Callable[[], Any], str, str, str]] = [
 ]
 
 
+_UNIFIED_READS_MIN_REVISION = "d4e5f6a7b8c9"
+
+
+def _assert_unified_reads_preconditions() -> None:
+    """
+    When ``MLFLOW_RBAC_UNIFIED_READS`` is on, the auth server must be running against a DB
+    that has the Phase 2 backfill applied. Otherwise legacy grants exist only in the
+    per-resource tables and unified reads would silently deny access. Fail fast on startup
+    with a clear pointer to ``alembic upgrade head``.
+    """
+    if not MLFLOW_RBAC_UNIFIED_READS.get():
+        return
+    from alembic.migration import MigrationContext
+    from alembic.script import ScriptDirectory
+
+    from mlflow.server.auth.db.utils import _get_alembic_config
+
+    alembic_cfg = _get_alembic_config(store.engine.url.render_as_string(hide_password=False))
+    script_dir = ScriptDirectory.from_config(alembic_cfg)
+    with store.engine.begin() as conn:
+        context = MigrationContext.configure(conn, opts={"version_table": "alembic_version_auth"})
+        current = context.get_current_revision()
+    if current is None:
+        raise MlflowException(
+            "MLFLOW_RBAC_UNIFIED_READS is enabled but the auth database has no Alembic "
+            "revision recorded. Run `mlflow-auth db upgrade` (or `alembic upgrade head`) "
+            f"to apply the Phase 2 backfill (revision {_UNIFIED_READS_MIN_REVISION}) "
+            "before enabling unified reads."
+        )
+    # The backfill has been applied iff _UNIFIED_READS_MIN_REVISION appears in the
+    # ancestry of the current revision. Iterate from current back to base; if we hit
+    # the required revision along the way, current >= required.
+    required_found = any(
+        rev.revision == _UNIFIED_READS_MIN_REVISION
+        for rev in script_dir.iterate_revisions(current, "base")
+    )
+    if not required_found:
+        raise MlflowException(
+            "MLFLOW_RBAC_UNIFIED_READS is enabled but the auth database is at Alembic "
+            f"revision '{current}', which precedes the Phase 2 backfill "
+            f"(revision {_UNIFIED_READS_MIN_REVISION}). Run `mlflow-auth db upgrade` "
+            "(or `alembic upgrade head`) before enabling unified reads."
+        )
+
+
 def create_app(app: Flask = app):
     """
     A factory to enable authentication and authorization for the MLflow server.
@@ -3742,6 +3870,7 @@ def create_app(app: Flask = app):
     csrf.init_app(app)
 
     store.init_db(auth_config.database_uri)
+    _assert_unified_reads_preconditions()
     create_admin_user(auth_config.admin_username, auth_config.admin_password)
 
     _auth_initialized = True

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -394,8 +394,9 @@ def _get_permission_from_store_or_default(
 
     When ``MLFLOW_RBAC_UNIFIED_READS`` is enabled, ``role_permission_func`` is the sole
     source of truth: the direct and workspace-level callbacks are skipped. This requires
-    the Phase 2 M2 backfill (Alembic revision ``d4e5f6a7b8c9``) — otherwise legacy grants
-    exist only in the per-resource tables and would not be visible.
+    the role_permissions backfill migration (Alembic revision ``d4e5f6a7b8c9``) —
+    otherwise pre-existing legacy grants only live in the per-resource tables and would
+    not be visible.
     """
     if MLFLOW_RBAC_UNIFIED_READS.get():
         if role_permission_func is not None:
@@ -3792,9 +3793,9 @@ _UNIFIED_READS_MIN_REVISION = "d4e5f6a7b8c9"
 def _assert_unified_reads_preconditions() -> None:
     """
     When ``MLFLOW_RBAC_UNIFIED_READS`` is on, the auth server must be running against a DB
-    that has the Phase 2 backfill applied. Otherwise legacy grants exist only in the
-    per-resource tables and unified reads would silently deny access. Fail fast on startup
-    with a clear pointer to ``alembic upgrade head``.
+    that has the role_permissions backfill migration applied. Otherwise pre-existing
+    legacy grants only live in the per-resource tables and unified reads would silently
+    deny access. Fail fast on startup with a clear pointer to ``alembic upgrade head``.
     """
     if not MLFLOW_RBAC_UNIFIED_READS.get():
         return
@@ -3812,7 +3813,7 @@ def _assert_unified_reads_preconditions() -> None:
         raise MlflowException(
             "MLFLOW_RBAC_UNIFIED_READS is enabled but the auth database has no Alembic "
             "revision recorded. Run `mlflow-auth db upgrade` (or `alembic upgrade head`) "
-            f"to apply the Phase 2 backfill (revision {_UNIFIED_READS_MIN_REVISION}) "
+            f"to apply the role_permissions backfill (revision {_UNIFIED_READS_MIN_REVISION}) "
             "before enabling unified reads."
         )
     # The backfill has been applied iff _UNIFIED_READS_MIN_REVISION appears in the
@@ -3825,7 +3826,7 @@ def _assert_unified_reads_preconditions() -> None:
     if not required_found:
         raise MlflowException(
             "MLFLOW_RBAC_UNIFIED_READS is enabled but the auth database is at Alembic "
-            f"revision '{current}', which precedes the Phase 2 backfill "
+            f"revision '{current}', which precedes the role_permissions backfill "
             f"(revision {_UNIFIED_READS_MIN_REVISION}). Run `mlflow-auth db upgrade` "
             "(or `alembic upgrade head`) before enabling unified reads."
         )

--- a/mlflow/server/auth/db/migrations/versions/d4e5f6a7b8c9_backfill_role_permissions.py
+++ b/mlflow/server/auth/db/migrations/versions/d4e5f6a7b8c9_backfill_role_permissions.py
@@ -6,8 +6,10 @@ Create Date: 2026-04-23 00:00:00.000000
 
 For each user with grants in the legacy per-resource permission tables, create a
 synthetic ``__user_<id>__`` role in the appropriate workspace and mirror every grant
-into ``role_permissions``. Paired with the M1 / M1.5 dual-write, this lets later
-phases flip reads onto ``role_permissions`` as the sole source of truth.
+into ``role_permissions``. Together with the runtime dual-write (every new or
+updated legacy grant is also mirrored into ``role_permissions``), this lets the
+role table serve as an authoritative permission source without a separate
+one-shot import.
 
 The migration is idempotent: each mirrored row is inserted via SELECT-then-INSERT
 so re-runs are safe.
@@ -18,9 +20,9 @@ Workspace scoping:
 - ``experiment_permissions``, ``scorer_permissions``, ``gateway_*_permissions``:
   these tables do not carry a workspace column. The legacy reader also ignores
   workspace for these tables, so we mirror them into ``DEFAULT_WORKSPACE_NAME``.
-  In multi-workspace deployments this places pre-M1 grants in the default
-  workspace's synthetic role; post-M1 dual-write already captures the grant's
-  workspace at request time.
+  In multi-workspace deployments this places pre-existing grants in the default
+  workspace's synthetic role; the runtime dual-write already captures the
+  grant's workspace at request time for subsequent mutations.
 
 """
 

--- a/mlflow/server/auth/db/migrations/versions/d4e5f6a7b8c9_backfill_role_permissions.py
+++ b/mlflow/server/auth/db/migrations/versions/d4e5f6a7b8c9_backfill_role_permissions.py
@@ -1,0 +1,222 @@
+"""Backfill role_permissions from legacy per-resource permission tables
+
+Revision ID: d4e5f6a7b8c9
+Revises: c3d4e5f6a7b8
+Create Date: 2026-04-23 00:00:00.000000
+
+For each user with grants in the legacy per-resource permission tables, create a
+synthetic ``__user_<id>__`` role in the appropriate workspace and mirror every grant
+into ``role_permissions``. Paired with the M1 / M1.5 dual-write, this lets later
+phases flip reads onto ``role_permissions`` as the sole source of truth.
+
+The migration is idempotent: each mirrored row is inserted via SELECT-then-INSERT
+so re-runs are safe.
+
+Workspace scoping:
+- ``workspace_permissions``: the workspace is in the row itself.
+- ``registered_model_permissions``: the workspace is in the row itself.
+- ``experiment_permissions``, ``scorer_permissions``, ``gateway_*_permissions``:
+  these tables do not carry a workspace column. The legacy reader also ignores
+  workspace for these tables, so we mirror them into ``DEFAULT_WORKSPACE_NAME``.
+  In multi-workspace deployments this places pre-M1 grants in the default
+  workspace's synthetic role; post-M1 dual-write already captures the grant's
+  workspace at request time.
+
+"""
+
+from alembic import op
+from sqlalchemy import bindparam, text
+
+from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
+
+# revision identifiers, used by Alembic.
+revision = "d4e5f6a7b8c9"
+down_revision = "c3d4e5f6a7b8"
+branch_labels = None
+depends_on = None
+
+
+_SYNTHETIC_ROLE_NAME = "__user_{user_id}__"
+
+
+def _get_or_create_synthetic_role(conn, user_id: int, workspace: str) -> int:
+    name = _SYNTHETIC_ROLE_NAME.format(user_id=user_id)
+    row = conn.execute(
+        text("SELECT id FROM roles WHERE workspace = :workspace AND name = :name"),
+        {"workspace": workspace, "name": name},
+    ).first()
+    if row is not None:
+        role_id = row[0]
+    else:
+        conn.execute(
+            text(
+                "INSERT INTO roles (name, workspace, description) VALUES (:name, :workspace, NULL)"
+            ),
+            {"name": name, "workspace": workspace},
+        )
+        role_id = conn.execute(
+            text("SELECT id FROM roles WHERE workspace = :workspace AND name = :name"),
+            {"workspace": workspace, "name": name},
+        ).scalar_one()
+    # Ensure the user is assigned.
+    assignment = conn.execute(
+        text(
+            "SELECT id FROM user_role_assignments WHERE user_id = :user_id AND role_id = :role_id"
+        ),
+        {"user_id": user_id, "role_id": role_id},
+    ).first()
+    if assignment is None:
+        conn.execute(
+            text(
+                "INSERT INTO user_role_assignments (user_id, role_id) VALUES (:user_id, :role_id)"
+            ),
+            {"user_id": user_id, "role_id": role_id},
+        )
+    return role_id
+
+
+def _insert_role_permission_if_missing(
+    conn, role_id: int, resource_type: str, resource_pattern: str, permission: str
+) -> None:
+    existing = conn.execute(
+        text(
+            "SELECT id FROM role_permissions "
+            "WHERE role_id = :role_id "
+            "AND resource_type = :resource_type "
+            "AND resource_pattern = :resource_pattern"
+        ),
+        {
+            "role_id": role_id,
+            "resource_type": resource_type,
+            "resource_pattern": resource_pattern,
+        },
+    ).first()
+    if existing is not None:
+        return
+    conn.execute(
+        text(
+            "INSERT INTO role_permissions "
+            "(role_id, resource_type, resource_pattern, permission) "
+            "VALUES (:role_id, :resource_type, :resource_pattern, :permission)"
+        ),
+        {
+            "role_id": role_id,
+            "resource_type": resource_type,
+            "resource_pattern": resource_pattern,
+            "permission": permission,
+        },
+    )
+
+
+def _backfill_table(
+    conn,
+    select_sql: str,
+    row_to_mirror,
+) -> None:
+    for row in conn.execute(text(select_sql)):
+        user_id, workspace, resource_type, resource_pattern, permission = row_to_mirror(row)
+        role_id = _get_or_create_synthetic_role(conn, user_id, workspace)
+        _insert_role_permission_if_missing(
+            conn, role_id, resource_type, resource_pattern, permission
+        )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    default = DEFAULT_WORKSPACE_NAME
+
+    # workspace_permissions → (resource_type='*', resource_pattern='*', permission)
+    _backfill_table(
+        conn,
+        "SELECT user_id, workspace, permission FROM workspace_permissions",
+        lambda r: (r.user_id, r.workspace, "*", "*", r.permission),
+    )
+
+    # experiment_permissions → (experiment, <experiment_id>, permission) in default ws
+    _backfill_table(
+        conn,
+        "SELECT user_id, experiment_id, permission FROM experiment_permissions",
+        lambda r: (r.user_id, default, "experiment", r.experiment_id, r.permission),
+    )
+
+    # registered_model_permissions → (registered_model, <name>, permission) in row's ws
+    _backfill_table(
+        conn,
+        "SELECT user_id, workspace, name, permission FROM registered_model_permissions",
+        lambda r: (r.user_id, r.workspace, "registered_model", r.name, r.permission),
+    )
+
+    # scorer_permissions → (scorer, <exp_id>/<scorer_name>, permission) in default ws
+    _backfill_table(
+        conn,
+        "SELECT user_id, experiment_id, scorer_name, permission FROM scorer_permissions",
+        lambda r: (
+            r.user_id,
+            default,
+            "scorer",
+            f"{r.experiment_id}/{r.scorer_name}",
+            r.permission,
+        ),
+    )
+
+    # gateway_secret_permissions → (gateway_secret, <secret_id>, permission) in default ws
+    _backfill_table(
+        conn,
+        "SELECT user_id, secret_id, permission FROM gateway_secret_permissions",
+        lambda r: (r.user_id, default, "gateway_secret", r.secret_id, r.permission),
+    )
+
+    # gateway_endpoint_permissions → (gateway_endpoint, <endpoint_id>, permission)
+    _backfill_table(
+        conn,
+        "SELECT user_id, endpoint_id, permission FROM gateway_endpoint_permissions",
+        lambda r: (r.user_id, default, "gateway_endpoint", r.endpoint_id, r.permission),
+    )
+
+    # gateway_model_definition_permissions → (gateway_model_definition, <id>, permission)
+    _backfill_table(
+        conn,
+        (
+            "SELECT user_id, model_definition_id, permission "
+            "FROM gateway_model_definition_permissions"
+        ),
+        lambda r: (
+            r.user_id,
+            default,
+            "gateway_model_definition",
+            r.model_definition_id,
+            r.permission,
+        ),
+    )
+
+
+def downgrade() -> None:
+    # Remove all synthetic per-user roles this migration could have created. The FK from
+    # role_permissions / user_role_assignments to roles doesn't declare ON DELETE CASCADE
+    # at the DB level, so delete child rows explicitly. Filter by the synthetic name
+    # pattern in Python (portable across dialects — cross-dialect LIKE with underscores
+    # and ESCAPE is error-prone).
+    conn = op.get_bind()
+    role_ids = [
+        row_id
+        for (row_id, name) in conn.execute(text("SELECT id, name FROM roles"))
+        if name.startswith("__user_") and name.endswith("__")
+    ]
+    if not role_ids:
+        return
+    conn.execute(
+        text("DELETE FROM role_permissions WHERE role_id IN :ids").bindparams(
+            bindparam("ids", expanding=True)
+        ),
+        {"ids": role_ids},
+    )
+    conn.execute(
+        text("DELETE FROM user_role_assignments WHERE role_id IN :ids").bindparams(
+            bindparam("ids", expanding=True)
+        ),
+        {"ids": role_ids},
+    )
+    conn.execute(
+        text("DELETE FROM roles WHERE id IN :ids").bindparams(bindparam("ids", expanding=True)),
+        {"ids": role_ids},
+    )

--- a/mlflow/server/auth/permissions.py
+++ b/mlflow/server/auth/permissions.py
@@ -92,8 +92,8 @@ VALID_RESOURCE_TYPES = frozenset({
     # management capabilities within the workspace.
     "workspace",
     # Special: a "default" permission on every resource of every type in the role's
-    # workspace. resource_pattern must be "*". Used by the Phase 2 dual-write to mirror
-    # the legacy `workspace_permissions` table — semantically distinct from
+    # workspace. resource_pattern must be "*". Used by the dual-write mirror of the
+    # legacy `workspace_permissions` table — semantically distinct from
     # `resource_type="workspace"` which conveys workspace-admin capability over role/user
     # management.
     "*",

--- a/mlflow/server/auth/permissions.py
+++ b/mlflow/server/auth/permissions.py
@@ -91,6 +91,12 @@ VALID_RESOURCE_TYPES = frozenset({
     # resource_pattern must be "*". permission=MANAGE additionally grants role/user
     # management capabilities within the workspace.
     "workspace",
+    # Special: a "default" permission on every resource of every type in the role's
+    # workspace. resource_pattern must be "*". Used by the Phase 2 dual-write to mirror
+    # the legacy `workspace_permissions` table — semantically distinct from
+    # `resource_type="workspace"` which conveys workspace-admin capability over role/user
+    # management.
+    "*",
 })
 
 

--- a/mlflow/server/auth/sqlalchemy_store.py
+++ b/mlflow/server/auth/sqlalchemy_store.py
@@ -143,9 +143,9 @@ class SqlAlchemyStore:
     def delete_user(self, username: str):
         with self.ManagedSessionMaker() as session:
             user = self._get_user(session, username)
-            # Clean up synthetic per-user roles created by the Phase 2 M1 dual-write so their
-            # role_permissions / user_role_assignments rows don't leak (and don't hit FK errors
-            # on backends that enforce referential integrity).
+            # Clean up the user's synthetic per-user roles (see the synthetic role helpers
+            # section below) so their role_permissions / user_role_assignments rows don't
+            # leak and don't hit FK errors on backends that enforce referential integrity.
             synthetic_name = self._synthetic_user_role_name(user.id)
             synthetic_roles = session.query(SqlRole).filter(SqlRole.name == synthetic_name).all()
             for role in synthetic_roles:
@@ -153,13 +153,13 @@ class SqlAlchemyStore:
             session.flush()
             session.delete(user)
 
-    # ---- Synthetic user-role helpers (Phase 2 M1 dual-write) ----
+    # ---- Synthetic user-role helpers (dual-write into role_permissions) ----
     #
-    # Per-resource grants (experiment_permissions, registered_model_permissions, ...) are
-    # mirrored into `role_permissions` under a synthetic role named `__user_<user_id>__`
-    # scoped to the resource's workspace. Reads still go through the per-resource tables;
-    # the mirrored grants make `get_role_permission_for_resource` a valid source of truth
-    # in parallel so later phases can flip reads over.
+    # Every legacy per-resource grant (experiment_permissions, registered_model_permissions,
+    # ...) is mirrored into `role_permissions` under a synthetic role named
+    # `__user_<user_id>__` scoped to the grant's workspace. This keeps
+    # `role_permissions` in sync with the per-resource tables so it can serve as an
+    # authoritative permission source without a separate backfill.
     #
     # The synthetic namespace (``__user_<int>__``) is RESERVED: ``create_role`` and
     # ``update_role`` reject names matching the pattern so an API consumer can't hijack a
@@ -185,7 +185,8 @@ class SqlAlchemyStore:
         if cls._is_synthetic_role_name(name):
             raise MlflowException.invalid_parameter_value(
                 f"Role name {name!r} matches the reserved synthetic pattern "
-                f"'__user_<id>__' used by Phase 2 dual-write. Choose a different name."
+                f"'__user_<id>__' used by the role_permissions dual-write. "
+                "Choose a different name."
             )
 
     def _get_or_create_synthetic_user_role(self, session, user_id: int, workspace: str) -> SqlRole:

--- a/mlflow/server/auth/sqlalchemy_store.py
+++ b/mlflow/server/auth/sqlalchemy_store.py
@@ -1,3 +1,5 @@
+import re
+
 from sqlalchemy import and_, or_, select
 from sqlalchemy.exc import IntegrityError, MultipleResultsFound, NoResultFound
 from sqlalchemy.orm import selectinload, sessionmaker
@@ -158,14 +160,40 @@ class SqlAlchemyStore:
     # scoped to the resource's workspace. Reads still go through the per-resource tables;
     # the mirrored grants make `get_role_permission_for_resource` a valid source of truth
     # in parallel so later phases can flip reads over.
+    #
+    # The synthetic namespace (``__user_<int>__``) is RESERVED: ``create_role`` and
+    # ``update_role`` reject names matching the pattern so an API consumer can't hijack a
+    # synthetic role to receive another user's mirrored grants. Bulk cleanup / rename
+    # helpers (``_unmirror_resource``, ``_rename_mirrored_resource``) also restrict their
+    # scope to synthetic roles so they never touch admin-created roles that happen to
+    # hold overlapping grants.
     _SYNTHETIC_ROLE_PREFIX = "__user_"
     _SYNTHETIC_ROLE_SUFFIX = "__"
+    _SYNTHETIC_ROLE_NAME_RE = re.compile(r"^__user_\d+__$")
 
     @classmethod
     def _synthetic_user_role_name(cls, user_id: int) -> str:
         return f"{cls._SYNTHETIC_ROLE_PREFIX}{user_id}{cls._SYNTHETIC_ROLE_SUFFIX}"
 
+    @classmethod
+    def _is_synthetic_role_name(cls, name: str | None) -> bool:
+        return name is not None and cls._SYNTHETIC_ROLE_NAME_RE.match(name) is not None
+
+    @classmethod
+    def _reject_synthetic_role_name(cls, name: str) -> None:
+        """Guard user-facing role CRUD against the reserved synthetic pattern."""
+        if cls._is_synthetic_role_name(name):
+            raise MlflowException.invalid_parameter_value(
+                f"Role name {name!r} matches the reserved synthetic pattern "
+                f"'__user_<id>__' used by Phase 2 dual-write. Choose a different name."
+            )
+
     def _get_or_create_synthetic_user_role(self, session, user_id: int, workspace: str) -> SqlRole:
+        # Race-proof: two concurrent permission mutations for the same (user, workspace)
+        # can both see "role doesn't exist yet" and both try to INSERT. Wrap the INSERT
+        # in a SAVEPOINT so the UniqueConstraint violation rolls back only that nested
+        # scope and we can recover by re-querying the winner's row. Same pattern for
+        # the user->role assignment.
         name = self._synthetic_user_role_name(user_id)
         role = (
             session
@@ -174,9 +202,18 @@ class SqlAlchemyStore:
             .first()
         )
         if role is None:
-            role = SqlRole(name=name, workspace=workspace, description=None)
-            session.add(role)
-            session.flush()
+            try:
+                with session.begin_nested():
+                    role = SqlRole(name=name, workspace=workspace, description=None)
+                    session.add(role)
+                    session.flush()
+            except IntegrityError:
+                role = (
+                    session
+                    .query(SqlRole)
+                    .filter(SqlRole.workspace == workspace, SqlRole.name == name)
+                    .one()
+                )
         assignment = (
             session
             .query(SqlUserRoleAssignment)
@@ -187,8 +224,13 @@ class SqlAlchemyStore:
             .first()
         )
         if assignment is None:
-            session.add(SqlUserRoleAssignment(user_id=user_id, role_id=role.id))
-            session.flush()
+            try:
+                with session.begin_nested():
+                    session.add(SqlUserRoleAssignment(user_id=user_id, role_id=role.id))
+                    session.flush()
+            except IntegrityError:
+                # Another concurrent write already assigned the user.
+                pass
         return role
 
     def _mirror_user_grant(
@@ -253,6 +295,17 @@ class SqlAlchemyStore:
         )
         session.flush()
 
+    def _synthetic_role_ids(self, session, workspace: str | None = None) -> list[int]:
+        """
+        Return ids of synthetic ``__user_<id>__`` roles, optionally scoped to
+        ``workspace``. Callers of bulk cleanup/rename helpers route through this so they
+        never touch admin-created roles that happen to share a grant.
+        """
+        query = session.query(SqlRole.id, SqlRole.name)
+        if workspace is not None:
+            query = query.filter(SqlRole.workspace == workspace)
+        return [rid for (rid, name) in query.all() if self._is_synthetic_role_name(name)]
+
     def _unmirror_resource(
         self,
         session,
@@ -263,22 +316,16 @@ class SqlAlchemyStore:
         # Delete all mirrored role_permissions rows for one resource across users.
         # `workspace=None` is used when the underlying resource ID is globally unique
         # (scorer, gateway_*), so mirrored rows are removed regardless of which
-        # synthetic role holds them.
-        query = session.query(SqlRolePermission).filter(
+        # synthetic role holds them. Restricted to synthetic roles so admin-created
+        # roles with an overlapping grant are never touched.
+        role_ids = self._synthetic_role_ids(session, workspace=workspace)
+        if not role_ids:
+            return
+        session.query(SqlRolePermission).filter(
+            SqlRolePermission.role_id.in_(role_ids),
             SqlRolePermission.resource_type == resource_type,
             SqlRolePermission.resource_pattern == resource_pattern,
-        )
-        if workspace is not None:
-            role_ids = [
-                rid
-                for (rid,) in (
-                    session.query(SqlRole.id).filter(SqlRole.workspace == workspace).all()
-                )
-            ]
-            if not role_ids:
-                return
-            query = query.filter(SqlRolePermission.role_id.in_(role_ids))
-        query.delete(synchronize_session=False)
+        ).delete(synchronize_session=False)
         session.flush()
 
     def _rename_mirrored_resource(
@@ -289,10 +336,8 @@ class SqlAlchemyStore:
         old_pattern: str,
         new_pattern: str,
     ) -> None:
-        role_ids = [
-            rid
-            for (rid,) in (session.query(SqlRole.id).filter(SqlRole.workspace == workspace).all())
-        ]
+        # Synthetic-role-only, same rationale as _unmirror_resource above.
+        role_ids = self._synthetic_role_ids(session, workspace=workspace)
         if not role_ids:
             return
         (
@@ -1087,6 +1132,7 @@ class SqlAlchemyStore:
         workspace: str,
         description: str | None = None,
     ) -> Role:
+        self._reject_synthetic_role_name(name)
         with self.ManagedSessionMaker() as session:
             try:
                 role = SqlRole(
@@ -1168,6 +1214,8 @@ class SqlAlchemyStore:
         name: str | None = None,
         description: str | None = None,
     ) -> Role:
+        if name is not None:
+            self._reject_synthetic_role_name(name)
         with self.ManagedSessionMaker() as session:
             role = self._get_role(session, role_id)
             if name is not None:

--- a/mlflow/server/auth/sqlalchemy_store.py
+++ b/mlflow/server/auth/sqlalchemy_store.py
@@ -681,6 +681,61 @@ class SqlAlchemyStore:
                 return get_permission(entity.permission)
         return None
 
+    def get_workspace_permission_via_roles(
+        self, username: str, workspace_name: str
+    ) -> Permission | None:
+        """
+        Role-table analog of ``get_workspace_permission``. Returns the union of
+        ``(resource_type='*', resource_pattern='*')`` and
+        ``(resource_type='workspace', resource_pattern='*')`` grants the user holds in
+        ``workspace_name``. Used by the unified-reads code path.
+        """
+        with self.ManagedSessionMaker() as session:
+            user = self._get_user(session, username=username)
+            rows = (
+                session
+                .query(SqlRolePermission.permission)
+                .join(SqlRole, SqlRole.id == SqlRolePermission.role_id)
+                .join(SqlUserRoleAssignment, SqlRole.id == SqlUserRoleAssignment.role_id)
+                .filter(
+                    SqlUserRoleAssignment.user_id == user.id,
+                    SqlRole.workspace == workspace_name,
+                    SqlRolePermission.resource_type.in_(("*", "workspace")),
+                    SqlRolePermission.resource_pattern == "*",
+                )
+                .all()
+            )
+        if not rows:
+            return None
+        best: str | None = None
+        for (perm,) in rows:
+            best = perm if best is None else max_permission(best, perm)
+        return get_permission(best) if best is not None else None
+
+    def list_accessible_workspace_names_via_roles(self, username: str | None) -> set[str]:
+        """
+        Role-table analog of ``list_accessible_workspace_names``. Returns every workspace
+        in which the user has at least one ``can_read``-capable ``role_permissions`` row,
+        regardless of resource_type. Used by the unified-reads code path.
+        """
+        if username is None:
+            return set()
+        with self.ManagedSessionMaker() as session:
+            user = self._get_user(session, username=username)
+            rows = (
+                session
+                .query(SqlRole.workspace, SqlRolePermission.permission)
+                .join(SqlRolePermission, SqlRole.id == SqlRolePermission.role_id)
+                .join(SqlUserRoleAssignment, SqlRole.id == SqlUserRoleAssignment.role_id)
+                .filter(SqlUserRoleAssignment.user_id == user.id)
+                .all()
+            )
+        accessible: set[str] = set()
+        for workspace, permission in rows:
+            if get_permission(permission).can_read:
+                accessible.add(workspace)
+        return accessible
+
     def create_scorer_permission(
         self, experiment_id: str, scorer_name: str, username: str, permission: str
     ) -> ScorerPermission:

--- a/mlflow/server/auth/sqlalchemy_store.py
+++ b/mlflow/server/auth/sqlalchemy_store.py
@@ -141,27 +141,196 @@ class SqlAlchemyStore:
     def delete_user(self, username: str):
         with self.ManagedSessionMaker() as session:
             user = self._get_user(session, username)
+            # Clean up synthetic per-user roles created by the Phase 2 M1 dual-write so their
+            # role_permissions / user_role_assignments rows don't leak (and don't hit FK errors
+            # on backends that enforce referential integrity).
+            synthetic_name = self._synthetic_user_role_name(user.id)
+            synthetic_roles = session.query(SqlRole).filter(SqlRole.name == synthetic_name).all()
+            for role in synthetic_roles:
+                session.delete(role)
+            session.flush()
             session.delete(user)
+
+    # ---- Synthetic user-role helpers (Phase 2 M1 dual-write) ----
+    #
+    # Per-resource grants (experiment_permissions, registered_model_permissions, ...) are
+    # mirrored into `role_permissions` under a synthetic role named `__user_<user_id>__`
+    # scoped to the resource's workspace. Reads still go through the per-resource tables;
+    # the mirrored grants make `get_role_permission_for_resource` a valid source of truth
+    # in parallel so later phases can flip reads over.
+    _SYNTHETIC_ROLE_PREFIX = "__user_"
+    _SYNTHETIC_ROLE_SUFFIX = "__"
+
+    @classmethod
+    def _synthetic_user_role_name(cls, user_id: int) -> str:
+        return f"{cls._SYNTHETIC_ROLE_PREFIX}{user_id}{cls._SYNTHETIC_ROLE_SUFFIX}"
+
+    def _get_or_create_synthetic_user_role(self, session, user_id: int, workspace: str) -> SqlRole:
+        name = self._synthetic_user_role_name(user_id)
+        role = (
+            session
+            .query(SqlRole)
+            .filter(SqlRole.workspace == workspace, SqlRole.name == name)
+            .first()
+        )
+        if role is None:
+            role = SqlRole(name=name, workspace=workspace, description=None)
+            session.add(role)
+            session.flush()
+        assignment = (
+            session
+            .query(SqlUserRoleAssignment)
+            .filter(
+                SqlUserRoleAssignment.user_id == user_id,
+                SqlUserRoleAssignment.role_id == role.id,
+            )
+            .first()
+        )
+        if assignment is None:
+            session.add(SqlUserRoleAssignment(user_id=user_id, role_id=role.id))
+            session.flush()
+        return role
+
+    def _mirror_user_grant(
+        self,
+        session,
+        user_id: int,
+        workspace: str,
+        resource_type: str,
+        resource_pattern: str,
+        permission: str,
+    ) -> None:
+        role = self._get_or_create_synthetic_user_role(session, user_id, workspace)
+        rp = (
+            session
+            .query(SqlRolePermission)
+            .filter(
+                SqlRolePermission.role_id == role.id,
+                SqlRolePermission.resource_type == resource_type,
+                SqlRolePermission.resource_pattern == resource_pattern,
+            )
+            .first()
+        )
+        if rp is None:
+            session.add(
+                SqlRolePermission(
+                    role_id=role.id,
+                    resource_type=resource_type,
+                    resource_pattern=resource_pattern,
+                    permission=permission,
+                )
+            )
+        else:
+            rp.permission = permission
+        session.flush()
+
+    def _unmirror_user_grant(
+        self,
+        session,
+        user_id: int,
+        workspace: str,
+        resource_type: str,
+        resource_pattern: str,
+    ) -> None:
+        name = self._synthetic_user_role_name(user_id)
+        role = (
+            session
+            .query(SqlRole)
+            .filter(SqlRole.workspace == workspace, SqlRole.name == name)
+            .first()
+        )
+        if role is None:
+            return
+        (
+            session
+            .query(SqlRolePermission)
+            .filter(
+                SqlRolePermission.role_id == role.id,
+                SqlRolePermission.resource_type == resource_type,
+                SqlRolePermission.resource_pattern == resource_pattern,
+            )
+            .delete(synchronize_session=False)
+        )
+        session.flush()
+
+    def _unmirror_resource(
+        self,
+        session,
+        resource_type: str,
+        resource_pattern: str,
+        workspace: str | None = None,
+    ) -> None:
+        # Delete all mirrored role_permissions rows for one resource across users.
+        # `workspace=None` is used when the underlying resource ID is globally unique
+        # (scorer, gateway_*), so mirrored rows are removed regardless of which
+        # synthetic role holds them.
+        query = session.query(SqlRolePermission).filter(
+            SqlRolePermission.resource_type == resource_type,
+            SqlRolePermission.resource_pattern == resource_pattern,
+        )
+        if workspace is not None:
+            role_ids = [
+                rid
+                for (rid,) in (
+                    session.query(SqlRole.id).filter(SqlRole.workspace == workspace).all()
+                )
+            ]
+            if not role_ids:
+                return
+            query = query.filter(SqlRolePermission.role_id.in_(role_ids))
+        query.delete(synchronize_session=False)
+        session.flush()
+
+    def _rename_mirrored_resource(
+        self,
+        session,
+        workspace: str,
+        resource_type: str,
+        old_pattern: str,
+        new_pattern: str,
+    ) -> None:
+        role_ids = [
+            rid
+            for (rid,) in (session.query(SqlRole.id).filter(SqlRole.workspace == workspace).all())
+        ]
+        if not role_ids:
+            return
+        (
+            session
+            .query(SqlRolePermission)
+            .filter(
+                SqlRolePermission.role_id.in_(role_ids),
+                SqlRolePermission.resource_type == resource_type,
+                SqlRolePermission.resource_pattern == old_pattern,
+            )
+            .update({SqlRolePermission.resource_pattern: new_pattern}, synchronize_session=False)
+        )
+        session.flush()
 
     def create_experiment_permission(
         self, experiment_id: str, username: str, permission: str
     ) -> ExperimentPermission:
         _validate_permission(permission)
         with self.ManagedSessionMaker() as session:
+            user = self._get_user(session, username=username)
+            workspace_name = self._get_active_workspace_name()
             try:
-                user = self._get_user(session, username=username)
                 perm = SqlExperimentPermission(
                     experiment_id=experiment_id, user_id=user.id, permission=permission
                 )
                 session.add(perm)
                 session.flush()
-                return perm.to_mlflow_entity()
+                entity = perm.to_mlflow_entity()
             except IntegrityError as e:
                 raise MlflowException(
                     f"Experiment permission (experiment_id={experiment_id}, username={username}) "
                     f"already exists. Error: {e}",
                     RESOURCE_ALREADY_EXISTS,
                 )
+            self._mirror_user_grant(
+                session, user.id, workspace_name, "experiment", experiment_id, permission
+            )
+            return entity
 
     def _get_experiment_permission(
         self, session, experiment_id: str, username: str
@@ -214,12 +383,20 @@ class SqlAlchemyStore:
         with self.ManagedSessionMaker() as session:
             perm = self._get_experiment_permission(session, experiment_id, username)
             perm.permission = permission
+            workspace_name = self._get_active_workspace_name()
+            self._mirror_user_grant(
+                session, perm.user_id, workspace_name, "experiment", experiment_id, permission
+            )
             return perm.to_mlflow_entity()
 
     def delete_experiment_permission(self, experiment_id: str, username: str):
         with self.ManagedSessionMaker() as session:
             perm = self._get_experiment_permission(session, experiment_id, username)
+            user_id = perm.user_id
+            workspace_name = self._get_active_workspace_name()
             session.delete(perm)
+            session.flush()
+            self._unmirror_user_grant(session, user_id, workspace_name, "experiment", experiment_id)
 
     def delete_workspace_permissions_for_workspace(self, workspace_name: str) -> None:
         with self.ManagedSessionMaker() as session:
@@ -232,9 +409,9 @@ class SqlAlchemyStore:
     ) -> RegisteredModelPermission:
         _validate_permission(permission)
         with self.ManagedSessionMaker() as session:
+            user = self._get_user(session, username=username)
+            workspace_name = self._get_active_workspace_name()
             try:
-                user = self._get_user(session, username=username)
-                workspace_name = self._get_active_workspace_name()
                 perm = SqlRegisteredModelPermission(
                     workspace=workspace_name,
                     name=name,
@@ -243,7 +420,7 @@ class SqlAlchemyStore:
                 )
                 session.add(perm)
                 session.flush()
-                return perm.to_mlflow_entity()
+                entity = perm.to_mlflow_entity()
             except IntegrityError as e:
                 raise MlflowException(
                     "Registered model permission "
@@ -251,6 +428,10 @@ class SqlAlchemyStore:
                     f"already exists. Error: {e}",
                     RESOURCE_ALREADY_EXISTS,
                 )
+            self._mirror_user_grant(
+                session, user.id, workspace_name, "registered_model", name, permission
+            )
+            return entity
 
     def _get_registered_model_permission(
         self, session, name: str, username: str
@@ -310,12 +491,19 @@ class SqlAlchemyStore:
         with self.ManagedSessionMaker() as session:
             perm = self._get_registered_model_permission(session, name, username)
             perm.permission = permission
+            self._mirror_user_grant(
+                session, perm.user_id, perm.workspace, "registered_model", name, permission
+            )
             return perm.to_mlflow_entity()
 
     def delete_registered_model_permission(self, name: str, username: str):
         with self.ManagedSessionMaker() as session:
             perm = self._get_registered_model_permission(session, name, username)
+            user_id = perm.user_id
+            workspace_name = perm.workspace
             session.delete(perm)
+            session.flush()
+            self._unmirror_user_grant(session, user_id, workspace_name, "registered_model", name)
 
     def delete_registered_model_permissions(self, name: str) -> None:
         """
@@ -332,6 +520,7 @@ class SqlAlchemyStore:
                 SqlRegisteredModelPermission.workspace == workspace_name,
                 SqlRegisteredModelPermission.name == name,
             ).delete(synchronize_session=False)
+            self._unmirror_resource(session, "registered_model", name, workspace=workspace_name)
 
     def rename_registered_model_permissions(self, old_name: str, new_name: str):
         with self.ManagedSessionMaker() as session:
@@ -347,6 +536,9 @@ class SqlAlchemyStore:
             )
             for perm in perms:
                 perm.name = new_name
+            self._rename_mirrored_resource(
+                session, workspace_name, "registered_model", old_name, new_name
+            )
 
     def list_workspace_permissions(self, workspace_name: str) -> list[WorkspacePermission]:
         with self.ManagedSessionMaker() as session:
@@ -444,8 +636,9 @@ class SqlAlchemyStore:
     ) -> ScorerPermission:
         _validate_permission(permission)
         with self.ManagedSessionMaker() as session:
+            user = self._get_user(session, username=username)
+            workspace_name = self._get_active_workspace_name()
             try:
-                user = self._get_user(session, username=username)
                 perm = SqlScorerPermission(
                     experiment_id=experiment_id,
                     scorer_name=scorer_name,
@@ -454,13 +647,22 @@ class SqlAlchemyStore:
                 )
                 session.add(perm)
                 session.flush()
-                return perm.to_mlflow_entity()
+                entity = perm.to_mlflow_entity()
             except IntegrityError as e:
                 raise MlflowException(
                     f"Scorer permission (experiment_id={experiment_id}, scorer_name={scorer_name}, "
                     f"username={username}) already exists. Error: {e}",
                     RESOURCE_ALREADY_EXISTS,
                 ) from e
+            self._mirror_user_grant(
+                session,
+                user.id,
+                workspace_name,
+                "scorer",
+                f"{experiment_id}/{scorer_name}",
+                permission,
+            )
+            return entity
 
     def _get_scorer_permission(
         self, session, experiment_id: str, scorer_name: str, username: str
@@ -516,12 +718,31 @@ class SqlAlchemyStore:
         with self.ManagedSessionMaker() as session:
             perm = self._get_scorer_permission(session, experiment_id, scorer_name, username)
             perm.permission = permission
+            workspace_name = self._get_active_workspace_name()
+            self._mirror_user_grant(
+                session,
+                perm.user_id,
+                workspace_name,
+                "scorer",
+                f"{experiment_id}/{scorer_name}",
+                permission,
+            )
             return perm.to_mlflow_entity()
 
     def delete_scorer_permission(self, experiment_id: str, scorer_name: str, username: str):
         with self.ManagedSessionMaker() as session:
             perm = self._get_scorer_permission(session, experiment_id, scorer_name, username)
+            user_id = perm.user_id
+            workspace_name = self._get_active_workspace_name()
             session.delete(perm)
+            session.flush()
+            self._unmirror_user_grant(
+                session,
+                user_id,
+                workspace_name,
+                "scorer",
+                f"{experiment_id}/{scorer_name}",
+            )
 
     def delete_scorer_permissions_for_scorer(self, experiment_id: str, scorer_name: str):
         with self.ManagedSessionMaker() as session:
@@ -529,26 +750,32 @@ class SqlAlchemyStore:
                 SqlScorerPermission.experiment_id == experiment_id,
                 SqlScorerPermission.scorer_name == scorer_name,
             ).delete()
+            self._unmirror_resource(session, "scorer", f"{experiment_id}/{scorer_name}")
 
     def create_gateway_secret_permission(
         self, secret_id: str, username: str, permission: str
     ) -> GatewaySecretPermission:
         _validate_permission(permission)
         with self.ManagedSessionMaker() as session:
+            user = self._get_user(session, username=username)
+            workspace_name = self._get_active_workspace_name()
             try:
-                user = self._get_user(session, username=username)
                 perm = SqlGatewaySecretPermission(
                     secret_id=secret_id, user_id=user.id, permission=permission
                 )
                 session.add(perm)
                 session.flush()
-                return perm.to_mlflow_entity()
+                entity = perm.to_mlflow_entity()
             except IntegrityError as e:
                 raise MlflowException(
                     f"Gateway secret permission (secret_id={secret_id}, username={username}) "
                     f"already exists. Error: {e}",
                     RESOURCE_ALREADY_EXISTS,
                 ) from e
+            self._mirror_user_grant(
+                session, user.id, workspace_name, "gateway_secret", secret_id, permission
+            )
+            return entity
 
     def _get_gateway_secret_permission(
         self, session, secret_id: str, username: str
@@ -603,38 +830,52 @@ class SqlAlchemyStore:
         with self.ManagedSessionMaker() as session:
             perm = self._get_gateway_secret_permission(session, secret_id, username)
             perm.permission = permission
+            workspace_name = self._get_active_workspace_name()
+            self._mirror_user_grant(
+                session, perm.user_id, workspace_name, "gateway_secret", secret_id, permission
+            )
             return perm.to_mlflow_entity()
 
     def delete_gateway_secret_permission(self, secret_id: str, username: str):
         with self.ManagedSessionMaker() as session:
             perm = self._get_gateway_secret_permission(session, secret_id, username)
+            user_id = perm.user_id
+            workspace_name = self._get_active_workspace_name()
             session.delete(perm)
+            session.flush()
+            self._unmirror_user_grant(session, user_id, workspace_name, "gateway_secret", secret_id)
 
     def delete_gateway_secret_permissions_for_secret(self, secret_id: str):
         with self.ManagedSessionMaker() as session:
             session.query(SqlGatewaySecretPermission).filter(
                 SqlGatewaySecretPermission.secret_id == secret_id,
             ).delete()
+            self._unmirror_resource(session, "gateway_secret", secret_id)
 
     def create_gateway_endpoint_permission(
         self, endpoint_id: str, username: str, permission: str
     ) -> GatewayEndpointPermission:
         _validate_permission(permission)
         with self.ManagedSessionMaker() as session:
+            user = self._get_user(session, username=username)
+            workspace_name = self._get_active_workspace_name()
             try:
-                user = self._get_user(session, username=username)
                 perm = SqlGatewayEndpointPermission(
                     endpoint_id=endpoint_id, user_id=user.id, permission=permission
                 )
                 session.add(perm)
                 session.flush()
-                return perm.to_mlflow_entity()
+                entity = perm.to_mlflow_entity()
             except IntegrityError as e:
                 raise MlflowException(
                     f"Gateway endpoint permission (endpoint_id={endpoint_id}, username={username}) "
                     f"already exists. Error: {e}",
                     RESOURCE_ALREADY_EXISTS,
                 ) from e
+            self._mirror_user_grant(
+                session, user.id, workspace_name, "gateway_endpoint", endpoint_id, permission
+            )
+            return entity
 
     def _get_gateway_endpoint_permission(
         self, session, endpoint_id: str, username: str
@@ -689,32 +930,44 @@ class SqlAlchemyStore:
         with self.ManagedSessionMaker() as session:
             perm = self._get_gateway_endpoint_permission(session, endpoint_id, username)
             perm.permission = permission
+            workspace_name = self._get_active_workspace_name()
+            self._mirror_user_grant(
+                session, perm.user_id, workspace_name, "gateway_endpoint", endpoint_id, permission
+            )
             return perm.to_mlflow_entity()
 
     def delete_gateway_endpoint_permission(self, endpoint_id: str, username: str):
         with self.ManagedSessionMaker() as session:
             perm = self._get_gateway_endpoint_permission(session, endpoint_id, username)
+            user_id = perm.user_id
+            workspace_name = self._get_active_workspace_name()
             session.delete(perm)
+            session.flush()
+            self._unmirror_user_grant(
+                session, user_id, workspace_name, "gateway_endpoint", endpoint_id
+            )
 
     def delete_gateway_endpoint_permissions_for_endpoint(self, endpoint_id: str):
         with self.ManagedSessionMaker() as session:
             session.query(SqlGatewayEndpointPermission).filter(
                 SqlGatewayEndpointPermission.endpoint_id == endpoint_id,
             ).delete()
+            self._unmirror_resource(session, "gateway_endpoint", endpoint_id)
 
     def create_gateway_model_definition_permission(
         self, model_definition_id: str, username: str, permission: str
     ) -> GatewayModelDefinitionPermission:
         _validate_permission(permission)
         with self.ManagedSessionMaker() as session:
+            user = self._get_user(session, username=username)
+            workspace_name = self._get_active_workspace_name()
             try:
-                user = self._get_user(session, username=username)
                 perm = SqlGatewayModelDefinitionPermission(
                     model_definition_id=model_definition_id, user_id=user.id, permission=permission
                 )
                 session.add(perm)
                 session.flush()
-                return perm.to_mlflow_entity()
+                entity = perm.to_mlflow_entity()
             except IntegrityError as e:
                 raise MlflowException(
                     f"Gateway model definition permission "
@@ -722,6 +975,15 @@ class SqlAlchemyStore:
                     f"already exists. Error: {e}",
                     RESOURCE_ALREADY_EXISTS,
                 ) from e
+            self._mirror_user_grant(
+                session,
+                user.id,
+                workspace_name,
+                "gateway_model_definition",
+                model_definition_id,
+                permission,
+            )
+            return entity
 
     def _get_gateway_model_definition_permission(
         self, session, model_definition_id: str, username: str
@@ -780,6 +1042,15 @@ class SqlAlchemyStore:
                 session, model_definition_id, username
             )
             perm.permission = permission
+            workspace_name = self._get_active_workspace_name()
+            self._mirror_user_grant(
+                session,
+                perm.user_id,
+                workspace_name,
+                "gateway_model_definition",
+                model_definition_id,
+                permission,
+            )
             return perm.to_mlflow_entity()
 
     def delete_gateway_model_definition_permission(self, model_definition_id: str, username: str):
@@ -787,7 +1058,17 @@ class SqlAlchemyStore:
             perm = self._get_gateway_model_definition_permission(
                 session, model_definition_id, username
             )
+            user_id = perm.user_id
+            workspace_name = self._get_active_workspace_name()
             session.delete(perm)
+            session.flush()
+            self._unmirror_user_grant(
+                session,
+                user_id,
+                workspace_name,
+                "gateway_model_definition",
+                model_definition_id,
+            )
 
     def delete_gateway_model_definition_permissions_for_model_definition(
         self, model_definition_id: str
@@ -796,6 +1077,7 @@ class SqlAlchemyStore:
             session.query(SqlGatewayModelDefinitionPermission).filter(
                 SqlGatewayModelDefinitionPermission.model_definition_id == model_definition_id,
             ).delete()
+            self._unmirror_resource(session, "gateway_model_definition", model_definition_id)
 
     # ---- Role CRUD ----
 

--- a/mlflow/server/auth/sqlalchemy_store.py
+++ b/mlflow/server/auth/sqlalchemy_store.py
@@ -449,6 +449,7 @@ class SqlAlchemyStore:
             session.query(SqlWorkspacePermission).filter(
                 SqlWorkspacePermission.workspace == workspace_name
             ).delete(synchronize_session=False)
+            self._unmirror_resource(session, "*", "*", workspace=workspace_name)
 
     def create_registered_model_permission(
         self, name: str, username: str, permission: str
@@ -628,6 +629,7 @@ class SqlAlchemyStore:
             else:
                 entity.permission = permission
             session.flush()
+            self._mirror_user_grant(session, user.id, workspace_name, "*", "*", permission)
             return entity.to_mlflow_entity()
 
     def delete_workspace_permission(self, workspace_name: str, username: str) -> None:
@@ -646,6 +648,8 @@ class SqlAlchemyStore:
                     RESOURCE_DOES_NOT_EXIST,
                 )
             session.delete(entity)
+            session.flush()
+            self._unmirror_user_grant(session, user.id, workspace_name, "*", "*")
 
     def list_accessible_workspace_names(self, username: str | None) -> set[str]:
         if username is None:
@@ -1276,12 +1280,11 @@ class SqlAlchemyStore:
     ) -> RolePermission:
         _validate_permission(permission)
         _validate_resource_type(resource_type)
-        # Workspace-scope grants only support the "*" pattern (apply to every resource in
-        # the role's workspace). Any other pattern would be silently ignored by the
-        # resolver, so reject it up front.
-        if resource_type == "workspace" and resource_pattern != "*":
+        # Workspace-scope and type-wildcard grants only support the "*" pattern. Any other
+        # pattern would be silently ignored by the resolver, so reject it up front.
+        if resource_type in ("workspace", "*") and resource_pattern != "*":
             raise MlflowException.invalid_parameter_value(
-                "resource_type='workspace' requires resource_pattern='*'. "
+                f"resource_type='{resource_type}' requires resource_pattern='*'. "
                 f"Got resource_pattern='{resource_pattern}'."
             )
         with self.ManagedSessionMaker() as session:
@@ -1478,8 +1481,11 @@ class SqlAlchemyStore:
             best_permission_name: str | None = None
             for role in roles:
                 for rp in role.permissions:
-                    # Workspace-wide permission — applies to every resource type.
-                    if rp.resource_type == "workspace" and rp.resource_pattern == "*":
+                    # Workspace-wide permission — applies to every resource type. Both
+                    # ``resource_type='workspace'`` (workspace admin) and ``resource_type='*'``
+                    # (type-wildcard, mirrors the legacy workspace_permissions table) match
+                    # every resource in the role's workspace.
+                    if rp.resource_type in ("workspace", "*") and rp.resource_pattern == "*":
                         best_permission_name = (
                             max_permission(best_permission_name, rp.permission)
                             if best_permission_name is not None
@@ -1584,9 +1590,10 @@ class SqlAlchemyStore:
         ``filter_experiment_ids``, which unions the result of this query with
         ``list_experiment_permissions`` from the legacy table).
 
-        Includes both grants on the specific resource_type and workspace-wide grants
-        (``resource_type='workspace'``, ``resource_pattern='*'``) since those apply to
-        every resource type.
+        Includes grants on the specific resource_type plus workspace-wide grants that
+        match every resource type: ``resource_type='workspace'`` (workspace admin) and
+        ``resource_type='*'`` (type-wildcard mirroring the legacy
+        ``workspace_permissions`` table).
 
         Returns a list of ``(resource_pattern, permission)`` tuples.
         """
@@ -1603,7 +1610,7 @@ class SqlAlchemyStore:
                     or_(
                         SqlRolePermission.resource_type == resource_type,
                         and_(
-                            SqlRolePermission.resource_type == "workspace",
+                            SqlRolePermission.resource_type.in_(("workspace", "*")),
                             SqlRolePermission.resource_pattern == "*",
                         ),
                     ),

--- a/tests/server/auth/db/test_backfill_migration.py
+++ b/tests/server/auth/db/test_backfill_migration.py
@@ -1,0 +1,219 @@
+from pathlib import Path
+
+import pytest
+from alembic.command import downgrade as alembic_downgrade
+from sqlalchemy import create_engine, text
+
+from mlflow.server.auth.db.utils import _get_alembic_config, migrate
+from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
+
+M1_REVISION = "c3d4e5f6a7b8"
+M2_REVISION = "d4e5f6a7b8c9"
+
+
+def _downgrade(engine, revision: str) -> None:
+    cfg = _get_alembic_config(engine.url.render_as_string(hide_password=False))
+    with engine.begin() as conn:
+        cfg.attributes["connection"] = conn
+        alembic_downgrade(cfg, revision)
+
+
+@pytest.fixture
+def engine(tmp_path: Path):
+    db = tmp_path / "backfill.db"
+    eng = create_engine(f"sqlite:///{db}")
+    yield eng
+    eng.dispose()
+
+
+def _seed_legacy_state(
+    engine, users: list[tuple[int, str]], grants: list[dict[str, object]]
+) -> None:
+    with engine.begin() as conn:
+        for user_id, username in users:
+            conn.execute(
+                text(
+                    "INSERT INTO users (id, username, password_hash, is_admin) "
+                    "VALUES (:id, :u, 'hash', 0)"
+                ),
+                {"id": user_id, "u": username},
+            )
+        for g in grants:
+            table = g.pop("table")
+            cols = ", ".join(g.keys())
+            placeholders = ", ".join(f":{k}" for k in g.keys())
+            conn.execute(text(f"INSERT INTO {table} ({cols}) VALUES ({placeholders})"), g)
+
+
+def _fetch_role_permissions(engine) -> list[dict[str, object]]:
+    with engine.begin() as conn:
+        rows = conn.execute(
+            text(
+                "SELECT r.workspace, r.name, rp.resource_type, rp.resource_pattern, rp.permission "
+                "FROM role_permissions rp "
+                "JOIN roles r ON r.id = rp.role_id "
+                "ORDER BY r.workspace, r.name, rp.resource_type, rp.resource_pattern"
+            )
+        ).mappings()
+        return [dict(row) for row in rows]
+
+
+def _fetch_assignments(engine) -> set[tuple[int, str]]:
+    with engine.begin() as conn:
+        rows = conn.execute(
+            text(
+                "SELECT a.user_id, r.name "
+                "FROM user_role_assignments a JOIN roles r ON r.id = a.role_id"
+            )
+        )
+        return {(r[0], r[1]) for r in rows}
+
+
+def test_backfill_mirrors_every_legacy_grant(engine):
+    migrate(engine, M1_REVISION)
+    _seed_legacy_state(
+        engine,
+        users=[(1, "alice"), (2, "bob")],
+        grants=[
+            {
+                "table": "experiment_permissions",
+                "user_id": 1,
+                "experiment_id": "exp1",
+                "permission": "READ",
+            },
+            {
+                "table": "experiment_permissions",
+                "user_id": 2,
+                "experiment_id": "exp1",
+                "permission": "EDIT",
+            },
+            {
+                "table": "registered_model_permissions",
+                "user_id": 1,
+                "workspace": "ws-a",
+                "name": "model_x",
+                "permission": "MANAGE",
+            },
+            {
+                "table": "scorer_permissions",
+                "user_id": 1,
+                "experiment_id": "exp1",
+                "scorer_name": "judge_a",
+                "permission": "USE",
+            },
+            {
+                "table": "gateway_secret_permissions",
+                "user_id": 2,
+                "secret_id": "sec1",
+                "permission": "READ",
+            },
+            {
+                "table": "gateway_endpoint_permissions",
+                "user_id": 1,
+                "endpoint_id": "ep1",
+                "permission": "USE",
+            },
+            {
+                "table": "gateway_model_definition_permissions",
+                "user_id": 1,
+                "model_definition_id": "md1",
+                "permission": "READ",
+            },
+            {
+                "table": "workspace_permissions",
+                "user_id": 2,
+                "workspace": "ws-a",
+                "permission": "MANAGE",
+            },
+        ],
+    )
+
+    migrate(engine, M2_REVISION)
+
+    rps = _fetch_role_permissions(engine)
+    # Convert to a lookup set of (workspace, role_name, type, pattern, perm).
+    triples = {
+        (r["workspace"], r["name"], r["resource_type"], r["resource_pattern"], r["permission"])
+        for r in rps
+    }
+    default = DEFAULT_WORKSPACE_NAME
+    assert (default, "__user_1__", "experiment", "exp1", "READ") in triples
+    assert (default, "__user_2__", "experiment", "exp1", "EDIT") in triples
+    assert ("ws-a", "__user_1__", "registered_model", "model_x", "MANAGE") in triples
+    assert (default, "__user_1__", "scorer", "exp1/judge_a", "USE") in triples
+    assert (default, "__user_2__", "gateway_secret", "sec1", "READ") in triples
+    assert (default, "__user_1__", "gateway_endpoint", "ep1", "USE") in triples
+    assert (default, "__user_1__", "gateway_model_definition", "md1", "READ") in triples
+    assert ("ws-a", "__user_2__", "*", "*", "MANAGE") in triples
+
+    # Each user is assigned to every synthetic role created for them.
+    assignments = _fetch_assignments(engine)
+    assert (1, "__user_1__") in assignments
+    assert (2, "__user_2__") in assignments
+
+
+def test_backfill_is_idempotent_under_downgrade_upgrade(engine):
+    # Legacy grants stay in place across the downgrade/upgrade cycle, so re-running the
+    # backfill must produce the same role_permissions state without duplicating rows.
+    migrate(engine, M1_REVISION)
+    _seed_legacy_state(
+        engine,
+        users=[(1, "alice")],
+        grants=[
+            {
+                "table": "experiment_permissions",
+                "user_id": 1,
+                "experiment_id": "exp1",
+                "permission": "READ",
+            },
+            {
+                "table": "workspace_permissions",
+                "user_id": 1,
+                "workspace": "ws-a",
+                "permission": "EDIT",
+            },
+        ],
+    )
+    migrate(engine, M2_REVISION)
+    snapshot_a = _fetch_role_permissions(engine)
+    assert snapshot_a  # sanity
+
+    _downgrade(engine, M1_REVISION)
+    migrate(engine, M2_REVISION)
+    snapshot_b = _fetch_role_permissions(engine)
+
+    assert snapshot_a == snapshot_b
+
+
+def test_backfill_downgrade_removes_synthetic_roles(engine):
+    migrate(engine, M1_REVISION)
+    # Also create a user-defined role to make sure downgrade doesn't nuke it.
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO roles (name, workspace, description) "
+                "VALUES ('viewer', 'ws-a', 'read only')"
+            )
+        )
+    _seed_legacy_state(
+        engine,
+        users=[(1, "alice")],
+        grants=[
+            {
+                "table": "experiment_permissions",
+                "user_id": 1,
+                "experiment_id": "exp1",
+                "permission": "READ",
+            },
+        ],
+    )
+    migrate(engine, M2_REVISION)
+
+    # Downgrade back to M1 — synthetic per-user roles should be removed, user-defined
+    # roles should survive.
+    _downgrade(engine, M1_REVISION)
+
+    with engine.begin() as conn:
+        names = [r[0] for r in conn.execute(text("SELECT name FROM roles"))]
+    assert "viewer" in names
+    assert all(not (n.startswith("__user_") and n.endswith("__")) for n in names)

--- a/tests/server/auth/db/test_cli.py
+++ b/tests/server/auth/db/test_cli.py
@@ -127,5 +127,5 @@ def test_upgrade_from_legacy_database(tmp_path: Path) -> None:
     assert "scorer_permissions" in tables
     assert "registered_model_permissions" in tables
     assert "workspace_permissions" in tables
-    assert version[0] == "c3d4e5f6a7b8"
+    assert version[0] == "d4e5f6a7b8c9"
     assert user == ("testuser", 1)

--- a/tests/server/auth/test_auth_unified_reads.py
+++ b/tests/server/auth/test_auth_unified_reads.py
@@ -1,0 +1,191 @@
+import pytest
+from alembic.command import downgrade as alembic_downgrade
+from sqlalchemy import create_engine
+
+from mlflow.environment_variables import MLFLOW_RBAC_UNIFIED_READS
+from mlflow.exceptions import MlflowException
+from mlflow.server import auth as auth_module
+from mlflow.server.auth.db.utils import _get_alembic_config, migrate
+from mlflow.server.auth.permissions import EDIT, MANAGE, READ
+from mlflow.server.auth.sqlalchemy_store import SqlAlchemyStore
+from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
+
+from tests.helper_functions import random_str
+
+pytestmark = pytest.mark.notrackingurimock
+
+
+@pytest.fixture
+def store(tmp_sqlite_uri):
+    store = SqlAlchemyStore()
+    store.init_db(tmp_sqlite_uri)
+    return store
+
+
+@pytest.fixture
+def user(store):
+    return store.create_user(random_str(), random_str())
+
+
+# ---- Resolver under the unified-reads flag ----
+
+
+def test_role_only_grant_resolves_via_unified_reads(store, user, monkeypatch):
+    # Mirror an explicit role grant directly (no dual-write detour).
+    role = store.create_role(name="viewer", workspace=DEFAULT_WORKSPACE_NAME)
+    store.add_role_permission(role.id, "experiment", "exp1", READ.name)
+    store.assign_role_to_user(user.id, role.id)
+
+    # Without the flag, legacy mode also finds it via role_permission_func.
+    resolved = store.get_role_permission_for_resource(
+        user.id, "experiment", "exp1", DEFAULT_WORKSPACE_NAME
+    )
+    assert resolved == READ
+
+
+def test_dual_written_grant_resolves_via_unified_reads(store, user):
+    # Legacy grant → dual-write mirrors it → unified reads surface the same permission.
+    store.create_experiment_permission("exp1", user.username, EDIT.name)
+    assert (
+        store.get_role_permission_for_resource(
+            user.id, "experiment", "exp1", DEFAULT_WORKSPACE_NAME
+        )
+        == EDIT
+    )
+
+
+def test_union_across_direct_and_role_grants_takes_max(store, user):
+    # Direct READ + role EDIT → EDIT. Dual-write mirrors the direct grant too, so the role
+    # resolution itself sees both.
+    role = store.create_role(name="editor", workspace=DEFAULT_WORKSPACE_NAME)
+    store.add_role_permission(role.id, "experiment", "*", EDIT.name)
+    store.assign_role_to_user(user.id, role.id)
+
+    store.create_experiment_permission("exp1", user.username, READ.name)
+
+    # The role resolver takes the max across all grants touching this resource.
+    assert (
+        store.get_role_permission_for_resource(
+            user.id, "experiment", "exp1", DEFAULT_WORKSPACE_NAME
+        )
+        == EDIT
+    )
+
+
+def test_unified_resolver_honors_explicit_no_permissions(store, user, monkeypatch):
+    # An explicit NO_PERMISSIONS grant must surface under the flag (it's a denial, not
+    # "no grant"). Critical for parity with the legacy direct-grant path.
+    monkeypatch.setenv(MLFLOW_RBAC_UNIFIED_READS.name, "true")
+    store.create_experiment_permission("exp1", user.username, "NO_PERMISSIONS")
+
+    role_perm = store.get_role_permission_for_resource(
+        user.id, "experiment", "exp1", DEFAULT_WORKSPACE_NAME
+    )
+    assert role_perm.name == "NO_PERMISSIONS"
+
+
+# ---- Workspace enumeration helpers ----
+
+
+def test_list_accessible_workspace_names_via_roles(store, user, monkeypatch):
+    role_a = store.create_role(name="reader", workspace="ws-a")
+    store.add_role_permission(role_a.id, "experiment", "*", READ.name)
+    store.assign_role_to_user(user.id, role_a.id)
+
+    role_b = store.create_role(name="manager", workspace="ws-b")
+    store.add_role_permission(role_b.id, "workspace", "*", MANAGE.name)
+    store.assign_role_to_user(user.id, role_b.id)
+
+    # A role in ws-c that grants no readable permission should not show up.
+    role_c = store.create_role(name="denied", workspace="ws-c")
+    store.add_role_permission(role_c.id, "experiment", "exp-x", "NO_PERMISSIONS")
+    store.assign_role_to_user(user.id, role_c.id)
+
+    assert store.list_accessible_workspace_names_via_roles(user.username) == {"ws-a", "ws-b"}
+
+
+def test_get_workspace_permission_via_roles(store, user):
+    # type-wildcard (`*`) grant should be visible to the workspace-permission helper.
+    role = store.create_role(name="ws", workspace="ws-a")
+    store.add_role_permission(role.id, "*", "*", READ.name)
+    store.assign_role_to_user(user.id, role.id)
+
+    assert store.get_workspace_permission_via_roles(user.username, "ws-a") == READ
+    # No grant in ws-b → None (triggers the "deny by default" workspace fallback in
+    # `_workspace_permission` when workspaces are enabled).
+    assert store.get_workspace_permission_via_roles(user.username, "ws-b") is None
+
+
+# ---- Filter-path helpers ----
+
+
+def test_role_can_read_map_returns_wildcard_flag(store, user, monkeypatch):
+    # ``_role_can_read_map`` powers the filter-function fast path for wildcard grants.
+    role = store.create_role(name="reader", workspace=DEFAULT_WORKSPACE_NAME)
+    store.add_role_permission(role.id, "experiment", "*", READ.name)
+    store.assign_role_to_user(user.id, role.id)
+
+    monkeypatch.setattr(auth_module, "store", store)
+    can_read, wildcard = auth_module._role_can_read_map(user.id, "experiment")
+    assert wildcard is True
+    assert can_read == {}
+
+
+def test_role_can_read_map_specific_grant(store, user, monkeypatch):
+    role = store.create_role(name="reader", workspace=DEFAULT_WORKSPACE_NAME)
+    store.add_role_permission(role.id, "experiment", "exp1", READ.name)
+    store.add_role_permission(role.id, "experiment", "exp2", "NO_PERMISSIONS")
+    store.assign_role_to_user(user.id, role.id)
+
+    monkeypatch.setattr(auth_module, "store", store)
+    can_read, wildcard = auth_module._role_can_read_map(user.id, "experiment")
+    assert wildcard is False
+    assert can_read == {"exp1": True, "exp2": False}
+
+
+# ---- Startup precondition ----
+
+
+def _make_store_at_revision(db_path, revision: str) -> SqlAlchemyStore:
+    """Migrate an auth DB to ``revision`` (possibly pre-head), then return a store bound
+    to the same engine WITHOUT re-running the normal ``init_db`` auto-upgrade path.
+    """
+    engine = create_engine(f"sqlite:///{db_path}")
+    migrate(engine, "d4e5f6a7b8c9")
+    if revision != "d4e5f6a7b8c9":
+        cfg = _get_alembic_config(engine.url.render_as_string(hide_password=False))
+        with engine.begin() as conn:
+            cfg.attributes["connection"] = conn
+            alembic_downgrade(cfg, revision)
+    fresh = SqlAlchemyStore()
+    fresh.engine = engine
+    return fresh
+
+
+def test_startup_assertion_rejects_pre_backfill_revision(tmp_path, monkeypatch):
+    store = _make_store_at_revision(tmp_path / "auth.db", "c3d4e5f6a7b8")
+    monkeypatch.setattr(auth_module, "store", store, raising=False)
+    monkeypatch.setenv(MLFLOW_RBAC_UNIFIED_READS.name, "true")
+
+    with pytest.raises(MlflowException, match="Phase 2 backfill"):
+        auth_module._assert_unified_reads_preconditions()
+
+    store.engine.dispose()
+
+
+def test_startup_assertion_accepts_post_backfill_revision(tmp_path, monkeypatch):
+    store = _make_store_at_revision(tmp_path / "auth.db", "d4e5f6a7b8c9")
+    monkeypatch.setattr(auth_module, "store", store, raising=False)
+    monkeypatch.setenv(MLFLOW_RBAC_UNIFIED_READS.name, "true")
+
+    auth_module._assert_unified_reads_preconditions()
+    store.engine.dispose()
+
+
+def test_startup_assertion_noop_when_flag_off(tmp_path, monkeypatch):
+    store = _make_store_at_revision(tmp_path / "auth.db", "c3d4e5f6a7b8")
+    monkeypatch.setattr(auth_module, "store", store, raising=False)
+    monkeypatch.delenv(MLFLOW_RBAC_UNIFIED_READS.name, raising=False)
+
+    auth_module._assert_unified_reads_preconditions()
+    store.engine.dispose()

--- a/tests/server/auth/test_auth_unified_reads.py
+++ b/tests/server/auth/test_auth_unified_reads.py
@@ -185,7 +185,8 @@ def test_startup_assertion_accepts_post_backfill_revision(tmp_path, monkeypatch)
 def test_startup_assertion_noop_when_flag_off(tmp_path, monkeypatch):
     store = _make_store_at_revision(tmp_path / "auth.db", "c3d4e5f6a7b8")
     monkeypatch.setattr(auth_module, "store", store, raising=False)
-    monkeypatch.delenv(MLFLOW_RBAC_UNIFIED_READS.name, raising=False)
+    # Explicitly force the flag off (default is True in 3.13+).
+    monkeypatch.setenv(MLFLOW_RBAC_UNIFIED_READS.name, "false")
 
     auth_module._assert_unified_reads_preconditions()
     store.engine.dispose()

--- a/tests/server/auth/test_auth_unified_reads.py
+++ b/tests/server/auth/test_auth_unified_reads.py
@@ -167,7 +167,7 @@ def test_startup_assertion_rejects_pre_backfill_revision(tmp_path, monkeypatch):
     monkeypatch.setattr(auth_module, "store", store, raising=False)
     monkeypatch.setenv(MLFLOW_RBAC_UNIFIED_READS.name, "true")
 
-    with pytest.raises(MlflowException, match="Phase 2 backfill"):
+    with pytest.raises(MlflowException, match="role_permissions backfill"):
         auth_module._assert_unified_reads_preconditions()
 
     store.engine.dispose()

--- a/tests/server/auth/test_auth_workspace.py
+++ b/tests/server/auth/test_auth_workspace.py
@@ -290,8 +290,14 @@ def test_workspace_permission_grants_default_access(monkeypatch):
         def get_workspace_permission(self, workspace_name, username):
             return None
 
+        def get_workspace_permission_via_roles(self, username, workspace_name):
+            return None
+
         def list_accessible_workspace_names(self, username):
             return []
+
+        def list_accessible_workspace_names_via_roles(self, username):
+            return set()
 
     dummy_store = DummyStore()
     monkeypatch.setattr(auth_module, "store", dummy_store, raising=False)
@@ -342,6 +348,9 @@ def test_filter_list_workspaces_includes_default_when_autogrant(monkeypatch):
         def list_accessible_workspace_names(self, username):
             return []
 
+        def list_accessible_workspace_names_via_roles(self, username):
+            return set()
+
     monkeypatch.setattr(auth_module, "store", DummyStore(), raising=False)
 
     response = Response(
@@ -375,6 +384,9 @@ def test_filter_list_workspaces_filters_to_allowed(monkeypatch):
     class DummyStore:
         def list_accessible_workspace_names(self, username):
             return ["team-a"]
+
+        def list_accessible_workspace_names_via_roles(self, username):
+            return {"team-a"}
 
     monkeypatch.setattr(auth_module, "store", DummyStore(), raising=False)
 
@@ -415,6 +427,9 @@ def test_validate_can_view_workspace_allows_default_autogrant(monkeypatch):
     class DummyStore:
         def list_accessible_workspace_names(self, username):
             return []
+
+        def list_accessible_workspace_names_via_roles(self, username):
+            return set()
 
     monkeypatch.setattr(auth_module, "store", DummyStore(), raising=False)
 

--- a/tests/server/auth/test_rbac_dual_write.py
+++ b/tests/server/auth/test_rbac_dual_write.py
@@ -1,5 +1,6 @@
 import pytest
 
+from mlflow.exceptions import MlflowException
 from mlflow.server.auth.permissions import EDIT, MANAGE, READ, get_permission
 from mlflow.server.auth.sqlalchemy_store import SqlAlchemyStore
 from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
@@ -217,3 +218,80 @@ def test_legacy_and_role_views_agree(store, user):
             store.create_experiment_permission("exp1", user.username, permission_name)
         legacy = store.get_experiment_permission("exp1", user.username).permission
         _assert_role_permission(store, user.id, "experiment", "exp1", get_permission(legacy))
+
+
+# ---- Synthetic-role scoping invariants ----
+#
+# The synthetic `__user_<id>__` namespace is reserved. Bulk cleanup/rename helpers must
+# never touch admin-created roles even when the (resource_type, resource_pattern) match.
+
+
+def test_bulk_delete_does_not_touch_admin_created_roles(store, user):
+    # Admin creates a regular role with a registered_model grant; user also has a
+    # mirrored registered_model permission. Bulk delete must only remove the mirror.
+    admin_role = store.create_role(name="team-editor", workspace=DEFAULT_WORKSPACE_NAME)
+    store.add_role_permission(admin_role.id, "registered_model", "model_a", EDIT.name)
+    store.create_registered_model_permission("model_a", user.username, READ.name)
+
+    store.delete_registered_model_permissions("model_a")
+
+    _assert_role_permission(store, user.id, "registered_model", "model_a", None)
+    admin_perms = store.list_role_permissions(admin_role.id)
+    assert len(admin_perms) == 1
+    assert admin_perms[0].resource_pattern == "model_a"
+    assert admin_perms[0].permission == EDIT.name
+
+
+def test_bulk_rename_does_not_touch_admin_created_roles(store, user):
+    admin_role = store.create_role(name="team-editor", workspace=DEFAULT_WORKSPACE_NAME)
+    store.add_role_permission(admin_role.id, "registered_model", "old_name", EDIT.name)
+    store.create_registered_model_permission("old_name", user.username, READ.name)
+
+    store.rename_registered_model_permissions("old_name", "new_name")
+
+    # User's mirror was renamed.
+    _assert_role_permission(store, user.id, "registered_model", "new_name", READ)
+    _assert_role_permission(store, user.id, "registered_model", "old_name", None)
+    # Admin-created role's permission pattern unchanged.
+    admin_perms = store.list_role_permissions(admin_role.id)
+    assert len(admin_perms) == 1
+    assert admin_perms[0].resource_pattern == "old_name"
+
+
+def test_scorer_bulk_delete_does_not_touch_admin_created_roles(store, user):
+    # Workspace=None bulk path (used by scorer/gateway_*) must also be synthetic-only.
+    admin_role = store.create_role(name="scorer-admin", workspace=DEFAULT_WORKSPACE_NAME)
+    store.add_role_permission(admin_role.id, "scorer", "exp1/judge", EDIT.name)
+    store.create_scorer_permission("exp1", "judge", user.username, READ.name)
+
+    store.delete_scorer_permissions_for_scorer("exp1", "judge")
+
+    _assert_role_permission(store, user.id, "scorer", "exp1/judge", None)
+    admin_perms = store.list_role_permissions(admin_role.id)
+    assert len(admin_perms) == 1
+    assert admin_perms[0].permission == EDIT.name
+
+
+def test_create_role_rejects_synthetic_name_pattern(store):
+    with pytest.raises(MlflowException, match="reserved synthetic pattern"):
+        store.create_role(name="__user_42__", workspace=DEFAULT_WORKSPACE_NAME)
+    # Non-integer suffix is allowed — only the exact pattern is reserved.
+    store.create_role(name="__user_foo__", workspace=DEFAULT_WORKSPACE_NAME)
+
+
+def test_update_role_rejects_synthetic_name_pattern(store):
+    role = store.create_role(name="normal", workspace=DEFAULT_WORKSPACE_NAME)
+    with pytest.raises(MlflowException, match="reserved synthetic pattern"):
+        store.update_role(role.id, name="__user_7__")
+
+
+def test_is_synthetic_role_name_rejects_edge_cases():
+    assert SqlAlchemyStore._is_synthetic_role_name("__user_1__") is True
+    assert SqlAlchemyStore._is_synthetic_role_name("__user_99999__") is True
+    # Wrong surroundings or missing id:
+    assert SqlAlchemyStore._is_synthetic_role_name("__user__") is False
+    assert SqlAlchemyStore._is_synthetic_role_name("__user_abc__") is False
+    assert SqlAlchemyStore._is_synthetic_role_name("user_1") is False
+    assert SqlAlchemyStore._is_synthetic_role_name("_user_1__") is False
+    assert SqlAlchemyStore._is_synthetic_role_name("__user_1_") is False
+    assert SqlAlchemyStore._is_synthetic_role_name(None) is False

--- a/tests/server/auth/test_rbac_dual_write.py
+++ b/tests/server/auth/test_rbac_dual_write.py
@@ -193,8 +193,8 @@ def test_delete_user_removes_synthetic_role(store, user):
     # Create a grant to force the synthetic role into existence, then remove the grant so
     # only the (now empty) synthetic role + assignment remain. This avoids tripping a
     # pre-existing FK issue on the legacy permission tables when a user is deleted while
-    # still holding direct grants — that issue exists independent of Phase 2 and will be
-    # addressed in its own fix.
+    # still holding direct grants — that issue is orthogonal to the dual-write cleanup and
+    # will be addressed in its own fix.
     store.create_experiment_permission("exp1", user.username, READ.name)
     store.delete_experiment_permission("exp1", user.username)
     user_id = user.id

--- a/tests/server/auth/test_rbac_dual_write.py
+++ b/tests/server/auth/test_rbac_dual_write.py
@@ -295,3 +295,76 @@ def test_is_synthetic_role_name_rejects_edge_cases():
     assert SqlAlchemyStore._is_synthetic_role_name("_user_1__") is False
     assert SqlAlchemyStore._is_synthetic_role_name("__user_1_") is False
     assert SqlAlchemyStore._is_synthetic_role_name(None) is False
+
+
+# ---- workspace_permissions dual-write (resource_type='*') ----
+#
+# The legacy ``workspace_permissions`` table expresses "user has permission X on every
+# resource of every type in this workspace." We mirror those grants as
+# ``(resource_type='*', resource_pattern='*', permission)`` rows on the synthetic role,
+# and the resolver treats type-wildcard rows as a match for any resource_type.
+
+
+def test_workspace_permission_dual_write_applies_to_every_type(store, user):
+    store.set_workspace_permission(DEFAULT_WORKSPACE_NAME, user.username, READ.name)
+
+    # A type-wildcard grant matches every resource type.
+    for resource_type in (
+        "experiment",
+        "registered_model",
+        "scorer",
+        "gateway_secret",
+        "gateway_endpoint",
+        "gateway_model_definition",
+    ):
+        _assert_role_permission(store, user.id, resource_type, "any-id", READ)
+
+
+def test_workspace_permission_dual_write_update_and_delete(store, user):
+    store.set_workspace_permission(DEFAULT_WORKSPACE_NAME, user.username, READ.name)
+    _assert_role_permission(store, user.id, "experiment", "exp1", READ)
+
+    store.set_workspace_permission(DEFAULT_WORKSPACE_NAME, user.username, EDIT.name)
+    _assert_role_permission(store, user.id, "experiment", "exp1", EDIT)
+
+    store.delete_workspace_permission(DEFAULT_WORKSPACE_NAME, user.username)
+    _assert_role_permission(store, user.id, "experiment", "exp1", None)
+
+
+def test_workspace_permissions_bulk_delete_unmirrors(store, user, user2):
+    store.set_workspace_permission(DEFAULT_WORKSPACE_NAME, user.username, READ.name)
+    store.set_workspace_permission(DEFAULT_WORKSPACE_NAME, user2.username, EDIT.name)
+
+    store.delete_workspace_permissions_for_workspace(DEFAULT_WORKSPACE_NAME)
+
+    _assert_role_permission(store, user.id, "experiment", "exp1", None)
+    _assert_role_permission(store, user2.id, "experiment", "exp1", None)
+
+
+def test_type_wildcard_unions_with_specific_grant(store, user):
+    # A type-wildcard READ on the workspace + a specific experiment MANAGE grant should
+    # resolve to MANAGE (higher of the two).
+    store.set_workspace_permission(DEFAULT_WORKSPACE_NAME, user.username, READ.name)
+    store.create_experiment_permission("exp1", user.username, MANAGE.name)
+
+    _assert_role_permission(store, user.id, "experiment", "exp1", MANAGE)
+    # Other experiments still see only the type-wildcard grant.
+    _assert_role_permission(store, user.id, "experiment", "exp2", READ)
+
+
+def test_type_wildcard_and_workspace_admin_coexist(store, user):
+    # A user can hold both a workspace-admin grant (role/user management) and a separate
+    # type-wildcard permission. Both rows apply and the resolver unions them.
+    admin_role = store.create_role(name="ws-admin", workspace=DEFAULT_WORKSPACE_NAME)
+    store.add_role_permission(admin_role.id, "workspace", "*", MANAGE.name)
+    store.assign_role_to_user(user.id, admin_role.id)
+
+    store.set_workspace_permission(DEFAULT_WORKSPACE_NAME, user.username, READ.name)
+
+    _assert_role_permission(store, user.id, "experiment", "exp1", MANAGE)
+
+
+def test_add_role_permission_type_wildcard_requires_pattern_wildcard(store):
+    role = store.create_role(name="r", workspace=DEFAULT_WORKSPACE_NAME)
+    with pytest.raises(MlflowException, match=r"resource_type='\*' requires"):
+        store.add_role_permission(role.id, "*", "exp1", READ.name)

--- a/tests/server/auth/test_rbac_dual_write.py
+++ b/tests/server/auth/test_rbac_dual_write.py
@@ -1,0 +1,219 @@
+import pytest
+
+from mlflow.server.auth.permissions import EDIT, MANAGE, READ, get_permission
+from mlflow.server.auth.sqlalchemy_store import SqlAlchemyStore
+from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
+
+from tests.helper_functions import random_str
+
+pytestmark = pytest.mark.notrackingurimock
+
+
+@pytest.fixture
+def store(tmp_sqlite_uri):
+    store = SqlAlchemyStore()
+    store.init_db(tmp_sqlite_uri)
+    return store
+
+
+@pytest.fixture
+def user(store):
+    return store.create_user(random_str(), random_str())
+
+
+@pytest.fixture
+def user2(store):
+    return store.create_user(random_str(), random_str())
+
+
+def _assert_role_permission(store, user_id, resource_type, resource_id, expected):
+    resolved = store.get_role_permission_for_resource(
+        user_id, resource_type, resource_id, DEFAULT_WORKSPACE_NAME
+    )
+    if expected is None:
+        assert resolved is None
+    else:
+        assert resolved == expected
+
+
+# ---- Per-resource dual-write invariants ----
+#
+# For each of the six per-resource permission tables, creating / updating / deleting a grant
+# via the legacy API must keep `get_role_permission_for_resource` in sync with the direct
+# lookup so later phases can flip reads over without changing semantics.
+
+
+def test_experiment_permission_dual_write(store, user):
+    store.create_experiment_permission("exp1", user.username, READ.name)
+    _assert_role_permission(store, user.id, "experiment", "exp1", READ)
+
+    store.update_experiment_permission("exp1", user.username, EDIT.name)
+    _assert_role_permission(store, user.id, "experiment", "exp1", EDIT)
+
+    store.delete_experiment_permission("exp1", user.username)
+    _assert_role_permission(store, user.id, "experiment", "exp1", None)
+
+
+def test_registered_model_permission_dual_write(store, user):
+    store.create_registered_model_permission("model_a", user.username, READ.name)
+    _assert_role_permission(store, user.id, "registered_model", "model_a", READ)
+
+    store.update_registered_model_permission("model_a", user.username, MANAGE.name)
+    _assert_role_permission(store, user.id, "registered_model", "model_a", MANAGE)
+
+    store.delete_registered_model_permission("model_a", user.username)
+    _assert_role_permission(store, user.id, "registered_model", "model_a", None)
+
+
+def test_registered_model_bulk_delete_unmirrors(store, user, user2):
+    store.create_registered_model_permission("model_a", user.username, READ.name)
+    store.create_registered_model_permission("model_a", user2.username, EDIT.name)
+    _assert_role_permission(store, user.id, "registered_model", "model_a", READ)
+    _assert_role_permission(store, user2.id, "registered_model", "model_a", EDIT)
+
+    store.delete_registered_model_permissions("model_a")
+
+    _assert_role_permission(store, user.id, "registered_model", "model_a", None)
+    _assert_role_permission(store, user2.id, "registered_model", "model_a", None)
+
+
+def test_registered_model_rename_updates_mirror(store, user):
+    store.create_registered_model_permission("old_name", user.username, EDIT.name)
+    _assert_role_permission(store, user.id, "registered_model", "old_name", EDIT)
+
+    store.rename_registered_model_permissions("old_name", "new_name")
+
+    _assert_role_permission(store, user.id, "registered_model", "old_name", None)
+    _assert_role_permission(store, user.id, "registered_model", "new_name", EDIT)
+
+
+def test_scorer_permission_dual_write(store, user):
+    store.create_scorer_permission("exp1", "scorer_a", user.username, READ.name)
+    _assert_role_permission(store, user.id, "scorer", "exp1/scorer_a", READ)
+
+    store.update_scorer_permission("exp1", "scorer_a", user.username, EDIT.name)
+    _assert_role_permission(store, user.id, "scorer", "exp1/scorer_a", EDIT)
+
+    store.delete_scorer_permission("exp1", "scorer_a", user.username)
+    _assert_role_permission(store, user.id, "scorer", "exp1/scorer_a", None)
+
+
+def test_scorer_bulk_delete_unmirrors(store, user, user2):
+    store.create_scorer_permission("exp1", "scorer_a", user.username, READ.name)
+    store.create_scorer_permission("exp1", "scorer_a", user2.username, EDIT.name)
+    store.delete_scorer_permissions_for_scorer("exp1", "scorer_a")
+    _assert_role_permission(store, user.id, "scorer", "exp1/scorer_a", None)
+    _assert_role_permission(store, user2.id, "scorer", "exp1/scorer_a", None)
+
+
+def test_gateway_secret_permission_dual_write(store, user):
+    store.create_gateway_secret_permission("secret1", user.username, READ.name)
+    _assert_role_permission(store, user.id, "gateway_secret", "secret1", READ)
+
+    store.update_gateway_secret_permission("secret1", user.username, MANAGE.name)
+    _assert_role_permission(store, user.id, "gateway_secret", "secret1", MANAGE)
+
+    store.delete_gateway_secret_permission("secret1", user.username)
+    _assert_role_permission(store, user.id, "gateway_secret", "secret1", None)
+
+
+def test_gateway_secret_bulk_delete_unmirrors(store, user, user2):
+    store.create_gateway_secret_permission("secret1", user.username, READ.name)
+    store.create_gateway_secret_permission("secret1", user2.username, EDIT.name)
+    store.delete_gateway_secret_permissions_for_secret("secret1")
+    _assert_role_permission(store, user.id, "gateway_secret", "secret1", None)
+    _assert_role_permission(store, user2.id, "gateway_secret", "secret1", None)
+
+
+def test_gateway_endpoint_permission_dual_write(store, user):
+    store.create_gateway_endpoint_permission("endpoint1", user.username, READ.name)
+    _assert_role_permission(store, user.id, "gateway_endpoint", "endpoint1", READ)
+
+    store.update_gateway_endpoint_permission("endpoint1", user.username, EDIT.name)
+    _assert_role_permission(store, user.id, "gateway_endpoint", "endpoint1", EDIT)
+
+    store.delete_gateway_endpoint_permission("endpoint1", user.username)
+    _assert_role_permission(store, user.id, "gateway_endpoint", "endpoint1", None)
+
+
+def test_gateway_endpoint_bulk_delete_unmirrors(store, user, user2):
+    store.create_gateway_endpoint_permission("endpoint1", user.username, READ.name)
+    store.create_gateway_endpoint_permission("endpoint1", user2.username, EDIT.name)
+    store.delete_gateway_endpoint_permissions_for_endpoint("endpoint1")
+    _assert_role_permission(store, user.id, "gateway_endpoint", "endpoint1", None)
+    _assert_role_permission(store, user2.id, "gateway_endpoint", "endpoint1", None)
+
+
+def test_gateway_model_definition_permission_dual_write(store, user):
+    store.create_gateway_model_definition_permission("model1", user.username, READ.name)
+    _assert_role_permission(store, user.id, "gateway_model_definition", "model1", READ)
+
+    store.update_gateway_model_definition_permission("model1", user.username, MANAGE.name)
+    _assert_role_permission(store, user.id, "gateway_model_definition", "model1", MANAGE)
+
+    store.delete_gateway_model_definition_permission("model1", user.username)
+    _assert_role_permission(store, user.id, "gateway_model_definition", "model1", None)
+
+
+def test_gateway_model_definition_bulk_delete_unmirrors(store, user, user2):
+    store.create_gateway_model_definition_permission("model1", user.username, READ.name)
+    store.create_gateway_model_definition_permission("model1", user2.username, EDIT.name)
+    store.delete_gateway_model_definition_permissions_for_model_definition("model1")
+    _assert_role_permission(store, user.id, "gateway_model_definition", "model1", None)
+    _assert_role_permission(store, user2.id, "gateway_model_definition", "model1", None)
+
+
+# ---- Synthetic role bookkeeping ----
+
+
+def test_synthetic_role_is_created_and_reused(store, user):
+    store.create_experiment_permission("exp1", user.username, READ.name)
+    store.create_registered_model_permission("model1", user.username, EDIT.name)
+
+    # A single synthetic role per (user, workspace) holds all mirrored grants.
+    roles = store.list_roles(DEFAULT_WORKSPACE_NAME)
+    synthetic = [r for r in roles if r.name == f"__user_{user.id}__"]
+    assert len(synthetic) == 1
+    patterns = {(p.resource_type, p.resource_pattern) for p in synthetic[0].permissions}
+    assert ("experiment", "exp1") in patterns
+    assert ("registered_model", "model1") in patterns
+
+
+def test_synthetic_role_is_user_scoped(store, user, user2):
+    store.create_experiment_permission("exp1", user.username, READ.name)
+    store.create_experiment_permission("exp1", user2.username, EDIT.name)
+
+    # Each user gets their own synthetic role — grants don't bleed across users.
+    _assert_role_permission(store, user.id, "experiment", "exp1", READ)
+    _assert_role_permission(store, user2.id, "experiment", "exp1", EDIT)
+
+
+def test_delete_user_removes_synthetic_role(store, user):
+    # Create a grant to force the synthetic role into existence, then remove the grant so
+    # only the (now empty) synthetic role + assignment remain. This avoids tripping a
+    # pre-existing FK issue on the legacy permission tables when a user is deleted while
+    # still holding direct grants — that issue exists independent of Phase 2 and will be
+    # addressed in its own fix.
+    store.create_experiment_permission("exp1", user.username, READ.name)
+    store.delete_experiment_permission("exp1", user.username)
+    user_id = user.id
+    assert any(r.name == f"__user_{user_id}__" for r in store.list_roles(DEFAULT_WORKSPACE_NAME))
+
+    store.delete_user(user.username)
+
+    assert not any(
+        r.name == f"__user_{user_id}__" for r in store.list_roles(DEFAULT_WORKSPACE_NAME)
+    )
+
+
+def test_legacy_and_role_views_agree(store, user):
+    # The goal of dual-write is that whatever the legacy read returns, the role-based
+    # resolution returns the same Permission object. Exercise that directly across a
+    # sequence of grant mutations.
+    for permission_name in (READ.name, EDIT.name, MANAGE.name):
+        if store.list_experiment_permissions(user.username):
+            store.update_experiment_permission("exp1", user.username, permission_name)
+        else:
+            store.create_experiment_permission("exp1", user.username, permission_name)
+        legacy = store.get_experiment_permission("exp1", user.username).permission
+        _assert_role_permission(store, user.id, "experiment", "exp1", get_permission(legacy))


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/22813/files/be4d18f78944a4e774af3a887149b3ee58baf230..47b65c5825ba3352700651a5a0beb666f671578b) to review incremental changes.
- [stack/rbac/data-model](https://github.com/mlflow/mlflow/pull/22721) [[Files changed](https://github.com/mlflow/mlflow/pull/22721/files)] [MERGED]
  - [stack/rbac/rest-api](https://github.com/mlflow/mlflow/pull/22722) [[Files changed](https://github.com/mlflow/mlflow/pull/22722/files)] [MERGED]
    - [stack/rbac/phase2-dual-write](https://github.com/mlflow/mlflow/pull/22806) [[Files changed](https://github.com/mlflow/mlflow/pull/22806/files)]
      - [stack/rbac/phase2-workspace-perms](https://github.com/mlflow/mlflow/pull/22809) [[Files changed](https://github.com/mlflow/mlflow/pull/22809/files/d34a20e7578eb5ecfe6b81eb6a6d69c672b4baa3..a619e25030e2a3201d94e069acdad2a5995998e3)]
        - [stack/rbac/phase2-backfill](https://github.com/mlflow/mlflow/pull/22810) [[Files changed](https://github.com/mlflow/mlflow/pull/22810/files/a619e25030e2a3201d94e069acdad2a5995998e3..be4d18f78944a4e774af3a887149b3ee58baf230)]
          - [**stack/rbac/phase2-unified-reads**](https://github.com/mlflow/mlflow/pull/22813) [[Files changed](https://github.com/mlflow/mlflow/pull/22813/files/be4d18f78944a4e774af3a887149b3ee58baf230..47b65c5825ba3352700651a5a0beb666f671578b)]

---------
### Related Issues/PRs

Part of the RBAC stack. Depends on #22810.

### What changes are proposed in this pull request?

**Phase 2 M3: flip auth reads to \`role_permissions\` under \`MLFLOW_RBAC_UNIFIED_READS\`.**

Dual-write (#22806, #22809) and backfill (#22810) landed \`role_permissions\` as a complete parallel source of truth. This PR adds the feature flag that actually uses it as the read path. Dual-write stays on so rollback-by-flag is safe; M4 will remove dual-write once M3 has baked.

**What happens under the flag:**
- Central resolver \`_get_permission_from_store_or_default\` consults only \`role_permission_func\`. Explicit \`NO_PERMISSIONS\` from the role resolver is honored as a denial. Workspace-level fallback still applies but routes through \`get_workspace_permission_via_roles\`, preserving "deny by default" cross-workspace isolation.
- \`_workspace_permission\` routes to \`get_workspace_permission_via_roles\`.
- \`_can_read_workspace\` / \`filter_list_workspaces\` use \`list_accessible_workspace_names_via_roles\`.
- Four filter functions (\`filter_experiment_ids\`, \`filter_search_experiments\`, \`filter_search_logged_models\`, \`filter_search_registered_models\`, \`filter_search_model_versions\`) build the \`can_read\` map from \`list_role_grants_for_user_in_workspace\` and short-circuit on wildcard grants.
- Derived helpers (\`_get_permission_from_run_id\`, \`_get_permission_from_model_id\`, \`_get_permission_from_prompt_optimization_job_id\`, \`_get_permission_from_trace_request_id\`, graphql permission helpers, metric-history / search-datasets / create-promptlab-run validators, model-definition use validator, \`_validate_gateway_use_permission\`) now delegate to the primary \`_get_experiment_permission\` / \`_get_registered_model_permission\` wrappers so the role_permission_func wiring takes effect consistently.

**Startup precondition.** On boot, if the flag is on and the Alembic revision is earlier than \`d4e5f6a7b8c9\` (Phase 2 M2 backfill), the auth server fails fast with a pointer to \`alembic upgrade head\`. Prevents the "enable unified reads before applying the migration" footgun which would otherwise silently deny access.

**Out of scope (deferred):**
- Dropping dual-write — M4.
- Converting admin CRUD endpoints (\`create/get/update/delete_*_permission\`, \`list_*_permissions\`) — M5, when legacy tables are dropped.
- Shadow-mode disagreement logging — follow-up.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Full auth suite (294 tests) passes under both flag states:
- \`uv run --frozen pytest tests/server/auth/\` (flag off) — 294 pass
- \`MLFLOW_RBAC_UNIFIED_READS=true uv run --frozen pytest tests/server/auth/\` (flag on) — 294 pass

New \`tests/server/auth/test_auth_unified_reads.py\` (11 tests) covers: role-only grant resolution, dual-written grant resolution, direct+role union, explicit NO_PERMISSIONS propagation, workspace enumeration helper (\`list_accessible_workspace_names_via_roles\`), workspace-permission helper (\`get_workspace_permission_via_roles\`), filter-path helper (\`_role_can_read_map\` wildcard + specific), and the startup precondition (pre-backfill raises / post-backfill succeeds / flag-off no-ops).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Introduces \`MLFLOW_RBAC_UNIFIED_READS\` (default off) for the MLflow auth server. When enabled, permission resolution reads from the unified \`role_permissions\` table instead of the legacy per-resource tables. Requires the Phase 2 backfill migration (\`alembic upgrade head\`) to be applied first; otherwise the server fails fast on startup.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] \`area/server-infra\`: MLflow Tracking server backend, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
