### PR TITLE
Fix missing Pydantic AI trace breakdown spans

### DIFF
--- a/mlflow/pydantic_ai/__init__.py
+++ b/mlflow/pydantic_ai/__init__.py
@@ -82,11 +82,31 @@ def _tool_manager_uses_execute_tool_call() -> bool:
     must patch execute_tool_call to capture the TOOL span.
     """
     try:
-        from pydantic_ai._tool_manager import ToolManager
-
+        from pydantic_ai.tool_manager import ToolManager
         return hasattr(ToolManager, "execute_tool_call")
     except ImportError:
+        try:
+            from pydantic_ai._tool_manager import ToolManager
+        except ImportError:
+            return False
+
+        return hasattr(ToolManager, "execute_tool_call")
+    except Exception:
         return False
+
+
+def _get_tool_manager_class_path() -> str:
+    try:
+        from pydantic_ai.tool_manager import ToolManager
+
+        return "pydantic_ai.tool_manager.ToolManager"
+    except ImportError:
+        try:
+            from pydantic_ai._tool_manager import ToolManager
+
+            return "pydantic_ai._tool_manager.ToolManager"
+        except ImportError:
+            return "pydantic_ai._tool_manager.ToolManager"
 
 
 @autologging_integration(FLAVOR_NAME)
@@ -120,7 +140,7 @@ def autolog(log_traces: bool = True, disable: bool = False, silent: bool = False
         # In pydantic-ai >= 1.63.0, _agent_graph calls execute_tool_call directly,
         # bypassing handle_call. Patch execute_tool_call when available; fall back to
         # handle_call for older versions where execute_tool_call doesn't exist.
-        "pydantic_ai._tool_manager.ToolManager": ["execute_tool_call"]
+        _get_tool_manager_class_path(): ["execute_tool_call"]
         if _tool_manager_uses_execute_tool_call()
         else ["handle_call"],
         "pydantic_ai.mcp.MCPServer": ["call_tool", "list_tools"],
@@ -135,21 +155,34 @@ def autolog(log_traces: bool = True, disable: bool = False, silent: bool = False
     except ImportError:
         pass
 
-    # Patch Agent.__init__ to auto-enable instrument=True so LLM spans
-    # are captured without requiring users to explicitly set it
+    # Patch Agent.__init__ (or use instrument_all) to auto-enable instrument=True
+    # so LLM spans are captured without requiring users to explicitly set it
     try:
         from pydantic_ai import Agent
 
-        original_init = Agent.__init__
+        if hasattr(Agent, "instrument_all"):
+            if log_traces:
+                Agent.instrument_all(True)
 
-        @functools.wraps(original_init)
-        def patched_init(self, *args, **kwargs):
-            return patched_agent_init(original_init, self, *args, **kwargs)
+                from mlflow.utils.autologging_utils.safety import _AUTOLOGGING_CLEANUP_CALLBACKS
 
-        patch = _wrap_patch(Agent, "__init__", patched_init)
-        _store_patch(FLAVOR_NAME, patch)
+                def cleanup_instrumentation():
+                    Agent.instrument_all(False)
+
+                _AUTOLOGGING_CLEANUP_CALLBACKS.setdefault(FLAVOR_NAME, []).append(
+                    cleanup_instrumentation
+                )
+        else:
+            original_init = Agent.__init__
+
+            @functools.wraps(original_init)
+            def patched_init(self, *args, **kwargs):
+                return patched_agent_init(original_init, self, *args, **kwargs)
+
+            patch = _wrap_patch(Agent, "__init__", patched_init)
+            _store_patch(FLAVOR_NAME, patch)
     except (ImportError, AttributeError) as e:
-        _logger.error("Error patching Agent.__init__: %s", e)
+        _logger.error("Error patching Agent for instrumentation: %s", e)
 
     for cls_path, methods in class_map.items():
         module_name, class_name = cls_path.rsplit(".", 1)

--- a/mlflow/pydantic_ai/autolog.py
+++ b/mlflow/pydantic_ai/autolog.py
@@ -354,11 +354,19 @@ def _get_span_type(instance) -> str:
         return SpanType.TOOL
 
     try:
-        from pydantic_ai._tool_manager import ToolManager
-
+        from pydantic_ai.tool_manager import ToolManager
+    except ImportError:
+        try:
+            from pydantic_ai._tool_manager import ToolManager
+        except ImportError:
+            pass
+        else:
+            if isinstance(instance, ToolManager):
+                return SpanType.TOOL
+    else:
         if isinstance(instance, ToolManager):
             return SpanType.TOOL
-    except ImportError:
+
         pass
     return SpanType.UNKNOWN
 

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -351,10 +351,13 @@ def detach_span_from_context(token: contextvars.Token):
     Args:
         token: The token returned by `_set_span_to_active` function.
     """
