### PR TITLE
Drop `claude-agent-sdk` from `analyze-ci` skill

### DIFF
--- a/.claude/skills/pyproject.toml
+++ b/.claude/skills/pyproject.toml
@@ -2,7 +2,7 @@
 name = "skills"
 version = "0.1.0"
 requires-python = ">=3.10"
-dependencies = ["aiohttp", "claude-agent-sdk", "pydantic", "typing_extensions"]
+dependencies = ["aiohttp", "pydantic", "typing_extensions"]
 
 [project.scripts]
 skills = "skills.cli:main"

--- a/.claude/skills/src/skills/commands/analyze_ci.py
+++ b/.claude/skills/src/skills/commands/analyze_ci.py
@@ -6,21 +6,12 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
-import os
 import re
 import sys
 import tempfile
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import Any
-
-from claude_agent_sdk import (
-    AssistantMessage,
-    ClaudeAgentOptions,
-    ResultMessage,
-    TextBlock,
-    query,
-)
 
 from skills.github import GitHubClient, Job, JobStep, get_github_token
 
@@ -244,32 +235,34 @@ async def analyze_single_job(job: JobLogs) -> AnalysisResult:
 
     # Use an isolated temp directory to avoid conflicts with the parent Claude session
     with tempfile.TemporaryDirectory() as tmpdir:
-        options = ClaudeAgentOptions(
-            system_prompt=ANALYZE_SYSTEM_PROMPT,
-            max_turns=1,
-            model="haiku",
+        proc = await asyncio.create_subprocess_exec(
+            "claude",
+            "--print",
+            "--model",
+            "haiku",
+            "--system-prompt",
+            ANALYZE_SYSTEM_PROMPT,
+            "--tools",
+            "",
+            "--output-format",
+            "json",
             cwd=tmpdir,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
         )
+        stdout, stderr = await proc.communicate(prompt.encode("utf-8"))
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"claude exited with code {proc.returncode}: "
+                f"{stderr.decode('utf-8', errors='replace')}"
+            )
 
-        text_parts: list[str] = []
-        total_cost_usd: float | None = None
-        usage: dict[str, Any] | None = None
-
-        async for message in query(prompt=prompt, options=options):
-            match message:
-                case AssistantMessage(content=content):
-                    for block in content:
-                        match block:
-                            case TextBlock(text=text):
-                                text_parts.append(text)
-                case ResultMessage(total_cost_usd=cost, usage=u):
-                    total_cost_usd = cost
-                    usage = u
-
+    data = json.loads(stdout)
     return AnalysisResult(
-        text="".join(text_parts),
-        total_cost_usd=total_cost_usd,
-        usage=usage,
+        text=data.get("result", ""),
+        total_cost_usd=data.get("total_cost_usd"),
+        usage=data.get("usage"),
     )
 
 
@@ -323,7 +316,4 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
 
 
 def run(args: argparse.Namespace) -> None:
-    # Unset CLAUDECODE so that claude_agent_sdk doesn't refuse to start
-    # when this skill is invoked from within a Claude Code session.
-    os.environ.pop("CLAUDECODE", None)
     asyncio.run(cmd_analyze_async(args.urls, args.debug))

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-10T12:31:52.037911909Z"
+exclude-newer = "2026-04-11T09:41:43.245724Z"
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
@@ -7994,7 +7994,6 @@ version = "0.1.0"
 source = { editable = ".claude/skills" }
 dependencies = [
     { name = "aiohttp" },
-    { name = "claude-agent-sdk" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
@@ -8002,7 +8001,6 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp" },
-    { name = "claude-agent-sdk" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Replace `claude_agent_sdk.query()` with a `claude --print` subprocess call in the `analyze-ci` skill (`.claude/skills/src/skills/commands/analyze_ci.py`) and remove `claude-agent-sdk` from `.claude/skills/pyproject.toml`. The CLI is invoked with `--output-format json`, and the resulting JSON is parsed for the same `result` / `total_cost_usd` / `usage` fields the SDK previously surfaced, so behavior — including parallel per-job analysis and `--debug` cost reporting — is preserved.

### How is this PR tested?

- [x] Manual tests

Ran the skill against four failed workflow runs in `mlflow/mlflow` and confirmed identical output shape and cost reporting:
- `runs/24827664160` (Lint) — transient GitHub 504, ~$0.008
- `runs/24899229536` (MLflow tests / database) — SQLite teardown lock, ~$0.04
- `runs/24904401359` (MLflow tests, 3 jobs) — schema snapshot drift (`spans.links`), ~$0.39 across jobs
- `runs/24924268687` (Preview docs) — missing build artifact, ~$0.011

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release