### PR TITLE
Cache successful basic-auth credential checks to eliminate per-request PBKDF2

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -278,9 +278,9 @@ _RESOURCE_WORKSPACE_CACHE: TTLCache[str, str | None] = TTLCache(
 )
 
 # Cache for successful basic-auth credential checks. Keyed by (username, sha256(password))
-# so the password itself is never held in memory. Skipping the PBKDF2 hash comparison
-# inside ``store.authenticate_user`` on cache hits is the dominant cost saving — a single
-# check_password_hash call costs tens of milliseconds by design.
+# so the plaintext password is not stored in the cache key. Skipping the PBKDF2 hash
+# comparison inside ``store.authenticate_user`` on cache hits is the dominant cost
+# saving — a single check_password_hash call costs tens of milliseconds by design.
 _USER_AUTH_CACHE: TTLCache[tuple[str, bytes], User] | None = (
     TTLCache(
         maxsize=auth_config.auth_cache_max_size,
@@ -305,12 +305,16 @@ def _authenticate_cached(username: str, password: str) -> User | None:
     (``_authenticate_fastapi_request``) auth paths so neither pays the PBKDF2
     cost twice for the same credential within ``auth_cache_ttl_seconds``.
 
-    Returns the ``User`` on success, or ``None`` when the credential is invalid.
+    Returns the ``User`` on success, or ``None`` when the credential is invalid
+    or the user has been deleted between ``authenticate_user`` and ``get_user``.
     """
     if _USER_AUTH_CACHE is None:
-        if store.authenticate_user(username, password):
+        if not store.authenticate_user(username, password):
+            return None
+        try:
             return store.get_user(username)
-        return None
+        except MlflowException:
+            return None
 
     key = _auth_cache_key(username, password)
     with _USER_AUTH_CACHE_LOCK:
@@ -322,7 +326,12 @@ def _authenticate_cached(username: str, password: str) -> User | None:
     # *different* credentials still run in parallel.
     if not store.authenticate_user(username, password):
         return None
-    user = store.get_user(username)
+    try:
+        user = store.get_user(username)
+    except MlflowException:
+        # User was deleted between authenticate_user and get_user — treat as auth
+        # failure and don't cache anything.
+        return None
     with _USER_AUTH_CACHE_LOCK:
         _USER_AUTH_CACHE[key] = user
     return user
@@ -1822,7 +1831,15 @@ def authenticate_request_basic_auth() -> Authorization | Response:
     if request.authorization is None:
         return make_basic_auth_response()
 
-    if _authenticate_cached(request.authorization.username, request.authorization.password):
+    username = request.authorization.username
+    password = request.authorization.password
+    # When the cache is disabled, don't pay the extra get_user round-trip that
+    # _authenticate_cached does for the sake of cache-population — the Flask
+    # path only cares about the yes/no auth decision.
+    if _USER_AUTH_CACHE is None:
+        if store.authenticate_user(username, password):
+            return request.authorization
+    elif _authenticate_cached(username, password):
         return request.authorization
     # let user attempt login again
     return make_basic_auth_response()

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import base64
 import functools
-import hashlib
+import hmac
 import importlib
 import json
 import logging
@@ -277,10 +277,13 @@ _RESOURCE_WORKSPACE_CACHE: TTLCache[str, str | None] = TTLCache(
     ttl=auth_config.workspace_cache_ttl_seconds,
 )
 
-# Cache for successful basic-auth credential checks. Keyed by (username, sha256(password))
-# so the plaintext password is not stored in the cache key. Skipping the PBKDF2 hash
-# comparison inside ``store.authenticate_user`` on cache hits is the dominant cost
-# saving — a single check_password_hash call costs tens of milliseconds by design.
+# Cache for successful basic-auth credential checks. Keys derive from the password via
+# HMAC-SHA256 using a per-process secret, so the plaintext password is not stored in the
+# cache key *and* the digest is not usable for offline dictionary attack if process memory
+# is ever compromised (an attacker without the HMAC key cannot recompute the digest).
+# Skipping the PBKDF2 hash comparison inside ``store.authenticate_user`` on cache hits is
+# the dominant cost saving — a single check_password_hash call costs tens of milliseconds
+# by design.
 _USER_AUTH_CACHE: TTLCache[tuple[str, bytes], User] | None = (
     TTLCache(
         maxsize=auth_config.auth_cache_max_size,
@@ -292,10 +295,16 @@ _USER_AUTH_CACHE: TTLCache[tuple[str, bytes], User] | None = (
 # cachetools.TTLCache is not thread-safe — Flask handlers run under gunicorn's thread
 # pool, so every touch of the cache needs to hold this lock.
 _USER_AUTH_CACHE_LOCK = threading.Lock()
+# Random per-process key for the HMAC that turns the password into a cache-key digest.
+# Regenerated at every server start; the cache is ephemeral anyway (process-local, TTL'd),
+# so invalidating the key on restart costs nothing beyond a one-time re-auth for each
+# active credential.
+_USER_AUTH_CACHE_HMAC_KEY = secrets.token_bytes(32)
 
 
 def _auth_cache_key(username: str, password: str) -> tuple[str, bytes]:
-    return (username, hashlib.sha256(password.encode("utf-8")).digest())
+    digest = hmac.new(_USER_AUTH_CACHE_HMAC_KEY, password.encode("utf-8"), "sha256").digest()
+    return (username, digest)
 
 
 def _authenticate_cached(username: str, password: str) -> User | None:

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -294,6 +294,18 @@ def _auth_cache_key(username: str, password: str) -> tuple[str, bytes]:
     return (username, hashlib.sha256(password.encode("utf-8")).digest())
 
 
+def _invalidate_user_auth_cache(username: str) -> None:
+    """Drop every cached credential for ``username``.
+
+    Called from user-mutation routes (password change, admin flag change, deletion)
+    so those changes take effect immediately instead of after ``auth_cache_ttl_seconds``.
+    """
+    if _USER_AUTH_CACHE is None:
+        return
+    for key in [k for k in _USER_AUTH_CACHE if k[0] == username]:
+        _USER_AUTH_CACHE.pop(key, None)
+
+
 def is_unprotected_route(path: str) -> bool:
     return path.startswith(("/static", "/favicon.ico", "/health"))
 
@@ -2517,6 +2529,7 @@ def update_user_password():
     username = _get_request_param("username")
     password = _get_request_param("password")
     store.update_user(username, password=password)
+    _invalidate_user_auth_cache(username)
     return make_response({})
 
 
@@ -2525,6 +2538,7 @@ def update_user_admin():
     username = _get_request_param("username")
     is_admin = _get_request_param("is_admin")
     store.update_user(username, is_admin=is_admin)
+    _invalidate_user_auth_cache(username)
     return make_response({})
 
 
@@ -2532,6 +2546,7 @@ def update_user_admin():
 def delete_user():
     username = _get_request_param("username")
     store.delete_user(username)
+    _invalidate_user_auth_cache(username)
     return make_response({})
 
 

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import base64
 import functools
+import hashlib
 import importlib
 import json
 import logging
@@ -274,6 +275,23 @@ _RESOURCE_WORKSPACE_CACHE: TTLCache[str, str | None] = TTLCache(
     maxsize=auth_config.workspace_cache_max_size,
     ttl=auth_config.workspace_cache_ttl_seconds,
 )
+
+# Cache for successful basic-auth credential checks. Keyed by (username, sha256(password))
+# so the password itself is never held in memory. Skipping the PBKDF2 hash comparison
+# inside ``store.authenticate_user`` on cache hits is the dominant cost saving — a single
+# check_password_hash call costs tens of milliseconds by design.
+_USER_AUTH_CACHE: TTLCache[tuple[str, bytes], User] | None = (
+    TTLCache(
+        maxsize=auth_config.auth_cache_max_size,
+        ttl=auth_config.auth_cache_ttl_seconds,
+    )
+    if auth_config.auth_cache_ttl_seconds > 0
+    else None
+)
+
+
+def _auth_cache_key(username: str, password: str) -> tuple[str, bytes]:
+    return (username, hashlib.sha256(password.encode("utf-8")).digest())
 
 
 def is_unprotected_route(path: str) -> bool:
@@ -2978,8 +2996,15 @@ def _authenticate_fastapi_request(request: StarletteRequest) -> User | None:
         ):
             return store.get_user(username)
 
+        cache_key = _auth_cache_key(username, password) if _USER_AUTH_CACHE is not None else None
+        if cache_key is not None and (cached := _USER_AUTH_CACHE.get(cache_key)) is not None:
+            return cached
+
         if store.authenticate_user(username, password):
-            return store.get_user(username)
+            user = store.get_user(username)
+            if cache_key is not None:
+                _USER_AUTH_CACHE[cache_key] = user
+            return user
     except Exception:
         return None
 

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -17,6 +17,7 @@ import json
 import logging
 import re
 import secrets
+import threading
 from http import HTTPStatus
 from typing import Any, Awaitable, Callable
 
@@ -288,10 +289,43 @@ _USER_AUTH_CACHE: TTLCache[tuple[str, bytes], User] | None = (
     if auth_config.auth_cache_ttl_seconds > 0
     else None
 )
+# cachetools.TTLCache is not thread-safe — Flask handlers run under gunicorn's thread
+# pool, so every touch of the cache needs to hold this lock.
+_USER_AUTH_CACHE_LOCK = threading.Lock()
 
 
 def _auth_cache_key(username: str, password: str) -> tuple[str, bytes]:
     return (username, hashlib.sha256(password.encode("utf-8")).digest())
+
+
+def _authenticate_cached(username: str, password: str) -> User | None:
+    """Run basic-auth verification with the credential cache in front of it.
+
+    Used by both the Flask (``authenticate_request_basic_auth``) and FastAPI
+    (``_authenticate_fastapi_request``) auth paths so neither pays the PBKDF2
+    cost twice for the same credential within ``auth_cache_ttl_seconds``.
+
+    Returns the ``User`` on success, or ``None`` when the credential is invalid.
+    """
+    if _USER_AUTH_CACHE is None:
+        if store.authenticate_user(username, password):
+            return store.get_user(username)
+        return None
+
+    key = _auth_cache_key(username, password)
+    with _USER_AUTH_CACHE_LOCK:
+        cached = _USER_AUTH_CACHE.get(key)
+    if cached is not None:
+        return cached
+
+    # Keep the PBKDF2 comparison outside the lock so concurrent verifications for
+    # *different* credentials still run in parallel.
+    if not store.authenticate_user(username, password):
+        return None
+    user = store.get_user(username)
+    with _USER_AUTH_CACHE_LOCK:
+        _USER_AUTH_CACHE[key] = user
+    return user
 
 
 def _invalidate_user_auth_cache(username: str) -> None:
@@ -302,8 +336,9 @@ def _invalidate_user_auth_cache(username: str) -> None:
     """
     if _USER_AUTH_CACHE is None:
         return
-    for key in [k for k in _USER_AUTH_CACHE if k[0] == username]:
-        _USER_AUTH_CACHE.pop(key, None)
+    with _USER_AUTH_CACHE_LOCK:
+        for key in [k for k in _USER_AUTH_CACHE if k[0] == username]:
+            _USER_AUTH_CACHE.pop(key, None)
 
 
 def is_unprotected_route(path: str) -> bool:
@@ -1787,13 +1822,10 @@ def authenticate_request_basic_auth() -> Authorization | Response:
     if request.authorization is None:
         return make_basic_auth_response()
 
-    username = request.authorization.username
-    password = request.authorization.password
-    if store.authenticate_user(username, password):
+    if _authenticate_cached(request.authorization.username, request.authorization.password):
         return request.authorization
-    else:
-        # let user attempt login again
-        return make_basic_auth_response()
+    # let user attempt login again
+    return make_basic_auth_response()
 
 
 def _find_validator(req: Request) -> Callable[[], bool] | None:
@@ -3011,19 +3043,9 @@ def _authenticate_fastapi_request(request: StarletteRequest) -> User | None:
         ):
             return store.get_user(username)
 
-        cache_key = _auth_cache_key(username, password) if _USER_AUTH_CACHE is not None else None
-        if cache_key is not None and (cached := _USER_AUTH_CACHE.get(cache_key)) is not None:
-            return cached
-
-        if store.authenticate_user(username, password):
-            user = store.get_user(username)
-            if cache_key is not None:
-                _USER_AUTH_CACHE[cache_key] = user
-            return user
+        return _authenticate_cached(username, password)
     except Exception:
         return None
-
-    return None
 
 
 def _extract_gateway_endpoint_name(path: str, body: dict[str, Any] | None) -> str | None:

--- a/mlflow/server/auth/basic_auth.ini
+++ b/mlflow/server/auth/basic_auth.ini
@@ -9,3 +9,8 @@ grant_default_workspace_access = false
 # Cache settings for resource-to-workspace lookups (used for permission checks).
 # workspace_cache_max_size = 10000
 # workspace_cache_ttl_seconds = 3600
+# Cache settings for basic-auth username/password verification. Successful credential
+# checks are cached for this long so PBKDF2 hash comparison runs at most once per
+# (user, password) per ttl window. Set ttl_seconds = 0 to disable the cache entirely.
+# auth_cache_max_size = 10000
+# auth_cache_ttl_seconds = 60

--- a/mlflow/server/auth/basic_auth.ini
+++ b/mlflow/server/auth/basic_auth.ini
@@ -11,6 +11,9 @@ grant_default_workspace_access = false
 # workspace_cache_ttl_seconds = 3600
 # Cache settings for basic-auth username/password verification. Successful credential
 # checks are cached for this long so PBKDF2 hash comparison runs at most once per
-# (user, password) per ttl window. Set ttl_seconds = 0 to disable the cache entirely.
+# (user, password) per TTL window. Password, admin-flag, and deletion changes made
+# via the HTTP APIs invalidate matching entries immediately, but if you mutate the
+# user table out-of-band (direct SQL, external IdP sync) those changes may not be
+# reflected until the TTL expires. Set auth_cache_ttl_seconds = 0 to disable.
 # auth_cache_max_size = 10000
 # auth_cache_ttl_seconds = 60

--- a/mlflow/server/auth/basic_auth.ini
+++ b/mlflow/server/auth/basic_auth.ini
@@ -9,17 +9,22 @@ grant_default_workspace_access = false
 # Cache settings for resource-to-workspace lookups (used for permission checks).
 # workspace_cache_max_size = 10000
 # workspace_cache_ttl_seconds = 3600
-# Cache settings for basic-auth username/password verification. Successful credential
-# checks are cached for this long so PBKDF2 hash comparison runs at most once per
-# (user, password) per TTL window. The cache lives inside each worker process, so:
+# Cache settings for basic-auth username/password verification. Disabled by default
+# (auth_cache_ttl_seconds = 0). When enabled, successful credential checks are
+# cached for this long so PBKDF2 hash comparison runs at most once per (user,
+# password) per TTL window — a ~3x throughput improvement on request-heavy
+# auth-enabled workloads.
+#
+# The cache lives inside each worker process, so enabling it introduces staleness:
 #   * Password, admin-flag, and deletion changes via the HTTP APIs invalidate the
-#     entry on whichever worker handled the mutation immediately. Other workers in a
-#     multi-worker deployment may continue to accept the old credential until the
-#     TTL expires (at most auth_cache_ttl_seconds).
-#   * Mutations made out-of-band (direct SQL, external IdP sync) reach the cache on
-#     no workers and are likewise reflected only after the TTL expires.
-# Set auth_cache_ttl_seconds = 0 if the deployment can't tolerate that staleness
-# window. The cache is bounded by auth_cache_max_size and the TTL, so there's no
-# unbounded memory growth.
+#     entry on whichever worker handled the mutation immediately. Other workers in
+#     a multi-worker deployment may continue to accept the old credential until
+#     the TTL expires (at most auth_cache_ttl_seconds).
+#   * Mutations made out-of-band (direct SQL, external IdP sync) reach the cache
+#     on no workers and are likewise reflected only after the TTL expires.
+#
+# The cache is bounded by auth_cache_max_size and the TTL, so there is no
+# unbounded memory growth. Set auth_cache_ttl_seconds to a positive value
+# (e.g. 60) to opt in.
 # auth_cache_max_size = 10000
-# auth_cache_ttl_seconds = 60
+# auth_cache_ttl_seconds = 0

--- a/mlflow/server/auth/basic_auth.ini
+++ b/mlflow/server/auth/basic_auth.ini
@@ -11,9 +11,15 @@ grant_default_workspace_access = false
 # workspace_cache_ttl_seconds = 3600
 # Cache settings for basic-auth username/password verification. Successful credential
 # checks are cached for this long so PBKDF2 hash comparison runs at most once per
-# (user, password) per TTL window. Password, admin-flag, and deletion changes made
-# via the HTTP APIs invalidate matching entries immediately, but if you mutate the
-# user table out-of-band (direct SQL, external IdP sync) those changes may not be
-# reflected until the TTL expires. Set auth_cache_ttl_seconds = 0 to disable.
+# (user, password) per TTL window. The cache lives inside each worker process, so:
+#   * Password, admin-flag, and deletion changes via the HTTP APIs invalidate the
+#     entry on whichever worker handled the mutation immediately. Other workers in a
+#     multi-worker deployment may continue to accept the old credential until the
+#     TTL expires (at most auth_cache_ttl_seconds).
+#   * Mutations made out-of-band (direct SQL, external IdP sync) reach the cache on
+#     no workers and are likewise reflected only after the TTL expires.
+# Set auth_cache_ttl_seconds = 0 if the deployment can't tolerate that staleness
+# window. The cache is bounded by auth_cache_max_size and the TTL, so there's no
+# unbounded memory growth.
 # auth_cache_max_size = 10000
 # auth_cache_ttl_seconds = 60

--- a/mlflow/server/auth/config.py
+++ b/mlflow/server/auth/config.py
@@ -48,5 +48,7 @@ def read_auth_config() -> AuthConfig:
             "mlflow", "workspace_cache_ttl_seconds", fallback=3600
         ),
         auth_cache_max_size=config.getint("mlflow", "auth_cache_max_size", fallback=10000),
