### PR TITLE
Fix uv custom index URLs omitted from model `requirements.txt`

### DIFF
--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -48,6 +48,7 @@ from mlflow.utils.timeout import MlflowTimeoutError, run_with_timeout
 from mlflow.utils.uv_utils import (
     detect_uv_project,
     export_uv_requirements,
+    extract_index_urls_from_uv_lock,
 )
 from mlflow.version import VERSION
 
@@ -461,7 +462,9 @@ def infer_pip_requirements(
                     f"Successfully exported {len(uv_requirements)} requirements from uv project. "
                     "Skipping package capture based inference."
                 )
-                return uv_requirements
+                private_index_urls = extract_index_urls_from_uv_lock(uv_project.uv_lock)
+                index_url_reqs = [f"--extra-index-url {url}" for url in private_index_urls]
+                return index_url_reqs + uv_requirements
             else:
                 _logger.warning(
                     "uv export failed or returned no requirements. "

--- a/tests/utils/test_uv_utils.py
+++ b/tests/utils/test_uv_utils.py
@@ -567,6 +567,70 @@ def test_infer_pip_requirements_explicit_uv_project_dir_overrides_disabled_auto_
         assert "numpy==1.24.0" in result
 
 
+def test_infer_pip_requirements_prepends_extra_index_urls_for_private_indexes(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("MLFLOW_UV_AUTO_DETECT", "true")
+
+    uv_lock_content = """version = 1
+requires-python = ">=3.10"
+
+[[package]]
+name = "my-internal-utils"
+version = "0.2.7"
+source = { registry = "https://pypi.internal.example.com/simple" }
+
+[[package]]
+name = "scikit-learn"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+"""
+    (tmp_path / _UV_LOCK_FILE).write_text(uv_lock_content)
+    (tmp_path / _PYPROJECT_FILE).touch()
+
+    mock_result = mock.Mock()
+    mock_result.stdout = "my-internal-utils==0.2.7\nscikit-learn==1.3.0\n"
+
+    with (
+        mock.patch("mlflow.utils.uv_utils._get_uv_binary", return_value="/usr/bin/uv"),
+        mock.patch("mlflow.utils.uv_utils.subprocess.run", return_value=mock_result),
+    ):
+        result = infer_pip_requirements("runs:/fake/model", "sklearn")
+
+    assert "--extra-index-url https://pypi.internal.example.com/simple" in result
+    assert "my-internal-utils==0.2.7" in result
+    assert "scikit-learn==1.3.0" in result
+
+
+def test_infer_pip_requirements_no_extra_index_urls_when_no_private_indexes(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("MLFLOW_UV_AUTO_DETECT", "true")
+
+    uv_lock_content = """version = 1
+requires-python = ">=3.10"
+
+[[package]]
+name = "scikit-learn"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+"""
+    (tmp_path / _UV_LOCK_FILE).write_text(uv_lock_content)
+    (tmp_path / _PYPROJECT_FILE).touch()
+
+    mock_result = mock.Mock()
+    mock_result.stdout = "scikit-learn==1.3.0\n"
+
+    with (
+        mock.patch("mlflow.utils.uv_utils._get_uv_binary", return_value="/usr/bin/uv"),
+        mock.patch("mlflow.utils.uv_utils.subprocess.run", return_value=mock_result),
+    ):
+        result = infer_pip_requirements("runs:/fake/model", "sklearn")
+
+    assert not any(req.startswith("--extra-index-url") for req in result)
+    assert "scikit-learn==1.3.0" in result
+
+
 def test_export_uv_requirements_strips_comment_lines(tmp_path):
     uv_output = """requests==2.28.0
 # via


### PR DESCRIPTION
### Related Issues/PRs

Closes #22881

### What changes are proposed in this pull request?

When a uv project declares a custom package index via `[[tool.uv.index]]`, `uv export` intentionally omits the index URL from its output (by design — see [uv#13572](https://github.com/astral-sh/uv/issues/13572)). MLflow then logs the incomplete requirements, causing `pip install` to fail at model serving time because packages sourced from the private index can't be resolved.

**Fix:** After `export_uv_requirements()` succeeds, call the existing `extract_index_urls_from_uv_lock()` helper to find all non-PyPI registry URLs in `uv.lock`, and prepend an `--extra-index-url <url>` line for each one to the returned requirements list.

The `--extra-index-url` entries survive the downstream `_deduplicate_requirements` and `warn_dependency_requirement_mismatches` pipelines because both functions already handle non-standard requirement strings gracefully.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Two new unit tests in `tests/utils/test_uv_utils.py`:
- `test_infer_pip_requirements_prepends_extra_index_urls_for_private_indexes` — verifies `--extra-index-url` is added when a uv.lock references a non-PyPI registry
- `test_infer_pip_requirements_no_extra_index_urls_when_no_private_indexes` — verifies no `--extra-index-url` lines are added for PyPI-only projects

Manual end-to-end repro: created a real uv project whose lock file resolved packages through `https://pypi-proxy.dev.databricks.com/simple/`. Logged a pyfunc model; the generated `requirements.txt` now correctly contains:
```
--extra-index-url https://pypi-proxy.dev.databricks.com/simple/
numpy==2.2.6; python_full_version < "3.11"
numpy==2.4.4; python_full_version >= "3.11"
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. When logging a model from a uv project that uses a custom package index, MLflow now includes `--extra-index-url` entries in the generated `requirements.txt` so that private packages can be resolved at model serving time.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Claude.