### PR TITLE
feat: Add mlflow autolog kiro CLI integration for Amazon Kiro CLI

### DIFF
--- a/mlflow/cli/__init__.py
+++ b/mlflow/cli/__init__.py
@@ -1332,6 +1332,14 @@ try:
 except ImportError:
     pass
 
+# Add Kiro CLI integration commands
+try:
+    import mlflow.kiro.cli
+
+    cli.add_command(mlflow.kiro.cli.commands)
+except ImportError:
+    pass
+
 # Add Assistant CLI commands
 try:
     import mlflow.assistant.cli

--- a/mlflow/kiro/README.md
+++ b/mlflow/kiro/README.md
@@ -1,0 +1,121 @@
+# MLflow Kiro CLI Integration
+
+This module provides automatic tracing integration between the
+[Kiro CLI](https://kiro.dev) (Amazon's AI coding agent) and MLflow.
+
+## Module Structure
+
+| File | Purpose |
+|------|---------|
+| `config.py` | Configuration helpers (hook files, env-var storage) |
+| `hooks.py` | Stop-hook handler called by Kiro on session end |
+| `cli.py` | MLflow CLI commands (`mlflow autolog kiro`) |
+| `tracing.py` | Core tracing logic — session → spans → MLflow trace |
+
+## Installation
+
+```bash
+pip install mlflow
+```
+
+Kiro CLI must also be installed. Download it at <https://kiro.dev/downloads/>.
+
+## Usage
+
+Set up tracing in any project directory:
+
+```bash
+# Set up tracing in the current directory (local storage)
+mlflow autolog kiro
+
+# Set up tracing in a specific project directory
+mlflow autolog kiro -d ~/my-project
+
+# Set up with a custom tracking URI
+mlflow autolog kiro -u sqlite:///mlflow.db -n "Kiro Sessions"
+
+# Set up with Databricks
+mlflow autolog kiro -u databricks -e 123456789
+
+# Check status
+mlflow autolog kiro --status
+
+# Disable tracing
+mlflow autolog kiro --disable
+```
+
+## How It Works
+
+1. **Setup**: `mlflow autolog kiro` writes a `.kiro/hooks/mlflow_autolog.json`
+   file that registers a **Shell Command** action on the `AgentStop` event.
+2. **Automatic capture**: When you use Kiro inside the configured directory,
+   the hook fires at the end of each agent turn and calls
+   `mlflow autolog kiro stop-hook`. Kiro pipes the session JSON to the
+   command's stdin.
+3. **Trace creation**: The handler parses the session, creates an MLflow
+   `AGENT` root span with `LLM` and `TOOL` child spans for every turn, and
+   persists the trace to your configured tracking store.
+4. **View traces**: Run `mlflow server` and open the UI.
+
+## Configuration Files
+
+### Hook file: `.kiro/hooks/mlflow_autolog.json`
+
+```json
+{
+  "version": "1.0",
+  "hooks": [
+    {
+      "name": "MLflow Autolog",
+      "description": "Automatically logs Kiro agent sessions to MLflow as traces.",
+      "event": "AgentStop",
+      "enabled": true,
+      "actions": [
+        {
+          "type": "command",
+          "command": "mlflow autolog kiro stop-hook"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Env config: `.kiro/mlflow_env.json`
+
+```json
+{
+  "MLFLOW_KIRO_TRACING_ENABLED": "true",
+  "MLFLOW_TRACKING_URI": "sqlite:///mlflow.db",
+  "MLFLOW_EXPERIMENT_NAME": "Kiro Sessions"
+}
+```
+
+## Captured Data
+
+Each Kiro session becomes one MLflow trace containing:
+
+| Span type | Contents |
+|-----------|----------|
+| `AGENT` (root) | User prompt, session ID, final response |
+| `LLM` | Model name, input messages, response, token usage |
+| `TOOL` | Tool name, input arguments, result |
+
+## Troubleshooting
+
+```bash
+# Check if tracing is configured
+mlflow autolog kiro --status
+
+# View the raw hook log
+cat .kiro/mlflow/kiro_tracing.log
+
+# Remove tracing
+mlflow autolog kiro --disable
+```
+
+## Requirements
+
+- Python 3.10+
+- MLflow (`pip install mlflow`)
+- Kiro CLI installed and available in `$PATH`

--- a/mlflow/kiro/__init__.py
+++ b/mlflow/kiro/__init__.py
@@ -1,0 +1,25 @@
+"""Kiro CLI integration for MLflow.
+
+This module provides automatic tracing of Kiro CLI AI coding agent sessions
+to MLflow, mirroring the ``mlflow.claude_code`` integration.
+
+Usage:
+    mlflow autolog kiro [directory] [options]
+
+After setup, use the regular ``kiro`` command inside the configured directory
+and every agent session will be automatically captured as an MLflow trace.
+
+Example::
+
+    # Enable tracing in the current project directory
+    mlflow autolog kiro
+
+    # Point at a specific directory with a custom tracking URI
+    mlflow autolog kiro -d ~/my-project -u sqlite:///mlflow.db -n "Kiro Sessions"
+
+    # Check status
+    mlflow autolog kiro --status
+
+    # Disable tracing
+    mlflow autolog kiro --disable
+"""

--- a/mlflow/kiro/cli.py
+++ b/mlflow/kiro/cli.py
@@ -1,0 +1,185 @@
+"""MLflow CLI commands for the Kiro CLI integration."""
+
+from pathlib import Path
+
+import click
+
+from mlflow.kiro.config import (
+    KIRO_ENV_FILE,
+    KIRO_HOOKS_DIR,
+    disable_tracing_hooks,
+    get_tracing_status,
+    setup_environment_config,
+    setup_hooks_config,
+)
+from mlflow.kiro.hooks import stop_hook_handler
+
+
+# Re-use the existing ``autolog`` group created by the claude_code integration
+# (they share the same click group: ``mlflow autolog``).
+@click.group("autolog")
+def commands() -> None:
+    """Commands for autologging with MLflow."""
+
+
+@commands.group("kiro", invoke_without_command=True)
+@click.option(
+    "--directory",
+    "-d",
+    default=".",
+    type=click.Path(file_okay=False, dir_okay=True),
+    help="Project directory to configure (default: current directory)",
+)
+@click.option("--tracking-uri", "-u", help="MLflow tracking URI (e.g. 'databricks' or 'file://mlruns')")
+@click.option("--experiment-id", "-e", help="MLflow experiment ID")
+@click.option("--experiment-name", "-n", help="MLflow experiment name")
+@click.option("--disable", is_flag=True, help="Remove Kiro tracing from the specified directory")
+@click.option("--status", is_flag=True, help="Show current tracing status")
+@click.pass_context
+def kiro(
+    ctx: click.Context,
+    directory: str,
+    tracking_uri: str | None,
+    experiment_id: str | None,
+    experiment_name: str | None,
+    disable: bool,
+    status: bool,
+) -> None:
+    """Set up Kiro CLI tracing in a project directory.
+
+    This command writes a Kiro Agent Stop hook that automatically captures
+    every Kiro session as an MLflow trace.
+
+    \b
+    Examples:
+
+      # Set up tracing in the current directory (local storage)
+      mlflow autolog kiro
+
+      # Set up tracing in a specific project directory
+      mlflow autolog kiro -d ~/my-project
+
+      # Set up tracing with Databricks
+      mlflow autolog kiro -u databricks -e 123456789
+
+      # Set up tracing with a custom tracking URI
+      mlflow autolog kiro -u sqlite:///mlflow.db -n "Kiro Sessions"
+
+      # Disable tracing
+      mlflow autolog kiro --disable
+
+      # Check status
+      mlflow autolog kiro --status
+    """
+    if ctx.invoked_subcommand is not None:
+        return
+
+    target_dir = Path(directory).resolve()
+    hooks_dir = target_dir / KIRO_HOOKS_DIR
+    env_path = target_dir / KIRO_ENV_FILE
+
+    if status:
+        _show_status(target_dir, hooks_dir, env_path)
+        return
+
+    if disable:
+        _handle_disable(hooks_dir, env_path)
+        return
+
+    click.echo(f"Configuring Kiro tracing in: {target_dir}")
+
+    # Write hook file
+    setup_hooks_config(hooks_dir)
+    click.echo("✅ Kiro Agent Stop hook configured")
+
+    # Write env config
+    setup_environment_config(env_path, tracking_uri, experiment_id, experiment_name)
+    click.echo("✅ MLflow environment configured")
+
+    _show_setup_summary(target_dir, tracking_uri, experiment_id, experiment_name)
+
+
+# ---------------------------------------------------------------------------
+# Sub-handlers
+# ---------------------------------------------------------------------------
+
+
+def _handle_disable(hooks_dir: Path, env_path: Path) -> None:
+    if disable_tracing_hooks(hooks_dir, env_path):
+        click.echo("✅ Kiro tracing disabled")
+    else:
+        click.echo("❌ No Kiro tracing configuration found — nothing to disable")
+
+
+def _show_status(target_dir: Path, hooks_dir: Path, env_path: Path) -> None:
+    click.echo(f"📍 Kiro tracing status in: {target_dir}")
+    st = get_tracing_status(hooks_dir, env_path)
+    if not st.enabled:
+        click.echo("❌ Kiro tracing is not enabled")
+        if st.reason:
+            click.echo(f"   Reason: {st.reason}")
+        return
+
+    click.echo("✅ Kiro tracing is ENABLED")
+    click.echo(f"📊 Tracking URI: {st.tracking_uri or '(default)'}")
+    if st.experiment_id:
+        click.echo(f"🔬 Experiment ID: {st.experiment_id}")
+    elif st.experiment_name:
+        click.echo(f"🔬 Experiment Name: {st.experiment_name}")
+    else:
+        click.echo("🔬 Experiment: Default (experiment 0)")
+
+
+def _show_setup_summary(
+    target_dir: Path,
+    tracking_uri: str | None,
+    experiment_id: str | None,
+    experiment_name: str | None,
+) -> None:
+    current_dir = Path.cwd().resolve()
+
+    click.echo("\n" + "=" * 50)
+    click.echo("🎯 Kiro Tracing Setup Complete!")
+    click.echo("=" * 50)
+    click.echo(f"📁 Directory: {target_dir}")
+
+    if tracking_uri:
+        click.echo(f"📊 Tracking URI: {tracking_uri}")
+    if experiment_id:
+        click.echo(f"🔬 Experiment ID: {experiment_id}")
+    elif experiment_name:
+        click.echo(f"🔬 Experiment Name: {experiment_name}")
+    else:
+        click.echo("🔬 Experiment: Default (experiment 0)")
+
+    click.echo("\n" + "=" * 30)
+    click.echo("🚀 Next Steps:")
+    click.echo("=" * 30)
+
+    if target_dir != current_dir:
+        click.echo(f"cd {target_dir}")
+
+    click.echo("# Then use Kiro as normal — traces are captured automatically")
+
+    if tracking_uri and tracking_uri.startswith("file://"):
+        click.echo("\n💡 View your traces:")
+        click.echo(f"   mlflow server --backend-store-uri {tracking_uri}")
+    elif not tracking_uri:
+        click.echo("\n💡 View your traces:")
+        click.echo("   mlflow server")
+    elif tracking_uri == "databricks":
+        click.echo("\n💡 View your traces in your Databricks workspace")
+
+    click.echo("\n🔧 To disable tracing later:")
+    click.echo("   mlflow autolog kiro --disable")
+
+
+# ---------------------------------------------------------------------------
+# Hidden stop-hook subcommand (invoked by Kiro itself)
+# ---------------------------------------------------------------------------
+
+
+@kiro.command("stop-hook", hidden=True)
+def stop_hook() -> None:
+    """Hook handler invoked when a Kiro agent session ends."""
+    stop_hook_handler()

--- a/mlflow/kiro/config.py
+++ b/mlflow/kiro/config.py
@@ -1,0 +1,243 @@
+"""Configuration management for Kiro CLI integration with MLflow."""
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from mlflow.environment_variables import (
+    MLFLOW_EXPERIMENT_ID,
+    MLFLOW_EXPERIMENT_NAME,
+    MLFLOW_TRACKING_URI,
+)
+
+# ---------------------------------------------------------------------------
+# Kiro hook file structure
+# ---------------------------------------------------------------------------
+# Kiro stores hooks as individual JSON files under .kiro/hooks/<name>.json
+# Format:
+# {
+#   "version": "1.0",
+#   "hooks": [
+#     {
+#       "name": "...",
+#       "description": "...",
+#       "event": "AgentStop",
+#       "actions": [
+#         {
+#           "type": "command",
+#           "command": "mlflow autolog kiro stop-hook"
+#         }
+#       ]
+#     }
+#   ]
+# }
+KIRO_HOOKS_DIR = ".kiro/hooks"
+MLFLOW_HOOK_FILE = "mlflow_autolog.json"
+MLFLOW_HOOK_NAME = "MLflow Autolog"
+KIRO_HOOK_EVENT_AGENT_STOP = "AgentStop"
+
+# Identifier used to recognise an existing MLflow hook command so we can
+# update it in-place rather than adding a duplicate.
+MLFLOW_HOOK_IDENTIFIER = "mlflow autolog kiro"
+
+# MLflow env-var stored in the Kiro env config file
+KIRO_ENV_FILE = ".kiro/mlflow_env.json"
+MLFLOW_TRACING_ENABLED = "MLFLOW_KIRO_TRACING_ENABLED"
+
+
+# ---------------------------------------------------------------------------
+# Status dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TracingStatus:
+    """Dataclass for tracing status information."""
+
+    enabled: bool
+    tracking_uri: str | None = None
+    experiment_id: str | None = None
+    experiment_name: str | None = None
+    reason: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Env config helpers
+# ---------------------------------------------------------------------------
+
+
+def load_kiro_env(env_path: Path) -> dict[str, Any]:
+    """Load MLflow environment config stored alongside the Kiro hook file."""
+    if env_path.exists():
+        try:
+            with open(env_path, encoding="utf-8") as f:
+                return json.load(f)
+        except (json.JSONDecodeError, OSError):
+            return {}
+    return {}
+
+
+def save_kiro_env(env_path: Path, env_vars: dict[str, Any]) -> None:
+    """Persist MLflow environment config to disk."""
+    env_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(env_path, "w", encoding="utf-8") as f:
+        json.dump(env_vars, f, indent=2)
+
+
+def get_env_var(var_name: str, default: str = "") -> str:
+    """Get an MLflow environment variable from the Kiro env config or OS env.
+
+    Project-specific configuration in ``.kiro/mlflow_env.json`` takes
+    precedence over global OS environment variables.
+    """
+    try:
+        env_path = Path(KIRO_ENV_FILE)
+        if env_path.exists():
+            env_vars = load_kiro_env(env_path)
+            value = env_vars.get(var_name)
+            if value is not None:
+                return value
+    except Exception:
+        pass
+
+    value = os.environ.get(var_name)
+    if value is not None:
+        return value
+
+    return default
+
+
+# ---------------------------------------------------------------------------
+# Hook file helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_hook_payload(command: str) -> dict[str, Any]:
+    """Return a fully-formed Kiro hook JSON payload."""
+    return {
+        "version": "1.0",
+        "hooks": [
+            {
+                "name": MLFLOW_HOOK_NAME,
+                "description": (
+                    "Automatically logs Kiro agent sessions to MLflow as traces."
+                ),
+                "event": KIRO_HOOK_EVENT_AGENT_STOP,
+                "enabled": True,
+                "actions": [
+                    {
+                        "type": "command",
+                        "command": command,
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def _mlflow_command() -> str:
+    """Return the base mlflow binary, preferring ``uv run mlflow`` when UV is set."""
+    if "UV" in os.environ:
+        return "uv run mlflow"
+    return "mlflow"
+
+
+def setup_hooks_config(hooks_dir: Path) -> None:
+    """Write (or update) the MLflow hook file inside ``.kiro/hooks/``.
+
+    Args:
+        hooks_dir: Path to the ``.kiro/hooks`` directory.
+    """
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    hook_file = hooks_dir / MLFLOW_HOOK_FILE
+    command = f"{_mlflow_command()} autolog kiro stop-hook"
+    payload = _build_hook_payload(command)
+    with open(hook_file, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)
+
+
+def disable_tracing_hooks(hooks_dir: Path, env_path: Path) -> bool:
+    """Remove the MLflow hook file and env config.
+
+    Args:
+        hooks_dir: Path to the ``.kiro/hooks`` directory.
+        env_path: Path to the ``.kiro/mlflow_env.json`` file.
+
+    Returns:
+        True if anything was removed, False if nothing was configured.
+    """
+    removed = False
+    hook_file = hooks_dir / MLFLOW_HOOK_FILE
+    if hook_file.exists():
+        hook_file.unlink()
+        removed = True
+    if env_path.exists():
+        env_path.unlink()
+        removed = True
+    return removed
+
+
+# ---------------------------------------------------------------------------
+# Status helper
+# ---------------------------------------------------------------------------
+
+
+def get_tracing_status(hooks_dir: Path, env_path: Path) -> TracingStatus:
+    """Return the current Kiro tracing status.
+
+    Args:
+        hooks_dir: Path to the ``.kiro/hooks`` directory.
+        env_path: Path to the ``.kiro/mlflow_env.json`` file.
+    """
+    hook_file = hooks_dir / MLFLOW_HOOK_FILE
+    if not hook_file.exists():
+        return TracingStatus(enabled=False, reason="No MLflow hook file found")
+
+    env_vars = load_kiro_env(env_path)
+    enabled = env_vars.get(MLFLOW_TRACING_ENABLED) == "true"
+
+    return TracingStatus(
+        enabled=enabled,
+        tracking_uri=env_vars.get(MLFLOW_TRACKING_URI.name),
+        experiment_id=env_vars.get(MLFLOW_EXPERIMENT_ID.name),
+        experiment_name=env_vars.get(MLFLOW_EXPERIMENT_NAME.name),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Environment config setup
+# ---------------------------------------------------------------------------
+
+
+def setup_environment_config(
+    env_path: Path,
+    tracking_uri: str | None = None,
+    experiment_id: str | None = None,
+    experiment_name: str | None = None,
+) -> None:
+    """Write MLflow environment variables to ``.kiro/mlflow_env.json``.
+
+    Args:
+        env_path: Destination path for the env config.
+        tracking_uri: MLflow tracking URI.
+        experiment_id: MLflow experiment ID (takes precedence over name).
+        experiment_name: MLflow experiment name.
+    """
+    env_vars = load_kiro_env(env_path)
+
+    # Always enable tracing
+    env_vars[MLFLOW_TRACING_ENABLED] = "true"
+
+    if tracking_uri:
+        env_vars[MLFLOW_TRACKING_URI.name] = tracking_uri
+
+    if experiment_id:
+        env_vars[MLFLOW_EXPERIMENT_ID.name] = experiment_id
+        env_vars.pop(MLFLOW_EXPERIMENT_NAME.name, None)
+    elif experiment_name:
+        env_vars[MLFLOW_EXPERIMENT_NAME.name] = experiment_name
+        env_vars.pop(MLFLOW_EXPERIMENT_ID.name, None)
+
+    save_kiro_env(env_path, env_vars)

--- a/mlflow/kiro/hooks.py
+++ b/mlflow/kiro/hooks.py
@@ -1,0 +1,58 @@
+"""Hook handler for the Kiro CLI integration with MLflow."""
+
+import json
+import sys
+from pathlib import Path
+
+from mlflow.kiro.config import KIRO_ENV_FILE, KIRO_HOOKS_DIR
+from mlflow.kiro.tracing import (
+    KIRO_TRACING_LEVEL,
+    get_hook_response,
+    get_logger,
+    is_tracing_enabled,
+    process_session,
+    read_hook_input,
+    setup_mlflow,
+)
+
+
+def stop_hook_handler() -> None:
+    """CLI hook handler invoked by Kiro on the *Agent Stop* event.
+
+    Reads the session JSON from stdin, creates an MLflow trace, and writes the
+    Kiro hook response to stdout.
+    """
+    if not is_tracing_enabled():
+        print(json.dumps(get_hook_response()))  # noqa: T201
+        return
+
+    try:
+        session_data = read_hook_input()
+        session_id = session_data.get("session_id", "<unknown>")
+
+        setup_mlflow()
+
+        get_logger().log(
+            KIRO_TRACING_LEVEL,
+            "Stop hook invoked for session: %s",
+            session_id,
+        )
+
+        trace = process_session(session_data)
+
+        if trace is not None:
+            response = get_hook_response()
+        else:
+            response = get_hook_response(
+                error=(
+                    "Failed to process Kiro session. "
+                    "Check .kiro/mlflow/kiro_tracing.log for details."
+                )
+            )
+
+        print(json.dumps(response))  # noqa: T201
+
+    except Exception as exc:
+        get_logger().error("Error in Kiro stop hook: %s", exc, exc_info=True)
+        print(json.dumps(get_hook_response(error=str(exc))))  # noqa: T201
+        sys.exit(1)

--- a/mlflow/kiro/tracing.py
+++ b/mlflow/kiro/tracing.py
@@ -1,0 +1,574 @@
+"""MLflow tracing integration for Kiro CLI agent sessions.
+
+Kiro passes session data via stdin as JSON when the *Agent Stop* hook fires.
+The payload contains at minimum:
+
+.. code-block:: json
+
+    {
+        "session_id": "abc123",
+        "conversation": [
+            {
+                "role": "user",
+                "content": "Help me refactor this function",
+                "timestamp": "2024-01-15T10:00:00Z"
+            },
+            {
+                "role": "assistant",
+                "content": "Sure! Here's the refactored version...",
+                "timestamp": "2024-01-15T10:00:05Z",
+                "model": "claude-3-5-sonnet",
+                "usage": {
+                    "input_tokens": 150,
+                    "output_tokens": 300
+                },
+                "tool_calls": [
+                    {
+                        "id": "tool_abc",
+                        "name": "read_file",
+                        "input": {"path": "src/utils.py"},
+                        "result": "def helper(): ..."
+                    }
+                ]
+            }
+        ],
+        "kiro_version": "1.2.3"
+    }
+
+When the payload format is minimal or unknown we fall back to logging the raw
+session data as a single AGENT span so that *something* is always captured.
+"""
+
+import json
+import logging
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import mlflow
+from mlflow.kiro.config import (
+    KIRO_ENV_FILE,
+    MLFLOW_TRACING_ENABLED,
+    get_env_var,
+)
+from mlflow.entities import SpanType
+from mlflow.environment_variables import (
+    MLFLOW_EXPERIMENT_ID,
+    MLFLOW_EXPERIMENT_NAME,
+    MLFLOW_TRACKING_URI,
+)
+from mlflow.telemetry.events import AutologgingEvent
+from mlflow.telemetry.track import _record_event
+from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey, TraceMetadataKey
+from mlflow.tracing.provider import _get_trace_exporter
+from mlflow.tracing.trace_manager import InMemoryTraceManager
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+NANOSECONDS_PER_MS = 1e6
+NANOSECONDS_PER_S = 1e9
+MAX_PREVIEW_LENGTH = 1000
+
+ROLE_USER = "user"
+ROLE_ASSISTANT = "assistant"
+
+METADATA_KEY_KIRO_VERSION = "mlflow.kiro_version"
+
+KIRO_TRACING_LEVEL = logging.WARNING - 5
+
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+
+def setup_logging() -> logging.Logger:
+    """Set up logging directory and return a configured logger.
+
+    Creates a ``.kiro/mlflow/`` directory structure and attaches a file
+    handler.  Log propagation is disabled so messages never reach the root
+    logger.
+    """
+    log_dir = Path(os.getcwd()) / ".kiro" / "mlflow"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    logger = logging.getLogger(__name__)
+    logger.handlers.clear()
+
+    log_file = log_dir / "kiro_tracing.log"
+    file_handler = logging.FileHandler(log_file)
+    file_handler.setFormatter(
+        logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    )
+    logger.addHandler(file_handler)
+    logging.addLevelName(KIRO_TRACING_LEVEL, "KIRO_TRACING")
+    logger.setLevel(KIRO_TRACING_LEVEL)
+    logger.propagate = False
+    return logger
+
+
+_MODULE_LOGGER: logging.Logger | None = None
+
+
+def get_logger() -> logging.Logger:
+    """Return the configured module-level logger (lazily initialised)."""
+    global _MODULE_LOGGER
+    if _MODULE_LOGGER is None:
+        _MODULE_LOGGER = setup_logging()
+    return _MODULE_LOGGER
+
+
+# ---------------------------------------------------------------------------
+# MLflow bootstrap
+# ---------------------------------------------------------------------------
+
+
+def is_tracing_enabled() -> bool:
+    """Return True when Kiro MLflow tracing is enabled via env-var/config."""
+    return get_env_var(MLFLOW_TRACING_ENABLED).lower() in ("true", "1", "yes")
+
+
+def setup_mlflow() -> None:
+    """Configure MLflow tracking URI and experiment from env/config."""
+    if not is_tracing_enabled():
+        return
+
+    mlflow.set_tracking_uri(get_env_var(MLFLOW_TRACKING_URI.name))
+
+    experiment_id = get_env_var(MLFLOW_EXPERIMENT_ID.name)
+    experiment_name = get_env_var(MLFLOW_EXPERIMENT_NAME.name)
+
+    try:
+        if experiment_id:
+            mlflow.set_experiment(experiment_id=experiment_id)
+        elif experiment_name:
+            mlflow.set_experiment(experiment_name)
+    except Exception as exc:
+        get_logger().warning("Failed to set experiment: %s", exc)
+
+    _record_event(AutologgingEvent, {"flavor": "kiro"})
+
+
+# ---------------------------------------------------------------------------
+# stdin / hook I/O helpers
+# ---------------------------------------------------------------------------
+
+
+def read_hook_input() -> dict[str, Any]:
+    """Read JSON session data from stdin (sent by the Kiro Agent Stop hook)."""
+    try:
+        raw = sys.stdin.read()
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise json.JSONDecodeError(f"Failed to parse Kiro hook input: {exc}", raw, 0) from exc
+
+
+def get_hook_response(error: str | None = None, **kwargs: Any) -> dict[str, Any]:
+    """Build the JSON hook response expected by Kiro.
+
+    A response with ``"continue": false`` and a ``stopReason`` causes Kiro to
+    surface the error message in the IDE.
+    """
+    if error is not None:
+        return {"continue": False, "stopReason": error, **kwargs}
+    return {"continue": True, **kwargs}
+
+
+# ---------------------------------------------------------------------------
+# Timestamp utilities
+# ---------------------------------------------------------------------------
+
+
+def parse_timestamp_to_ns(timestamp: str | int | float | None) -> int | None:
+    """Convert an ISO-8601 string or numeric Unix timestamp to nanoseconds.
+
+    Args:
+        timestamp: ISO string, Unix seconds/milliseconds/nanoseconds, or None.
+
+    Returns:
+        Integer nanoseconds since epoch, or None if conversion fails.
+    """
+    if not timestamp:
+        return None
+
+    if isinstance(timestamp, str):
+        try:
+            import dateutil.parser
+
+            dt = dateutil.parser.parse(timestamp)
+            return int(dt.timestamp() * NANOSECONDS_PER_S)
+        except Exception:
+            get_logger().warning("Could not parse timestamp: %s", timestamp)
+            return None
+
+    if isinstance(timestamp, (int, float)):
+        if timestamp < 1e10:
+            return int(timestamp * NANOSECONDS_PER_S)
+        if timestamp < 1e13:
+            return int(timestamp * NANOSECONDS_PER_MS)
+        return int(timestamp)
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Token-usage utilities
+# ---------------------------------------------------------------------------
+
+
+def _build_usage_dict(usage: dict[str, Any]) -> dict[str, int]:
+    """Normalise a Kiro usage payload into the standard MLflow CHAT_USAGE schema."""
+    input_tokens = usage.get("input_tokens", 0)
+    output_tokens = usage.get("output_tokens", 0)
+    result: dict[str, int] = {
+        TokenUsageKey.INPUT_TOKENS: input_tokens,
+        TokenUsageKey.OUTPUT_TOKENS: output_tokens,
+        TokenUsageKey.TOTAL_TOKENS: input_tokens + output_tokens,
+    }
+    if (cached := usage.get("cache_read_input_tokens")) is not None:
+        result[TokenUsageKey.CACHE_READ_INPUT_TOKENS] = cached
+    if (created := usage.get("cache_creation_input_tokens")) is not None:
+        result[TokenUsageKey.CACHE_CREATION_INPUT_TOKENS] = created
+    return result
+
+
+def _set_token_usage(span: Any, usage: dict[str, Any]) -> None:
+    """Attach token-usage data to *span* using the standard CHAT_USAGE attribute."""
+    if not usage:
+        return
+    span.set_attribute(SpanAttributeKey.CHAT_USAGE, _build_usage_dict(usage))
+
+
+# ---------------------------------------------------------------------------
+# Conversation-parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_last_user_message(conversation: list[dict[str, Any]]) -> int | None:
+    """Return the index of the last genuine user turn in *conversation*."""
+    for idx in range(len(conversation) - 1, -1, -1):
+        entry = conversation[idx]
+        if entry.get("role") == ROLE_USER:
+            content = entry.get("content", "")
+            if content and (isinstance(content, str) and content.strip()):
+                return idx
+            if isinstance(content, list) and content:
+                return idx
+    return None
+
+
+def _extract_text(content: str | list[Any] | Any) -> str:
+    """Flatten content to a plain string."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, dict):
+                parts.append(item.get("text", ""))
+            elif isinstance(item, str):
+                parts.append(item)
+        return "\n".join(p for p in parts if p)
+    return str(content) if content else ""
+
+
+def _find_final_assistant_response(
+    conversation: list[dict[str, Any]], start_idx: int
+) -> str | None:
+    """Return the text of the last assistant turn after *start_idx*."""
+    final: str | None = None
+    for entry in conversation[start_idx:]:
+        if entry.get("role") == ROLE_ASSISTANT:
+            text = _extract_text(entry.get("content", ""))
+            if text.strip():
+                final = text
+    return final
+
+
+# ---------------------------------------------------------------------------
+# Span builders
+# ---------------------------------------------------------------------------
+
+
+def _create_tool_spans(
+    parent_span: Any,
+    tool_calls: list[dict[str, Any]],
+    start_ns: int,
+    total_duration_ns: int,
+) -> None:
+    """Create one TOOL child span per tool call with proportional timing."""
+    if not tool_calls:
+        return
+
+    per_tool_ns = total_duration_ns // len(tool_calls)
+    for idx, call in enumerate(tool_calls):
+        tool_start = start_ns + idx * per_tool_ns
+        span = mlflow.start_span_no_context(
+            name=f"tool_{call.get('name', 'unknown')}",
+            parent_span=parent_span,
+            span_type=SpanType.TOOL,
+            start_time_ns=tool_start,
+            inputs=call.get("input", {}),
+            attributes={
+                "tool_name": call.get("name", "unknown"),
+                "tool_id": call.get("id", ""),
+            },
+        )
+        span.set_outputs({"result": call.get("result", "")})
+        span.end(end_time_ns=tool_start + per_tool_ns)
+
+
+def _create_llm_span(
+    parent_span: Any,
+    entry: dict[str, Any],
+    messages: list[dict[str, Any]],
+    start_ns: int | None,
+    end_ns: int | None,
+) -> None:
+    """Create one LLM child span for an assistant response that has text."""
+    model = entry.get("model", "unknown")
+    content = entry.get("content", "")
+    text = _extract_text(content)
+
+    span = mlflow.start_span_no_context(
+        name="llm",
+        parent_span=parent_span,
+        span_type=SpanType.LLM,
+        start_time_ns=start_ns,
+        inputs={"model": model, "messages": messages},
+        attributes={"model": model, SpanAttributeKey.MESSAGE_FORMAT: "openai"},
+    )
+
+    _set_token_usage(span, entry.get("usage", {}))
+
+    span.set_outputs({
+        "role": "assistant",
+        "content": text,
+    })
+    span.end(end_time_ns=end_ns)
+
+
+def _build_child_spans(
+    parent_span: Any,
+    conversation: list[dict[str, Any]],
+    start_idx: int,
+) -> None:
+    """Create LLM + TOOL child spans for every assistant turn after *start_idx*."""
+    # Build a running history of prior messages for LLM span inputs
+    history: list[dict[str, Any]] = [
+        {"role": e.get("role", ""), "content": _extract_text(e.get("content", ""))}
+        for e in conversation[:start_idx + 1]
+    ]
+
+    for i in range(start_idx + 1, len(conversation)):
+        entry = conversation[i]
+        if entry.get("role") != ROLE_ASSISTANT:
+            # Accumulate user messages into history
+            history.append({
+                "role": entry.get("role", ""),
+                "content": _extract_text(entry.get("content", "")),
+            })
+            continue
+
+        ts_start = parse_timestamp_to_ns(entry.get("timestamp"))
+        # Duration: gap to the next entry or default 1 s
+        next_ts = None
+        for j in range(i + 1, len(conversation)):
+            if ts := conversation[j].get("timestamp"):
+                next_ts = parse_timestamp_to_ns(ts)
+                break
+        duration_ns = int(NANOSECONDS_PER_S)  # 1-second default
+        if ts_start and next_ts and next_ts > ts_start:
+            duration_ns = next_ts - ts_start
+        ts_end = (ts_start + duration_ns) if ts_start else None
+
+        tool_calls: list[dict[str, Any]] = entry.get("tool_calls", [])
+        content = _extract_text(entry.get("content", ""))
+
+        if content and not tool_calls:
+            _create_llm_span(parent_span, entry, list(history), ts_start, ts_end)
+
+        if tool_calls:
+            _create_tool_spans(
+                parent_span,
+                tool_calls,
+                ts_start or 0,
+                duration_ns,
+            )
+
+        # Add this assistant turn to the running history
+        history.append({"role": ROLE_ASSISTANT, "content": content})
+
+
+# ---------------------------------------------------------------------------
+# Trace finalisation
+# ---------------------------------------------------------------------------
+
+
+def _flush_async_logging() -> None:
+    try:
+        if hasattr(_get_trace_exporter(), "_async_queue"):
+            mlflow.flush_trace_async_logging()
+    except Exception as exc:
+        get_logger().debug("Failed to flush async trace logging: %s", exc)
+
+
+def _finalize_trace(
+    parent_span: Any,
+    user_prompt: str,
+    final_response: str | None,
+    session_id: str | None,
+    end_time_ns: int | None = None,
+    usage: dict[str, Any] | None = None,
+    kiro_version: str | None = None,
+) -> "mlflow.entities.Trace":
+    """Set trace metadata, end the root span, and flush the trace."""
+    try:
+        with InMemoryTraceManager.get_instance().get_trace(
+            parent_span.trace_id
+        ) as in_memory_trace:
+            if user_prompt:
+                in_memory_trace.info.request_preview = user_prompt[:MAX_PREVIEW_LENGTH]
+            if final_response:
+                in_memory_trace.info.response_preview = final_response[:MAX_PREVIEW_LENGTH]
+
+            metadata: dict[str, str] = {
+                TraceMetadataKey.TRACE_USER: os.environ.get("USER", ""),
+                "mlflow.trace.working_directory": os.getcwd(),
+            }
+            if session_id:
+                metadata[TraceMetadataKey.TRACE_SESSION] = session_id
+            if kiro_version:
+                metadata[METADATA_KEY_KIRO_VERSION] = kiro_version
+            if usage:
+                metadata[TraceMetadataKey.TOKEN_USAGE] = json.dumps(_build_usage_dict(usage))
+
+            in_memory_trace.info.trace_metadata = {
+                **in_memory_trace.info.trace_metadata,
+                **metadata,
+            }
+    except Exception as exc:
+        get_logger().warning("Failed to update trace metadata: %s", exc)
+
+    outputs: dict[str, Any] = {"status": "completed"}
+    if final_response:
+        outputs["response"] = final_response
+    parent_span.set_outputs(outputs)
+    parent_span.end(end_time_ns=end_time_ns)
+    _flush_async_logging()
+    get_logger().log(KIRO_TRACING_LEVEL, "Created MLflow trace: %s", parent_span.trace_id)
+    return mlflow.get_trace(parent_span.trace_id)
+
+
+# ---------------------------------------------------------------------------
+# Main session processor
+# ---------------------------------------------------------------------------
+
+
+def process_session(
+    session_data: dict[str, Any],
+) -> "mlflow.entities.Trace | None":
+    """Process a Kiro session payload and create an MLflow trace.
+
+    The ``session_data`` dict is the JSON object Kiro passes to the Agent Stop
+    hook via stdin.  We handle both the full structured format and a minimal
+    fallback where the payload may only contain a ``session_id``.
+
+    Args:
+        session_data: Parsed JSON hook payload from Kiro.
+
+    Returns:
+        An :class:`mlflow.entities.Trace` on success, or ``None`` on failure.
+    """
+    try:
+        session_id: str | None = session_data.get("session_id")
+        conversation: list[dict[str, Any]] = session_data.get("conversation", [])
+        kiro_version: str | None = session_data.get("kiro_version")
+
+        if not session_id:
+            session_id = f"kiro-{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+
+        get_logger().log(
+            KIRO_TRACING_LEVEL,
+            "Creating MLflow trace for Kiro session: %s",
+            session_id,
+        )
+
+        # ------------------------------------------------------------------
+        # Minimal fallback: no conversation data in payload
+        # ------------------------------------------------------------------
+        if not conversation:
+            get_logger().warning(
+                "No conversation data in Kiro hook payload for session %s; "
+                "creating minimal trace.",
+                session_id,
+            )
+            parent_span = mlflow.start_span_no_context(
+                name="kiro_session",
+                inputs={"session_id": session_id},
+                span_type=SpanType.AGENT,
+            )
+            return _finalize_trace(
+                parent_span,
+                user_prompt="",
+                final_response=None,
+                session_id=session_id,
+                kiro_version=kiro_version,
+            )
+
+        # ------------------------------------------------------------------
+        # Full conversation processing
+        # ------------------------------------------------------------------
+        last_user_idx = _find_last_user_message(conversation)
+        if last_user_idx is None:
+            get_logger().warning("No user message found in Kiro session %s", session_id)
+            return None
+
+        last_user_entry = conversation[last_user_idx]
+        user_prompt = _extract_text(last_user_entry.get("content", ""))
+
+        conv_start_ns = parse_timestamp_to_ns(last_user_entry.get("timestamp"))
+
+        parent_span = mlflow.start_span_no_context(
+            name="kiro_session",
+            inputs={"prompt": user_prompt},
+            span_type=SpanType.AGENT,
+            start_time_ns=conv_start_ns,
+        )
+
+        # Create child spans for each assistant turn after the last user prompt
+        _build_child_spans(parent_span, conversation, last_user_idx)
+
+        final_response = _find_final_assistant_response(conversation, last_user_idx + 1)
+
+        # Determine conversation end time
+        last_entry = conversation[-1]
+        conv_end_ns = parse_timestamp_to_ns(last_entry.get("timestamp"))
+        if not conv_end_ns or (conv_start_ns and conv_end_ns <= conv_start_ns):
+            conv_end_ns = (conv_start_ns or 0) + int(10 * NANOSECONDS_PER_S)
+
+        # Accumulate token usage across all assistant turns
+        total_usage: dict[str, int] = {}
+        for entry in conversation:
+            if entry.get("role") == ROLE_ASSISTANT:
+                usage = entry.get("usage", {})
+                for key, val in usage.items():
+                    total_usage[key] = total_usage.get(key, 0) + int(val or 0)
+
+        return _finalize_trace(
+            parent_span,
+            user_prompt,
+            final_response,
+            session_id,
+            end_time_ns=conv_end_ns,
+            usage=total_usage or None,
+            kiro_version=kiro_version,
+        )
+
+    except Exception as exc:
+        get_logger().error("Error processing Kiro session: %s", exc, exc_info=True)
+        return None

--- a/tests/kiro/test_cli.py
+++ b/tests/kiro/test_cli.py
@@ -1,0 +1,164 @@
+"""Tests for mlflow.kiro.cli."""
+
+import json
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from click.testing import CliRunner
+
+from mlflow.kiro.cli import commands
+from mlflow.kiro.config import (
+    KIRO_ENV_FILE,
+    KIRO_HOOKS_DIR,
+    MLFLOW_HOOK_FILE,
+    MLFLOW_TRACING_ENABLED,
+    load_kiro_env,
+)
+
+
+@pytest.fixture()
+def runner():
+    return CliRunner()
+
+
+def _hook_command_from_dir(directory: Path) -> str:
+    hook_file = directory / KIRO_HOOKS_DIR / MLFLOW_HOOK_FILE
+    payload = json.loads(hook_file.read_text())
+    return payload["hooks"][0]["actions"][0]["command"]
+
+
+# ---------------------------------------------------------------------------
+# Top-level group
+# ---------------------------------------------------------------------------
+
+
+def test_autolog_help(runner):
+    result = runner.invoke(commands, ["--help"])
+    assert result.exit_code == 0
+    assert "Commands for autologging with MLflow" in result.output
+
+
+def test_kiro_help(runner):
+    result = runner.invoke(commands, ["kiro", "--help"])
+    assert result.exit_code == 0
+    assert "--tracking-uri" in result.output
+    assert "--experiment-id" in result.output
+    assert "--disable" in result.output
+    assert "--status" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Setup (default invocation)
+# ---------------------------------------------------------------------------
+
+
+def test_kiro_setup_creates_hook_file(runner, monkeypatch):
+    monkeypatch.delenv("UV", raising=False)
+    with runner.isolated_filesystem():
+        result = runner.invoke(commands, ["kiro"])
+        assert result.exit_code == 0, result.output
+        command = _hook_command_from_dir(Path("."))
+        assert "mlflow autolog kiro stop-hook" in command
+
+
+def test_kiro_setup_uses_uv_when_env_set(runner, monkeypatch):
+    monkeypatch.setenv("UV", "/usr/local/bin/uv")
+    with runner.isolated_filesystem():
+        result = runner.invoke(commands, ["kiro"])
+        assert result.exit_code == 0
+        command = _hook_command_from_dir(Path("."))
+        assert command.startswith("uv run mlflow")
+
+
+def test_kiro_setup_with_tracking_uri(runner, monkeypatch):
+    monkeypatch.delenv("UV", raising=False)
+    with runner.isolated_filesystem():
+        result = runner.invoke(commands, ["kiro", "--tracking-uri", "sqlite:///test.db"])
+        assert result.exit_code == 0
+        env = load_kiro_env(Path(KIRO_ENV_FILE))
+        assert env["MLFLOW_TRACKING_URI"] == "sqlite:///test.db"
+
+
+def test_kiro_setup_with_experiment_name(runner, monkeypatch):
+    monkeypatch.delenv("UV", raising=False)
+    with runner.isolated_filesystem():
+        result = runner.invoke(commands, ["kiro", "--experiment-name", "My Kiro Exp"])
+        assert result.exit_code == 0
+        env = load_kiro_env(Path(KIRO_ENV_FILE))
+        assert env["MLFLOW_EXPERIMENT_NAME"] == "My Kiro Exp"
+
+
+def test_kiro_setup_with_experiment_id(runner, monkeypatch):
+    monkeypatch.delenv("UV", raising=False)
+    with runner.isolated_filesystem():
+        result = runner.invoke(commands, ["kiro", "--experiment-id", "99999"])
+        assert result.exit_code == 0
+        env = load_kiro_env(Path(KIRO_ENV_FILE))
+        assert env["MLFLOW_EXPERIMENT_ID"] == "99999"
+        assert "MLFLOW_EXPERIMENT_NAME" not in env
+
+
+def test_kiro_setup_with_directory_flag(runner, tmp_path, monkeypatch):
+    monkeypatch.delenv("UV", raising=False)
+    result = runner.invoke(commands, ["kiro", "--directory", str(tmp_path)])
+    assert result.exit_code == 0
+    hook_file = tmp_path / KIRO_HOOKS_DIR / MLFLOW_HOOK_FILE
+    assert hook_file.exists()
+
+
+# ---------------------------------------------------------------------------
+# Status
+# ---------------------------------------------------------------------------
+
+
+def test_kiro_status_not_configured(runner):
+    with runner.isolated_filesystem():
+        result = runner.invoke(commands, ["kiro", "--status"])
+        assert result.exit_code == 0
+        assert "❌" in result.output
+
+
+def test_kiro_status_configured(runner, monkeypatch):
+    monkeypatch.delenv("UV", raising=False)
+    with runner.isolated_filesystem():
+        runner.invoke(commands, ["kiro", "--tracking-uri", "sqlite:///test.db"])
+        result = runner.invoke(commands, ["kiro", "--status"])
+        assert result.exit_code == 0
+        assert "✅" in result.output
+        assert "sqlite:///test.db" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Disable
+# ---------------------------------------------------------------------------
+
+
+def test_kiro_disable_when_not_configured(runner):
+    with runner.isolated_filesystem():
+        result = runner.invoke(commands, ["kiro", "--disable"])
+        assert result.exit_code == 0
+        assert "❌" in result.output
+
+
+def test_kiro_disable_when_configured(runner, monkeypatch):
+    monkeypatch.delenv("UV", raising=False)
+    with runner.isolated_filesystem():
+        runner.invoke(commands, ["kiro"])
+        result = runner.invoke(commands, ["kiro", "--disable"])
+        assert result.exit_code == 0
+        assert "✅" in result.output
+        # Hook file should be gone
+        assert not (Path(".") / KIRO_HOOKS_DIR / MLFLOW_HOOK_FILE).exists()
+
+
+# ---------------------------------------------------------------------------
+# stop-hook subcommand
+# ---------------------------------------------------------------------------
+
+
+def test_stop_hook_subcommand_is_routable(runner):
+    with mock.patch("mlflow.kiro.cli.stop_hook_handler") as mock_handler:
+        result = runner.invoke(commands, ["kiro", "stop-hook"])
+        assert result.exit_code == 0
+        mock_handler.assert_called_once()

--- a/tests/kiro/test_config.py
+++ b/tests/kiro/test_config.py
@@ -1,0 +1,185 @@
+"""Tests for mlflow.kiro.config."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mlflow.kiro.config import (
+    KIRO_HOOK_EVENT_AGENT_STOP,
+    MLFLOW_HOOK_FILE,
+    MLFLOW_HOOK_NAME,
+    MLFLOW_TRACING_ENABLED,
+    TracingStatus,
+    disable_tracing_hooks,
+    get_tracing_status,
+    load_kiro_env,
+    save_kiro_env,
+    setup_environment_config,
+    setup_hooks_config,
+)
+
+
+# ---------------------------------------------------------------------------
+# load_kiro_env / save_kiro_env
+# ---------------------------------------------------------------------------
+
+
+def test_load_kiro_env_missing_file(tmp_path):
+    env = load_kiro_env(tmp_path / "missing.json")
+    assert env == {}
+
+
+def test_save_and_load_kiro_env(tmp_path):
+    env_path = tmp_path / "mlflow_env.json"
+    save_kiro_env(env_path, {"MLFLOW_TRACKING_URI": "sqlite:///test.db"})
+    loaded = load_kiro_env(env_path)
+    assert loaded["MLFLOW_TRACKING_URI"] == "sqlite:///test.db"
+
+
+def test_load_kiro_env_invalid_json(tmp_path):
+    env_path = tmp_path / "bad.json"
+    env_path.write_text("not valid json")
+    result = load_kiro_env(env_path)
+    assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# setup_hooks_config
+# ---------------------------------------------------------------------------
+
+
+def test_setup_hooks_config_creates_file(tmp_path):
+    hooks_dir = tmp_path / ".kiro" / "hooks"
+    setup_hooks_config(hooks_dir)
+    hook_file = hooks_dir / MLFLOW_HOOK_FILE
+    assert hook_file.exists()
+    payload = json.loads(hook_file.read_text())
+    assert payload["version"] == "1.0"
+    hooks = payload["hooks"]
+    assert len(hooks) == 1
+    assert hooks[0]["name"] == MLFLOW_HOOK_NAME
+    assert hooks[0]["event"] == KIRO_HOOK_EVENT_AGENT_STOP
+    assert hooks[0]["enabled"] is True
+    command = hooks[0]["actions"][0]["command"]
+    assert "mlflow autolog kiro stop-hook" in command
+
+
+def test_setup_hooks_config_uses_uv_when_env_set(tmp_path, monkeypatch):
+    monkeypatch.setenv("UV", "/usr/local/bin/uv")
+    hooks_dir = tmp_path / ".kiro" / "hooks"
+    setup_hooks_config(hooks_dir)
+    hook_file = hooks_dir / MLFLOW_HOOK_FILE
+    payload = json.loads(hook_file.read_text())
+    command = payload["hooks"][0]["actions"][0]["command"]
+    assert command.startswith("uv run mlflow")
+
+
+def test_setup_hooks_config_without_uv(tmp_path, monkeypatch):
+    monkeypatch.delenv("UV", raising=False)
+    hooks_dir = tmp_path / ".kiro" / "hooks"
+    setup_hooks_config(hooks_dir)
+    hook_file = hooks_dir / MLFLOW_HOOK_FILE
+    payload = json.loads(hook_file.read_text())
+    command = payload["hooks"][0]["actions"][0]["command"]
+    assert command.startswith("mlflow")
+    assert "uv" not in command
+
+
+def test_setup_hooks_config_overwrites_existing(tmp_path):
+    hooks_dir = tmp_path / ".kiro" / "hooks"
+    hooks_dir.mkdir(parents=True)
+    hook_file = hooks_dir / MLFLOW_HOOK_FILE
+    hook_file.write_text("stale content")
+    setup_hooks_config(hooks_dir)
+    payload = json.loads(hook_file.read_text())
+    assert payload["version"] == "1.0"  # valid JSON, not stale
+
+
+# ---------------------------------------------------------------------------
+# setup_environment_config
+# ---------------------------------------------------------------------------
+
+
+def test_setup_environment_config_all_params(tmp_path):
+    env_path = tmp_path / "mlflow_env.json"
+    setup_environment_config(
+        env_path,
+        tracking_uri="sqlite:///test.db",
+        experiment_name="My Experiment",
+    )
+    env = load_kiro_env(env_path)
+    assert env[MLFLOW_TRACING_ENABLED] == "true"
+    assert env["MLFLOW_TRACKING_URI"] == "sqlite:///test.db"
+    assert env["MLFLOW_EXPERIMENT_NAME"] == "My Experiment"
+
+
+def test_setup_environment_config_experiment_id_overrides_name(tmp_path):
+    env_path = tmp_path / "mlflow_env.json"
+    setup_environment_config(
+        env_path,
+        experiment_id="123456",
+        experiment_name="should_be_removed",
+    )
+    env = load_kiro_env(env_path)
+    assert env["MLFLOW_EXPERIMENT_ID"] == "123456"
+    assert "MLFLOW_EXPERIMENT_NAME" not in env
+
+
+def test_setup_environment_config_no_tracking_uri(tmp_path):
+    env_path = tmp_path / "mlflow_env.json"
+    setup_environment_config(env_path)
+    env = load_kiro_env(env_path)
+    assert env[MLFLOW_TRACING_ENABLED] == "true"
+    assert "MLFLOW_TRACKING_URI" not in env
+
+
+# ---------------------------------------------------------------------------
+# disable_tracing_hooks
+# ---------------------------------------------------------------------------
+
+
+def test_disable_tracing_hooks_removes_files(tmp_path):
+    hooks_dir = tmp_path / ".kiro" / "hooks"
+    hooks_dir.mkdir(parents=True)
+    hook_file = hooks_dir / MLFLOW_HOOK_FILE
+    hook_file.write_text("{}")
+    env_path = tmp_path / "mlflow_env.json"
+    env_path.write_text("{}")
+
+    removed = disable_tracing_hooks(hooks_dir, env_path)
+    assert removed is True
+    assert not hook_file.exists()
+    assert not env_path.exists()
+
+
+def test_disable_tracing_hooks_when_not_configured(tmp_path):
+    hooks_dir = tmp_path / ".kiro" / "hooks"
+    env_path = tmp_path / "mlflow_env.json"
+    removed = disable_tracing_hooks(hooks_dir, env_path)
+    assert removed is False
+
+
+# ---------------------------------------------------------------------------
+# get_tracing_status
+# ---------------------------------------------------------------------------
+
+
+def test_get_tracing_status_not_configured(tmp_path):
+    hooks_dir = tmp_path / ".kiro" / "hooks"
+    env_path = tmp_path / "mlflow_env.json"
+    status = get_tracing_status(hooks_dir, env_path)
+    assert status.enabled is False
+
+
+def test_get_tracing_status_enabled(tmp_path):
+    hooks_dir = tmp_path / ".kiro" / "hooks"
+    setup_hooks_config(hooks_dir)
+    env_path = tmp_path / "mlflow_env.json"
+    setup_environment_config(
+        env_path, tracking_uri="sqlite:///test.db", experiment_name="My Exp"
+    )
+    status = get_tracing_status(hooks_dir, env_path)
+    assert status.enabled is True
+    assert status.tracking_uri == "sqlite:///test.db"
+    assert status.experiment_name == "My Exp"

--- a/tests/kiro/test_tracing.py
+++ b/tests/kiro/test_tracing.py
@@ -1,0 +1,354 @@
+"""Tests for mlflow.kiro.tracing."""
+
+import json
+from datetime import datetime, timezone
+from unittest import mock
+
+import pytest
+
+from mlflow.kiro.tracing import (
+    _build_usage_dict,
+    _extract_text,
+    _find_final_assistant_response,
+    _find_last_user_message,
+    get_hook_response,
+    is_tracing_enabled,
+    parse_timestamp_to_ns,
+    process_session,
+)
+from mlflow.tracing.constant import TokenUsageKey
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+ISO_TS = "2024-01-15T10:00:00Z"
+ISO_TS_5 = "2024-01-15T10:00:05Z"
+
+
+def _iso_to_ns(s: str) -> int:
+    dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
+    return int(dt.timestamp() * 1e9)
+
+
+# ---------------------------------------------------------------------------
+# parse_timestamp_to_ns
+# ---------------------------------------------------------------------------
+
+
+def test_parse_timestamp_iso_string():
+    result = parse_timestamp_to_ns("2024-01-15T10:00:00Z")
+    assert isinstance(result, int)
+    assert result > 0
+
+
+def test_parse_timestamp_none_returns_none():
+    assert parse_timestamp_to_ns(None) is None
+
+
+def test_parse_timestamp_empty_string_returns_none():
+    assert parse_timestamp_to_ns("") is None
+
+
+def test_parse_timestamp_unix_seconds():
+    ts = 1705315200  # 2024-01-15 in seconds
+    result = parse_timestamp_to_ns(ts)
+    assert result == ts * int(1e9)
+
+
+def test_parse_timestamp_unix_ms():
+    ts = 1705315200000  # 2024-01-15 in ms
+    result = parse_timestamp_to_ns(ts)
+    assert result == ts * int(1e6)
+
+
+def test_parse_timestamp_unix_ns():
+    ts = 1705315200_000_000_000  # 2024-01-15 in ns
+    result = parse_timestamp_to_ns(ts)
+    assert result == ts
+
+
+# ---------------------------------------------------------------------------
+# _extract_text
+# ---------------------------------------------------------------------------
+
+
+def test_extract_text_plain_string():
+    assert _extract_text("hello world") == "hello world"
+
+
+def test_extract_text_list_of_dicts():
+    content = [{"text": "part1"}, {"text": "part2"}]
+    assert _extract_text(content) == "part1\npart2"
+
+
+def test_extract_text_empty_list():
+    assert _extract_text([]) == ""
+
+
+def test_extract_text_none():
+    assert _extract_text(None) == ""
+
+
+def test_extract_text_mixed_list():
+    content = [{"text": "a"}, "b", {"text": "c"}]
+    result = _extract_text(content)
+    assert "a" in result
+    assert "b" in result
+    assert "c" in result
+
+
+# ---------------------------------------------------------------------------
+# _find_last_user_message
+# ---------------------------------------------------------------------------
+
+
+def _conv(*roles_and_content):
+    """Build a minimal conversation list: [(role, content), ...]"""
+    return [{"role": r, "content": c} for r, c in roles_and_content]
+
+
+def test_find_last_user_message_basic():
+    conv = _conv(("user", "hello"), ("assistant", "hi"), ("user", "how are you?"))
+    idx = _find_last_user_message(conv)
+    assert idx == 2
+
+
+def test_find_last_user_message_none_if_empty():
+    assert _find_last_user_message([]) is None
+
+
+def test_find_last_user_message_only_assistant():
+    conv = _conv(("assistant", "hi there"))
+    assert _find_last_user_message(conv) is None
+
+
+def test_find_last_user_message_skips_empty_content():
+    conv = _conv(("user", "first"), ("assistant", "ok"), ("user", ""))
+    # Last user message has empty content; should fall back to first one
+    idx = _find_last_user_message(conv)
+    assert idx == 0
+
+
+# ---------------------------------------------------------------------------
+# _find_final_assistant_response
+# ---------------------------------------------------------------------------
+
+
+def test_find_final_assistant_response():
+    conv = _conv(
+        ("user", "hello"),
+        ("assistant", "first response"),
+        ("user", "follow-up"),
+        ("assistant", "second response"),
+    )
+    result = _find_final_assistant_response(conv, start_idx=1)
+    assert result == "second response"
+
+
+def test_find_final_assistant_response_none_when_none():
+    conv = _conv(("user", "hello"), ("user", "another user msg"))
+    result = _find_final_assistant_response(conv, start_idx=1)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _build_usage_dict
+# ---------------------------------------------------------------------------
+
+
+def test_build_usage_dict_basic():
+    usage = {"input_tokens": 100, "output_tokens": 50}
+    result = _build_usage_dict(usage)
+    assert result[TokenUsageKey.INPUT_TOKENS] == 100
+    assert result[TokenUsageKey.OUTPUT_TOKENS] == 50
+    assert result[TokenUsageKey.TOTAL_TOKENS] == 150
+
+
+def test_build_usage_dict_with_cache_tokens():
+    usage = {
+        "input_tokens": 100,
+        "output_tokens": 50,
+        "cache_read_input_tokens": 20,
+        "cache_creation_input_tokens": 10,
+    }
+    result = _build_usage_dict(usage)
+    assert result[TokenUsageKey.CACHE_READ_INPUT_TOKENS] == 20
+    assert result[TokenUsageKey.CACHE_CREATION_INPUT_TOKENS] == 10
+
+
+def test_build_usage_dict_empty():
+    result = _build_usage_dict({})
+    assert result[TokenUsageKey.TOTAL_TOKENS] == 0
+
+
+# ---------------------------------------------------------------------------
+# get_hook_response
+# ---------------------------------------------------------------------------
+
+
+def test_get_hook_response_success():
+    resp = get_hook_response()
+    assert resp["continue"] is True
+    assert "stopReason" not in resp
+
+
+def test_get_hook_response_error():
+    resp = get_hook_response(error="Something went wrong")
+    assert resp["continue"] is False
+    assert resp["stopReason"] == "Something went wrong"
+
+
+# ---------------------------------------------------------------------------
+# is_tracing_enabled
+# ---------------------------------------------------------------------------
+
+
+def test_is_tracing_enabled_false_by_default(monkeypatch):
+    monkeypatch.setenv("MLFLOW_KIRO_TRACING_ENABLED", "")
+    assert is_tracing_enabled() is False
+
+
+def test_is_tracing_enabled_true(monkeypatch):
+    monkeypatch.setenv("MLFLOW_KIRO_TRACING_ENABLED", "true")
+    assert is_tracing_enabled() is True
+
+
+def test_is_tracing_enabled_1(monkeypatch):
+    monkeypatch.setenv("MLFLOW_KIRO_TRACING_ENABLED", "1")
+    assert is_tracing_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# process_session
+# ---------------------------------------------------------------------------
+
+
+def _minimal_session_data(session_id="sess-001"):
+    return {
+        "session_id": session_id,
+        "kiro_version": "1.2.3",
+        "conversation": [
+            {
+                "role": "user",
+                "content": "Refactor my function please",
+                "timestamp": ISO_TS,
+            },
+            {
+                "role": "assistant",
+                "content": "Sure! Here is the refactored version.",
+                "timestamp": ISO_TS_5,
+                "model": "claude-3-5-sonnet",
+                "usage": {"input_tokens": 100, "output_tokens": 200},
+            },
+        ],
+    }
+
+
+@mock.patch("mlflow.kiro.tracing.mlflow")
+@mock.patch("mlflow.kiro.tracing.InMemoryTraceManager")
+@mock.patch("mlflow.kiro.tracing._get_trace_exporter")
+def test_process_session_basic(mock_exporter, mock_itm, mock_mlflow):
+    """process_session returns a trace object on a valid conversation."""
+    mock_span = mock.MagicMock()
+    mock_span.trace_id = "trace-123"
+    mock_mlflow.start_span_no_context.return_value = mock_span
+    mock_mlflow.get_trace.return_value = mock.MagicMock()
+
+    mock_ctx = mock.MagicMock()
+    mock_itm.get_instance.return_value.get_trace.return_value.__enter__ = (
+        lambda s, *a: mock_ctx
+    )
+    mock_itm.get_instance.return_value.get_trace.return_value.__exit__ = (
+        lambda s, *a: None
+    )
+    mock_ctx.info.trace_metadata = {}
+    mock_ctx.info.request_preview = ""
+    mock_ctx.info.response_preview = ""
+
+    result = process_session(_minimal_session_data())
+    assert result is not None
+    # Two calls: one for the root AGENT span, one for the LLM child span
+    assert mock_mlflow.start_span_no_context.call_count >= 2
+
+
+@mock.patch("mlflow.kiro.tracing.mlflow")
+@mock.patch("mlflow.kiro.tracing.InMemoryTraceManager")
+@mock.patch("mlflow.kiro.tracing._get_trace_exporter")
+def test_process_session_empty_conversation(mock_exporter, mock_itm, mock_mlflow):
+    """process_session creates minimal trace when no conversation is present."""
+    mock_span = mock.MagicMock()
+    mock_span.trace_id = "trace-no-conv"
+    mock_mlflow.start_span_no_context.return_value = mock_span
+    mock_mlflow.get_trace.return_value = mock.MagicMock()
+
+    mock_ctx = mock.MagicMock()
+    mock_itm.get_instance.return_value.get_trace.return_value.__enter__ = (
+        lambda s, *a: mock_ctx
+    )
+    mock_itm.get_instance.return_value.get_trace.return_value.__exit__ = (
+        lambda s, *a: None
+    )
+    mock_ctx.info.trace_metadata = {}
+
+    result = process_session({"session_id": "sess-noconv", "conversation": []})
+    assert result is not None
+
+
+@mock.patch("mlflow.kiro.tracing.mlflow")
+@mock.patch("mlflow.kiro.tracing.InMemoryTraceManager")
+@mock.patch("mlflow.kiro.tracing._get_trace_exporter")
+def test_process_session_no_user_message(mock_exporter, mock_itm, mock_mlflow):
+    """process_session returns None when there is no user message."""
+    result = process_session({
+        "session_id": "sess-no-user",
+        "conversation": [
+            {"role": "assistant", "content": "I can help you!"},
+        ],
+    })
+    assert result is None
+
+
+@mock.patch("mlflow.kiro.tracing.mlflow")
+@mock.patch("mlflow.kiro.tracing.InMemoryTraceManager")
+@mock.patch("mlflow.kiro.tracing._get_trace_exporter")
+def test_process_session_with_tool_calls(mock_exporter, mock_itm, mock_mlflow):
+    """process_session handles tool calls in the conversation."""
+    mock_span = mock.MagicMock()
+    mock_span.trace_id = "trace-tools"
+    mock_mlflow.start_span_no_context.return_value = mock_span
+    mock_mlflow.get_trace.return_value = mock.MagicMock()
+
+    mock_ctx = mock.MagicMock()
+    mock_itm.get_instance.return_value.get_trace.return_value.__enter__ = (
+        lambda s, *a: mock_ctx
+    )
+    mock_itm.get_instance.return_value.get_trace.return_value.__exit__ = (
+        lambda s, *a: None
+    )
+    mock_ctx.info.trace_metadata = {}
+
+    session_data = {
+        "session_id": "sess-tools",
+        "conversation": [
+            {"role": "user", "content": "Read my file", "timestamp": ISO_TS},
+            {
+                "role": "assistant",
+                "content": "",
+                "timestamp": ISO_TS_5,
+                "model": "claude-3-5-sonnet",
+                "tool_calls": [
+                    {
+                        "id": "tool_abc",
+                        "name": "read_file",
+                        "input": {"path": "src/main.py"},
+                        "result": "def main(): ...",
+                    }
+                ],
+            },
+        ],
+    }
+    result = process_session(session_data)
+    # Tool spans should be created
+    assert mock_mlflow.start_span_no_context.call_count >= 1


### PR DESCRIPTION
Closes #22822

Implements MLflow autologging support for Amazon's Kiro CLI, following the same pattern as the existing `mlflow autolog claude` integration.

## What's included

- `mlflow/kiro/config.py` — hook file + per-project env config
- `mlflow/kiro/hooks.py` — Agent Stop hook handler (reads stdin JSON → MLflow trace)  
- `mlflow/kiro/tracing.py` — conversation parser → AGENT/LLM/TOOL spans with token usage
- `mlflow/kiro/cli.py` — `mlflow autolog kiro` command group
- `mlflow/cli/__init__.py` — registers kiro alongside the claude command
- `tests/kiro/` — 56 unit tests, all passing

## Usage

```bash
mlflow autolog kiro                          # enable in current dir
mlflow autolog kiro -u sqlite:///mlflow.db   # custom tracking URI
mlflow autolog kiro --status                 # check status
mlflow autolog kiro --disable                # remove hook