-        auth_cache_ttl_seconds=config.getint("mlflow", "auth_cache_ttl_seconds", fallback=60),
+        # Off by default — enabling the cache introduces a per-worker staleness window
+        # (see basic_auth.ini for details). Operators must explicitly opt in.
+        auth_cache_ttl_seconds=config.getint("mlflow", "auth_cache_ttl_seconds", fallback=0),
     )

--- a/mlflow/server/auth/config.py
+++ b/mlflow/server/auth/config.py
@@ -16,6 +16,8 @@ class AuthConfig(NamedTuple):
     grant_default_workspace_access: bool
     workspace_cache_max_size: int
     workspace_cache_ttl_seconds: int
+    auth_cache_max_size: int
+    auth_cache_ttl_seconds: int
 
 
 def _get_auth_config_path() -> str:
@@ -45,4 +47,6 @@ def read_auth_config() -> AuthConfig:
         workspace_cache_ttl_seconds=config.getint(
             "mlflow", "workspace_cache_ttl_seconds", fallback=3600
         ),
+        auth_cache_max_size=config.getint("mlflow", "auth_cache_max_size", fallback=10000),
+        auth_cache_ttl_seconds=config.getint("mlflow", "auth_cache_ttl_seconds", fallback=60),
     )

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -3303,6 +3303,44 @@ def test_basic_auth_cache_keyed_by_username_and_password(
     ]
 
 
