### PR TITLE
Add RBAC regression tests + gateway validator fix

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -3497,9 +3497,7 @@ def _validate_gateway_use_permission(endpoint_name: str, username: str) -> bool:
     # TODO: we need to query endpoint ID by name from the database.
     # Revisit the mutability of the endpoint name if it causes latency issues.
     try:
-        from mlflow.tracking._tracking_service.utils import _get_store
-
-        tracking_store = _get_store()
+        tracking_store = _get_tracking_store()
         endpoint = tracking_store.get_gateway_endpoint(name=endpoint_name)
         endpoint_id = endpoint.endpoint_id
 
@@ -3507,6 +3505,16 @@ def _validate_gateway_use_permission(endpoint_name: str, username: str) -> bool:
             lambda: store.get_gateway_endpoint_permission(endpoint_id, username).permission,
             workspace_level_permission_func=lambda: _workspace_permission_for_gateway_endpoint(
                 username, endpoint_id
+            ),
+            role_permission_func=_role_permission_for(
+                username=username,
+                resource_type="gateway_endpoint",
+                resource_key=endpoint_id,
+                workspace_lookup_id=endpoint_id,
+                workspace_fetcher=lambda eid: _get_tracking_store().get_gateway_endpoint(
+                    endpoint_id=eid
+                ),
+                workspace_label="gateway endpoint",
             ),
         )
         return permission.can_use

--- a/tests/server/auth/test_auth_workspace.py
+++ b/tests/server/auth/test_auth_workspace.py
@@ -118,15 +118,19 @@ class _TrackingStore:
         raise ValueError("Must provide secret_id or secret_name")
 
     def get_gateway_endpoint(self, endpoint_id: str | None = None, name: str | None = None):
-        if endpoint_id:
-            if endpoint_id not in self._gateway_endpoint_workspaces:
+        # For test simplicity we treat ``name`` as a synonym for ``endpoint_id``
+        # (our fixture data uses the same string for both). This mirrors how the
+        # real store resolves a name → id lookup before returning the endpoint.
+        lookup_id = endpoint_id or name
+        if lookup_id:
+            if lookup_id not in self._gateway_endpoint_workspaces:
                 raise MlflowException(
-                    f"GatewayEndpoint not found ({endpoint_id})",
+                    f"GatewayEndpoint not found ({lookup_id})",
                     error_code=RESOURCE_DOES_NOT_EXIST,
                 )
             # Add workspace attribute so _get_resource_workspace can extract it
             return SimpleNamespace(
-                endpoint_id=endpoint_id, workspace=self._gateway_endpoint_workspaces[endpoint_id]
+                endpoint_id=lookup_id, workspace=self._gateway_endpoint_workspaces[lookup_id]
             )
         raise ValueError("Must provide endpoint_id or name")
 
