### PR TITLE
RBAC Phase 2: collapse cascade helpers into 3 internal grant methods

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -55,7 +55,6 @@ from mlflow.protos.databricks_pb2 import (
     BAD_REQUEST,
     INTERNAL_ERROR,
     INVALID_PARAMETER_VALUE,
-    RESOURCE_ALREADY_EXISTS,
     RESOURCE_DOES_NOT_EXIST,
     ErrorCode,
 )
@@ -2284,7 +2283,7 @@ def set_can_manage_experiment_permission(resp: Response):
     parse_dict(resp.json, response_message)
     experiment_id = response_message.experiment_id
     username = authenticate_request().username
-    store.create_experiment_permission(experiment_id, username, MANAGE.name)
+    store.grant_user_permission(username, "experiment", experiment_id, MANAGE.name)
 
 
 def set_can_manage_registered_model_permission(resp: Response):
@@ -2292,21 +2291,17 @@ def set_can_manage_registered_model_permission(resp: Response):
     parse_dict(resp.json, response_message)
     name = response_message.registered_model.name
     username = authenticate_request().username
-    store.create_registered_model_permission(name, username, MANAGE.name)
+    store.grant_user_permission(username, "registered_model", name, MANAGE.name)
 
 
 def delete_can_manage_registered_model_permission(resp: Response):
     """
-    Delete registered model permissions when the model is deleted.
-
-    We need to do this because the primary key of the registered model is the name,
-    unlike the experiment where the primary key is experiment_id (UUID). Therefore,
-    we have to delete existing permission records when the model is deleted; otherwise, they would
-    implicitly apply if a new model is later created with the same name.
+    Sweep registered-model grants when the model is deleted. The model's primary
+    key is its name (unlike experiments which use a UUID), so a future model
+    with the same name would otherwise inherit stale grants.
     """
-    # Get model name from request context because it's not available in the response
     name = request.get_json(force=True, silent=True)["name"]
-    store.delete_registered_model_permissions(name)
+    store.delete_grants_for_resource("registered_model", name, workspace_scoped=True)
 
 
 # ---- Role management handlers (RBAC) ----
