### PR TITLE
Preserve cache_read tokens in `@mlflow/claude-code` TypeScript plugin for cache observability

### DIFF
--- a/libs/typescript/integrations/claude-code/src/tracing.ts
+++ b/libs/typescript/integrations/claude-code/src/tracing.ts
@@ -204,21 +204,37 @@ function getInputMessages(
 // ============================================================================
 
 /**
- * Set token usage on a span. Input = input_tokens + cache_creation (cache_read excluded).
+ * Normalize a Claude Code usage payload into the TOKEN_USAGE schema.
+ * Stores fields as the Anthropic API reports them, matching
+ * `mlflow.anthropic.autolog`: `input_tokens` is the non-cached input,
+ * cache tokens are exposed as separate optional keys so consumers can
+ * compute cache hit rate, and `total_tokens` follows the
+ * `mlflow.anthropic` convention of `input_tokens + output_tokens`
+ * (cache tokens excluded).
  */
+function buildUsageDict(usage: TokenUsage): Record<string, number> {
+  const inputTokens = usage.input_tokens ?? 0;
+  const outputTokens = usage.output_tokens ?? 0;
+
+  const usageDict: Record<string, number> = {
+    [TokenUsageKey.INPUT_TOKENS]: inputTokens,
+    [TokenUsageKey.OUTPUT_TOKENS]: outputTokens,
+    [TokenUsageKey.TOTAL_TOKENS]: inputTokens + outputTokens,
+  };
+  if (usage.cache_read_input_tokens !== undefined) {
+    usageDict[TokenUsageKey.CACHE_READ_INPUT_TOKENS] = usage.cache_read_input_tokens;
+  }
+  if (usage.cache_creation_input_tokens !== undefined) {
+    usageDict[TokenUsageKey.CACHE_CREATION_INPUT_TOKENS] = usage.cache_creation_input_tokens;
+  }
+  return usageDict;
+}
+
 function setTokenUsageAttribute(span: LiveSpan, usage: TokenUsage | undefined): void {
   if (!usage) {
     return;
   }
-
-  const inputTokens = (usage.input_tokens ?? 0) + (usage.cache_creation_input_tokens ?? 0);
-  const outputTokens = usage.output_tokens ?? 0;
-
-  span.setAttribute(SpanAttributeKey.TOKEN_USAGE, {
-    [TokenUsageKey.INPUT_TOKENS]: inputTokens,
-    [TokenUsageKey.OUTPUT_TOKENS]: outputTokens,
-    [TokenUsageKey.TOTAL_TOKENS]: inputTokens + outputTokens,
-  });
+  span.setAttribute(SpanAttributeKey.TOKEN_USAGE, buildUsageDict(usage));
 }
 
 // ============================================================================

--- a/libs/typescript/integrations/claude-code/tests/tracing.test.ts
+++ b/libs/typescript/integrations/claude-code/tests/tracing.test.ts
@@ -97,6 +97,8 @@ jest.mock('@mlflow/core', () => {
       INPUT_TOKENS: 'input_tokens',
       OUTPUT_TOKENS: 'output_tokens',
       TOTAL_TOKENS: 'total_tokens',
+      CACHE_READ_INPUT_TOKENS: 'cache_read_input_tokens',
+      CACHE_CREATION_INPUT_TOKENS: 'cache_creation_input_tokens',
     },
     InMemoryTraceManager: {
       getInstance: jest.fn(() => ({
@@ -227,7 +229,7 @@ describe('processTranscript', () => {
   // --------------------------------------------------------------------------
 
   describe('token usage', () => {
-    it('sets token usage with cache_creation included and cache_read excluded', async () => {
+    it('preserves cache tokens as separate fields and excludes cache from total', async () => {
       await processTranscript(resolve(FIXTURES_DIR, 'with-usage.jsonl'), 'test-session-usage');
 
       const llms = getSpansByType('LLM');
@@ -235,10 +237,45 @@ describe('processTranscript', () => {
 
       const tokenUsage = llms[0].attributes['mlflow.chat.tokenUsage'];
       expect(tokenUsage).toBeDefined();
-      // input_tokens=10 + cache_creation=100 = 110 (cache_read=40 excluded)
-      expect(tokenUsage.input_tokens).toBe(110);
+      // input_tokens stays as the non-cached input the API reports.
+      expect(tokenUsage.input_tokens).toBe(10);
       expect(tokenUsage.output_tokens).toBe(25);
-      expect(tokenUsage.total_tokens).toBe(135);
+      // total = input + output, cache excluded (matches mlflow.anthropic.autolog).
+      expect(tokenUsage.total_tokens).toBe(35);
+      // Cache fields are surfaced as separate optional keys.
+      expect(tokenUsage.cache_read_input_tokens).toBe(40);
+      expect(tokenUsage.cache_creation_input_tokens).toBe(100);
+    });
+
+    it('omits cache token keys when the API does not report them', async () => {
+      const tmpDir = mkdtempSync(resolve(tmpdir(), 'cc-test-'));
+      const transcriptPath = resolve(tmpDir, 'no-cache.jsonl');
+      const entries: TranscriptEntry[] = [
+        {
+          type: 'user',
+          message: { role: 'user', content: 'Hi' },
+          timestamp: '2025-01-15T10:00:00.000Z',
+        },
+        {
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'Hello!' }],
+            usage: { input_tokens: 7, output_tokens: 3 },
+          },
+          timestamp: '2025-01-15T10:00:01.000Z',
+        },
+      ];
+      writeFileSync(transcriptPath, entries.map((e) => JSON.stringify(e)).join('\n') + '\n');
+
+      await processTranscript(transcriptPath, 'no-cache-session');
+
+      const tokenUsage = getSpansByType('LLM')[0].attributes['mlflow.chat.tokenUsage'];
+      expect(tokenUsage.input_tokens).toBe(7);
+      expect(tokenUsage.output_tokens).toBe(3);
+      expect(tokenUsage.total_tokens).toBe(10);
+      expect(tokenUsage).not.toHaveProperty('cache_read_input_tokens');
+      expect(tokenUsage).not.toHaveProperty('cache_creation_input_tokens');
     });
   });
 


### PR DESCRIPTION
### Related Issues/PRs

Closes #22905. Relates to #22683 (Python equivalent, merged) and #22338 (TS plugin migration).

### What changes are proposed in this pull request?

The `@mlflow/claude-code` TypeScript plugin (introduced in #22338) reads `message.usage` from the Claude Code transcript — which contains all four Anthropic usage fields (`input_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`, `output_tokens`) — but folded `cache_creation_input_tokens` into `input_tokens` and dropped `cache_read_input_tokens` entirely. As a result, prompt-cache hit rate was unobservable from emitted traces. #22683 fixed this on the Python side; this PR ports the same fix to the TypeScript plugin.

The `TokenUsageKey.CACHE_READ_INPUT_TOKENS` and `TokenUsageKey.CACHE_CREATION_INPUT_TOKENS` constants are already exported from `@mlflow/core` ([`libs/typescript/core/src/core/constants.ts:92-93`](https://github.com/mlflow/mlflow/blob/master/libs/typescript/core/src/core/constants.ts#L92-L93)), so no SDK changes are required — only a behavior fix in `setTokenUsageAttribute` plus test updates.

Changes:
- Preserve `input_tokens` as the non-cached input the Anthropic API reports, matching `mlflow.anthropic.autolog` and the Python `_build_usage_dict`. `total_tokens` follows the same convention (`input_tokens + output_tokens`, cache excluded).
- Expose `cache_read_input_tokens` and `cache_creation_input_tokens` as separate optional keys on `TOKEN_USAGE` whenever the API reports them, using `!== undefined` so explicit zeroes are preserved.
- Extract a `buildUsageDict` helper mirroring the Python version.
- Update the existing token-usage test to assert the corrected schema and add a no-cache test verifying optional keys are omitted when the API does not report them.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

`npm run test:claude-code` from `libs/typescript`: 43/43 pass (was 42 before; +1 new no-cache test). Lint clean. Prettier clean on source.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`@mlflow/claude-code` traces now expose `cache_read_input_tokens` and `cache_creation_input_tokens` as separate keys on token usage, enabling prompt-cache hit-rate analysis from MLflow traces. `input_tokens` and `total_tokens` no longer fold cache-creation into the non-cached input, matching `@mlflow/anthropic` and `mlflow.anthropic.autolog`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release