### PR TITLE
Speed up skills CLI by scoping `uv run` to the `skills` package

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -5,7 +5,7 @@ A Python package that provides CLI commands for Claude Code skills.
 ## Usage
 
 ```bash
-uv run skills <command> [args]
+uv run --package skills skills <command> [args]
 ```
 
-Run `uv run skills --help` to see available commands.
+Run `uv run --package skills skills --help` to see available commands.

--- a/.claude/skills/add-review-comment/SKILL.md
+++ b/.claude/skills/add-review-comment/SKILL.md
@@ -4,7 +4,7 @@ description: Add a review comment to a GitHub pull request.
 allowed-tools:
   - Bash(gh api:*)
   - Bash(gh pr view:*)
-  - Bash(uv run skills fetch-diff:*)
+  - Bash(uv run --package skills skills fetch-diff:*)
 ---
 
 # Add Review Comment

--- a/.claude/skills/analyze-ci/SKILL.md
+++ b/.claude/skills/analyze-ci/SKILL.md
@@ -2,7 +2,7 @@
 name: analyze-ci
 description: Analyze failed GitHub Action jobs for a pull request.
 allowed-tools:
-  - Bash(uv run skills analyze-ci:*)
+  - Bash(uv run --package skills skills analyze-ci:*)
 ---
 
 # Analyze CI Failures
@@ -19,16 +19,16 @@ This skill analyzes logs from failed GitHub Action jobs using Claude.
 
 ```bash
 # Analyze all failed jobs in a PR
-uv run skills analyze-ci '<pr_url>'
+uv run --package skills skills analyze-ci '<pr_url>'
 
 # Analyze all failed jobs in a workflow run
-uv run skills analyze-ci '<run_url>'
+uv run --package skills skills analyze-ci '<run_url>'
 
 # Analyze specific job URLs directly
-uv run skills analyze-ci '<job_url>' ['<job_url>' ...]
+uv run --package skills skills analyze-ci '<job_url>' ['<job_url>' ...]
 
 # Show debug info (tokens and costs)
-uv run skills analyze-ci '<pr_url>' --debug
+uv run --package skills skills analyze-ci '<pr_url>' --debug
 ```
 
 Output: A concise failure summary with root cause, error messages, test names, and relevant log snippets.
@@ -37,11 +37,11 @@ Output: A concise failure summary with root cause, error messages, test names, a
 
 ```bash
 # Analyze CI failures for a PR
-uv run skills analyze-ci 'https://github.com/mlflow/mlflow/pull/19601'
+uv run --package skills skills analyze-ci 'https://github.com/mlflow/mlflow/pull/19601'
 
 # Analyze a specific workflow run
-uv run skills analyze-ci 'https://github.com/mlflow/mlflow/actions/runs/22626454465'
+uv run --package skills skills analyze-ci 'https://github.com/mlflow/mlflow/actions/runs/22626454465'
 
 # Analyze specific job URLs directly
-uv run skills analyze-ci 'https://github.com/mlflow/mlflow/actions/runs/12345/job/67890'
+uv run --package skills skills analyze-ci 'https://github.com/mlflow/mlflow/actions/runs/12345/job/67890'
 ```

--- a/.claude/skills/fetch-diff/SKILL.md
+++ b/.claude/skills/fetch-diff/SKILL.md
@@ -2,7 +2,7 @@
 name: fetch-diff
 description: Fetch PR diff with filtering and line numbers for code review.
 allowed-tools:
-  - Bash(uv run skills fetch-diff:*)
+  - Bash(uv run --package skills skills fetch-diff:*)
 ---
 
 # Fetch PR Diff
