### PR TITLE
Gateway: preserve client auth header for subscription-based CLI tools (`claude-cli`, `Codex-Desktop`, `GeminiCLI`)

### DIFF
--- a/mlflow/gateway/providers/anthropic.py
+++ b/mlflow/gateway/providers/anthropic.py
@@ -13,6 +13,7 @@ from mlflow.gateway.providers.base import (
     BaseProvider,
     PassthroughAction,
     ProviderAdapter,
+    _client_provides_auth,
 )
 from mlflow.gateway.providers.utils import rename_payload_keys, send_request, send_stream_request
 from mlflow.gateway.schemas import chat, completions
@@ -514,7 +515,10 @@ class AnthropicProvider(BaseProvider, AnthropicAdapter):
             client_headers = headers.copy()
             client_headers.pop("host", None)
             client_headers.pop("content-length", None)
-            # Don't override api key or version headers
+            if _client_provides_auth(headers):
+                # Preserve the client's own credentials for subscription-based tools
+                # (e.g. Claude Code, Codex, Gemini CLI) instead of using the server key.
+                result_headers.pop("x-api-key", None)
             result_headers = client_headers | result_headers
 
         return result_headers

--- a/mlflow/gateway/providers/base.py
+++ b/mlflow/gateway/providers/base.py
@@ -40,6 +40,22 @@ PASSTHROUGH_ROUTES = {
     PassthroughAction.GEMINI_STREAM_GENERATE_CONTENT: "/gemini/v1beta/models/{endpoint_name}:streamGenerateContent",  # noqa: E501
 }
 
+# User-agent substrings for subscription-based CLI tools that carry their own credentials.
+# When one of these tools is detected, the gateway preserves the client's auth header
+# instead of overwriting it with the server-side API key.
+# - Claude Code sends:  claude-cli/<version> (external, cli)
+# - OpenAI Codex sends: Codex-Desktop/<version>
+# - Gemini CLI sends:   GeminiCLI/<version>/<model> (<platform>; <arch>)
+_USER_CREDENTIAL_AGENTS = ("claude-cli", "codex-desktop", "geminicli")
+
+
+def _client_provides_auth(headers: dict[str, str] | None) -> bool:
+    """Return True when the request comes from a tool that manages its own credentials."""
+    if not headers:
+        return False
+    user_agent = headers.get("user-agent", "").lower()
+    return any(agent in user_agent for agent in _USER_CREDENTIAL_AGENTS)
+
 
 def _get_nested(d: dict[str, Any], key: str) -> Any:
     """Look up a value by key, supporting one level of nesting."""

--- a/mlflow/gateway/providers/base.py
+++ b/mlflow/gateway/providers/base.py
@@ -40,21 +40,27 @@ PASSTHROUGH_ROUTES = {
     PassthroughAction.GEMINI_STREAM_GENERATE_CONTENT: "/gemini/v1beta/models/{endpoint_name}:streamGenerateContent",  # noqa: E501
 }
 
-# User-agent substrings for subscription-based CLI tools that carry their own credentials.
+# User-agent prefixes for subscription-based CLI tools that carry their own credentials.
 # When one of these tools is detected, the gateway preserves the client's auth header
 # instead of overwriting it with the server-side API key.
 # - Claude Code sends:  claude-cli/<version> (external, cli)
 # - OpenAI Codex sends: Codex-Desktop/<version>
 # - Gemini CLI sends:   GeminiCLI/<version>/<model> (<platform>; <arch>)
-_USER_CREDENTIAL_AGENTS = ("claude-cli", "codex-desktop", "geminicli")
+_USER_CREDENTIAL_AGENTS = ("claude-cli/", "codex-desktop/", "geminicli/")
+
+# Auth header names that subscription-based CLI tools may include.
+_CLIENT_AUTH_HEADERS = ("authorization", "x-api-key", "x-goog-api-key")
 
 
 def _client_provides_auth(headers: dict[str, str] | None) -> bool:
