### PR TITLE
fix: add `UserWarning` when logging NaN or infinite metric values

### DIFF
--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -235,7 +235,9 @@ def _validate_metric(key, value, timestamp, step, path=""):
     # Warn if value is NaN or infinite, as these may not be stored accurately.
     # Infinity values are replaced with max/min float by SQL-based stores,
     # and NaN may cause unexpected behavior in the UI and downstream analysis.
-    if isinstance(value, float) and (math.isnan(value) or math.isinf(value)):
+    # We check with math.isnan/isinf directly as they work on both Python floats
+    # and numpy floating types (e.g. np.float32, np.float64).
+    if _is_numeric(value) and (math.isnan(value) or math.isinf(value)):
         warnings.warn(
             f"MLflow metric '{key}' has value '{value}' which may not be stored accurately. "
             "Infinity values are replaced with max/min float values by SQL-based stores. "

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -1,3 +1,5 @@
+import warnings
+import math
 """
 Utilities for validating user inputs such as metric names and parameter names.
 """
@@ -228,6 +230,19 @@ def _validate_metric(key, value, timestamp, step, path=""):
                 f"Please specify value as a valid double (64-bit floating point)",
             ),
             INVALID_PARAMETER_VALUE,
+        )
+
+    # Warn if value is NaN or infinite, as these may not be stored accurately.
+    # Infinity values are replaced with max/min float by SQL-based stores,
+    # and NaN may cause unexpected behavior in the UI and downstream analysis.
+    if isinstance(value, float) and (math.isnan(value) or math.isinf(value)):
+        warnings.warn(
+            f"MLflow metric '{key}' has value '{value}' which may not be stored accurately. "
+            "Infinity values are replaced with max/min float values by SQL-based stores. "
+            "NaN values may cause unexpected behavior in the UI and downstream analysis. "
+            "Consider using a finite numeric value instead.",
+            UserWarning,
+            stacklevel=4,
         )
 
     if not isinstance(timestamp, numbers.Number) or timestamp < 0:


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22826

### What changes are proposed in this pull request?

When `log_metric()` is called with `float('inf')`, `float('-inf')`, or `float('nan')`, MLflow silently accepts the value without any warning. This causes silent data corruption:

- `float('inf')` is stored as `1.7976931348623157e+308` (max float) — a completely different number
- `float('-inf')` is stored as `-1.7976931348623157e+308`
- `float('nan')` is stored as-is but causes unexpected UI behavior

This PR adds a `UserWarning` in `_validate_metric()` in `mlflow/utils/validation.py` when the metric value is NaN or infinite, so users are informed their data may not be stored accurately.

### How is this PR tested?

- [x] Manual tests

```python
import warnings
from mlflow.utils.validation import _validate_metric
import time

ts = int(time.time() * 1000)

with warnings.catch_warnings(record=True) as w:
    warnings.simplefilter('always')
    _validate_metric('test_inf', float('inf'), ts, 0)
    print(w[0].message)  # UserWarning raised ✅

with warnings.catch_warnings(record=True) as w:
    warnings.simplefilter('always')
    _validate_metric('test_normal', 0.95, ts, 0)
    print(len(w))  # 0 — no warning for normal values ✅
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Adds a `UserWarning` when `log_metric()` is called with `NaN` or infinite float values, informing users that their data may not be stored accurately by SQL-based stores.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release