### PR TITLE
Set `mlflow.message.format` on gateway passthrough spans to enable Chat tab

### DIFF
--- a/mlflow/gateway/tracing_utils.py
+++ b/mlflow/gateway/tracing_utils.py
@@ -167,6 +167,7 @@ def maybe_traced_gateway_call(
     request_headers: dict[str, str] | None = None,
     request_type: GatewayRequestType | None = None,
     on_complete: Callable[[], None] | None = None,
+    message_format: str | None = None,
 ) -> Callable[..., Any]:
     """
     Wrap a gateway function with tracing.
@@ -181,6 +182,9 @@ def maybe_traced_gateway_call(
         request_type: The type of gateway request (e.g., GatewayRequestType.CHAT).
         on_complete: A no-arg callback invoked inside the trace context after the
             provider call completes (in ``finally``).
+        message_format: Optional message format string (e.g. ``"anthropic"``,
+            ``"gemini"``) stored as ``mlflow.message.format`` on the span so the
+            UI can render the Chat tab for provider-native response shapes.
 
     Returns:
         A traced version of the function.
@@ -191,9 +195,13 @@ def maybe_traced_gateway_call(
     if not endpoint_config.usage_tracking:
         return func
 
+    span_attributes = _gateway_span_attributes(endpoint_config, request_headers)
+    if message_format:
+        span_attributes[SpanAttributeKey.MESSAGE_FORMAT] = message_format
+
     trace_kwargs = {
         "name": _gateway_span_name(endpoint_config),
-        "attributes": _gateway_span_attributes(endpoint_config, request_headers),
+        "attributes": span_attributes,
         "output_reducer": output_reducer,
         "trace_destination": MlflowExperimentLocation(endpoint_config.experiment_id),
     }

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -1132,6 +1132,7 @@ async def gemini_passthrough_generate_content(endpoint_name: str, request: Reque
         request_headers=headers,
         request_type=GatewayRequestType.PASSTHROUGH_MODEL_GEMINI_GENERATE_CONTENT,
         on_complete=make_budget_on_complete(store, workspace),
+        message_format="gemini",
     )
     return await traced_passthrough(
         action=PassthroughAction.GEMINI_GENERATE_CONTENT, payload=body, headers=headers

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -1068,6 +1068,7 @@ async def anthropic_passthrough_messages(request: Request):
             request_headers=headers,
             request_type=GatewayRequestType.PASSTHROUGH_MODEL_ANTHROPIC_MESSAGES,
             on_complete=make_budget_on_complete(store, workspace),
+            message_format="anthropic",
         )
         return StreamingResponse(
             safe_stream(traced_stream(body), as_bytes=True), media_type="text/event-stream"
@@ -1080,6 +1081,7 @@ async def anthropic_passthrough_messages(request: Request):
         request_headers=headers,
         request_type=GatewayRequestType.PASSTHROUGH_MODEL_ANTHROPIC_MESSAGES,
         on_complete=make_budget_on_complete(store, workspace),
+        message_format="anthropic",
     )
     return await traced_passthrough(
         action=PassthroughAction.ANTHROPIC_MESSAGES, payload=body, headers=headers
@@ -1190,6 +1192,7 @@ async def gemini_passthrough_stream_generate_content(endpoint_name: str, request
         request_headers=headers,
         request_type=GatewayRequestType.PASSTHROUGH_MODEL_GEMINI_GENERATE_CONTENT,
         on_complete=make_budget_on_complete(store, workspace),
+        message_format="gemini",
     )
     return StreamingResponse(
         safe_stream(traced_stream(body), as_bytes=True), media_type="text/event-stream"

--- a/tests/gateway/test_tracing_utils.py
+++ b/tests/gateway/test_tracing_utils.py
@@ -325,7 +325,10 @@ async def test_maybe_traced_gateway_call_with_message_format(endpoint_config):
 
     traces = get_traces()
     assert len(traces) == 1
-    gateway_span = traces[0].data.spans[0]
+    trace = traces[0]
+
+    span_name_to_span = {span.name: span for span in trace.data.spans}
+    gateway_span = span_name_to_span[f"gateway/{endpoint_config.endpoint_name}"]
     assert gateway_span.get_attribute("mlflow.message.format") == "anthropic"
 
 

--- a/tests/gateway/test_tracing_utils.py
+++ b/tests/gateway/test_tracing_utils.py
@@ -330,20 +330,6 @@ async def test_maybe_traced_gateway_call_with_message_format(endpoint_config):
 
 
 @pytest.mark.asyncio
-async def test_maybe_traced_gateway_call_without_message_format(endpoint_config):
-    async def mock_async_func(payload):
-        return {"result": "ok"}
-
-    traced_func = maybe_traced_gateway_call(mock_async_func, endpoint_config)
-    await traced_func({"messages": [{"role": "user", "content": "hi"}]})
-
-    traces = get_traces()
-    assert len(traces) == 1
-    gateway_span = traces[0].data.spans[0]
-    assert gateway_span.get_attribute("mlflow.message.format") is None
-
-
-@pytest.mark.asyncio
 async def test_maybe_traced_gateway_call_with_payload_kwarg(endpoint_config):
     async def mock_passthrough_func(action, payload, headers=None):
         return {"result": "success", "action": action, "payload": payload}

--- a/tests/gateway/test_tracing_utils.py
+++ b/tests/gateway/test_tracing_utils.py
@@ -312,6 +312,38 @@ async def test_maybe_traced_gateway_call_with_output_reducer(endpoint_config):
 
 
 @pytest.mark.asyncio
+async def test_maybe_traced_gateway_call_with_message_format(endpoint_config):
+    async def mock_async_func(payload):
+        return {"id": "msg_1", "type": "message", "role": "assistant", "content": []}
+
+    traced_func = maybe_traced_gateway_call(
+        mock_async_func,
+        endpoint_config,
+        message_format="anthropic",
+    )
+    await traced_func({"messages": [{"role": "user", "content": "hi"}]})
+
+    traces = get_traces()
+    assert len(traces) == 1
+    gateway_span = traces[0].data.spans[0]
+    assert gateway_span.get_attribute("mlflow.message.format") == "anthropic"
+
+
+@pytest.mark.asyncio
+async def test_maybe_traced_gateway_call_without_message_format(endpoint_config):
+    async def mock_async_func(payload):
+        return {"result": "ok"}
+
+    traced_func = maybe_traced_gateway_call(mock_async_func, endpoint_config)
+    await traced_func({"messages": [{"role": "user", "content": "hi"}]})
+
+    traces = get_traces()
+    assert len(traces) == 1
+    gateway_span = traces[0].data.spans[0]
+    assert gateway_span.get_attribute("mlflow.message.format") is None
+
+
+@pytest.mark.asyncio
 async def test_maybe_traced_gateway_call_with_payload_kwarg(endpoint_config):
     async def mock_passthrough_func(action, payload, headers=None):
         return {"result": "success", "action": action, "payload": payload}


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22763, #22764, #22775

### What changes are proposed in this pull request?

Anthropic Messages API and Gemini `streamGenerateContent` passthrough responses use provider-native JSON shapes. Without `mlflow.message.format` set on the span, the trace explorer's `normalizeConversation` falls through to the OpenAI/Langchain default case and returns `null` — so the Chat tab never appears.

This PR:
- Adds a `message_format: str | None` parameter to `maybe_traced_gateway_call` in `mlflow/gateway/tracing_utils.py`. When provided, it is written as `mlflow.message.format` into the root span attributes.
- Passes `message_format="anthropic"` for both streaming and non-streaming Anthropic Messages passthrough calls.
- Passes `message_format="gemini"` for the Gemini `streamGenerateContent` passthrough call.

With this change the UI routes outputs through `normalizeAnthropicChatOutput` / `normalizeGeminiChatOutput`, enabling the Chat tab for these passthrough traces.

### How is this PR tested?

- [x] New unit/integration tests

Added `test_maybe_traced_gateway_call_with_message_format` and `test_maybe_traced_gateway_call_without_message_format` in `tests/gateway/test_tracing_utils.py`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The Chat tab now renders correctly for Anthropic Messages API and Gemini `streamGenerateContent` gateway passthrough traces.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release