### PR TITLE
Fix uncaught rejection in `CreateBudgetPolicyModal` submit

### DIFF
--- a/mlflow/server/js/src/gateway/components/budgets/CreateBudgetPolicyModal.test.tsx
+++ b/mlflow/server/js/src/gateway/components/budgets/CreateBudgetPolicyModal.test.tsx
@@ -83,4 +83,46 @@ describe('CreateBudgetPolicyModal', () => {
 
     expect(screen.getByText('Budget limit reached')).toBeInTheDocument();
   });
+
+  test('does not propagate unhandled rejection when submit fails (e.g. 403)', async () => {
+    const onClose = jest.fn();
+    const onSuccess = jest.fn();
+    // Lazy-construct the rejection so it isn't created at mock-setup time
+    // (which would briefly look unhandled before the modal awaits it).
+    const rejectingMutateAsync = jest
+      .fn()
+      .mockImplementation(() => Promise.reject(new Error('You do not have permission to access this resource.')));
+    jest.mocked(useCreateBudgetPolicy).mockReturnValue({
+      mutateAsync: rejectingMutateAsync,
+      isLoading: false,
+      error: null,
+      reset: jest.fn(),
+    } as any);
+
+    const unhandledRejections: unknown[] = [];
+    const handler = (event: PromiseRejectionEvent) => {
+      unhandledRejections.push(event.reason);
+    };
+    window.addEventListener('unhandledrejection', handler);
+
+    try {
+      renderWithDesignSystem(<CreateBudgetPolicyModal open onClose={onClose} onSuccess={onSuccess} />);
+
+      const amountInput = screen.getByPlaceholderText('e.g., 100.00');
+      await userEvent.type(amountInput, '50');
+
+      const createButton = screen.getByRole('button', { name: 'Create' });
+      await userEvent.click(createButton);
+
+      expect(rejectingMutateAsync).toHaveBeenCalledTimes(1);
+      // Modal stays open and onSuccess does not fire on failure.
+      expect(onClose).not.toHaveBeenCalled();
+      expect(onSuccess).not.toHaveBeenCalled();
+      // The rejection must not surface as an unhandled promise rejection
+      // (which would render as the dev-server runtime error overlay).
+      expect(unhandledRejections).toEqual([]);
+    } finally {
+      window.removeEventListener('unhandledrejection', handler);
+    }
+  });
 });

