### PR TITLE
Migrate R package from FileStore to SQLite backend

### DIFF
--- a/docs/api_reference/source/R-api.rst
+++ b/docs/api_reference/source/R-api.rst
@@ -1823,7 +1823,8 @@ Wrapper for ``mlflow server``.
      port = 5000,
      workers = NULL,
      static_prefix = NULL,
-     serve_artifacts = FALSE
+     serve_artifacts = FALSE,
+     backend_store_uri = NULL
    )
 
 .. _arguments-41:
@@ -1835,7 +1836,9 @@ Arguments
 | Argument                      | Description                          |
 +===============================+======================================+
 | ``file_store``                | The root of the backing file store   |
-|                               | for experiment and run data.         |
+|                               | for experiment and run data. Ignored |
+|                               | when ``backend_store_uri`` is        |
+|                               | provided.                            |
 +-------------------------------+--------------------------------------+
 | ``default_artifact_root``     | Local or S3 URI to store artifacts   |
 |                               | in, for newly created experiments.   |
@@ -1855,6 +1858,12 @@ Arguments
 | ``serve_artifacts``           | A flag specifying whether or not to  |
 |                               | enable artifact serving (default:    |
 |                               | FALSE).                              |
++-------------------------------+--------------------------------------+
+| ``backend_store_uri``         | URI for the backend store (e.g.,     |
+|                               | ``sqlite:///mlflow.db``,             |
+|                               | ``postgresql://user:pass@host/db``). |
+|                               | When set, takes precedence over      |
+|                               | ``file_store``.                      |
 +-------------------------------+--------------------------------------+
 
 ``mlflow_set_experiment_tag``

--- a/docs/api_reference/source/R-api.rst
+++ b/docs/api_reference/source/R-api.rst
@@ -1838,9 +1838,8 @@ Arguments
 | ``file_store``                | Deprecated. Use                      |
 |                               | ``backend_store_uri`` instead. The   |
 |                               | root of the backing file store for   |
-|                               | experiment and run data. Ignored     |
-|                               | when ``backend_store_uri`` is        |
-|                               | provided.                            |
+|                               | experiment and run data. Cannot be   |
+|                               | combined with ``backend_store_uri``. |
 +-------------------------------+--------------------------------------+
 | ``default_artifact_root``     | Local or S3 URI to store artifacts   |
 |                               | in, for newly created experiments.   |
@@ -1864,7 +1863,7 @@ Arguments
 | ``backend_store_uri``         | URI for the backend store (e.g.,     |
 |                               | ``sqlite:///mlflow.db``,             |
 |                               | ``postgresql://user:pass@host/db``). |
-|                               | When set, takes precedence over      |
+|                               | Cannot be combined with              |
 |                               | ``file_store``. When neither is      |
 |                               | provided, a local SQLite database    |
 |                               | under ``mlruns/`` is used.           |

--- a/docs/api_reference/source/R-api.rst
+++ b/docs/api_reference/source/R-api.rst
@@ -1835,8 +1835,10 @@ Arguments
 +-------------------------------+--------------------------------------+
 | Argument                      | Description                          |
 +===============================+======================================+
-| ``file_store``                | The root of the backing file store   |
-|                               | for experiment and run data. Ignored |
+| ``file_store``                | Deprecated. Use                      |
+|                               | ``backend_store_uri`` instead. The   |
+|                               | root of the backing file store for   |
+|                               | experiment and run data. Ignored     |
 |                               | when ``backend_store_uri`` is        |
 |                               | provided.                            |
 +-------------------------------+--------------------------------------+
@@ -1863,7 +1865,9 @@ Arguments
 |                               | ``sqlite:///mlflow.db``,             |
 |                               | ``postgresql://user:pass@host/db``). |
 |                               | When set, takes precedence over      |
-|                               | ``file_store``.                      |
+|                               | ``file_store``. When neither is      |
+|                               | provided, a local SQLite database    |
+|                               | under ``mlruns/`` is used.           |
 +-------------------------------+--------------------------------------+
 
 ``mlflow_set_experiment_tag``

--- a/mlflow/R/mlflow/R/tracking-client.R
+++ b/mlflow/R/mlflow/R/tracking-client.R
@@ -84,9 +84,11 @@ new_mlflow_client.mlflow_file <- function(tracking_uri) {
     mlflow_register_local_server(tracking_uri = path, local_server = local_server)
     local_server$server_url
   }
-  new_mlflow_client_impl(get_host_creds = function () {
-    new_mlflow_host_creds(host = server_url)
-  }, class = "mlflow_file_client")
+  new_mlflow_client_impl(
+    get_host_creds = function() new_mlflow_host_creds(host = server_url),
+    get_cli_env = function() list(MLFLOW_TRACKING_URI = server_url),
+    class = "mlflow_file_client"
+  )
 }
 
 new_mlflow_client.default <- function(tracking_uri) {

--- a/mlflow/R/mlflow/R/tracking-client.R
+++ b/mlflow/R/mlflow/R/tracking-client.R
@@ -80,7 +80,16 @@ new_mlflow_client.mlflow_file <- function(tracking_uri) {
   server_url <- if (!is.null(mlflow_local_server(path)$server_url)) {
     mlflow_local_server(path)$server_url
   } else {
-    local_server <- mlflow_server(file_store = path, port = mlflow_connect_port())
+    abs_path <- fs::path_abs(path)
+    if (!dir.exists(abs_path)) {
+      dir.create(abs_path, recursive = TRUE, showWarnings = FALSE)
+    }
+    sqlite_uri <- paste0("sqlite:///", abs_path, "/mlflow.db")
+    local_server <- mlflow_server(
+      file_store = sqlite_uri,
+      default_artifact_root = abs_path,
+      port = mlflow_connect_port()
+    )
     mlflow_register_local_server(tracking_uri = path, local_server = local_server)
     local_server$server_url
   }

--- a/mlflow/R/mlflow/R/tracking-client.R
+++ b/mlflow/R/mlflow/R/tracking-client.R
@@ -86,7 +86,7 @@ new_mlflow_client.mlflow_file <- function(tracking_uri) {
     }
     sqlite_uri <- paste0("sqlite:///", abs_path, "/mlflow.db")
     local_server <- mlflow_server(
-      file_store = sqlite_uri,
+      backend_store_uri = sqlite_uri,
       default_artifact_root = abs_path,
       port = mlflow_connect_port()
     )

--- a/mlflow/R/mlflow/R/tracking-client.R
+++ b/mlflow/R/mlflow/R/tracking-client.R
@@ -95,21 +95,22 @@ new_local_backend_client <- function(key, backend_store_uri, default_artifact_ro
 }
 
 new_mlflow_client.mlflow_file <- function(tracking_uri) {
-  path <- tracking_uri$path
-  abs_path <- fs::path_abs(path)
-  if (!dir.exists(abs_path)) {
-    dir.create(abs_path, recursive = TRUE, showWarnings = FALSE)
-  }
-  sqlite_uri <- paste0("sqlite:///", abs_path, "/mlflow.db")
-  new_local_backend_client(
-    key = path,
-    backend_store_uri = sqlite_uri,
-    default_artifact_root = abs_path
+  stop(
+    "FileStore-style tracking URIs (e.g., 'file:///mlruns') are no longer supported. ",
+    "Use a SQL backend instead, e.g., ",
+    "mlflow_set_tracking_uri('sqlite:///path/to/mlflow.db').",
+    call. = FALSE
   )
 }
 
 new_mlflow_client.mlflow_sqlite <- function(tracking_uri) {
   full_uri <- paste0(tracking_uri$scheme, "://", tracking_uri$path)
+  if (startsWith(tracking_uri$path, "/")) {
+    parent <- dirname(tracking_uri$path)
+    if (!dir.exists(parent)) {
+      dir.create(parent, recursive = TRUE, showWarnings = FALSE)
+    }
+  }
   new_local_backend_client(key = full_uri, backend_store_uri = full_uri)
 }
 

--- a/mlflow/R/mlflow/R/tracking-client.R
+++ b/mlflow/R/mlflow/R/tracking-client.R
@@ -75,22 +75,16 @@ print.mlflow_host_creds <- function(x, ...) {
   cat(")\n")
 }
 
-new_mlflow_client.mlflow_file <- function(tracking_uri) {
-  path <- tracking_uri$path
-  server_url <- if (!is.null(mlflow_local_server(path)$server_url)) {
-    mlflow_local_server(path)$server_url
+new_local_backend_client <- function(key, backend_store_uri, default_artifact_root = NULL) {
+  server_url <- if (!is.null(mlflow_local_server(key)$server_url)) {
+    mlflow_local_server(key)$server_url
   } else {
-    abs_path <- fs::path_abs(path)
-    if (!dir.exists(abs_path)) {
-      dir.create(abs_path, recursive = TRUE, showWarnings = FALSE)
-    }
-    sqlite_uri <- paste0("sqlite:///", abs_path, "/mlflow.db")
     local_server <- mlflow_server(
-      backend_store_uri = sqlite_uri,
-      default_artifact_root = abs_path,
+      backend_store_uri = backend_store_uri,
+      default_artifact_root = default_artifact_root,
       port = mlflow_connect_port()
     )
-    mlflow_register_local_server(tracking_uri = path, local_server = local_server)
+    mlflow_register_local_server(tracking_uri = key, local_server = local_server)
     local_server$server_url
   }
   new_mlflow_client_impl(
@@ -98,6 +92,25 @@ new_mlflow_client.mlflow_file <- function(tracking_uri) {
     get_cli_env = function() list(MLFLOW_TRACKING_URI = server_url),
     class = "mlflow_file_client"
   )
+}
+
+new_mlflow_client.mlflow_file <- function(tracking_uri) {
+  path <- tracking_uri$path
+  abs_path <- fs::path_abs(path)
+  if (!dir.exists(abs_path)) {
+    dir.create(abs_path, recursive = TRUE, showWarnings = FALSE)
+  }
+  sqlite_uri <- paste0("sqlite:///", abs_path, "/mlflow.db")
+  new_local_backend_client(
+    key = path,
+    backend_store_uri = sqlite_uri,
+    default_artifact_root = abs_path
+  )
+}
+
+new_mlflow_client.mlflow_sqlite <- function(tracking_uri) {
+  full_uri <- paste0(tracking_uri$scheme, "://", tracking_uri$path)
+  new_local_backend_client(key = full_uri, backend_store_uri = full_uri)
 }
 
 new_mlflow_client.default <- function(tracking_uri) {

--- a/mlflow/R/mlflow/R/tracking-globals.R
+++ b/mlflow/R/mlflow/R/tracking-globals.R
@@ -52,6 +52,10 @@ mlflow_set_tracking_uri <- function(uri) {
 mlflow_get_tracking_uri <- function() {
   .globals$tracking_uri %||% {
     env_uri <- Sys.getenv("MLFLOW_TRACKING_URI")
-    if (nchar(env_uri)) env_uri else paste("file://", fs::path_abs("mlruns"), sep = "")
+    if (nchar(env_uri)) {
+      env_uri
+    } else {
+      paste0("sqlite:///", fs::path_abs("mlruns"), "/mlflow.db")
+    }
   }
 }

--- a/mlflow/R/mlflow/R/tracking-server.R
+++ b/mlflow/R/mlflow/R/tracking-server.R
@@ -57,17 +57,13 @@ mlflow_cli_param <- function(args, param, value) {
 mlflow_server <- function(file_store = "mlruns", default_artifact_root = NULL,
                           host = "127.0.0.1", port = 5000, workers = NULL, static_prefix = NULL,
                           serve_artifacts = FALSE) {
-  file_store <- fs::path_abs(file_store)
-  if (!dir.exists(file_store)) {
-    dir.create(file_store, recursive = TRUE, showWarnings = FALSE)
-  }
-  backend_store_uri <- paste0("sqlite:///", file_store, "/mlflow.db")
-  if (is.null(default_artifact_root)) {
-    default_artifact_root <- file_store
+  if (!grepl("://", file_store)) {
+    file_store <- fs::path_abs(file_store)
+    if (.Platform$OS.type == "windows") file_store <- paste0("file://", file_store)
   }
 
   args <- mlflow_cli_param(list(), "--port", port) %>%
-    mlflow_cli_param("--backend-store-uri", backend_store_uri) %>%
+    mlflow_cli_param("--backend-store-uri", file_store) %>%
     mlflow_cli_param("--default-artifact-root", default_artifact_root) %>%
     mlflow_cli_param("--host", host) %>%
     mlflow_cli_param("--port", port) %>%

--- a/mlflow/R/mlflow/R/tracking-server.R
+++ b/mlflow/R/mlflow/R/tracking-server.R
@@ -46,8 +46,9 @@ mlflow_cli_param <- function(args, param, value) {
 #'
 #' Wrapper for `mlflow server`.
 #'
-#' @param file_store The root of the backing file store for experiment and run data.
-#'   Ignored when `backend_store_uri` is provided.
+#' @param file_store Deprecated. Use `backend_store_uri` instead. The root of the
+#'   backing file store for experiment and run data. Ignored when
+#'   `backend_store_uri` is provided.
 #' @param default_artifact_root Local or S3 URI to store artifacts in, for newly created experiments.
 #' @param host The network address to listen on (default: 127.0.0.1).
 #' @param port The port to listen on (default: 5000).
@@ -56,13 +57,30 @@ mlflow_cli_param <- function(args, param, value) {
 #' @param serve_artifacts A flag specifying whether or not to enable artifact serving (default: FALSE).
 #' @param backend_store_uri URI for the backend store (e.g., `sqlite:///mlflow.db`,
 #'   `postgresql://user:pass@host/db`). When set, takes precedence over `file_store`.
+#'   When neither is provided, a local SQLite database under `mlruns/` is used.
 #' @export
 mlflow_server <- function(file_store = "mlruns", default_artifact_root = NULL,
                           host = "127.0.0.1", port = 5000, workers = NULL, static_prefix = NULL,
                           serve_artifacts = FALSE, backend_store_uri = NULL) {
   if (is.null(backend_store_uri)) {
-    backend_store_uri <- fs::path_abs(file_store)
-    if (.Platform$OS.type == "windows") backend_store_uri <- paste0("file://", backend_store_uri)
+    if (!missing(file_store)) {
+      warning(
+        "The `file_store` argument is deprecated. Use `backend_store_uri` instead ",
+        "(e.g., `mlflow_server(backend_store_uri = \"sqlite:///mlflow.db\")`).",
+        call. = FALSE
+      )
+      backend_store_uri <- fs::path_abs(file_store)
+      if (.Platform$OS.type == "windows") backend_store_uri <- paste0("file://", backend_store_uri)
+    } else {
+      backing_dir <- fs::path_abs(file_store)
+      if (!dir.exists(backing_dir)) {
+        dir.create(backing_dir, recursive = TRUE, showWarnings = FALSE)
+      }
+      backend_store_uri <- paste0("sqlite:///", backing_dir, "/mlflow.db")
+      if (is.null(default_artifact_root)) {
+        default_artifact_root <- backing_dir
+      }
+    }
   }
 
   args <- mlflow_cli_param(list(), "--port", port) %>%

--- a/mlflow/R/mlflow/R/tracking-server.R
+++ b/mlflow/R/mlflow/R/tracking-server.R
@@ -47,23 +47,26 @@ mlflow_cli_param <- function(args, param, value) {
 #' Wrapper for `mlflow server`.
 #'
 #' @param file_store The root of the backing file store for experiment and run data.
+#'   Ignored when `backend_store_uri` is provided.
 #' @param default_artifact_root Local or S3 URI to store artifacts in, for newly created experiments.
 #' @param host The network address to listen on (default: 127.0.0.1).
 #' @param port The port to listen on (default: 5000).
 #' @param workers Number of gunicorn worker processes to handle requests (default: 4).
 #' @param static_prefix A prefix which will be prepended to the path of all static paths.
 #' @param serve_artifacts A flag specifying whether or not to enable artifact serving (default: FALSE).
+#' @param backend_store_uri URI for the backend store (e.g., `sqlite:///mlflow.db`,
+#'   `postgresql://user:pass@host/db`). When set, takes precedence over `file_store`.
 #' @export
 mlflow_server <- function(file_store = "mlruns", default_artifact_root = NULL,
                           host = "127.0.0.1", port = 5000, workers = NULL, static_prefix = NULL,
-                          serve_artifacts = FALSE) {
-  if (!grepl("://", file_store)) {
-    file_store <- fs::path_abs(file_store)
-    if (.Platform$OS.type == "windows") file_store <- paste0("file://", file_store)
+                          serve_artifacts = FALSE, backend_store_uri = NULL) {
+  if (is.null(backend_store_uri)) {
+    backend_store_uri <- fs::path_abs(file_store)
+    if (.Platform$OS.type == "windows") backend_store_uri <- paste0("file://", backend_store_uri)
   }
 
   args <- mlflow_cli_param(list(), "--port", port) %>%
-    mlflow_cli_param("--backend-store-uri", file_store) %>%
+    mlflow_cli_param("--backend-store-uri", backend_store_uri) %>%
     mlflow_cli_param("--default-artifact-root", default_artifact_root) %>%
     mlflow_cli_param("--host", host) %>%
     mlflow_cli_param("--port", port) %>%

--- a/mlflow/R/mlflow/R/tracking-server.R
+++ b/mlflow/R/mlflow/R/tracking-server.R
@@ -46,11 +46,8 @@ mlflow_cli_param <- function(args, param, value) {
 #'
 #' Wrapper for `mlflow server`.
 #'
-#' @param file_store The root directory used to back the local tracking server.
-#'   A SQLite database (`mlflow.db`) is created inside this directory, and the
-#'   directory is also used as the default artifact root.
+#' @param file_store The root of the backing file store for experiment and run data.
 #' @param default_artifact_root Local or S3 URI to store artifacts in, for newly created experiments.
-#'   Defaults to `file_store` when not provided.
 #' @param host The network address to listen on (default: 127.0.0.1).
 #' @param port The port to listen on (default: 5000).
 #' @param workers Number of gunicorn worker processes to handle requests (default: 4).

--- a/mlflow/R/mlflow/R/tracking-server.R
+++ b/mlflow/R/mlflow/R/tracking-server.R
@@ -47,8 +47,8 @@ mlflow_cli_param <- function(args, param, value) {
 #' Wrapper for `mlflow server`.
 #'
 #' @param file_store Deprecated. Use `backend_store_uri` instead. The root of the
-#'   backing file store for experiment and run data. Ignored when
-#'   `backend_store_uri` is provided.
+#'   backing file store for experiment and run data. Cannot be combined with
+#'   `backend_store_uri`.
 #' @param default_artifact_root Local or S3 URI to store artifacts in, for newly created experiments.
 #' @param host The network address to listen on (default: 127.0.0.1).
 #' @param port The port to listen on (default: 5000).
@@ -56,12 +56,19 @@ mlflow_cli_param <- function(args, param, value) {
 #' @param static_prefix A prefix which will be prepended to the path of all static paths.
 #' @param serve_artifacts A flag specifying whether or not to enable artifact serving (default: FALSE).
 #' @param backend_store_uri URI for the backend store (e.g., `sqlite:///mlflow.db`,
-#'   `postgresql://user:pass@host/db`). When set, takes precedence over `file_store`.
+#'   `postgresql://user:pass@host/db`). Cannot be combined with `file_store`.
 #'   When neither is provided, a local SQLite database under `mlruns/` is used.
 #' @export
 mlflow_server <- function(file_store = "mlruns", default_artifact_root = NULL,
                           host = "127.0.0.1", port = 5000, workers = NULL, static_prefix = NULL,
                           serve_artifacts = FALSE, backend_store_uri = NULL) {
+  if (!is.null(backend_store_uri) && !missing(file_store)) {
+    stop(
+      "Cannot specify both `file_store` and `backend_store_uri`. ",
+      "Use `backend_store_uri` only.",
+      call. = FALSE
+    )
+  }
   if (is.null(backend_store_uri)) {
     if (!missing(file_store)) {
       warning(

--- a/mlflow/R/mlflow/R/tracking-server.R
+++ b/mlflow/R/mlflow/R/tracking-server.R
@@ -46,8 +46,11 @@ mlflow_cli_param <- function(args, param, value) {
 #'
 #' Wrapper for `mlflow server`.
 #'
-#' @param file_store The root of the backing file store for experiment and run data.
+#' @param file_store The root directory used to back the local tracking server.
+#'   A SQLite database (`mlflow.db`) is created inside this directory, and the
+#'   directory is also used as the default artifact root.
 #' @param default_artifact_root Local or S3 URI to store artifacts in, for newly created experiments.
+#'   Defaults to `file_store` when not provided.
 #' @param host The network address to listen on (default: 127.0.0.1).
 #' @param port The port to listen on (default: 5000).
 #' @param workers Number of gunicorn worker processes to handle requests (default: 4).
@@ -58,10 +61,16 @@ mlflow_server <- function(file_store = "mlruns", default_artifact_root = NULL,
                           host = "127.0.0.1", port = 5000, workers = NULL, static_prefix = NULL,
                           serve_artifacts = FALSE) {
   file_store <- fs::path_abs(file_store)
-  if (.Platform$OS.type == "windows") file_store <- paste0("file://", file_store)
+  if (!dir.exists(file_store)) {
+    dir.create(file_store, recursive = TRUE, showWarnings = FALSE)
+  }
+  backend_store_uri <- paste0("sqlite:///", file_store, "/mlflow.db")
+  if (is.null(default_artifact_root)) {
+    default_artifact_root <- file_store
+  }
 
   args <- mlflow_cli_param(list(), "--port", port) %>%
-    mlflow_cli_param("--backend-store-uri", file_store) %>%
+    mlflow_cli_param("--backend-store-uri", backend_store_uri) %>%
     mlflow_cli_param("--default-artifact-root", default_artifact_root) %>%
     mlflow_cli_param("--host", host) %>%
     mlflow_cli_param("--port", port) %>%

--- a/mlflow/R/mlflow/man/mlflow_server.Rd
+++ b/mlflow/R/mlflow/man/mlflow_server.Rd
@@ -17,8 +17,8 @@ mlflow_server(
 }
 \arguments{
 \item{file_store}{Deprecated. Use \code{backend_store_uri} instead. The root of the
-backing file store for experiment and run data. Ignored when
-\code{backend_store_uri} is provided.}
+backing file store for experiment and run data. Cannot be combined with
+\code{backend_store_uri}.}
 
 \item{default_artifact_root}{Local or S3 URI to store artifacts in, for newly created experiments.}
 
@@ -33,7 +33,7 @@ backing file store for experiment and run data. Ignored when
 \item{serve_artifacts}{A flag specifying whether or not to enable artifact serving (default: FALSE).}
 
 \item{backend_store_uri}{URI for the backend store (e.g., \code{sqlite:///mlflow.db},
-\code{postgresql://user:pass@host/db}). When set, takes precedence over \code{file_store}.
+\code{postgresql://user:pass@host/db}). Cannot be combined with \code{file_store}.
 When neither is provided, a local SQLite database under \code{mlruns/} is used.}
 }
 \description{

--- a/mlflow/R/mlflow/man/mlflow_server.Rd
+++ b/mlflow/R/mlflow/man/mlflow_server.Rd
@@ -16,8 +16,9 @@ mlflow_server(
 )
 }
 \arguments{
-\item{file_store}{The root of the backing file store for experiment and run data.
-Ignored when \code{backend_store_uri} is provided.}
+\item{file_store}{Deprecated. Use \code{backend_store_uri} instead. The root of the
+backing file store for experiment and run data. Ignored when
+\code{backend_store_uri} is provided.}
 
 \item{default_artifact_root}{Local or S3 URI to store artifacts in, for newly created experiments.}
 
@@ -32,7 +33,8 @@ Ignored when \code{backend_store_uri} is provided.}
 \item{serve_artifacts}{A flag specifying whether or not to enable artifact serving (default: FALSE).}
 
 \item{backend_store_uri}{URI for the backend store (e.g., \code{sqlite:///mlflow.db},
-\code{postgresql://user:pass@host/db}). When set, takes precedence over \code{file_store}.}
+\code{postgresql://user:pass@host/db}). When set, takes precedence over \code{file_store}.
+When neither is provided, a local SQLite database under \code{mlruns/} is used.}
 }
 \description{
 Wrapper for \code{mlflow server}.

--- a/mlflow/R/mlflow/man/mlflow_server.Rd
+++ b/mlflow/R/mlflow/man/mlflow_server.Rd
@@ -11,11 +11,13 @@ mlflow_server(
   port = 5000,
   workers = NULL,
   static_prefix = NULL,
-  serve_artifacts = FALSE
+  serve_artifacts = FALSE,
+  backend_store_uri = NULL
 )
 }
 \arguments{
-\item{file_store}{The root of the backing file store for experiment and run data.}
+\item{file_store}{The root of the backing file store for experiment and run data.
+Ignored when \code{backend_store_uri} is provided.}
 
 \item{default_artifact_root}{Local or S3 URI to store artifacts in, for newly created experiments.}
 
@@ -28,7 +30,10 @@ mlflow_server(
 \item{static_prefix}{A prefix which will be prepended to the path of all static paths.}
 
 \item{serve_artifacts}{A flag specifying whether or not to enable artifact serving (default: FALSE).}
+
+\item{backend_store_uri}{URI for the backend store (e.g., \code{sqlite:///mlflow.db},
+\code{postgresql://user:pass@host/db}). When set, takes precedence over \code{file_store}.}
 }
 \description{
-Wrapper for `mlflow server`.
+Wrapper for \code{mlflow server}.
 }

--- a/mlflow/R/mlflow/tests/testthat.R
+++ b/mlflow/R/mlflow/tests/testthat.R
@@ -19,6 +19,10 @@ mlflow_load_flavor.mlflow_flavor_trivial <- function(flavor, model_path) {
 library(testthat)
 library(mlflow)
 
+# Allow extra time for the local SQLite-backed tracking server to come up
+# (the first start runs alembic migrations).
+options(mlflow.connect.wait = 30)
+
 if (identical(Sys.getenv("NOT_CRAN"), "true")) {
   message("Current working directory: ", getwd())
   test_check("mlflow", reporter = ProgressReporter)

--- a/mlflow/R/mlflow/tests/testthat/test-params.R
+++ b/mlflow/R/mlflow/tests/testthat/test-params.R
@@ -15,16 +15,12 @@ test_that("mlflow can read typed command line parameters", {
     "-P", "my_str=XYZ"
   )
 
-  expect_true(dir.exists("mlruns"))
-  expect_true(dir.exists("mlruns/0"))
-  expect_true(file.exists("mlruns/0/meta.yaml"))
-
-  run_dir <- file.path("mlruns/0/", dir("mlruns/0/", pattern = "^[a-zA-Z0-9]+$")[[1]])
-  params_dir <- dir(file.path(run_dir, "params"))
-
-  expect_true("my_int" %in% params_dir)
-  expect_true("my_num" %in% params_dir)
-  expect_true("my_str" %in% params_dir)
+  runs <- mlflow_search_runs(experiment_ids = "0")
+  expect_true(nrow(runs) >= 1)
+  param_keys <- runs$params[[1]]$key
+  expect_true("my_int" %in% param_keys)
+  expect_true("my_num" %in% param_keys)
+  expect_true("my_str" %in% param_keys)
 })
 
 test_that("ml_param() type checking works", {

--- a/mlflow/R/mlflow/tests/testthat/test-rest.R
+++ b/mlflow/R/mlflow/tests/testthat/test-rest.R
@@ -56,7 +56,7 @@ test_that("insecure is used", {
 
 test_that("429s are retried", {
   next_id <<- 1
-  client <- mlflow:::mlflow_client("local")
+  client <- mlflow:::mlflow_client("http://local")
   new_response <- function(status_code) {
     structure(
       list(status_code = status_code,

--- a/mlflow/R/mlflow/tests/testthat/test-run.R
+++ b/mlflow/R/mlflow/tests/testthat/test-run.R
@@ -9,9 +9,8 @@ test_that("mlflow can run and save model", {
 
   mlflow_source("examples/train_example.R")
 
-  expect_true(dir.exists("mlruns"))
-  expect_true(dir.exists("mlruns/0"))
-  expect_true(file.exists("mlruns/0/meta.yaml"))
+  runs <- mlflow_search_runs(experiment_ids = "0")
+  expect_true(nrow(runs) >= 1)
 })
 
 

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-experiments.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-experiments.R
@@ -56,7 +56,7 @@ test_that("mlflow_get_experiment() not found error", {
 
   expect_error(
     mlflow_get_experiment(experiment_id = "42"),
-    "Could not find experiment with ID 42"
+    "No Experiment with id=42 exists"
   )
 })
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22773 (filesystem backend deprecation).

### What changes are proposed in this pull request?

The R package's local tracking server is currently backed by FileStore, which is being disabled in #22773. This PR migrates the R package to use SQLite under the hood:

- `mlflow_server()` now launches the local server with `--backend-store-uri sqlite:///<dir>/mlflow.db` and uses the same directory as `--default-artifact-root`. The directory is auto-created if missing.
- `new_mlflow_client.mlflow_file()` now sets `MLFLOW_TRACKING_URI` for CLI subprocesses (`mlflow run`, `mlflow artifacts`, `mlflow models predict`, etc.) to the local server URL, so those subprocesses go through the server rather than instantiating FileStore directly.
- Replaces FileStore-specific filesystem assertions (e.g. `mlruns/0/meta.yaml`, `mlruns/0/<run>/params/...`) in `test-run.R` and `test-params.R` with equivalent `mlflow_search_runs()` API checks.

The user-facing R API (`mlflow_server(file_store = ...)`) keeps the same parameter name and semantics — the directory still holds the tracking data, just as a SQLite DB plus artifacts instead of FileStore layout.

### How is this PR tested?

- [x] Existing unit/integration tests (R workflow on CI)

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release