### PR TITLE
Isolate auth integration test DB from dev server

### DIFF
--- a/tests/server/auth/auth_test_utils.py
+++ b/tests/server/auth/auth_test_utils.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from mlflow.environment_variables import MLFLOW_TRACKING_PASSWORD, MLFLOW_TRACKING_USERNAME
 from mlflow.server.auth import auth_config
 
@@ -8,6 +10,31 @@ PERMISSION = "READ"
 NEW_PERMISSION = "EDIT"
 ADMIN_USERNAME = auth_config.admin_username
 ADMIN_PASSWORD = auth_config.admin_password
+
+
+def write_isolated_auth_config(tmp_path: Path) -> Path:
+    """Write a basic_auth.ini under ``tmp_path`` whose ``database_uri`` points
+    at an SQLite file inside the same dir, and return the config path.
+
+    Tests that spawn the auth server via ``_init_server`` must point
+    ``MLFLOW_AUTH_CONFIG_PATH`` at the returned file (through ``extra_env``) so
+    the spawned auth server writes to the temp DB instead of the repo-root
+    ``basic_auth.db`` shared with the dev server. Without this, integration
+    tests pollute (and depending on the fixture, delete) the developer's local
+    auth state.
+    """
+    config_path = tmp_path / "basic_auth.ini"
+    db_path = tmp_path / "basic_auth.db"
+    config_path.write_text(
+        "[mlflow]\n"
+        "default_permission = READ\n"
+        f"database_uri = sqlite:///{db_path}\n"
+        f"admin_username = {ADMIN_USERNAME}\n"
+        f"admin_password = {ADMIN_PASSWORD}\n"
+        "authorization_function = mlflow.server.auth:authenticate_request_basic_auth\n"
+        "grant_default_workspace_access = false\n"
+    )
+    return config_path
 
 
 def create_user(tracking_uri: str, username: str | None = None, password: str | None = None):

--- a/tests/server/auth/test_client.py
+++ b/tests/server/auth/test_client.py
@@ -1,4 +1,3 @@
-import os
 from contextlib import contextmanager
 
 import pytest
@@ -6,6 +5,7 @@ import pytest
 import mlflow
 from mlflow import MlflowException
 from mlflow.environment_variables import (
+    MLFLOW_AUTH_CONFIG_PATH,
     MLFLOW_FLASK_SERVER_SECRET_KEY,
     MLFLOW_TRACKING_PASSWORD,
     MLFLOW_TRACKING_USERNAME,
@@ -16,7 +16,6 @@ from mlflow.protos.databricks_pb2 import (
     UNAUTHENTICATED,
     ErrorCode,
 )
-from mlflow.server.auth import auth_config
 from mlflow.server.auth.client import AuthServiceClient
 from mlflow.utils.os import is_windows
 from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
@@ -29,6 +28,7 @@ from tests.server.auth.auth_test_utils import (
     PERMISSION,
     User,
     create_user,
+    write_isolated_auth_config,
 )
 from tests.tracking.integration_test_utils import _init_server
 
@@ -41,11 +41,7 @@ def clear_credentials(monkeypatch):
 
 @pytest.fixture
 def client(tmp_path):
-    # clean up users & permissions created from previous tests
-    db_file = os.path.abspath(os.path.basename(auth_config.database_uri))
-    if os.path.exists(db_file):
-        os.remove(db_file)
-
+    auth_config_path = write_isolated_auth_config(tmp_path)
     path = tmp_path.joinpath("sqlalchemy.db").as_uri()
     backend_uri = ("sqlite://" if is_windows() else "sqlite:////") + path[len("file://") :]
 
@@ -53,7 +49,10 @@ def client(tmp_path):
         backend_uri=backend_uri,
         root_artifact_uri=tmp_path.joinpath("artifacts").as_uri(),
         app="mlflow.server.auth:create_app",
-        extra_env={MLFLOW_FLASK_SERVER_SECRET_KEY.name: "my-secret-key"},
+        extra_env={
+            MLFLOW_FLASK_SERVER_SECRET_KEY.name: "my-secret-key",
+            MLFLOW_AUTH_CONFIG_PATH.name: str(auth_config_path),
+        },
         server_type="flask",
     ) as url:
         yield AuthServiceClient(url)

--- a/tests/server/auth/test_client_rbac.py
+++ b/tests/server/auth/test_client_rbac.py
@@ -1,4 +1,3 @@
-import os
 from contextlib import contextmanager
 
 import pytest
