### PR TITLE
feat: record caller in gateway traces from request headers

### DIFF
--- a/mlflow/gateway/tracing_utils.py
+++ b/mlflow/gateway/tracing_utils.py
@@ -10,6 +10,7 @@ import mlflow
 from mlflow.entities import SpanStatus, SpanType
 from mlflow.entities.trace_location import MlflowExperimentLocation
 from mlflow.gateway.config import GatewayRequestType
+from mlflow.gateway.constants import MLFLOW_GATEWAY_CALLER_HEADER
 from mlflow.gateway.schemas.chat import StreamResponsePayload
 from mlflow.gateway.utils import parse_sse_lines
 from mlflow.store.tracking.gateway.entities import GatewayEndpointConfig
@@ -27,6 +28,25 @@ class _ModelSpanInfo:
     status: SpanStatus | None = None
     start_time_ns: int | None = None
     end_time_ns: int | None = None
+
+
+def _extract_caller(request_headers: dict[str, str] | None) -> str | None:
+    """Extract a caller identifier from request headers.
+
+    Checks the ``X-MLflow-Gateway-Caller`` header first, then falls back to the
+    product token of the ``User-Agent`` header (the part before the first ``/``).
+    Returns ``None`` when no useful identifier is found.
+    """
+    if not request_headers:
+        return None
+    lower = {k.lower(): v for k, v in request_headers.items()}
+    if caller := lower.get(MLFLOW_GATEWAY_CALLER_HEADER.lower()):
+        return caller
+    if user_agent := lower.get("user-agent", ""):
+        product = user_agent.split("/")[0].strip()
+        if product:
+            return product
+    return None
 
 
 def _maybe_unwrap_single_arg_input(args: tuple[Any], kwargs: dict[str, Any]):
