### PR TITLE
fix(model-registry): populate aliases in search_model_versions() results

### DIFF
--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -1036,6 +1036,29 @@ class SqlAlchemyStore(AbstractStore):
         ]
         return version
 
+    def _batch_populate_model_version_aliases(
+        self, session, sql_model_versions: list[SqlModelVersion], model_version_entities: list
+    ) -> None:
+        """
+        Batch-fetch aliases for a list of model version entities to avoid N+1 queries.
+        Mutates each entity in ``model_version_entities`` in-place by setting its ``aliases``
+        field.
+        """
+        model_names = list({mv.name for mv in sql_model_versions})
+        if not model_names:
+            return
+        aliases = (
+            session.query(SqlRegisteredModelAlias)
+            .filter(SqlRegisteredModelAlias.name.in_(model_names))
+            .all()
+        )
+        alias_map: dict[tuple[str, int], list[str]] = {}
+        for alias in aliases:
+            key = (alias.name, alias.version)
+            alias_map.setdefault(key, []).append(alias.alias)
+        for sql_mv, entity in zip(sql_model_versions, model_version_entities):
+            entity.aliases = alias_map.get((sql_mv.name, sql_mv.version), [])
+
     def _get_model_version_from_db(self, session, name, version, conditions, query_options=None):
         if query_options is None:
             query_options = []
@@ -1308,7 +1331,9 @@ class SqlAlchemyStore(AbstractStore):
             next_page_token = self._compute_next_token(
                 max_results_for_query, len(sql_model_versions), offset, max_results
             )
-            model_versions = [mv.to_mlflow_entity() for mv in sql_model_versions][:max_results]
+            sql_results = sql_model_versions[:max_results]
+            model_versions = [mv.to_mlflow_entity() for mv in sql_results]
+            self._batch_populate_model_version_aliases(session, sql_results, model_versions)
             return PagedList(model_versions, next_page_token)
 
     @classmethod

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -1760,6 +1760,30 @@ def test_delete_model_deletes_alias(store):
         store.get_model_version_by_alias(model_name, "test_alias")
 
 
+def test_search_model_versions_returns_aliases(store):
+    # Regression test for https://github.com/mlflow/mlflow/issues/16734
+    # search_model_versions() must return populated aliases, not empty lists.
+    model_name = "SearchMV_Aliases_TestMod"
+    _setup_and_test_aliases(store, model_name)
+
+    results = store.search_model_versions(f"name='{model_name}'")
+    version_to_aliases = {mv.version: mv.aliases for mv in results}
+
+    assert version_to_aliases[1] == []
+    assert version_to_aliases[2] == ["test_alias"]
+
+
+def test_search_registered_models_returns_aliases(store):
+    # Regression test for https://github.com/mlflow/mlflow/issues/16734
+    # search_registered_models() must return populated aliases, not empty dicts.
+    model_name = "SearchRM_Aliases_TestMod"
+    _setup_and_test_aliases(store, model_name)
+
+    results = store.search_registered_models(f"name='{model_name}'")
+    assert len(results) == 1
+    assert results[0].aliases == {"test_alias": 2}
+
+
 @pytest.mark.parametrize("copy_to_same_model", [False, True])
 def test_copy_model_version(store, copy_to_same_model):
     name1 = "test_for_copy_MV1"


### PR DESCRIPTION
### Related Issues/PRs

Closes #16734

### What changes are proposed in this pull request?

`MlflowClient().search_model_versions()` always returned `aliases=[]` for every
`ModelVersion` object, even when aliases had been explicitly set via
`set_registered_model_alias()`.

**Root cause:** `SqlModelVersion.to_mlflow_entity()` hardcoded `aliases=[]`.
Other single-record methods (`get_model_version`, `get_model_version_by_alias`)
correctly populated aliases via `_populate_model_version_aliases()`, but
`search_model_versions()` had no equivalent post-processing step.

**Fix:** Added `_batch_populate_model_version_aliases()` which fetches all aliases
for the returned model versions in a single batch SQL query (no N+1 queries), then
populates the `aliases` field on each entity in-place.

### How is this PR tested?

- [x] New unit/integration tests

Added two regression tests in `tests/store/model_registry/test_sqlalchemy_store.py`:
- `test_search_model_versions_returns_aliases`
- `test_search_registered_models_returns_aliases`

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the MLflow Skills repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. `search_model_versions()` now correctly returns populated `aliases` fields instead of always returning an empty list.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release