--- a/mlflow/server/js/src/gateway/components/budgets/CreateBudgetPolicyModal.test.tsx
+++ b/mlflow/server/js/src/gateway/components/budgets/CreateBudgetPolicyModal.test.tsx
@@ -118,7 +118,7 @@ describe('CreateBudgetPolicyModal', () => {
       const createButton = screen.getByRole('button', { name: 'Create' });
       await userEvent.click(createButton);
 
-      // ``unhandledrejection`` is dispatched asynchronously, so a regression
+      // `unhandledrejection` is dispatched asynchronously, so a regression
       // could fire it on a later turn. Wait for the rejected mutation to be
       // observed, then advance one macrotask so any pending rejection event
       // has had a chance to run before we assert.

--- a/mlflow/server/js/src/gateway/components/budgets/CreateBudgetPolicyModal.test.tsx
+++ b/mlflow/server/js/src/gateway/components/budgets/CreateBudgetPolicyModal.test.tsx
@@ -1,6 +1,6 @@
 import { describe, jest, beforeEach, test, expect } from '@jest/globals';
 import userEvent from '@testing-library/user-event';
-import { renderWithDesignSystem, screen } from '../../../common/utils/TestUtils.react18';
+import { renderWithDesignSystem, screen, waitFor } from '../../../common/utils/TestUtils.react18';
 import { CreateBudgetPolicyModal } from './CreateBudgetPolicyModal';
 import { useCreateBudgetPolicy } from '../../hooks/useCreateBudgetPolicy';
 
@@ -101,6 +101,10 @@ describe('CreateBudgetPolicyModal', () => {
 
     const unhandledRejections: unknown[] = [];
     const handler = (event: PromiseRejectionEvent) => {
+      // Suppress the runtime's default behavior so a reintroduced unhandled
+      // rejection surfaces as a clean assertion failure below rather than
+      // crashing the whole jest worker.
+      event.preventDefault();
       unhandledRejections.push(event.reason);
     };
     window.addEventListener('unhandledrejection', handler);
@@ -114,13 +118,17 @@ describe('CreateBudgetPolicyModal', () => {
       const createButton = screen.getByRole('button', { name: 'Create' });
       await userEvent.click(createButton);
 
-      expect(rejectingMutateAsync).toHaveBeenCalledTimes(1);
+      // ``unhandledrejection`` is dispatched asynchronously, so a regression
+      // could fire it on a later turn. Wait for the rejected mutation to be
+      // observed, then advance one macrotask so any pending rejection event
+      // has had a chance to run before we assert.
+      await waitFor(() => expect(rejectingMutateAsync).toHaveBeenCalledTimes(1));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(unhandledRejections).toEqual([]);
       // Modal stays open and onSuccess does not fire on failure.
       expect(onClose).not.toHaveBeenCalled();
       expect(onSuccess).not.toHaveBeenCalled();
-      // The rejection must not surface as an unhandled promise rejection
-      // (which would render as the dev-server runtime error overlay).
-      expect(unhandledRejections).toEqual([]);
     } finally {
       window.removeEventListener('unhandledrejection', handler);
     }

--- a/mlflow/server/js/src/gateway/components/budgets/CreateBudgetPolicyModal.tsx
+++ b/mlflow/server/js/src/gateway/components/budgets/CreateBudgetPolicyModal.tsx
@@ -84,13 +84,14 @@ export const CreateBudgetPolicyModal = ({ open, onClose, onSuccess }: CreateBudg
         target_scope: getWorkspacesEnabledSync() ? 'WORKSPACE' : 'GLOBAL',
         budget_action: formData.budgetAction,
       });
-      handleClose();
-      onSuccess?.();
     } catch {
-      // ``mutationError`` is populated by ``useCreateBudgetPolicy`` and rendered
-      // inline via ``errorMessage``. Swallow here so the rejection doesn't bubble
-      // to the dev-server overlay / global ``unhandledrejection`` handler.
+      // `mutationError` is populated by `useCreateBudgetPolicy` and rendered
+      // inline via `errorMessage`. Swallow here so the rejection doesn't bubble
+      // to the dev-server overlay / global `unhandledrejection` handler.
+      return;
     }
+    handleClose();
+    onSuccess?.();
   }, [isFormValid, formData, createBudgetPolicy, handleClose, onSuccess]);
 
   const errorMessage = useMemo((): string | null => {

--- a/mlflow/server/js/src/gateway/components/budgets/CreateBudgetPolicyModal.tsx
+++ b/mlflow/server/js/src/gateway/components/budgets/CreateBudgetPolicyModal.tsx
@@ -76,16 +76,21 @@ export const CreateBudgetPolicyModal = ({ open, onClose, onSuccess }: CreateBudg
 
     const { unit, value } = DURATION_MAP[formData.duration];
 
-    await createBudgetPolicy({
-      budget_unit: 'USD',
-      budget_amount: parseFloat(formData.budgetAmount),
-      duration: { unit, value },
-      target_scope: getWorkspacesEnabledSync() ? 'WORKSPACE' : 'GLOBAL',
-      budget_action: formData.budgetAction,
-    }).then(() => {
+    try {
+      await createBudgetPolicy({
+        budget_unit: 'USD',
+        budget_amount: parseFloat(formData.budgetAmount),
+        duration: { unit, value },
+        target_scope: getWorkspacesEnabledSync() ? 'WORKSPACE' : 'GLOBAL',
+        budget_action: formData.budgetAction,
+      });
       handleClose();
       onSuccess?.();
-    });
+    } catch {
+      // ``mutationError`` is populated by ``useCreateBudgetPolicy`` and rendered
+      // inline via ``errorMessage``. Swallow here so the rejection doesn't bubble
+      // to the dev-server overlay / global ``unhandledrejection`` handler.
+    }
   }, [isFormValid, formData, createBudgetPolicy, handleClose, onSuccess]);
 
   const errorMessage = useMemo((): string | null => {


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22724 (RBAC admin UI work surfaced this — caught while testing as an editor user, but the bug exists on master and applies to any failure mode, not just permission errors).

### What changes are proposed in this pull request?

`CreateBudgetPolicyModal.handleSubmit` is written as

```ts
await createBudgetPolicy({...}).then(() => {
  handleClose();
  onSuccess?.();
});
```

The `await` re-throws on rejection, and `handleSubmit` is an async function with no surrounding try/catch — so any failure from `createBudgetPolicy` (a 403, a network blip, etc.) becomes an unhandled promise rejection. Webpack-dev-server's runtime-error overlay catches it and renders across the whole UI.

Ironically the component already wires `mutationError` (from `useCreateBudgetPolicy`) to an inline `Alert` via the `errorMessage` memo — that path just never gets reached because the unhandled rejection trips the overlay first.

The fix wraps the submit in `try/catch`. The `catch` is intentionally empty: React Query populates `mutationError` for us, and the existing render path turns it into a friendly inline message.

**Reproduction:** log in as a user without `MANAGE` on the workspace, open the create-budget-policy modal, click Create. Before the fix: the dev-server overlay covers the page. After: the modal stays open and shows the backend's error message inline.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests — added `does not propagate unhandled rejection when submit fails (e.g. 403)` to `CreateBudgetPolicyModal.test.tsx`. Registers a `window.unhandledrejection` listener around a submit flow whose `mutateAsync` rejects, and asserts no rejection escapes. **Verified the test fails on master and passes with this fix.**
- [x] Manual: ran the dev server, attempted budget-policy creation as a non-MANAGE user — overlay no longer appears; inline error message renders in the modal as designed.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix a bug where the AI Gateway "Create Budget Policy" modal would render a full-screen runtime-error overlay (in development mode) on failed submissions instead of showing the backend error inline.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, JavaScript web client
- [x] `area/gateway`: AI Gateway client APIs, server, and third-party AI service clients

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release

This pull request and its description were written by Claude.