@@ -211,6 +231,8 @@ def maybe_traced_gateway_call(
     combined_metadata[TraceMetadataKey.GATEWAY_ENDPOINT_ID] = endpoint_config.endpoint_id
     if request_type:
         combined_metadata[TraceMetadataKey.GATEWAY_REQUEST_TYPE] = request_type
+    if caller := _extract_caller(request_headers):
+        combined_metadata[TraceMetadataKey.GATEWAY_CALLER] = caller
 
     # Wrap function to set metadata inside the trace context
     if inspect.isasyncgenfunction(func):

--- a/mlflow/gateway/tracing_utils.py
+++ b/mlflow/gateway/tracing_utils.py
@@ -43,8 +43,7 @@ def _extract_caller(request_headers: dict[str, str] | None) -> str | None:
     if caller := lower.get(MLFLOW_GATEWAY_CALLER_HEADER.lower()):
         return caller
     if user_agent := lower.get("user-agent", ""):
-        product = user_agent.split("/")[0].strip()
-        if product:
+        if product := user_agent.split("/")[0].strip():
             return product
     return None
 

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -31,6 +31,7 @@ class TraceMetadataKey:
     # Gateway-specific metadata keys
     GATEWAY_ENDPOINT_ID = "mlflow.gateway.endpointId"
     GATEWAY_REQUEST_TYPE = "mlflow.gateway.requestType"
+    GATEWAY_CALLER = "mlflow.gateway.caller"
     # Store the user ID/name from authentication
     AUTH_USER_ID = "mlflow.auth.userId"
     AUTH_USERNAME = "mlflow.auth.username"

--- a/tests/gateway/test_tracing_utils.py
+++ b/tests/gateway/test_tracing_utils.py
@@ -1049,3 +1049,67 @@ def test_aggregate_gemini_stream_chunks_finish_reason(finish_reasons, expected):
     chunks = [_gemini_text_chunk(f"t{i}", finish_reason=fr) for i, fr in enumerate(finish_reasons)]
     result = aggregate_gemini_stream_generate_content_chunks(chunks)
     assert result["candidates"][0]["finishReason"] == expected
+
+
+# ---------------------------------------------------------------------------
+# _extract_caller tests
+# ---------------------------------------------------------------------------
+
+
+from mlflow.gateway.constants import MLFLOW_GATEWAY_CALLER_HEADER
+from mlflow.gateway.tracing_utils import _extract_caller
+
+
+@pytest.mark.parametrize(
+    ("headers", "expected"),
+    [
+        (None, None),
+        ({}, None),
+        ({"User-Agent": "openai-python/1.0.0"}, "openai-python"),
+        ({"user-agent": "claude-cli/1.2.3"}, "claude-cli"),
+        ({"User-Agent": "GeminiCLI/1.0 (Linux; x64)"}, "GeminiCLI"),
+        ({"User-Agent": "anthropic/0.20.0 CPython/3.11.0 Darwin/23.0.0"}, "anthropic"),
+        (
+            {MLFLOW_GATEWAY_CALLER_HEADER: "judge", "User-Agent": "openai-python/1.0.0"},
+            "judge",
+        ),
+        ({MLFLOW_GATEWAY_CALLER_HEADER: "judge"}, "judge"),
+        ({"User-Agent": "   "}, None),
+    ],
+)
+def test_extract_caller(headers, expected):
+    assert _extract_caller(headers) == expected
+
+
+def test_maybe_traced_gateway_call_records_caller(endpoint_config):
+    async def fake_func(payload):
+        return {"ok": True}
+
+    traced = maybe_traced_gateway_call(
+        fake_func,
+        endpoint_config,
+        request_headers={"User-Agent": "openai-python/1.0.0"},
+    )
+
+    import asyncio
+
+    asyncio.get_event_loop().run_until_complete(traced({"prompt": "hi"}))
+
+    traces = get_traces()
+    assert traces
+    assert traces[0].info.request_metadata.get(TraceMetadataKey.GATEWAY_CALLER) == "openai-python"
+
+
+def test_maybe_traced_gateway_call_no_caller_when_no_headers(endpoint_config):
+    async def fake_func(payload):
+        return {"ok": True}
+
+    traced = maybe_traced_gateway_call(fake_func, endpoint_config, request_headers=None)
+
+    import asyncio
+
+    asyncio.get_event_loop().run_until_complete(traced({"prompt": "hi"}))
+
+    traces = get_traces()
+    assert traces
+    assert TraceMetadataKey.GATEWAY_CALLER not in (traces[0].info.request_metadata or {})

--- a/tests/gateway/test_tracing_utils.py
+++ b/tests/gateway/test_tracing_utils.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from typing import Any
 
@@ -5,8 +6,10 @@ import pytest
 
 import mlflow
 from mlflow.entities import SpanType
+from mlflow.gateway.constants import MLFLOW_GATEWAY_CALLER_HEADER
 from mlflow.gateway.schemas.chat import StreamResponsePayload
 from mlflow.gateway.tracing_utils import (
+    _extract_caller,
     _get_model_span_info,
     aggregate_anthropic_messages_stream_chunks,
     aggregate_chat_stream_chunks,
@@ -1056,10 +1059,6 @@ def test_aggregate_gemini_stream_chunks_finish_reason(finish_reasons, expected):
 # ---------------------------------------------------------------------------
 
 
-from mlflow.gateway.constants import MLFLOW_GATEWAY_CALLER_HEADER
-from mlflow.gateway.tracing_utils import _extract_caller
-
-
 @pytest.mark.parametrize(
     ("headers", "expected"),
     [
@@ -1091,8 +1090,6 @@ def test_maybe_traced_gateway_call_records_caller(endpoint_config):
         request_headers={"User-Agent": "openai-python/1.0.0"},
     )
 
-    import asyncio
-
     asyncio.get_event_loop().run_until_complete(traced({"prompt": "hi"}))
 
     traces = get_traces()
@@ -1105,8 +1102,6 @@ def test_maybe_traced_gateway_call_no_caller_when_no_headers(endpoint_config):
         return {"ok": True}
 
     traced = maybe_traced_gateway_call(fake_func, endpoint_config, request_headers=None)
-
-    import asyncio
 
     asyncio.get_event_loop().run_until_complete(traced({"prompt": "hi"}))
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22917

### What changes are proposed in this pull request?

Adds `TraceMetadataKey.GATEWAY_CALLER` (`mlflow.gateway.caller`) and populates it automatically in `maybe_traced_gateway_call` by inspecting incoming request headers:

1. `X-MLflow-Gateway-Caller` header (explicit, takes precedence — already used by internal callers like `judge`)
2. `User-Agent` product token as fallback (e.g. `openai-python/1.0.0` → `openai-python`, `claude-cli/1.2.3` → `claude-cli`)

This makes it easy to filter or group gateway traces by the calling client (SDK, CLI tool, internal service, etc.) in the MLflow UI.

### How is this PR tested?

- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Gateway traces now record the calling client in the `mlflow.gateway.caller` trace metadata field, populated from the `X-MLflow-Gateway-Caller` header or the `User-Agent` product token.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release