### PR TITLE
Sanitize `uv.lock` registry URLs when regenerating

### DIFF
--- a/dev/pyproject.py
+++ b/dev/pyproject.py
@@ -461,6 +461,36 @@ def build(package_type: PackageType) -> None:
 
         write_file_if_changed(out_path, formatted_full_content)
         subprocess.check_call(["uv", "lock"])
+        _sanitize_uv_lock_indexes(Path("uv.lock"))
+
+
+# Indexes that are allowed to appear in uv.lock. Any other registry URL (e.g. a
+# contributor's private uv mirror that leaked in via UV_DEFAULT_INDEX) is
+# rewritten back to public PyPI before the lockfile is committed. See
+# https://github.com/astral-sh/uv/issues/6349.
+_PUBLIC_PYPI_INDEX = "https://pypi.org/simple"
+_ALLOWED_LOCK_INDEXES = frozenset(
+    {
+        _PUBLIC_PYPI_INDEX,
+        "https://download.pytorch.org/whl/cpu",
+    }
+)
+_REGISTRY_RE = re.compile(r'registry = "(https?://[^"]+)"')
+
+
+def _sanitize_uv_lock_indexes(lock_path: Path) -> None:
+    content = lock_path.read_text()
+
+    def replace(match: re.Match[str]) -> str:
+        url = match.group(1)
+        if url in _ALLOWED_LOCK_INDEXES:
+            return match.group(0)
+        return f'registry = "{_PUBLIC_PYPI_INDEX}"'
+
+    new_content = _REGISTRY_RE.sub(replace, content)
+    if new_content != content:
+        print(f"Rewrote non-public registry URLs in {lock_path} to {_PUBLIC_PYPI_INDEX}")
+        lock_path.write_text(new_content)
 
 
 def _get_package_data(package_type: PackageType) -> dict[str, list[str]] | None:

--- a/tests/dev/test_pyproject.py
+++ b/tests/dev/test_pyproject.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+from dev.pyproject import _PUBLIC_PYPI_INDEX, _sanitize_uv_lock_indexes
+
+
+def test_sanitize_rewrites_only_disallowed_indexes(tmp_path: Path) -> None:
+    lock = tmp_path / "uv.lock"
+    lock.write_text(
+        '[[package]]\n'
+        'name = "torch"\n'
+        'source = { registry = "https://download.pytorch.org/whl/cpu" }\n'
+        '\n'
+        '[[package]]\n'
+        'name = "foo"\n'
+        'source = { registry = "https://private-mirror.example.com/simple" }\n'
+        '\n'
+        '[[package]]\n'
+        'name = "bar"\n'
+        f'source = {{ registry = "{_PUBLIC_PYPI_INDEX}" }}\n'
+    )
+
+    _sanitize_uv_lock_indexes(lock)
+
+    assert lock.read_text() == (
+        '[[package]]\n'
+        'name = "torch"\n'
+        'source = { registry = "https://download.pytorch.org/whl/cpu" }\n'
+        '\n'
+        '[[package]]\n'
+        'name = "foo"\n'
+        f'source = {{ registry = "{_PUBLIC_PYPI_INDEX}" }}\n'
+        '\n'
+        '[[package]]\n'
+        'name = "bar"\n'
+        f'source = {{ registry = "{_PUBLIC_PYPI_INDEX}" }}\n'
+    )
+
+
+def test_sanitize_is_no_op_when_already_clean(tmp_path: Path) -> None:
+    lock = tmp_path / "uv.lock"
+    original = (
+        '[[package]]\n'
+        'name = "foo"\n'
+        f'source = {{ registry = "{_PUBLIC_PYPI_INDEX}" }}\n'
+    )
+    lock.write_text(original)
+    mtime_before = lock.stat().st_mtime_ns
+
+    _sanitize_uv_lock_indexes(lock)
+
+    assert lock.read_text() == original
+    assert lock.stat().st_mtime_ns == mtime_before


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22849

### What changes are proposed in this pull request?

The scheduled "Update requirements.yaml" job (which produces PRs like #22849) can leak a local private uv index into the OSS `uv.lock` when `uv lock` runs as part of `dev/pyproject.py`. That happened on #22849 and had to be cleaned up manually before the release could proceed.

Rather than fight `uv lock`'s index resolution (which involves `UV_DEFAULT_INDEX`, user-level uv config files, and the upstream limitation tracked in astral-sh/uv#6349), this PR post-processes the generated `uv.lock` and rewrites any non-allowlisted `registry = "..."` entry back to `https://pypi.org/simple` before it would land in a PR.

Allowlisted indexes are kept as-is:
- `https://pypi.org/simple` (default)
- `https://download.pytorch.org/whl/cpu` (explicit index declared in `pyproject.toml`)

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests

1. Unit: `tests/dev/test_pyproject.py` covers the rewrite/preservation logic and the no-op path against an already-clean lockfile.
2. End-to-end: ran `python dev/pyproject.py` with `UV_DEFAULT_INDEX` and `UV_INDEX_URL` spoofed to a private mirror. After the run, `uv.lock` had 0 private-mirror entries and 485 `https://pypi.org/simple` entries (only the `exclude-newer` timestamp drifted, which is normal `uv lock` behavior).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release