### PR TITLE
Auto-approve `rerun` workflow runs after `/review` approval

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -201,13 +201,13 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
-          COMMENT_TS: ${{ github.event.comment.created_at }}
+          COMMENT_CREATED_AT: ${{ github.event.comment.created_at }}
         run: |
           count=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
             --jq '[.[]
                    | select(.user.login == "mlflow-app[bot]"
                             and .state == "APPROVED"
-                            and .submitted_at >= env.COMMENT_TS)
+                            and .submitted_at >= env.COMMENT_CREATED_AT)
                   ] | length')
           approved=$([ "$count" -gt 0 ] && echo true || echo false)
           echo "approved=$approved" >> "$GITHUB_OUTPUT"
@@ -226,7 +226,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
-          COMMENT_TS: ${{ github.event.comment.created_at }}
+          COMMENT_CREATED_AT: ${{ github.event.comment.created_at }}
         run: |
           head_sha=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid --jq '.headRefOid')
 
@@ -241,7 +241,7 @@ jobs:
                       | select(.name == "rerun"
                                and .conclusion == "action_required"
                                and .actor.login == "mlflow-app[bot]"
-                               and .created_at >= env.COMMENT_TS)
+                               and .created_at >= env.COMMENT_CREATED_AT)
                       | .id'
             )
             [ -n "$run_ids" ] && break

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -254,8 +254,7 @@ jobs:
             exit 0
           fi
 
-          # /rerun, not /approve: review-triggered runs are recorded against
-          # the base repo, so /approve 403s with "not a fork pull request".
+          # Use /rerun since /approve fails with "not a fork pull request" on runs from `pull_request_review` events.
           while IFS= read -r run_id; do
             gh api --method POST "repos/${REPO}/actions/runs/${run_id}/rerun" >/dev/null \
               && echo "Approved run $run_id" \

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -22,6 +22,8 @@ jobs:
     permissions:
       pull-requests: write
     timeout-minutes: 30
+    outputs:
+      bot-approved: ${{ steps.check-approval.outputs.approved }}
     # Security: Only run for authorized users.
     # - pull_request: Only run for non-fork PRs
     # - issue_comment: BOTH PR author and commenter must be authorized (can't trust external PRs)
@@ -191,3 +193,68 @@ jobs:
               comment_id: comment.id,
               body: updatedBody
             });
+
+      - name: Check bot approval
+        id: check-approval
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          COMMENT_TS: ${{ github.event.comment.created_at }}
+        run: |
+          count=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+            --jq '[.[]
+                   | select(.user.login == "mlflow-app[bot]"
+                            and .state == "APPROVED"
+                            and .submitted_at >= env.COMMENT_TS)
+                  ] | length')
+          approved=$([ "$count" -gt 0 ] && echo true || echo false)
+          echo "approved=$approved" >> "$GITHUB_OUTPUT"
+
+  post-review:
+    needs: review
+    if: github.event_name == 'issue_comment' && needs.review.outputs.bot-approved == 'true'
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    steps:
+      - name: Approve queued rerun workflows
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          COMMENT_TS: ${{ github.event.comment.created_at }}
+        run: |
+          head_sha=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid --jq '.headRefOid')
+
+          # Poll for up to ~30s: the `rerun` workflow may not be queued yet
+          # when this step starts, since mlflow-app[bot]'s approval review
+          # fires it asynchronously.
+          run_ids=""
+          for i in $(seq 1 6); do
+            run_ids=$(
+              gh api --paginate "repos/${REPO}/actions/runs?head_sha=${head_sha}" \
+                --jq '.workflow_runs[]
+                      | select(.name == "rerun"
+                               and .conclusion == "action_required"
+                               and .actor.login == "mlflow-app[bot]"
+                               and .created_at >= env.COMMENT_TS)
+                      | .id'
+            )
+            [ -n "$run_ids" ] && break
+            echo "No action_required rerun yet (attempt $i); sleeping 5s..."
+            sleep 5
+          done
+
+          if [ -z "$run_ids" ]; then
+            echo "Timed out waiting for action_required rerun workflows"
+            exit 0
+          fi
+
+          while IFS= read -r run_id; do
+            gh api --method POST "repos/${REPO}/actions/runs/${run_id}/rerun" >/dev/null \
+              && echo "Approved run $run_id" \
+              || echo "Failed to approve run $run_id"
+          done <<< "$run_ids"

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -219,6 +219,7 @@ jobs:
     timeout-minutes: 5
     permissions:
       actions: write
+      pull-requests: read
     steps:
       - name: Approve queued rerun workflows
         env:
@@ -253,6 +254,8 @@ jobs:
             exit 0
           fi
 
+          # /rerun, not /approve: review-triggered runs are recorded against
+          # the base repo, so /approve 403s with "not a fork pull request".
           while IFS= read -r run_id; do
             gh api --method POST "repos/${REPO}/actions/runs/${run_id}/rerun" >/dev/null \
               && echo "Approved run $run_id" \


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

When `mlflow-app[bot]` approves via `/review` on a fork PR, the queued `rerun` workflow lands in `action_required` and currently needs manual approval.

This PR adds a `post-review` job that, when the bot approved the current `/review`, polls for the `action_required` `rerun` run and POSTs `/rerun` to release it. Filtering by the trigger comment's `created_at` avoids picking up prior approvals on the same PR.

### How is this PR tested?

- [x] Manual tests — verified the approval check and runs filter against PR #22886.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release