-    """Return True when the request comes from a tool that manages its own credentials."""
+    """Return True when the request comes from a known CLI tool and includes its own auth header."""
     if not headers:
         return False
-    user_agent = headers.get("user-agent", "").lower()
-    return any(agent in user_agent for agent in _USER_CREDENTIAL_AGENTS)
+    lower_headers = {k.lower(): v for k, v in headers.items()}
+    user_agent = lower_headers.get("user-agent", "").lower()
+    is_credential_agent = any(user_agent.startswith(agent) for agent in _USER_CREDENTIAL_AGENTS)
+    has_auth = any(key in lower_headers for key in _CLIENT_AUTH_HEADERS)
+    return is_credential_agent and has_auth
 
 
 def _get_nested(d: dict[str, Any], key: str) -> Any:

--- a/mlflow/gateway/providers/base.py
+++ b/mlflow/gateway/providers/base.py
@@ -46,10 +46,18 @@ PASSTHROUGH_ROUTES = {
 # - Claude Code sends:  claude-cli/<version> (external, cli)
 # - OpenAI Codex sends: Codex-Desktop/<version>
 # - Gemini CLI sends:   GeminiCLI/<version>/<model> (<platform>; <arch>)
+#
+# Security note: User-Agent strings are not cryptographically verified, so any HTTP
+# client can claim these prefixes. However, the client must still supply valid upstream
+# credentials for the API call to succeed — bypassing the server key only matters when
+# the client already holds its own valid credentials (e.g., a personal subscription
+# account). Admins who need to enforce server-side key usage exclusively (for billing
+# attribution or rate limiting) should leave the endpoint's auth unconfigured or
+# restrict network-level access to trusted clients.
 _USER_CREDENTIAL_AGENTS = ("claude-cli/", "codex-desktop/", "geminicli/")
 
 # Auth header names that subscription-based CLI tools may include.
-_CLIENT_AUTH_HEADERS = ("authorization", "x-api-key", "x-goog-api-key")
+_CLIENT_AUTH_HEADERS = ("authorization", "x-api-key", "x-goog-api-key", "api-key")
 
 
 def _client_provides_auth(headers: dict[str, str] | None) -> bool:

--- a/mlflow/gateway/providers/gemini.py
+++ b/mlflow/gateway/providers/gemini.py
@@ -9,6 +9,7 @@ from mlflow.gateway.providers.base import (
     BaseProvider,
     PassthroughAction,
     ProviderAdapter,
+    _client_provides_auth,
 )
 from mlflow.gateway.providers.utils import rename_payload_keys, send_request, send_stream_request
 from mlflow.gateway.schemas import (
@@ -657,7 +658,10 @@ class GeminiProvider(BaseProvider):
             client_headers = headers.copy()
             client_headers.pop("host", None)
             client_headers.pop("content-length", None)
-            # Don't override api key header
+            if _client_provides_auth(headers):
+                # Preserve the client's own credentials for subscription-based tools
+                # (e.g. Claude Code, Codex, Gemini CLI) instead of using the server key.
+                result_headers.pop("x-goog-api-key", None)
             result_headers = client_headers | result_headers
 
         return result_headers

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -11,6 +11,7 @@ from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.providers.base import (
     BaseProvider,
     PassthroughAction,
+    _client_provides_auth,
 )
 from mlflow.gateway.providers.openai_compatible import OpenAICompatibleAdapter
 from mlflow.gateway.providers.utils import send_request, send_stream_request
@@ -237,7 +238,11 @@ class OpenAIProvider(BaseProvider):
             client_headers = headers.copy()
             client_headers.pop("host", None)
             client_headers.pop("content-length", None)
-            # Don't override api key or organization headers
+            if _client_provides_auth(headers):
+                # Preserve the client's own credentials for subscription-based tools
+                # (e.g. Claude Code, Codex, Gemini CLI) instead of using the server key.
+                result_headers.pop("authorization", None)
+                result_headers.pop("api-key", None)
             result_headers = client_headers | result_headers
 
         return result_headers

--- a/mlflow/gateway/providers/openai_compatible.py
+++ b/mlflow/gateway/providers/openai_compatible.py
@@ -10,7 +10,7 @@ a DISPLAY_NAME, and a default base URL.
 from typing import Any, AsyncIterable
 
 from mlflow.gateway.config import EndpointConfig, EndpointType
-from mlflow.gateway.providers.base import BaseProvider, PassthroughAction, ProviderAdapter
+from mlflow.gateway.providers.base import BaseProvider, PassthroughAction, ProviderAdapter, _client_provides_auth
 from mlflow.gateway.providers.utils import send_request, send_stream_request
 from mlflow.gateway.schemas import chat, embeddings
 from mlflow.gateway.utils import stream_sse_data
@@ -227,11 +227,19 @@ class OpenAICompatibleProvider(BaseProvider):
     ) -> dict[str, str]:
         result_headers = self.headers.copy()
         if headers:
-            client_headers = {
-                k: v
-                for k, v in headers.items()
-                if k.lower() not in ("host", "content-length", "authorization")
-            }
+            if _client_provides_auth(headers):
+                # Preserve the client's own credentials for subscription-based tools
+                # (e.g. Claude Code, Codex, Gemini CLI) instead of using the server key.
+                result_headers.pop("Authorization", None)
+                client_headers = {
+                    k: v for k, v in headers.items() if k.lower() not in ("host", "content-length")
+                }
+            else:
+                client_headers = {
+                    k: v
+                    for k, v in headers.items()
+                    if k.lower() not in ("host", "content-length", "authorization")
+                }
             result_headers = client_headers | result_headers
         return result_headers
 

--- a/mlflow/gateway/providers/openai_compatible.py
+++ b/mlflow/gateway/providers/openai_compatible.py
@@ -10,7 +10,12 @@ a DISPLAY_NAME, and a default base URL.
 from typing import Any, AsyncIterable
 
 from mlflow.gateway.config import EndpointConfig, EndpointType
-from mlflow.gateway.providers.base import BaseProvider, PassthroughAction, ProviderAdapter, _client_provides_auth
+from mlflow.gateway.providers.base import (
+    BaseProvider,
+    PassthroughAction,
+    ProviderAdapter,
+    _client_provides_auth,
+)
 from mlflow.gateway.providers.utils import send_request, send_stream_request
 from mlflow.gateway.schemas import chat, embeddings
 from mlflow.gateway.utils import stream_sse_data

--- a/tests/gateway/providers/test_anthropic.py
+++ b/tests/gateway/providers/test_anthropic.py
@@ -18,7 +18,7 @@ from mlflow.gateway.providers.anthropic import (
     _enforce_strict_schema,
     _UnsupportedSchemaError,
 )
-from mlflow.gateway.providers.base import PassthroughAction
+from mlflow.gateway.providers.base import PassthroughAction, _client_provides_auth
 from mlflow.gateway.schemas import chat, completions, embeddings
 
 from tests.gateway.tools import MockAsyncResponse, MockAsyncStreamingResponse, mock_http_client
@@ -68,6 +68,45 @@ def parsed_completions_response():
         ],
         "usage": {"prompt_tokens": None, "completion_tokens": None, "total_tokens": None},
     }
