### PR TITLE
Add `starlette` as an explicit dependency

### DIFF
--- a/libs/skinny/pyproject.toml
+++ b/libs/skinny/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
   "pyyaml<7,>=5.1",
   "requests<3,>=2.17.3",
   "sqlparse<1,>=0.4.0",
+  "starlette<1",
   "typing-extensions<5,>=4.0.0",
   "uvicorn<1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dependencies = [
   "skops<1",
   "sqlalchemy<3,>=1.4.0",
   "sqlparse<1,>=0.4.0",
+  "starlette<1",
   "typing-extensions<5,>=4.0.0",
   "uvicorn<1",
   "waitress<4; platform_system == 'Windows'",

--- a/requirements/skinny-requirements.yaml
+++ b/requirements/skinny-requirements.yaml
@@ -99,6 +99,10 @@ fastapi:
   pip_release: fastapi
   max_major_version: 0
 
+starlette:
+  pip_release: starlette
+  max_major_version: 0
+
 uvicorn:
   pip_release: uvicorn
   max_major_version: 0

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-09T01:40:05.487966547Z"
+exclude-newer = "2026-04-10T01:44:23.222204Z"
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
@@ -4285,6 +4285,7 @@ dependencies = [
     { name = "skops" },
     { name = "sqlalchemy" },
     { name = "sqlparse" },
+    { name = "starlette" },
     { name = "typing-extensions" },
     { name = "uvicorn" },
     { name = "waitress", marker = "sys_platform == 'win32'" },
@@ -4536,6 +4537,7 @@ requires-dist = [
     { name = "slowapi", marker = "extra == 'genai'", specifier = ">=0.1.9,<1" },
     { name = "sqlalchemy", specifier = ">=1.4.0,<3" },
     { name = "sqlparse", specifier = ">=0.4.0,<1" },
+    { name = "starlette", specifier = "<1" },
     { name = "tiktoken", marker = "extra == 'gateway'", specifier = "<1" },
     { name = "tiktoken", marker = "extra == 'genai'", specifier = "<1" },
     { name = "typing-extensions", specifier = ">=4.0.0,<5" },


### PR DESCRIPTION
### Related Issues/PRs

Relates to N/A

### What changes are proposed in this pull request?

MLflow imports directly from `starlette` in several places (`mlflow/server/fastapi_app.py`, `mlflow/server/fastapi_security.py`, `mlflow/server/auth/__init__.py`, `mlflow/gateway/utils.py`) but was relying on it being pulled in transitively through FastAPI. This adds it as an explicit dependency to make the requirement explicit and avoid potential breakage.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)