### PR TITLE
Fix  instructions accumulation on multiple `align()` calls

### DIFF
--- a/mlflow/genai/judges/optimizers/memalign/optimizer.py
+++ b/mlflow/genai/judges/optimizers/memalign/optimizer.py
@@ -147,6 +147,7 @@ class MemoryAugmentedJudge(Judge):
         )
 
         self._base_judge = effective_base_judge
+        self._base_instructions = effective_base_judge.instructions
         self._retrieval_k = retrieval_k
         self._reflection_lm = reflection_lm if reflection_lm is not None else get_default_model()
         self._embedding_model = (
@@ -267,7 +268,7 @@ class MemoryAugmentedJudge(Judge):
 
     @property
     def instructions(self) -> str:
-        instructions = self._base_judge.instructions
+        instructions = self._base_instructions
         if self._semantic_memory:
             instructions += f"\n\nDistilled Guidelines ({len(self._semantic_memory)}):\n"
             for guideline in self._semantic_memory:

--- a/mlflow/genai/judges/optimizers/memalign/optimizer.py
+++ b/mlflow/genai/judges/optimizers/memalign/optimizer.py
@@ -295,6 +295,7 @@ class MemoryAugmentedJudge(Judge):
 
         memory_augmented_data = {
             "base_judge": base_judge_data,
+            "base_instructions": self._base_instructions,
             "episodic_trace_ids": self._episodic_trace_ids,
             "semantic_memory": [g.model_dump() for g in self._semantic_memory],
             **{field: getattr(self, f"_{field}") for field in _CONFIG_FIELDS},
@@ -337,6 +338,11 @@ class MemoryAugmentedJudge(Judge):
         instance._semantic_memory = [Guideline(**g) for g in data["semantic_memory"]]
         instance._episodic_trace_ids = data.get("episodic_trace_ids") or []
 
+        # Restore base_instructions if present (for backward compatibility with old serialized judges)
+        if "base_instructions" in data:
+            instance._base_instructions = data["base_instructions"]
+        # else: _base_instructions is already set from base_judge.instructions in __init__
+
         return instance
 
     def _create_copy(self) -> "MemoryAugmentedJudge":
@@ -358,6 +364,7 @@ class MemoryAugmentedJudge(Judge):
         )
         judge_copy._semantic_memory = copy.deepcopy(self._semantic_memory)
         judge_copy._episodic_trace_ids = self._episodic_trace_ids.copy()
+        judge_copy._base_instructions = self._base_instructions
 
         return judge_copy
 

--- a/mlflow/genai/judges/optimizers/memalign/optimizer.py
+++ b/mlflow/genai/judges/optimizers/memalign/optimizer.py
@@ -508,7 +508,7 @@ class MemoryAugmentedJudge(Judge):
         existing_guideline_texts = [g.guideline_text for g in self._semantic_memory]
         new_guidelines = distill_guidelines(
             examples=new_examples,
-            judge_instructions=self._base_judge.instructions,
+            judge_instructions=self._base_instructions,
             reflection_lm=self._reflection_lm,
             existing_guidelines=existing_guideline_texts,
         )

--- a/tests/genai/judges/optimizers/memalign/test_optimizer.py
+++ b/tests/genai/judges/optimizers/memalign/test_optimizer.py
@@ -348,6 +348,34 @@ def test_incremental_alignment_redistills_guidelines(sample_judge, sample_traces
         assert "Guideline B" in guideline_texts
 
 
+def test_multiple_align_calls_single_distilled_guidelines_section(sample_judge, sample_traces):
+    """Test that calling align() multiple times doesn't accumulate 'Distilled Guidelines' sections."""
+    # First alignment: distills 8 guidelines
+    with mock_apis(guidelines=[f"Guideline {i}" for i in range(8)]):
+        optimizer = MemAlignOptimizer()
+        judge_v2 = optimizer.align(sample_judge, sample_traces[:2])
+        assert len(judge_v2._semantic_memory) == 8
+
+        # Check instructions only has one "Distilled Guidelines" section
+        instructions_v2 = judge_v2.instructions
+        assert instructions_v2.count("Distilled Guidelines") == 1
+        assert "Distilled Guidelines (8):" in instructions_v2
+
+    # Second alignment: distills 6 more guidelines
+    with mock_apis(guidelines=[f"Guideline New {i}" for i in range(6)]):
+        judge_v3 = optimizer.align(judge_v2, sample_traces[2:4])
+        # Should have 8 + 6 = 14 guidelines total
+        assert len(judge_v3._semantic_memory) == 14
+
+        # Check instructions still only has ONE "Distilled Guidelines" section
+        instructions_v3 = judge_v3.instructions
+        assert instructions_v3.count("Distilled Guidelines") == 1
+        assert "Distilled Guidelines (14):" in instructions_v3
+
+        # Verify the base instructions are still present
+        assert sample_judge.instructions in instructions_v3
+
+
 def test_unalign_filters_guidelines_by_source_ids(sample_judge, sample_traces):
     # Test that unalign() filters guidelines based on source_ids
     with mock_apis(guidelines=["Guideline 1", "Guideline 2"]):

--- a/tests/genai/judges/optimizers/memalign/test_optimizer.py
+++ b/tests/genai/judges/optimizers/memalign/test_optimizer.py
@@ -536,6 +536,35 @@ def test_memory_augmented_judge_round_trip_serialization(sample_judge, sample_tr
         assert set(restored_judge._episodic_trace_ids) == set(original_judge._episodic_trace_ids)
 
 
+def test_base_instructions_preserved_after_serialization(sample_judge, sample_traces):
+    """Test that _base_instructions is preserved through serialization to prevent accumulation."""
+    with mock_apis(guidelines=["Guideline A", "Guideline B"]):
+        optimizer = MemAlignOptimizer()
+        aligned_judge = optimizer.align(sample_judge, sample_traces[:2])
+
+        # Store original base instructions
+        original_base_instructions = aligned_judge._base_instructions
+
+        # Verify instructions has one "Distilled Guidelines" section
+        assert aligned_judge.instructions.count("Distilled Guidelines") == 1
+        assert "Distilled Guidelines (2):" in aligned_judge.instructions
+
+        # Serialize and deserialize
+        dumped = aligned_judge.model_dump()
+        serialized = SerializedScorer(**dumped)
+        restored_judge = MemoryAugmentedJudge._from_serialized(serialized)
+
+        # Verify _base_instructions is preserved exactly
+        assert restored_judge._base_instructions == original_base_instructions
+
+        # Verify instructions property still works correctly with single section
+        assert restored_judge.instructions.count("Distilled Guidelines") == 1
+        assert "Distilled Guidelines (2):" in restored_judge.instructions
+
+        # Verify base instructions are present in the final instructions
+        assert sample_judge.instructions in restored_judge.instructions
+
+
 def test_memory_augmented_judge_lazy_init_triggered_on_call(sample_judge, sample_traces):
     with mock_apis(guidelines=[]):
         optimizer = MemAlignOptimizer()


### PR DESCRIPTION
### Related Issues/PRs

Relates to #20708

### What changes are proposed in this pull request?

This PR fixes a bug where calling `align()` multiple times on a `MemoryAugmentedJudge` would accumulate multiple "Distilled Guidelines" sections in the `instructions` property instead of maintaining a single consolidated section.

**Root Cause:**
The `instructions` property was reading from `self._base_judge.instructions`, which could already contain distilled guidelines from previous alignment rounds, causing accumulation.

**Changes:**
1. Store base instructions separately (`_base_instructions`) during initialization from the unwrapped base judge
2. Use stored base instructions in the `instructions` property instead of `_base_judge.instructions`
3. Apply the same fix to `_distill_new_guidelines()` for consistency
4. Serialize/deserialize `_base_instructions` to preserve the fix across serialization cycles
5. Add comprehensive tests for multiple `align()` calls and serialization

**Example of the bug (before fix):**
```
judge_v1 = optimizer.align(judge, traces1)  # Guidelines: (8)
judge_v2 = optimizer.align(judge_v1, traces2)  # Guidelines: (8) + (6) ❌
# instructions would show:
# "Distilled Guidelines (8):\n...\nDistilled Guidelines (6):\n..."
```

**After fix:**
```
judge_v2 = optimizer.align(judge_v1, traces2)  # Guidelines: (14) ✓
# instructions shows single section:
# "Distilled Guidelines (14):\n..."
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests:
  - `test_multiple_align_calls_single_distilled_guidelines_section`: Verifies single "Distilled Guidelines" section after 2 `align()` calls
  - `test_base_instructions_preserved_after_serialization`: Verifies `_base_instructions` preserved through serialize/deserialize

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed `MemoryAugmentedJudge` (MemAlign) accumulating duplicate "Distilled Guidelines" sections when calling `align()` multiple times. The judge now correctly maintains a single consolidated guidelines section regardless of how many alignment iterations are performed.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release