### PR TITLE
Remove rendering size guards from artifact image and video views

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactImageView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactImageView.tsx
@@ -13,7 +13,6 @@ import {
   getLoggedModelArtifactLocationUrl,
 } from '../../../common/utils/ArtifactUtils';
 import { ImagePreviewGroup, Image } from '../../../shared/building_blocks/Image';
-import { DownloadLink, exceedsRenderSizeLimit } from '../../../shared/web-shared/media-rendering-utils';
 import type { LoggedModelArtifactViewerProps } from './ArtifactViewComponents.types';
 import { fetchArtifactUnified } from './utils/fetchArtifactUnified';
 
@@ -35,9 +34,6 @@ const ShowArtifactImageView = ({
   const [isLoading, setIsLoading] = useState(true);
   const [previewVisible, setPreviewVisible] = useState(false);
   const [imageUrl, setImageUrl] = useState(null);
-  const [contentLength, setContentLength] = useState(0);
-
-  const contentType = path.toLowerCase().endsWith('.svg') ? 'image/svg+xml' : 'image/png';
 
   useEffect(() => {
     setIsLoading(true);
@@ -56,26 +52,11 @@ const ShowArtifactImageView = ({
       getArtifact,
     ).then((result: any) => {
       const options = path.toLowerCase().endsWith('.svg') ? { type: 'image/svg+xml' } : undefined;
-      const blob = new Blob([new Uint8Array(result)], options);
-      setContentLength(blob.size);
       // @ts-expect-error TS(2345): Argument of type 'string' is not assignable to par... Remove this comment to see the full error message
-      setImageUrl(URL.createObjectURL(blob));
+      setImageUrl(URL.createObjectURL(new Blob([new Uint8Array(result)], options)));
       setIsLoading(false);
     });
   }, [runUuid, path, getArtifact, isLoggedModelsMode, loggedModelId, experimentId, entityTags]);
-
-  if (exceedsRenderSizeLimit(contentType, contentLength) && imageUrl) {
-    return (
-      <div css={{ padding: '10px' }}>
-        <DownloadLink
-          url={imageUrl}
-          contentType={contentType}
-          contentLength={contentLength}
-          filename={path.split('/').pop()}
-        />
-      </div>
-    );
-  }
 
   return (
     imageUrl && (

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactVideoView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactVideoView.tsx
@@ -5,7 +5,6 @@ import {
   getArtifactLocationUrl,
   getLoggedModelArtifactLocationUrl,
 } from '../../../common/utils/ArtifactUtils';
-import { DownloadLink, exceedsRenderSizeLimit } from '../../../shared/web-shared/media-rendering-utils';
 import type { LoggedModelArtifactViewerProps } from './ArtifactViewComponents.types';
 
 type Props = {
@@ -22,7 +21,6 @@ const ShowArtifactVideoView = ({
   loggedModelId,
 }: Props) => {
   const [videoUrl, setVideoUrl] = useState<string>();
-  const [contentLength, setContentLength] = useState(0);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -35,7 +33,6 @@ const ShowArtifactVideoView = ({
 
     getArtifact(artifactUrl).then((blob: Blob) => {
       objUrl = URL.createObjectURL(blob);
-      setContentLength(blob.size);
       setVideoUrl(objUrl);
       setLoading(false);
     });
@@ -60,19 +57,6 @@ const ShowArtifactVideoView = ({
       display: 'block',
     },
   };
-
-  if (exceedsRenderSizeLimit('video/mp4', contentLength) && videoUrl) {
-    return (
-      <div css={{ padding: 10 }}>
-        <DownloadLink
-          url={videoUrl}
-          contentType="video/mp4"
-          contentLength={contentLength}
-          filename={path.split('/').pop()}
-        />
-      </div>
-    );
-  }
 
   return (
     <div css={{ flex: 1 }}>


### PR DESCRIPTION
### Related Issues/PRs

Reverts the artifact-view portion of #22574.

### What changes are proposed in this pull request?

Removes the rendering size guards from `ShowArtifactImageView` and `ShowArtifactVideoView`. The size guards in the trace-explorer code paths are unchanged.

Concretely, undoes the `ShowArtifactImageView.tsx` and `ShowArtifactVideoView.tsx` portions of #22574:

- Removes `DownloadLink` / `exceedsRenderSizeLimit` imports from both files
- Removes the `contentLength` state and the `setContentLength(blob.size)` calls
- Removes the `contentType` computation in `ShowArtifactImageView` (only used for the size check)
- Removes the conditional `DownloadLink` return branch in both components

Net effect: these two components behave exactly as they did before #22574 landed.

### Why

From Daniel: the size guards were appropriate for the trace explorer (where many media items can render at once on a single page, so any one oversized attachment can freeze the browser), but not for the artifact view (where users are viewing a single artifact they explicitly selected).

If someone logs a video as a run artifact, they should be able to view it in the UI without being forced into a download flow.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

No new tests. #22574 did not add tests for the artifact-view guard logic (only trace-explorer tests), so there's nothing on the test side to remove either. Existing `ShowArtifactImageView.enzyme.test.tsx` and `ShowArtifactVideoView.test.tsx` continue to pass because this PR restores the exact pre-#22574 behavior.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Restores full inline rendering of image and video artifacts in the run artifact view (removes a size-based gate introduced in a recent release that forced a download link for large media files).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release