@@ -12,23 +12,23 @@ Fetches a pull request diff and adds line numbers for easier review comment plac
 ## Usage
 
 ```bash
-uv run skills fetch-diff <pr_url> [--files <pattern> ...]
+uv run --package skills skills fetch-diff <pr_url> [--files <pattern> ...]
 ```
 
 Examples:
 
 ```bash
 # Fetch the full diff
-uv run skills fetch-diff https://github.com/mlflow/mlflow/pull/123
+uv run --package skills skills fetch-diff https://github.com/mlflow/mlflow/pull/123
 
 # Fetch only Python files
-uv run skills fetch-diff https://github.com/mlflow/mlflow/pull/123 --files '*.py'
+uv run --package skills skills fetch-diff https://github.com/mlflow/mlflow/pull/123 --files '*.py'
 
 # Fetch only frontend files
-uv run skills fetch-diff https://github.com/mlflow/mlflow/pull/123 --files 'mlflow/server/js/*'
+uv run --package skills skills fetch-diff https://github.com/mlflow/mlflow/pull/123 --files 'mlflow/server/js/*'
 
 # Multiple patterns
-uv run skills fetch-diff https://github.com/mlflow/mlflow/pull/123 --files '*.py' '*.ts'
+uv run --package skills skills fetch-diff https://github.com/mlflow/mlflow/pull/123 --files '*.py' '*.ts'
 ```
 
 Token is auto-detected from `GH_TOKEN` env var or `gh auth token`.

--- a/.claude/skills/fetch-unresolved-comments/SKILL.md
+++ b/.claude/skills/fetch-unresolved-comments/SKILL.md
@@ -2,7 +2,7 @@
 name: fetch-unresolved-comments
 description: Fetch unresolved PR review comments using GitHub GraphQL API, filtering out resolved feedback.
 allowed-tools:
-  - Bash(uv run skills fetch-unresolved-comments:*)
+  - Bash(uv run --package skills skills fetch-unresolved-comments:*)
 ---
 
 # Fetch Unresolved PR Review Comments
@@ -26,13 +26,13 @@ Uses GitHub's GraphQL API to fetch only unresolved review thread comments from a
 2. **Run the skill**:
 
    ```bash
-   uv run skills fetch-unresolved-comments <pr_url>
+   uv run --package skills skills fetch-unresolved-comments <pr_url>
    ```
 
    Example:
 
    ```bash
-   uv run skills fetch-unresolved-comments https://github.com/mlflow/mlflow/pull/18327
+   uv run --package skills skills fetch-unresolved-comments https://github.com/mlflow/mlflow/pull/18327
    ```
 
    The script automatically reads the GitHub token from:


### PR DESCRIPTION
### Related Issues/PRs

Relates to #

### What changes are proposed in this pull request?

Update the four `SKILL.md` files and `.claude/skills/README.md` to invoke the skills CLI as:

```bash
uv run --package skills skills <command>
```

instead of `uv run skills <command>`.

**Why**: `.claude/skills` is a uv workspace member of the mlflow project (see `pyproject.toml:266-272`). Without `--package`, `uv run` treats the mlflow workspace root as the active project and syncs **all** of mlflow's dependencies into the venv before running anything — that's hundreds of packages, ~1.2 GB, and ~100 seconds cold on a CI runner with `enable-uv-cache: false` (which `review.yml` uses).

With `--package skills`, uv scopes the sync to just the skills package and its three deps (`aiohttp`, `pydantic`, `typing_extensions`) plus their transitives — 15 packages, a few MB.

**Measured impact**:

| | install size | cold start |
|---|---|---|
| `uv run skills …` | ~1.2 GB (full mlflow workspace) | ~100s (observed on CI) |
| `uv run --package skills skills …` | ~few MB (skills + 14 transitive deps) | ~3s |

The biggest win is the `review` workflow, where `fetch-diff` is the first thing Claude calls and currently eats ~100 seconds of cold-sync time per `/review` invocation.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Verified locally:

```bash
$ rm -rf .venv
$ time uv run --package skills skills --help
…
real    0m2.991s
$ uv pip list | wc -l
18   # 15 packages + 3 header lines, vs 145 for the full workspace
```

No `torch`, `pandas`, `flask`, etc. in the resulting venv.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release