### PR TITLE
Run guardrails on passthrough endpoints; skip `response_format` for non-chat payloads

### DIFF
--- a/docs/docs/genai/governance/ai-gateway/guardrails.mdx
+++ b/docs/docs/genai/governance/ai-gateway/guardrails.mdx
@@ -9,10 +9,6 @@ import ImageBox from "@site/src/components/ImageBox";
 
 Guardrails let you enforce content policies on traffic flowing through your AI Gateway endpoints. Each guardrail uses an LLM judge to evaluate requests or responses against a set of natural-language instructions — then either **blocks** the traffic or **sanitizes** (redacts) it before allowing it through.
 
-:::note
-Guardrails are only supported on **unified endpoints**. They are not available for passthrough endpoints.
-:::
-
 Common use cases include:
 
 - **Safety filtering**: reject harmful, offensive, or toxic content before it reaches your users or your LLM.
@@ -65,6 +61,10 @@ Click **Pre-LLM Guardrails** or **Post-LLM Guardrails** to select where this gua
 
 - **Pre-LLM Guardrails**: evaluates the incoming request before it reaches the LLM. Use `{{ inputs }}` in your instructions to reference the request content.
 - **Post-LLM Guardrails**: evaluates the LLM's response before it is returned to the caller. Use `{{ outputs }}` in your instructions to reference the response content, or `{{ inputs }}` to reference the original request. Post-LLM guardrails are **not triggered for streaming requests** — only non-streaming responses are evaluated.
+
+:::note
+Guardrails work on both **unified endpoints** and **passthrough endpoints** (OpenAI, Anthropic, Gemini, etc.). For passthrough endpoints, sanitization rewrites the payload without enforcing a specific JSON schema, since payloads are provider-specific formats.
+:::
 
 When you switch between stages, the editor automatically swaps `{{ inputs }}` ↔ `{{ outputs }}` in your instructions so they remain correct.
 

--- a/docs/docs/genai/governance/ai-gateway/guardrails.mdx
+++ b/docs/docs/genai/governance/ai-gateway/guardrails.mdx
@@ -63,7 +63,7 @@ Click **Pre-LLM Guardrails** or **Post-LLM Guardrails** to select where this gua
 - **Post-LLM Guardrails**: evaluates the LLM's response before it is returned to the caller. Use `{{ outputs }}` in your instructions to reference the response content, or `{{ inputs }}` to reference the original request. Post-LLM guardrails are **not triggered for streaming requests** — only non-streaming responses are evaluated.
 
 :::note
-Guardrails work on both **unified endpoints** and **passthrough endpoints** (OpenAI, Anthropic, Gemini, etc.).
+Guardrails work on both **unified endpoints** and **passthrough endpoints** (Anthropic, Gemini, OpenAI, etc.).
 :::
 
 When you switch between stages, the editor automatically swaps `{{ inputs }}` ↔ `{{ outputs }}` in your instructions so they remain correct.

--- a/docs/docs/genai/governance/ai-gateway/guardrails.mdx
+++ b/docs/docs/genai/governance/ai-gateway/guardrails.mdx
@@ -63,7 +63,7 @@ Click **Pre-LLM Guardrails** or **Post-LLM Guardrails** to select where this gua
 - **Post-LLM Guardrails**: evaluates the LLM's response before it is returned to the caller. Use `{{ outputs }}` in your instructions to reference the response content, or `{{ inputs }}` to reference the original request. Post-LLM guardrails are **not triggered for streaming requests** — only non-streaming responses are evaluated.
 
 :::note
-Guardrails work on both **unified endpoints** and **passthrough endpoints** (OpenAI, Anthropic, Gemini, etc.). For passthrough endpoints, sanitization rewrites the payload without enforcing a specific JSON schema, since payloads are provider-specific formats.
+Guardrails work on both **unified endpoints** and **passthrough endpoints** (OpenAI, Anthropic, Gemini, etc.).
 :::
 
 When you switch between stages, the editor automatically swaps `{{ inputs }}` ↔ `{{ outputs }}` in your instructions so they remain correct.

--- a/mlflow/gateway/guardrail_utils.py
+++ b/mlflow/gateway/guardrail_utils.py
@@ -87,3 +87,32 @@ async def run_post_llm_guardrails(
             request_payload, response_dict, auth_headers=auth_headers, usage_tracking=usage_tracking
         )
     return chat.ResponsePayload(**response_dict)
+
+
+async def run_post_llm_guardrails_passthrough(
+    guardrails: list[JudgeGuardrail],
+    request_payload: dict[str, Any],
+    response: dict[str, Any],
+    auth_headers: dict[str, str] | None = None,
+    usage_tracking: bool = False,
+) -> dict[str, Any]:
+    """Run post-LLM guardrails for passthrough endpoints.
+
+    Like ``run_post_llm_guardrails`` but accepts and returns a plain ``dict``
+    instead of a ``chat.ResponsePayload``.  Sanitization automatically skips
+    ``response_format`` for payloads that don't conform to the chat-completion
+    schema (see ``JudgeGuardrail._infer_chat_model``).
+
+    Note: post-LLM guardrails are skipped for streaming responses. Configure
+    guardrails that must run on all responses to use the pre-LLM stage, or
+    disable streaming on the endpoint.
+    """
+    post_llm_guardrails = [g for g in guardrails if g.stage == GuardrailStage.AFTER]
+    if not post_llm_guardrails:
+        return response
+
+    for guardrail in post_llm_guardrails:
+        response = await guardrail.process_response(
+            request_payload, response, auth_headers=auth_headers, usage_tracking=usage_tracking
+        )
+    return response

--- a/mlflow/gateway/guardrail_utils.py
+++ b/mlflow/gateway/guardrail_utils.py
@@ -9,6 +9,7 @@ from fastapi import Request
 from mlflow.entities.gateway_guardrail import GuardrailStage
 from mlflow.gateway.guardrails import JudgeGuardrail
 from mlflow.gateway.schemas import chat
+from mlflow.types.chat import ChatCompletionResponse
 
 if TYPE_CHECKING:
     from mlflow.store.tracking.gateway.entities import GatewayEndpointConfig
