### PR TITLE
Override exclude-newer for pydocket to fix fakeredis 2.35.0 incompatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -239,7 +239,9 @@ docs = [
 
 [tool.uv]
 exclude-newer = "P14D"
-exclude-newer-package = { torch = false, torchvision = false }
+# TODO: Remove pydocket override on/after 2026-05-04, when pydocket 0.19.2 (released 2026-04-20)
+# enters the P14D window. pydocket<0.19 breaks with fakeredis>=2.35.0.
+exclude-newer-package = { torch = false, torchvision = false, pydocket = "2026-04-21" }
 required-version = ">=0.10.12"
 constraint-dependencies = [
   # xgboost 3.1.0 changed base_score format to vector for multi-output models, breaking shap compatibility


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22863

### What changes are proposed in this pull request?

Adds a per-package `exclude-newer` override for `pydocket` so the resolver can pick `pydocket>=0.19.2` (released 2026-04-20).

`pydocket<0.19` imports the now-removed `FakeConnection` symbol from `fakeredis.aioredis`, which was renamed to `FakeAsyncRedisConnection` in fakeredis 2.35.0 (released 2026-04-09). This breaks MCP server startup in the `test-requirements` workflow:

```
ImportError: cannot import name 'FakeConnection' from 'fakeredis.aioredis'
  File ".../docket/_redis.py", line 257, in _memory_connection_pool
    from fakeredis.aioredis import FakeConnection, FakeServer
```

pydocket 0.19.2 fixes the import on its side but falls outside the repo's `P14D` `exclude-newer` window. The per-package date override lets it through until the window rolls forward naturally on 2026-05-04 (at which point the override can be removed — TODO noted inline).

### How is this PR tested?

- [x] Manual tests

Verified locally that with the override in place, `uv pip install pydocket` resolves to `0.19.2` and `tests/mcp/` all pass against `fakeredis==2.35.0`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release