@@ -1274,3 +1278,304 @@ def test_cross_workspace_graphql_access_denied(workspace_permission_setup, monke
     assert not auth_module._graphql_can_read_experiment("exp-other-ws", username)
     assert not auth_module._graphql_can_read_run("run-other-ws", username)
     assert not auth_module._graphql_can_read_model("model-other-ws", username)
+
+
+# =============================================================================
+# Role-based permission coverage for gateway resources
+# =============================================================================
+#
+# The fixture grants workspace MANAGE by default. These tests first strip that
+# grant (set to NO_PERMISSIONS) so the only path to a positive permission is
+# the role assignment being exercised. That isolates the role-based resolver
+# from the legacy workspace_permissions fallback.
+
+
+def _assign_role_with_permission(
+    store: SqlAlchemyStore, username: str, workspace: str, resource_type: str, permission: str
+) -> None:
+    """Create a role in ``workspace`` with a wildcard grant of ``permission`` on
+    ``resource_type``, and assign ``username`` to it.
+
+    Using ``random_str`` keeps the role names unique so multiple calls within a
+    single test don't collide on the (workspace, name) unique constraint.
+    """
+    role = store.create_role(name=random_str(), workspace=workspace)
+    store.add_role_permission(role.id, resource_type, "*", permission)
+    user = store.get_user(username)
+    store.assign_role_to_user(user.id, role.id)
+
+
+# ---- Gateway endpoint: role-based permission levels ----
+
+
+@pytest.mark.parametrize(
+    ("granted", "expected_read", "expected_delete", "expected_manage"),
+    [
+        ("READ", True, False, False),
+        ("USE", True, False, False),
+        ("EDIT", True, False, False),
+        ("MANAGE", True, True, True),
+    ],
+)
+def test_role_grant_on_gateway_endpoint_gates_validator_capabilities(
+    workspace_permission_setup, granted, expected_read, expected_delete, expected_manage
+):
+    """A role grant at permission level ``granted`` exposes exactly the
+    capabilities that level implies on the endpoint validators — no more, no
+    less. Catches regressions where a validator starts accepting a weaker
+    permission than it should (or refuses a stronger one).
+    """
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+
+    # Strip the default workspace MANAGE so the only positive grant is the role.
+    store.set_workspace_permission("team-a", username, NO_PERMISSIONS.name)
+
+    _assign_role_with_permission(store, username, "team-a", "gateway_endpoint", granted)
+
+    with auth_module.app.test_request_context(
+        "/api/3.0/mlflow/gateway/endpoints/get",
+        method="GET",
+        query_string={"endpoint_id": "endpoint-1"},
+    ):
+        assert auth_module.validate_can_read_gateway_endpoint() is expected_read
+        assert auth_module.validate_can_delete_gateway_endpoint() is expected_delete
+        assert auth_module.validate_can_manage_gateway_endpoint() is expected_manage
+
+
+def test_role_grant_read_on_gateway_endpoint_does_not_permit_use(
+    workspace_permission_setup,
+):
+    """Regression guard specific to the bug class the user called out:
+    a user with only READ on a gateway endpoint should not be able to *invoke*
+    it. USE is a stricter capability than READ and has its own validator.
+    """
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    store.set_workspace_permission("team-a", username, NO_PERMISSIONS.name)
+
+    _assign_role_with_permission(store, username, "team-a", "gateway_endpoint", "READ")
+
+    # _validate_gateway_use_permission looks up the endpoint by name, resolves
+    # the endpoint id, then checks ``can_use`` via the permission resolver.
+    with auth_module.app.test_request_context("/"):
+        assert auth_module._validate_gateway_use_permission("endpoint-1", username) is False
+
+
+def test_role_grant_use_on_gateway_endpoint_permits_use(workspace_permission_setup):
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    store.set_workspace_permission("team-a", username, NO_PERMISSIONS.name)
+
+    _assign_role_with_permission(store, username, "team-a", "gateway_endpoint", "USE")
+
+    with auth_module.app.test_request_context("/"):
+        assert auth_module._validate_gateway_use_permission("endpoint-1", username) is True
+
+
+@pytest.mark.parametrize(
+    ("granted", "expected_can_use"),
+    [
+        ("READ", False),  # READ does not imply USE.
+        ("USE", True),
+        ("EDIT", True),  # EDIT implies USE.
+        ("MANAGE", True),  # MANAGE implies USE.
+    ],
+)
+def test_role_grant_permission_level_determines_use_capability(
+    workspace_permission_setup, granted, expected_can_use
+):
+    """Parametrized matrix for the USE capability specifically. READ should NOT
+    let the user invoke; every stronger permission should.
+    """
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    store.set_workspace_permission("team-a", username, NO_PERMISSIONS.name)
+
+    _assign_role_with_permission(store, username, "team-a", "gateway_endpoint", granted)
+
+    with auth_module.app.test_request_context("/"):
+        assert (
+            auth_module._validate_gateway_use_permission("endpoint-1", username) is expected_can_use
+        )
+
+
+# ---- Workspace-wide role grants on gateway resources ----
+
+
+@pytest.mark.parametrize("granted", ["READ", "USE", "EDIT", "MANAGE"])
+def test_role_workspace_wide_grant_applies_to_gateway_endpoints(
+    workspace_permission_setup, granted
+):
+    """``(workspace, *, X)`` grants apply to every resource type in the
+    workspace — including gateway endpoints. Confirms the workspace-wide
+    short-circuit isn't accidentally gated behind resource_type=='experiment'
+    or similar, which would silently lock workspace admins out of gateway
+    resources.
+    """
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    store.set_workspace_permission("team-a", username, NO_PERMISSIONS.name)
+
+    _assign_role_with_permission(store, username, "team-a", "workspace", granted)
+
+    with auth_module.app.test_request_context(
+        "/api/3.0/mlflow/gateway/endpoints/get",
+        method="GET",
+        query_string={"endpoint_id": "endpoint-1"},
+    ):
+        # All four levels grant READ.
+        assert auth_module.validate_can_read_gateway_endpoint() is True
+
+        # Only MANAGE grants can_delete / can_manage.
+        assert auth_module.validate_can_delete_gateway_endpoint() is (granted == "MANAGE")
+        assert auth_module.validate_can_manage_gateway_endpoint() is (granted == "MANAGE")
+
+
+def test_role_workspace_wide_read_does_not_imply_use_on_gateway_endpoint(
+    workspace_permission_setup,
+):
+    """``(workspace, *, READ)`` grants READ on every resource but not USE.
+    Users with a workspace-wide viewer role shouldn't be able to invoke
+    gateway endpoints.
+    """
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    store.set_workspace_permission("team-a", username, NO_PERMISSIONS.name)
+
+    _assign_role_with_permission(store, username, "team-a", "workspace", "READ")
+
+    with auth_module.app.test_request_context("/"):
+        assert auth_module._validate_gateway_use_permission("endpoint-1", username) is False
+
+
+@pytest.mark.parametrize("granted", ["USE", "EDIT", "MANAGE"])
+def test_role_workspace_wide_non_read_grants_imply_use_on_gateway_endpoint(
+    workspace_permission_setup, granted
+):
+    """``(workspace, *, {USE,EDIT,MANAGE})`` all imply USE → invocation
+    allowed.
+    """
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    store.set_workspace_permission("team-a", username, NO_PERMISSIONS.name)
+
+    _assign_role_with_permission(store, username, "team-a", "workspace", granted)
+
+    with auth_module.app.test_request_context("/"):
+        assert auth_module._validate_gateway_use_permission("endpoint-1", username) is True
+
+
+# ---- Gateway secret and model definition parity ----
+
+
+@pytest.mark.parametrize(
+    ("granted", "expected_read", "expected_delete"),
+    [
+        ("READ", True, False),
+        ("EDIT", True, False),
+        ("MANAGE", True, True),
+    ],
+)
+def test_role_grant_on_gateway_secret_gates_validator(
+    workspace_permission_setup, granted, expected_read, expected_delete
+):
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    store.set_workspace_permission("team-a", username, NO_PERMISSIONS.name)
+
+    _assign_role_with_permission(store, username, "team-a", "gateway_secret", granted)
+
+    with auth_module.app.test_request_context(
+        "/api/3.0/mlflow/gateway/secrets/get",
+        method="GET",
+        query_string={"secret_id": "secret-1"},
+    ):
+        assert auth_module.validate_can_read_gateway_secret() is expected_read
+        assert auth_module.validate_can_delete_gateway_secret() is expected_delete
+
+
+@pytest.mark.parametrize(
+    ("granted", "expected_read", "expected_delete"),
+    [
+        ("READ", True, False),
+        ("EDIT", True, False),
+        ("MANAGE", True, True),
+    ],
+)
+def test_role_grant_on_gateway_model_definition_gates_validator(
+    workspace_permission_setup, granted, expected_read, expected_delete
+):
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    store.set_workspace_permission("team-a", username, NO_PERMISSIONS.name)
+
+    _assign_role_with_permission(store, username, "team-a", "gateway_model_definition", granted)
+
+    with auth_module.app.test_request_context(
+        "/api/3.0/mlflow/gateway/model-definitions/get",
+        method="GET",
+        query_string={"model_definition_id": "model-def-1"},
+    ):
+        assert auth_module.validate_can_read_gateway_model_definition() is expected_read
+        assert auth_module.validate_can_delete_gateway_model_definition() is expected_delete
+
+
+# ---- Cross-workspace isolation for role-based gateway grants ----
+
+
+def test_role_in_other_workspace_does_not_grant_gateway_endpoint_access(
+    workspace_permission_setup,
+):
+    """A role in team-b with MANAGE on gateway_endpoints must not grant any
+    access when resolving an endpoint that belongs to team-a. The resolver
+    scopes role permissions to the role's workspace.
+    """
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    store.set_workspace_permission("team-a", username, NO_PERMISSIONS.name)
+
+    # Role with MANAGE in team-b — should NOT apply to team-a endpoints.
+    _assign_role_with_permission(store, username, "team-b", "gateway_endpoint", "MANAGE")
+
+    with auth_module.app.test_request_context(
+        "/api/3.0/mlflow/gateway/endpoints/get",
+        method="GET",
+        query_string={"endpoint_id": "endpoint-1"},  # endpoint-1 is in team-a.
+    ):
+        assert auth_module.validate_can_read_gateway_endpoint() is False
+        assert auth_module.validate_can_manage_gateway_endpoint() is False
+
+
+def test_role_in_other_workspace_does_not_grant_gateway_use(workspace_permission_setup):
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    store.set_workspace_permission("team-a", username, NO_PERMISSIONS.name)
+
+    _assign_role_with_permission(store, username, "team-b", "gateway_endpoint", "USE")
+
+    with auth_module.app.test_request_context("/"):
+        # endpoint-1 is in team-a; role grant is in team-b.
+        assert auth_module._validate_gateway_use_permission("endpoint-1", username) is False
+
+
+# ---- Multi-role union: best grant wins ----
+
+
+def test_role_union_best_permission_wins_for_gateway_endpoint(workspace_permission_setup):
+    """Two roles: one grants READ, the other grants MANAGE. Validator should
+    reflect the max (MANAGE).
+    """
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    store.set_workspace_permission("team-a", username, NO_PERMISSIONS.name)
+
+    _assign_role_with_permission(store, username, "team-a", "gateway_endpoint", "READ")
+    _assign_role_with_permission(store, username, "team-a", "gateway_endpoint", "MANAGE")
+
+    with auth_module.app.test_request_context(
+        "/api/3.0/mlflow/gateway/endpoints/get",
+        method="GET",
+        query_string={"endpoint_id": "endpoint-1"},
+    ):
+        assert auth_module.validate_can_manage_gateway_endpoint() is True

--- a/tests/server/auth/test_auth_workspace.py
+++ b/tests/server/auth/test_auth_workspace.py
@@ -1654,35 +1654,6 @@ def role_auth_setup(tmp_path, monkeypatch):
     auth_store.engine.dispose()
 
 
-# Expected manage-roles results, keyed by (actor, target_workspace).
-_MANAGE_EXPECTATIONS = {
-    ("super_admin", "foo"): True,
-    ("super_admin", "bar"): True,
-    ("ws_admin_foo", "foo"): True,
-    ("ws_admin_foo", "bar"): False,
-    ("ws_admin_bar", "foo"): False,
-    ("ws_admin_bar", "bar"): True,
-    ("ws_member_foo", "foo"): False,
-    ("ws_member_foo", "bar"): False,
-    ("outsider", "foo"): False,
-    ("outsider", "bar"): False,
-}
-
-# Expected view-roles results (requires is_admin OR any role in the workspace).
-_VIEW_EXPECTATIONS = {
-    ("super_admin", "foo"): True,
-    ("super_admin", "bar"): True,
-    ("ws_admin_foo", "foo"): True,
-    ("ws_admin_foo", "bar"): False,
-    ("ws_admin_bar", "foo"): False,
-    ("ws_admin_bar", "bar"): True,
-    ("ws_member_foo", "foo"): True,
-    ("ws_member_foo", "bar"): False,
-    ("outsider", "foo"): False,
-    ("outsider", "bar"): False,
-}
-
-
 def _request_context_for_shape(shape, role_auth_setup, workspace):
     match shape:
         case "role_id":
@@ -1717,27 +1688,64 @@ def _request_context_for_shape(shape, role_auth_setup, workspace):
             raise ValueError(f"Unknown shape: {shape}")
 
 
-@pytest.mark.parametrize("workspace", ["foo", "bar"])
-@pytest.mark.parametrize("shape", ["role_id", "role_permission_id", "workspace"])
+# Authorization matrices are exercised with a single request shape (role_id);
+# shape-resolution itself is covered independently below so we don't multiply
+# every actor-case by three shape-cases.
+
+
 @pytest.mark.parametrize(
-    "actor", ["super_admin", "ws_admin_foo", "ws_admin_bar", "ws_member_foo", "outsider"]
+    ("actor", "workspace", "expected"),
+    [
+        # Super admin short-circuits regardless of workspace — one case suffices.
+        ("super_admin", "foo", True),
+        # Outsider has no role anywhere — one case suffices.
+        ("outsider", "foo", False),
+        # Workspace admins manage only their own workspace.
+        ("ws_admin_foo", "foo", True),
+        ("ws_admin_foo", "bar", False),
+        ("ws_admin_bar", "foo", False),
+        ("ws_admin_bar", "bar", True),
+        # Plain role membership is not enough to manage — needs workspace MANAGE.
+        ("ws_member_foo", "foo", False),
+        ("ws_member_foo", "bar", False),
+    ],
 )
-def test_validate_can_manage_roles(role_auth_setup, actor, shape, workspace):
+def test_validate_can_manage_roles_authorization(role_auth_setup, actor, workspace, expected):
     role_auth_setup["login_as"](actor)
-    expected = _MANAGE_EXPECTATIONS[(actor, workspace)]
-    with _request_context_for_shape(shape, role_auth_setup, workspace):
+    with _request_context_for_shape("role_id", role_auth_setup, workspace):
         assert auth_module.validate_can_manage_roles() is expected
 
 
 @pytest.mark.parametrize("workspace", ["foo", "bar"])
-@pytest.mark.parametrize("shape", ["role_id", "role_permission_id"])
-@pytest.mark.parametrize(
-    "actor", ["super_admin", "ws_admin_foo", "ws_admin_bar", "ws_member_foo", "outsider"]
-)
-def test_validate_can_view_roles(role_auth_setup, actor, shape, workspace):
-    role_auth_setup["login_as"](actor)
-    expected = _VIEW_EXPECTATIONS[(actor, workspace)]
+@pytest.mark.parametrize("shape", ["role_id", "role_permission_id", "workspace"])
+def test_manage_roles_resolves_workspace_from_each_shape(role_auth_setup, shape, workspace):
+    # Sanity check that _get_role_workspace_from_request correctly dispatches
+    # on every request shape. Use ws_admin_foo — their answer differs by
+    # workspace, so an incorrectly resolved (or swapped) workspace flips the
+    # result and the test fails.
+    role_auth_setup["login_as"]("ws_admin_foo")
+    expected = workspace == "foo"
     with _request_context_for_shape(shape, role_auth_setup, workspace):
+        assert auth_module.validate_can_manage_roles() is expected
+
+
+@pytest.mark.parametrize(
+    ("actor", "workspace", "expected"),
+    [
+        ("super_admin", "foo", True),
+        ("outsider", "foo", False),
+        ("ws_admin_foo", "foo", True),
+        ("ws_admin_foo", "bar", False),
+        ("ws_admin_bar", "foo", False),
+        ("ws_admin_bar", "bar", True),
+        # Unlike manage, a plain workspace member can view roles.
+        ("ws_member_foo", "foo", True),
+        ("ws_member_foo", "bar", False),
+    ],
+)
+def test_validate_can_view_roles_authorization(role_auth_setup, actor, workspace, expected):
+    role_auth_setup["login_as"](actor)
+    with _request_context_for_shape("role_id", role_auth_setup, workspace):
         assert auth_module.validate_can_view_roles() is expected
 
 
@@ -1745,10 +1753,9 @@ def test_validate_can_view_roles(role_auth_setup, actor, shape, workspace):
     ("actor", "expected"),
     [
         ("super_admin", True),
+        # Any non-admin is denied regardless of their workspace memberships —
+        # one representative non-admin is enough.
         ("ws_admin_foo", False),
-        ("ws_admin_bar", False),
-        ("ws_member_foo", False),
-        ("outsider", False),
     ],
 )
 def test_validate_can_list_roles_unscoped_is_super_admin_only(role_auth_setup, actor, expected):
