### PR TITLE
Cache `is_test_file` in `clint` linter

### DIFF
--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -400,6 +400,7 @@ class Linter(ast.NodeVisitor):
         self.violations: list[Violation] = []
         self.in_TYPE_CHECKING = False
         self.is_mlflow_init_py = path == Path("mlflow", "__init__.py")
+        self.is_test_file = path.name.startswith("test_")
         self.imported_modules: set[str] = set()
         self.lazy_modules: dict[str, Range] = {}
         self.offset = offset or Position(0, 0)
@@ -525,7 +526,7 @@ class Linter(ast.NodeVisitor):
         self.generic_visit(node)
 
     def _is_in_test(self) -> bool:
-        if not self.path.name.startswith("test_"):
+        if not self.is_test_file:
             return False
 
         if not self.stack:


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Compute `path.name.startswith("test_")` once in `Linter.__init__` and store it as `self.is_test_file`, instead of recomputing it on every `_is_in_test()` call.

`_is_in_test()` is invoked many times per node visit (e.g. ~5 times per `visit_Call`), but `self.path` is invariant for the linter instance. Profiling against the full `mlflow` codebase shows `_is_in_test()` cumulative time drops from ~0.65s to ~0.19s (3.3× faster), with a corresponding drop in `pathlib.PurePath.name` calls.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release