### PR TITLE
Add telemetry for tracking server startup

### DIFF
--- a/mlflow/cli/__init__.py
+++ b/mlflow/cli/__init__.py
@@ -36,6 +36,8 @@ from mlflow.store.tracking import (
     DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH,
 )
 from mlflow.store.workspace.utils import get_default_workspace_optional
+from mlflow.telemetry.events import TrackingServerStartEvent
+from mlflow.telemetry.track import _record_event
 from mlflow.tracking import _get_store
 from mlflow.tracking._tracking_service.utils import (
     _get_default_tracking_uri,
@@ -48,8 +50,6 @@ from mlflow.utils.logging_utils import eprint
 from mlflow.utils.os import is_windows
 from mlflow.utils.plugins import get_entry_points
 from mlflow.utils.process import ShellCommandException
-from mlflow.telemetry.events import TrackingServerStartEvent
-from mlflow.telemetry.track import _record_event
 from mlflow.utils.server_cli_utils import (
     artifacts_only_config_validation,
     assert_server_workspace_env_unset,
@@ -685,18 +685,16 @@ def server(
 
     _record_event(
         TrackingServerStartEvent,
-        TrackingServerStartEvent.parse(
-            {
-                "backend_store_uri": backend_store_uri,
-                "serve_artifacts": serve_artifacts,
-                "artifacts_only": artifacts_only,
-                "expose_prometheus": expose_prometheus,
-                "app_name": app_name,
-                "enable_workspaces": enable_workspaces,
-                "workers": workers,
-                "dev": dev,
-            }
-        )
+        TrackingServerStartEvent.parse({
+            "backend_store_uri": backend_store_uri,
+            "serve_artifacts": serve_artifacts,
+            "artifacts_only": artifacts_only,
+            "expose_prometheus": expose_prometheus,
+            "app_name": app_name,
+            "enable_workspaces": enable_workspaces,
+            "workers": workers,
+            "dev": dev,
+        })
         or {},
     )
 

--- a/mlflow/cli/__init__.py
+++ b/mlflow/cli/__init__.py
@@ -48,6 +48,8 @@ from mlflow.utils.logging_utils import eprint
 from mlflow.utils.os import is_windows
 from mlflow.utils.plugins import get_entry_points
 from mlflow.utils.process import ShellCommandException
+from mlflow.telemetry.events import TrackingServerStartEvent
+from mlflow.telemetry.track import _record_event
 from mlflow.utils.server_cli_utils import (
     artifacts_only_config_validation,
     assert_server_workspace_env_unset,
@@ -680,6 +682,23 @@ def server(
                 origins_list.append(f"and {len(cors_allowed_origins.split(',')) - 3} more")
             parts.append(f"CORS origins: {', '.join(origins_list)}")
         click.echo(". ".join(parts) + ".", err=True)
+
+    _record_event(
+        TrackingServerStartEvent,
+        TrackingServerStartEvent.parse(
+            {
+                "backend_store_uri": backend_store_uri,
+                "serve_artifacts": serve_artifacts,
+                "artifacts_only": artifacts_only,
+                "expose_prometheus": expose_prometheus,
+                "app_name": app_name,
+                "enable_workspaces": enable_workspaces,
+                "workers": workers,
+                "dev": dev,
+            }
+        )
+        or {},
+    )
 
     try:
         _run_server(

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -408,6 +408,36 @@ class McpRunEvent(Event):
     name: str = "mcp_run"
 
 
+class TrackingServerStartEvent(Event):
+    name: str = "tracking_server_start"
+
+    @classmethod
+    def parse(cls, arguments: dict[str, Any]) -> dict[str, Any] | None:
+        from urllib.parse import urlparse
+
+        backend_store_uri = arguments.get("backend_store_uri") or ""
+        scheme = urlparse(backend_store_uri).scheme
+        if not scheme:
+            backend_store_type = "file"
+        elif scheme in ("sqlite", "postgresql", "mysql", "mssql"):
+            backend_store_type = scheme
+        else:
+            backend_store_type = scheme
+
+        app_name = arguments.get("app_name")
+        return {
+            "auth_enabled": app_name is not None,
+            "app_name": app_name,
+            "backend_store_type": backend_store_type,
+            "serve_artifacts": bool(arguments.get("serve_artifacts")),
+            "artifacts_only": bool(arguments.get("artifacts_only")),
+            "expose_prometheus": arguments.get("expose_prometheus") is not None,
+            "enable_workspaces": bool(arguments.get("enable_workspaces")),
+            "workers": arguments.get("workers"),
+            "dev": bool(arguments.get("dev")),
+        }
+
+
 class GatewayStartEvent(Event):
     name: str = "gateway_start"
 

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -416,16 +416,14 @@ class TrackingServerStartEvent(Event):
     def parse(cls, arguments: dict[str, Any]) -> dict[str, Any] | None:
         backend_store_uri = arguments.get("backend_store_uri") or ""
         scheme = urlparse(backend_store_uri).scheme
-        if not scheme:
-            backend_store_type = "file"
-        elif scheme in ("sqlite", "postgresql", "mysql", "mssql"):
-            backend_store_type = scheme
-        else:
-            backend_store_type = scheme
+        # Treat empty schemes (relative paths) and single-letter schemes
+        # (Windows drive letters like C:\) as local file storage.
+        # Strip SQLAlchemy driver suffixes (e.g. mysql+pymysql → mysql).
+        backend_store_type = "file" if not scheme or len(scheme) == 1 else scheme.split("+")[0]
 
         app_name = arguments.get("app_name")
         return {
-            "auth_enabled": app_name is not None,
+            "auth_enabled": app_name == "basic-auth",
             "app_name": app_name,
             "backend_store_type": backend_store_type,
             "serve_artifacts": bool(arguments.get("serve_artifacts")),

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -4,6 +4,7 @@ import sys
 from collections import Counter
 from enum import Enum
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
 
 from mlflow.entities import Feedback
 from mlflow.entities.issue import IssueSeverity, IssueStatus
@@ -413,8 +414,6 @@ class TrackingServerStartEvent(Event):
 
     @classmethod
     def parse(cls, arguments: dict[str, Any]) -> dict[str, Any] | None:
-        from urllib.parse import urlparse
-
         backend_store_uri = arguments.get("backend_store_uri") or ""
         scheme = urlparse(backend_store_uri).scheme
         if not scheme:

--- a/tests/telemetry/test_tracked_events.py
+++ b/tests/telemetry/test_tracked_events.py
@@ -91,7 +91,6 @@ from mlflow.telemetry.events import (
     GatewayListSecretsEvent,
     GatewayStartEvent,
     GatewayUpdateBudgetPolicyEvent,
-    TrackingServerStartEvent,
     GatewayUpdateEndpointEvent,
     GatewayUpdateGuardrailEvent,
     GatewayUpdateSecretEvent,
@@ -113,6 +112,7 @@ from mlflow.telemetry.events import (
     SimulateConversationEvent,
     StartTraceEvent,
     TracingContextPropagation,
+    TrackingServerStartEvent,
     UpdateIssueEvent,
 )
 from mlflow.tracing.distributed import (
@@ -1257,7 +1257,9 @@ def test_tracking_server_start(
 
     runner = CliRunner(catch_exceptions=False)
     with (
-        mock.patch("mlflow.server._run_server", side_effect=assert_event_recorded_before_run_server),
+        mock.patch(
+            "mlflow.server._run_server", side_effect=assert_event_recorded_before_run_server
+        ),
         mock.patch("mlflow.server.handlers.initialize_backend_stores"),
     ):
         runner.invoke(server, cli_args)

--- a/tests/telemetry/test_tracked_events.py
+++ b/tests/telemetry/test_tracked_events.py
@@ -91,6 +91,7 @@ from mlflow.telemetry.events import (
     GatewayListSecretsEvent,
     GatewayStartEvent,
     GatewayUpdateBudgetPolicyEvent,
+    TrackingServerStartEvent,
     GatewayUpdateEndpointEvent,
     GatewayUpdateGuardrailEvent,
     GatewayUpdateSecretEvent,
@@ -1180,6 +1181,86 @@ endpoints:
     runner = CliRunner(catch_exceptions=False)
     with mock.patch("mlflow.gateway.cli.run_app", side_effect=assert_event_recorded_before_run_app):
         runner.invoke(start, ["--config-path", str(config)])
+
+
+@pytest.mark.parametrize(
+    ("cli_args", "expected_params"),
+    [
+        (
+            ["--backend-store-uri", "sqlite:///test.db"],
+            {
+                "auth_enabled": False,
+                "app_name": None,
+                "backend_store_type": "sqlite",
+                "serve_artifacts": True,
+                "artifacts_only": False,
+                "expose_prometheus": False,
+                "enable_workspaces": False,
+                "workers": None,
+                "dev": False,
+            },
+        ),
+        (
+            ["--backend-store-uri", "sqlite:///test.db", "--app-name", "basic-auth"],
+            {
+                "auth_enabled": True,
+                "app_name": "basic-auth",
+                "backend_store_type": "sqlite",
+                "serve_artifacts": True,
+                "artifacts_only": False,
+                "expose_prometheus": False,
+                "enable_workspaces": False,
+                "workers": None,
+                "dev": False,
+            },
+        ),
+        (
+            [
+                "--backend-store-uri",
+                "sqlite:///test.db",
+                "--no-serve-artifacts",
+                "--expose-prometheus",
+                "/tmp/metrics",
+                "--enable-workspaces",
+            ],
+            {
+                "auth_enabled": False,
+                "app_name": None,
+                "backend_store_type": "sqlite",
+                "serve_artifacts": False,
+                "artifacts_only": False,
+                "expose_prometheus": True,
+                "enable_workspaces": True,
+                "workers": None,
+                "dev": False,
+            },
+        ),
+    ],
+)
+def test_tracking_server_start(
+    tmp_path,
+    mock_requests,
+    mock_telemetry_client: TelemetryClient,
+    cli_args,
+    expected_params,
+):
+    from mlflow.cli import server
+
+    def assert_event_recorded_before_run_server(**kwargs):
+        mock_telemetry_client.flush()
+        validate_telemetry_record(
+            mock_telemetry_client,
+            mock_requests,
+            TrackingServerStartEvent.name,
+            expected_params,
+        )
+
+    runner = CliRunner(catch_exceptions=False)
+    with (
+        mock.patch("mlflow.server._run_server", side_effect=assert_event_recorded_before_run_server),
+        mock.patch("mlflow.server.handlers.initialize_backend_stores"),
+    ):
+        runner.invoke(server, cli_args)
 
 
 def test_ai_command_run(mock_requests, mock_telemetry_client: TelemetryClient):

--- a/tests/telemetry/test_tracked_events.py
+++ b/tests/telemetry/test_tracked_events.py
@@ -1241,10 +1241,23 @@ def test_tracking_server_start(
     tmp_path,
     mock_requests,
     mock_telemetry_client: TelemetryClient,
+    monkeypatch,
     cli_args,
     expected_params,
 ):
+
     from mlflow.cli import server
+
+    # Isolate env vars that server() mutates so they don't leak into other tests
+    for key in (
+        "MLFLOW_ENABLE_WORKSPACES",
+        "MLFLOW_WORKSPACE_STORE_URI",
+        "MLFLOW_SERVER_DISABLE_SECURITY_MIDDLEWARE",
+        "MLFLOW_SERVER_ALLOWED_HOSTS",
+        "MLFLOW_SERVER_CORS_ALLOWED_ORIGINS",
+        "MLFLOW_SERVER_X_FRAME_OPTIONS",
+    ):
+        monkeypatch.delenv(key, raising=False)
 
     def assert_event_recorded_before_run_server(**kwargs):
         mock_telemetry_client.flush()


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Adds a `tracking_server_start` telemetry event emitted when `mlflow server` is run. The event captures:
- `auth_enabled` / `app_name`: whether an auth plugin (e.g. `basic-auth`) is active
- `backend_store_type`: URI scheme of the backend store (e.g. `sqlite`, `postgresql`, `file`)
- `serve_artifacts`, `artifacts_only`: artifact serving mode
- `expose_prometheus`: whether the Prometheus metrics endpoint is enabled
- `enable_workspaces`: whether workspaces mode is enabled
- `workers`, `dev`: server configuration

This follows the same pattern as `GatewayStartEvent` in the gateway CLI.

### How is this PR tested?

- [x] New unit/integration tests

Added parametrized tests in `tests/telemetry/test_tracked_events.py` covering:
- Default server (no flags)
- Auth-enabled server (`--app-name basic-auth`)
- Server with `--no-serve-artifacts`, `--expose-prometheus`, and `--enable-workspaces`

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release