### PR TITLE
Memoize `Resolver.resolve()` in `clint`

### DIFF
--- a/dev/clint/src/clint/resolver.py
+++ b/dev/clint/src/clint/resolver.py
@@ -7,11 +7,16 @@ class Resolver:
     def __init__(self) -> None:
         self.name_map: dict[str, list[str]] = {}
         self._scope_stack: list[dict[str, list[str]]] = []
+        # Memoize resolve() results by id(node). Each AST node is visited at most once
+        # per traversal, but a single node is often resolved many times (e.g. visit_Call
+        # invokes >10 rules that each call resolve() on the same node).
+        self._resolve_cache: dict[int, list[str] | None] = {}
 
     def clear(self) -> None:
         """Clear all name mappings. Useful when starting to process a new file."""
         self.name_map.clear()
         self._scope_stack.clear()
+        self._resolve_cache.clear()
 
     def enter_scope(self) -> None:
         """Enter a new scope by taking a snapshot of current mappings."""
@@ -58,6 +63,11 @@ class Resolver:
         Returns:
             List of name parts (e.g., ["threading", "Thread"]) or None if unresolvable
         """
+        node_id = id(node)
+        cache = self._resolve_cache
+        if node_id in cache:
+            return cache[node_id]
+
         if isinstance(node, ast.Call):
             parts = self._extract_call_parts(node.func)
         elif isinstance(node, ast.Name):
@@ -65,9 +75,12 @@ class Resolver:
         elif isinstance(node, ast.Attribute):
             parts = self._extract_call_parts(node)
         else:
+            cache[node_id] = None
             return None
 
-        return self._resolve_parts(parts) if parts else None
+        result = self._resolve_parts(parts) if parts else None
+        cache[node_id] = result
+        return result
 
     def _extract_call_parts(self, node: ast.expr) -> list[str]:
         if isinstance(node, ast.Name):


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Cache `Resolver.resolve()` results by `id(node)` so repeated lookups on the same AST node hit the cache instead of re-walking it.

Profiling shows ~10 rules per `visit_Call` each call `resolve()` on the same node, leading to 1.7M `resolve()` calls on the `mlflow` codebase. The cache lives on the `Resolver` instance, which is created fresh per file (one `Resolver` per `Linter`), so the cache is bounded by single-file AST size and freed between files. Memory impact is negligible.

Profile against the full `mlflow` codebase:

| Metric | Before | After |
| --- | --- | --- |
| `resolve()` cumtime | 1.97s | 0.95s (-52%) |
| `_extract_call_parts` calls | 2.62M | 507k (5x reduction) |
| Total profiled time | 15.55s | 14.44s (-7%) |
| Wall (`uv run --frozen clint .`) | 3.96s | 3.84s (-3.1%) |

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release