### PR TITLE
Fix `_get_token_usage` dropping cache token fields

### DIFF
--- a/mlflow/tracing/otel/translation/__init__.py
+++ b/mlflow/tracing/otel/translation/__init__.py
@@ -189,11 +189,23 @@ def _get_token_usage(attributes: dict[str, Any]) -> dict[str, Any]:
             total_tokens = input_tokens + output_tokens
 
         if input_tokens and output_tokens and total_tokens:
-            return {
+            usage = {
                 TokenUsageKey.INPUT_TOKENS: input_tokens,
                 TokenUsageKey.OUTPUT_TOKENS: output_tokens,
                 TokenUsageKey.TOTAL_TOKENS: total_tokens,
             }
+
+            cache_read = _parse_int_attribute(translator.get_cache_read_input_tokens(attributes))
+            if cache_read is not None:
+                usage[TokenUsageKey.CACHE_READ_INPUT_TOKENS] = cache_read
+
+            cache_creation = _parse_int_attribute(
+                translator.get_cache_creation_input_tokens(attributes)
+            )
+            if cache_creation is not None:
+                usage[TokenUsageKey.CACHE_CREATION_INPUT_TOKENS] = cache_creation
+
+            return usage
 
 
 def _get_input_value(attributes: dict[str, Any], events: list[dict[str, Any]] | None = None) -> Any:

--- a/mlflow/tracing/otel/translation/base.py
+++ b/mlflow/tracing/otel/translation/base.py
@@ -25,6 +25,8 @@ class OtelSchemaTranslator:
     INPUT_TOKEN_KEY: str | None = None
     OUTPUT_TOKEN_KEY: str | None = None
     TOTAL_TOKEN_KEY: str | None = None
+    CACHE_READ_INPUT_TOKEN_KEY: str | None = None
+    CACHE_CREATION_INPUT_TOKEN_KEY: str | None = None
     INPUT_VALUE_KEYS: list[str] | None = None
     OUTPUT_VALUE_KEYS: list[str] | None = None
     MODEL_NAME_KEYS: list[str] | None = None
@@ -111,6 +113,14 @@ class OtelSchemaTranslator:
         """
         if self.TOTAL_TOKEN_KEY:
             return attributes.get(self.TOTAL_TOKEN_KEY)
+
+    def get_cache_read_input_tokens(self, attributes: dict[str, Any]) -> int | None:
+        if self.CACHE_READ_INPUT_TOKEN_KEY:
+            return attributes.get(self.CACHE_READ_INPUT_TOKEN_KEY)
+
+    def get_cache_creation_input_tokens(self, attributes: dict[str, Any]) -> int | None:
+        if self.CACHE_CREATION_INPUT_TOKEN_KEY:
+            return attributes.get(self.CACHE_CREATION_INPUT_TOKEN_KEY)
 
     def get_model_name(self, attributes: dict[str, Any]) -> str | None:
         """

--- a/mlflow/tracing/otel/translation/genai_semconv.py
+++ b/mlflow/tracing/otel/translation/genai_semconv.py
@@ -41,6 +41,8 @@ class GenAiTranslator(OtelSchemaTranslator):
     # Reference: https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/#genai-attributes
     INPUT_TOKEN_KEY = "gen_ai.usage.input_tokens"
     OUTPUT_TOKEN_KEY = "gen_ai.usage.output_tokens"
+    CACHE_READ_INPUT_TOKEN_KEY = "gen_ai.usage.cache_read.input_tokens"
+    CACHE_CREATION_INPUT_TOKEN_KEY = "gen_ai.usage.cache_creation.input_tokens"
 
     # Input/Output attribute keys from OTEL GenAI semantic conventions
     # Reference: https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/#gen-ai-input-messages

--- a/tests/tracing/otel/test_span_translation.py
+++ b/tests/tracing/otel/test_span_translation.py
@@ -309,6 +309,51 @@ def test_translate_token_usage_edge_cases(
     assert usage[TokenUsageKey.TOTAL_TOKENS] == expected_total
 
 
+def test_translate_token_usage_with_cache_fields():
+    span = mock.Mock(spec=Span)
+    span.parent_id = "parent_123"
+    span_dict = {
+        "attributes": {
+            "gen_ai.usage.input_tokens": 100,
+            "gen_ai.usage.output_tokens": 50,
+            "gen_ai.usage.cache_read.input_tokens": 80,
+            "gen_ai.usage.cache_creation.input_tokens": 20,
+        }
+    }
+    span.to_dict.return_value = span_dict
+
+    result = translate_span_when_storing(span)
+
+    usage = json.loads(result["attributes"][SpanAttributeKey.CHAT_USAGE])
+    assert usage[TokenUsageKey.INPUT_TOKENS] == 100
+    assert usage[TokenUsageKey.OUTPUT_TOKENS] == 50
+    assert usage[TokenUsageKey.TOTAL_TOKENS] == 150
+    assert usage[TokenUsageKey.CACHE_READ_INPUT_TOKENS] == 80
+    assert usage[TokenUsageKey.CACHE_CREATION_INPUT_TOKENS] == 20
+
+
+def test_translate_token_usage_with_partial_cache_fields():
+    span = mock.Mock(spec=Span)
+    span.parent_id = "parent_123"
+    span_dict = {
+        "attributes": {
+            "gen_ai.usage.input_tokens": 100,
+            "gen_ai.usage.output_tokens": 50,
+            "gen_ai.usage.cache_read.input_tokens": 80,
+        }
+    }
+    span.to_dict.return_value = span_dict
+
+    result = translate_span_when_storing(span)
+
+    usage = json.loads(result["attributes"][SpanAttributeKey.CHAT_USAGE])
+    assert usage[TokenUsageKey.INPUT_TOKENS] == 100
+    assert usage[TokenUsageKey.OUTPUT_TOKENS] == 50
+    assert usage[TokenUsageKey.TOTAL_TOKENS] == 150
+    assert usage[TokenUsageKey.CACHE_READ_INPUT_TOKENS] == 80
+    assert TokenUsageKey.CACHE_CREATION_INPUT_TOKENS not in usage
+
+
 @pytest.mark.parametrize(
     "translator",
     [


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22745

### What changes are proposed in this pull request?

`_get_token_usage` in the OTel GenAI ingest path never reads `gen_ai.usage.cache_read.input_tokens` or `gen_ai.usage.cache_creation.input_tokens`, so OTLP producers following OTel GenAI semconv lose cache breakdown at ingest. Downstream cost calculation charges the uncached input tier for everything.

**Changes:**

- `base.py`: Add `CACHE_READ_INPUT_TOKEN_KEY` / `CACHE_CREATION_INPUT_TOKEN_KEY` class attrs and getters to `OtelSchemaTranslator`
- `genai_semconv.py`: Map the two OTel GenAI semconv cache attribute names on `GenAiTranslator`
- `__init__.py`: Collect cache fields into the usage dict when present

Other translators (OpenInference, Traceloop, Spring AI, etc.) default to `None` for cache keys — unaffected. `LiveKitTranslator` inherits from `GenAiTranslator`, so cache fields flow through automatically.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

New tests in `test_span_translation.py`:
- `test_translate_token_usage_with_cache_fields` — both cache keys flow through
- `test_translate_token_usage_with_partial_cache_fields` — only `cache_read` present, `cache_creation` omitted

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. OTel GenAI ingest now preserves `cache_read_input_tokens` and `cache_creation_input_tokens` on the `mlflow.chat.tokenUsage` span attribute.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release