@@ -6,6 +5,7 @@ import requests
 
 from mlflow import MlflowException
 from mlflow.environment_variables import (
+    MLFLOW_AUTH_CONFIG_PATH,
     MLFLOW_FLASK_SERVER_SECRET_KEY,
     MLFLOW_TRACKING_PASSWORD,
     MLFLOW_TRACKING_USERNAME,
@@ -17,7 +17,6 @@ from mlflow.protos.databricks_pb2 import (
     UNAUTHENTICATED,
     ErrorCode,
 )
-from mlflow.server.auth import auth_config
 from mlflow.server.auth.client import AuthServiceClient
 from mlflow.utils.os import is_windows
 
@@ -26,6 +25,7 @@ from tests.server.auth.auth_test_utils import (
     ADMIN_PASSWORD,
     ADMIN_USERNAME,
     User,
+    write_isolated_auth_config,
 )
 from tests.tracking.integration_test_utils import _init_server
 
@@ -38,10 +38,7 @@ def clear_credentials(monkeypatch):
 
 @pytest.fixture
 def client(tmp_path):
-    db_file = os.path.abspath(os.path.basename(auth_config.database_uri))
-    if os.path.exists(db_file):
-        os.remove(db_file)
-
+    auth_config_path = write_isolated_auth_config(tmp_path)
     path = tmp_path.joinpath("sqlalchemy.db").as_uri()
     backend_uri = ("sqlite://" if is_windows() else "sqlite:////") + path[len("file://") :]
 
@@ -49,7 +46,10 @@ def client(tmp_path):
         backend_uri=backend_uri,
         root_artifact_uri=tmp_path.joinpath("artifacts").as_uri(),
         app="mlflow.server.auth:create_app",
-        extra_env={MLFLOW_FLASK_SERVER_SECRET_KEY.name: "my-secret-key"},
+        extra_env={
+            MLFLOW_FLASK_SERVER_SECRET_KEY.name: "my-secret-key",
+            MLFLOW_AUTH_CONFIG_PATH.name: str(auth_config_path),
+        },
         server_type="flask",
     ) as url:
         yield AuthServiceClient(url)

--- a/tests/server/auth/test_client_workspace.py
+++ b/tests/server/auth/test_client_workspace.py
@@ -5,6 +5,7 @@ import requests
 
 from mlflow import MlflowException
 from mlflow.environment_variables import (
+    MLFLOW_AUTH_CONFIG_PATH,
     MLFLOW_ENABLE_WORKSPACES,
     MLFLOW_FLASK_SERVER_SECRET_KEY,
     MLFLOW_RBAC_SEED_DEFAULT_ROLES,
@@ -23,6 +24,7 @@ from tests.server.auth.auth_test_utils import (
     ADMIN_USERNAME,
     User,
     create_user,
+    write_isolated_auth_config,
 )
 from tests.tracking.integration_test_utils import _init_server
 
@@ -35,6 +37,7 @@ def clear_credentials(monkeypatch):
 
 @pytest.fixture
 def workspace_client(tmp_path):
+    auth_config_path = write_isolated_auth_config(tmp_path)
     path = tmp_path.joinpath("sqlalchemy.db").as_uri()
     backend_uri = ("sqlite://" if is_windows() else "sqlite:////") + path[len("file://") :]
 
@@ -44,6 +47,7 @@ def workspace_client(tmp_path):
         app="mlflow.server.auth:create_app",
         extra_env={
             MLFLOW_FLASK_SERVER_SECRET_KEY.name: "my-secret-key",
+            MLFLOW_AUTH_CONFIG_PATH.name: str(auth_config_path),
             MLFLOW_ENABLE_WORKSPACES.name: "true",
             MLFLOW_WORKSPACE_STORE_URI.name: backend_uri,
             # Force seeding on so tests don't depend on the caller's shell env.


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22724 (caught while developing the admin UI — the dev `basic_auth.db` was filling up with test artifacts).

### What changes are proposed in this pull request?

The three auth integration test fixtures (`test_client.py`, `test_client_rbac.py`, `test_client_workspace.py`) spawn an auth server via `_init_server` and let it use the default `basic_auth.ini`, whose `database_uri = sqlite:///basic_auth.db` resolves *relative to the test runner's CWD*. With pytest run from the repo root (the standard way), that's the same file the local dev server uses.

Two failure modes were observed:

1. **Pollution.** `test_client_rbac.py` creates roles like `r-ajax-api` in workspace `path-parity` and dozens of `random_str()` users. If pytest is killed or a test crashes, those records persist in the dev DB, where they show up in the admin UI on the next page load.
2. **Data loss.** `test_client.py` and `test_client_rbac.py` try to "clean up" by `os.remove`'ing `basic_auth.db` at fixture start — which silently deletes whatever state the dev server had built up.

**Fix:** write a tmp `basic_auth.ini` per test that points at a `tmp_path`-scoped SQLite file, and pass `MLFLOW_AUTH_CONFIG_PATH` to the spawned auth server via `extra_env`. The spawned server now writes to the temp file; the dev DB is never read or written. The `os.remove` cleanup hack is removed.

New helper `tests/server/auth/auth_test_utils.write_isolated_auth_config(tmp_path)` writes the temp config and returns its path.

### How is this PR tested?

- [x] Existing unit/integration tests — 44 tests across the three affected files all pass (`test_client.py` 14, `test_client_rbac.py` 23, `test_client_workspace.py` 7).
- [x] Manual: confirmed the dev `basic_auth.db` file's mtime is unchanged before vs. after running the affected test files (whereas before the fix, the file was being deleted/recreated/written on every test run).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/server-infra`: MLflow Tracking server, JavaScript dev server

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included.

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release

This pull request and its description were written by Claude.