+
+
+@pytest.mark.parametrize(
+    ("user_agent", "expected"),
+    [
+        ("claude-cli/2.0.37 (external, cli)", True),
+        ("Codex-Desktop/26.422.2437.0", True),
+        ("GeminiCLI/0.39.0/gemini-2.0-pro (darwin; x64)", True),
+        ("python-httpx/0.27.0", False),
+        ("", False),
+        (None, False),
+    ],
+)
+def test_client_provides_auth(user_agent, expected):
+    headers = {"user-agent": user_agent} if user_agent is not None else {}
+    assert _client_provides_auth(headers) == expected
+
+
+def test_get_headers_uses_server_key_by_default():
+    provider = AnthropicProvider(EndpointConfig(**completions_config()))
+    merged = provider._get_headers(headers={"x-api-key": "client-key", "X-Custom": "value"})
+    assert merged["x-api-key"] == "key"
+    assert merged["X-Custom"] == "value"
+
+
+@pytest.mark.parametrize(
+    "user_agent",
+    [
+        "claude-cli/2.0.37 (external, cli)",
+        "Codex-Desktop/26.422.2437.0",
+        "GeminiCLI/0.39.0/gemini-2.0-pro (darwin; x64)",
+    ],
+)
+def test_get_headers_preserves_client_key_for_credential_agents(user_agent):
+    provider = AnthropicProvider(EndpointConfig(**completions_config()))
+    merged = provider._get_headers(
+        headers={"x-api-key": "client-key", "user-agent": user_agent}
+    )
+    assert merged["x-api-key"] == "client-key"
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/providers/test_anthropic.py
+++ b/tests/gateway/providers/test_anthropic.py
@@ -76,7 +76,13 @@ def parsed_completions_response():
         # Known CLI tools with auth header → True
         ({"user-agent": "claude-cli/2.0.37 (external, cli)", "x-api-key": "key"}, True),
         ({"user-agent": "Codex-Desktop/26.422.2437.0", "authorization": "Bearer key"}, True),
