### PR TITLE
Add `AgentInfo` metadata to `AgentServer` for runtime discovery

### DIFF
--- a/mlflow/genai/agent_server/__init__.py
+++ b/mlflow/genai/agent_server/__init__.py
@@ -10,10 +10,12 @@ from mlflow.genai.agent_server.utils import (
     set_request_headers,
     setup_mlflow_git_based_version_tracking,
 )
+from mlflow.types.agent_info import AgentInfo
 
 __all__ = [
     "set_request_headers",
     "get_request_headers",
+    "AgentInfo",
     "AgentServer",
     "invoke",
     "stream",

--- a/mlflow/genai/agent_server/server.py
+++ b/mlflow/genai/agent_server/server.py
@@ -17,6 +17,7 @@ from mlflow.genai.agent_server.utils import get_request_headers, set_request_hea
 from mlflow.genai.agent_server.validator import BaseAgentValidator, ResponsesAgentValidator
 from mlflow.pyfunc import ResponsesAgent
 from mlflow.tracing.constant import SpanAttributeKey
+from mlflow.types.agent_info import AgentInfo
 
 logger = logging.getLogger(__name__)
 STREAM_KEY = "stream"
@@ -105,12 +106,26 @@ class AgentServer:
     See https://mlflow.org/docs/latest/genai/serving/agent-server for more information.
     """
 
-    def __init__(self, agent_type: AgentType | None = None, enable_chat_proxy: bool = False):
+    def __init__(
+        self,
+        agent_type: AgentType | None = None,
+        enable_chat_proxy: bool = False,
+        agent_info: AgentInfo | None = None,
+    ):
         self.agent_type = agent_type
         if agent_type == "ResponsesAgent":
             self.validator = ResponsesAgentValidator()
         else:
             self.validator = BaseAgentValidator()
+
+        if agent_info is not None:
+            self.agent_info = agent_info
+        else:
+            self.agent_info = AgentInfo(
+                name=os.environ.get("DATABRICKS_APP_NAME", "mlflow_agent_server"),
+            )
+        if self.agent_type == "ResponsesAgent" and self.agent_info.agent_api is None:
+            self.agent_info.agent_api = "responses"
 
         self.app = FastAPI(title="Agent Server")
 
@@ -244,21 +259,7 @@ class AgentServer:
 
         @self.app.get("/agent/info")
         async def agent_info_endpoint() -> dict[str, Any]:
-            # Get app name from environment or use default
-            app_name = os.environ.get("DATABRICKS_APP_NAME", "mlflow_agent_server")
-
-            # Base info payload
-            info = {
-                "name": app_name,
-                "use_case": "agent",
-                "mlflow_version": mlflow.__version__,
-            }
-
-            # Conditionally add agent_api field for ResponsesAgent only
-            if self.agent_type == "ResponsesAgent":
-                info["agent_api"] = "responses"
-
-            return info
+            return self.agent_info.model_dump(exclude_none=True)
 
         @self.app.get("/health")
         async def health_check() -> dict[str, str]:

--- a/mlflow/types/__init__.py
+++ b/mlflow/types/__init__.py
@@ -3,6 +3,7 @@ The :py:mod:`mlflow.types` module defines data types and utilities to be used by
 components to describe interface independent of other frameworks or languages.
 """
 
+from mlflow.types.agent_info import AgentInfo
 from mlflow.version import IS_TRACING_SDK_ONLY
 
 if not IS_TRACING_SDK_ONLY:
@@ -28,6 +29,7 @@ if not IS_TRACING_SDK_ONLY:
         )
 
         __all__ = [
+            "AgentInfo",
             "Schema",
             "ColSpec",
             "DataType",

--- a/mlflow/types/agent_info.py
+++ b/mlflow/types/agent_info.py
@@ -1,0 +1,33 @@
+from typing import Any
+from pydantic import BaseModel, Field
+import mlflow
+
+class AgentInfo(BaseModel):
+    """Metadata describing an agent server's identity and interface.
+
+    Passed to ``AgentServer`` as a constructor argument to enrich the
+    ``GET /agent/info`` endpoint with additional discovery information.
+
+    Args:
+        name: Server/agent name. Defaults to the ``DATABRICKS_APP_NAME``
+            environment variable or ``"mlflow_agent_server"``.
+        use_case: The use case category. Defaults to ``"agent"``.
+        mlflow_version: The MLflow version running the server.
+            Defaults to the installed ``mlflow.__version__``.
+        agent_api: The agent API protocol (e.g. ``"responses"``).
+            Automatically set when ``agent_type="ResponsesAgent"``.
+        description: Human-readable description of what the agent does.
+        version: Version string for the agent.
+        metadata: Extensible dict for additional information.
+            Reserved keys: ``custom_inputs_schema``, ``custom_outputs_schema``.
+        tags: Arbitrary key-value metadata for categorization.
+    """
+
+    name: str = "mlflow_agent_server"
+    use_case: str = "agent"
+    mlflow_version: str = Field(default_factory=lambda: mlflow.__version__)
+    agent_api: str | None = None
+    description: str | None = None
+    version: str | None = None
+    metadata: dict[str, Any] | None = None
+    tags: dict[str, str] | None = None

--- a/tests/genai/test_agent_server.py
+++ b/tests/genai/test_agent_server.py
@@ -6,6 +6,7 @@ import httpx
 import pytest
 from fastapi.testclient import TestClient
 
+import mlflow
 from mlflow.genai.agent_server import (
     AgentServer,
     get_invoke_function,
@@ -16,6 +17,7 @@ from mlflow.genai.agent_server import (
     stream,
 )
 from mlflow.genai.agent_server.validator import ResponsesAgentValidator
+from mlflow.types.agent_info import AgentInfo
 from mlflow.types.responses import (
     ResponsesAgentRequest,
     ResponsesAgentResponse,
@@ -1322,3 +1324,103 @@ def test_return_trace_header_case_insensitive(header_value):
         assert "output" in response_json
         assert response_json["metadata"] == {"trace_id": "test-trace-id-123"}
         mock_span.assert_called_once()
+
+
+def test_agent_info_default_without_agent_info():
+    server = AgentServer("ResponsesAgent")
+    client = TestClient(server.app)
+
+    response = client.get("/agent/info")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "mlflow_agent_server"
+    assert data["use_case"] == "agent"
+    assert data["mlflow_version"] == mlflow.__version__
+    assert data["agent_api"] == "responses"
+    assert "description" not in data
+    assert "version" not in data
+    assert "metadata" not in data
+    assert "tags" not in data
+
+
+def test_agent_info_default_without_responses_agent():
+    server = AgentServer()
+    client = TestClient(server.app)
+
+    response = client.get("/agent/info")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "mlflow_agent_server"
+    assert data["use_case"] == "agent"
+    assert data["mlflow_version"] == mlflow.__version__
+    assert "agent_api" not in data
+
+
+def test_agent_info_with_custom_agent_info():
+    info = AgentInfo(
+        name="my-agent",
+        description="A custom agent",
+        version="2.0.0",
+        tags={"team": "ml"},
+    )
+    server = AgentServer("ResponsesAgent", agent_info=info)
+    client = TestClient(server.app)
+
+    response = client.get("/agent/info")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "my-agent"
+    assert data["description"] == "A custom agent"
+    assert data["version"] == "2.0.0"
+    assert data["agent_api"] == "responses"
+    assert data["tags"] == {"team": "ml"}
+
+
+def test_agent_info_agent_api_auto_set_for_responses_agent():
+    info = AgentInfo(name="auto-api-agent")
+    server = AgentServer("ResponsesAgent", agent_info=info)
+    assert server.agent_info.agent_api == "responses"
+
+
+def test_agent_info_agent_api_not_overridden_if_set():
+    info = AgentInfo(name="custom-api-agent", agent_api="custom")
+    server = AgentServer("ResponsesAgent", agent_info=info)
+    assert server.agent_info.agent_api == "custom"
+
+
+def test_agent_info_with_metadata_schemas():
+    info = AgentInfo(
+        name="schema-agent",
+        metadata={
+            "custom_inputs_schema": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+            },
+            "custom_outputs_schema": {
+                "type": "object",
+                "properties": {"answer": {"type": "string"}},
+            },
+        },
+    )
+    server = AgentServer("ResponsesAgent", agent_info=info)
+    client = TestClient(server.app)
+
+    response = client.get("/agent/info")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "schema-agent"
+    assert data["metadata"]["custom_inputs_schema"]["properties"]["query"]["type"] == "string"
+    assert data["metadata"]["custom_outputs_schema"]["properties"]["answer"]["type"] == "string"
+
+
+def test_agent_info_name_from_env_var():
+    from mlflow.types.agent_info import AgentInfo
+
+    with patch.dict("os.environ", {"DATABRICKS_APP_NAME": "env-app-name"}):
+        server = AgentServer("ResponsesAgent")
+    assert server.agent_info.name == "env-app-name"
+
+    info = AgentInfo(name="explicit-name")
+    with patch.dict("os.environ", {"DATABRICKS_APP_NAME": "env-app-name"}):
+        server = AgentServer("ResponsesAgent", agent_info=info)
+    assert server.agent_info.name == "explicit-name"

--- a/tests/types/test_agent_info.py
+++ b/tests/types/test_agent_info.py
@@ -1,0 +1,110 @@
+import pytest
+
+import mlflow
+from mlflow.types.agent_info import AgentInfo
+
+
+def test_default_fields():
+    info = AgentInfo()
+    assert info.name == "mlflow_agent_server"
+    assert info.use_case == "agent"
+    assert info.mlflow_version == mlflow.__version__
+    assert info.agent_api is None
+    assert info.description is None
+    assert info.version is None
+    assert info.metadata is None
+    assert info.tags is None
+
+
+def test_model_dump_excludes_none():
+    info = AgentInfo()
+    result = info.model_dump(exclude_none=True)
+    assert result == {
+        "name": "mlflow_agent_server",
+        "use_case": "agent",
+        "mlflow_version": mlflow.__version__,
+    }
+    assert "agent_api" not in result
+    assert "description" not in result
+    assert "version" not in result
+    assert "metadata" not in result
+    assert "tags" not in result
+
+
+def test_all_fields_populated():
+    info = AgentInfo(
+        name="my-agent",
+        use_case="agent",
+        agent_api="responses",
+        description="A test agent",
+        version="1.0.0",
+        metadata={
+            "custom_inputs_schema": {"type": "object", "properties": {"query": {"type": "string"}}},
+            "custom_outputs_schema": {
+                "type": "object",
+                "properties": {"answer": {"type": "string"}},
+            },
+        },
+        tags={"team": "ml", "env": "prod"},
+    )
+    result = info.model_dump(exclude_none=True)
+    assert result["name"] == "my-agent"
+    assert result["use_case"] == "agent"
+    assert result["mlflow_version"] == mlflow.__version__
+    assert result["agent_api"] == "responses"
+    assert result["description"] == "A test agent"
+    assert result["version"] == "1.0.0"
+    assert result["metadata"]["custom_inputs_schema"]["properties"]["query"]["type"] == "string"
+    assert result["metadata"]["custom_outputs_schema"]["properties"]["answer"]["type"] == "string"
+    assert result["tags"] == {"team": "ml", "env": "prod"}
+
+
+def test_metadata_with_schemas():
+    info = AgentInfo(
+        name="schema-agent",
+        metadata={
+            "custom_inputs_schema": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}, "temperature": {"type": "number"}},
+            },
+            "custom_outputs_schema": {
+                "type": "object",
+                "properties": {"result": {"type": "string"}},
+            },
+        },
+    )
+    result = info.model_dump(exclude_none=True)
+    assert "custom_inputs_schema" in result["metadata"]
+    assert "custom_outputs_schema" in result["metadata"]
+    assert "query" in result["metadata"]["custom_inputs_schema"]["properties"]
+
+
+def test_custom_name_overrides_default():
+    info = AgentInfo(name="custom-name")
+    assert info.name == "custom-name"
+    result = info.model_dump(exclude_none=True)
+    assert result["name"] == "custom-name"
+
+
+def test_subclassing():
+    class ExtendedAgentInfo(AgentInfo):
+        capabilities: list[str] = []
+
+    info = ExtendedAgentInfo(name="extended", capabilities=["qa", "search"])
+    result = info.model_dump(exclude_none=True)
+    assert result["name"] == "extended"
+    assert result["capabilities"] == ["qa", "search"]
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("description", "A helpful agent"),
+        ("version", "2.0.0"),
+        ("tags", {"team": "backend"}),
+    ],
+)
+def test_optional_fields_individually(field, value):
+    info = AgentInfo(**{field: value})
+    result = info.model_dump(exclude_none=True)
+    assert result[field] == value


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22900

### What changes are proposed in this pull request?

Introduces `AgentInfo`, a Pydantic `BaseModel` that captures agent identity metadata (name, description, version, metadata, tags). `AgentServer` accepts it as a constructor argument and serves it via the existing `GET /agent/info` endpoint. When no `AgentInfo` is provided, the endpoint returns the same default response as before.

### How is this PR tested?

- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added `AgentInfo` model to `AgentServer` enabling agents to expose identity metadata (name, description, version, tags) at runtime via the `GET /agent/info` endpoint.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)