### PR TITLE
fix: add UserWarning when logging NaN or infinite metric values

### DIFF
--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -1,3 +1,5 @@
+import warnings
+import math
 """
 Utilities for validating user inputs such as metric names and parameter names.
 """
@@ -228,6 +230,19 @@ def _validate_metric(key, value, timestamp, step, path=""):
                 f"Please specify value as a valid double (64-bit floating point)",
             ),
             INVALID_PARAMETER_VALUE,
+        )
+
+    # Warn if value is NaN or infinite, as these may not be stored accurately.
+    # Infinity values are replaced with max/min float by SQL-based stores,
+    # and NaN may cause unexpected behavior in the UI and downstream analysis.
+    if isinstance(value, float) and (math.isnan(value) or math.isinf(value)):
+        warnings.warn(
+            f"MLflow metric '{key}' has value '{value}' which may not be stored accurately. "
+            "Infinity values are replaced with max/min float values by SQL-based stores. "
+            "NaN values may cause unexpected behavior in the UI and downstream analysis. "
+            "Consider using a finite numeric value instead.",
+            UserWarning,
+            stacklevel=4,
         )
 
     if not isinstance(timestamp, numbers.Number) or timestamp < 0:


### PR DESCRIPTION
## Summary
Adds a `UserWarning` when `log_metric()` is called with `NaN` or 
infinite float values, informing users that their data may not be 
stored accurately.

## Problem
MLflow silently accepts NaN and infinity metric values without any 
warning:
- `float('inf')` is stored as `1.7976931348623157e+308` (max float) 
  — silent data corruption
- `float('-inf')` is stored as `-1.7976931348623157e+308`
- `float('nan')` is stored as-is but causes unexpected UI behavior

Users have no indication their data has been altered or may behave 
unexpectedly downstream.

## Reproduction
```python
import mlflow
with mlflow.start_run() as run:
    mlflow.log_metric('test_inf', float('inf'))
    val = mlflow.get_run(run.info.run_id).data.metrics.get('test_inf')
    print(val)                          # 1.7976931348623157e+308
    print(float('inf') == val)          # False — silently corrupted!
```

## Fix
Added a `UserWarning` in `_validate_metric()` in 
`mlflow/utils/validation.py` when the metric value is NaN or infinite.

## Notes
MLflow docs acknowledge this behavior for SQL stores but no warning 
is surfaced to users. This fix makes the silent behavior visible.