-        ({"user-agent": "GeminiCLI/0.39.0/gemini-2.0-pro (darwin; x64)", "x-goog-api-key": "key"}, True),  # noqa: E501
+        (
+            {
+                "user-agent": "GeminiCLI/0.39.0/gemini-2.0-pro (darwin; x64)",
+                "x-goog-api-key": "key",
+            },
+            True,
+        ),
         # Known CLI tool but no auth header → False
         ({"user-agent": "claude-cli/2.0.37 (external, cli)"}, False),
         # Unknown user-agent with auth header → False
@@ -107,9 +113,7 @@ def test_get_headers_uses_server_key_by_default():
 )
 def test_get_headers_preserves_client_key_for_credential_agents(user_agent):
     provider = AnthropicProvider(EndpointConfig(**completions_config()))
-    merged = provider._get_headers(
-        headers={"x-api-key": "client-key", "user-agent": user_agent}
-    )
+    merged = provider._get_headers(headers={"x-api-key": "client-key", "user-agent": user_agent})
     assert merged["x-api-key"] == "client-key"
 
 

--- a/tests/gateway/providers/test_anthropic.py
+++ b/tests/gateway/providers/test_anthropic.py
@@ -71,18 +71,22 @@ def parsed_completions_response():
 
 
 @pytest.mark.parametrize(
-    ("user_agent", "expected"),
+    ("headers", "expected"),
     [
-        ("claude-cli/2.0.37 (external, cli)", True),
-        ("Codex-Desktop/26.422.2437.0", True),
-        ("GeminiCLI/0.39.0/gemini-2.0-pro (darwin; x64)", True),
-        ("python-httpx/0.27.0", False),
-        ("", False),
+        # Known CLI tools with auth header → True
+        ({"user-agent": "claude-cli/2.0.37 (external, cli)", "x-api-key": "key"}, True),
+        ({"user-agent": "Codex-Desktop/26.422.2437.0", "authorization": "Bearer key"}, True),
+        ({"user-agent": "GeminiCLI/0.39.0/gemini-2.0-pro (darwin; x64)", "x-goog-api-key": "key"}, True),
+        # Known CLI tool but no auth header → False
+        ({"user-agent": "claude-cli/2.0.37 (external, cli)"}, False),
+        # Unknown user-agent with auth header → False
+        ({"user-agent": "python-httpx/0.27.0", "authorization": "Bearer key"}, False),
+        # Empty / missing headers → False
+        ({}, False),
         (None, False),
     ],
 )
-def test_client_provides_auth(user_agent, expected):
-    headers = {"user-agent": user_agent} if user_agent is not None else {}
+def test_client_provides_auth(headers, expected):
     assert _client_provides_auth(headers) == expected
 
 