@@ -1758,48 +1765,50 @@ def test_validate_can_list_roles_unscoped_is_super_admin_only(role_auth_setup, a
         assert auth_module.validate_can_list_roles() is expected
 
 
-@pytest.mark.parametrize("workspace", ["foo", "bar"])
 @pytest.mark.parametrize(
-    "actor", ["super_admin", "ws_admin_foo", "ws_admin_bar", "ws_member_foo", "outsider"]
+    ("actor", "workspace", "expected"),
+    [
+        ("super_admin", "foo", True),
+        ("outsider", "foo", False),
+        ("ws_admin_foo", "foo", True),
+        ("ws_admin_foo", "bar", False),
+        ("ws_admin_bar", "foo", False),
+        ("ws_admin_bar", "bar", True),
+        ("ws_member_foo", "foo", True),
+        ("ws_member_foo", "bar", False),
+    ],
 )
-def test_validate_can_list_roles_workspace_scoped(role_auth_setup, actor, workspace):
+def test_validate_can_list_roles_workspace_scoped(role_auth_setup, actor, workspace, expected):
     role_auth_setup["login_as"](actor)
-    # When a workspace is provided, non-admins need any role in that workspace.
-    expected = _VIEW_EXPECTATIONS[(actor, workspace)]
     with auth_module.app.test_request_context(
         "/api/3.0/mlflow/roles/list", method="GET", query_string={"workspace": workspace}
     ):
         assert auth_module.validate_can_list_roles() is expected
 
 
-@pytest.mark.parametrize(
-    "blank_workspace",
-    ["", "   "],
-)
-def test_validate_can_list_roles_blank_workspace_denied_for_non_admin(
-    role_auth_setup, blank_workspace
-):
-    # A blank workspace param doesn't count as scoping — treat as unscoped and
-    # deny non-admins (super admins always bypass, tested separately).
+def test_validate_can_list_roles_blank_workspace_denied_for_non_admin(role_auth_setup):
+    # Blank workspace param hits a *different* branch from the missing-param
+    # case: validate_can_list_roles checks ``workspace.strip()`` and denies
+    # rather than raising, unlike _get_role_workspace_from_request which would
+    # raise on blank workspace. Kept as a guard for that specific branch.
     role_auth_setup["login_as"]("ws_admin_foo")
     with auth_module.app.test_request_context(
         "/api/3.0/mlflow/roles/list",
         method="GET",
-        query_string={"workspace": blank_workspace},
+        query_string={"workspace": "   "},
     ):
         assert auth_module.validate_can_list_roles() is False
 
 
-@pytest.mark.parametrize(
-    "actor", ["super_admin", "ws_admin_foo", "ws_admin_bar", "ws_member_foo", "outsider"]
-)
-def test_validate_can_view_user_roles_self_always_allowed(role_auth_setup, actor):
-    # A user can always read their own role list.
-    role_auth_setup["login_as"](actor)
+def test_validate_can_view_user_roles_self_always_allowed(role_auth_setup):
+    # A user can always read their own role list, even one with no roles.
+    # Using ``outsider`` (zero roles) exercises the self-short-circuit without
+    # any membership helping.
+    role_auth_setup["login_as"]("outsider")
     with auth_module.app.test_request_context(
         "/api/3.0/mlflow/users/roles/list",
         method="GET",
-        query_string={"username": actor},
+        query_string={"username": "outsider"},
     ):
         assert auth_module.validate_can_view_user_roles() is True
 
@@ -1912,7 +1921,9 @@ def test_validate_can_manage_roles_blank_workspace_raises(role_auth_setup):
             auth_module.validate_can_manage_roles()
 
 
-def test_validate_can_manage_roles_non_integer_role_id_raises(role_auth_setup):
+def test_validate_can_manage_roles_propagates_param_coercion_errors(role_auth_setup):
+    # Integration check: a non-integer role_id in the request surfaces the
+    # coercion error through the validator chain rather than silently denying.
     role_auth_setup["login_as"]("ws_admin_foo")
     with auth_module.app.test_request_context(
         "/api/3.0/mlflow/roles/get",

--- a/tests/server/auth/test_auth_workspace.py
+++ b/tests/server/auth/test_auth_workspace.py
@@ -121,8 +121,7 @@ class _TrackingStore:
         # For test simplicity we treat ``name`` as a synonym for ``endpoint_id``
         # (our fixture data uses the same string for both). This mirrors how the
         # real store resolves a name → id lookup before returning the endpoint.
-        lookup_id = endpoint_id or name
-        if lookup_id:
+        if lookup_id := (endpoint_id or name):
             if lookup_id not in self._gateway_endpoint_workspaces:
                 raise MlflowException(
                     f"GatewayEndpoint not found ({lookup_id})",

--- a/tests/server/auth/test_auth_workspace.py
+++ b/tests/server/auth/test_auth_workspace.py
@@ -1578,3 +1578,346 @@ def test_role_union_best_permission_wins_for_gateway_endpoint(workspace_permissi
         query_string={"endpoint_id": "endpoint-1"},
     ):
         assert auth_module.validate_can_manage_gateway_endpoint() is True
+
+
+# =============================================================================
+# Authorization for role management endpoints (Batch 5)
+# =============================================================================
+#
+# Four validators guard the role endpoints:
+#   - validate_can_manage_roles: create/update/delete role, add/remove/update
+#     role_permission, assign/unassign role. Super admin OR workspace admin
+#     in the resolved workspace.
+#   - validate_can_view_roles: get_role, list_role_permissions. Super admin
+#     OR any role assignment in the resolved workspace.
+#   - validate_can_list_roles: list_roles. Super admin unconditionally; for
+#     non-admins the request must scope to a workspace where the caller holds
+#     at least one role.
+#   - validate_can_view_user_roles: list_user_roles. Super admin, the target
+#     themselves, or a workspace admin over any workspace the target is in.
+#
+# _get_role_workspace_from_request resolves the workspace from role_id,
+# role_permission_id, or a literal ``workspace`` param. These tests exercise
+# all three shapes and every actor x endpoint combination.
+
+
+@pytest.fixture
+def role_auth_setup(tmp_path, monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+    monkeypatch.setattr(
+        auth_module,
+        "auth_config",
+        auth_module.auth_config._replace(default_permission=NO_PERMISSIONS.name),
+    )
+
+    db_uri = f"sqlite:///{tmp_path / 'auth-store.db'}"
+    auth_store = SqlAlchemyStore()
+    auth_store.init_db(db_uri)
+    monkeypatch.setattr(auth_module, "store", auth_store, raising=False)
+
+    auth_store.create_user("super_admin", "supersecurepassword", is_admin=True)
+    for name in ("ws_admin_foo", "ws_admin_bar", "ws_member_foo", "outsider"):
+        auth_store.create_user(name, "supersecurepassword", is_admin=False)
+
+    admin_role_foo = auth_store.create_role(name="admin-foo", workspace="foo")
+    auth_store.add_role_permission(admin_role_foo.id, "workspace", "*", MANAGE.name)
+    auth_store.assign_role_to_user(auth_store.get_user("ws_admin_foo").id, admin_role_foo.id)
+
+    admin_role_bar = auth_store.create_role(name="admin-bar", workspace="bar")
+    auth_store.add_role_permission(admin_role_bar.id, "workspace", "*", MANAGE.name)
+    auth_store.assign_role_to_user(auth_store.get_user("ws_admin_bar").id, admin_role_bar.id)
+
+    member_role_foo = auth_store.create_role(name="member-foo", workspace="foo")
+    auth_store.add_role_permission(member_role_foo.id, "experiment", "*", READ.name)
+    auth_store.assign_role_to_user(auth_store.get_user("ws_member_foo").id, member_role_foo.id)
+
+    role_foo = auth_store.create_role(name="target-foo", workspace="foo")
+    role_bar = auth_store.create_role(name="target-bar", workspace="bar")
+    rp_foo = auth_store.add_role_permission(role_foo.id, "experiment", "*", READ.name)
+    rp_bar = auth_store.add_role_permission(role_bar.id, "experiment", "*", READ.name)
+
+    def login_as(username: str) -> None:
+        monkeypatch.setattr(
+            auth_module,
+            "authenticate_request",
+            lambda: SimpleNamespace(username=username),
+        )
+
+    yield {
+        "store": auth_store,
+        "login_as": login_as,
+        "role_foo_id": role_foo.id,
+        "role_bar_id": role_bar.id,
+        "role_permission_foo_id": rp_foo.id,
+        "role_permission_bar_id": rp_bar.id,
+    }
+    auth_store.engine.dispose()
+
+
+# Expected manage-roles results, keyed by (actor, target_workspace).
+_MANAGE_EXPECTATIONS = {
+    ("super_admin", "foo"): True,
+    ("super_admin", "bar"): True,
+    ("ws_admin_foo", "foo"): True,
+    ("ws_admin_foo", "bar"): False,
+    ("ws_admin_bar", "foo"): False,
+    ("ws_admin_bar", "bar"): True,
+    ("ws_member_foo", "foo"): False,
+    ("ws_member_foo", "bar"): False,
+    ("outsider", "foo"): False,
+    ("outsider", "bar"): False,
+}
+
+# Expected view-roles results (requires is_admin OR any role in the workspace).
+_VIEW_EXPECTATIONS = {
+    ("super_admin", "foo"): True,
+    ("super_admin", "bar"): True,
+    ("ws_admin_foo", "foo"): True,
+    ("ws_admin_foo", "bar"): False,
+    ("ws_admin_bar", "foo"): False,
+    ("ws_admin_bar", "bar"): True,
+    ("ws_member_foo", "foo"): True,
+    ("ws_member_foo", "bar"): False,
+    ("outsider", "foo"): False,
+    ("outsider", "bar"): False,
+}
+
+
+def _request_context_for_shape(shape, role_auth_setup, workspace):
+    match shape:
+        case "role_id":
+            role_id = (
+                role_auth_setup["role_foo_id"]
+                if workspace == "foo"
+                else role_auth_setup["role_bar_id"]
+            )
+            return auth_module.app.test_request_context(
+                "/api/3.0/mlflow/roles/get",
+                method="GET",
+                query_string={"role_id": str(role_id)},
+            )
+        case "role_permission_id":
+            rp_id = (
+                role_auth_setup["role_permission_foo_id"]
+                if workspace == "foo"
+                else role_auth_setup["role_permission_bar_id"]
+            )
+            return auth_module.app.test_request_context(
+                "/api/3.0/mlflow/roles/permissions/update",
+                method="PATCH",
+                json={"role_permission_id": rp_id, "permission": READ.name},
+            )
+        case "workspace":
+            return auth_module.app.test_request_context(
+                "/api/3.0/mlflow/roles/create",
+                method="POST",
+                json={"name": "new-role", "workspace": workspace},
+            )
+        case _:
+            raise ValueError(f"Unknown shape: {shape}")
+
+
+@pytest.mark.parametrize("workspace", ["foo", "bar"])
+@pytest.mark.parametrize("shape", ["role_id", "role_permission_id", "workspace"])
+@pytest.mark.parametrize(
+    "actor", ["super_admin", "ws_admin_foo", "ws_admin_bar", "ws_member_foo", "outsider"]
+)
+def test_validate_can_manage_roles(role_auth_setup, actor, shape, workspace):
+    role_auth_setup["login_as"](actor)
+    expected = _MANAGE_EXPECTATIONS[(actor, workspace)]
+    with _request_context_for_shape(shape, role_auth_setup, workspace):
+        assert auth_module.validate_can_manage_roles() is expected
+
+
+@pytest.mark.parametrize("workspace", ["foo", "bar"])
+@pytest.mark.parametrize("shape", ["role_id", "role_permission_id"])
+@pytest.mark.parametrize(
+    "actor", ["super_admin", "ws_admin_foo", "ws_admin_bar", "ws_member_foo", "outsider"]
+)
+def test_validate_can_view_roles(role_auth_setup, actor, shape, workspace):
+    role_auth_setup["login_as"](actor)
+    expected = _VIEW_EXPECTATIONS[(actor, workspace)]
+    with _request_context_for_shape(shape, role_auth_setup, workspace):
+        assert auth_module.validate_can_view_roles() is expected
+
+
+@pytest.mark.parametrize(
+    ("actor", "expected"),
+    [
+        ("super_admin", True),
+        ("ws_admin_foo", False),
+        ("ws_admin_bar", False),
+        ("ws_member_foo", False),
+        ("outsider", False),
+    ],
+)
+def test_validate_can_list_roles_unscoped_is_super_admin_only(role_auth_setup, actor, expected):
+    # No workspace param: only super admins may list every role in the system.
+    role_auth_setup["login_as"](actor)
+    with auth_module.app.test_request_context("/api/3.0/mlflow/roles/list", method="GET"):
+        assert auth_module.validate_can_list_roles() is expected
+
+
+@pytest.mark.parametrize("workspace", ["foo", "bar"])
+@pytest.mark.parametrize(
+    "actor", ["super_admin", "ws_admin_foo", "ws_admin_bar", "ws_member_foo", "outsider"]
+)
+def test_validate_can_list_roles_workspace_scoped(role_auth_setup, actor, workspace):
+    role_auth_setup["login_as"](actor)
+    # When a workspace is provided, non-admins need any role in that workspace.
+    expected = _VIEW_EXPECTATIONS[(actor, workspace)]
+    with auth_module.app.test_request_context(
+        "/api/3.0/mlflow/roles/list", method="GET", query_string={"workspace": workspace}
+    ):
+        assert auth_module.validate_can_list_roles() is expected
+
+
+@pytest.mark.parametrize(
+    "blank_workspace",
+    ["", "   "],
+)
+def test_validate_can_list_roles_blank_workspace_denied_for_non_admin(
+    role_auth_setup, blank_workspace
+):
+    # A blank workspace param doesn't count as scoping — treat as unscoped and
+    # deny non-admins (super admins always bypass, tested separately).
+    role_auth_setup["login_as"]("ws_admin_foo")
+    with auth_module.app.test_request_context(
+        "/api/3.0/mlflow/roles/list",
+        method="GET",
+        query_string={"workspace": blank_workspace},
+    ):
+        assert auth_module.validate_can_list_roles() is False
+
+
+@pytest.mark.parametrize(
+    "actor", ["super_admin", "ws_admin_foo", "ws_admin_bar", "ws_member_foo", "outsider"]
+)
+def test_validate_can_view_user_roles_self_always_allowed(role_auth_setup, actor):
+    # A user can always read their own role list.
+    role_auth_setup["login_as"](actor)
+    with auth_module.app.test_request_context(
+        "/api/3.0/mlflow/users/roles/list",
+        method="GET",
+        query_string={"username": actor},
+    ):
+        assert auth_module.validate_can_view_user_roles() is True
+
+
+@pytest.mark.parametrize(
+    ("requester", "target", "expected"),
+    [
+        ("super_admin", "ws_member_foo", True),
+        ("ws_admin_foo", "ws_member_foo", True),
+        ("ws_admin_bar", "ws_member_foo", False),
+        ("ws_member_foo", "ws_admin_foo", False),
+        ("outsider", "ws_member_foo", False),
+    ],
+)
+def test_validate_can_view_user_roles_cross_user(role_auth_setup, requester, target, expected):
+    role_auth_setup["login_as"](requester)
+    with auth_module.app.test_request_context(
+        "/api/3.0/mlflow/users/roles/list",
+        method="GET",
+        query_string={"username": target},
+    ):
+        assert auth_module.validate_can_view_user_roles() is expected
+
+
+def test_validate_can_view_user_roles_nonexistent_target_denied_for_non_admin(
+    role_auth_setup,
+):
+    # Non-existent target: return False rather than leaking existence via the
+    # RESOURCE_DOES_NOT_EXIST the handler would raise downstream.
+    role_auth_setup["login_as"]("ws_admin_foo")
+    with auth_module.app.test_request_context(
+        "/api/3.0/mlflow/users/roles/list",
+        method="GET",
+        query_string={"username": "ghost"},
+    ):
+        assert auth_module.validate_can_view_user_roles() is False
+
+
+def test_validate_can_view_user_roles_nonexistent_target_allowed_for_super_admin(
+    role_auth_setup,
+):
+    # Super admin short-circuits before the target lookup — they're authorized
+    # regardless of whether the target exists (the handler then 404s cleanly).
+    role_auth_setup["login_as"]("super_admin")
+    with auth_module.app.test_request_context(
+        "/api/3.0/mlflow/users/roles/list",
+        method="GET",
+        query_string={"username": "ghost"},
+    ):
+        assert auth_module.validate_can_view_user_roles() is True
+
+
+@pytest.mark.parametrize("shape", ["role_id", "role_permission_id"])
+def test_validate_can_manage_roles_nonexistent_resource_denied(role_auth_setup, shape):
+    # A non-admin pointing at a role/role_permission that doesn't exist fails
+    # closed: _get_role_workspace_from_request returns None and the validator
+    # treats that as unauthorized rather than leaking existence.
+    role_auth_setup["login_as"]("ws_admin_foo")
+    bogus_id = 999_999
+    if shape == "role_id":
+        ctx = auth_module.app.test_request_context(
+            "/api/3.0/mlflow/roles/get",
+            method="GET",
+            query_string={"role_id": str(bogus_id)},
+        )
+    else:
+        ctx = auth_module.app.test_request_context(
+            "/api/3.0/mlflow/roles/permissions/update",
+            method="PATCH",
+            json={"role_permission_id": bogus_id, "permission": READ.name},
+        )
+    with ctx:
+        assert auth_module.validate_can_manage_roles() is False
+
+
+def test_validate_can_manage_roles_nonexistent_role_id_bypassed_by_super_admin(
+    role_auth_setup,
+):
+    # Super admins skip the workspace resolution entirely — an unresolvable
+    # role_id still produces True at the validator layer.
+    role_auth_setup["login_as"]("super_admin")
+    with auth_module.app.test_request_context(
+        "/api/3.0/mlflow/roles/get",
+        method="GET",
+        query_string={"role_id": "999999"},
+    ):
+        assert auth_module.validate_can_manage_roles() is True
+
+
+def test_validate_can_manage_roles_missing_workspace_params_raises(role_auth_setup):
+    # No role_id / role_permission_id / workspace in the request body: the
+    # resolver raises INVALID_PARAMETER_VALUE — callers that hit this path have
+    # a client bug, and we surface it instead of silently denying.
+    role_auth_setup["login_as"]("ws_admin_foo")
+    with auth_module.app.test_request_context(
+        "/api/3.0/mlflow/roles/create", method="POST", json={}
+    ):
+        with pytest.raises(MlflowException, match="must include one of"):
+            auth_module.validate_can_manage_roles()
+
+
+def test_validate_can_manage_roles_blank_workspace_raises(role_auth_setup):
+    role_auth_setup["login_as"]("ws_admin_foo")
+    with auth_module.app.test_request_context(
+        "/api/3.0/mlflow/roles/create",
+        method="POST",
+        json={"name": "new-role", "workspace": "   "},
+    ):
+        with pytest.raises(MlflowException, match="non-empty string"):
+            auth_module.validate_can_manage_roles()
+
+
+def test_validate_can_manage_roles_non_integer_role_id_raises(role_auth_setup):
+    role_auth_setup["login_as"]("ws_admin_foo")
+    with auth_module.app.test_request_context(
+        "/api/3.0/mlflow/roles/get",
+        method="GET",
+        query_string={"role_id": "not-an-int"},
+    ):
+        with pytest.raises(MlflowException, match="must be an integer"):
+            auth_module.validate_can_manage_roles()

--- a/tests/server/auth/test_permissions.py
+++ b/tests/server/auth/test_permissions.py
@@ -1,0 +1,143 @@
+import pytest
+
+from mlflow.exceptions import MlflowException
+from mlflow.server.auth.permissions import (
+    ALL_PERMISSIONS,
+    EDIT,
+    MANAGE,
+    NO_PERMISSIONS,
+    PERMISSION_PRIORITY,
+    READ,
+    USE,
+    VALID_RESOURCE_TYPES,
+    _validate_permission,
+    _validate_resource_type,
+    get_permission,
+    max_permission,
+)
+
+# ---- Permission hierarchy ---------------------------------------------------
+
+# The canonical ordering the rest of the auth layer relies on.
+_EXPECTED_ORDER = [NO_PERMISSIONS, READ, USE, EDIT, MANAGE]
+
+
+def test_permission_priority_is_total_order():
+    priorities = [PERMISSION_PRIORITY[p.name] for p in _EXPECTED_ORDER]
+    assert priorities == sorted(priorities)
+    assert len(set(priorities)) == len(priorities)
+
+
+@pytest.mark.parametrize(
+    ("permission", "can_read", "can_use", "can_update", "can_delete", "can_manage"),
+    [
+        (NO_PERMISSIONS, False, False, False, False, False),
+        (READ, True, False, False, False, False),
+        (USE, True, True, False, False, False),
+        (EDIT, True, True, True, False, False),
+        (MANAGE, True, True, True, True, True),
+    ],
+)
+def test_permission_capability_matrix(
+    permission, can_read, can_use, can_update, can_delete, can_manage
+):
+    """Each permission level exposes exactly the capabilities it should.
+
+    This pins the capability semantics: upgrading READ → USE adds can_use,
+    USE → EDIT adds can_update, EDIT → MANAGE adds can_delete AND can_manage.
+    If a capability bit shifts without the corresponding test update, this
+    catches it.
+    """
+    assert permission.can_read is can_read
+    assert permission.can_use is can_use
+    assert permission.can_update is can_update
+    assert permission.can_delete is can_delete
+    assert permission.can_manage is can_manage
+
+
+@pytest.mark.parametrize("permission", _EXPECTED_ORDER)
+def test_get_permission_roundtrip(permission):
+    assert get_permission(permission.name) is permission
+
+
+def test_all_permissions_dict_is_complete():
+    assert set(ALL_PERMISSIONS) == {p.name for p in _EXPECTED_ORDER}
+
+
+# ---- max_permission ---------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("a", "b", "expected"),
+    [
+        # Identical inputs return the same value.
+        ("READ", "READ", "READ"),
+        ("MANAGE", "MANAGE", "MANAGE"),
+        # Higher on the right wins.
+        ("READ", "USE", "USE"),
+        ("USE", "EDIT", "EDIT"),
+        ("EDIT", "MANAGE", "MANAGE"),
+        # Higher on the left wins.
+        ("USE", "READ", "USE"),
+        ("EDIT", "USE", "EDIT"),
+        ("MANAGE", "EDIT", "MANAGE"),
+        # NO_PERMISSIONS loses to everything — a user with any active grant
+        # beats an explicit deny.
+        ("NO_PERMISSIONS", "READ", "READ"),
+        ("READ", "NO_PERMISSIONS", "READ"),
+        ("NO_PERMISSIONS", "MANAGE", "MANAGE"),
+        ("NO_PERMISSIONS", "NO_PERMISSIONS", "NO_PERMISSIONS"),
+    ],
+)
+def test_max_permission(a, b, expected):
+    assert max_permission(a, b) == expected
+
+
+def test_max_permission_is_symmetric():
+    for a_perm in _EXPECTED_ORDER:
+        for b_perm in _EXPECTED_ORDER:
+            forward = max_permission(a_perm.name, b_perm.name)
+            reverse = max_permission(b_perm.name, a_perm.name)
+            assert forward == reverse
+
+
+def test_max_permission_treats_unknown_as_lowest():
+    # Defensive behavior: an unknown permission name should not silently win.
+    assert max_permission("UNKNOWN", "READ") == "READ"
+    assert max_permission("READ", "UNKNOWN") == "READ"
+    # Two unknowns → the first wins (fallback to priority 0 for both, ``>=`` breaks the tie).
+    assert max_permission("UNKNOWN_A", "UNKNOWN_B") == "UNKNOWN_A"
+
+
+# ---- Validators -------------------------------------------------------------
+
+
+@pytest.mark.parametrize("permission", [p.name for p in _EXPECTED_ORDER])
+def test_validate_permission_accepts_known(permission):
+    _validate_permission(permission)
+
+
+@pytest.mark.parametrize("bogus", ["", "read", "ADMIN", "Manage", "NONE"])
+def test_validate_permission_rejects_unknown(bogus):
+    with pytest.raises(MlflowException, match="Invalid permission"):
+        _validate_permission(bogus)
+
+
+@pytest.mark.parametrize("resource_type", sorted(VALID_RESOURCE_TYPES))
+def test_validate_resource_type_accepts_known(resource_type):
+    _validate_resource_type(resource_type)
+
+
+@pytest.mark.parametrize("bogus", ["", "Experiment", "workspaces", "run", "trace"])
+def test_validate_resource_type_rejects_unknown(bogus):
+    with pytest.raises(MlflowException, match="Invalid resource type"):
+        _validate_resource_type(bogus)
+
+
+def test_workspace_is_a_valid_resource_type():
+    """Regression guard: the role-based permission model depends on
+    ``workspace`` being a first-class resource type for the workspace-wide
+    grant shape ``(workspace, *, PERMISSION)``. If it's ever removed from
+    VALID_RESOURCE_TYPES, the UI and the role-resolution logic both break.
+    """
+    assert "workspace" in VALID_RESOURCE_TYPES

--- a/tests/server/auth/test_sqlalchemy_store_rbac.py
+++ b/tests/server/auth/test_sqlalchemy_store_rbac.py
@@ -489,6 +489,282 @@ def test_list_workspace_admin_workspaces_ignores_non_manage(store, user):
     assert store.list_workspace_admin_workspaces(user.id) == set()
 
 
+# ---- Resolver coverage: cross-workspace isolation, NO_PERMISSIONS, resource types ----
+
+
+def test_resolver_cross_workspace_isolation(store, user):
+    """A role scoped to ws1 must not grant anything when resolving in ws2,
+    even if the user has the role assigned and the permission pattern matches.
+    """
+    role = store.create_role(name="editor", workspace="ws1")
+    store.add_role_permission(role.id, "experiment", "*", "EDIT")
+    store.assign_role_to_user(user.id, role.id)
+
+    # ws1: resolver finds the role and returns EDIT.
+    assert store.get_role_permission_for_resource(user.id, "experiment", "1", "ws1") == EDIT
+    # ws2: no role tied to ws2 for this user — resolver returns None.
+    assert store.get_role_permission_for_resource(user.id, "experiment", "1", "ws2") is None
+
+
+def test_resolver_role_assignment_in_other_workspace_doesnt_leak(store, user):
+    r_ws1 = store.create_role(name="ws1-editor", workspace="ws1")
+    store.add_role_permission(r_ws1.id, "experiment", "*", "EDIT")
+    store.assign_role_to_user(user.id, r_ws1.id)
+
+    r_ws2 = store.create_role(name="ws2-reader", workspace="ws2")
+    store.add_role_permission(r_ws2.id, "experiment", "*", "READ")
+    store.assign_role_to_user(user.id, r_ws2.id)
+
+    assert store.get_role_permission_for_resource(user.id, "experiment", "1", "ws1") == EDIT
+    assert store.get_role_permission_for_resource(user.id, "experiment", "1", "ws2") == READ
+    assert store.get_role_permission_for_resource(user.id, "experiment", "1", "ws3") is None
+
+
+def test_resolver_returns_no_permissions_when_role_only_has_no_permissions(store, user):
+    """If a user's only grant is NO_PERMISSIONS, the resolver returns that —
+    not ``None``. Callers can then distinguish 'no role at all' (None) from
+    'role with explicit deny' (NO_PERMISSIONS). This matters because the
+    outer permission chain treats these differently: None falls through to
+    workspace_permissions / default_permission, NO_PERMISSIONS short-circuits.
+    """
+    role = store.create_role(name="locked", workspace="ws1")
+    store.add_role_permission(role.id, "experiment", "*", "NO_PERMISSIONS")
+    store.assign_role_to_user(user.id, role.id)
+
+    result = store.get_role_permission_for_resource(user.id, "experiment", "1", "ws1")
+    assert result is not None
+    assert result.name == "NO_PERMISSIONS"
+
+
+def test_resolver_no_permissions_loses_to_any_positive_grant(store, user):
+    """When a user has both NO_PERMISSIONS and a positive grant (from different
+    roles or the same role), the positive grant wins. Reflects the
+    ``max_permission`` policy where explicit grants outrank explicit denies.
+    """
+    r_deny = store.create_role(name="deny", workspace="ws1")
+    store.add_role_permission(r_deny.id, "experiment", "*", "NO_PERMISSIONS")
+    store.assign_role_to_user(user.id, r_deny.id)
+
+    r_read = store.create_role(name="reader", workspace="ws1")
+    store.add_role_permission(r_read.id, "experiment", "*", "READ")
+    store.assign_role_to_user(user.id, r_read.id)
+
+    assert store.get_role_permission_for_resource(user.id, "experiment", "1", "ws1") == READ
+
+
+def test_resolver_unassigned_role_doesnt_grant(store, user):
+    """A role in the workspace with the right permissions doesn't help if the
+    user isn't assigned to it.
+    """
+    role = store.create_role(name="editor", workspace="ws1")
+    store.add_role_permission(role.id, "experiment", "*", "EDIT")
+    # Intentionally skip assign_role_to_user.
+
+    assert store.get_role_permission_for_resource(user.id, "experiment", "1", "ws1") is None
+
+
+def test_resolver_resource_type_filter(store, user):
+    """A grant on resource_type=registered_model does not satisfy an
+    experiment lookup (and vice versa). Only the ``workspace`` resource type
+    promotes across all types.
+    """
+    role = store.create_role(name="models-only", workspace="ws1")
+    store.add_role_permission(role.id, "registered_model", "*", "EDIT")
+    store.assign_role_to_user(user.id, role.id)
+
+    assert store.get_role_permission_for_resource(user.id, "experiment", "1", "ws1") is None
+    assert store.get_role_permission_for_resource(user.id, "registered_model", "m1", "ws1") == EDIT
+
+
+# ---- Resolver coverage: permission hierarchy matrix ----
+
+
+@pytest.mark.parametrize(
+    "resource_type",
+    [
+        "experiment",
+        "registered_model",
+        "scorer",
+        "gateway_secret",
+        "gateway_endpoint",
+        "gateway_model_definition",
+    ],
+)
+@pytest.mark.parametrize(
+    ("granted", "expected"),
+    [
+        ("READ", READ),
+        ("USE", USE),
+        ("EDIT", EDIT),
+        ("MANAGE", MANAGE),
+    ],
+)
+def test_resolver_returns_granted_permission_for_each_resource_type(
+    store, user, resource_type, granted, expected
+):
+    """For each (resource_type, granted_permission) pair, resolving the user's
+    permission on a specific resource of that type returns exactly the granted
+    permission. This ensures the resolver applies uniformly across every
+    resource type the system knows about.
+    """
+    role = store.create_role(name=f"{resource_type}-{granted}", workspace="ws1")
+    store.add_role_permission(role.id, resource_type, "*", granted)
+    store.assign_role_to_user(user.id, role.id)
+
+    assert store.get_role_permission_for_resource(user.id, resource_type, "id", "ws1") == expected
+
+
+@pytest.mark.parametrize(
+    "resource_type",
+    [
+        "experiment",
+        "registered_model",
+        "gateway_endpoint",
+        "gateway_secret",
+        "gateway_model_definition",
+        "scorer",
+    ],
+)
+def test_resolver_workspace_grant_promotes_to_every_resource_type(store, user, resource_type):
+    """``(workspace, *, MANAGE)`` should grant MANAGE on every known resource
+    type in the role's workspace. This is the workspace-admin short-circuit —
+    if it regresses, workspace admins silently lose authority over specific
+    resource types.
+    """
+    role = store.create_role(name="ws-admin", workspace="ws1")
+    store.add_role_permission(role.id, "workspace", "*", "MANAGE")
+    store.assign_role_to_user(user.id, role.id)
+
+    assert store.get_role_permission_for_resource(user.id, resource_type, "any-id", "ws1") == MANAGE
+
+
+@pytest.mark.parametrize(
+    ("granted", "expected"),
+    [
+        ("READ", READ),
+        ("USE", USE),
+        ("EDIT", EDIT),
+        ("MANAGE", MANAGE),
+    ],
+)
+def test_resolver_workspace_grant_propagates_at_every_level(store, user, granted, expected):
+    """``(workspace, *, X)`` where X ∈ {READ, USE, EDIT, MANAGE} promotes X to
+    every resource type — not just MANAGE. This ensures workspace-wide grants
+    work as a blanket baseline permission, which the UI relies on (e.g. the
+    seeded ``viewer`` and ``editor`` roles use this form).
+    """
+    role = store.create_role(name=f"ws-{granted}", workspace="ws1")
+    store.add_role_permission(role.id, "workspace", "*", granted)
+    store.assign_role_to_user(user.id, role.id)
+
+    for resource_type in [
+        "experiment",
+        "registered_model",
+        "gateway_endpoint",
+        "gateway_secret",
+        "gateway_model_definition",
+        "scorer",
+    ]:
+        assert (
+            store.get_role_permission_for_resource(user.id, resource_type, "id", "ws1") == expected
+        )
+
+
+def test_resolver_workspace_grant_scoped_to_role_workspace(store, user):
+    """A workspace-wide grant in ws1 has no effect when resolving in ws2 —
+    the role's workspace scopes the grant.
+    """
+    role = store.create_role(name="ws1-admin", workspace="ws1")
+    store.add_role_permission(role.id, "workspace", "*", "MANAGE")
+    store.assign_role_to_user(user.id, role.id)
+
+    assert store.get_role_permission_for_resource(user.id, "experiment", "1", "ws1") == MANAGE
+    assert store.get_role_permission_for_resource(user.id, "experiment", "1", "ws2") is None
+
+
+# ---- Resolver coverage: pattern matching completeness ----
+
+
+def test_resolver_specific_pattern_does_not_apply_to_different_id(store, user):
+    role = store.create_role(name="e42-editor", workspace="ws1")
+    store.add_role_permission(role.id, "experiment", "42", "EDIT")
+    store.assign_role_to_user(user.id, role.id)
+
+    assert store.get_role_permission_for_resource(user.id, "experiment", "42", "ws1") == EDIT
+    assert store.get_role_permission_for_resource(user.id, "experiment", "99", "ws1") is None
+
+
+def test_resolver_wildcard_applies_to_any_id(store, user):
+    role = store.create_role(name="any-experiment", workspace="ws1")
+    store.add_role_permission(role.id, "experiment", "*", "READ")
+    store.assign_role_to_user(user.id, role.id)
+
+    for eid in ["1", "42", "long-uuid-6a4c", ""]:
+        assert store.get_role_permission_for_resource(user.id, "experiment", eid, "ws1") == READ
+
+
+def test_resolver_specific_outranks_wildcard_when_higher(store, user):
+    # Specific grant > wildcard grant → specific wins.
+    role = store.create_role(name="mixed", workspace="ws1")
+    store.add_role_permission(role.id, "experiment", "*", "READ")
+    store.add_role_permission(role.id, "experiment", "42", "EDIT")
+    store.assign_role_to_user(user.id, role.id)
+
+    assert store.get_role_permission_for_resource(user.id, "experiment", "42", "ws1") == EDIT
+    assert store.get_role_permission_for_resource(user.id, "experiment", "99", "ws1") == READ
+
+
+def test_resolver_wildcard_outranks_specific_when_higher(store, user):
+    """Wildcard grant > specific grant → wildcard wins (best grant policy,
+    not "most specific wins"). This prevents an operator from accidentally
+    *downgrading* a user's access by adding a narrower grant with a lower
+    permission level.
+    """
+    role = store.create_role(name="mixed", workspace="ws1")
+    store.add_role_permission(role.id, "experiment", "*", "EDIT")
+    store.add_role_permission(role.id, "experiment", "42", "READ")
+    store.assign_role_to_user(user.id, role.id)
+
+    assert store.get_role_permission_for_resource(user.id, "experiment", "42", "ws1") == EDIT
+    assert store.get_role_permission_for_resource(user.id, "experiment", "99", "ws1") == EDIT
+
+
+# ---- Resolver coverage: multi-role union ----
+
+
+def test_resolver_union_picks_max_across_roles(store, user):
+    # Permissions union across all roles assigned to the user — max wins.
+    r1 = store.create_role(name="r1", workspace="ws1")
+    store.add_role_permission(r1.id, "experiment", "*", "READ")
+    store.assign_role_to_user(user.id, r1.id)
+
+    r2 = store.create_role(name="r2", workspace="ws1")
+    store.add_role_permission(r2.id, "experiment", "*", "USE")
+    store.assign_role_to_user(user.id, r2.id)
+
+    r3 = store.create_role(name="r3", workspace="ws1")
+    store.add_role_permission(r3.id, "experiment", "*", "MANAGE")
+    store.assign_role_to_user(user.id, r3.id)
+
+    assert store.get_role_permission_for_resource(user.id, "experiment", "1", "ws1") == MANAGE
+
+
+def test_resolver_union_mixes_workspace_and_resource_grants(store, user):
+    """A workspace-wide EDIT + a specific experiment READ → resolver still
+    surfaces EDIT for that experiment, because the workspace grant already
+    covers it. Specific grants only promote, never downgrade.
+    """
+    r_ws = store.create_role(name="ws-editor", workspace="ws1")
+    store.add_role_permission(r_ws.id, "workspace", "*", "EDIT")
+    store.assign_role_to_user(user.id, r_ws.id)
+
+    r_specific = store.create_role(name="one-reader", workspace="ws1")
+    store.add_role_permission(r_specific.id, "experiment", "42", "READ")
+    store.assign_role_to_user(user.id, r_specific.id)
+
+    assert store.get_role_permission_for_resource(user.id, "experiment", "42", "ws1") == EDIT
+
+
 # ---- Legacy workspace_permissions as workspace-admin source ----
 #
 # Pre-RBAC operators relied on `workspace_permissions` MANAGE to convey workspace-wide

--- a/tests/server/auth/test_sqlalchemy_store_rbac.py
+++ b/tests/server/auth/test_sqlalchemy_store_rbac.py
@@ -2,7 +2,12 @@ import pytest
 
 from mlflow.exceptions import MlflowException
 from mlflow.server.auth.entities import Role, RolePermission, UserRoleAssignment
-from mlflow.server.auth.permissions import EDIT, MANAGE, READ, USE
+from mlflow.server.auth.permissions import EDIT, MANAGE, READ, USE, VALID_RESOURCE_TYPES
+
+# Every concrete resource type the resolver accepts, excluding the special
+# ``"workspace"`` bucket which is exercised separately (it's not a real resource
+# type — it's the workspace-wide grant form).
+_CONCRETE_RESOURCE_TYPES = sorted(VALID_RESOURCE_TYPES - {"workspace"})
 from mlflow.server.auth.sqlalchemy_store import SqlAlchemyStore
 
 from tests.helper_functions import random_str
@@ -521,11 +526,12 @@ def test_resolver_role_assignment_in_other_workspace_doesnt_leak(store, user):
 
 
 def test_resolver_returns_no_permissions_when_role_only_has_no_permissions(store, user):
-    """If a user's only grant is NO_PERMISSIONS, the resolver returns that —
-    not ``None``. Callers can then distinguish 'no role at all' (None) from
-    'role with explicit deny' (NO_PERMISSIONS). This matters because the
-    outer permission chain treats these differently: None falls through to
-    workspace_permissions / default_permission, NO_PERMISSIONS short-circuits.
+    """If a user's only grant is NO_PERMISSIONS, ``get_role_permission_for_resource``
+    returns that permission object — not ``None``. Documents the distinction at the
+    store layer between 'no role grant found' (None) and 'role grant resolved to an
+    explicit NO_PERMISSIONS' without implying different fallback behavior in the
+    outer resolver — at that layer (_get_permission_from_store_or_default) both
+    cases fall through to the direct grant / workspace / default chain identically.
     """
     role = store.create_role(name="locked", workspace="ws1")
     store.add_role_permission(role.id, "experiment", "*", "NO_PERMISSIONS")
@@ -579,17 +585,7 @@ def test_resolver_resource_type_filter(store, user):
 # ---- Resolver coverage: permission hierarchy matrix ----
 
 
-@pytest.mark.parametrize(
-    "resource_type",
-    [
-        "experiment",
-        "registered_model",
-        "scorer",
-        "gateway_secret",
-        "gateway_endpoint",
-        "gateway_model_definition",
-    ],
-)
+@pytest.mark.parametrize("resource_type", _CONCRETE_RESOURCE_TYPES)
 @pytest.mark.parametrize(
     ("granted", "expected"),
     [
@@ -614,17 +610,7 @@ def test_resolver_returns_granted_permission_for_each_resource_type(
     assert store.get_role_permission_for_resource(user.id, resource_type, "id", "ws1") == expected
 
 
-@pytest.mark.parametrize(
-    "resource_type",
-    [
-        "experiment",
-        "registered_model",
-        "gateway_endpoint",
-        "gateway_secret",
-        "gateway_model_definition",
-        "scorer",
-    ],
-)
+@pytest.mark.parametrize("resource_type", _CONCRETE_RESOURCE_TYPES)
 def test_resolver_workspace_grant_promotes_to_every_resource_type(store, user, resource_type):
     """``(workspace, *, MANAGE)`` should grant MANAGE on every known resource
     type in the role's workspace. This is the workspace-admin short-circuit —
@@ -657,14 +643,7 @@ def test_resolver_workspace_grant_propagates_at_every_level(store, user, granted
     store.add_role_permission(role.id, "workspace", "*", granted)
     store.assign_role_to_user(user.id, role.id)
 
-    for resource_type in [
-        "experiment",
-        "registered_model",
-        "gateway_endpoint",
-        "gateway_secret",
-        "gateway_model_definition",
-        "scorer",
-    ]:
+    for resource_type in _CONCRETE_RESOURCE_TYPES:
         assert (
             store.get_role_permission_for_resource(user.id, resource_type, "id", "ws1") == expected
         )
@@ -699,7 +678,7 @@ def test_resolver_wildcard_applies_to_any_id(store, user):
     store.add_role_permission(role.id, "experiment", "*", "READ")
     store.assign_role_to_user(user.id, role.id)
 
-    for eid in ["1", "42", "long-uuid-6a4c", ""]:
+    for eid in ["1", "42", "long-uuid-6a4c"]:
         assert store.get_role_permission_for_resource(user.id, "experiment", eid, "ws1") == READ
 
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22721 (Phase 1 RBAC data model — merged) · #22722 (RBAC REST API — merged)

### What changes are proposed in this pull request?

Three sections:

#### 1. RBAC permission-resolution regression tests (no prod changes)

**`tests/server/auth/test_permissions.py`** — 49 tests against the pure permissions module:

- Hierarchy / priority ordering and the READ < USE < EDIT < MANAGE capability matrix.
- `max_permission` semantics: symmetry; `NO_PERMISSIONS` loses to any positive grant; unknowns fall back to the lowest priority rather than raising.
- `_validate_permission` / `_validate_resource_type` reject garbage, accept every documented value.
- Regression guard that `"workspace"` stays in `VALID_RESOURCE_TYPES` — the role model relies on the `(workspace, *, X)` grant shape, so silently dropping it would break the resolver.

**`tests/server/auth/test_sqlalchemy_store_rbac.py`** — ~35 tests added against `get_role_permission_for_resource`:

- **Cross-workspace isolation** — roles in `ws1` grant nothing in `ws2`.
- **`NO_PERMISSIONS` handling** — explicit deny is returned (not `None`) but loses to any positive grant in the multi-role union.
- **Resource-type × permission-level matrix** — all six resource types resolve correctly across READ/USE/EDIT/MANAGE (parameterized).
- **Workspace-wide grant promotion** — `(workspace, *, X)` promotes to every resource type at every level.
- **Pattern matching completeness** — wildcard vs specific interaction, best-grant policy (wildcard EDIT still wins over specific READ).
- **Multi-role union** — max across all assignments.

#### 2. Gateway validator bug fix + matrix tests

Found while writing the resolver tests: **`_validate_gateway_use_permission`** (the `invoke` path for gateway endpoints invoked by name) bypassed role-based permissions entirely. It passed only the legacy `workspace_level_permission_func` to `_get_permission_from_store_or_default` with no `role_permission_func` — every other gateway permission lookup already wires both paths. Users who held USE/EDIT/MANAGE on a gateway endpoint solely via a role assignment (e.g. through the `workspace-admin` role from #22857) were silently denied when invoking the endpoint by name, unless they also happened to have a legacy `workspace_permissions` grant.

**Fix** (`mlflow/server/auth/__init__.py`, +11/−3):
- Wire `_role_permission_for(resource_type="gateway_endpoint", resource_key=endpoint_id, …)` into the validator, matching `_get_permission_from_gateway_endpoint_id`.
- Switch the local `_get_store` import to `_get_tracking_store` (the pattern used by every other tracking-store call in `auth/__init__.py`).

**Tests** (`tests/server/auth/test_auth_workspace.py`, +27):
- Role grants on `gateway_endpoint` at each permission level → validators return the right capability bits.
- Capability-bit matrix: READ doesn't grant USE; USE/EDIT/MANAGE all grant USE (parameterized).
- Workspace-wide role grants `(workspace, *, X)` promote to gateway endpoints at every level.
- Parity across the three gateway resource types (secret / endpoint / model definition).
- Cross-workspace isolation — role in `team-b` can't invoke endpoints in `team-a`.
- Multi-role union picks the highest grant.

Mock `_TrackingStore.get_gateway_endpoint` extended to accept the `name` keyword (synonym for `endpoint_id` in tests), since the real resolver hits that signature on the by-name invocation path.

#### 3. Role-management endpoint authorization tests (no prod changes)

`tests/server/auth/test_auth_workspace.py` — 47 parametrized cases covering the four validators that guard the role CRUD endpoints:

- **`validate_can_manage_roles`** (create / update / delete role, add / remove / update role_permission, assign / unassign role) — super admin OR workspace admin in the resolved workspace.
- **`validate_can_view_roles`** (get_role, list_role_permissions) — super admin OR any role assignment in the resolved workspace.
- **`validate_can_list_roles`** (list_roles) — super-admin-only when unscoped; non-admin must scope to a workspace where they hold a role.
- **`validate_can_view_user_roles`** (list_user_roles) — super admin, self, or workspace admin over any workspace the target is present in.

Actor matrix: `super_admin` (is_admin=True), `ws_admin_foo`, `ws_admin_bar`, `ws_member_foo` (has a role in `foo` but not MANAGE), `outsider` (no roles). Target workspace `foo` or `bar`.

Shape-resolution (the three access paths through `_get_role_workspace_from_request` — `role_id`, `role_permission_id`, or literal `workspace` param) is factored into a dedicated 6-case test so the authorization matrices don't multiply by shape.

Edge cases:
- Non-existent `role_id` / `role_permission_id` fail closed for non-admins; super admins short-circuit before resolution.
- Missing / blank workspace params raise `INVALID_PARAMETER_VALUE` instead of silently denying.
- Non-integer `role_id` propagates the coercion error through the validator chain.

### How is this PR tested?

- [x] Existing unit/integration tests — full auth suite passes.
- [x] New unit/integration tests — 158 new cases across the three test files (49 + ~35 + 27 + 47).

Each validator fix / matrix was verified to catch regressions: reverted the production behavior and confirmed the relevant parametrized IDs failed (e.g. breaking `validate_can_manage_roles` to always-allow fails 23/36 manage-roles cases with clear IDs).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Users holding USE/EDIT/MANAGE on a gateway endpoint solely via an RBAC role assignment can now invoke the endpoint by name. Previously only the `endpoint_id` path respected role-based permissions; the by-name path required a legacy `workspace_permissions` grant or access would be silently denied.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/server-infra`: MLflow Tracking server, JavaScript dev server
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Claude.