### PR TITLE
Fix SQLAlchemy trace token usage rollup

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -178,10 +178,10 @@ from mlflow.tracing.otel.translation import (
     translate_loaded_span,
     translate_span_when_storing,
     update_cost,
-    update_token_usage,
 )
 from mlflow.tracing.utils import (
     TraceJSONEncoder,
+    aggregate_usage_from_spans,
     generate_request_id_v2,
 )
 from mlflow.tracing.utils.truncation import _get_truncated_preview
@@ -4543,19 +4543,16 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             max_end_ms = (max(end_times) // 1_000_000) if end_times else None
             root_span_status = self._get_trace_status_from_root_span(trace_spans)
 
-            aggregated_token_usage = {}
             aggregated_cost = {}
             session_id = None
             user_id = None
             root_span_dict = None
+            span_dicts = []
             for span in trace_spans:
                 span_dict = translate_span_when_storing(span)
+                span_dicts.append(span_dict)
                 span_cost = None
                 if span_attributes := span_dict.get("attributes", {}):
-                    if span_token_usage := span_attributes.get(SpanAttributeKey.CHAT_USAGE):
-                        aggregated_token_usage = update_token_usage(
-                            aggregated_token_usage, span_token_usage
-                        )
                     if span_cost := span_attributes.get(SpanAttributeKey.LLM_COST):
                         aggregated_cost = update_cost(aggregated_cost, span_cost)
                     # Session ID from OTel semantic conventions:
@@ -4615,7 +4612,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 max_end_ms=max_end_ms,
                 root_span_status=root_span_status,
                 trace_status=root_span_status or TraceState.IN_PROGRESS.value,
-                aggregated_token_usage=aggregated_token_usage,
+                aggregated_token_usage=_aggregate_token_usage_from_span_dicts(span_dicts) or {},
                 aggregated_cost=aggregated_cost,
                 session_id=session_id,
                 user_id=user_id,
@@ -4742,6 +4739,34 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                     elif row.key == TraceMetadataKey.COST:
                         existing_cost[row.request_id] = row
 
+            trace_ids_to_recompute_token_usage = [
+                trace_id
+                for trace_id in trace_ids_with_token_usage
+                if trace_id not in finalized_trace_ids or trace_id not in existing_token_usage
+            ]
+            if trace_ids_to_recompute_token_usage:
+                spans_by_trace_id = defaultdict(list)
+                rows = (
+                    session
+                    .query(SqlSpan.trace_id, SqlSpan.content)
+                    .filter(SqlSpan.trace_id.in_(trace_ids_to_recompute_token_usage))
+                    .all()
+                )
+                for trace_id, content in rows:
+                    try:
+                        spans_by_trace_id[trace_id].append(json.loads(content))
+                    except Exception:
+                        _logger.debug(
+                            "Failed to load span while aggregating token usage for trace %s",
+                            trace_id,
+                            exc_info=True,
+                        )
+
+                for trace_id in trace_ids_to_recompute_token_usage:
+                    trace_aggregates[trace_id].aggregated_token_usage = (
+                        _aggregate_token_usage_from_span_dicts(spans_by_trace_id[trace_id]) or {}
+                    )
+
             existing_sessions: set[str] = set()
             if trace_ids_with_session:
                 existing_sessions = {
@@ -4811,10 +4836,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 if aggregated_token_usage := agg.aggregated_token_usage:
                     existing_record = existing_token_usage.get(trace_id)
                     if trace_id not in finalized_trace_ids or not existing_record:
-                        trace_token_usage = update_token_usage(
-                            existing_record.value if existing_record else {},
-                            aggregated_token_usage,
-                        )
+                        trace_token_usage = aggregated_token_usage
                         session.merge(
                             SqlTraceMetadata(
                                 request_id=trace_id,
@@ -4822,6 +4844,10 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                                 value=json.dumps(trace_token_usage),
                             )
                         )
+                        session.query(SqlTraceMetrics).filter(
+                            SqlTraceMetrics.request_id == trace_id,
+                            SqlTraceMetrics.key.in_(TokenUsageKey.all_keys()),
+                        ).delete(synchronize_session=False)
                         for key in TokenUsageKey.all_keys():
                             if (value := trace_token_usage.get(key)) is not None:
                                 session.merge(
@@ -7213,12 +7239,38 @@ def _get_search_datasets_order_by_clauses(order_by):
     return [col.asc() if ascending else col.desc() for col, ascending in order_by_clauses]
 
 
-def _try_parse_json_string(value: str) -> str:
+def _try_parse_json_string(value: str) -> Any:
     try:
         return json.loads(value)
     except json.JSONDecodeError:
         pass
     return value
+
+
+@dataclass
+class _SpanDictAggregateView:
+    span_dict: dict[str, Any]
+
+    @property
+    def span_id(self) -> str:
+        return self.span_dict["span_id"]
+
+    @property
+    def parent_id(self) -> str | None:
+        return self.span_dict.get("parent_span_id")
+
+    def get_attribute(self, key: str) -> Any:
+        value = self.span_dict.get("attributes", {}).get(key)
+        value = _try_parse_json_string(value) if isinstance(value, str) else value
+        return value if isinstance(value, dict) else None
+
+
+def _aggregate_token_usage_from_span_dicts(
+    span_dicts: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    return aggregate_usage_from_spans([
+        _SpanDictAggregateView(span_dict) for span_dict in span_dicts
+    ])
 
 
 @dataclass

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store.py
@@ -12858,6 +12858,84 @@ def test_log_spans_token_usage(store: SqlAlchemyStore) -> None:
     assert trace.info.token_usage["total_tokens"] == 150
 
 
+def _create_rollup_token_usage_spans(trace_id: str):
+    parent_usage = {
+        "input_tokens": 2000,
+        "output_tokens": 1000,
+        "total_tokens": 3000,
+    }
+    child_usage = {
+        "input_tokens": 1000,
+        "output_tokens": 500,
+        "total_tokens": 1500,
+        "cache_read_input_tokens": 100,
+    }
+
+    parent = create_test_span(
+        trace_id=trace_id,
+        name="invoke_agent",
+        span_id=111,
+        span_type="AGENT",
+        attributes={SpanAttributeKey.CHAT_USAGE: parent_usage},
+    )
+    children = [
+        create_test_span(
+            trace_id=trace_id,
+            name=f"chat_{i}",
+            span_id=span_id,
+            parent_id=111,
+            attributes={SpanAttributeKey.CHAT_USAGE: child_usage},
+        )
+        for i, span_id in enumerate([222, 333], start=1)
+    ]
+    children_usage = {
+        **parent_usage,
+        "cache_read_input_tokens": 200,
+    }
+    return parent, children, parent_usage, children_usage
+
+
+def _get_trace_token_usage_metrics(store: SqlAlchemyStore, trace_id: str) -> dict[str, float]:
+    with store.ManagedSessionMaker() as session:
+        metrics = (
+            session
+            .query(SqlTraceMetrics)
+            .filter(SqlTraceMetrics.request_id == trace_id)
+            .order_by(SqlTraceMetrics.key)
+            .all()
+        )
+        return {metric.key: metric.value for metric in metrics}
+
+
+def test_log_spans_token_usage_does_not_double_count_descendants(
+    store: SqlAlchemyStore,
+) -> None:
+    experiment_id = store.create_experiment("test_log_spans_token_usage_dedup_descendants")
+    trace_id = f"tr-{uuid.uuid4().hex}"
+    parent, children, parent_usage, _ = _create_rollup_token_usage_spans(trace_id)
+
+    store.log_spans(experiment_id, [children[0], parent, children[1]])
+
+    trace_info = store.get_trace_info(trace_id)
+    assert trace_info.token_usage == parent_usage
+    assert _get_trace_token_usage_metrics(store, trace_id) == parent_usage
+
+
+def test_log_spans_token_usage_recomputes_when_parent_rollup_arrives_later(
+    store: SqlAlchemyStore,
+) -> None:
+    experiment_id = store.create_experiment("test_log_spans_token_usage_recompute_rollup")
+    trace_id = f"tr-{uuid.uuid4().hex}"
+    parent, children, parent_usage, children_usage = _create_rollup_token_usage_spans(trace_id)
+
+    store.log_spans(experiment_id, children)
+    assert store.get_trace_info(trace_id).token_usage == children_usage
+
+    store.log_spans(experiment_id, [parent])
+    assert store.get_trace_info(trace_id).token_usage == parent_usage
+    assert _get_trace_token_usage_metrics(store, trace_id) == parent_usage
+
+
 def test_log_spans_update_token_usage_incrementally(store: SqlAlchemyStore) -> None:
     experiment_id = store.create_experiment("test_log_spans_update_token_usage")
     trace_id = f"tr-{uuid.uuid4().hex}"


### PR DESCRIPTION
### Related Issues/PRs

Closes #22746

### What changes are proposed in this pull request?

This PR fixes SQLAlchemy-backed trace token usage rollups for traces where an ancestor span and descendant spans both carry `mlflow.chat.tokenUsage`.

The SQLAlchemy `log_spans()` path now reuses MLflow's canonical ancestor-wins token aggregation semantics via a small adapter for translated/stored span dictionaries. It also recomputes trace-level token usage from stored spans after span upsert so both same-batch logging and incremental child-before-parent roll-up logging avoid double-counting. Trace token metrics are refreshed from the recomputed aggregate so optional token metrics, such as cache-token keys, do not remain stale.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Validated with:

- `.venv/bin/python -m pytest tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store.py::test_log_spans_token_usage_does_not_double_count_descendants tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store.py::test_log_spans_token_usage_recomputes_when_parent_rollup_arrives_later tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store.py::test_log_spans_token_usage tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store.py::test_log_spans_update_token_usage_incrementally tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store.py::test_log_spans_updates_trace_metrics_incrementally`
  - 10 passed
- `.venv/bin/python -m pytest tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store.py`
  - 920 passed, 34 skipped
- `git diff --check`

Manual validation:

- Attempted full unfiltered `.venv/bin/python -m pytest`; collection is blocked by missing optional integration dependencies/services unrelated to this change, for example `openai`, `anthropic`, `tensorflow`, `transformers`, `xgboost`, and Docker daemon availability.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. SQLAlchemy-backed tracking stores now avoid double-counting trace token usage when parent roll-up spans and descendant LLM spans both include token usage.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release