@@ -2782,9 +2777,13 @@ def rename_registered_model_permission(resp: Response):
 
     Changing the model registry name must be propagated to all users.
     """
-    # get registry model name before update
     data = request.get_json(force=True, silent=True)
-    store.rename_registered_model_permissions(data.get("name"), data.get("new_name"))
+    store.rename_grants_for_resource(
+        "registered_model",
+        data.get("name"),
+        data.get("new_name"),
+        workspace_scoped=True,
+    )
 
 
 def set_can_manage_scorer_permission(resp: Response):
@@ -2793,13 +2792,10 @@ def set_can_manage_scorer_permission(resp: Response):
     experiment_id = response_message.experiment_id
     name = response_message.name
     username = authenticate_request().username
-    try:
-        store.create_scorer_permission(experiment_id, name, username, MANAGE.name)
-    except MlflowException as e:
-        if e.error_code == ErrorCode.Name(RESOURCE_ALREADY_EXISTS):
-            pass  # Permission already exists from a previous registration
-        else:
-            raise
+    # ``grant_user_permission`` is upsert, so re-registration is a no-op
+    # rather than an error — no try/except needed.
+    pattern = store._scorer_pattern(experiment_id, name)
+    store.grant_user_permission(username, "scorer", pattern, MANAGE.name)
 
 
 def delete_scorer_permissions_cascade(resp: Response):
@@ -2807,7 +2803,8 @@ def delete_scorer_permissions_cascade(resp: Response):
     experiment_id = data.get("experiment_id")
     name = data.get("name")
     if experiment_id and name:
-        store.delete_scorer_permissions_for_scorer(experiment_id, name)
+        pattern = store._scorer_pattern(experiment_id, name)
+        store.delete_grants_for_resource("scorer", pattern)
 
 
 def set_can_manage_gateway_secret_permission(resp: Response):
@@ -2815,13 +2812,13 @@ def set_can_manage_gateway_secret_permission(resp: Response):
     parse_dict(resp.json, response_message)
     secret_id = response_message.secret.secret_id
     username = authenticate_request().username
-    store.create_gateway_secret_permission(secret_id, username, MANAGE.name)
+    store.grant_user_permission(username, "gateway_secret", secret_id, MANAGE.name)
 
 
 def delete_gateway_secret_permissions_cascade(resp: Response):
     data = request.get_json(force=True, silent=True)
     if secret_id := data.get("secret_id"):
-        store.delete_gateway_secret_permissions_for_secret(secret_id)
+        store.delete_grants_for_resource("gateway_secret", secret_id)
 
 
 def set_can_manage_gateway_endpoint_permission(resp: Response):
@@ -2829,13 +2826,13 @@ def set_can_manage_gateway_endpoint_permission(resp: Response):
     parse_dict(resp.json, response_message)
     endpoint_id = response_message.endpoint.endpoint_id
     username = authenticate_request().username
-    store.create_gateway_endpoint_permission(endpoint_id, username, MANAGE.name)
+    store.grant_user_permission(username, "gateway_endpoint", endpoint_id, MANAGE.name)
 
 
 def delete_gateway_endpoint_permissions_cascade(resp: Response):
     data = request.get_json(force=True, silent=True)
     if endpoint_id := data.get("endpoint_id"):
-        store.delete_gateway_endpoint_permissions_for_endpoint(endpoint_id)
+        store.delete_grants_for_resource("gateway_endpoint", endpoint_id)
 
 
 def set_can_manage_gateway_model_definition_permission(resp: Response):
@@ -2843,13 +2840,15 @@ def set_can_manage_gateway_model_definition_permission(resp: Response):
     parse_dict(resp.json, response_message)
     model_definition_id = response_message.model_definition.model_definition_id
     username = authenticate_request().username
-    store.create_gateway_model_definition_permission(model_definition_id, username, MANAGE.name)
+    store.grant_user_permission(
+        username, "gateway_model_definition", model_definition_id, MANAGE.name
+    )
 
 
 def delete_gateway_model_definition_permissions_cascade(resp: Response):
     data = request.get_json(force=True, silent=True)
     if model_definition_id := data.get("model_definition_id"):
-        store.delete_gateway_model_definition_permissions_for_model_definition(model_definition_id)
+        store.delete_grants_for_resource("gateway_model_definition", model_definition_id)
 
 
 AFTER_REQUEST_PATH_HANDLERS = {

--- a/mlflow/server/auth/sqlalchemy_store.py
+++ b/mlflow/server/auth/sqlalchemy_store.py
@@ -335,6 +335,111 @@ class SqlAlchemyStore:
             query = query.filter(SqlRole.workspace == workspace)
         return [rid for (rid, name) in query.all() if self._is_synthetic_role_name(name)]
 
+    # ---- Per-user grant helpers ----
+    #
+    # Generic API for per-user permission grants on the user's synthetic
+    # ``__user_<id>__`` role in the active workspace. Cascade handlers
+    # (``set_can_manage_*_permission``, ``delete_*_permissions_cascade``,
+    # ``rename_registered_model_permission``) call these directly. Per-resource
+    # CRUD methods below remain only as tombstones backing the deprecated REST
+    # surface; remove them when the deprecated handlers are dropped.
+
+    def grant_user_permission(
+        self,
+        username: str,
+        resource_type: str,
+        resource_pattern: str,
+        permission: str,
+    ) -> None:
+        """
+        Upsert a ``permission`` grant on ``(resource_type, resource_pattern)`` for
+        ``username`` via their synthetic role in the active workspace.
+        """
+        _validate_permission_for_resource_type(permission, resource_type)
+        with self.ManagedSessionMaker() as session:
+            user = self._get_user(session, username=username)
+            workspace_name = self._get_active_workspace_name()
+            role = self._get_or_create_synthetic_user_role(session, user.id, workspace_name)
+            existing = (
+                session
+                .query(SqlRolePermission)
+                .filter(
+                    SqlRolePermission.role_id == role.id,
+                    SqlRolePermission.resource_type == resource_type,
+                    SqlRolePermission.resource_pattern == resource_pattern,
+                )
+                .first()
+            )
+            if existing is None:
+                session.add(
+                    SqlRolePermission(
+                        role_id=role.id,
+                        resource_type=resource_type,
+                        resource_pattern=resource_pattern,
+                        permission=permission,
+                    )
+                )
+            else:
+                existing.permission = permission
+
+    def delete_grants_for_resource(
+        self,
+        resource_type: str,
+        resource_pattern: str,
+        *,
+        workspace_scoped: bool = False,
+    ) -> None:
+        """
+        Delete every synthetic-role grant matching ``(resource_type,
+        resource_pattern)``. ``workspace_scoped=True`` restricts to the active
+        workspace — for resources whose pattern can collide across workspaces
+        (e.g. registered-model names). Admin-created roles are never touched.
+        """
+        with self.ManagedSessionMaker() as session:
+            workspace = self._get_active_workspace_name() if workspace_scoped else None
+            role_ids = self._synthetic_role_ids(session, workspace=workspace)
+            if not role_ids:
+                return
+            session.query(SqlRolePermission).filter(
+                SqlRolePermission.role_id.in_(role_ids),
+                SqlRolePermission.resource_type == resource_type,
+                SqlRolePermission.resource_pattern == resource_pattern,
+            ).delete(synchronize_session=False)
+
+    def rename_grants_for_resource(
+        self,
+        resource_type: str,
+        old_pattern: str,
+        new_pattern: str,
+        *,
+        workspace_scoped: bool = False,
+    ) -> None:
+        """
+        Rewrite every synthetic-role grant on ``(resource_type, old_pattern)`` to
+        ``(resource_type, new_pattern)``. Used for resources whose pattern is the
+        primary key and can change (e.g. registered-model rename).
+        """
+        with self.ManagedSessionMaker() as session:
+            workspace = self._get_active_workspace_name() if workspace_scoped else None
+            role_ids = self._synthetic_role_ids(session, workspace=workspace)
+            if not role_ids:
+                return
+            session.query(SqlRolePermission).filter(
+                SqlRolePermission.role_id.in_(role_ids),
+                SqlRolePermission.resource_type == resource_type,
+                SqlRolePermission.resource_pattern == old_pattern,
+            ).update(
+                {SqlRolePermission.resource_pattern: new_pattern},
+                synchronize_session=False,
+            )
+
+    # ---- Legacy per-resource CRUD (tombstones) ----
+    #
+    # The methods below back the deprecated REST handlers in ``__init__.py``.
+    # Internal callers should use ``grant_user_permission`` /
+    # ``delete_grants_for_resource`` / ``rename_grants_for_resource`` instead.
+    # Remove these when the deprecated REST surface is dropped.
+
     def create_experiment_permission(
         self, experiment_id: str, username: str, permission: str
     ) -> ExperimentPermission:
@@ -633,41 +738,6 @@ class SqlAlchemyStore:
         with self.ManagedSessionMaker() as session:
             _, _, rp = self._get_registered_model_permission_row(session, name, username)
             session.delete(rp)
-
-    def delete_registered_model_permissions(self, name: str) -> None:
-        """
-        Delete *all* registered model permission rows for the given model name in the active
-        workspace.
-
-        This is primarily used as cleanup when a registered model is deleted to ensure that
-        previously granted permissions do not implicitly carry over if a new model is later created
-        with the same name. Synthetic-role-only — admin-created roles with an overlapping
-        registered_model grant are untouched.
-        """
-        with self.ManagedSessionMaker() as session:
-            workspace_name = self._get_active_workspace_name()
-            role_ids = self._synthetic_role_ids(session, workspace=workspace_name)
-            if not role_ids:
-                return
-            session.query(SqlRolePermission).filter(
-                SqlRolePermission.role_id.in_(role_ids),
-                SqlRolePermission.resource_type == RESOURCE_TYPE_REGISTERED_MODEL,
-                SqlRolePermission.resource_pattern == name,
-            ).delete(synchronize_session=False)
-
-    def rename_registered_model_permissions(self, old_name: str, new_name: str):
-        # Synthetic-role-only rename; admin-created roles with a grant on ``old_name``
-        # are untouched so we don't accidentally mutate their grants.
-        with self.ManagedSessionMaker() as session:
-            workspace_name = self._get_active_workspace_name()
-            role_ids = self._synthetic_role_ids(session, workspace=workspace_name)
-            if not role_ids:
-                return
-            session.query(SqlRolePermission).filter(
-                SqlRolePermission.role_id.in_(role_ids),
-                SqlRolePermission.resource_type == RESOURCE_TYPE_REGISTERED_MODEL,
-                SqlRolePermission.resource_pattern == old_name,
-            ).update({SqlRolePermission.resource_pattern: new_name}, synchronize_session=False)
 
     def _list_workspace_perm_rows(
         self,
@@ -1078,19 +1148,6 @@ class SqlAlchemyStore:
             _, rp = self._get_scorer_permission_row(session, experiment_id, scorer_name, username)
             session.delete(rp)
 
-    def delete_scorer_permissions_for_scorer(self, experiment_id: str, scorer_name: str):
-        """Synthetic-role-only cleanup for when a scorer is deleted."""
-        pattern = self._scorer_pattern(experiment_id, scorer_name)
-        with self.ManagedSessionMaker() as session:
-            role_ids = self._synthetic_role_ids(session)
-            if not role_ids:
-                return
-            session.query(SqlRolePermission).filter(
-                SqlRolePermission.role_id.in_(role_ids),
-                SqlRolePermission.resource_type == RESOURCE_TYPE_SCORER,
-                SqlRolePermission.resource_pattern == pattern,
-            ).delete(synchronize_session=False)
-
     # ---- Gateway permission helpers ----
     #
     # The three gateway resource types (secret / endpoint / model_definition) share a
@@ -1238,20 +1295,6 @@ class SqlAlchemyStore:
             # access.
             return user_id, rows
 
-    def _delete_per_resource_permissions_for_resource(
-        self, resource_type: str, resource_pattern: str
-    ) -> None:
-        """Synthetic-role-only cleanup when a resource itself is deleted."""
-        with self.ManagedSessionMaker() as session:
-            role_ids = self._synthetic_role_ids(session)
-            if not role_ids:
-                return
-            session.query(SqlRolePermission).filter(
-                SqlRolePermission.role_id.in_(role_ids),
-                SqlRolePermission.resource_type == resource_type,
-                SqlRolePermission.resource_pattern == resource_pattern,
-            ).delete(synchronize_session=False)
-
     # ---- gateway_secret ----
 
     def create_gateway_secret_permission(
@@ -1323,9 +1366,6 @@ class SqlAlchemyStore:
                 f"username={username} not found"
             ),
         )
-
-    def delete_gateway_secret_permissions_for_secret(self, secret_id: str) -> None:
-        self._delete_per_resource_permissions_for_resource(RESOURCE_TYPE_GATEWAY_SECRET, secret_id)
 
     # ---- gateway_endpoint ----
 
@@ -1399,11 +1439,6 @@ class SqlAlchemyStore:
                 f"Gateway endpoint permission with endpoint_id={endpoint_id} and "
                 f"username={username} not found"
             ),
-        )
-
-    def delete_gateway_endpoint_permissions_for_endpoint(self, endpoint_id: str) -> None:
-        self._delete_per_resource_permissions_for_resource(
-            RESOURCE_TYPE_GATEWAY_ENDPOINT, endpoint_id
         )
 
     # ---- gateway_model_definition ----
@@ -1492,13 +1527,6 @@ class SqlAlchemyStore:
                 f"Gateway model definition permission with "
                 f"model_definition_id={model_definition_id} and username={username} not found"
             ),
-        )
-
-    def delete_gateway_model_definition_permissions_for_model_definition(
-        self, model_definition_id: str
-    ) -> None:
-        self._delete_per_resource_permissions_for_resource(
-            RESOURCE_TYPE_GATEWAY_MODEL_DEFINITION, model_definition_id
         )
 
     # ---- Role CRUD ----


### PR DESCRIPTION
## 🥞 Stacked PR

- [stack/rbac/phase2-simplified](https://github.com/mlflow/mlflow/pull/22855) — ✅ MERGED
- [stack/rbac/phase2-legacy-endpoints](https://github.com/mlflow/mlflow/pull/22859) — ✅ MERGED
  - **[stack/rbac/phase2-store-cleanup](https://github.com/mlflow/mlflow/pull/22861)** [[Files changed](https://github.com/mlflow/mlflow/pull/22861/files)] ← you are here
    - [stack/rbac/phase2-drop-legacy-tables](https://github.com/mlflow/mlflow/pull/23089) [[Files changed (incremental)](https://github.com/mlflow/mlflow/pull/23089/files/bc3ce389b..9fe8311af)] — DRAFT, graduation, target MLflow 3.X+2

**Stacks directly on `master`** now that #22855 and #22859 have merged. Rebased onto current master at `bc3ce389b`.

---

### What this PR does

Adds three generic per-user grant helpers in `mlflow/server/auth/sqlalchemy_store.py`:

- `grant_user_permission(username, resource_type, resource_pattern, permission)` — upsert
- `delete_grants_for_resource(resource_type, resource_pattern, *, workspace_scoped=False)`
- `rename_grants_for_resource(resource_type, old_pattern, new_pattern, *, workspace_scoped=False)`

All operate on the user's synthetic `__user_<id>__` role; admin-created roles with overlapping grants are never touched.

Cascade hooks in `__init__.py` route through these:

- `set_can_manage_*_permission` (6 hooks: experiment, registered_model, scorer, gateway secret/endpoint/model_definition) → `grant_user_permission`
- `delete_can_manage_registered_model_permission` → `delete_grants_for_resource("registered_model", name, workspace_scoped=True)`
- `delete_*_permissions_cascade` (scorer + 3× gateway) → `delete_grants_for_resource(...)`
- `rename_registered_model_permission` → `rename_grants_for_resource("registered_model", old, new, workspace_scoped=True)`
- The scorer cascade no longer needs its `try/except RESOURCE_ALREADY_EXISTS` guard since `grant_user_permission` is upsert.

### What this PR doesn't do (after rebase)

The original revision deleted the per-resource `create/get/update/delete/list_*_permission` store methods + their entity classes wholesale. After @TomeHirata's review on #22859 kept the deprecated REST surface, those store methods stay as **tombstones** backing the deprecated REST handlers — they're labelled with a banner comment (`# ---- Legacy per-resource CRUD (tombstones) ----`) and should be removed in a follow-up when the deprecated REST surface is dropped.

Net effect of the rebase: the helpful cleanup (3 generic helpers + 6 cascade-helper deletions + cascade-hook rewires) lands; the per-resource methods + entities stay alive as tombstones.

### Review pointers

| File | What changed | Reviewer focus |
|---|---|---|
| `mlflow/server/auth/sqlalchemy_store.py` | 3 new generic helpers added; 6 per-resource cascade helpers (`delete_registered_model_permissions`, `rename_registered_model_permissions`, `delete_scorer_permissions_for_scorer`, 3× `delete_gateway_*_permissions_for_*`) + the shared `_delete_per_resource_permissions_for_resource` factor deleted; tombstone banner over the per-resource CRUD region. | The `workspace_scoped` flag on delete/rename is the subtle bit: restricts the sweep to the active workspace for resources whose pattern can collide across workspaces (e.g. `registered_model` names). Synthetic-role-only sweeps protect admin-created roles. |
| `mlflow/server/auth/__init__.py` | Cascade hooks rewired to call the three helpers. Scorer hook no longer needs its try/except. `RESOURCE_ALREADY_EXISTS` import dropped. | Verify cascades cover all paths. |

### How is this PR tested?

- [x] Existing unit/integration tests — full `tests/server/auth/` suite (~492 tests) passes.
- [x] Lint clean: `uv run ruff check`, `uv run ruff format --check`, `uv run clint`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No. This is an internal refactor of the auth store.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/server-infra`: MLflow Tracking server, JavaScript dev server

#### How should the PR be classified in the release notes?

- [x] `rn/none-required` — internal-only.

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release