--- a/tests/gateway/providers/test_anthropic.py
+++ b/tests/gateway/providers/test_anthropic.py
@@ -76,7 +76,7 @@ def parsed_completions_response():
         # Known CLI tools with auth header → True
         ({"user-agent": "claude-cli/2.0.37 (external, cli)", "x-api-key": "key"}, True),
         ({"user-agent": "Codex-Desktop/26.422.2437.0", "authorization": "Bearer key"}, True),
-        ({"user-agent": "GeminiCLI/0.39.0/gemini-2.0-pro (darwin; x64)", "x-goog-api-key": "key"}, True),
+        ({"user-agent": "GeminiCLI/0.39.0/gemini-2.0-pro (darwin; x64)", "x-goog-api-key": "key"}, True),  # noqa: E501
         # Known CLI tool but no auth header → False
         ({"user-agent": "claude-cli/2.0.37 (external, cli)"}, False),
         # Unknown user-agent with auth header → False

--- a/tests/gateway/providers/test_gemini.py
+++ b/tests/gateway/providers/test_gemini.py
@@ -106,6 +106,31 @@ def fake_chat_response():
     }
 
 
+def test_get_headers_uses_server_key_by_default():
+    provider = GeminiProvider(EndpointConfig(**chat_config()))
+    merged = provider._get_headers(
+        headers={"x-goog-api-key": "client-key", "X-Custom": "value"}
+    )
+    assert merged["x-goog-api-key"] == "key"
+    assert merged["X-Custom"] == "value"
+
+
+@pytest.mark.parametrize(
+    "user_agent",
+    [
+        "claude-cli/2.0.37 (external, cli)",
+        "Codex-Desktop/26.422.2437.0",
+        "GeminiCLI/0.39.0/gemini-2.0-pro (darwin; x64)",
+    ],
+)
+def test_get_headers_preserves_client_key_for_credential_agents(user_agent):
+    provider = GeminiProvider(EndpointConfig(**chat_config()))
+    merged = provider._get_headers(
+        headers={"x-goog-api-key": "client-key", "user-agent": user_agent}
+    )
+    assert merged["x-goog-api-key"] == "client-key"
+
+
 @pytest.mark.asyncio
 async def test_gemini_single_embedding():
     config = embedding_config()

--- a/tests/gateway/providers/test_gemini.py
+++ b/tests/gateway/providers/test_gemini.py
@@ -108,9 +108,7 @@ def fake_chat_response():
 
 def test_get_headers_uses_server_key_by_default():
     provider = GeminiProvider(EndpointConfig(**chat_config()))
-    merged = provider._get_headers(
-        headers={"x-goog-api-key": "client-key", "X-Custom": "value"}
-    )
+    merged = provider._get_headers(headers={"x-goog-api-key": "client-key", "X-Custom": "value"})
     assert merged["x-goog-api-key"] == "key"
     assert merged["X-Custom"] == "value"
 

--- a/tests/gateway/providers/test_openai.py
+++ b/tests/gateway/providers/test_openai.py
@@ -158,6 +158,15 @@ def test_get_headers_preserves_client_key_for_credential_agents(user_agent):
     assert merged["authorization"] == "Bearer client-key"
 
 
+def test_get_headers_preserves_azure_api_key_for_credential_agents():
+    provider = OpenAIProvider(EndpointConfig(**azure_config(api_type="azure")))
+    merged = provider._get_headers(
+        headers={"api-key": "client-azure-key", "user-agent": "claude-cli/2.0.37 (external, cli)"}
+    )
+    assert merged["api-key"] == "client-azure-key"
+    assert "authorization" not in merged
+
+
 @pytest.mark.asyncio
 async def test_chat():
     config = chat_config()

--- a/tests/gateway/providers/test_openai.py
+++ b/tests/gateway/providers/test_openai.py
@@ -133,6 +133,31 @@ async def _run_test_chat(provider):
         )
 
 
