### PR TITLE
Expose Codex and Qwen Code hooks as installable CLI binaries

### DIFF
--- a/libs/typescript/integrations/codex/esbuild.config.mjs
+++ b/libs/typescript/integrations/codex/esbuild.config.mjs
@@ -2,11 +2,11 @@ import { build } from 'esbuild';
 import { chmodSync } from 'node:fs';
 
 await build({
-  entryPoints: ['dist/hooks/stop.js'],
+  entryPoints: ['dist/cli.js'],
   bundle: true,
   platform: 'node',
   format: 'esm',
-  outfile: 'bundle/stop.js',
+  outfile: 'bundle/cli.js',
   external: ['node:*'],
   banner: {
     // Create a require function for CJS dependencies that use bare node specifiers
@@ -18,4 +18,4 @@ await build({
   },
 });
 
-chmodSync('bundle/stop.js', 0o755);
+chmodSync('bundle/cli.js', 0o755);

--- a/libs/typescript/integrations/codex/package.json
+++ b/libs/typescript/integrations/codex/package.json
@@ -33,6 +33,9 @@
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "bin": {
+    "mlflow-codex": "./bundle/cli.js"
+  },
   "scripts": {
     "build": "tsc && npm run build:bundle",
     "build:bundle": "node esbuild.config.mjs",

--- a/libs/typescript/integrations/codex/src/cli.ts
+++ b/libs/typescript/integrations/codex/src/cli.ts
@@ -1,25 +1,38 @@
 /**
  * CLI dispatcher for `@mlflow/codex`.
  *
- * Installed as the `mlflow-codex` bin. Dispatches on the first CLI arg:
- *   - `setup`       → registers the notify hook in ~/.codex/config.toml
+ * Installed as the `mlflow-codex` bin. Subcommands:
+ *   - `setup`       → registers the notify hook and writes mlflow-tracing.json
+ *   - `notify-hook` → runs the Codex notify handler (Codex appends the JSON
+ *                     payload as the final argv entry)
  *   - `--help`/`-h` → prints usage
- *   - otherwise     → treats the argument as a Codex notify payload and runs
- *                     the hook. This is the form Codex itself uses, which
- *                     appends the JSON payload as the final argv entry.
+ *
+ * Codex invokes `mlflow-codex notify-hook` as the registered notify handler.
+ * Codex appends the turn JSON as the final argument.
  */
 
 import { runNotifyHook } from './hooks/stop.js';
 import { runSetup } from './commands/setup.js';
 
 function printUsage(): void {
-  console.error('Usage: mlflow-codex [command | <notify-payload>]');
+  console.error('Usage: mlflow-codex <command> [options]');
   console.error('');
   console.error('Commands:');
-  console.error('  setup       Register the notify hook in ~/.codex/config.toml');
+  console.error('  setup        Register the notify hook in ~/.codex/config.toml and configure');
+  console.error('               the MLflow tracking URI / experiment ID. Runs interactively');
+  console.error('               by default.');
   console.error('');
-  console.error('When invoked with a JSON argument, treats it as a Codex notify');
-  console.error('payload. This is the form Codex itself uses via config.toml.');
+  console.error('               Flags:');
+  console.error('                 --project, -p          Write to ./.codex/ instead of ~/.codex/');
+  console.error(
+    '                 --non-interactive, -y  Skip prompts; use flag values or defaults',
+  );
+  console.error('                 --tracking-uri <url>   Bypass the prompt for the tracking URI');
+  console.error('                 --experiment-id <id>   Bypass the prompt for the experiment ID');
+  console.error('');
+  console.error('  notify-hook  Run the Codex notify handler. Codex appends the turn JSON as');
+  console.error('               the final argument — this is the form Codex itself uses via');
+  console.error('               config.toml.');
 }
 
 async function main(): Promise<void> {
@@ -27,15 +40,31 @@ async function main(): Promise<void> {
 
   if (command === undefined || command === '--help' || command === '-h' || command === 'help') {
     printUsage();
+    if (command === undefined) {
+      process.exitCode = 1;
+    }
     return;
   }
 
   if (command === 'setup') {
-    runSetup(rest);
+    await runSetup(rest);
     return;
   }
 
-  await runNotifyHook(command);
+  if (command === 'notify-hook') {
+    const payload = rest[0];
+    if (payload === undefined) {
+      console.error('[mlflow] notify-hook expects a JSON payload as the first argument');
+      process.exitCode = 1;
+      return;
+    }
+    await runNotifyHook(payload);
+    return;
+  }
+
+  console.error(`[mlflow] Unknown command: ${command}`);
+  printUsage();
+  process.exitCode = 1;
 }
 
 void main();

--- a/libs/typescript/integrations/codex/src/cli.ts
+++ b/libs/typescript/integrations/codex/src/cli.ts
@@ -27,7 +27,9 @@ function printUsage(): void {
   console.error('');
   console.error(`               ${dim('Flags:')}`);
   console.error(
-    dim('                 --project, -p          Write to ./.codex/ instead of ~/.codex/'),
+    dim(
+      '                 --project, -p          Write to ./.codex/ (skip the interactive scope prompt)',
+    ),
   );
   console.error(
     dim('                 --non-interactive, -y  Skip prompts; use flag values or defaults'),

--- a/libs/typescript/integrations/codex/src/cli.ts
+++ b/libs/typescript/integrations/codex/src/cli.ts
@@ -1,0 +1,41 @@
+/**
+ * CLI dispatcher for `@mlflow/codex`.
+ *
+ * Installed as the `mlflow-codex` bin. Dispatches on the first CLI arg:
+ *   - `setup`       → registers the notify hook in ~/.codex/config.toml
+ *   - `--help`/`-h` → prints usage
+ *   - otherwise     → treats the argument as a Codex notify payload and runs
+ *                     the hook. This is the form Codex itself uses, which
+ *                     appends the JSON payload as the final argv entry.
+ */
+
+import { runNotifyHook } from './hooks/stop.js';
+import { runSetup } from './commands/setup.js';
+
+function printUsage(): void {
+  console.error('Usage: mlflow-codex [command | <notify-payload>]');
+  console.error('');
+  console.error('Commands:');
+  console.error('  setup       Register the notify hook in ~/.codex/config.toml');
+  console.error('');
+  console.error('When invoked with a JSON argument, treats it as a Codex notify');
+  console.error('payload. This is the form Codex itself uses via config.toml.');
+}
+
+async function main(): Promise<void> {
+  const [, , command, ...rest] = process.argv;
+
+  if (command === undefined || command === '--help' || command === '-h' || command === 'help') {
+    printUsage();
+    return;
+  }
+
+  if (command === 'setup') {
+    runSetup(rest);
+    return;
+  }
+
+  await runNotifyHook(command);
+}
+
+void main();

--- a/libs/typescript/integrations/codex/src/cli.ts
+++ b/libs/typescript/integrations/codex/src/cli.ts
@@ -13,24 +13,35 @@
 
 import { runNotifyHook } from './hooks/stop.js';
 import { runSetup } from './commands/setup.js';
+import { FAIL, bold, dim } from './ui.js';
 
 function printUsage(): void {
-  console.error('Usage: mlflow-codex <command> [options]');
+  console.error(`${bold('Usage:')} mlflow-codex <command> [options]`);
   console.error('');
-  console.error('Commands:');
-  console.error('  setup        Register the notify hook in ~/.codex/config.toml and configure');
+  console.error(bold('Commands:'));
+  console.error(
+    `  ${bold('setup')}        Register the notify hook in ~/.codex/config.toml and configure`,
+  );
   console.error('               the MLflow tracking URI / experiment ID. Runs interactively');
   console.error('               by default.');
   console.error('');
-  console.error('               Flags:');
-  console.error('                 --project, -p          Write to ./.codex/ instead of ~/.codex/');
+  console.error(`               ${dim('Flags:')}`);
   console.error(
-    '                 --non-interactive, -y  Skip prompts; use flag values or defaults',
+    dim('                 --project, -p          Write to ./.codex/ instead of ~/.codex/'),
   );
-  console.error('                 --tracking-uri <url>   Bypass the prompt for the tracking URI');
-  console.error('                 --experiment-id <id>   Bypass the prompt for the experiment ID');
+  console.error(
+    dim('                 --non-interactive, -y  Skip prompts; use flag values or defaults'),
+  );
+  console.error(
+    dim('                 --tracking-uri <url>   Bypass the prompt for the tracking URI'),
+  );
+  console.error(
+    dim('                 --experiment-id <id>   Bypass the prompt for the experiment ID'),
+  );
   console.error('');
-  console.error('  notify-hook  Run the Codex notify handler. Codex appends the turn JSON as');
+  console.error(
+    `  ${bold('notify-hook')}  Run the Codex notify handler. Codex appends the turn JSON as`,
+  );
   console.error('               the final argument — this is the form Codex itself uses via');
   console.error('               config.toml.');
 }
@@ -54,7 +65,7 @@ async function main(): Promise<void> {
   if (command === 'notify-hook') {
     const payload = rest[0];
     if (payload === undefined) {
-      console.error('[mlflow] notify-hook expects a JSON payload as the first argument');
+      console.error(`${FAIL} notify-hook expects a JSON payload as the first argument`);
       process.exitCode = 1;
       return;
     }
@@ -62,7 +73,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  console.error(`[mlflow] Unknown command: ${command}`);
+  console.error(`${FAIL} Unknown command: ${bold(command)}\n`);
   printUsage();
   process.exitCode = 1;
 }

--- a/libs/typescript/integrations/codex/src/commands/setup.ts
+++ b/libs/typescript/integrations/codex/src/commands/setup.ts
@@ -3,13 +3,17 @@
  * Codex config and write an MLflow tracing config alongside it.
  *
  * Writes:
- *   - `~/.codex/config.toml` — prepends `notify = ["mlflow-codex", "notify-hook"]`
+ *   - `config.toml` — prepends `notify = ["mlflow-codex", "notify-hook"]`
  *     ahead of any `[section]` headers. Refuses to modify a pre-existing
  *     `notify = ...` entry to avoid mangling the user's config.
- *   - `~/.codex/mlflow-tracing.json` — persists the tracking URI and
- *     experiment ID so the hook can run without shell exports.
+ *   - `mlflow-tracing.json` — persists the tracking URI and experiment ID
+ *     so the hook can run without shell exports.
  *
- * `--project` (or `-p`) writes to `./.codex/` instead of `~/.codex/`.
+ * Scope selection:
+ *   - Interactive runs prompt for project-local (`./.codex/`) vs user-level
+ *     (`~/.codex/`), defaulting to project-local.
+ *   - `--project` / `-p` forces project-local and skips the prompt.
+ *   - `--non-interactive` without `--project` falls back to user-level.
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
@@ -18,6 +22,7 @@ import { dirname, resolve } from 'node:path';
 import { createInterface } from 'node:readline';
 
 import { FAIL, OK, WARN, bold, cyan, dim } from '../ui.js';
+import { selectPrompt } from '../ui-select.js';
 
 const HOOK_LINE = 'notify = ["mlflow-codex", "notify-hook"]';
 const NOTIFY_LINE_RE = /^\s*notify\s*=.*$/m;
@@ -86,9 +91,15 @@ function writeTracingConfig(
  *   --non-interactive / -y
  *   --tracking-uri <url>
  *   --experiment-id <id>
+ *
+ * `projectLocal` is left undefined when `--project` is not passed so the
+ * interactive flow can prompt for it (and non-interactive can fall back to
+ * user-level).
  */
-export function parseSetupArgs(args: string[]): SetupOptions & { projectLocal: boolean } {
-  const out: SetupOptions & { projectLocal: boolean } = { projectLocal: false };
+export function parseSetupArgs(
+  args: string[],
+): SetupOptions & { projectLocal: boolean | undefined } {
+  const out: SetupOptions & { projectLocal: boolean | undefined } = { projectLocal: undefined };
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if (arg === '--project' || arg === '-p') {
@@ -132,41 +143,42 @@ function askOn(
 const validateTrackingUri = (value: string): string | null =>
   isValidTrackingUri(value) ? null : 'Must be an absolute http:// or https:// URL.';
 
-async function resolveTracingValues(
-  options: SetupOptions,
-): Promise<{ trackingUri: string; experimentId: string }> {
-  if (options.nonInteractive) {
-    return {
-      trackingUri: options.trackingUri ?? DEFAULT_TRACKING_URI,
-      experimentId: options.experimentId ?? DEFAULT_EXPERIMENT_ID,
-    };
-  }
-  if (options.trackingUri && options.experimentId) {
-    return { trackingUri: options.trackingUri, experimentId: options.experimentId };
-  }
-  console.error(`\n${bold('Configure MLflow tracing for Codex CLI')}`);
-  const rl = createInterface({ input: process.stdin, output: process.stdout });
-  try {
-    const trackingUri =
-      options.trackingUri ??
-      (await askOn(rl, 'MLflow tracking URI', DEFAULT_TRACKING_URI, validateTrackingUri));
-    const experimentId =
-      options.experimentId ?? (await askOn(rl, 'MLflow experiment ID', DEFAULT_EXPERIMENT_ID));
-    return { trackingUri, experimentId };
-  } finally {
-    rl.close();
-  }
+function promptScope(): Promise<boolean> {
+  return selectPrompt<boolean>({
+    question: 'Where should MLflow tracing be installed?',
+    options: [
+      { value: true, label: 'Project', hint: './.codex/' },
+      { value: false, label: 'User', hint: '~/.codex/' },
+    ],
+    defaultIndex: 0,
+  });
 }
 
 export async function runSetup(args: string[], options: SetupOptions = {}): Promise<void> {
   const parsed = parseSetupArgs(args);
-  const merged: SetupOptions & { projectLocal: boolean } = {
+  const merged: SetupOptions & { projectLocal: boolean | undefined } = {
     ...parsed,
     ...options,
     projectLocal: parsed.projectLocal,
   };
-  const configPath = resolveConfigPath(merged.projectLocal, merged);
-  const tracingConfigPath = resolveTracingConfigPath(merged.projectLocal, merged);
+
+  const interactive = !merged.nonInteractive;
+  const needsBanner =
+    interactive &&
+    (merged.projectLocal === undefined || !merged.trackingUri || !merged.experimentId);
+  if (needsBanner) {
+    console.error(`\n${bold('Configure MLflow tracing for Codex CLI')}`);
+  }
+
+  const projectLocal =
+    merged.projectLocal !== undefined
+      ? merged.projectLocal
+      : interactive
+        ? await promptScope()
+        : false;
+
+  const configPath = resolveConfigPath(projectLocal, merged);
+  const tracingConfigPath = resolveTracingConfigPath(projectLocal, merged);
 
   let hookRegistered = false;
   if (!existsSync(configPath)) {
@@ -195,8 +207,33 @@ export async function runSetup(args: string[], options: SetupOptions = {}): Prom
   if (!hookRegistered) {
     return;
   }
+  console.error('');
 
-  const { trackingUri, experimentId } = await resolveTracingValues(merged);
+  const needsTextPrompt = interactive && (!merged.trackingUri || !merged.experimentId);
+  const rl = needsTextPrompt
+    ? createInterface({ input: process.stdin, output: process.stdout })
+    : null;
+  try {
+    const trackingUri =
+      merged.trackingUri ??
+      (rl
+        ? await askOn(rl, 'MLflow tracking URI', DEFAULT_TRACKING_URI, validateTrackingUri)
+        : DEFAULT_TRACKING_URI);
+    const experimentId =
+      merged.experimentId ??
+      (rl ? await askOn(rl, 'MLflow experiment ID', DEFAULT_EXPERIMENT_ID) : DEFAULT_EXPERIMENT_ID);
+
+    writeTracingConfigIfValid(tracingConfigPath, trackingUri, experimentId);
+  } finally {
+    rl?.close();
+  }
+}
+
+function writeTracingConfigIfValid(
+  tracingConfigPath: string,
+  trackingUri: string,
+  experimentId: string,
+): void {
   if (!isValidTrackingUri(trackingUri)) {
     console.error(
       `${FAIL} Invalid tracking URI: ${bold(trackingUri)} — must be an absolute http:// or https:// URL.`,

--- a/libs/typescript/integrations/codex/src/commands/setup.ts
+++ b/libs/typescript/integrations/codex/src/commands/setup.ts
@@ -12,7 +12,8 @@ import { homedir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 
 const HOOK_LINE = 'notify = ["mlflow-codex"]';
-const NOTIFY_LINE_RE = /^\s*notify\s*=/m;
+const NOTIFY_LINE_RE = /^\s*notify\s*=.*$/m;
+const NOTIFY_HAS_MLFLOW_RE = /^\s*notify\s*=.*["']mlflow-codex["']/m;
 
 export interface SetupOptions {
   /** Override the user home directory. Defaults to `os.homedir()`. */
@@ -39,7 +40,7 @@ export function runSetup(_args: string[], options: SetupOptions = {}): void {
   } else {
     const content = readFileSync(configPath, 'utf-8');
     if (NOTIFY_LINE_RE.test(content)) {
-      if (content.includes('mlflow-codex')) {
+      if (NOTIFY_HAS_MLFLOW_RE.test(content)) {
         console.error(`[mlflow] Hook already registered in ${configPath}`);
       } else {
         console.error(`[mlflow] ${configPath} already has a \`notify = ...\` entry.`);

--- a/libs/typescript/integrations/codex/src/commands/setup.ts
+++ b/libs/typescript/integrations/codex/src/commands/setup.ts
@@ -17,11 +17,28 @@ import { homedir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { createInterface } from 'node:readline';
 
+import { FAIL, OK, WARN, bold, cyan, dim } from '../ui.js';
+
 const HOOK_LINE = 'notify = ["mlflow-codex", "notify-hook"]';
 const NOTIFY_LINE_RE = /^\s*notify\s*=.*$/m;
 const NOTIFY_HAS_MLFLOW_RE = /^\s*notify\s*=.*["']mlflow-codex["']/m;
 const DEFAULT_TRACKING_URI = 'http://localhost:5000';
 const DEFAULT_EXPERIMENT_ID = '0';
+
+/**
+ * Returns true only when `raw` parses as a URL with an http(s) scheme.
+ * Rejects scheme-less inputs like `localhost:5000` (which `new URL` otherwise
+ * interprets as a custom scheme with an empty port).
+ */
+export function isValidTrackingUri(raw: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return false;
+  }
+  return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+}
 
 export interface SetupOptions {
   /** Override the user home directory. Defaults to `os.homedir()`. */
@@ -87,15 +104,33 @@ export function parseSetupArgs(args: string[]): SetupOptions & { projectLocal: b
   return out;
 }
 
-function prompt(label: string, defaultValue: string): Promise<string> {
+type Readline = ReturnType<typeof createInterface>;
+
+function askOn(
+  rl: Readline,
+  label: string,
+  defaultValue: string,
+  validate?: (value: string) => string | null,
+): Promise<string> {
   return new Promise((resolvePromise) => {
-    const rl = createInterface({ input: process.stdin, output: process.stdout });
-    rl.question(`${label} [${defaultValue}]: `, (answer) => {
-      rl.close();
-      resolvePromise(answer.trim() || defaultValue);
-    });
+    const ask = (): void => {
+      rl.question(`  ${label} ${dim(`[${defaultValue}]`)} `, (answer) => {
+        const value = answer.trim() || defaultValue;
+        const err = validate?.(value);
+        if (err) {
+          console.error(`  ${FAIL} ${err}`);
+          ask();
+          return;
+        }
+        resolvePromise(value);
+      });
+    };
+    ask();
   });
 }
+
+const validateTrackingUri = (value: string): string | null =>
+  isValidTrackingUri(value) ? null : 'Must be an absolute http:// or https:// URL.';
 
 async function resolveTracingValues(
   options: SetupOptions,
@@ -109,12 +144,18 @@ async function resolveTracingValues(
   if (options.trackingUri && options.experimentId) {
     return { trackingUri: options.trackingUri, experimentId: options.experimentId };
   }
-  console.error('[mlflow] Configuring MLflow tracing for Codex CLI.');
-  const trackingUri =
-    options.trackingUri ?? (await prompt('MLflow tracking URI', DEFAULT_TRACKING_URI));
-  const experimentId =
-    options.experimentId ?? (await prompt('MLflow experiment ID', DEFAULT_EXPERIMENT_ID));
-  return { trackingUri, experimentId };
+  console.error(`\n${bold('Configure MLflow tracing for Codex CLI')}`);
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const trackingUri =
+      options.trackingUri ??
+      (await askOn(rl, 'MLflow tracking URI', DEFAULT_TRACKING_URI, validateTrackingUri));
+    const experimentId =
+      options.experimentId ?? (await askOn(rl, 'MLflow experiment ID', DEFAULT_EXPERIMENT_ID));
+    return { trackingUri, experimentId };
+  } finally {
+    rl.close();
+  }
 }
 
 export async function runSetup(args: string[], options: SetupOptions = {}): Promise<void> {
@@ -130,23 +171,23 @@ export async function runSetup(args: string[], options: SetupOptions = {}): Prom
   let hookRegistered = false;
   if (!existsSync(configPath)) {
     writeConfigWithHook(configPath, null);
-    console.error(`[mlflow] Created ${configPath} with notify hook`);
+    console.error(`${OK} Created ${cyan(configPath)} with notify hook`);
     hookRegistered = true;
   } else {
     const content = readFileSync(configPath, 'utf-8');
     if (NOTIFY_LINE_RE.test(content)) {
       if (NOTIFY_HAS_MLFLOW_RE.test(content)) {
-        console.error(`[mlflow] Notify hook already registered in ${configPath}`);
+        console.error(`${WARN} Notify hook already registered in ${cyan(configPath)}`);
         hookRegistered = true;
       } else {
-        console.error(`[mlflow] ${configPath} already has a \`notify = ...\` entry.`);
-        console.error(`[mlflow] Update it manually to: ${HOOK_LINE}`);
+        console.error(`${FAIL} ${cyan(configPath)} already has a \`notify = ...\` entry.`);
+        console.error(`  Update it manually to: ${bold(HOOK_LINE)}`);
         process.exitCode = 1;
         return;
       }
     } else {
       writeConfigWithHook(configPath, content);
-      console.error(`[mlflow] Added notify hook to ${configPath}`);
+      console.error(`${OK} Added notify hook to ${cyan(configPath)}`);
       hookRegistered = true;
     }
   }
@@ -156,17 +197,24 @@ export async function runSetup(args: string[], options: SetupOptions = {}): Prom
   }
 
   const { trackingUri, experimentId } = await resolveTracingValues(merged);
+  if (!isValidTrackingUri(trackingUri)) {
+    console.error(
+      `${FAIL} Invalid tracking URI: ${bold(trackingUri)} — must be an absolute http:// or https:// URL.`,
+    );
+    process.exitCode = 1;
+    return;
+  }
   writeTracingConfig(tracingConfigPath, { trackingUri, experimentId });
-  console.error(`[mlflow] Wrote tracing config to ${tracingConfigPath}`);
+  console.error(`\n${OK} Wrote tracing config to ${cyan(tracingConfigPath)}`);
 
-  console.error('\nNext steps:');
+  const port = new URL(trackingUri).port || '5000';
+  console.error(`\n${bold('Next steps')}`);
   console.error('  1. Start the MLflow tracking server in a separate terminal:');
+  console.error(`       ${cyan(`mlflow server --port ${port}`)}`);
   console.error(
-    `       mlflow server --host 0.0.0.0 --port ${new URL(trackingUri).port || '5000'}`,
+    `  2. Launch ${cyan('codex')} — traces appear at ${bold(trackingUri)} after each turn.`,
   );
-  console.error(`  2. Launch \`codex\` — traces appear at ${trackingUri} after each turn.`);
   console.error(
-    '\nThe tracking URI and experiment ID can be overridden per-shell with',
-    '$MLFLOW_TRACKING_URI / $MLFLOW_EXPERIMENT_ID.',
+    `\n${dim('Override per-shell with $MLFLOW_TRACKING_URI / $MLFLOW_EXPERIMENT_ID.')}`,
   );
 }

--- a/libs/typescript/integrations/codex/src/commands/setup.ts
+++ b/libs/typescript/integrations/codex/src/commands/setup.ts
@@ -1,0 +1,63 @@
+/**
+ * `mlflow-codex setup` — register the notify hook in the user's Codex config
+ * so tracing is active on the next `codex` invocation.
+ *
+ * Writes to `~/.codex/config.toml`. Creates the file if it doesn't exist; if
+ * a `notify = ...` line already exists we do NOT rewrite it — TOML structure
+ * is fragile and we'd rather preserve the user's config than mangle it.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, resolve } from 'node:path';
+
+const HOOK_LINE = 'notify = ["mlflow-codex"]';
+const NOTIFY_LINE_RE = /^\s*notify\s*=/m;
+
+export interface SetupOptions {
+  /** Override the user home directory. Defaults to `os.homedir()`. */
+  home?: string;
+}
+
+export function resolveConfigPath(options: SetupOptions = {}): string {
+  return resolve(options.home ?? homedir(), '.codex', 'config.toml');
+}
+
+function writeConfigWithHook(path: string, original: string | null): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const prefix = `# Added by \`mlflow-codex setup\` — forwards each Codex turn to MLflow Tracing.\n${HOOK_LINE}\n`;
+  const content = original ? prefix + '\n' + original : prefix;
+  writeFileSync(path, content, 'utf-8');
+}
+
+export function runSetup(_args: string[], options: SetupOptions = {}): void {
+  const configPath = resolveConfigPath(options);
+
+  if (!existsSync(configPath)) {
+    writeConfigWithHook(configPath, null);
+    console.error(`[mlflow] Created ${configPath} with notify hook`);
+  } else {
+    const content = readFileSync(configPath, 'utf-8');
+    if (NOTIFY_LINE_RE.test(content)) {
+      if (content.includes('mlflow-codex')) {
+        console.error(`[mlflow] Hook already registered in ${configPath}`);
+      } else {
+        console.error(`[mlflow] ${configPath} already has a \`notify = ...\` entry.`);
+        console.error('[mlflow] Update it manually to: notify = ["mlflow-codex"]');
+        process.exitCode = 1;
+        return;
+      }
+    } else {
+      writeConfigWithHook(configPath, content);
+      console.error(`[mlflow] Added notify hook to ${configPath}`);
+    }
+  }
+
+  console.error('\nNext steps:');
+  console.error('  1. Export MLflow environment variables in the shell that launches `codex`:');
+  console.error('       export MLFLOW_TRACKING_URI=http://localhost:5000');
+  console.error('       export MLFLOW_EXPERIMENT_ID=0');
+  console.error('  2. Start the MLflow tracking server in a separate terminal:');
+  console.error('       mlflow server --host 0.0.0.0 --port 5000');
+  console.error('  3. Launch `codex` — traces appear at http://localhost:5000 after each turn.');
+}

--- a/libs/typescript/integrations/codex/src/commands/setup.ts
+++ b/libs/typescript/integrations/codex/src/commands/setup.ts
@@ -1,27 +1,51 @@
 /**
- * `mlflow-codex setup` — register the notify hook in the user's Codex config
- * so tracing is active on the next `codex` invocation.
+ * `mlflow-codex setup` — interactively register the notify hook in the user's
+ * Codex config and write an MLflow tracing config alongside it.
  *
- * Writes to `~/.codex/config.toml`. Creates the file if it doesn't exist; if
- * a `notify = ...` line already exists we do NOT rewrite it — TOML structure
- * is fragile and we'd rather preserve the user's config than mangle it.
+ * Writes:
+ *   - `~/.codex/config.toml` — prepends `notify = ["mlflow-codex", "notify-hook"]`
+ *     ahead of any `[section]` headers. Refuses to modify a pre-existing
+ *     `notify = ...` entry to avoid mangling the user's config.
+ *   - `~/.codex/mlflow-tracing.json` — persists the tracking URI and
+ *     experiment ID so the hook can run without shell exports.
+ *
+ * `--project` (or `-p`) writes to `./.codex/` instead of `~/.codex/`.
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, resolve } from 'node:path';
+import { createInterface } from 'node:readline';
 
-const HOOK_LINE = 'notify = ["mlflow-codex"]';
+const HOOK_LINE = 'notify = ["mlflow-codex", "notify-hook"]';
 const NOTIFY_LINE_RE = /^\s*notify\s*=.*$/m;
 const NOTIFY_HAS_MLFLOW_RE = /^\s*notify\s*=.*["']mlflow-codex["']/m;
+const DEFAULT_TRACKING_URI = 'http://localhost:5000';
+const DEFAULT_EXPERIMENT_ID = '0';
 
 export interface SetupOptions {
   /** Override the user home directory. Defaults to `os.homedir()`. */
   home?: string;
+  /** Override the current working directory. Defaults to `process.cwd()`. */
+  cwd?: string;
+  /** Pre-supplied tracking URI. Skips the interactive prompt. */
+  trackingUri?: string;
+  /** Pre-supplied experiment ID. Skips the interactive prompt. */
+  experimentId?: string;
+  /** Suppress prompts entirely. Uses defaults for any unset values. */
+  nonInteractive?: boolean;
 }
 
-export function resolveConfigPath(options: SetupOptions = {}): string {
-  return resolve(options.home ?? homedir(), '.codex', 'config.toml');
+export function resolveConfigPath(projectLocal: boolean, options: SetupOptions = {}): string {
+  return projectLocal
+    ? resolve(options.cwd ?? process.cwd(), '.codex', 'config.toml')
+    : resolve(options.home ?? homedir(), '.codex', 'config.toml');
+}
+
+function resolveTracingConfigPath(projectLocal: boolean, options: SetupOptions = {}): string {
+  return projectLocal
+    ? resolve(options.cwd ?? process.cwd(), '.codex', 'mlflow-tracing.json')
+    : resolve(options.home ?? homedir(), '.codex', 'mlflow-tracing.json');
 }
 
 function writeConfigWithHook(path: string, original: string | null): void {
@@ -31,34 +55,118 @@ function writeConfigWithHook(path: string, original: string | null): void {
   writeFileSync(path, content, 'utf-8');
 }
 
-export function runSetup(_args: string[], options: SetupOptions = {}): void {
-  const configPath = resolveConfigPath(options);
+function writeTracingConfig(
+  path: string,
+  config: { trackingUri: string; experimentId: string },
+): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+}
 
+/**
+ * Parse raw CLI args for the setup command. Supports:
+ *   --project / -p
+ *   --non-interactive / -y
+ *   --tracking-uri <url>
+ *   --experiment-id <id>
+ */
+export function parseSetupArgs(args: string[]): SetupOptions & { projectLocal: boolean } {
+  const out: SetupOptions & { projectLocal: boolean } = { projectLocal: false };
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--project' || arg === '-p') {
+      out.projectLocal = true;
+    } else if (arg === '--non-interactive' || arg === '-y') {
+      out.nonInteractive = true;
+    } else if (arg === '--tracking-uri') {
+      out.trackingUri = args[++i];
+    } else if (arg === '--experiment-id') {
+      out.experimentId = args[++i];
+    }
+  }
+  return out;
+}
+
+function prompt(label: string, defaultValue: string): Promise<string> {
+  return new Promise((resolvePromise) => {
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    rl.question(`${label} [${defaultValue}]: `, (answer) => {
+      rl.close();
+      resolvePromise(answer.trim() || defaultValue);
+    });
+  });
+}
+
+async function resolveTracingValues(
+  options: SetupOptions,
+): Promise<{ trackingUri: string; experimentId: string }> {
+  if (options.nonInteractive) {
+    return {
+      trackingUri: options.trackingUri ?? DEFAULT_TRACKING_URI,
+      experimentId: options.experimentId ?? DEFAULT_EXPERIMENT_ID,
+    };
+  }
+  if (options.trackingUri && options.experimentId) {
+    return { trackingUri: options.trackingUri, experimentId: options.experimentId };
+  }
+  console.error('[mlflow] Configuring MLflow tracing for Codex CLI.');
+  const trackingUri =
+    options.trackingUri ?? (await prompt('MLflow tracking URI', DEFAULT_TRACKING_URI));
+  const experimentId =
+    options.experimentId ?? (await prompt('MLflow experiment ID', DEFAULT_EXPERIMENT_ID));
+  return { trackingUri, experimentId };
+}
+
+export async function runSetup(args: string[], options: SetupOptions = {}): Promise<void> {
+  const parsed = parseSetupArgs(args);
+  const merged: SetupOptions & { projectLocal: boolean } = {
+    ...parsed,
+    ...options,
+    projectLocal: parsed.projectLocal,
+  };
+  const configPath = resolveConfigPath(merged.projectLocal, merged);
+  const tracingConfigPath = resolveTracingConfigPath(merged.projectLocal, merged);
+
+  let hookRegistered = false;
   if (!existsSync(configPath)) {
     writeConfigWithHook(configPath, null);
     console.error(`[mlflow] Created ${configPath} with notify hook`);
+    hookRegistered = true;
   } else {
     const content = readFileSync(configPath, 'utf-8');
     if (NOTIFY_LINE_RE.test(content)) {
       if (NOTIFY_HAS_MLFLOW_RE.test(content)) {
-        console.error(`[mlflow] Hook already registered in ${configPath}`);
+        console.error(`[mlflow] Notify hook already registered in ${configPath}`);
+        hookRegistered = true;
       } else {
         console.error(`[mlflow] ${configPath} already has a \`notify = ...\` entry.`);
-        console.error('[mlflow] Update it manually to: notify = ["mlflow-codex"]');
+        console.error(`[mlflow] Update it manually to: ${HOOK_LINE}`);
         process.exitCode = 1;
         return;
       }
     } else {
       writeConfigWithHook(configPath, content);
       console.error(`[mlflow] Added notify hook to ${configPath}`);
+      hookRegistered = true;
     }
   }
 
+  if (!hookRegistered) {
+    return;
+  }
+
+  const { trackingUri, experimentId } = await resolveTracingValues(merged);
+  writeTracingConfig(tracingConfigPath, { trackingUri, experimentId });
+  console.error(`[mlflow] Wrote tracing config to ${tracingConfigPath}`);
+
   console.error('\nNext steps:');
-  console.error('  1. Export MLflow environment variables in the shell that launches `codex`:');
-  console.error('       export MLFLOW_TRACKING_URI=http://localhost:5000');
-  console.error('       export MLFLOW_EXPERIMENT_ID=0');
-  console.error('  2. Start the MLflow tracking server in a separate terminal:');
-  console.error('       mlflow server --host 0.0.0.0 --port 5000');
-  console.error('  3. Launch `codex` — traces appear at http://localhost:5000 after each turn.');
+  console.error('  1. Start the MLflow tracking server in a separate terminal:');
+  console.error(
+    `       mlflow server --host 0.0.0.0 --port ${new URL(trackingUri).port || '5000'}`,
+  );
+  console.error(`  2. Launch \`codex\` — traces appear at ${trackingUri} after each turn.`);
+  console.error(
+    '\nThe tracking URI and experiment ID can be overridden per-shell with',
+    '$MLFLOW_TRACKING_URI / $MLFLOW_EXPERIMENT_ID.',
+  );
 }

--- a/libs/typescript/integrations/codex/src/config.ts
+++ b/libs/typescript/integrations/codex/src/config.ts
@@ -1,27 +1,75 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
+
 import { init } from '@mlflow/core';
 
 let initialized = false;
 
+const TRACING_CONFIG_FILE = 'mlflow-tracing.json';
+
+interface TracingConfig {
+  trackingUri?: string;
+  experimentId?: string;
+}
+
+export interface ResolveConfigOptions {
+  /** Override the user home directory. Defaults to `os.homedir()`. */
+  home?: string;
+  /** Override the current working directory. Defaults to `process.cwd()`. */
+  cwd?: string;
+}
+
+function readTracingConfigFile(path: string): TracingConfig {
+  if (!existsSync(path)) {
+    return {};
+  }
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as TracingConfig;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Resolve the effective MLflow tracing config. Precedence (highest first):
+ *   1. `MLFLOW_TRACKING_URI` / `MLFLOW_EXPERIMENT_ID` environment variables
+ *   2. `./.codex/mlflow-tracing.json` (project-local)
+ *   3. `~/.codex/mlflow-tracing.json` (user-level)
+ */
+export function resolveTracingConfig(options: ResolveConfigOptions = {}): TracingConfig {
+  const projectPath = resolve(options.cwd ?? process.cwd(), '.codex', TRACING_CONFIG_FILE);
+  const userPath = resolve(options.home ?? homedir(), '.codex', TRACING_CONFIG_FILE);
+  const projectConfig = readTracingConfigFile(projectPath);
+  const userConfig = readTracingConfigFile(userPath);
+  return {
+    trackingUri:
+      process.env.MLFLOW_TRACKING_URI ?? projectConfig.trackingUri ?? userConfig.trackingUri,
+    experimentId:
+      process.env.MLFLOW_EXPERIMENT_ID ?? projectConfig.experimentId ?? userConfig.experimentId,
+  };
+}
+
 /**
  * Initialize the MLflow SDK with tracking URI and experiment settings.
- * No-ops if already initialized or if required env vars are missing.
+ * No-ops if already initialized or if required config is missing.
  */
 export function ensureInitialized(): boolean {
   if (initialized) {
     return true;
   }
 
-  const trackingUri = process.env.MLFLOW_TRACKING_URI;
+  const { trackingUri, experimentId } = resolveTracingConfig();
   if (!trackingUri) {
-    console.error('[mlflow] MLFLOW_TRACKING_URI is not set');
+    console.error(
+      '[mlflow] MLflow tracking URI is not configured — checked $MLFLOW_TRACKING_URI,',
+      './.codex/mlflow-tracing.json, and ~/.codex/mlflow-tracing.json.',
+    );
+    console.error('[mlflow] Run `mlflow-codex setup` to configure.');
     return false;
   }
 
-  init({
-    trackingUri,
-    experimentId: process.env.MLFLOW_EXPERIMENT_ID,
-  });
-
+  init({ trackingUri, experimentId });
   initialized = true;
   return true;
 }

--- a/libs/typescript/integrations/codex/src/hooks/stop.ts
+++ b/libs/typescript/integrations/codex/src/hooks/stop.ts
@@ -1,31 +1,24 @@
 /**
- * Codex notify hook entry point.
+ * Codex notify hook handler.
  *
  * Codex passes the turn data as a JSON string in the first CLI argument:
- *   node stop.js '{"type":"agent-turn-complete","thread-id":"...","input-messages":[...],...}'
+ *   node cli.js '{"type":"agent-turn-complete","thread-id":"...","input-messages":[...],...}'
  *
  * Configured in ~/.codex/config.toml:
- *   notify = ["node", "/path/to/bundle/stop.js"]
+ *   notify = ["mlflow-codex"]
  */
 
 import { ensureInitialized } from '../config.js';
 import { processNotify } from '../tracing.js';
 import type { NotifyPayload } from '../types.js';
 
-async function main(): Promise<void> {
+export async function runNotifyHook(rawPayload: string): Promise<void> {
   try {
-    // Initialize early to fail fast if MLFLOW_TRACKING_URI is not set,
-    // before spending time parsing the payload.
     if (!ensureInitialized()) {
       return;
     }
 
-    const arg = process.argv[2];
-    if (!arg) {
-      return;
-    }
-
-    const payload = JSON.parse(arg) as NotifyPayload;
+    const payload = JSON.parse(rawPayload) as NotifyPayload;
     if (payload.type !== 'agent-turn-complete') {
       return;
     }
@@ -35,5 +28,3 @@ async function main(): Promise<void> {
     console.error('[mlflow]', err);
   }
 }
-
-void main();

--- a/libs/typescript/integrations/codex/src/ui-select.ts
+++ b/libs/typescript/integrations/codex/src/ui-select.ts
@@ -1,0 +1,96 @@
+/**
+ * Minimal arrow-key select prompt for the `mlflow-codex` setup CLI.
+ *
+ * No runtime dependency on `inquirer`/`prompts`: we manage raw-mode stdin
+ * ourselves so the bundled binary stays small, matching the policy in
+ * `ui.ts`. Falls back to the default option when stdin is not a TTY so
+ * piped input (CI, `echo "" | mlflow-codex setup`) never hangs.
+ */
+
+import { emitKeypressEvents } from 'node:readline';
+
+import { bold, cyan, dim } from './ui.js';
+
+export interface SelectOption<T> {
+  value: T;
+  label: string;
+  hint?: string;
+}
+
+export interface SelectPromptOptions<T> {
+  question: string;
+  options: SelectOption<T>[];
+  defaultIndex?: number;
+  input?: NodeJS.ReadStream;
+  output?: NodeJS.WriteStream;
+}
+
+export function selectPrompt<T>(opts: SelectPromptOptions<T>): Promise<T> {
+  const input = opts.input ?? process.stdin;
+  const output = opts.output ?? process.stdout;
+  const defaultIndex = opts.defaultIndex ?? 0;
+  const { options, question } = opts;
+
+  if (!input.isTTY) {
+    return Promise.resolve(options[defaultIndex].value);
+  }
+
+  let current = defaultIndex;
+  let linesRendered = 0;
+
+  const formatLines = (): string[] => [
+    `${bold('?')} ${question}`,
+    ...options.map((o, i) => {
+      const marker = i === current ? cyan('●') : dim('○');
+      const label = i === current ? cyan(o.label) : o.label;
+      const hint = o.hint ? `  ${dim(o.hint)}` : '';
+      const defaultTag = i === defaultIndex ? dim('  (default)') : '';
+      return `  ${marker} ${label}${hint}${defaultTag}`;
+    }),
+    '',
+    `  ${dim('↑/↓ to move, enter to select')}`,
+  ];
+
+  const render = (): void => {
+    if (linesRendered > 0) {
+      output.write(`\x1b[${linesRendered}A\x1b[0J`);
+    }
+    const lines = formatLines();
+    output.write(lines.join('\n') + '\n');
+    linesRendered = lines.length;
+  };
+
+  emitKeypressEvents(input);
+  const wasRaw = input.isRaw;
+  input.setRawMode(true);
+  input.resume();
+
+  return new Promise<T>((resolvePromise) => {
+    const cleanup = (): void => {
+      input.removeListener('keypress', onKeypress);
+      if (!wasRaw) {
+        input.setRawMode(false);
+      }
+      input.pause();
+    };
+
+    const onKeypress = (_str: string, key: { name?: string; ctrl?: boolean }): void => {
+      if (key.ctrl && key.name === 'c') {
+        cleanup();
+        process.exit(130);
+      } else if (key.name === 'up' || key.name === 'k') {
+        current = (current - 1 + options.length) % options.length;
+        render();
+      } else if (key.name === 'down' || key.name === 'j') {
+        current = (current + 1) % options.length;
+        render();
+      } else if (key.name === 'return') {
+        cleanup();
+        resolvePromise(options[current].value);
+      }
+    };
+
+    input.on('keypress', onKeypress);
+    render();
+  });
+}

--- a/libs/typescript/integrations/codex/src/ui.ts
+++ b/libs/typescript/integrations/codex/src/ui.ts
@@ -1,0 +1,31 @@
+/**
+ * Tiny ANSI styling helpers for the `mlflow-codex` CLI.
+ *
+ * No runtime dependency on `chalk`/`kleur`: we keep the bundle small and
+ * respect the usual opt-outs (non-TTY stdout, `NO_COLOR`, `FORCE_COLOR=0`).
+ */
+
+const COLOR_ENABLED = (() => {
+  if (process.env.FORCE_COLOR === '0' || process.env.NO_COLOR) {
+    return false;
+  }
+  if (process.env.FORCE_COLOR) {
+    return true;
+  }
+  return Boolean(process.stdout.isTTY);
+})();
+
+function wrap(code: string): (s: string) => string {
+  return (s: string) => (COLOR_ENABLED ? `\x1b[${code}m${s}\x1b[0m` : s);
+}
+
+export const bold = wrap('1');
+export const dim = wrap('2');
+export const green = wrap('32');
+export const red = wrap('31');
+export const cyan = wrap('36');
+export const yellow = wrap('33');
+
+export const OK = green('✓');
+export const FAIL = red('✗');
+export const WARN = yellow('!');

--- a/libs/typescript/integrations/codex/tests/setup.test.ts
+++ b/libs/typescript/integrations/codex/tests/setup.test.ts
@@ -1,0 +1,74 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { runSetup } from '../src/commands/setup';
+
+describe('runSetup', () => {
+  let tmpHome: string;
+  let originalExitCode: number | string | undefined;
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), 'codex-setup-test-'));
+    originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    rmSync(tmpHome, { recursive: true, force: true });
+    process.exitCode = originalExitCode;
+  });
+
+  function readConfig(path: string): string {
+    return readFileSync(path, 'utf-8');
+  }
+
+  it('creates ~/.codex/config.toml with the notify hook when absent', () => {
+    runSetup([], { home: tmpHome });
+
+    const configPath = join(tmpHome, '.codex', 'config.toml');
+    expect(existsSync(configPath)).toBe(true);
+    const content = readConfig(configPath);
+    expect(content).toContain('notify = ["mlflow-codex"]');
+  });
+
+  it('prepends the notify hook to an existing config that has no notify entry', () => {
+    const configPath = join(tmpHome, '.codex', 'config.toml');
+    mkdirSync(join(tmpHome, '.codex'), { recursive: true });
+    const existing = '[some.section]\nkey = "value"\n';
+    writeFileSync(configPath, existing, 'utf-8');
+
+    runSetup([], { home: tmpHome });
+
+    const content = readConfig(configPath);
+    expect(content).toContain('notify = ["mlflow-codex"]');
+    expect(content).toContain('[some.section]');
+    expect(content).toContain('key = "value"');
+    // notify line must come before the section header so TOML parses correctly
+    expect(content.indexOf('notify = ')).toBeLessThan(content.indexOf('[some.section]'));
+  });
+
+  it('is idempotent when the hook is already registered', () => {
+    runSetup([], { home: tmpHome });
+    const configPath = join(tmpHome, '.codex', 'config.toml');
+    const first = readConfig(configPath);
+
+    runSetup([], { home: tmpHome });
+    const second = readConfig(configPath);
+
+    expect(second).toBe(first);
+    expect(process.exitCode).toBeFalsy();
+  });
+
+  it('refuses to overwrite a different notify entry and signals exit 1', () => {
+    const configPath = join(tmpHome, '.codex', 'config.toml');
+    mkdirSync(join(tmpHome, '.codex'), { recursive: true });
+    writeFileSync(configPath, 'notify = ["some-other-tool"]\n', 'utf-8');
+
+    runSetup([], { home: tmpHome });
+
+    const content = readConfig(configPath);
+    expect(content).toBe('notify = ["some-other-tool"]\n');
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/libs/typescript/integrations/codex/tests/setup.test.ts
+++ b/libs/typescript/integrations/codex/tests/setup.test.ts
@@ -115,6 +115,19 @@ describe('runSetup', () => {
     expect(content).not.toContain(HOOK_LINE);
   });
 
+  it('rejects a tracking URI that is missing an http(s) scheme and exits 1', async () => {
+    await runSetup(
+      ['--non-interactive', '--tracking-uri', 'localhost:5678', '--experiment-id', '48'],
+      { home: tmpHome },
+    );
+
+    expect(process.exitCode).toBe(1);
+    // The notify hook is still registered (that step happens before URI
+    // validation and is idempotent), but the tracing config must not be
+    // written with an invalid URI.
+    expect(existsSync(join(tmpHome, '.codex', 'mlflow-tracing.json'))).toBe(false);
+  });
+
   it('writes to ./.codex/ when --project is passed', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'codex-project-test-'));
     try {

--- a/libs/typescript/integrations/codex/tests/setup.test.ts
+++ b/libs/typescript/integrations/codex/tests/setup.test.ts
@@ -4,6 +4,9 @@ import { join } from 'node:path';
 
 import { runSetup } from '../src/commands/setup';
 
+const HOOK_LINE = 'notify = ["mlflow-codex", "notify-hook"]';
+const NON_INTERACTIVE = ['--non-interactive'];
+
 describe('runSetup', () => {
   let tmpHome: string;
   let originalExitCode: number | string | undefined;
@@ -23,72 +26,105 @@ describe('runSetup', () => {
     return readFileSync(path, 'utf-8');
   }
 
-  it('creates ~/.codex/config.toml with the notify hook when absent', () => {
-    runSetup([], { home: tmpHome });
+  function readJson(path: string): Record<string, unknown> {
+    return JSON.parse(readFileSync(path, 'utf-8')) as Record<string, unknown>;
+  }
+
+  it('creates config.toml and mlflow-tracing.json with defaults when absent', async () => {
+    await runSetup(NON_INTERACTIVE, { home: tmpHome });
 
     const configPath = join(tmpHome, '.codex', 'config.toml');
+    const tracingPath = join(tmpHome, '.codex', 'mlflow-tracing.json');
     expect(existsSync(configPath)).toBe(true);
-    const content = readConfig(configPath);
-    expect(content).toContain('notify = ["mlflow-codex"]');
+    expect(existsSync(tracingPath)).toBe(true);
+    expect(readConfig(configPath)).toContain(HOOK_LINE);
+    expect(readJson(tracingPath)).toEqual({
+      trackingUri: 'http://localhost:5000',
+      experimentId: '0',
+    });
   });
 
-  it('prepends the notify hook to an existing config that has no notify entry', () => {
+  it('writes the supplied --tracking-uri and --experiment-id to mlflow-tracing.json', async () => {
+    await runSetup(
+      ['--non-interactive', '--tracking-uri', 'http://mlflow.example/', '--experiment-id', '42'],
+      { home: tmpHome },
+    );
+
+    expect(readJson(join(tmpHome, '.codex', 'mlflow-tracing.json'))).toEqual({
+      trackingUri: 'http://mlflow.example/',
+      experimentId: '42',
+    });
+  });
+
+  it('prepends the notify hook to an existing config that has no notify entry', async () => {
     const configPath = join(tmpHome, '.codex', 'config.toml');
     mkdirSync(join(tmpHome, '.codex'), { recursive: true });
     const existing = '[some.section]\nkey = "value"\n';
     writeFileSync(configPath, existing, 'utf-8');
 
-    runSetup([], { home: tmpHome });
+    await runSetup(NON_INTERACTIVE, { home: tmpHome });
 
     const content = readConfig(configPath);
-    expect(content).toContain('notify = ["mlflow-codex"]');
+    expect(content).toContain(HOOK_LINE);
     expect(content).toContain('[some.section]');
     expect(content).toContain('key = "value"');
     // notify line must come before the section header so TOML parses correctly
     expect(content.indexOf('notify = ')).toBeLessThan(content.indexOf('[some.section]'));
   });
 
-  it('is idempotent when the hook is already registered', () => {
-    runSetup([], { home: tmpHome });
+  it('is idempotent when the hook is already registered', async () => {
+    await runSetup(NON_INTERACTIVE, { home: tmpHome });
     const configPath = join(tmpHome, '.codex', 'config.toml');
     const first = readConfig(configPath);
 
-    runSetup([], { home: tmpHome });
+    await runSetup(NON_INTERACTIVE, { home: tmpHome });
     const second = readConfig(configPath);
 
     expect(second).toBe(first);
     expect(process.exitCode).toBeFalsy();
   });
 
-  it('refuses to overwrite a different notify entry and signals exit 1', () => {
+  it('refuses to overwrite a different notify entry and signals exit 1', async () => {
     const configPath = join(tmpHome, '.codex', 'config.toml');
     mkdirSync(join(tmpHome, '.codex'), { recursive: true });
     writeFileSync(configPath, 'notify = ["some-other-tool"]\n', 'utf-8');
 
-    runSetup([], { home: tmpHome });
+    await runSetup(NON_INTERACTIVE, { home: tmpHome });
 
     const content = readConfig(configPath);
     expect(content).toBe('notify = ["some-other-tool"]\n');
     expect(process.exitCode).toBe(1);
+    // mlflow-tracing.json must not be written when we refuse to touch config.toml.
+    expect(existsSync(join(tmpHome, '.codex', 'mlflow-tracing.json'))).toBe(false);
   });
 
-  it('does not treat a comment mentioning "mlflow-codex" as an existing registration', () => {
+  it('does not treat a comment mentioning "mlflow-codex" as an existing registration', async () => {
     const configPath = join(tmpHome, '.codex', 'config.toml');
     mkdirSync(join(tmpHome, '.codex'), { recursive: true });
-    // The mlflow-codex string appears in a comment, not in the notify
-    // assignment. The user's actual notify hook is some-other-tool, so the
-    // setup command must error out rather than silently claim success.
     writeFileSync(
       configPath,
       '# TODO: switch to mlflow-codex\nnotify = ["some-other-tool"]\n',
       'utf-8',
     );
 
-    runSetup([], { home: tmpHome });
+    await runSetup(NON_INTERACTIVE, { home: tmpHome });
 
     expect(process.exitCode).toBe(1);
     const content = readConfig(configPath);
     expect(content).toContain('notify = ["some-other-tool"]');
-    expect(content).not.toContain('notify = ["mlflow-codex"]');
+    expect(content).not.toContain(HOOK_LINE);
+  });
+
+  it('writes to ./.codex/ when --project is passed', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'codex-project-test-'));
+    try {
+      await runSetup([...NON_INTERACTIVE, '--project'], { home: tmpHome, cwd });
+      expect(existsSync(join(cwd, '.codex', 'config.toml'))).toBe(true);
+      expect(existsSync(join(cwd, '.codex', 'mlflow-tracing.json'))).toBe(true);
+      expect(existsSync(join(tmpHome, '.codex', 'config.toml'))).toBe(false);
+      expect(existsSync(join(tmpHome, '.codex', 'mlflow-tracing.json'))).toBe(false);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
   });
 });

--- a/libs/typescript/integrations/codex/tests/setup.test.ts
+++ b/libs/typescript/integrations/codex/tests/setup.test.ts
@@ -71,4 +71,24 @@ describe('runSetup', () => {
     expect(content).toBe('notify = ["some-other-tool"]\n');
     expect(process.exitCode).toBe(1);
   });
+
+  it('does not treat a comment mentioning "mlflow-codex" as an existing registration', () => {
+    const configPath = join(tmpHome, '.codex', 'config.toml');
+    mkdirSync(join(tmpHome, '.codex'), { recursive: true });
+    // The mlflow-codex string appears in a comment, not in the notify
+    // assignment. The user's actual notify hook is some-other-tool, so the
+    // setup command must error out rather than silently claim success.
+    writeFileSync(
+      configPath,
+      '# TODO: switch to mlflow-codex\nnotify = ["some-other-tool"]\n',
+      'utf-8',
+    );
+
+    runSetup([], { home: tmpHome });
+
+    expect(process.exitCode).toBe(1);
+    const content = readConfig(configPath);
+    expect(content).toContain('notify = ["some-other-tool"]');
+    expect(content).not.toContain('notify = ["mlflow-codex"]');
+  });
 });

--- a/libs/typescript/integrations/codex/tests/setup.test.ts
+++ b/libs/typescript/integrations/codex/tests/setup.test.ts
@@ -4,6 +4,36 @@ import { join } from 'node:path';
 
 import { runSetup } from '../src/commands/setup';
 
+jest.mock('node:readline', () => ({ createInterface: jest.fn() }));
+jest.mock('../src/ui-select', () => ({ selectPrompt: jest.fn() }));
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { createInterface } = require('node:readline') as {
+  createInterface: jest.Mock;
+};
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { selectPrompt } = require('../src/ui-select') as {
+  selectPrompt: jest.Mock;
+};
+
+function mockTextPrompts(answers: string[]): void {
+  const queue = [...answers];
+  createInterface.mockImplementation(() => ({
+    question: (_prompt: string, cb: (answer: string) => void) => {
+      const next = queue.shift();
+      if (next === undefined) {
+        throw new Error('mockTextPrompts: ran out of answers');
+      }
+      cb(next);
+    },
+    close: () => {},
+  }));
+}
+
+beforeEach(() => {
+  selectPrompt.mockReset();
+  createInterface.mockReset();
+});
+
 const HOOK_LINE = 'notify = ["mlflow-codex", "notify-hook"]';
 const NON_INTERACTIVE = ['--non-interactive'];
 
@@ -136,6 +166,64 @@ describe('runSetup', () => {
       expect(existsSync(join(cwd, '.codex', 'mlflow-tracing.json'))).toBe(true);
       expect(existsSync(join(tmpHome, '.codex', 'config.toml'))).toBe(false);
       expect(existsSync(join(tmpHome, '.codex', 'mlflow-tracing.json'))).toBe(false);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('interactive scope prompt picks project-local when the user selects Project', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'codex-interactive-project-'));
+    try {
+      selectPrompt.mockResolvedValueOnce(true);
+      mockTextPrompts(['', '']);
+      await runSetup([], { home: tmpHome, cwd });
+
+      expect(selectPrompt).toHaveBeenCalledTimes(1);
+      expect(existsSync(join(cwd, '.codex', 'config.toml'))).toBe(true);
+      expect(existsSync(join(cwd, '.codex', 'mlflow-tracing.json'))).toBe(true);
+      expect(existsSync(join(tmpHome, '.codex', 'config.toml'))).toBe(false);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('interactive scope prompt writes user-level when the user selects User', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'codex-interactive-user-'));
+    try {
+      selectPrompt.mockResolvedValueOnce(false);
+      mockTextPrompts(['', '']);
+      await runSetup([], { home: tmpHome, cwd });
+
+      expect(existsSync(join(tmpHome, '.codex', 'config.toml'))).toBe(true);
+      expect(existsSync(join(tmpHome, '.codex', 'mlflow-tracing.json'))).toBe(true);
+      expect(existsSync(join(cwd, '.codex', 'config.toml'))).toBe(false);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('skips the scope prompt when --project is explicitly passed', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'codex-interactive-flag-'));
+    try {
+      mockTextPrompts(['', '']);
+      await runSetup(['--project'], { home: tmpHome, cwd });
+
+      expect(selectPrompt).not.toHaveBeenCalled();
+      expect(existsSync(join(cwd, '.codex', 'config.toml'))).toBe(true);
+      expect(existsSync(join(tmpHome, '.codex', 'config.toml'))).toBe(false);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('skips the scope prompt in --non-interactive mode and defaults to user-level', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'codex-non-interactive-scope-'));
+    try {
+      await runSetup(NON_INTERACTIVE, { home: tmpHome, cwd });
+
+      expect(selectPrompt).not.toHaveBeenCalled();
+      expect(existsSync(join(tmpHome, '.codex', 'config.toml'))).toBe(true);
+      expect(existsSync(join(cwd, '.codex', 'config.toml'))).toBe(false);
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }

--- a/libs/typescript/integrations/codex/tests/setup.test.ts
+++ b/libs/typescript/integrations/codex/tests/setup.test.ts
@@ -1,37 +1,36 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { createInterface } from 'node:readline';
 
 import { runSetup } from '../src/commands/setup';
+import { selectPrompt } from '../src/ui-select';
 
 jest.mock('node:readline', () => ({ createInterface: jest.fn() }));
 jest.mock('../src/ui-select', () => ({ selectPrompt: jest.fn() }));
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const { createInterface } = require('node:readline') as {
-  createInterface: jest.Mock;
-};
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const { selectPrompt } = require('../src/ui-select') as {
-  selectPrompt: jest.Mock;
-};
+const createInterfaceMock = jest.mocked(createInterface);
+const selectPromptMock = jest.mocked(selectPrompt);
 
 function mockTextPrompts(answers: string[]): void {
   const queue = [...answers];
-  createInterface.mockImplementation(() => ({
-    question: (_prompt: string, cb: (answer: string) => void) => {
-      const next = queue.shift();
-      if (next === undefined) {
-        throw new Error('mockTextPrompts: ran out of answers');
-      }
-      cb(next);
-    },
-    close: () => {},
-  }));
+  createInterfaceMock.mockImplementation(
+    () =>
+      ({
+        question: (_prompt: string, cb: (answer: string) => void) => {
+          const next = queue.shift();
+          if (next === undefined) {
+            throw new Error('mockTextPrompts: ran out of answers');
+          }
+          cb(next);
+        },
+        close: () => {},
+      }) as unknown as ReturnType<typeof createInterface>,
+  );
 }
 
 beforeEach(() => {
-  selectPrompt.mockReset();
-  createInterface.mockReset();
+  selectPromptMock.mockReset();
+  createInterfaceMock.mockReset();
 });
 
 const HOOK_LINE = 'notify = ["mlflow-codex", "notify-hook"]';
@@ -174,11 +173,11 @@ describe('runSetup', () => {
   it('interactive scope prompt picks project-local when the user selects Project', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'codex-interactive-project-'));
     try {
-      selectPrompt.mockResolvedValueOnce(true);
+      selectPromptMock.mockResolvedValueOnce(true);
       mockTextPrompts(['', '']);
       await runSetup([], { home: tmpHome, cwd });
 
-      expect(selectPrompt).toHaveBeenCalledTimes(1);
+      expect(selectPromptMock).toHaveBeenCalledTimes(1);
       expect(existsSync(join(cwd, '.codex', 'config.toml'))).toBe(true);
       expect(existsSync(join(cwd, '.codex', 'mlflow-tracing.json'))).toBe(true);
       expect(existsSync(join(tmpHome, '.codex', 'config.toml'))).toBe(false);
@@ -190,7 +189,7 @@ describe('runSetup', () => {
   it('interactive scope prompt writes user-level when the user selects User', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'codex-interactive-user-'));
     try {
-      selectPrompt.mockResolvedValueOnce(false);
+      selectPromptMock.mockResolvedValueOnce(false);
       mockTextPrompts(['', '']);
       await runSetup([], { home: tmpHome, cwd });
 
@@ -208,7 +207,7 @@ describe('runSetup', () => {
       mockTextPrompts(['', '']);
       await runSetup(['--project'], { home: tmpHome, cwd });
 
-      expect(selectPrompt).not.toHaveBeenCalled();
+      expect(selectPromptMock).not.toHaveBeenCalled();
       expect(existsSync(join(cwd, '.codex', 'config.toml'))).toBe(true);
       expect(existsSync(join(tmpHome, '.codex', 'config.toml'))).toBe(false);
     } finally {
@@ -221,7 +220,7 @@ describe('runSetup', () => {
     try {
       await runSetup(NON_INTERACTIVE, { home: tmpHome, cwd });
 
-      expect(selectPrompt).not.toHaveBeenCalled();
+      expect(selectPromptMock).not.toHaveBeenCalled();
       expect(existsSync(join(tmpHome, '.codex', 'config.toml'))).toBe(true);
       expect(existsSync(join(cwd, '.codex', 'config.toml'))).toBe(false);
     } finally {

--- a/libs/typescript/integrations/qwen-code/esbuild.config.mjs
+++ b/libs/typescript/integrations/qwen-code/esbuild.config.mjs
@@ -2,11 +2,11 @@ import { build } from 'esbuild';
 import { chmodSync } from 'node:fs';
 
 await build({
-  entryPoints: ['dist/hooks/stop.js'],
+  entryPoints: ['dist/cli.js'],
   bundle: true,
   platform: 'node',
   format: 'esm',
-  outfile: 'bundle/stop.js',
+  outfile: 'bundle/cli.js',
   external: ['node:*'],
   banner: {
     js: [
@@ -17,4 +17,4 @@ await build({
   },
 });
 
-chmodSync('bundle/stop.js', 0o755);
+chmodSync('bundle/cli.js', 0o755);

--- a/libs/typescript/integrations/qwen-code/package.json
+++ b/libs/typescript/integrations/qwen-code/package.json
@@ -30,6 +30,9 @@
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "bin": {
+    "mlflow-qwen-code": "./bundle/cli.js"
+  },
   "scripts": {
     "build": "tsc && npm run build:bundle",
     "build:bundle": "node esbuild.config.mjs",

--- a/libs/typescript/integrations/qwen-code/src/cli.ts
+++ b/libs/typescript/integrations/qwen-code/src/cli.ts
@@ -25,7 +25,9 @@ function printUsage(): void {
   console.error('');
   console.error(`              ${dim('Flags:')}`);
   console.error(
-    dim('                --project, -p          Write to ./.qwen/ instead of ~/.qwen/'),
+    dim(
+      '                --project, -p          Write to ./.qwen/ (skip the interactive scope prompt)',
+    ),
   );
   console.error(
     dim('                --non-interactive, -y  Skip prompts; use flag values or defaults'),

--- a/libs/typescript/integrations/qwen-code/src/cli.ts
+++ b/libs/typescript/integrations/qwen-code/src/cli.ts
@@ -1,49 +1,59 @@
 /**
  * CLI dispatcher for `@mlflow/qwen-code`.
  *
- * Installed as the `mlflow-qwen-code` bin. Dispatches on the first CLI arg:
- *   - no args       → runs the Stop hook (reads stdin JSON from Qwen Code)
- *   - `setup`       → registers the hook in ~/.qwen/settings.json
+ * Installed as the `mlflow-qwen-code` bin. Subcommands:
+ *   - `setup`       → registers the hook and writes mlflow-tracing.json
+ *   - `stop-hook`   → runs the Stop hook (reads stdin JSON from Qwen Code)
  *   - `--help`/`-h` → prints usage
+ *
+ * Qwen Code invokes `mlflow-qwen-code stop-hook` as the registered Stop hook.
  */
 
 import { runStopHook } from './hooks/stop.js';
 import { runSetup } from './commands/setup.js';
 
 function printUsage(): void {
-  console.error('Usage: mlflow-qwen-code [command]');
+  console.error('Usage: mlflow-qwen-code <command> [options]');
   console.error('');
   console.error('Commands:');
-  console.error('  setup [--project|-p]   Register the Stop hook in Qwen settings.json');
-  console.error(
-    '                         (user-level by default; --project or -p writes to ./.qwen/settings.json)',
-  );
+  console.error('  setup       Register the Stop hook in Qwen settings.json and configure');
+  console.error('              the MLflow tracking URI / experiment ID. Runs interactively');
+  console.error('              by default.');
   console.error('');
-  console.error('When invoked with no command, reads a Stop hook payload from stdin.');
-  console.error('This is the form Qwen Code itself uses via settings.json.');
+  console.error('              Flags:');
+  console.error('                --project, -p          Write to ./.qwen/ instead of ~/.qwen/');
+  console.error('                --non-interactive, -y  Skip prompts; use flag values or defaults');
+  console.error('                --tracking-uri <url>   Bypass the prompt for the tracking URI');
+  console.error('                --experiment-id <id>   Bypass the prompt for the experiment ID');
+  console.error('');
+  console.error('  stop-hook   Run the Qwen Code Stop hook. Reads the hook payload from stdin');
+  console.error('              — this is the form Qwen itself invokes via settings.json.');
 }
 
 async function main(): Promise<void> {
   const [, , command, ...rest] = process.argv;
 
-  if (command === '--help' || command === '-h' || command === 'help') {
+  if (command === undefined || command === '--help' || command === '-h' || command === 'help') {
     printUsage();
+    if (command === undefined) {
+      process.exitCode = 1;
+    }
     return;
   }
 
   if (command === 'setup') {
-    runSetup(rest);
+    await runSetup(rest);
     return;
   }
 
-  if (command !== undefined) {
-    console.error(`[mlflow] Unknown command: ${command}`);
-    printUsage();
-    process.exitCode = 1;
+  if (command === 'stop-hook') {
+    await runStopHook();
     return;
   }
 
-  await runStopHook();
+  console.error(`[mlflow] Unknown command: ${command}`);
+  printUsage();
+  process.exitCode = 1;
 }
 
 void main();

--- a/libs/typescript/integrations/qwen-code/src/cli.ts
+++ b/libs/typescript/integrations/qwen-code/src/cli.ts
@@ -14,9 +14,9 @@ function printUsage(): void {
   console.error('Usage: mlflow-qwen-code [command]');
   console.error('');
   console.error('Commands:');
-  console.error('  setup [--project]   Register the Stop hook in Qwen settings.json');
+  console.error('  setup [--project|-p]   Register the Stop hook in Qwen settings.json');
   console.error(
-    '                      (user-level by default; --project writes to ./.qwen/settings.json)',
+    '                         (user-level by default; --project or -p writes to ./.qwen/settings.json)',
   );
   console.error('');
   console.error('When invoked with no command, reads a Stop hook payload from stdin.');

--- a/libs/typescript/integrations/qwen-code/src/cli.ts
+++ b/libs/typescript/integrations/qwen-code/src/cli.ts
@@ -11,22 +11,35 @@
 
 import { runStopHook } from './hooks/stop.js';
 import { runSetup } from './commands/setup.js';
+import { FAIL, bold, dim } from './ui.js';
 
 function printUsage(): void {
-  console.error('Usage: mlflow-qwen-code <command> [options]');
+  console.error(`${bold('Usage:')} mlflow-qwen-code <command> [options]`);
   console.error('');
-  console.error('Commands:');
-  console.error('  setup       Register the Stop hook in Qwen settings.json and configure');
+  console.error(bold('Commands:'));
+  console.error(
+    `  ${bold('setup')}       Register the Stop hook in Qwen settings.json and configure`,
+  );
   console.error('              the MLflow tracking URI / experiment ID. Runs interactively');
   console.error('              by default.');
   console.error('');
-  console.error('              Flags:');
-  console.error('                --project, -p          Write to ./.qwen/ instead of ~/.qwen/');
-  console.error('                --non-interactive, -y  Skip prompts; use flag values or defaults');
-  console.error('                --tracking-uri <url>   Bypass the prompt for the tracking URI');
-  console.error('                --experiment-id <id>   Bypass the prompt for the experiment ID');
+  console.error(`              ${dim('Flags:')}`);
+  console.error(
+    dim('                --project, -p          Write to ./.qwen/ instead of ~/.qwen/'),
+  );
+  console.error(
+    dim('                --non-interactive, -y  Skip prompts; use flag values or defaults'),
+  );
+  console.error(
+    dim('                --tracking-uri <url>   Bypass the prompt for the tracking URI'),
+  );
+  console.error(
+    dim('                --experiment-id <id>   Bypass the prompt for the experiment ID'),
+  );
   console.error('');
-  console.error('  stop-hook   Run the Qwen Code Stop hook. Reads the hook payload from stdin');
+  console.error(
+    `  ${bold('stop-hook')}   Run the Qwen Code Stop hook. Reads the hook payload from stdin`,
+  );
   console.error('              — this is the form Qwen itself invokes via settings.json.');
 }
 
@@ -51,7 +64,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  console.error(`[mlflow] Unknown command: ${command}`);
+  console.error(`${FAIL} Unknown command: ${bold(command)}\n`);
   printUsage();
   process.exitCode = 1;
 }

--- a/libs/typescript/integrations/qwen-code/src/cli.ts
+++ b/libs/typescript/integrations/qwen-code/src/cli.ts
@@ -1,0 +1,49 @@
+/**
+ * CLI dispatcher for `@mlflow/qwen-code`.
+ *
+ * Installed as the `mlflow-qwen-code` bin. Dispatches on the first CLI arg:
+ *   - no args       → runs the Stop hook (reads stdin JSON from Qwen Code)
+ *   - `setup`       → registers the hook in ~/.qwen/settings.json
+ *   - `--help`/`-h` → prints usage
+ */
+
+import { runStopHook } from './hooks/stop.js';
+import { runSetup } from './commands/setup.js';
+
+function printUsage(): void {
+  console.error('Usage: mlflow-qwen-code [command]');
+  console.error('');
+  console.error('Commands:');
+  console.error('  setup [--project]   Register the Stop hook in Qwen settings.json');
+  console.error(
+    '                      (user-level by default; --project writes to ./.qwen/settings.json)',
+  );
+  console.error('');
+  console.error('When invoked with no command, reads a Stop hook payload from stdin.');
+  console.error('This is the form Qwen Code itself uses via settings.json.');
+}
+
+async function main(): Promise<void> {
+  const [, , command, ...rest] = process.argv;
+
+  if (command === '--help' || command === '-h' || command === 'help') {
+    printUsage();
+    return;
+  }
+
+  if (command === 'setup') {
+    runSetup(rest);
+    return;
+  }
+
+  if (command !== undefined) {
+    console.error(`[mlflow] Unknown command: ${command}`);
+    printUsage();
+    process.exitCode = 1;
+    return;
+  }
+
+  await runStopHook();
+}
+
+void main();

--- a/libs/typescript/integrations/qwen-code/src/commands/setup.ts
+++ b/libs/typescript/integrations/qwen-code/src/commands/setup.ts
@@ -43,7 +43,7 @@ export function resolveSettingsPath(projectLocal: boolean, options: SetupOptions
     : resolve(options.home ?? homedir(), '.qwen', 'settings.json');
 }
 
-function readSettings(path: string): QwenSettings {
+function readSettings(path: string): QwenSettings | null {
   if (!existsSync(path)) {
     return {};
   }
@@ -51,7 +51,14 @@ function readSettings(path: string): QwenSettings {
   if (!content) {
     return {};
   }
-  return JSON.parse(content) as QwenSettings;
+  try {
+    return JSON.parse(content) as QwenSettings;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[mlflow] Failed to parse ${path}: ${msg}`);
+    console.error('[mlflow] Fix the file manually and rerun `mlflow-qwen-code setup`.');
+    return null;
+  }
 }
 
 function writeSettings(path: string, settings: QwenSettings): void {
@@ -68,6 +75,10 @@ export function runSetup(args: string[], options: SetupOptions = {}): void {
   const settingsPath = resolveSettingsPath(projectLocal, options);
 
   const settings = readSettings(settingsPath);
+  if (settings == null) {
+    process.exitCode = 1;
+    return;
+  }
   settings.hooks ??= {};
   settings.hooks.Stop ??= [];
 

--- a/libs/typescript/integrations/qwen-code/src/commands/setup.ts
+++ b/libs/typescript/integrations/qwen-code/src/commands/setup.ts
@@ -1,17 +1,24 @@
 /**
- * `mlflow-qwen-code setup` — register the Stop hook in the user's Qwen Code
- * settings file so tracing is active on the next `qwen` invocation.
+ * `mlflow-qwen-code setup` — interactively register the Stop hook in the
+ * user's Qwen Code settings and write an MLflow tracing config alongside it.
  *
- * Writes to `~/.qwen/settings.json` by default, or `./.qwen/settings.json`
- * when `--project` is passed. Creates the file if it doesn't exist; leaves
- * existing fields untouched.
+ * Writes:
+ *   - `~/.qwen/settings.json` — registers the `mlflow-qwen-code stop-hook`
+ *     entry under `hooks.Stop`; leaves unrelated fields untouched.
+ *   - `~/.qwen/mlflow-tracing.json` — persists the tracking URI and
+ *     experiment ID so the hook can run without shell exports.
+ *
+ * `--project` (or `-p`) writes to `./.qwen/` instead of `~/.qwen/`.
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, resolve } from 'node:path';
+import { createInterface } from 'node:readline';
 
-const HOOK_COMMAND = 'mlflow-qwen-code';
+const HOOK_COMMAND = 'mlflow-qwen-code stop-hook';
+const DEFAULT_TRACKING_URI = 'http://localhost:5000';
+const DEFAULT_EXPERIMENT_ID = '0';
 
 interface QwenHookEntry {
   type: string;
@@ -35,12 +42,24 @@ export interface SetupOptions {
   home?: string;
   /** Override the current working directory. Defaults to `process.cwd()`. */
   cwd?: string;
+  /** Pre-supplied tracking URI. Skips the interactive prompt. */
+  trackingUri?: string;
+  /** Pre-supplied experiment ID. Skips the interactive prompt. */
+  experimentId?: string;
+  /** Suppress prompts entirely. Uses defaults for any unset values. */
+  nonInteractive?: boolean;
 }
 
 export function resolveSettingsPath(projectLocal: boolean, options: SetupOptions = {}): string {
   return projectLocal
     ? resolve(options.cwd ?? process.cwd(), '.qwen', 'settings.json')
     : resolve(options.home ?? homedir(), '.qwen', 'settings.json');
+}
+
+function resolveTracingConfigPath(projectLocal: boolean, options: SetupOptions = {}): string {
+  return projectLocal
+    ? resolve(options.cwd ?? process.cwd(), '.qwen', 'mlflow-tracing.json')
+    : resolve(options.home ?? homedir(), '.qwen', 'mlflow-tracing.json');
 }
 
 function readSettings(path: string): QwenSettings | null {
@@ -66,13 +85,81 @@ function writeSettings(path: string, settings: QwenSettings): void {
   writeFileSync(path, JSON.stringify(settings, null, 2) + '\n', 'utf-8');
 }
 
+function writeTracingConfig(
+  path: string,
+  config: { trackingUri: string; experimentId: string },
+): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+}
+
 function hasMlflowHook(groups: QwenHookGroup[]): boolean {
   return groups.some((group) => group.hooks?.some((hook) => hook.command?.trim() === HOOK_COMMAND));
 }
 
-export function runSetup(args: string[], options: SetupOptions = {}): void {
-  const projectLocal = args.includes('--project') || args.includes('-p');
-  const settingsPath = resolveSettingsPath(projectLocal, options);
+/**
+ * Parse raw CLI args for the setup command. Supports:
+ *   --project / -p
+ *   --non-interactive / -y
+ *   --tracking-uri <url>
+ *   --experiment-id <id>
+ */
+export function parseSetupArgs(args: string[]): SetupOptions & { projectLocal: boolean } {
+  const out: SetupOptions & { projectLocal: boolean } = { projectLocal: false };
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--project' || arg === '-p') {
+      out.projectLocal = true;
+    } else if (arg === '--non-interactive' || arg === '-y') {
+      out.nonInteractive = true;
+    } else if (arg === '--tracking-uri') {
+      out.trackingUri = args[++i];
+    } else if (arg === '--experiment-id') {
+      out.experimentId = args[++i];
+    }
+  }
+  return out;
+}
+
+function prompt(label: string, defaultValue: string): Promise<string> {
+  return new Promise((resolvePromise) => {
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    rl.question(`${label} [${defaultValue}]: `, (answer) => {
+      rl.close();
+      resolvePromise(answer.trim() || defaultValue);
+    });
+  });
+}
+
+async function resolveTracingValues(
+  options: SetupOptions,
+): Promise<{ trackingUri: string; experimentId: string }> {
+  if (options.nonInteractive) {
+    return {
+      trackingUri: options.trackingUri ?? DEFAULT_TRACKING_URI,
+      experimentId: options.experimentId ?? DEFAULT_EXPERIMENT_ID,
+    };
+  }
+  if (options.trackingUri && options.experimentId) {
+    return { trackingUri: options.trackingUri, experimentId: options.experimentId };
+  }
+  console.error('[mlflow] Configuring MLflow tracing for Qwen Code.');
+  const trackingUri =
+    options.trackingUri ?? (await prompt('MLflow tracking URI', DEFAULT_TRACKING_URI));
+  const experimentId =
+    options.experimentId ?? (await prompt('MLflow experiment ID', DEFAULT_EXPERIMENT_ID));
+  return { trackingUri, experimentId };
+}
+
+export async function runSetup(args: string[], options: SetupOptions = {}): Promise<void> {
+  const parsed = parseSetupArgs(args);
+  const merged: SetupOptions & { projectLocal: boolean } = {
+    ...parsed,
+    ...options,
+    projectLocal: parsed.projectLocal,
+  };
+  const settingsPath = resolveSettingsPath(merged.projectLocal, merged);
+  const tracingConfigPath = resolveTracingConfigPath(merged.projectLocal, merged);
 
   const settings = readSettings(settingsPath);
   if (settings == null) {
@@ -83,7 +170,7 @@ export function runSetup(args: string[], options: SetupOptions = {}): void {
   settings.hooks.Stop ??= [];
 
   if (hasMlflowHook(settings.hooks.Stop)) {
-    console.error(`[mlflow] Hook already registered in ${settingsPath}`);
+    console.error(`[mlflow] Stop hook already registered in ${settingsPath}`);
   } else {
     settings.hooks.Stop.push({
       hooks: [{ type: 'command', command: HOOK_COMMAND }],
@@ -92,11 +179,18 @@ export function runSetup(args: string[], options: SetupOptions = {}): void {
     console.error(`[mlflow] Registered Stop hook in ${settingsPath}`);
   }
 
+  const { trackingUri, experimentId } = await resolveTracingValues(merged);
+  writeTracingConfig(tracingConfigPath, { trackingUri, experimentId });
+  console.error(`[mlflow] Wrote tracing config to ${tracingConfigPath}`);
+
   console.error('\nNext steps:');
-  console.error('  1. Export MLflow environment variables in the shell that launches `qwen`:');
-  console.error('       export MLFLOW_TRACKING_URI=http://localhost:5000');
-  console.error('       export MLFLOW_EXPERIMENT_ID=0');
-  console.error('  2. Start the MLflow tracking server in a separate terminal:');
-  console.error('       mlflow server --host 0.0.0.0 --port 5000');
-  console.error('  3. Launch `qwen` — traces appear at http://localhost:5000 after each turn.');
+  console.error('  1. Start the MLflow tracking server in a separate terminal:');
+  console.error(
+    `       mlflow server --host 0.0.0.0 --port ${new URL(trackingUri).port || '5000'}`,
+  );
+  console.error(`  2. Launch \`qwen\` — traces appear at ${trackingUri} after each turn.`);
+  console.error(
+    '\nThe tracking URI and experiment ID can be overridden per-shell with',
+    '$MLFLOW_TRACKING_URI / $MLFLOW_EXPERIMENT_ID.',
+  );
 }

--- a/libs/typescript/integrations/qwen-code/src/commands/setup.ts
+++ b/libs/typescript/integrations/qwen-code/src/commands/setup.ts
@@ -16,9 +16,26 @@ import { homedir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { createInterface } from 'node:readline';
 
+import { FAIL, OK, WARN, bold, cyan, dim } from '../ui.js';
+
 const HOOK_COMMAND = 'mlflow-qwen-code stop-hook';
 const DEFAULT_TRACKING_URI = 'http://localhost:5000';
 const DEFAULT_EXPERIMENT_ID = '0';
+
+/**
+ * Returns true only when `raw` parses as a URL with an http(s) scheme.
+ * Rejects scheme-less inputs like `localhost:5000` (which `new URL` otherwise
+ * interprets as a custom scheme with an empty port).
+ */
+export function isValidTrackingUri(raw: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return false;
+  }
+  return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+}
 
 interface QwenHookEntry {
   type: string;
@@ -74,8 +91,8 @@ function readSettings(path: string): QwenSettings | null {
     return JSON.parse(content) as QwenSettings;
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    console.error(`[mlflow] Failed to parse ${path}: ${msg}`);
-    console.error('[mlflow] Fix the file manually and rerun `mlflow-qwen-code setup`.');
+    console.error(`${FAIL} Failed to parse ${cyan(path)}: ${msg}`);
+    console.error(`  Fix the file manually and rerun ${cyan('mlflow-qwen-code setup')}.`);
     return null;
   }
 }
@@ -121,15 +138,33 @@ export function parseSetupArgs(args: string[]): SetupOptions & { projectLocal: b
   return out;
 }
 
-function prompt(label: string, defaultValue: string): Promise<string> {
+type Readline = ReturnType<typeof createInterface>;
+
+function askOn(
+  rl: Readline,
+  label: string,
+  defaultValue: string,
+  validate?: (value: string) => string | null,
+): Promise<string> {
   return new Promise((resolvePromise) => {
-    const rl = createInterface({ input: process.stdin, output: process.stdout });
-    rl.question(`${label} [${defaultValue}]: `, (answer) => {
-      rl.close();
-      resolvePromise(answer.trim() || defaultValue);
-    });
+    const ask = (): void => {
+      rl.question(`  ${label} ${dim(`[${defaultValue}]`)} `, (answer) => {
+        const value = answer.trim() || defaultValue;
+        const err = validate?.(value);
+        if (err) {
+          console.error(`  ${FAIL} ${err}`);
+          ask();
+          return;
+        }
+        resolvePromise(value);
+      });
+    };
+    ask();
   });
 }
+
+const validateTrackingUri = (value: string): string | null =>
+  isValidTrackingUri(value) ? null : 'Must be an absolute http:// or https:// URL.';
 
 async function resolveTracingValues(
   options: SetupOptions,
@@ -143,12 +178,18 @@ async function resolveTracingValues(
   if (options.trackingUri && options.experimentId) {
     return { trackingUri: options.trackingUri, experimentId: options.experimentId };
   }
-  console.error('[mlflow] Configuring MLflow tracing for Qwen Code.');
-  const trackingUri =
-    options.trackingUri ?? (await prompt('MLflow tracking URI', DEFAULT_TRACKING_URI));
-  const experimentId =
-    options.experimentId ?? (await prompt('MLflow experiment ID', DEFAULT_EXPERIMENT_ID));
-  return { trackingUri, experimentId };
+  console.error(`\n${bold('Configure MLflow tracing for Qwen Code')}`);
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const trackingUri =
+      options.trackingUri ??
+      (await askOn(rl, 'MLflow tracking URI', DEFAULT_TRACKING_URI, validateTrackingUri));
+    const experimentId =
+      options.experimentId ?? (await askOn(rl, 'MLflow experiment ID', DEFAULT_EXPERIMENT_ID));
+    return { trackingUri, experimentId };
+  } finally {
+    rl.close();
+  }
 }
 
 export async function runSetup(args: string[], options: SetupOptions = {}): Promise<void> {
@@ -170,27 +211,34 @@ export async function runSetup(args: string[], options: SetupOptions = {}): Prom
   settings.hooks.Stop ??= [];
 
   if (hasMlflowHook(settings.hooks.Stop)) {
-    console.error(`[mlflow] Stop hook already registered in ${settingsPath}`);
+    console.error(`${WARN} Stop hook already registered in ${cyan(settingsPath)}`);
   } else {
     settings.hooks.Stop.push({
       hooks: [{ type: 'command', command: HOOK_COMMAND }],
     });
     writeSettings(settingsPath, settings);
-    console.error(`[mlflow] Registered Stop hook in ${settingsPath}`);
+    console.error(`${OK} Registered Stop hook in ${cyan(settingsPath)}`);
   }
 
   const { trackingUri, experimentId } = await resolveTracingValues(merged);
+  if (!isValidTrackingUri(trackingUri)) {
+    console.error(
+      `${FAIL} Invalid tracking URI: ${bold(trackingUri)} — must be an absolute http:// or https:// URL.`,
+    );
+    process.exitCode = 1;
+    return;
+  }
   writeTracingConfig(tracingConfigPath, { trackingUri, experimentId });
-  console.error(`[mlflow] Wrote tracing config to ${tracingConfigPath}`);
+  console.error(`\n${OK} Wrote tracing config to ${cyan(tracingConfigPath)}`);
 
-  console.error('\nNext steps:');
+  const port = new URL(trackingUri).port || '5000';
+  console.error(`\n${bold('Next steps')}`);
   console.error('  1. Start the MLflow tracking server in a separate terminal:');
+  console.error(`       ${cyan(`mlflow server --port ${port}`)}`);
   console.error(
-    `       mlflow server --host 0.0.0.0 --port ${new URL(trackingUri).port || '5000'}`,
+    `  2. Launch ${cyan('qwen')} — traces appear at ${bold(trackingUri)} after each turn.`,
   );
-  console.error(`  2. Launch \`qwen\` — traces appear at ${trackingUri} after each turn.`);
   console.error(
-    '\nThe tracking URI and experiment ID can be overridden per-shell with',
-    '$MLFLOW_TRACKING_URI / $MLFLOW_EXPERIMENT_ID.',
+    `\n${dim('Override per-shell with $MLFLOW_TRACKING_URI / $MLFLOW_EXPERIMENT_ID.')}`,
   );
 }

--- a/libs/typescript/integrations/qwen-code/src/commands/setup.ts
+++ b/libs/typescript/integrations/qwen-code/src/commands/setup.ts
@@ -1,0 +1,91 @@
+/**
+ * `mlflow-qwen-code setup` — register the Stop hook in the user's Qwen Code
+ * settings file so tracing is active on the next `qwen` invocation.
+ *
+ * Writes to `~/.qwen/settings.json` by default, or `./.qwen/settings.json`
+ * when `--project` is passed. Creates the file if it doesn't exist; leaves
+ * existing fields untouched.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, resolve } from 'node:path';
+
+const HOOK_COMMAND = 'mlflow-qwen-code';
+
+interface QwenHookEntry {
+  type: string;
+  command: string;
+}
+
+interface QwenHookGroup {
+  hooks: QwenHookEntry[];
+}
+
+interface QwenSettings {
+  hooks?: {
+    Stop?: QwenHookGroup[];
+    [key: string]: QwenHookGroup[] | undefined;
+  };
+  [key: string]: unknown;
+}
+
+export interface SetupOptions {
+  /** Override the user home directory. Defaults to `os.homedir()`. */
+  home?: string;
+  /** Override the current working directory. Defaults to `process.cwd()`. */
+  cwd?: string;
+}
+
+export function resolveSettingsPath(projectLocal: boolean, options: SetupOptions = {}): string {
+  return projectLocal
+    ? resolve(options.cwd ?? process.cwd(), '.qwen', 'settings.json')
+    : resolve(options.home ?? homedir(), '.qwen', 'settings.json');
+}
+
+function readSettings(path: string): QwenSettings {
+  if (!existsSync(path)) {
+    return {};
+  }
+  const content = readFileSync(path, 'utf-8').trim();
+  if (!content) {
+    return {};
+  }
+  return JSON.parse(content) as QwenSettings;
+}
+
+function writeSettings(path: string, settings: QwenSettings): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(settings, null, 2) + '\n', 'utf-8');
+}
+
+function hasMlflowHook(groups: QwenHookGroup[]): boolean {
+  return groups.some((group) => group.hooks?.some((hook) => hook.command?.trim() === HOOK_COMMAND));
+}
+
+export function runSetup(args: string[], options: SetupOptions = {}): void {
+  const projectLocal = args.includes('--project') || args.includes('-p');
+  const settingsPath = resolveSettingsPath(projectLocal, options);
+
+  const settings = readSettings(settingsPath);
+  settings.hooks ??= {};
+  settings.hooks.Stop ??= [];
+
+  if (hasMlflowHook(settings.hooks.Stop)) {
+    console.error(`[mlflow] Hook already registered in ${settingsPath}`);
+  } else {
+    settings.hooks.Stop.push({
+      hooks: [{ type: 'command', command: HOOK_COMMAND }],
+    });
+    writeSettings(settingsPath, settings);
+    console.error(`[mlflow] Registered Stop hook in ${settingsPath}`);
+  }
+
+  console.error('\nNext steps:');
+  console.error('  1. Export MLflow environment variables in the shell that launches `qwen`:');
+  console.error('       export MLFLOW_TRACKING_URI=http://localhost:5000');
+  console.error('       export MLFLOW_EXPERIMENT_ID=0');
+  console.error('  2. Start the MLflow tracking server in a separate terminal:');
+  console.error('       mlflow server --host 0.0.0.0 --port 5000');
+  console.error('  3. Launch `qwen` — traces appear at http://localhost:5000 after each turn.');
+}

--- a/libs/typescript/integrations/qwen-code/src/commands/setup.ts
+++ b/libs/typescript/integrations/qwen-code/src/commands/setup.ts
@@ -3,12 +3,16 @@
  * user's Qwen Code settings and write an MLflow tracing config alongside it.
  *
  * Writes:
- *   - `~/.qwen/settings.json` — registers the `mlflow-qwen-code stop-hook`
- *     entry under `hooks.Stop`; leaves unrelated fields untouched.
- *   - `~/.qwen/mlflow-tracing.json` — persists the tracking URI and
- *     experiment ID so the hook can run without shell exports.
+ *   - `settings.json` — registers the `mlflow-qwen-code stop-hook` entry
+ *     under `hooks.Stop`; leaves unrelated fields untouched.
+ *   - `mlflow-tracing.json` — persists the tracking URI and experiment ID
+ *     so the hook can run without shell exports.
  *
- * `--project` (or `-p`) writes to `./.qwen/` instead of `~/.qwen/`.
+ * Scope selection:
+ *   - Interactive runs prompt for project-local (`./.qwen/`) vs user-level
+ *     (`~/.qwen/`), defaulting to project-local.
+ *   - `--project` / `-p` forces project-local and skips the prompt.
+ *   - `--non-interactive` without `--project` falls back to user-level.
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
@@ -17,6 +21,7 @@ import { dirname, resolve } from 'node:path';
 import { createInterface } from 'node:readline';
 
 import { FAIL, OK, WARN, bold, cyan, dim } from '../ui.js';
+import { selectPrompt } from '../ui-select.js';
 
 const HOOK_COMMAND = 'mlflow-qwen-code stop-hook';
 const DEFAULT_TRACKING_URI = 'http://localhost:5000';
@@ -120,9 +125,15 @@ function hasMlflowHook(groups: QwenHookGroup[]): boolean {
  *   --non-interactive / -y
  *   --tracking-uri <url>
  *   --experiment-id <id>
+ *
+ * `projectLocal` is left undefined when `--project` is not passed so the
+ * interactive flow can prompt for it (and non-interactive can fall back to
+ * user-level).
  */
-export function parseSetupArgs(args: string[]): SetupOptions & { projectLocal: boolean } {
-  const out: SetupOptions & { projectLocal: boolean } = { projectLocal: false };
+export function parseSetupArgs(
+  args: string[],
+): SetupOptions & { projectLocal: boolean | undefined } {
+  const out: SetupOptions & { projectLocal: boolean | undefined } = { projectLocal: undefined };
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if (arg === '--project' || arg === '-p') {
@@ -166,41 +177,42 @@ function askOn(
 const validateTrackingUri = (value: string): string | null =>
   isValidTrackingUri(value) ? null : 'Must be an absolute http:// or https:// URL.';
 
-async function resolveTracingValues(
-  options: SetupOptions,
-): Promise<{ trackingUri: string; experimentId: string }> {
-  if (options.nonInteractive) {
-    return {
-      trackingUri: options.trackingUri ?? DEFAULT_TRACKING_URI,
-      experimentId: options.experimentId ?? DEFAULT_EXPERIMENT_ID,
-    };
-  }
-  if (options.trackingUri && options.experimentId) {
-    return { trackingUri: options.trackingUri, experimentId: options.experimentId };
-  }
-  console.error(`\n${bold('Configure MLflow tracing for Qwen Code')}`);
-  const rl = createInterface({ input: process.stdin, output: process.stdout });
-  try {
-    const trackingUri =
-      options.trackingUri ??
-      (await askOn(rl, 'MLflow tracking URI', DEFAULT_TRACKING_URI, validateTrackingUri));
-    const experimentId =
-      options.experimentId ?? (await askOn(rl, 'MLflow experiment ID', DEFAULT_EXPERIMENT_ID));
-    return { trackingUri, experimentId };
-  } finally {
-    rl.close();
-  }
+function promptScope(): Promise<boolean> {
+  return selectPrompt<boolean>({
+    question: 'Where should MLflow tracing be installed?',
+    options: [
+      { value: true, label: 'Project', hint: './.qwen/' },
+      { value: false, label: 'User', hint: '~/.qwen/' },
+    ],
+    defaultIndex: 0,
+  });
 }
 
 export async function runSetup(args: string[], options: SetupOptions = {}): Promise<void> {
   const parsed = parseSetupArgs(args);
-  const merged: SetupOptions & { projectLocal: boolean } = {
+  const merged: SetupOptions & { projectLocal: boolean | undefined } = {
     ...parsed,
     ...options,
     projectLocal: parsed.projectLocal,
   };
-  const settingsPath = resolveSettingsPath(merged.projectLocal, merged);
-  const tracingConfigPath = resolveTracingConfigPath(merged.projectLocal, merged);
+
+  const interactive = !merged.nonInteractive;
+  const needsBanner =
+    interactive &&
+    (merged.projectLocal === undefined || !merged.trackingUri || !merged.experimentId);
+  if (needsBanner) {
+    console.error(`\n${bold('Configure MLflow tracing for Qwen Code')}`);
+  }
+
+  const projectLocal =
+    merged.projectLocal !== undefined
+      ? merged.projectLocal
+      : interactive
+        ? await promptScope()
+        : false;
+
+  const settingsPath = resolveSettingsPath(projectLocal, merged);
+  const tracingConfigPath = resolveTracingConfigPath(projectLocal, merged);
 
   const settings = readSettings(settingsPath);
   if (settings == null) {
@@ -219,26 +231,43 @@ export async function runSetup(args: string[], options: SetupOptions = {}): Prom
     writeSettings(settingsPath, settings);
     console.error(`${OK} Registered Stop hook in ${cyan(settingsPath)}`);
   }
+  console.error('');
 
-  const { trackingUri, experimentId } = await resolveTracingValues(merged);
-  if (!isValidTrackingUri(trackingUri)) {
+  const needsTextPrompt = interactive && (!merged.trackingUri || !merged.experimentId);
+  const rl = needsTextPrompt
+    ? createInterface({ input: process.stdin, output: process.stdout })
+    : null;
+  try {
+    const trackingUri =
+      merged.trackingUri ??
+      (rl
+        ? await askOn(rl, 'MLflow tracking URI', DEFAULT_TRACKING_URI, validateTrackingUri)
+        : DEFAULT_TRACKING_URI);
+    const experimentId =
+      merged.experimentId ??
+      (rl ? await askOn(rl, 'MLflow experiment ID', DEFAULT_EXPERIMENT_ID) : DEFAULT_EXPERIMENT_ID);
+
+    if (!isValidTrackingUri(trackingUri)) {
+      console.error(
+        `${FAIL} Invalid tracking URI: ${bold(trackingUri)} — must be an absolute http:// or https:// URL.`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+    writeTracingConfig(tracingConfigPath, { trackingUri, experimentId });
+    console.error(`\n${OK} Wrote tracing config to ${cyan(tracingConfigPath)}`);
+
+    const port = new URL(trackingUri).port || '5000';
+    console.error(`\n${bold('Next steps')}`);
+    console.error('  1. Start the MLflow tracking server in a separate terminal:');
+    console.error(`       ${cyan(`mlflow server --port ${port}`)}`);
     console.error(
-      `${FAIL} Invalid tracking URI: ${bold(trackingUri)} — must be an absolute http:// or https:// URL.`,
+      `  2. Launch ${cyan('qwen')} — traces appear at ${bold(trackingUri)} after each turn.`,
     );
-    process.exitCode = 1;
-    return;
+    console.error(
+      `\n${dim('Override per-shell with $MLFLOW_TRACKING_URI / $MLFLOW_EXPERIMENT_ID.')}`,
+    );
+  } finally {
+    rl?.close();
   }
-  writeTracingConfig(tracingConfigPath, { trackingUri, experimentId });
-  console.error(`\n${OK} Wrote tracing config to ${cyan(tracingConfigPath)}`);
-
-  const port = new URL(trackingUri).port || '5000';
-  console.error(`\n${bold('Next steps')}`);
-  console.error('  1. Start the MLflow tracking server in a separate terminal:');
-  console.error(`       ${cyan(`mlflow server --port ${port}`)}`);
-  console.error(
-    `  2. Launch ${cyan('qwen')} — traces appear at ${bold(trackingUri)} after each turn.`,
-  );
-  console.error(
-    `\n${dim('Override per-shell with $MLFLOW_TRACKING_URI / $MLFLOW_EXPERIMENT_ID.')}`,
-  );
 }

--- a/libs/typescript/integrations/qwen-code/src/config.ts
+++ b/libs/typescript/integrations/qwen-code/src/config.ts
@@ -1,6 +1,54 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
+
 import { init } from '@mlflow/core';
 
 let initialized = false;
+
+const TRACING_CONFIG_FILE = 'mlflow-tracing.json';
+
+interface TracingConfig {
+  trackingUri?: string;
+  experimentId?: string;
+}
+
+export interface ResolveConfigOptions {
+  /** Override the user home directory. Defaults to `os.homedir()`. */
+  home?: string;
+  /** Override the current working directory. Defaults to `process.cwd()`. */
+  cwd?: string;
+}
+
+function readTracingConfigFile(path: string): TracingConfig {
+  if (!existsSync(path)) {
+    return {};
+  }
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as TracingConfig;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Resolve the effective MLflow tracing config. Precedence (highest first):
+ *   1. `MLFLOW_TRACKING_URI` / `MLFLOW_EXPERIMENT_ID` environment variables
+ *   2. `./.qwen/mlflow-tracing.json` (project-local)
+ *   3. `~/.qwen/mlflow-tracing.json` (user-level)
+ */
+export function resolveTracingConfig(options: ResolveConfigOptions = {}): TracingConfig {
+  const projectPath = resolve(options.cwd ?? process.cwd(), '.qwen', TRACING_CONFIG_FILE);
+  const userPath = resolve(options.home ?? homedir(), '.qwen', TRACING_CONFIG_FILE);
+  const projectConfig = readTracingConfigFile(projectPath);
+  const userConfig = readTracingConfigFile(userPath);
+  return {
+    trackingUri:
+      process.env.MLFLOW_TRACKING_URI ?? projectConfig.trackingUri ?? userConfig.trackingUri,
+    experimentId:
+      process.env.MLFLOW_EXPERIMENT_ID ?? projectConfig.experimentId ?? userConfig.experimentId,
+  };
+}
 
 /**
  * Initialize the MLflow SDK with tracking URI and experiment settings.
@@ -10,17 +58,17 @@ export function ensureInitialized(): boolean {
     return true;
   }
 
-  const trackingUri = process.env.MLFLOW_TRACKING_URI;
+  const { trackingUri, experimentId } = resolveTracingConfig();
   if (!trackingUri) {
-    console.error('[mlflow] MLFLOW_TRACKING_URI is not set');
+    console.error(
+      '[mlflow] MLflow tracking URI is not configured — checked $MLFLOW_TRACKING_URI,',
+      './.qwen/mlflow-tracing.json, and ~/.qwen/mlflow-tracing.json.',
+    );
+    console.error('[mlflow] Run `mlflow-qwen-code setup` to configure.');
     return false;
   }
 
-  init({
-    trackingUri,
-    experimentId: process.env.MLFLOW_EXPERIMENT_ID,
-  });
-
+  init({ trackingUri, experimentId });
   initialized = true;
   return true;
 }

--- a/libs/typescript/integrations/qwen-code/src/hooks/stop.ts
+++ b/libs/typescript/integrations/qwen-code/src/hooks/stop.ts
@@ -1,5 +1,5 @@
 /**
- * Qwen Code Stop hook entry point.
+ * Qwen Code Stop hook handler.
  *
  * Qwen Code fires the Stop hook via stdin with JSON:
  *   {"session_id": "...", "transcript_path": "...", "cwd": "...", ...}
@@ -12,9 +12,8 @@ import { ensureInitialized } from '../config.js';
 import { processTranscript } from '../tracing.js';
 import type { StopHookInput } from '../types.js';
 
-async function main(): Promise<void> {
+export async function runStopHook(): Promise<void> {
   try {
-    // Initialize early to fail fast if MLFLOW_TRACKING_URI is not set
     if (!ensureInitialized()) {
       return;
     }
@@ -24,5 +23,3 @@ async function main(): Promise<void> {
     console.error('[mlflow]', err);
   }
 }
-
-void main();

--- a/libs/typescript/integrations/qwen-code/src/ui-select.ts
+++ b/libs/typescript/integrations/qwen-code/src/ui-select.ts
@@ -1,0 +1,96 @@
+/**
+ * Minimal arrow-key select prompt for the `mlflow-qwen-code` setup CLI.
+ *
+ * No runtime dependency on `inquirer`/`prompts`: we manage raw-mode stdin
+ * ourselves so the bundled binary stays small, matching the policy in
+ * `ui.ts`. Falls back to the default option when stdin is not a TTY so
+ * piped input (CI, `echo "" | mlflow-qwen-code setup`) never hangs.
+ */
+
+import { emitKeypressEvents } from 'node:readline';
+
+import { bold, cyan, dim } from './ui.js';
+
+export interface SelectOption<T> {
+  value: T;
+  label: string;
+  hint?: string;
+}
+
+export interface SelectPromptOptions<T> {
+  question: string;
+  options: SelectOption<T>[];
+  defaultIndex?: number;
+  input?: NodeJS.ReadStream;
+  output?: NodeJS.WriteStream;
+}
+
+export function selectPrompt<T>(opts: SelectPromptOptions<T>): Promise<T> {
+  const input = opts.input ?? process.stdin;
+  const output = opts.output ?? process.stdout;
+  const defaultIndex = opts.defaultIndex ?? 0;
+  const { options, question } = opts;
+
+  if (!input.isTTY) {
+    return Promise.resolve(options[defaultIndex].value);
+  }
+
+  let current = defaultIndex;
+  let linesRendered = 0;
+
+  const formatLines = (): string[] => [
+    `${bold('?')} ${question}`,
+    ...options.map((o, i) => {
+      const marker = i === current ? cyan('●') : dim('○');
+      const label = i === current ? cyan(o.label) : o.label;
+      const hint = o.hint ? `  ${dim(o.hint)}` : '';
+      const defaultTag = i === defaultIndex ? dim('  (default)') : '';
+      return `  ${marker} ${label}${hint}${defaultTag}`;
+    }),
+    '',
+    `  ${dim('↑/↓ to move, enter to select')}`,
+  ];
+
+  const render = (): void => {
+    if (linesRendered > 0) {
+      output.write(`\x1b[${linesRendered}A\x1b[0J`);
+    }
+    const lines = formatLines();
+    output.write(lines.join('\n') + '\n');
+    linesRendered = lines.length;
+  };
+
+  emitKeypressEvents(input);
+  const wasRaw = input.isRaw;
+  input.setRawMode(true);
+  input.resume();
+
+  return new Promise<T>((resolvePromise) => {
+    const cleanup = (): void => {
+      input.removeListener('keypress', onKeypress);
+      if (!wasRaw) {
+        input.setRawMode(false);
+      }
+      input.pause();
+    };
+
+    const onKeypress = (_str: string, key: { name?: string; ctrl?: boolean }): void => {
+      if (key.ctrl && key.name === 'c') {
+        cleanup();
+        process.exit(130);
+      } else if (key.name === 'up' || key.name === 'k') {
+        current = (current - 1 + options.length) % options.length;
+        render();
+      } else if (key.name === 'down' || key.name === 'j') {
+        current = (current + 1) % options.length;
+        render();
+      } else if (key.name === 'return') {
+        cleanup();
+        resolvePromise(options[current].value);
+      }
+    };
+
+    input.on('keypress', onKeypress);
+    render();
+  });
+}

--- a/libs/typescript/integrations/qwen-code/src/ui.ts
+++ b/libs/typescript/integrations/qwen-code/src/ui.ts
@@ -1,0 +1,31 @@
+/**
+ * Tiny ANSI styling helpers for the `mlflow-qwen-code` CLI.
+ *
+ * No runtime dependency on `chalk`/`kleur`: we keep the bundle small and
+ * respect the usual opt-outs (non-TTY stdout, `NO_COLOR`, `FORCE_COLOR=0`).
+ */
+
+const COLOR_ENABLED = (() => {
+  if (process.env.FORCE_COLOR === '0' || process.env.NO_COLOR) {
+    return false;
+  }
+  if (process.env.FORCE_COLOR) {
+    return true;
+  }
+  return Boolean(process.stdout.isTTY);
+})();
+
+function wrap(code: string): (s: string) => string {
+  return (s: string) => (COLOR_ENABLED ? `\x1b[${code}m${s}\x1b[0m` : s);
+}
+
+export const bold = wrap('1');
+export const dim = wrap('2');
+export const green = wrap('32');
+export const red = wrap('31');
+export const cyan = wrap('36');
+export const yellow = wrap('33');
+
+export const OK = green('✓');
+export const FAIL = red('✗');
+export const WARN = yellow('!');

--- a/libs/typescript/integrations/qwen-code/tests/setup.test.ts
+++ b/libs/typescript/integrations/qwen-code/tests/setup.test.ts
@@ -4,6 +4,9 @@ import { join } from 'node:path';
 
 import { runSetup } from '../src/commands/setup';
 
+const HOOK_COMMAND = 'mlflow-qwen-code stop-hook';
+const NON_INTERACTIVE = ['--non-interactive'];
+
 describe('runSetup', () => {
   let tmpHome: string;
 
@@ -19,19 +22,37 @@ describe('runSetup', () => {
     return JSON.parse(readFileSync(path, 'utf-8')) as Record<string, unknown>;
   }
 
-  it('creates ~/.qwen/settings.json when it does not exist', () => {
-    runSetup([], { home: tmpHome });
+  it('creates settings.json and mlflow-tracing.json with defaults when absent', async () => {
+    await runSetup(NON_INTERACTIVE, { home: tmpHome });
 
     const settingsPath = join(tmpHome, '.qwen', 'settings.json');
+    const tracingPath = join(tmpHome, '.qwen', 'mlflow-tracing.json');
     expect(existsSync(settingsPath)).toBe(true);
+    expect(existsSync(tracingPath)).toBe(true);
     expect(read(settingsPath)).toEqual({
       hooks: {
-        Stop: [{ hooks: [{ type: 'command', command: 'mlflow-qwen-code' }] }],
+        Stop: [{ hooks: [{ type: 'command', command: HOOK_COMMAND }] }],
       },
+    });
+    expect(read(tracingPath)).toEqual({
+      trackingUri: 'http://localhost:5000',
+      experimentId: '0',
     });
   });
 
-  it('preserves unrelated fields when merging into an existing file', () => {
+  it('writes the supplied --tracking-uri and --experiment-id to mlflow-tracing.json', async () => {
+    await runSetup(
+      ['--non-interactive', '--tracking-uri', 'http://mlflow.example/', '--experiment-id', '42'],
+      { home: tmpHome },
+    );
+
+    expect(read(join(tmpHome, '.qwen', 'mlflow-tracing.json'))).toEqual({
+      trackingUri: 'http://mlflow.example/',
+      experimentId: '42',
+    });
+  });
+
+  it('preserves unrelated fields when merging into an existing settings.json', async () => {
     const settingsPath = join(tmpHome, '.qwen', 'settings.json');
     mkdirSync(join(tmpHome, '.qwen'), { recursive: true });
     writeFileSync(
@@ -40,28 +61,28 @@ describe('runSetup', () => {
       'utf-8',
     );
 
-    runSetup([], { home: tmpHome });
+    await runSetup(NON_INTERACTIVE, { home: tmpHome });
 
     const settings = read(settingsPath);
     expect(settings.theme).toBe('dark');
     expect(settings.security).toEqual({ auth: { selectedType: 'openai' } });
     expect((settings.hooks as { Stop: unknown }).Stop).toEqual([
-      { hooks: [{ type: 'command', command: 'mlflow-qwen-code' }] },
+      { hooks: [{ type: 'command', command: HOOK_COMMAND }] },
     ]);
   });
 
-  it('is idempotent when the hook is already registered', () => {
-    runSetup([], { home: tmpHome });
+  it('is idempotent when the hook is already registered', async () => {
+    await runSetup(NON_INTERACTIVE, { home: tmpHome });
     const settingsPath = join(tmpHome, '.qwen', 'settings.json');
-    const first = readFileSync(settingsPath, 'utf-8');
+    const firstSettings = readFileSync(settingsPath, 'utf-8');
 
-    runSetup([], { home: tmpHome });
-    const second = readFileSync(settingsPath, 'utf-8');
+    await runSetup(NON_INTERACTIVE, { home: tmpHome });
+    const secondSettings = readFileSync(settingsPath, 'utf-8');
 
-    expect(second).toBe(first);
+    expect(secondSettings).toBe(firstSettings);
   });
 
-  it('appends alongside other Stop hooks without overwriting them', () => {
+  it('appends alongside other Stop hooks without overwriting them', async () => {
     const settingsPath = join(tmpHome, '.qwen', 'settings.json');
     mkdirSync(join(tmpHome, '.qwen'), { recursive: true });
     writeFileSync(
@@ -72,34 +93,32 @@ describe('runSetup', () => {
       'utf-8',
     );
 
-    runSetup([], { home: tmpHome });
+    await runSetup(NON_INTERACTIVE, { home: tmpHome });
 
     const settings = read(settingsPath) as { hooks: { Stop: unknown[] } };
     expect(settings.hooks.Stop).toHaveLength(2);
     expect(settings.hooks.Stop).toEqual([
       { hooks: [{ type: 'command', command: 'some-other-hook' }] },
-      { hooks: [{ type: 'command', command: 'mlflow-qwen-code' }] },
+      { hooks: [{ type: 'command', command: HOOK_COMMAND }] },
     ]);
   });
 
-  it('writes to ./.qwen/settings.json when --project is passed', () => {
+  it('writes to ./.qwen/ when --project is passed', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'qwen-project-test-'));
     try {
-      runSetup(['--project'], { home: tmpHome, cwd });
+      await runSetup([...NON_INTERACTIVE, '--project'], { home: tmpHome, cwd });
       const projectPath = join(cwd, '.qwen', 'settings.json');
+      const projectTracingPath = join(cwd, '.qwen', 'mlflow-tracing.json');
       expect(existsSync(projectPath)).toBe(true);
-      expect(read(projectPath)).toEqual({
-        hooks: {
-          Stop: [{ hooks: [{ type: 'command', command: 'mlflow-qwen-code' }] }],
-        },
-      });
+      expect(existsSync(projectTracingPath)).toBe(true);
       expect(existsSync(join(tmpHome, '.qwen', 'settings.json'))).toBe(false);
+      expect(existsSync(join(tmpHome, '.qwen', 'mlflow-tracing.json'))).toBe(false);
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
   });
 
-  it('reports a friendly error and exits 1 when settings.json is malformed', () => {
+  it('reports a friendly error and exits 1 when settings.json is malformed', async () => {
     const settingsPath = join(tmpHome, '.qwen', 'settings.json');
     mkdirSync(join(tmpHome, '.qwen'), { recursive: true });
     writeFileSync(settingsPath, '{ not valid json', 'utf-8');
@@ -107,10 +126,11 @@ describe('runSetup', () => {
     process.exitCode = undefined;
 
     try {
-      runSetup([], { home: tmpHome });
+      await runSetup(NON_INTERACTIVE, { home: tmpHome });
       expect(process.exitCode).toBe(1);
-      // The malformed file must be left untouched so the user can fix it by hand.
       expect(readFileSync(settingsPath, 'utf-8')).toBe('{ not valid json');
+      // mlflow-tracing.json must not have been written when setup bails early.
+      expect(existsSync(join(tmpHome, '.qwen', 'mlflow-tracing.json'))).toBe(false);
     } finally {
       process.exitCode = originalExitCode;
     }

--- a/libs/typescript/integrations/qwen-code/tests/setup.test.ts
+++ b/libs/typescript/integrations/qwen-code/tests/setup.test.ts
@@ -4,6 +4,36 @@ import { join } from 'node:path';
 
 import { runSetup } from '../src/commands/setup';
 
+jest.mock('node:readline', () => ({ createInterface: jest.fn() }));
+jest.mock('../src/ui-select', () => ({ selectPrompt: jest.fn() }));
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { createInterface } = require('node:readline') as {
+  createInterface: jest.Mock;
+};
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { selectPrompt } = require('../src/ui-select') as {
+  selectPrompt: jest.Mock;
+};
+
+function mockTextPrompts(answers: string[]): void {
+  const queue = [...answers];
+  createInterface.mockImplementation(() => ({
+    question: (_prompt: string, cb: (answer: string) => void) => {
+      const next = queue.shift();
+      if (next === undefined) {
+        throw new Error('mockTextPrompts: ran out of answers');
+      }
+      cb(next);
+    },
+    close: () => {},
+  }));
+}
+
+beforeEach(() => {
+  selectPrompt.mockReset();
+  createInterface.mockReset();
+});
+
 const HOOK_COMMAND = 'mlflow-qwen-code stop-hook';
 const NON_INTERACTIVE = ['--non-interactive'];
 
@@ -132,6 +162,64 @@ describe('runSetup', () => {
       expect(existsSync(projectTracingPath)).toBe(true);
       expect(existsSync(join(tmpHome, '.qwen', 'settings.json'))).toBe(false);
       expect(existsSync(join(tmpHome, '.qwen', 'mlflow-tracing.json'))).toBe(false);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('interactive scope prompt picks project-local when the user selects Project', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'qwen-interactive-project-'));
+    try {
+      selectPrompt.mockResolvedValueOnce(true);
+      mockTextPrompts(['', '']);
+      await runSetup([], { home: tmpHome, cwd });
+
+      expect(selectPrompt).toHaveBeenCalledTimes(1);
+      expect(existsSync(join(cwd, '.qwen', 'settings.json'))).toBe(true);
+      expect(existsSync(join(cwd, '.qwen', 'mlflow-tracing.json'))).toBe(true);
+      expect(existsSync(join(tmpHome, '.qwen', 'settings.json'))).toBe(false);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('interactive scope prompt writes user-level when the user selects User', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'qwen-interactive-user-'));
+    try {
+      selectPrompt.mockResolvedValueOnce(false);
+      mockTextPrompts(['', '']);
+      await runSetup([], { home: tmpHome, cwd });
+
+      expect(existsSync(join(tmpHome, '.qwen', 'settings.json'))).toBe(true);
+      expect(existsSync(join(tmpHome, '.qwen', 'mlflow-tracing.json'))).toBe(true);
+      expect(existsSync(join(cwd, '.qwen', 'settings.json'))).toBe(false);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('skips the scope prompt when --project is explicitly passed', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'qwen-interactive-flag-'));
+    try {
+      mockTextPrompts(['', '']);
+      await runSetup(['--project'], { home: tmpHome, cwd });
+
+      expect(selectPrompt).not.toHaveBeenCalled();
+      expect(existsSync(join(cwd, '.qwen', 'settings.json'))).toBe(true);
+      expect(existsSync(join(tmpHome, '.qwen', 'settings.json'))).toBe(false);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('skips the scope prompt in --non-interactive mode and defaults to user-level', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'qwen-non-interactive-scope-'));
+    try {
+      await runSetup(NON_INTERACTIVE, { home: tmpHome, cwd });
+
+      expect(selectPrompt).not.toHaveBeenCalled();
+      expect(existsSync(join(tmpHome, '.qwen', 'settings.json'))).toBe(true);
+      expect(existsSync(join(cwd, '.qwen', 'settings.json'))).toBe(false);
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }

--- a/libs/typescript/integrations/qwen-code/tests/setup.test.ts
+++ b/libs/typescript/integrations/qwen-code/tests/setup.test.ts
@@ -98,4 +98,21 @@ describe('runSetup', () => {
       rmSync(cwd, { recursive: true, force: true });
     }
   });
+
+  it('reports a friendly error and exits 1 when settings.json is malformed', () => {
+    const settingsPath = join(tmpHome, '.qwen', 'settings.json');
+    mkdirSync(join(tmpHome, '.qwen'), { recursive: true });
+    writeFileSync(settingsPath, '{ not valid json', 'utf-8');
+    const originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+
+    try {
+      runSetup([], { home: tmpHome });
+      expect(process.exitCode).toBe(1);
+      // The malformed file must be left untouched so the user can fix it by hand.
+      expect(readFileSync(settingsPath, 'utf-8')).toBe('{ not valid json');
+    } finally {
+      process.exitCode = originalExitCode;
+    }
+  });
 });

--- a/libs/typescript/integrations/qwen-code/tests/setup.test.ts
+++ b/libs/typescript/integrations/qwen-code/tests/setup.test.ts
@@ -1,0 +1,101 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { runSetup } from '../src/commands/setup';
+
+describe('runSetup', () => {
+  let tmpHome: string;
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), 'qwen-setup-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  function read(path: string): Record<string, unknown> {
+    return JSON.parse(readFileSync(path, 'utf-8')) as Record<string, unknown>;
+  }
+
+  it('creates ~/.qwen/settings.json when it does not exist', () => {
+    runSetup([], { home: tmpHome });
+
+    const settingsPath = join(tmpHome, '.qwen', 'settings.json');
+    expect(existsSync(settingsPath)).toBe(true);
+    expect(read(settingsPath)).toEqual({
+      hooks: {
+        Stop: [{ hooks: [{ type: 'command', command: 'mlflow-qwen-code' }] }],
+      },
+    });
+  });
+
+  it('preserves unrelated fields when merging into an existing file', () => {
+    const settingsPath = join(tmpHome, '.qwen', 'settings.json');
+    mkdirSync(join(tmpHome, '.qwen'), { recursive: true });
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({ theme: 'dark', security: { auth: { selectedType: 'openai' } } }),
+      'utf-8',
+    );
+
+    runSetup([], { home: tmpHome });
+
+    const settings = read(settingsPath);
+    expect(settings.theme).toBe('dark');
+    expect(settings.security).toEqual({ auth: { selectedType: 'openai' } });
+    expect((settings.hooks as { Stop: unknown }).Stop).toEqual([
+      { hooks: [{ type: 'command', command: 'mlflow-qwen-code' }] },
+    ]);
+  });
+
+  it('is idempotent when the hook is already registered', () => {
+    runSetup([], { home: tmpHome });
+    const settingsPath = join(tmpHome, '.qwen', 'settings.json');
+    const first = readFileSync(settingsPath, 'utf-8');
+
+    runSetup([], { home: tmpHome });
+    const second = readFileSync(settingsPath, 'utf-8');
+
+    expect(second).toBe(first);
+  });
+
+  it('appends alongside other Stop hooks without overwriting them', () => {
+    const settingsPath = join(tmpHome, '.qwen', 'settings.json');
+    mkdirSync(join(tmpHome, '.qwen'), { recursive: true });
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        hooks: { Stop: [{ hooks: [{ type: 'command', command: 'some-other-hook' }] }] },
+      }),
+      'utf-8',
+    );
+
+    runSetup([], { home: tmpHome });
+
+    const settings = read(settingsPath) as { hooks: { Stop: unknown[] } };
+    expect(settings.hooks.Stop).toHaveLength(2);
+    expect(settings.hooks.Stop).toEqual([
+      { hooks: [{ type: 'command', command: 'some-other-hook' }] },
+      { hooks: [{ type: 'command', command: 'mlflow-qwen-code' }] },
+    ]);
+  });
+
+  it('writes to ./.qwen/settings.json when --project is passed', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'qwen-project-test-'));
+    try {
+      runSetup(['--project'], { home: tmpHome, cwd });
+      const projectPath = join(cwd, '.qwen', 'settings.json');
+      expect(existsSync(projectPath)).toBe(true);
+      expect(read(projectPath)).toEqual({
+        hooks: {
+          Stop: [{ hooks: [{ type: 'command', command: 'mlflow-qwen-code' }] }],
+        },
+      });
+      expect(existsSync(join(tmpHome, '.qwen', 'settings.json'))).toBe(false);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/libs/typescript/integrations/qwen-code/tests/setup.test.ts
+++ b/libs/typescript/integrations/qwen-code/tests/setup.test.ts
@@ -103,6 +103,25 @@ describe('runSetup', () => {
     ]);
   });
 
+  it('rejects a tracking URI that is missing an http(s) scheme and exits 1', async () => {
+    const originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+
+    try {
+      await runSetup(
+        ['--non-interactive', '--tracking-uri', 'localhost:5678', '--experiment-id', '48'],
+        { home: tmpHome },
+      );
+      expect(process.exitCode).toBe(1);
+      // The Stop hook is still registered (that step happens before URI
+      // validation and is idempotent), but the tracing config must not be
+      // written with an invalid URI.
+      expect(existsSync(join(tmpHome, '.qwen', 'mlflow-tracing.json'))).toBe(false);
+    } finally {
+      process.exitCode = originalExitCode;
+    }
+  });
+
   it('writes to ./.qwen/ when --project is passed', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'qwen-project-test-'));
     try {

--- a/libs/typescript/integrations/qwen-code/tests/setup.test.ts
+++ b/libs/typescript/integrations/qwen-code/tests/setup.test.ts
@@ -1,37 +1,36 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { createInterface } from 'node:readline';
 
 import { runSetup } from '../src/commands/setup';
+import { selectPrompt } from '../src/ui-select';
 
 jest.mock('node:readline', () => ({ createInterface: jest.fn() }));
 jest.mock('../src/ui-select', () => ({ selectPrompt: jest.fn() }));
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const { createInterface } = require('node:readline') as {
-  createInterface: jest.Mock;
-};
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const { selectPrompt } = require('../src/ui-select') as {
-  selectPrompt: jest.Mock;
-};
+const createInterfaceMock = jest.mocked(createInterface);
+const selectPromptMock = jest.mocked(selectPrompt);
 
 function mockTextPrompts(answers: string[]): void {
   const queue = [...answers];
-  createInterface.mockImplementation(() => ({
-    question: (_prompt: string, cb: (answer: string) => void) => {
-      const next = queue.shift();
-      if (next === undefined) {
-        throw new Error('mockTextPrompts: ran out of answers');
-      }
-      cb(next);
-    },
-    close: () => {},
-  }));
+  createInterfaceMock.mockImplementation(
+    () =>
+      ({
+        question: (_prompt: string, cb: (answer: string) => void) => {
+          const next = queue.shift();
+          if (next === undefined) {
+            throw new Error('mockTextPrompts: ran out of answers');
+          }
+          cb(next);
+        },
+        close: () => {},
+      }) as unknown as ReturnType<typeof createInterface>,
+  );
 }
 
 beforeEach(() => {
-  selectPrompt.mockReset();
-  createInterface.mockReset();
+  selectPromptMock.mockReset();
+  createInterfaceMock.mockReset();
 });
 
 const HOOK_COMMAND = 'mlflow-qwen-code stop-hook';
@@ -170,11 +169,11 @@ describe('runSetup', () => {
   it('interactive scope prompt picks project-local when the user selects Project', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'qwen-interactive-project-'));
     try {
-      selectPrompt.mockResolvedValueOnce(true);
+      selectPromptMock.mockResolvedValueOnce(true);
       mockTextPrompts(['', '']);
       await runSetup([], { home: tmpHome, cwd });
 
-      expect(selectPrompt).toHaveBeenCalledTimes(1);
+      expect(selectPromptMock).toHaveBeenCalledTimes(1);
       expect(existsSync(join(cwd, '.qwen', 'settings.json'))).toBe(true);
       expect(existsSync(join(cwd, '.qwen', 'mlflow-tracing.json'))).toBe(true);
       expect(existsSync(join(tmpHome, '.qwen', 'settings.json'))).toBe(false);
@@ -186,7 +185,7 @@ describe('runSetup', () => {
   it('interactive scope prompt writes user-level when the user selects User', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'qwen-interactive-user-'));
     try {
-      selectPrompt.mockResolvedValueOnce(false);
+      selectPromptMock.mockResolvedValueOnce(false);
       mockTextPrompts(['', '']);
       await runSetup([], { home: tmpHome, cwd });
 
@@ -204,7 +203,7 @@ describe('runSetup', () => {
       mockTextPrompts(['', '']);
       await runSetup(['--project'], { home: tmpHome, cwd });
 
-      expect(selectPrompt).not.toHaveBeenCalled();
+      expect(selectPromptMock).not.toHaveBeenCalled();
       expect(existsSync(join(cwd, '.qwen', 'settings.json'))).toBe(true);
       expect(existsSync(join(tmpHome, '.qwen', 'settings.json'))).toBe(false);
     } finally {
@@ -217,7 +216,7 @@ describe('runSetup', () => {
     try {
       await runSetup(NON_INTERACTIVE, { home: tmpHome, cwd });
 
-      expect(selectPrompt).not.toHaveBeenCalled();
+      expect(selectPromptMock).not.toHaveBeenCalled();
       expect(existsSync(join(tmpHome, '.qwen', 'settings.json'))).toBe(true);
       expect(existsSync(join(cwd, '.qwen', 'settings.json'))).toBe(false);
     } finally {


### PR DESCRIPTION
### Related Issues/PRs

Follow-up to #22410 (Codex TS) and #22411 (Qwen Code TS). Addresses reviewer feedback from @harupy and @B-Step62 on [#22412 (discussion)](https://github.com/mlflow/mlflow/pull/22412#discussion_r3130132610) — full scope now incorporated (subcommand model, interactive setup, persistent MLflow config, Codex project-level config).

### What changes are proposed in this pull request?

Exposes `@mlflow/codex` and `@mlflow/qwen-code` as installable CLI binaries (`mlflow-codex`, `mlflow-qwen-code`) with a subcommand surface, an interactive `setup` flow, and a persistent tracing config file so users don't have to re-export env vars in every shell.

**Why:** the previous pattern required hand-editing `~/.codex/config.toml` / `~/.qwen/settings.json` with an absolute `node /path/to/bundle/stop.js`, which broke shared settings across teammates (different global `node_modules` roots), and forced users to export `MLFLOW_TRACKING_URI` / `MLFLOW_EXPERIMENT_ID` in every shell they ran the agent from.

#### CLI shape

Each package exposes a single bin with explicit subcommands:

| Command | Purpose |
|---|---|
| `mlflow-qwen-code stop-hook` | Runs the Qwen Stop hook (stdin JSON). Qwen invokes this. |
| `mlflow-qwen-code setup` | Interactive registration + tracing config. |
| `mlflow-codex notify-hook` | Runs the Codex notify handler (Codex appends the payload as argv). |
| `mlflow-codex setup` | Interactive registration + tracing config. |

Unknown commands or missing subcommands print usage and exit 1. The subcommand shape leaves room to add more hook types later without another argv-overloading special case.

#### `setup` — interactive

Prompts for the MLflow tracking URI (default `http://localhost:5000`) and experiment ID (default `0`) via `node:readline`. Flags bypass prompts:

- `--project`, `-p` — write to `./.qwen/` or `./.codex/` (project-level) instead of the user-level config
- `--non-interactive`, `-y` — skip prompts, use defaults for any unset values
- `--tracking-uri <url>` — bypass the prompt for the URI
- `--experiment-id <id>` — bypass the prompt for the experiment ID

Setup writes two files:

1. **Agent config** (`~/.qwen/settings.json` or `~/.codex/config.toml`) — adds the hook entry. Qwen's JSON is deep-merged idempotently; Codex's TOML is prepended ahead of any `[section]` headers. A pre-existing non-MLflow `notify = ...` entry aborts with exit 1 instead of being overwritten.
2. **`mlflow-tracing.json`** (`~/.qwen/mlflow-tracing.json` or `~/.codex/mlflow-tracing.json`) — persists the prompted URI and experiment ID so the hook can run without shell exports.

#### Config resolution at hook-fire time

`ensureInitialized` now resolves the tracking URI / experiment ID from (highest precedence first):

1. `$MLFLOW_TRACKING_URI` / `$MLFLOW_EXPERIMENT_ID`
2. `./.qwen/mlflow-tracing.json` or `./.codex/mlflow-tracing.json` (project-local)
3. `~/.qwen/mlflow-tracing.json` or `~/.codex/mlflow-tracing.json` (user-level)

Shell env still overrides, so CI / per-run flags work the same as before.

#### Codex `--project` support

Codex's config reference confirms that `.codex/config.toml` files in the current project are read alongside `~/.codex/config.toml`. Codex setup now mirrors Qwen's `--project` flag for symmetry.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

**Jest tests** (98 total: 56 qwen + 42 codex): subcommand dispatch, setup writing both files, preserving unrelated fields, idempotency, project-flag paths, default vs flag-supplied values, malformed-settings handling, codex comment false-positive avoidance.

**Manual:** smoke-tested `npm install -g ./` → `mlflow-qwen-code setup --non-interactive` → `qwen "list files in /tmp"` → trace landed in experiment 2 with the correct span structure (6 spans, `llm_call` + `tool_run_shell_command` under the AGENT root).

Follow-up: stack 6 docs PR #22412 will be updated to reference `mlflow-<tool> setup` and drop the shell-export step, once this lands.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [x] Instructions

Docs update will land in #22412 once this PR merges.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