+def test_basic_auth_returns_none_when_user_deleted_between_authenticate_and_get(
+    mock_auth_store, mock_auth_config, monkeypatch
+):
+    # TOCTOU: authenticate_user returned True but the user disappeared before get_user.
+    monkeypatch.delenv(_MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN.name, raising=False)
+    mock_auth_store.get_user.side_effect = MlflowException("User not found")
+    credentials = base64.b64encode(b"ghost:password123").decode("ascii")
+    request = _make_request("/x", f"Basic {credentials}")
+
+    # Flask and FastAPI paths both must treat this as an auth failure, not surface
+    # a 500 and, critically, must not cache the (ghost, password123) pair.
+    assert _authenticate_fastapi_request(request) is None
+    if auth_module._USER_AUTH_CACHE is not None:
+        assert (
+            auth_module._auth_cache_key("ghost", "password123") not in auth_module._USER_AUTH_CACHE
+        )
+
+
+def test_flask_basic_auth_skips_get_user_when_cache_disabled(
+    mock_auth_store, mock_auth_config, monkeypatch
+):
+    monkeypatch.delenv(_MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN.name, raising=False)
+    fake_flask_request = mock.Mock()
+    fake_flask_request.authorization.username = "alice"
+    fake_flask_request.authorization.password = "password123"
+
+    with (
+        mock.patch("mlflow.server.auth._USER_AUTH_CACHE", None),
+        mock.patch("mlflow.server.auth.request", fake_flask_request),
+    ):
+        result = auth_module.authenticate_request_basic_auth()
+
+    assert result is fake_flask_request.authorization
+    mock_auth_store.authenticate_user.assert_called_once_with("alice", "password123")
+    # Cache disabled + Flask path only needs the yes/no answer → no user fetch.
+    mock_auth_store.get_user.assert_not_called()
+
+
 def test_flask_basic_auth_shares_cache_with_fastapi_path(
     mock_auth_store, mock_auth_config, monkeypatch
 ):

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -3303,6 +3303,27 @@ def test_basic_auth_cache_keyed_by_username_and_password(
     ]
 
 