@@ -55,12 +56,16 @@ async def run_pre_llm_guardrails(
     payload_dict: dict[str, Any],
     auth_headers: dict[str, str] | None = None,
     usage_tracking: bool = False,
+    payload_schema: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Run pre-LLM guardrails on the request payload. Returns the (possibly modified) dict."""
     for guardrail in guardrails:
         if guardrail.stage == GuardrailStage.BEFORE:
             payload_dict = await guardrail.process_request(
-                payload_dict, auth_headers=auth_headers, usage_tracking=usage_tracking
+                payload_dict,
+                auth_headers=auth_headers,
+                usage_tracking=usage_tracking,
+                payload_schema=payload_schema,
             )
     return payload_dict
 
@@ -82,9 +87,14 @@ async def run_post_llm_guardrails(
         return response
 
     response_dict = response.model_dump()
+    schema = ChatCompletionResponse.model_json_schema()
     for guardrail in post_llm_guardrails:
         response_dict = await guardrail.process_response(
-            request_payload, response_dict, auth_headers=auth_headers, usage_tracking=usage_tracking
+            request_payload,
+            response_dict,
+            auth_headers=auth_headers,
+            usage_tracking=usage_tracking,
+            payload_schema=schema,
         )
     return chat.ResponsePayload(**response_dict)
 
@@ -99,9 +109,8 @@ async def run_post_llm_guardrails_passthrough(
     """Run post-LLM guardrails for passthrough endpoints.
 
     Like ``run_post_llm_guardrails`` but accepts and returns a plain ``dict``
-    instead of a ``chat.ResponsePayload``.  Sanitization automatically skips
-    ``response_format`` for payloads that don't conform to the chat-completion
-    schema (see ``JudgeGuardrail._infer_chat_model``).
+    instead of a ``chat.ResponsePayload``. No ``response_format`` schema constraint
+    is applied since passthrough responses are provider-specific formats.
 
     Note: post-LLM guardrails are skipped for streaming responses. Configure
     guardrails that must run on all responses to use the pre-LLM stage, or

--- a/mlflow/gateway/guardrail_utils.py
+++ b/mlflow/gateway/guardrail_utils.py
@@ -107,11 +107,9 @@ async def run_post_llm_guardrails_passthrough(
     guardrails that must run on all responses to use the pre-LLM stage, or
     disable streaming on the endpoint.
     """
-    post_llm_guardrails = [g for g in guardrails if g.stage == GuardrailStage.AFTER]
-    if not post_llm_guardrails:
-        return response
-
-    for guardrail in post_llm_guardrails:
+    for guardrail in guardrails:
+        if guardrail.stage != GuardrailStage.AFTER:
+            continue
         response = await guardrail.process_response(
             request_payload, response, auth_headers=auth_headers, usage_tracking=usage_tracking
         )

--- a/mlflow/gateway/guardrails.py
+++ b/mlflow/gateway/guardrails.py
@@ -22,7 +22,7 @@ from mlflow.gateway.providers.utils import send_request
 from mlflow.genai.judges.utils import CategoricalRating
 from mlflow.metrics.genai.model_utils import _parse_model_uri
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
-from mlflow.types.chat import ChatCompletionRequest, ChatCompletionResponse
+from mlflow.types.chat import ChatCompletionResponse
 
 if TYPE_CHECKING:
     from mlflow.genai.scorers import Scorer
@@ -211,15 +211,24 @@ class JudgeGuardrail(Guardrail):
     @staticmethod
     def _infer_chat_model(
         payload: dict[str, Any],
-    ) -> type[ChatCompletionRequest] | type[ChatCompletionResponse] | None:
-        """Return the chat model that *payload* validates against, or ``None``."""
-        for model in (ChatCompletionRequest, ChatCompletionResponse):
-            try:
-                model.model_validate(payload)
-                return model
-            except ValidationError:
-                pass
-        return None
+    ) -> type[ChatCompletionResponse] | None:
+        """Return ``ChatCompletionResponse`` if *payload* validates against it, else ``None``.
+
+        Only ``ChatCompletionResponse`` is detected: its ``choices`` field is a
+        reliable discriminator absent from Anthropic (``content``), Gemini
+        (``candidates``), and Responses API payloads.  Request-side payloads are
+        not detected because ``ChatCompletionRequest`` inherits
+        ``extra="ignore"`` from ``BaseRequestPayload``, causing Anthropic-style
+        payloads (which share ``messages`` and ``max_tokens``) to pass
+        validation incorrectly.
+        """
+        if "choices" not in payload:
+            return None
+        try:
+            ChatCompletionResponse.model_validate(payload)
+            return ChatCompletionResponse
+        except ValidationError:
+            return None
 
     async def _sanitize(
         self,
@@ -234,9 +243,9 @@ class JudgeGuardrail(Guardrail):
         resolved gateway invocations URL.
 
         ``response_format`` is included only when *payload* validates against
-        ``ChatCompletionRequest`` or ``ChatCompletionResponse``; for passthrough
-        payloads that don't conform to either schema it is omitted so the action
-        LLM is not constrained to a specific JSON schema.
+        ``ChatCompletionResponse``; for all other payloads (request-side or
+        passthrough) it is omitted so the action LLM is not constrained to a
+        specific JSON schema.
         """
         if not self.action_llm_url or not self.action_endpoint_name:
             raise GuardrailViolation(

--- a/mlflow/gateway/guardrails.py
+++ b/mlflow/gateway/guardrails.py
@@ -7,7 +7,6 @@ from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any
 
 from fastapi import HTTPException
-from pydantic import ValidationError
 
 import mlflow
 from mlflow.entities import SpanType
@@ -22,7 +21,6 @@ from mlflow.gateway.providers.utils import send_request
 from mlflow.genai.judges.utils import CategoricalRating
 from mlflow.metrics.genai.model_utils import _parse_model_uri
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
-from mlflow.types.chat import ChatCompletionResponse
 
 if TYPE_CHECKING:
     from mlflow.genai.scorers import Scorer
@@ -208,44 +206,23 @@ class JudgeGuardrail(Guardrail):
             raw = str(result)
         return raw[:_MAX_RATIONALE_LEN]
 
-    @staticmethod
-    def _infer_chat_model(
-        payload: dict[str, Any],
-    ) -> type[ChatCompletionResponse] | None:
-        """Return ``ChatCompletionResponse`` if *payload* validates against it, else ``None``.
-
-        Only ``ChatCompletionResponse`` is detected: its ``choices`` field is a
-        reliable discriminator absent from Anthropic (``content``), Gemini
-        (``candidates``), and Responses API payloads.  Request-side payloads are
-        not detected because ``ChatCompletionRequest`` inherits
-        ``extra="ignore"`` from ``BaseRequestPayload``, causing Anthropic-style
-        payloads (which share ``messages`` and ``max_tokens``) to pass
-        validation incorrectly.
-        """
-        if "choices" not in payload:
-            return None
-        try:
-            ChatCompletionResponse.model_validate(payload)
-            return ChatCompletionResponse
-        except ValidationError:
-            return None
-
     async def _sanitize(
         self,
         payload: dict[str, Any],
         rationale: str,
         auth_headers: dict[str, str] | None = None,
         usage_tracking: bool = False,
+        payload_schema: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Send the full payload to the action endpoint LLM for rewriting.
 
         Posts a chat request to ``action_llm_url`` which is the fully
         resolved gateway invocations URL.
 
-        ``response_format`` is included only when *payload* validates against
-        ``ChatCompletionResponse``; for all other payloads (request-side or
-        passthrough) it is omitted so the action LLM is not constrained to a
-        specific JSON schema.
+        When ``payload_schema`` is provided the sanitization request includes a
+        ``response_format`` constraint so the action LLM returns a JSON object
+        that matches the schema.  Pass ``None`` (the default) for passthrough or
+        request-side payloads where no schema constraint is needed.
         """
         if not self.action_llm_url or not self.action_endpoint_name:
             raise GuardrailViolation(
@@ -266,13 +243,13 @@ class JudgeGuardrail(Guardrail):
                 },
             ],
         }
-        if (payload_model := self._infer_chat_model(payload)) is not None:
+        if payload_schema is not None:
             body["response_format"] = {
                 "type": "json_schema",
                 "json_schema": {
                     "name": "sanitized_payload",
                     "strict": False,
-                    "schema": payload_model.model_json_schema(),
+                    "schema": payload_schema,
                 },
             }
 
@@ -328,6 +305,7 @@ class JudgeGuardrail(Guardrail):
         result: ScorerResult,
         auth_headers: dict[str, str] | None,
         usage_tracking: bool = False,
+        payload_schema: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Block or sanitize *payload* based on *result*.
 
@@ -348,6 +326,7 @@ class JudgeGuardrail(Guardrail):
             rationale,
             auth_headers=auth_headers,
             usage_tracking=usage_tracking,
+            payload_schema=payload_schema,
         )
 
     async def process_request(
@@ -355,13 +334,14 @@ class JudgeGuardrail(Guardrail):
         request: dict[str, Any],
         auth_headers: dict[str, str] | None = None,
         usage_tracking: bool = False,
+        payload_schema: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         if self.stage == GuardrailStage.AFTER:
             return request
 
         if not usage_tracking:
             result = await asyncio.to_thread(self._invoke_judge, inputs=request)
-            return await self._enforce(request, result, auth_headers)
+            return await self._enforce(request, result, auth_headers, payload_schema=payload_schema)
 
         with mlflow.start_span(
             name=f"guardrail/{self.name}", span_type=SpanType.GUARDRAIL
@@ -372,7 +352,11 @@ class JudgeGuardrail(Guardrail):
                 passed = self._is_passing(result)
                 jspan.set_outputs({"passed": passed, "rationale": self._get_rationale(result)})
             output = await self._enforce(
-                request, result, auth_headers, usage_tracking=usage_tracking
+                request,
+                result,
+                auth_headers,
+                usage_tracking=usage_tracking,
+                payload_schema=payload_schema,
             )
             gspan.set_outputs(output)
             return output
@@ -383,13 +367,16 @@ class JudgeGuardrail(Guardrail):
         response: dict[str, Any],
         auth_headers: dict[str, str] | None = None,
         usage_tracking: bool = False,
+        payload_schema: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         if self.stage == GuardrailStage.BEFORE:
             return response
 
         if not usage_tracking:
             result = await asyncio.to_thread(self._invoke_judge, inputs=request, outputs=response)
-            return await self._enforce(response, result, auth_headers)
+            return await self._enforce(
+                response, result, auth_headers, payload_schema=payload_schema
+            )
 
         with mlflow.start_span(
             name=f"guardrail/{self.name}", span_type=SpanType.GUARDRAIL
@@ -402,7 +389,11 @@ class JudgeGuardrail(Guardrail):
                 passed = self._is_passing(result)
                 jspan.set_outputs({"passed": passed, "rationale": self._get_rationale(result)})
             output = await self._enforce(
-                response, result, auth_headers, usage_tracking=usage_tracking
+                response,
+                result,
+                auth_headers,
+                usage_tracking=usage_tracking,
+                payload_schema=payload_schema,
             )
             gspan.set_outputs(output)
             return output

--- a/mlflow/gateway/guardrails.py
+++ b/mlflow/gateway/guardrails.py
@@ -207,11 +207,23 @@ class JudgeGuardrail(Guardrail):
             raw = str(result)
         return raw[:_MAX_RATIONALE_LEN]
 
+    @staticmethod
+    def _infer_chat_model(
+        payload: dict[str, Any],
+    ) -> type[ChatCompletionRequest] | type[ChatCompletionResponse] | None:
+        """Return the chat model that *payload* validates against, or ``None``."""
+        for model in (ChatCompletionRequest, ChatCompletionResponse):
+            try:
+                model.model_validate(payload)
+                return model
+            except Exception:
+                pass
+        return None
+
     async def _sanitize(
         self,
         payload: dict[str, Any],
         rationale: str,
-        payload_model: type[ChatCompletionRequest] | type[ChatCompletionResponse],
         auth_headers: dict[str, str] | None = None,
         usage_tracking: bool = False,
     ) -> dict[str, Any]:
@@ -219,6 +231,11 @@ class JudgeGuardrail(Guardrail):
 
         Posts a chat request to ``action_llm_url`` which is the fully
         resolved gateway invocations URL.
+
+        ``response_format`` is included only when *payload* validates against
+        ``ChatCompletionRequest`` or ``ChatCompletionResponse``; for passthrough
+        payloads that don't conform to either schema it is omitted so the action
+        LLM is not constrained to a specific JSON schema.
         """
         if not self.action_llm_url or not self.action_endpoint_name:
             raise GuardrailViolation(
@@ -228,7 +245,7 @@ class JudgeGuardrail(Guardrail):
 
         url = self.action_llm_url
         path = f"gateway/{self.action_endpoint_name}/mlflow/invocations"
-        body = {
+        body: dict[str, Any] = {
             "messages": [
                 {
                     "role": "user",
@@ -238,15 +255,16 @@ class JudgeGuardrail(Guardrail):
                     ),
                 },
             ],
-            "response_format": {
+        }
+        if (payload_model := self._infer_chat_model(payload)) is not None:
+            body["response_format"] = {
                 "type": "json_schema",
                 "json_schema": {
                     "name": "sanitized_payload",
                     "strict": False,
                     "schema": payload_model.model_json_schema(),
                 },
-            },
-        }
+            }
 
         headers = (
             {k: v for k, v in auth_headers.items() if k.lower() in _ALLOWED_AUTH_HEADERS}
@@ -297,7 +315,6 @@ class JudgeGuardrail(Guardrail):
     async def _enforce(
         self,
         payload: dict[str, Any],
-        payload_model: type[ChatCompletionRequest] | type[ChatCompletionResponse],
         result: ScorerResult,
         auth_headers: dict[str, str] | None,
         usage_tracking: bool = False,
@@ -319,7 +336,6 @@ class JudgeGuardrail(Guardrail):
         return await self._sanitize(
             payload,
             rationale,
-            payload_model,
             auth_headers=auth_headers,
             usage_tracking=usage_tracking,
         )
@@ -335,7 +351,7 @@ class JudgeGuardrail(Guardrail):
 
         if not usage_tracking:
             result = await asyncio.to_thread(self._invoke_judge, inputs=request)
-            return await self._enforce(request, ChatCompletionRequest, result, auth_headers)
+            return await self._enforce(request, result, auth_headers)
 
         with mlflow.start_span(
             name=f"guardrail/{self.name}", span_type=SpanType.GUARDRAIL
@@ -346,7 +362,7 @@ class JudgeGuardrail(Guardrail):
                 passed = self._is_passing(result)
                 jspan.set_outputs({"passed": passed, "rationale": self._get_rationale(result)})
             output = await self._enforce(
-                request, ChatCompletionRequest, result, auth_headers, usage_tracking=usage_tracking
+                request, result, auth_headers, usage_tracking=usage_tracking
             )
             gspan.set_outputs(output)
             return output
@@ -363,7 +379,7 @@ class JudgeGuardrail(Guardrail):
 
         if not usage_tracking:
             result = await asyncio.to_thread(self._invoke_judge, inputs=request, outputs=response)
-            return await self._enforce(response, ChatCompletionResponse, result, auth_headers)
+            return await self._enforce(response, result, auth_headers)
 
         with mlflow.start_span(
             name=f"guardrail/{self.name}", span_type=SpanType.GUARDRAIL
@@ -376,11 +392,7 @@ class JudgeGuardrail(Guardrail):
                 passed = self._is_passing(result)
                 jspan.set_outputs({"passed": passed, "rationale": self._get_rationale(result)})
             output = await self._enforce(
-                response,
-                ChatCompletionResponse,
-                result,
-                auth_headers,
-                usage_tracking=usage_tracking,
+                response, result, auth_headers, usage_tracking=usage_tracking
             )
             gspan.set_outputs(output)
             return output

--- a/mlflow/gateway/guardrails.py
+++ b/mlflow/gateway/guardrails.py
@@ -7,6 +7,7 @@ from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any
 
 from fastapi import HTTPException
+from pydantic import ValidationError
 
 import mlflow
 from mlflow.entities import SpanType
@@ -216,7 +217,7 @@ class JudgeGuardrail(Guardrail):
             try:
                 model.model_validate(payload)
                 return model
-            except Exception:
+            except ValidationError:
                 pass
         return None
 

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -40,6 +40,7 @@ from mlflow.gateway.guardrail_utils import (
     extract_auth_headers,
     load_guardrails,
     run_post_llm_guardrails,
+    run_post_llm_guardrails_passthrough,
     run_pre_llm_guardrails,
 )
 from mlflow.gateway.guardrails import (
@@ -858,19 +859,25 @@ async def openai_passthrough_chat(request: Request):
     )
     _set_gateway_telemetry_state(request, endpoint_config)
     check_budget_limit(store, endpoint_config, workspace=workspace)
+    guardrails, auth_headers = _get_guardrails_and_auth(store, endpoint_config, request)
 
     if body.get("stream", False):
-        stream = await provider.passthrough(
-            action=PassthroughAction.OPENAI_CHAT, payload=body, headers=headers
-        )
-
-        # Wrap stream iteration in an async generator so @mlflow.trace properly captures chunks
-        async def yield_stream(body: dict[str, Any]):
+        # Post-LLM guardrails are not applied to streaming responses.
+        async def _guarded_stream(body: dict[str, Any]):
+            request_dict = await run_pre_llm_guardrails(
+                guardrails,
+                body,
+                auth_headers=auth_headers,
+                usage_tracking=endpoint_config.usage_tracking,
+            )
+            stream = await provider.passthrough(
+                action=PassthroughAction.OPENAI_CHAT, payload=request_dict, headers=headers
+            )
             async for chunk in stream:
                 yield chunk
 
         traced_stream = maybe_traced_gateway_call(
-            yield_stream,
+            _guarded_stream,
             endpoint_config,
             user_metadata,
             request_headers=headers,
@@ -881,17 +888,33 @@ async def openai_passthrough_chat(request: Request):
             safe_stream(traced_stream(body), as_bytes=True), media_type="text/event-stream"
         )
 
-    traced_passthrough = maybe_traced_gateway_call(
-        provider.passthrough,
-        endpoint_config,
-        user_metadata,
-        request_headers=headers,
-        request_type=GatewayRequestType.PASSTHROUGH_MODEL_OPENAI_CHAT,
-        on_complete=make_budget_on_complete(store, workspace),
-    )
-    return await traced_passthrough(
-        action=PassthroughAction.OPENAI_CHAT, payload=body, headers=headers
-    )
+    try:
+        body = await run_pre_llm_guardrails(
+            guardrails,
+            body,
+            auth_headers=auth_headers,
+            usage_tracking=endpoint_config.usage_tracking,
+        )
+        traced_passthrough = maybe_traced_gateway_call(
+            provider.passthrough,
+            endpoint_config,
+            user_metadata,
+            request_headers=headers,
+            request_type=GatewayRequestType.PASSTHROUGH_MODEL_OPENAI_CHAT,
+            on_complete=make_budget_on_complete(store, workspace),
+        )
+        response = await traced_passthrough(
+            action=PassthroughAction.OPENAI_CHAT, payload=body, headers=headers
+        )
+        return await run_post_llm_guardrails_passthrough(
+            guardrails,
+            body,
+            response,
+            auth_headers=auth_headers,
+            usage_tracking=endpoint_config.usage_tracking,
+        )
+    except GuardrailViolation as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
 
 @gateway_router.post(PASSTHROUGH_ROUTES[PassthroughAction.OPENAI_EMBEDDINGS], response_model=None)
@@ -926,18 +949,35 @@ async def openai_passthrough_embeddings(request: Request):
     )
     _set_gateway_telemetry_state(request, endpoint_config)
     check_budget_limit(store, endpoint_config, workspace=workspace)
+    guardrails, auth_headers = _get_guardrails_and_auth(store, endpoint_config, request)
 
-    traced_passthrough = maybe_traced_gateway_call(
-        provider.passthrough,
-        endpoint_config,
-        user_metadata,
-        request_headers=headers,
-        request_type=GatewayRequestType.PASSTHROUGH_MODEL_OPENAI_EMBEDDINGS,
-        on_complete=make_budget_on_complete(store, workspace),
-    )
-    return await traced_passthrough(
-        action=PassthroughAction.OPENAI_EMBEDDINGS, payload=body, headers=headers
-    )
+    try:
+        body = await run_pre_llm_guardrails(
+            guardrails,
+            body,
+            auth_headers=auth_headers,
+            usage_tracking=endpoint_config.usage_tracking,
+        )
+        traced_passthrough = maybe_traced_gateway_call(
+            provider.passthrough,
+            endpoint_config,
+            user_metadata,
+            request_headers=headers,
+            request_type=GatewayRequestType.PASSTHROUGH_MODEL_OPENAI_EMBEDDINGS,
+            on_complete=make_budget_on_complete(store, workspace),
+        )
+        response = await traced_passthrough(
+            action=PassthroughAction.OPENAI_EMBEDDINGS, payload=body, headers=headers
+        )
+        return await run_post_llm_guardrails_passthrough(
+            guardrails,
+            body,
+            response,
+            auth_headers=auth_headers,
+            usage_tracking=endpoint_config.usage_tracking,
+        )
+    except GuardrailViolation as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
 
 @gateway_router.post(PASSTHROUGH_ROUTES[PassthroughAction.OPENAI_RESPONSES], response_model=None)
@@ -976,19 +1016,25 @@ async def openai_passthrough_responses(request: Request):
     )
     _set_gateway_telemetry_state(request, endpoint_config)
     check_budget_limit(store, endpoint_config, workspace=workspace)
+    guardrails, auth_headers = _get_guardrails_and_auth(store, endpoint_config, request)
 
     if body.get("stream", False):
-        stream = await provider.passthrough(
-            action=PassthroughAction.OPENAI_RESPONSES, payload=body, headers=headers
-        )
-
-        # Wrap stream iteration in an async generator so @mlflow.trace properly captures chunks
-        async def yield_stream(body: dict[str, Any]):
+        # Post-LLM guardrails are not applied to streaming responses.
+        async def _guarded_stream(body: dict[str, Any]):
+            request_dict = await run_pre_llm_guardrails(
+                guardrails,
+                body,
+                auth_headers=auth_headers,
+                usage_tracking=endpoint_config.usage_tracking,
+            )
+            stream = await provider.passthrough(
+                action=PassthroughAction.OPENAI_RESPONSES, payload=request_dict, headers=headers
+            )
             async for chunk in stream:
                 yield chunk
 
         traced_stream = maybe_traced_gateway_call(
-            yield_stream,
+            _guarded_stream,
             endpoint_config,
             user_metadata,
             output_reducer=aggregate_openai_responses_stream_chunks,
@@ -1000,17 +1046,33 @@ async def openai_passthrough_responses(request: Request):
             safe_stream(traced_stream(body), as_bytes=True), media_type="text/event-stream"
         )
 
-    traced_passthrough = maybe_traced_gateway_call(
-        provider.passthrough,
-        endpoint_config,
-        user_metadata,
-        request_headers=headers,
-        request_type=GatewayRequestType.PASSTHROUGH_MODEL_OPENAI_RESPONSES,
-        on_complete=make_budget_on_complete(store, workspace),
-    )
-    return await traced_passthrough(
-        action=PassthroughAction.OPENAI_RESPONSES, payload=body, headers=headers
-    )
+    try:
+        body = await run_pre_llm_guardrails(
+            guardrails,
+            body,
+            auth_headers=auth_headers,
+            usage_tracking=endpoint_config.usage_tracking,
+        )
+        traced_passthrough = maybe_traced_gateway_call(
+            provider.passthrough,
+            endpoint_config,
+            user_metadata,
+            request_headers=headers,
+            request_type=GatewayRequestType.PASSTHROUGH_MODEL_OPENAI_RESPONSES,
+            on_complete=make_budget_on_complete(store, workspace),
+        )
+        response = await traced_passthrough(
+            action=PassthroughAction.OPENAI_RESPONSES, payload=body, headers=headers
+        )
+        return await run_post_llm_guardrails_passthrough(
+            guardrails,
+            body,
+            response,
+            auth_headers=auth_headers,
+            usage_tracking=endpoint_config.usage_tracking,
+        )
+    except GuardrailViolation as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
 
 @gateway_router.post(PASSTHROUGH_ROUTES[PassthroughAction.ANTHROPIC_MESSAGES], response_model=None)
@@ -1049,19 +1111,25 @@ async def anthropic_passthrough_messages(request: Request):
     )
     _set_gateway_telemetry_state(request, endpoint_config)
     check_budget_limit(store, endpoint_config, workspace=workspace)
+    guardrails, auth_headers = _get_guardrails_and_auth(store, endpoint_config, request)
 
     if body.get("stream", False):
-        stream = await provider.passthrough(
-            action=PassthroughAction.ANTHROPIC_MESSAGES, payload=body, headers=headers
-        )
-
-        # Wrap stream iteration in an async generator so @mlflow.trace properly captures chunks
-        async def yield_stream(body: dict[str, Any]):
+        # Post-LLM guardrails are not applied to streaming responses.
+        async def _guarded_stream(body: dict[str, Any]):
+            request_dict = await run_pre_llm_guardrails(
+                guardrails,
+                body,
+                auth_headers=auth_headers,
+                usage_tracking=endpoint_config.usage_tracking,
+            )
+            stream = await provider.passthrough(
+                action=PassthroughAction.ANTHROPIC_MESSAGES, payload=request_dict, headers=headers
+            )
             async for chunk in stream:
                 yield chunk
 
         traced_stream = maybe_traced_gateway_call(
-            yield_stream,
+            _guarded_stream,
             endpoint_config,
             user_metadata,
             output_reducer=aggregate_anthropic_messages_stream_chunks,
@@ -1074,18 +1142,34 @@ async def anthropic_passthrough_messages(request: Request):
             safe_stream(traced_stream(body), as_bytes=True), media_type="text/event-stream"
         )
 
-    traced_passthrough = maybe_traced_gateway_call(
-        provider.passthrough,
-        endpoint_config,
-        user_metadata,
-        request_headers=headers,
-        request_type=GatewayRequestType.PASSTHROUGH_MODEL_ANTHROPIC_MESSAGES,
-        on_complete=make_budget_on_complete(store, workspace),
-        message_format="anthropic",
-    )
-    return await traced_passthrough(
-        action=PassthroughAction.ANTHROPIC_MESSAGES, payload=body, headers=headers
-    )
+    try:
+        body = await run_pre_llm_guardrails(
+            guardrails,
+            body,
+            auth_headers=auth_headers,
+            usage_tracking=endpoint_config.usage_tracking,
+        )
+        traced_passthrough = maybe_traced_gateway_call(
+            provider.passthrough,
+            endpoint_config,
+            user_metadata,
+            request_headers=headers,
+            request_type=GatewayRequestType.PASSTHROUGH_MODEL_ANTHROPIC_MESSAGES,
+            on_complete=make_budget_on_complete(store, workspace),
+            message_format="anthropic",
+        )
+        response = await traced_passthrough(
+            action=PassthroughAction.ANTHROPIC_MESSAGES, payload=body, headers=headers
+        )
+        return await run_post_llm_guardrails_passthrough(
+            guardrails,
+            body,
+            response,
+            auth_headers=auth_headers,
+            usage_tracking=endpoint_config.usage_tracking,
+        )
+    except GuardrailViolation as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
 
 @gateway_router.post(
@@ -1124,19 +1208,36 @@ async def gemini_passthrough_generate_content(endpoint_name: str, request: Reque
     )
     _set_gateway_telemetry_state(request, endpoint_config)
     check_budget_limit(store, endpoint_config, workspace=workspace)
+    guardrails, auth_headers = _get_guardrails_and_auth(store, endpoint_config, request)
 
-    traced_passthrough = maybe_traced_gateway_call(
-        provider.passthrough,
-        endpoint_config,
-        user_metadata,
-        request_headers=headers,
-        request_type=GatewayRequestType.PASSTHROUGH_MODEL_GEMINI_GENERATE_CONTENT,
-        on_complete=make_budget_on_complete(store, workspace),
-        message_format="gemini",
-    )
-    return await traced_passthrough(
-        action=PassthroughAction.GEMINI_GENERATE_CONTENT, payload=body, headers=headers
-    )
+    try:
+        body = await run_pre_llm_guardrails(
+            guardrails,
+            body,
+            auth_headers=auth_headers,
+            usage_tracking=endpoint_config.usage_tracking,
+        )
+        traced_passthrough = maybe_traced_gateway_call(
+            provider.passthrough,
+            endpoint_config,
+            user_metadata,
+            request_headers=headers,
+            request_type=GatewayRequestType.PASSTHROUGH_MODEL_GEMINI_GENERATE_CONTENT,
+            on_complete=make_budget_on_complete(store, workspace),
+            message_format="gemini",
+        )
+        response = await traced_passthrough(
+            action=PassthroughAction.GEMINI_GENERATE_CONTENT, payload=body, headers=headers
+        )
+        return await run_post_llm_guardrails_passthrough(
+            guardrails,
+            body,
+            response,
+            auth_headers=auth_headers,
+            usage_tracking=endpoint_config.usage_tracking,
+        )
+    except GuardrailViolation as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
 
 @gateway_router.post(
@@ -1175,18 +1276,26 @@ async def gemini_passthrough_stream_generate_content(endpoint_name: str, request
     )
     _set_gateway_telemetry_state(request, endpoint_config)
     check_budget_limit(store, endpoint_config, workspace=workspace)
+    guardrails, auth_headers = _get_guardrails_and_auth(store, endpoint_config, request)
 
-    stream = await provider.passthrough(
-        action=PassthroughAction.GEMINI_STREAM_GENERATE_CONTENT, payload=body, headers=headers
-    )
-
-    # Wrap stream iteration in an async generator so @mlflow.trace properly captures chunks
-    async def yield_stream(body: dict[str, Any]):
+    # Post-LLM guardrails are not applied to streaming responses.
+    async def _guarded_stream(body: dict[str, Any]):
+        request_dict = await run_pre_llm_guardrails(
+            guardrails,
+            body,
+            auth_headers=auth_headers,
+            usage_tracking=endpoint_config.usage_tracking,
+        )
+        stream = await provider.passthrough(
+            action=PassthroughAction.GEMINI_STREAM_GENERATE_CONTENT,
+            payload=request_dict,
+            headers=headers,
+        )
         async for chunk in stream:
             yield chunk
 
     traced_stream = maybe_traced_gateway_call(
-        yield_stream,
+        _guarded_stream,
         endpoint_config,
         user_metadata,
         output_reducer=aggregate_gemini_stream_generate_content_chunks,

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -79,6 +79,7 @@ from mlflow.telemetry.events import GatewayInvocationEvent, GatewayInvocationTyp
 from mlflow.telemetry.track import _record_event
 from mlflow.tracing.constant import TraceMetadataKey
 from mlflow.tracking._tracking_service.utils import _get_store
+from mlflow.types.chat import ChatCompletionRequest
 from mlflow.utils.provider_filter import is_provider_allowed, normalize_provider_name
 from mlflow.utils.workspace_context import get_request_workspace
 
@@ -640,6 +641,7 @@ async def invocations(endpoint_name: str, request: Request):
                     payload.model_dump(),
                     auth_headers=auth_headers,
                     usage_tracking=endpoint_config.usage_tracking,
+                    payload_schema=ChatCompletionRequest.model_json_schema(),
                 )
                 async for chunk in provider.chat_stream(chat.RequestPayload(**request_dict)):
                     yield chunk
@@ -667,6 +669,7 @@ async def invocations(endpoint_name: str, request: Request):
                     payload.model_dump(),
                     auth_headers=auth_headers,
                     usage_tracking=endpoint_config.usage_tracking,
+                    payload_schema=ChatCompletionRequest.model_json_schema(),
                 )
                 modified_payload = chat.RequestPayload(**request_dict)
                 response = await provider.chat(modified_payload)
@@ -772,6 +775,7 @@ async def chat_completions(request: Request):
                 payload.model_dump(),
                 auth_headers=auth_headers,
                 usage_tracking=endpoint_config.usage_tracking,
+                payload_schema=ChatCompletionRequest.model_json_schema(),
             )
             async for chunk in provider.chat_stream(chat.RequestPayload(**request_dict)):
                 yield chunk
@@ -799,6 +803,7 @@ async def chat_completions(request: Request):
                 payload.model_dump(),
                 auth_headers=auth_headers,
                 usage_tracking=endpoint_config.usage_tracking,
+                payload_schema=ChatCompletionRequest.model_json_schema(),
             )
             modified_payload = chat.RequestPayload(**request_dict)
             response = await provider.chat(modified_payload)

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -958,26 +958,22 @@ async def openai_passthrough_embeddings(request: Request):
             auth_headers=auth_headers,
             usage_tracking=endpoint_config.usage_tracking,
         )
-        traced_passthrough = maybe_traced_gateway_call(
-            provider.passthrough,
-            endpoint_config,
-            user_metadata,
-            request_headers=headers,
-            request_type=GatewayRequestType.PASSTHROUGH_MODEL_OPENAI_EMBEDDINGS,
-            on_complete=make_budget_on_complete(store, workspace),
-        )
-        response = await traced_passthrough(
-            action=PassthroughAction.OPENAI_EMBEDDINGS, payload=body, headers=headers
-        )
-        return await run_post_llm_guardrails_passthrough(
-            guardrails,
-            body,
-            response,
-            auth_headers=auth_headers,
-            usage_tracking=endpoint_config.usage_tracking,
-        )
     except GuardrailViolation as e:
         raise HTTPException(status_code=400, detail=str(e))
+
+    traced_passthrough = maybe_traced_gateway_call(
+        provider.passthrough,
+        endpoint_config,
+        user_metadata,
+        request_headers=headers,
+        request_type=GatewayRequestType.PASSTHROUGH_MODEL_OPENAI_EMBEDDINGS,
+        on_complete=make_budget_on_complete(store, workspace),
+    )
+    # Post-LLM guardrails are skipped for embeddings: responses are float vectors
+    # that content judges cannot meaningfully evaluate.
+    return await traced_passthrough(
+        action=PassthroughAction.OPENAI_EMBEDDINGS, payload=body, headers=headers
+    )
 
 
 @gateway_router.post(PASSTHROUGH_ROUTES[PassthroughAction.OPENAI_RESPONSES], response_model=None)

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -893,22 +893,14 @@ async def openai_passthrough_chat(request: Request):
             safe_stream(traced_stream(body), as_bytes=True), media_type="text/event-stream"
         )
 
-    try:
+    async def _guarded_passthrough(body: dict[str, Any]) -> dict[str, Any]:
         body = await run_pre_llm_guardrails(
             guardrails,
             body,
             auth_headers=auth_headers,
             usage_tracking=endpoint_config.usage_tracking,
         )
-        traced_passthrough = maybe_traced_gateway_call(
-            provider.passthrough,
-            endpoint_config,
-            user_metadata,
-            request_headers=headers,
-            request_type=GatewayRequestType.PASSTHROUGH_MODEL_OPENAI_CHAT,
-            on_complete=make_budget_on_complete(store, workspace),
-        )
-        response = await traced_passthrough(
+        response = await provider.passthrough(
             action=PassthroughAction.OPENAI_CHAT, payload=body, headers=headers
         )
         return await run_post_llm_guardrails_passthrough(
@@ -918,6 +910,16 @@ async def openai_passthrough_chat(request: Request):
             auth_headers=auth_headers,
             usage_tracking=endpoint_config.usage_tracking,
         )
+
+    try:
+        return await maybe_traced_gateway_call(
+            _guarded_passthrough,
+            endpoint_config,
+            user_metadata,
+            request_headers=headers,
+            request_type=GatewayRequestType.PASSTHROUGH_MODEL_OPENAI_CHAT,
+            on_complete=make_budget_on_complete(store, workspace),
+        )(body)
     except GuardrailViolation as e:
         raise HTTPException(status_code=400, detail=str(e))
 
@@ -1047,22 +1049,14 @@ async def openai_passthrough_responses(request: Request):
             safe_stream(traced_stream(body), as_bytes=True), media_type="text/event-stream"
         )
 
-    try:
+    async def _guarded_passthrough(body: dict[str, Any]) -> dict[str, Any]:
         body = await run_pre_llm_guardrails(
             guardrails,
             body,
             auth_headers=auth_headers,
             usage_tracking=endpoint_config.usage_tracking,
         )
-        traced_passthrough = maybe_traced_gateway_call(
-            provider.passthrough,
-            endpoint_config,
-            user_metadata,
-            request_headers=headers,
-            request_type=GatewayRequestType.PASSTHROUGH_MODEL_OPENAI_RESPONSES,
-            on_complete=make_budget_on_complete(store, workspace),
-        )
-        response = await traced_passthrough(
+        response = await provider.passthrough(
             action=PassthroughAction.OPENAI_RESPONSES, payload=body, headers=headers
         )
         return await run_post_llm_guardrails_passthrough(
@@ -1072,6 +1066,16 @@ async def openai_passthrough_responses(request: Request):
             auth_headers=auth_headers,
             usage_tracking=endpoint_config.usage_tracking,
         )
+
+    try:
+        return await maybe_traced_gateway_call(
+            _guarded_passthrough,
+            endpoint_config,
+            user_metadata,
+            request_headers=headers,
+            request_type=GatewayRequestType.PASSTHROUGH_MODEL_OPENAI_RESPONSES,
+            on_complete=make_budget_on_complete(store, workspace),
+        )(body)
     except GuardrailViolation as e:
         raise HTTPException(status_code=400, detail=str(e))
 
@@ -1143,23 +1147,14 @@ async def anthropic_passthrough_messages(request: Request):
             safe_stream(traced_stream(body), as_bytes=True), media_type="text/event-stream"
         )
 
-    try:
+    async def _guarded_passthrough(body: dict[str, Any]) -> dict[str, Any]:
         body = await run_pre_llm_guardrails(
             guardrails,
             body,
             auth_headers=auth_headers,
             usage_tracking=endpoint_config.usage_tracking,
         )
-        traced_passthrough = maybe_traced_gateway_call(
-            provider.passthrough,
-            endpoint_config,
-            user_metadata,
-            request_headers=headers,
-            request_type=GatewayRequestType.PASSTHROUGH_MODEL_ANTHROPIC_MESSAGES,
-            on_complete=make_budget_on_complete(store, workspace),
-            message_format="anthropic",
-        )
-        response = await traced_passthrough(
+        response = await provider.passthrough(
             action=PassthroughAction.ANTHROPIC_MESSAGES, payload=body, headers=headers
         )
         return await run_post_llm_guardrails_passthrough(
@@ -1169,6 +1164,17 @@ async def anthropic_passthrough_messages(request: Request):
             auth_headers=auth_headers,
             usage_tracking=endpoint_config.usage_tracking,
         )
+
+    try:
+        return await maybe_traced_gateway_call(
+            _guarded_passthrough,
+            endpoint_config,
+            user_metadata,
+            request_headers=headers,
+            request_type=GatewayRequestType.PASSTHROUGH_MODEL_ANTHROPIC_MESSAGES,
+            on_complete=make_budget_on_complete(store, workspace),
+            message_format="anthropic",
+        )(body)
     except GuardrailViolation as e:
         raise HTTPException(status_code=400, detail=str(e))
 
@@ -1211,23 +1217,14 @@ async def gemini_passthrough_generate_content(endpoint_name: str, request: Reque
     check_budget_limit(store, endpoint_config, workspace=workspace)
     guardrails, auth_headers = _get_guardrails_and_auth(store, endpoint_config, request)
 
-    try:
+    async def _guarded_passthrough(body: dict[str, Any]) -> dict[str, Any]:
         body = await run_pre_llm_guardrails(
             guardrails,
             body,
             auth_headers=auth_headers,
             usage_tracking=endpoint_config.usage_tracking,
         )
-        traced_passthrough = maybe_traced_gateway_call(
-            provider.passthrough,
-            endpoint_config,
-            user_metadata,
-            request_headers=headers,
-            request_type=GatewayRequestType.PASSTHROUGH_MODEL_GEMINI_GENERATE_CONTENT,
-            on_complete=make_budget_on_complete(store, workspace),
-            message_format="gemini",
-        )
-        response = await traced_passthrough(
+        response = await provider.passthrough(
             action=PassthroughAction.GEMINI_GENERATE_CONTENT, payload=body, headers=headers
         )
         return await run_post_llm_guardrails_passthrough(
@@ -1237,6 +1234,17 @@ async def gemini_passthrough_generate_content(endpoint_name: str, request: Reque
             auth_headers=auth_headers,
             usage_tracking=endpoint_config.usage_tracking,
         )
+
+    try:
+        return await maybe_traced_gateway_call(
+            _guarded_passthrough,
+            endpoint_config,
+            user_metadata,
+            request_headers=headers,
+            request_type=GatewayRequestType.PASSTHROUGH_MODEL_GEMINI_GENERATE_CONTENT,
+            on_complete=make_budget_on_complete(store, workspace),
+            message_format="gemini",
+        )(body)
     except GuardrailViolation as e:
         raise HTTPException(status_code=400, detail=str(e))
 

--- a/tests/gateway/test_guardrail_utils.py
+++ b/tests/gateway/test_guardrail_utils.py
@@ -13,6 +13,7 @@ from mlflow.entities.scorer import ScorerVersion
 from mlflow.gateway.guardrail_utils import (
     load_guardrails,
     run_post_llm_guardrails,
+    run_post_llm_guardrails_passthrough,
     run_pre_llm_guardrails,
 )
 from mlflow.gateway.guardrails import GuardrailViolation, JudgeGuardrail
@@ -182,6 +183,48 @@ async def test_run_post_llm_guardrails_blocks():
 async def test_run_post_llm_guardrails_no_guardrails_returns_response():
     response = _make_response_payload()
     result = await run_post_llm_guardrails([], _make_request_payload(), response)
+    assert result is response
+
+
+# ─── run_post_llm_guardrails_passthrough ─────────────────────────────────────
+
+
+def _make_passthrough_response():
+    return {"candidates": [{"content": {"parts": [{"text": "hi"}]}}]}
+
+
+@pytest.mark.asyncio
+async def test_run_post_llm_guardrails_passthrough_passes():
+    g = _make_judge("AFTER")
+    req = _make_request_payload()
+    response = _make_passthrough_response()
+    result = await run_post_llm_guardrails_passthrough([g], req, response)
+    assert result == response
+    assert g.scorer.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_run_post_llm_guardrails_passthrough_skips_before_stage():
+    g = _make_judge("BEFORE")
+    response = _make_passthrough_response()
+    result = await run_post_llm_guardrails_passthrough([g], _make_request_payload(), response)
+    assert result is response
+    assert g.scorer.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_run_post_llm_guardrails_passthrough_blocks():
+    g = _make_judge("AFTER", passing=False)
+    with pytest.raises(GuardrailViolation, match="blocked"):
+        await run_post_llm_guardrails_passthrough(
+            [g], _make_request_payload(), _make_passthrough_response()
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_post_llm_guardrails_passthrough_no_guardrails_returns_response():
+    response = _make_passthrough_response()
+    result = await run_post_llm_guardrails_passthrough([], _make_request_payload(), response)
     assert result is response
 
 

--- a/tests/gateway/test_guardrails.py
+++ b/tests/gateway/test_guardrails.py
@@ -11,7 +11,7 @@ from mlflow.entities.assessment import Feedback
 from mlflow.entities.gateway_guardrail import GuardrailAction, GuardrailStage
 from mlflow.gateway.guardrails import GuardrailViolation, JudgeGuardrail
 from mlflow.tracing.client import TracingClient
-from mlflow.types.chat import ChatCompletionRequest, ChatCompletionResponse
+from mlflow.types.chat import ChatCompletionResponse
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -218,7 +218,10 @@ async def test_sanitization_passes_on_good_content():
 
 
 @pytest.mark.asyncio
-async def test_sanitization_uses_json_object_response_format():
+async def test_sanitization_skips_response_format_for_request_payload():
+    # Request payloads are not schema-constrained during sanitization because
+    # ChatCompletionRequest shares field names with Anthropic-style payloads
+    # (both use 'messages' and 'max_tokens'), making reliable detection impossible.
     scorer = _SimpleScorer(_feedback(value=False, rationale="issue"))
     guard = JudgeGuardrail(
         scorer,
@@ -238,14 +241,7 @@ async def test_sanitization_uses_json_object_response_format():
     with mock.patch("mlflow.gateway.guardrails.send_request", side_effect=capture_send_request):
         await guard.process_request(_make_request())
 
-    assert captured[0]["payload"]["response_format"] == {
-        "type": "json_schema",
-        "json_schema": {
-            "name": "sanitized_payload",
-            "strict": False,
-            "schema": ChatCompletionRequest.model_json_schema(),
-        },
-    }
+    assert "response_format" not in captured[0]["payload"]
 
 
 def _make_full_response(text="I'm a helpful assistant."):
@@ -326,9 +322,12 @@ async def test_sanitization_skips_response_format_for_passthrough_payload():
 # ---------------------------------------------------------------------------
 
 
-def test_infer_chat_model_identifies_request():
+def test_infer_chat_model_returns_none_for_request():
+    # Request payloads are not detected: ChatCompletionRequest inherits extra="ignore"
+    # from BaseRequestPayload, so Anthropic-style payloads (messages + max_tokens)
+    # would pass validation incorrectly. We only detect response payloads.
     payload = {"messages": [{"role": "user", "content": "hello"}]}
-    assert JudgeGuardrail._infer_chat_model(payload) is ChatCompletionRequest
+    assert JudgeGuardrail._infer_chat_model(payload) is None
 
 
 def test_infer_chat_model_identifies_response():

--- a/tests/gateway/test_guardrails.py
+++ b/tests/gateway/test_guardrails.py
@@ -11,7 +11,7 @@ from mlflow.entities.assessment import Feedback
 from mlflow.entities.gateway_guardrail import GuardrailAction, GuardrailStage
 from mlflow.gateway.guardrails import GuardrailViolation, JudgeGuardrail
 from mlflow.tracing.client import TracingClient
-from mlflow.types.chat import ChatCompletionRequest
+from mlflow.types.chat import ChatCompletionRequest, ChatCompletionResponse
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -246,6 +246,87 @@ async def test_sanitization_uses_json_object_response_format():
             "schema": ChatCompletionRequest.model_json_schema(),
         },
     }
+
+
+@pytest.mark.asyncio
+async def test_sanitization_uses_response_format_for_chat_response():
+    """response_format uses ChatCompletionResponse schema when the payload looks like a response."""
+    scorer = _SimpleScorer(_feedback(value=False, rationale="issue"))
+    guard = JudgeGuardrail(
+        scorer,
+        GuardrailStage.AFTER,
+        GuardrailAction.SANITIZATION,
+        "test",
+        action_llm_url="http://localhost:5000",
+        action_endpoint_name="ep-sanitizer",
+    )
+    sanitized = _make_response("cleaned")
+    captured: list[dict[str, Any]] = []
+
+    async def capture_send_request(*args, **kwargs):
+        captured.append(kwargs)
+        return {"choices": [{"message": {"content": json.dumps(sanitized)}}]}
+
+    with mock.patch("mlflow.gateway.guardrails.send_request", side_effect=capture_send_request):
+        await guard.process_response(_make_request(), _make_response("bad"))
+
+    assert captured[0]["payload"]["response_format"]["json_schema"]["schema"] == (
+        ChatCompletionResponse.model_json_schema()
+    )
+
+
+@pytest.mark.asyncio
+async def test_sanitization_skips_response_format_for_passthrough_payload():
+    """response_format is omitted when the payload doesn't match chat-completion schemas."""
+    scorer = _SimpleScorer(_feedback(value=False, rationale="issue"))
+    guard = JudgeGuardrail(
+        scorer,
+        GuardrailStage.BEFORE,
+        GuardrailAction.SANITIZATION,
+        "test",
+        action_llm_url="http://localhost:5000",
+        action_endpoint_name="ep-sanitizer",
+    )
+    # Anthropic-style payload that doesn't conform to ChatCompletionRequest
+    anthropic_request = {
+        "messages": [{"role": "user", "content": "hello"}],
+        "max_tokens": 1024,
+    }
+    sanitized = {**anthropic_request}
+    captured: list[dict[str, Any]] = []
+
+    async def capture_send_request(*args, **kwargs):
+        captured.append(kwargs)
+        return {"choices": [{"message": {"content": json.dumps(sanitized)}}]}
+
+    with mock.patch("mlflow.gateway.guardrails.send_request", side_effect=capture_send_request):
+        await guard.process_request(anthropic_request)
+
+    assert "response_format" not in captured[0]["payload"]
+
+
+# ---------------------------------------------------------------------------
+# _infer_chat_model
+# ---------------------------------------------------------------------------
+
+
+def test_infer_chat_model_identifies_request():
+    payload = {"messages": [{"role": "user", "content": "hello"}]}
+    assert JudgeGuardrail._infer_chat_model(payload) is ChatCompletionRequest
+
+
+def test_infer_chat_model_identifies_response():
+    payload = {
+        "choices": [{"message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10},
+    }
+    assert JudgeGuardrail._infer_chat_model(payload) is ChatCompletionResponse
+
+
+def test_infer_chat_model_returns_none_for_passthrough():
+    # Gemini-style payload
+    payload = {"contents": [{"role": "user", "parts": [{"text": "hello"}]}]}
+    assert JudgeGuardrail._infer_chat_model(payload) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_guardrails.py
+++ b/tests/gateway/test_guardrails.py
@@ -248,6 +248,24 @@ async def test_sanitization_uses_json_object_response_format():
     }
 
 
+def _make_full_response(text="I'm a helpful assistant."):
+    """Return a response dict that satisfies ChatCompletionResponse validation."""
+    return {
+        "id": "chatcmpl-test",
+        "object": "chat.completion",
+        "created": 123,
+        "model": "gpt-4o-mini",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": text},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10},
+    }
+
+
 @pytest.mark.asyncio
 async def test_sanitization_uses_response_format_for_chat_response():
     scorer = _SimpleScorer(_feedback(value=False, rationale="issue"))
@@ -259,7 +277,7 @@ async def test_sanitization_uses_response_format_for_chat_response():
         action_llm_url="http://localhost:5000",
         action_endpoint_name="ep-sanitizer",
     )
-    sanitized = _make_response("cleaned")
+    sanitized = _make_full_response("cleaned")
     captured: list[dict[str, Any]] = []
 
     async def capture_send_request(*args, **kwargs):
@@ -267,7 +285,7 @@ async def test_sanitization_uses_response_format_for_chat_response():
         return {"choices": [{"message": {"content": json.dumps(sanitized)}}]}
 
     with mock.patch("mlflow.gateway.guardrails.send_request", side_effect=capture_send_request):
-        await guard.process_response(_make_request(), _make_response("bad"))
+        await guard.process_response(_make_request(), _make_full_response("bad"))
 
     assert captured[0]["payload"]["response_format"]["json_schema"]["schema"] == (
         ChatCompletionResponse.model_json_schema()
@@ -314,10 +332,7 @@ def test_infer_chat_model_identifies_request():
 
 
 def test_infer_chat_model_identifies_response():
-    payload = {
-        "choices": [{"message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
-        "usage": {"prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10},
-    }
+    payload = _make_full_response("hi")
     assert JudgeGuardrail._infer_chat_model(payload) is ChatCompletionResponse
 
 

--- a/tests/gateway/test_guardrails.py
+++ b/tests/gateway/test_guardrails.py
@@ -218,10 +218,11 @@ async def test_sanitization_passes_on_good_content():
 
 
 @pytest.mark.asyncio
-async def test_sanitization_skips_response_format_for_request_payload():
-    # Request payloads are not schema-constrained during sanitization because
-    # ChatCompletionRequest shares field names with Anthropic-style payloads
-    # (both use 'messages' and 'max_tokens'), making reliable detection impossible.
+async def test_sanitization_skips_response_format_when_no_schema_provided():
+    # When payload_schema is None (the default), sanitization omits response_format.
+    # Used by passthrough endpoints, where ChatCompletionRequest shares field names
+    # with provider-specific shapes (e.g. Anthropic also uses messages/max_tokens),
+    # making reliable detection impossible — so callers explicitly opt in via payload_schema.
     scorer = _SimpleScorer(_feedback(value=False, rationale="issue"))
     guard = JudgeGuardrail(
         scorer,

--- a/tests/gateway/test_guardrails.py
+++ b/tests/gateway/test_guardrails.py
@@ -250,7 +250,6 @@ async def test_sanitization_uses_json_object_response_format():
 
 @pytest.mark.asyncio
 async def test_sanitization_uses_response_format_for_chat_response():
-    """response_format uses ChatCompletionResponse schema when the payload looks like a response."""
     scorer = _SimpleScorer(_feedback(value=False, rationale="issue"))
     guard = JudgeGuardrail(
         scorer,
@@ -277,7 +276,6 @@ async def test_sanitization_uses_response_format_for_chat_response():
 
 @pytest.mark.asyncio
 async def test_sanitization_skips_response_format_for_passthrough_payload():
-    """response_format is omitted when the payload doesn't match chat-completion schemas."""
     scorer = _SimpleScorer(_feedback(value=False, rationale="issue"))
     guard = JudgeGuardrail(
         scorer,

--- a/tests/gateway/test_guardrails.py
+++ b/tests/gateway/test_guardrails.py
@@ -281,7 +281,11 @@ async def test_sanitization_uses_response_format_for_chat_response():
         return {"choices": [{"message": {"content": json.dumps(sanitized)}}]}
 
     with mock.patch("mlflow.gateway.guardrails.send_request", side_effect=capture_send_request):
-        await guard.process_response(_make_request(), _make_full_response("bad"))
+        await guard.process_response(
+            _make_request(),
+            _make_full_response("bad"),
+            payload_schema=ChatCompletionResponse.model_json_schema(),
+        )
 
     assert captured[0]["payload"]["response_format"]["json_schema"]["schema"] == (
         ChatCompletionResponse.model_json_schema()
@@ -315,30 +319,6 @@ async def test_sanitization_skips_response_format_for_passthrough_payload():
         await guard.process_request(anthropic_request)
 
     assert "response_format" not in captured[0]["payload"]
-
-
-# ---------------------------------------------------------------------------
-# _infer_chat_model
-# ---------------------------------------------------------------------------
-
-
-def test_infer_chat_model_returns_none_for_request():
-    # Request payloads are not detected: ChatCompletionRequest inherits extra="ignore"
-    # from BaseRequestPayload, so Anthropic-style payloads (messages + max_tokens)
-    # would pass validation incorrectly. We only detect response payloads.
-    payload = {"messages": [{"role": "user", "content": "hello"}]}
-    assert JudgeGuardrail._infer_chat_model(payload) is None
-
-
-def test_infer_chat_model_identifies_response():
-    payload = _make_full_response("hi")
-    assert JudgeGuardrail._infer_chat_model(payload) is ChatCompletionResponse
-
-
-def test_infer_chat_model_returns_none_for_passthrough():
-    # Gemini-style payload
-    payload = {"contents": [{"role": "user", "parts": [{"text": "hello"}]}]}
-    assert JudgeGuardrail._infer_chat_model(payload) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/server/test_gateway_api.py
+++ b/tests/server/test_gateway_api.py
@@ -1535,12 +1535,12 @@ async def test_openai_passthrough_chat_streaming(store: SqlAlchemyStore):
     ) as mock_send_stream:
         response = await openai_passthrough_chat(mock_request)
 
-        assert mock_send_stream.called
         assert isinstance(response, StreamingResponse)
         assert response.media_type == "text/event-stream"
 
         chunks = [chunk async for chunk in response.body_iterator]
 
+        assert mock_send_stream.called
         assert len(chunks) == 3
         assert b"Hello" in chunks[0]
         assert b"world" in chunks[1]
@@ -1604,12 +1604,12 @@ async def test_openai_passthrough_responses_streaming(store: SqlAlchemyStore):
     ) as mock_send_stream:
         response = await openai_passthrough_responses(mock_request)
 
-        assert mock_send_stream.called
         assert isinstance(response, StreamingResponse)
         assert response.media_type == "text/event-stream"
 
         chunks = [chunk async for chunk in response.body_iterator]
 
+        assert mock_send_stream.called
         assert len(chunks) == 8
         assert b"response.created" in chunks[0]
         assert b"response.output_item.added" in chunks[1]
@@ -1741,11 +1741,12 @@ async def test_anthropic_passthrough_messages_streaming(store: SqlAlchemyStore):
     ) as mock_send_stream:
         response = await anthropic_passthrough_messages(mock_request)
 
-        assert mock_send_stream.called
         assert isinstance(response, StreamingResponse)
         assert response.media_type == "text/event-stream"
 
         chunks = [chunk async for chunk in response.body_iterator]
+
+        assert mock_send_stream.called
 
         assert len(chunks) == 7
         assert b"message_start" in chunks[0]
@@ -1892,11 +1893,12 @@ async def test_gemini_passthrough_stream_generate_content(store: SqlAlchemyStore
             "gemini-stream-passthrough-endpoint", mock_request
         )
 
-        assert mock_send_stream.called
         assert isinstance(response, StreamingResponse)
         assert response.media_type == "text/event-stream"
 
         chunks = [chunk async for chunk in response.body_iterator]
+
+        assert mock_send_stream.called
 
         assert len(chunks) == 3
         assert b"Hello" in chunks[0]


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

**Schema-aware sanitization** — `_sanitize()` no longer requires an explicit `payload_model` argument. A new `JudgeGuardrail._infer_chat_model(payload)` static method tries to validate the payload against `ChatCompletionRequest` then `ChatCompletionResponse`. If neither matches (e.g. Anthropic, Gemini, or OpenAI Responses format), `response_format` is omitted from the sanitization request so the action LLM is not constrained to a specific JSON schema. This removes the `payload_model` parameter from `_enforce()` and `_sanitize()`.

**Guardrails on passthrough endpoints** — Pre- and post-LLM guardrails are now wired into all five passthrough handlers in `gateway_api.py`:
- `openai_passthrough_chat`
- `openai_passthrough_embeddings`
- `openai_passthrough_responses`
- `anthropic_passthrough_messages`
- `gemini_passthrough_generate_content`
- `gemini_passthrough_stream_generate_content` (pre-LLM only; streaming skips post-LLM guardrails, consistent with unified endpoints)

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests


### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Instructions (`docs/docs/genai/governance/ai-gateway/guardrails.mdx`)

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Guardrails (validation and sanitization) now apply to passthrough endpoints (OpenAI, Anthropic, Gemini). For non-chat-completion payloads, sanitization omits the `response_format` constraint so the action LLM can rewrite provider-specific formats freely.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release