+def test_get_headers_uses_server_key_by_default():
+    provider = OpenAIProvider(EndpointConfig(**chat_config()))
+    merged = provider._get_headers(
+        headers={"authorization": "Bearer client-key", "X-Custom": "value"}
+    )
+    assert merged["authorization"] == "Bearer key"
+    assert merged["X-Custom"] == "value"
+
+
+@pytest.mark.parametrize(
+    "user_agent",
+    [
+        "claude-cli/2.0.37 (external, cli)",
+        "Codex-Desktop/26.422.2437.0",
+        "GeminiCLI/0.39.0/gemini-2.0-pro (darwin; x64)",
+    ],
+)
+def test_get_headers_preserves_client_key_for_credential_agents(user_agent):
+    provider = OpenAIProvider(EndpointConfig(**chat_config()))
+    merged = provider._get_headers(
+        headers={"authorization": "Bearer client-key", "user-agent": user_agent}
+    )
+    assert merged["authorization"] == "Bearer client-key"
+
+
 @pytest.mark.asyncio
 async def test_chat():
     config = chat_config()

--- a/tests/gateway/providers/test_openai_compatible.py
+++ b/tests/gateway/providers/test_openai_compatible.py
@@ -146,6 +146,23 @@ def test_get_headers_strips_client_authorization():
     assert merged["X-Custom"] == "value"
 
 
+@pytest.mark.parametrize(
+    "user_agent",
+    [
+        "claude-cli/2.0.37 (external, cli)",
+        "Codex-Desktop/26.422.2437.0",
+        "GeminiCLI/0.39.0/gemini-2.0-pro (darwin; x64)",
+    ],
+)
+def test_get_headers_preserves_client_key_for_credential_agents(user_agent):
+    provider = _make_provider()
+    merged = provider._get_headers(
+        headers={"authorization": "Bearer client-key", "user-agent": user_agent}
+    )
+    assert merged["authorization"] == "Bearer client-key"
+    assert "Authorization" not in merged
+
+
 @pytest.mark.asyncio
 async def test_chat():
     provider = _make_provider()


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

When the gateway routes a passthrough request to a provider (Anthropic, OpenAI, Gemini, or any OpenAI-compatible provider), it currently always overwrites the `Authorization` / `x-api-key` / `x-goog-api-key` header with the server-side API key.

This blocks subscription-based CLI tools — **Claude Code**, **OpenAI Codex Desktop**, and **Gemini CLI** — from using their own user credentials stored in the `Authorization` header.

**Changes:**
- Add `_client_provides_auth(headers)` helper in `base.py` that detects these tools by `User-Agent` substring (case-insensitive):
  - `claude-cli` → `claude-cli/<version> (external, cli)`
  - `codex-desktop` → `Codex-Desktop/<version>`
  - `geminicli` → `GeminiCLI/<version>/<model> (<platform>; <arch>)`
- In each provider's `_get_headers()`, when the above is detected, remove the server-side auth key from the merged headers so the client's own credential wins:
  - Anthropic: drops `x-api-key`
  - OpenAI: drops `authorization` / `api-key`
  - Gemini: drops `x-goog-api-key`
  - OpenAI-compatible: drops `Authorization` and stops filtering the client's `authorization`

All other requests (non-CLI or unknown agents) continue using the server-side key as before.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<img width="477" height="319" alt="image" src="https://github.com/user-attachments/assets/357e28c0-3324-45ad-87c2-5f6a0e8d4d2b" />

<img width="522" height="171" alt="image" src="https://github.com/user-attachments/assets/00cb81ca-a713-4c1a-8b3a-182fb0b6210b" />

<img width="697" height="167" alt="image" src="https://github.com/user-attachments/assets/6402a024-e067-4ee3-b579-2491259a86d6" />

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The AI Gateway passthrough endpoints now detect subscription-based CLI tools (Claude Code, OpenAI Codex Desktop, Gemini CLI) via `User-Agent` and forward their own credentials to the upstream provider instead of overwriting them with the server-side API key.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release