+def test_flask_basic_auth_shares_cache_with_fastapi_path(
+    mock_auth_store, mock_auth_config, monkeypatch
+):
+    monkeypatch.delenv(_MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN.name, raising=False)
+    # Prime the cache via the FastAPI path.
+    credentials = base64.b64encode(b"alice:password123").decode("ascii")
+    _authenticate_fastapi_request(_make_request("/x", f"Basic {credentials}"))
+    mock_auth_store.authenticate_user.assert_called_once_with("alice", "password123")
+
+    # A subsequent Flask-side call for the same credentials must be served from
+    # cache — no second PBKDF2 verification, no second user fetch.
+    fake_flask_request = mock.Mock()
+    fake_flask_request.authorization.username = "alice"
+    fake_flask_request.authorization.password = "password123"
+    with mock.patch("mlflow.server.auth.request", fake_flask_request):
+        result = auth_module.authenticate_request_basic_auth()
+
+    assert result is fake_flask_request.authorization
+    mock_auth_store.authenticate_user.assert_called_once_with("alice", "password123")
+
+
 def test_invalidate_user_auth_cache_drops_only_matching_username(
     mock_auth_store, mock_auth_config, monkeypatch
 ):

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -3100,10 +3100,14 @@ def test_webhook_admin_only_permissions(client, monkeypatch):
 
 @pytest.fixture
 def mock_auth_store():
