### PR TITLE
Speed up `clint` walrus rule visitor

### DIFF
--- a/dev/clint/src/clint/rules/use_walrus_operator.py
+++ b/dev/clint/src/clint/rules/use_walrus_operator.py
@@ -122,51 +122,68 @@ class WalrusOperatorVisitor(ast.NodeVisitor):
                 if UseWalrusOperator.check(stmt, prev_stmt, following_stmts):
                     self.violations.append(prev_stmt)
 
+    def _visit_stmts(self, stmts: list[ast.stmt]) -> None:
+        for stmt in stmts:
+            self.visit(stmt)
+
+    # Walrus opportunities only exist inside statement blocks, so skip descent into
+    # expressions, decorators, args, etc. This trims the AST walk dramatically on
+    # expression-heavy functions.
+    def generic_visit(self, node: ast.AST) -> None:
+        return
+
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
         self._check_stmts(node.body)
-        self.generic_visit(node)
+        self._visit_stmts(node.body)
 
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
         self._check_stmts(node.body)
-        self.generic_visit(node)
+        self._visit_stmts(node.body)
 
     def visit_If(self, node: ast.If) -> None:
         self._check_stmts(node.body)
         self._check_stmts(node.orelse)
-        self.generic_visit(node)
+        self._visit_stmts(node.body)
+        self._visit_stmts(node.orelse)
 
     def visit_For(self, node: ast.For) -> None:
         self._check_stmts(node.body)
         self._check_stmts(node.orelse)
-        self.generic_visit(node)
+        self._visit_stmts(node.body)
+        self._visit_stmts(node.orelse)
 
     def visit_AsyncFor(self, node: ast.AsyncFor) -> None:
         self._check_stmts(node.body)
         self._check_stmts(node.orelse)
-        self.generic_visit(node)
+        self._visit_stmts(node.body)
+        self._visit_stmts(node.orelse)
 
     def visit_While(self, node: ast.While) -> None:
         self._check_stmts(node.body)
         self._check_stmts(node.orelse)
-        self.generic_visit(node)
+        self._visit_stmts(node.body)
+        self._visit_stmts(node.orelse)
 
     def visit_With(self, node: ast.With) -> None:
         self._check_stmts(node.body)
-        self.generic_visit(node)
+        self._visit_stmts(node.body)
 
     def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
         self._check_stmts(node.body)
-        self.generic_visit(node)
+        self._visit_stmts(node.body)
 
     def visit_Try(self, node: ast.Try) -> None:
         self._check_stmts(node.body)
-        for handler in node.handlers:
-            self._check_stmts(handler.body)
         self._check_stmts(node.orelse)
         self._check_stmts(node.finalbody)
-        self.generic_visit(node)
+        self._visit_stmts(node.body)
+        for handler in node.handlers:
+            self._check_stmts(handler.body)
+            self._visit_stmts(handler.body)
+        self._visit_stmts(node.orelse)
+        self._visit_stmts(node.finalbody)
 
     def visit_Match(self, node: ast.Match) -> None:
         for case in node.cases:
             self._check_stmts(case.body)
-        self.generic_visit(node)
+            self._visit_stmts(case.body)


### PR DESCRIPTION
### Related Issues/PRs

Relates to #

### What changes are proposed in this pull request?

Optimize `WalrusOperatorVisitor` (`dev/clint/src/clint/rules/use_walrus_operator.py`).

The visitor used the inherited `ast.NodeVisitor.generic_visit`, which descends into **every** child of every node — including expressions, annotations, decorators, args, returns, `Name`s, `Constant`s, `Call`s, `BinOp`s, etc. Walrus opportunities only appear at sibling-statement boundaries inside statement blocks (function/if/for/while/with/try/match bodies), so descending into expressions is pure waste.

Fix: override `generic_visit` to a no-op and explicitly walk statement children via a small `_visit_stmts` helper. Also drop the unused `visit_ClassDef` path — only 2 classes in the entire repo have any control-flow at body level (both simple `If`s, neither containing walrus patterns), and the `Linter` already invokes `_check_walrus_operator` separately on every method via its own traversal.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

A/B microbenchmark over **28,253 `FunctionDef` / `AsyncFunctionDef`** nodes from every `*.py` file in the repo:

| | best (5 trials) | violations found |
|---|---|---|
| Old visitor | 1640 ms | 3 |
| New visitor | 111 ms | 3 |

**~14.7× faster**, identical violations.

End-to-end `clint .` wallclock (median of 3 back-to-back runs on the same machine):

| | wallclock |
|---|---|
| Before | 4.94s |
| After | 4.29s |

**~13% faster.** All 270 clint unit tests pass.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release