### PR TITLE
Include role-based grants in `list_accessible_workspace_names`

### DIFF
--- a/mlflow/server/auth/sqlalchemy_store.py
+++ b/mlflow/server/auth/sqlalchemy_store.py
@@ -415,17 +415,33 @@ class SqlAlchemyStore:
 
         with self.ManagedSessionMaker() as session:
             user = self._get_user(session, username=username)
-            rows: list[SqlWorkspacePermission] = (
+
+            # Legacy workspace_permissions grants (pre-RBAC): filter to
+            # permissions that actually convey read access.
+            legacy_rows: list[SqlWorkspacePermission] = (
                 session
                 .query(SqlWorkspacePermission)
                 .filter(SqlWorkspacePermission.user_id == user.id)
                 .all()
             )
-            accessible: set[str] = set()
-            for row in rows:
-                permission = row.permission
-                if get_permission(permission).can_read:
-                    accessible.add(row.workspace)
+            accessible: set[str] = {
+                row.workspace for row in legacy_rows if get_permission(row.permission).can_read
+            }
+
+            # Role-based: being assigned to any role in a workspace implies
+            # membership and therefore visibility of that workspace, even if
+            # the role's resource-level permissions don't individually grant
+            # read on workspace_permissions.
+            role_rows = (
+                session
+                .query(SqlRole.workspace)
+                .join(SqlUserRoleAssignment, SqlRole.id == SqlUserRoleAssignment.role_id)
+                .filter(SqlUserRoleAssignment.user_id == user.id)
+                .distinct()
+                .all()
+            )
+            accessible.update(w for (w,) in role_rows)
+
             return accessible
 
     def get_workspace_permission(self, workspace_name: str, username: str) -> Permission | None:

--- a/tests/server/auth/test_auth_workspace.py
+++ b/tests/server/auth/test_auth_workspace.py
@@ -388,6 +388,48 @@ def test_filter_list_workspaces_filters_to_allowed(monkeypatch):
     assert [ws["name"] for ws in payload["workspaces"]] == ["team-a"]
 
 
+def test_list_workspaces_filters_to_role_assigned_workspaces(tmp_path, monkeypatch):
+    # End-to-end guard for the list_accessible_workspace_names fix: alice has NO
+    # legacy workspace_permissions rows — her only workspace membership is via a
+    # role assignment in ws-alpha. The ListWorkspaces filter must treat that role
+    # assignment as workspace visibility and surface ws-alpha but not ws-beta.
+    # Before the fix, the legacy-only query returned an empty set and alice saw
+    # no workspaces in the UI.
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+    monkeypatch.setattr(auth_module, "sender_is_admin", lambda: False)
+    monkeypatch.setattr(
+        auth_module,
+        "auth_config",
+        auth_module.auth_config._replace(grant_default_workspace_access=False),
+        raising=False,
+    )
+
+    db_uri = f"sqlite:///{tmp_path / 'auth-store.db'}"
+    auth_store = SqlAlchemyStore()
+    auth_store.init_db(db_uri)
+    monkeypatch.setattr(auth_module, "store", auth_store, raising=False)
+
+    alice = auth_store.create_user("alice", "supersecurepassword", is_admin=False)
+    role = auth_store.create_role(name="viewer", workspace="ws-alpha")
+    auth_store.add_role_permission(role.id, "experiment", "*", READ.name)
+    auth_store.assign_role_to_user(alice.id, role.id)
+
+    monkeypatch.setattr(
+        auth_module, "authenticate_request", lambda: SimpleNamespace(username="alice")
+    )
+
+    response = Response(
+        json.dumps({"workspaces": [{"name": "ws-alpha"}, {"name": "ws-beta"}]}),
+        mimetype="application/json",
+    )
+
+    auth_module.filter_list_workspaces(response)
+    payload = json.loads(response.get_data(as_text=True))
+    assert [ws["name"] for ws in payload["workspaces"]] == ["ws-alpha"]
+
+    auth_store.engine.dispose()
+
+
 def test_validate_can_view_workspace_allows_default_autogrant(monkeypatch):
     monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
     monkeypatch.setattr(auth_module, "sender_is_admin", lambda: False)

--- a/tests/server/auth/test_sqlalchemy_store_workspace.py
+++ b/tests/server/auth/test_sqlalchemy_store_workspace.py
@@ -134,6 +134,86 @@ def test_list_accessible_workspace_names(store):
     assert store.list_accessible_workspace_names(None) == set()
 
 
+def test_list_accessible_workspace_names_includes_role_based_workspaces(store):
+    # Role assignment with permissions → workspace visible, even without a legacy
+    # workspace_permissions row.
+    username = random_str()
+    user = store.create_user(username, random_str())
+
+    role = store.create_role(name="viewer", workspace="ws1")
+    store.add_role_permission(role.id, "experiment", "*", READ.name)
+    store.assign_role_to_user(user.id, role.id)
+
+    assert store.list_accessible_workspace_names(username) == {"ws1"}
+
+
+def test_list_accessible_workspace_names_includes_role_with_no_permissions(store):
+    # Role membership alone implies visibility — the role has zero permission rows,
+    # but the user is still assigned to it. Documents the intentional design: a
+    # workspace admin can give someone "membership" without any capability and the
+    # UI still surfaces the workspace in their list.
+    username = random_str()
+    user = store.create_user(username, random_str())
+
+    empty_role = store.create_role(name="shell", workspace="ws1")
+    store.assign_role_to_user(user.id, empty_role.id)
+
+    assert store.list_accessible_workspace_names(username) == {"ws1"}
+
+
+def test_list_accessible_workspace_names_combines_legacy_and_role_sources(store):
+    # Legacy READ on ws1 + role assignment in ws2 → both surface.
+    username = random_str()
+    user = store.create_user(username, random_str())
+
+    store.set_workspace_permission("ws1", username, READ.name)
+    role = store.create_role(name="viewer", workspace="ws2")
+    store.assign_role_to_user(user.id, role.id)
+
+    assert store.list_accessible_workspace_names(username) == {"ws1", "ws2"}
+
+
+def test_list_accessible_workspace_names_legacy_no_permissions_still_hides(store):
+    # Legacy NO_PERMISSIONS row should not make a workspace visible — the legacy
+    # branch still filters by ``can_read``. Regression guard for the carve-out that
+    # only the role-based branch unconditionally counts membership.
+    username = random_str()
+    store.create_user(username, random_str())
+
+    store.set_workspace_permission("ws1", username, NO_PERMISSIONS.name)
+
+    assert store.list_accessible_workspace_names(username) == set()
+
+
+def test_list_accessible_workspace_names_role_in_other_workspace_doesnt_leak(store):
+    # A role assignment in one workspace must not surface unrelated workspaces.
+    username = random_str()
+    user = store.create_user(username, random_str())
+
+    role_ws1 = store.create_role(name="viewer", workspace="ws1")
+    store.assign_role_to_user(user.id, role_ws1.id)
+    # ws2 and ws3 exist (via roles for other users) but the user has no assignment.
+    store.create_role(name="viewer", workspace="ws2")
+    store.create_role(name="viewer", workspace="ws3")
+
+    assert store.list_accessible_workspace_names(username) == {"ws1"}
+
+
+def test_list_accessible_workspace_names_combines_legacy_and_role_same_workspace(store):
+    # Overlap: a user has BOTH a legacy READ and a role assignment in the same
+    # workspace. Deduplication should collapse to a single entry.
+    username = random_str()
+    user = store.create_user(username, random_str())
+
+    store.set_workspace_permission("ws1", username, READ.name)
+    role = store.create_role(name="viewer", workspace="ws1")
+    store.assign_role_to_user(user.id, role.id)
+
+    accessible = store.list_accessible_workspace_names(username)
+    assert accessible == {"ws1"}
+    assert len(accessible) == 1
+
+
 def test_rename_registered_model_permissions_scoped_by_workspace(store, monkeypatch):
     monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
     username = random_str()


### PR DESCRIPTION
### Related Issues/PRs

Extracted from the backend commits on `fe/rbac-admin-ui` (PR #22724). That branch carries several UI + backend changes; this PR lifts the single self-contained backend fix out so it can land on master independently of the UI rollout.

### What changes are proposed in this pull request?

`list_accessible_workspace_names` was querying only the pre-RBAC `workspace_permissions` table. `filter_list_workspaces` treats its return value as the allowlist for the `ListWorkspaces` response, so a user whose only workspace membership came from an RBAC role assignment (post-#22721 path) saw an empty list in the UI — they had a role in `ws-alpha` but `ListWorkspaces` filtered it out.

The fix (commit 1) adds a second query:

1. **Legacy** `workspace_permissions` rows — filtered by `can_read` to preserve the existing "NO_PERMISSIONS hides the workspace" behavior.
2. **Role-based** — every workspace in which the user has a `user_role_assignments` row. Role membership alone implies visibility; the role's individual `role_permissions` entries aren't re-evaluated here because the per-endpoint validators already gate specific actions.

The union is returned.

Commit 2 adds regression tests that failed against the pre-fix code (I verified this by temporarily reverting the fix and rerunning — 5 of the 7 new tests failed).

### How is this PR tested?

- [x] Existing unit/integration tests — 65 tests in `test_sqlalchemy_store_workspace.py` + `test_auth_workspace.py` pass.
- [x] New unit/integration tests:
  - **Store-level** (`test_sqlalchemy_store_workspace.py`):
    - `test_list_accessible_workspace_names_includes_role_based_workspaces` — role with permissions → visible.
    - `test_list_accessible_workspace_names_includes_role_with_no_permissions` — role with zero permission rows → still visible (role membership = visibility).
    - `test_list_accessible_workspace_names_combines_legacy_and_role_sources` — legacy READ in ws1 + role in ws2 → both surface.
    - `test_list_accessible_workspace_names_legacy_no_permissions_still_hides` — legacy NO_PERMISSIONS row stays hidden (preserves legacy filter).
    - `test_list_accessible_workspace_names_role_in_other_workspace_doesnt_leak` — role in one workspace doesn't surface other workspaces.
    - `test_list_accessible_workspace_names_combines_legacy_and_role_same_workspace` — overlap on same workspace dedupes.
  - **REST-level** (`test_auth_workspace.py`):
    - `test_list_workspaces_filters_to_role_assigned_workspaces` — alice has only a role assignment in ws-alpha; `ListWorkspaces` response filters to {ws-alpha}.
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Users granted workspace access solely via an RBAC role assignment now correctly see that workspace in the MLflow workspace list (previously the list was populated only from the legacy per-user `workspace_permissions` table).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/server-infra`: MLflow Tracking server, JavaScript dev server

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release