+    if auth_module._USER_AUTH_CACHE is not None:
+        auth_module._USER_AUTH_CACHE.clear()
     with mock.patch("mlflow.server.auth.store") as mock_store:
         mock_store.get_user.side_effect = lambda username: mock.Mock(username=username)
         mock_store.authenticate_user.return_value = True
         yield mock_store
+    if auth_module._USER_AUTH_CACHE is not None:
+        auth_module._USER_AUTH_CACHE.clear()
 
 
 @pytest.fixture
@@ -3247,3 +3251,51 @@ def test_fastapi_malformed_authorization_header(mock_auth_store, mock_auth_confi
     user = _authenticate_fastapi_request(request)
 
     assert user is None
+
+
+# -- Basic auth credential cache --
+
+
+def test_basic_auth_caches_successful_credentials(mock_auth_store, mock_auth_config, monkeypatch):
+    monkeypatch.delenv(_MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN.name, raising=False)
+    credentials = base64.b64encode(b"alice:password123").decode("ascii")
+    request = _make_request("/api/3.0/mlflow/experiments/list", f"Basic {credentials}")
+
+    user_a = _authenticate_fastapi_request(request)
+    user_b = _authenticate_fastapi_request(request)
+
+    assert user_a.username == "alice"
+    assert user_b.username == "alice"
+    mock_auth_store.authenticate_user.assert_called_once_with("alice", "password123")
+
+
+def test_basic_auth_cache_does_not_store_failed_credentials(
+    mock_auth_store, mock_auth_config, monkeypatch
+):
+    monkeypatch.delenv(_MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN.name, raising=False)
+    mock_auth_store.authenticate_user.return_value = False
+    credentials = base64.b64encode(b"alice:wrong").decode("ascii")
+    request = _make_request("/api/3.0/mlflow/experiments/list", f"Basic {credentials}")
+
+    assert _authenticate_fastapi_request(request) is None
+    assert _authenticate_fastapi_request(request) is None
+    assert mock_auth_store.authenticate_user.call_count == 2
+
+
+def test_basic_auth_cache_keyed_by_username_and_password(
+    mock_auth_store, mock_auth_config, monkeypatch
+):
+    monkeypatch.delenv(_MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN.name, raising=False)
+    alice = base64.b64encode(b"alice:password123").decode("ascii")
+    bob = base64.b64encode(b"bob:password123").decode("ascii")
+    alice_wrong = base64.b64encode(b"alice:other-password").decode("ascii")
+
+    _authenticate_fastapi_request(_make_request("/x", f"Basic {alice}"))
+    _authenticate_fastapi_request(_make_request("/x", f"Basic {bob}"))
+    _authenticate_fastapi_request(_make_request("/x", f"Basic {alice_wrong}"))
+
+    assert mock_auth_store.authenticate_user.call_args_list == [
+        mock.call("alice", "password123"),
+        mock.call("bob", "password123"),
+        mock.call("alice", "other-password"),
+    ]

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -3266,7 +3266,9 @@ def test_basic_auth_caches_successful_credentials(mock_auth_store, mock_auth_con
 
     assert user_a.username == "alice"
     assert user_b.username == "alice"
+    # Both PBKDF2 check and user fetch should run exactly once across the two requests.
     mock_auth_store.authenticate_user.assert_called_once_with("alice", "password123")
+    mock_auth_store.get_user.assert_called_once_with("alice")
 
 
 def test_basic_auth_cache_does_not_store_failed_credentials(
@@ -3299,3 +3301,25 @@ def test_basic_auth_cache_keyed_by_username_and_password(
         mock.call("bob", "password123"),
         mock.call("alice", "other-password"),
     ]
+
+
+def test_invalidate_user_auth_cache_drops_only_matching_username(
+    mock_auth_store, mock_auth_config, monkeypatch
+):
+    monkeypatch.delenv(_MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN.name, raising=False)
+    alice = base64.b64encode(b"alice:password123").decode("ascii")
+    alice_alt = base64.b64encode(b"alice:other-password").decode("ascii")
+    bob = base64.b64encode(b"bob:password123").decode("ascii")
+
+    _authenticate_fastapi_request(_make_request("/x", f"Basic {alice}"))
+    _authenticate_fastapi_request(_make_request("/x", f"Basic {alice_alt}"))
+    _authenticate_fastapi_request(_make_request("/x", f"Basic {bob}"))
+    assert mock_auth_store.authenticate_user.call_count == 3
+
+    auth_module._invalidate_user_auth_cache("alice")
+
+    # Alice's two cached credentials are re-checked; bob's cache entry stays hot.
+    _authenticate_fastapi_request(_make_request("/x", f"Basic {alice}"))
+    _authenticate_fastapi_request(_make_request("/x", f"Basic {alice_alt}"))
+    _authenticate_fastapi_request(_make_request("/x", f"Basic {bob}"))
+    assert mock_auth_store.authenticate_user.call_count == 5

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -14,6 +14,7 @@ from unittest import mock
 import jwt
 import pytest
 import requests
+from cachetools import TTLCache
 from cryptography.fernet import Fernet
 
 import mlflow
@@ -3119,6 +3120,14 @@ def mock_auth_config():
         yield mock_config
 
 
+@pytest.fixture
+def enable_auth_cache():
+    # The credential cache is disabled by default; cache-behavior tests must opt in.
+    cache = TTLCache(maxsize=10000, ttl=60)
+    with mock.patch("mlflow.server.auth._USER_AUTH_CACHE", cache):
+        yield cache
+
+
 def _make_request(path, authorization=None):
     request = mock.Mock()
     request.url.path = path
@@ -3258,7 +3267,9 @@ def test_fastapi_malformed_authorization_header(mock_auth_store, mock_auth_confi
 # -- Basic auth credential cache --
 
 
-def test_basic_auth_caches_successful_credentials(mock_auth_store, mock_auth_config, monkeypatch):
+def test_basic_auth_caches_successful_credentials(
+    enable_auth_cache, mock_auth_store, mock_auth_config, monkeypatch
+):
     monkeypatch.delenv(_MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN.name, raising=False)
     credentials = base64.b64encode(b"alice:password123").decode("ascii")
     request = _make_request("/api/3.0/mlflow/experiments/list", f"Basic {credentials}")
@@ -3274,7 +3285,7 @@ def test_basic_auth_caches_successful_credentials(mock_auth_store, mock_auth_con
 
 
 def test_basic_auth_cache_does_not_store_failed_credentials(
-    mock_auth_store, mock_auth_config, monkeypatch
+    enable_auth_cache, mock_auth_store, mock_auth_config, monkeypatch
 ):
     monkeypatch.delenv(_MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN.name, raising=False)
     mock_auth_store.authenticate_user.return_value = False
@@ -3287,7 +3298,7 @@ def test_basic_auth_cache_does_not_store_failed_credentials(
 
 
 def test_basic_auth_cache_keyed_by_username_and_password(
-    mock_auth_store, mock_auth_config, monkeypatch
+    enable_auth_cache, mock_auth_store, mock_auth_config, monkeypatch
 ):
     monkeypatch.delenv(_MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN.name, raising=False)
     alice = base64.b64encode(b"alice:password123").decode("ascii")
@@ -3306,7 +3317,7 @@ def test_basic_auth_cache_keyed_by_username_and_password(
 
 
 def test_basic_auth_returns_none_when_user_deleted_between_authenticate_and_get(
-    mock_auth_store, mock_auth_config, monkeypatch
+    enable_auth_cache, mock_auth_store, mock_auth_config, monkeypatch
 ):
     # TOCTOU: authenticate_user returned True but the user disappeared before get_user.
     monkeypatch.delenv(_MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN.name, raising=False)
@@ -3344,7 +3355,7 @@ def test_flask_basic_auth_skips_get_user_when_cache_disabled(
 
 
 def test_flask_basic_auth_shares_cache_with_fastapi_path(
-    mock_auth_store, mock_auth_config, monkeypatch
+    enable_auth_cache, mock_auth_store, mock_auth_config, monkeypatch
 ):
     monkeypatch.delenv(_MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN.name, raising=False)
     # Prime the cache via the FastAPI path.
@@ -3365,7 +3376,7 @@ def test_flask_basic_auth_shares_cache_with_fastapi_path(
 
 
 def test_invalidate_user_auth_cache_drops_only_matching_username(
-    mock_auth_store, mock_auth_config, monkeypatch
+    enable_auth_cache, mock_auth_store, mock_auth_config, monkeypatch
 ):
     monkeypatch.delenv(_MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN.name, raising=False)
     alice = base64.b64encode(b"alice:password123").decode("ascii")

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -3101,13 +3101,15 @@ def test_webhook_admin_only_permissions(client, monkeypatch):
 @pytest.fixture
 def mock_auth_store():
     if auth_module._USER_AUTH_CACHE is not None:
-        auth_module._USER_AUTH_CACHE.clear()
+        with auth_module._USER_AUTH_CACHE_LOCK:
+            auth_module._USER_AUTH_CACHE.clear()
     with mock.patch("mlflow.server.auth.store") as mock_store:
         mock_store.get_user.side_effect = lambda username: mock.Mock(username=username)
         mock_store.authenticate_user.return_value = True
         yield mock_store
     if auth_module._USER_AUTH_CACHE is not None:
-        auth_module._USER_AUTH_CACHE.clear()
+        with auth_module._USER_AUTH_CACHE_LOCK:
+            auth_module._USER_AUTH_CACHE.clear()
 
 
 @pytest.fixture


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22807 (the gateway benchmark that surfaced this).

### What changes are proposed in this pull request?

`_authenticate_fastapi_request` and `authenticate_request_basic_auth` currently call `store.authenticate_user()` on every request, which in turn runs a PBKDF2 hash comparison via `werkzeug.check_password_hash`. PBKDF2 is deliberately slow (~50–100 ms per verification) — that's the whole point of a password KDF — but it means every authenticated gateway invocation pays tens of ms of CPU on a synchronous worker. With a modest benchmark (4 workers, 50 concurrent clients, fixed-latency upstream) this shows up as ~2x mean latency and ~3.5x lower throughput versus auth-disabled.

This PR introduces a per-process `TTLCache` keyed by `(username, HMAC-SHA256(password))` (with a per-process random HMAC key) that stores the `User` object returned by a successful `authenticate_user` + `get_user` pair. Cache hits skip both the PBKDF2 check and the follow-up user fetch. Specifically:

- **Opt-in, disabled by default.** `auth_cache_ttl_seconds` defaults to `0` in `basic_auth.ini`; operators must explicitly set a positive TTL to enable. This avoids silently subjecting any existing basic-auth deployment to the per-worker staleness window.
- **Only successful authentications are cached.** Wrong-password attempts fall through to `authenticate_user` every time — attackers can't prime the cache by guessing, and rate-limiting / lockout tools that inspect the store still see every failed attempt.
- **Keyed by HMAC of the password, not raw hash.** Key uses `hmac.new(secret, password, 'sha256')` with a 32-byte random secret generated per process at module load, so if process memory is ever exposed, the cached digest is useless without the per-process secret.
- **Thread-safe.** `cachetools.TTLCache` is not thread-safe on its own; every read/write/iteration is held under `_USER_AUTH_CACHE_LOCK`. PBKDF2 verification runs outside the lock so concurrent checks for *different* credentials still parallelize.
- **Shared by Flask and FastAPI auth paths.** Both `authenticate_request_basic_auth` (tracking API / AJAX / signup) and `_authenticate_fastapi_request` (gateway routes) route through a single `_authenticate_cached(username, password) -> User | None` helper.
- **Eager invalidation on HTTP mutations** (password change, admin flag, deletion) drops matching entries on the worker that handled the mutation immediately.
- **Internal-token fast path bypasses the cache entirely.** The `_MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN` shortcut returns `store.get_user(username)` directly (restricted to `/gateway/` routes) — never enters the cache, and the token can't leak into the cache as a regular password because it won't match.
- **TOCTOU safe.** If a user is deleted between `authenticate_user` returning True and `get_user`, the raised `MlflowException` is caught and treated as an auth failure; no half-populated cache entry is written.
- **Flask short-circuits when cache is disabled.** When `_USER_AUTH_CACHE is None`, `authenticate_request_basic_auth` skips straight to `store.authenticate_user`, preserving the pre-PR behavior (no extra `get_user` round-trip).

### Known limitation (documented, follow-up planned)

The cache lives per worker process. When operators enable it, user-mutation HTTP requests only invalidate the cache on the worker that handled the mutation — other workers may continue accepting the old credential / stale admin flag for up to `auth_cache_ttl_seconds`. This is called out in `basic_auth.ini`. Cross-process invalidation (e.g. Redis pub/sub, which MLflow already optionally supports for the gateway budget tracker) is a reasonable follow-up but out of scope for this PR.

### Measurements (with cache enabled: `auth_cache_ttl_seconds = 60`)

Run against `dev/benchmarks/gateway` (single MLflow instance, PostgreSQL backend, 4 workers, 50 concurrent, fixed 50ms upstream, 3 × 2000 requests).

|                | No auth | Auth (cache off, this PR default) | **Auth (cache enabled)** |
| -------------- | ------- | --------------------------------- | ------------------------ |
| Mean ms        | 273     | 957                               | **268**                  |
| P50 ms         | 303     | 784                               | **127**                  |
| P99 ms         | 421     | 2072                              | **586**                  |
| Throughput r/s | 185     | 52                                | **185**                  |

With the cache enabled, throughput returns to parity with auth-disabled. P99 stays above auth-disabled because each worker's cache has to warm up independently on first use.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New unit tests in `tests/server/auth/test_auth.py` (all gated by an `enable_auth_cache` fixture that patches `_USER_AUTH_CACHE` with a fresh TTLCache, since the cache is disabled by default):

1. `test_basic_auth_caches_successful_credentials` — two consecutive requests with the same valid credential only call `authenticate_user` **and** `get_user` once.
2. `test_basic_auth_cache_does_not_store_failed_credentials` — wrong passwords are never cached.
3. `test_basic_auth_cache_keyed_by_username_and_password` — different users and different passwords produce separate entries.
4. `test_basic_auth_returns_none_when_user_deleted_between_authenticate_and_get` — TOCTOU: `get_user` raising doesn't leak to a 500 and doesn't populate the cache.
5. `test_flask_basic_auth_skips_get_user_when_cache_disabled` — with the cache disabled, Flask path doesn't pay an extra `get_user` round-trip.
6. `test_flask_basic_auth_shares_cache_with_fastapi_path` — the Flask and FastAPI paths share a single cache.
7. `test_invalidate_user_auth_cache_drops_only_matching_username` — `_invalidate_user_auth_cache('alice')` removes all Alice entries but leaves Bob intact.

Full `tests/server/auth/test_auth.py` passes (76/76).

Manual:
- `uv run dev/benchmarks/gateway/run.py --instances 1 --database postgres --auth` with `AUTH_CACHE_TTL_SECONDS=60` exported → numbers in the table above.
- Same invocation without the env var → cache-off baseline matches the unchanged pre-PR behavior.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated: …

New tunables are documented inline in `mlflow/server/auth/basic_auth.ini` alongside the existing `workspace_cache_*` settings, including the per-worker staleness tradeoff. No public API reference or user guide changes — this is a transparent server-side optimization, and the off-by-default means upgrade-time behavior doesn't change.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

MLflow basic-auth now supports an optional per-process credential cache. When opted in via `auth_cache_ttl_seconds > 0` in `basic_auth.ini`, successful credential verifications are memoized for the TTL window, eliminating a per-request PBKDF2 hash comparison. Typical request-heavy auth-enabled workloads see ~3x lower latency and ~3x higher throughput. Disabled by default to preserve the existing strict-consistency behavior; operators should read the `basic_auth.ini` comment explaining the per-worker staleness tradeoff before enabling.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release