-    if MLFLOW_USE_DEFAULT_TRACER_PROVIDER.get():
-        mlflow_runtime_context.detach(token)
-    else:
-        context_api.detach(token)
+    try:
+        if MLFLOW_USE_DEFAULT_TRACER_PROVIDER.get():
+            mlflow_runtime_context.detach(token)
+        else:
+            context_api.detach(token)
+    except ValueError:
+        pass
 
 
 def set_destination(destination: TraceLocationBase, *, context_local: bool = False):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -559,6 +559,7 @@ filterwarnings = [
   "error::pydantic.PydanticDeprecatedSince20:tests",
   # Silence filesystem backend deprecation warnings (https://github.com/mlflow/mlflow/issues/18534)
   "ignore:The filesystem (tracking|model registry) backend.*is deprecated:FutureWarning",
+  "ignore:There is no current event loop:DeprecationWarning:pydantic_ai\\._utils",
   # Prevent deprecated generator.throw(type, value, tb) signature from being used (Python 3.12+)
   "error:the \\(type, exc, tb\\) signature of throw\\(\\) is deprecated:DeprecationWarning",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -712,8 +712,13 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     except ImportError:
         pass
     else:
-        current_process = psutil.Process()
-        if children := current_process.children(recursive=True):
+        try:
+            current_process = psutil.Process()
+            children = current_process.children(recursive=True)
+        except (PermissionError, psutil.Error):
+            children = []
+
+        if children:
             terminalreporter.section("Remaining child processes", yellow=True)
             for idx, child in enumerate(children, start=1):
                 terminalreporter.write(f"{idx}: {child}\n")

--- a/tests/pydantic_ai/test_pydanticai_fluent_tracing.py
+++ b/tests/pydantic_ai/test_pydanticai_fluent_tracing.py
@@ -26,17 +26,21 @@ IS_USAGE_DEPRECATED = PYDANTIC_AI_VERSION >= Version("0.7.3")
 HAS_RUN_STREAM_SYNC = hasattr(Agent, "run_stream_sync")
 # Streaming tests require pydantic-ai >= 1.0.0 due to API changes
 HAS_STABLE_STREAMING_API = PYDANTIC_AI_VERSION >= Version("1.0.0")
-# In pydantic-ai >= 1.63.0, _agent_graph calls execute_tool_call directly instead of handle_call.
-# _tool_manager module doesn't exist in older versions (e.g. 0.2.x).
 try:
-    from pydantic_ai._tool_manager import ToolManager as _ToolManager
+    from pydantic_ai.tool_manager import ToolManager as _ToolManager
+except ImportError:
+    try:
+        from pydantic_ai._tool_manager import ToolManager as _ToolManager
+    except ImportError:
+        _ToolManager = None
 
+if _ToolManager is not None:
     TOOL_MANAGER_SPAN_NAME = (
         "ToolManager.execute_tool_call"
         if hasattr(_ToolManager, "execute_tool_call")
         else "ToolManager.handle_call"
     )
-except ImportError:
+else:
     TOOL_MANAGER_SPAN_NAME = "ToolManager.handle_call"
 
 

--- a/tests/pydantic_ai/test_pydanticai_tracing.py
+++ b/tests/pydantic_ai/test_pydanticai_tracing.py
@@ -467,11 +467,26 @@ def test_autolog_auto_enables_instrument():
     mlflow.pydantic_ai.autolog(log_traces=True)
 
     agent = Agent("openai:gpt-4o", system_prompt="Test")
-    assert agent.instrument is not None
+    if hasattr(Agent, "instrument_all"):
+        assert agent.instrument is None
+    else:
+        assert agent.instrument is not None
 
-    # Verify the user can still explicitly set instrument=False
     agent_no_instrument = Agent("openai:gpt-4o", system_prompt="Test", instrument=False)
     assert agent_no_instrument.instrument is None or agent_no_instrument.instrument is False
+
+
+@pytest.mark.skipif(
+    not hasattr(Agent, "instrument_all"),
+    reason="Agent.instrument_all added in newer pydantic-ai versions",
+)
+def test_autolog_uses_global_instrumentation_when_available():
+    with patch.object(Agent, "instrument_all") as mock_instrument_all:
+        mlflow.pydantic_ai.autolog(log_traces=True)
+        mock_instrument_all.assert_called_once_with(True)
+
+        mlflow.pydantic_ai.autolog(disable=True)
+        mock_instrument_all.assert_any_call(False)
 
 
 def test_autolog_auto_instrument_captures_llm_spans(mock_litellm_cost):

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -34,6 +34,7 @@ from mlflow.tracing.provider import (
     _get_tracer,
     _initialize_tracer_provider,
     _IsolatedRandomIdGenerator,
+    detach_span_from_context,
     is_tracing_enabled,
     start_span_in_context,
     trace_disabled,
@@ -385,6 +386,28 @@ def test_disable_enable_tracing_not_mutate_otel_provider(monkeypatch):
 
     test_fn()
     assert trace.get_tracer_provider() is otel_tracer_provider
+
+
+@pytest.mark.parametrize(
+    ("use_default_provider", "detach_target"),
+    [
+        (True, "mlflow.tracing.provider.mlflow_runtime_context.detach"),
+        (False, "mlflow.tracing.provider.context_api.detach"),
+    ],
+)
+def test_detach_span_from_context_ignores_cross_context_value_error(
+    monkeypatch, use_default_provider, detach_target
+):
+    monkeypatch.setenv(
+        MLFLOW_USE_DEFAULT_TRACER_PROVIDER.name,
+        str(use_default_provider).lower(),
+    )
+
+    with mock.patch(
+        detach_target,
+        side_effect=ValueError("token was created in a different Context"),
+    ):
+        detach_span_from_context(mock.sentinel.token)
 
 
 def test_is_tracing_enabled():


### PR DESCRIPTION
### Related Issues/PRs

Closes #22208

### What changes are proposed in this pull request?

- restore Pydantic AI request and tool spans in trace breakdown for newer `pydantic_ai` versions
- support newer `ToolManager` import paths and tool execution entrypoints
- use global instrumentation when supported by newer `pydantic_ai`
- harden trace context cleanup and test teardown handling
- add regression coverage for the updated tracing behavior

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

- `python3 -m pytest tests/pydantic_ai/test_pydanticai_tracing.py -q`
- `python3 -m pytest tests/pydantic_ai/test_pydanticai_fluent_tracing.py -q`
- `python3 -m pytest tests/tracing/test_provider.py -q -k detach_span_from_context_ignores_cross_context_value_error`

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixes a regression where Pydantic AI traces could miss request and tool spans in the trace breakdown UI when used with newer `pydantic_ai` versions.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
