### PR TITLE
Surface review metrics in `/review` PR comment

### DIFF
--- a/.claude/scripts/stream.sh
+++ b/.claude/scripts/stream.sh
@@ -19,7 +19,7 @@ tee "${1:-/dev/null}" \
       | select(.type == "tool_result")
       | "📥 tool_result (\(.content | tostring | length) chars)\(if .is_error then " ❌" else "" end)"
     elif .type == "result" then
-      "✅ Done (\(.duration_ms / 1000)s, \(.usage.input_tokens + .usage.output_tokens) tokens, $\(.total_cost_usd * 100 | round / 100))"
+      "✅ Done (\((.duration_ms / 100 | round) / 10)s, \(.num_turns) turns, \(.usage.input_tokens + .usage.output_tokens) tokens, $\(.total_cost_usd * 100 | round / 100))"
     else
       empty
     end'

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -169,6 +169,10 @@ jobs:
                 const events = claudeOutput.trim().split('\n').filter(Boolean).map(JSON.parse);
                 const resultEvent = events.findLast(({ type }) => type === 'result');
                 if (resultEvent) {
+                  const seconds = (resultEvent.duration_ms / 1000).toFixed(1);
+                  const tokens = (resultEvent.usage?.input_tokens ?? 0) + (resultEvent.usage?.output_tokens ?? 0);
+                  const cost = (Math.round(resultEvent.total_cost_usd * 100) / 100).toFixed(2);
+                  resultLine += ` (${seconds}s, ${resultEvent.num_turns} turns, ${tokens} tokens, $${cost})`;
                   resultLine += `\n<details><summary>Review Output</summary>\n\n${resultEvent.result}\n\n</details>`;
                 }
               } catch (e) {


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

When `/review` finishes, the comment now reads:

```
✅ [Review](…) completed (12.5s, 7 turns, 4823 tokens, $0.21)
```

Previously the metrics were only printed to the workflow log via `stream.sh`. The values are pulled from the same `result` event already saved to `/tmp/output.json`, so no extra plumbing is needed.

Also trimmed the seconds field to one decimal in both `stream.sh` and the workflow's JS extraction so the line stays compact.

Verified locally by piping a captured headless `claude --print --output-format stream-json` run through `stream.sh` and through the workflow's Node extraction logic — both produce identical output.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release