### PR TITLE
[Admin-UI-1/4] Add backend auth endpoints

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -193,8 +193,12 @@ from mlflow.server.auth.routes import (
     AJAX_ADD_ROLE_PERMISSION,
     AJAX_ASSIGN_ROLE,
     AJAX_CREATE_ROLE,
+    AJAX_CREATE_USER,
     AJAX_DELETE_ROLE,
+    AJAX_DELETE_USER,
+    AJAX_GET_CURRENT_USER,
     AJAX_GET_ROLE,
+    AJAX_GET_USER,
     AJAX_LIST_ROLE_PERMISSIONS,
     AJAX_LIST_ROLE_USERS,
     AJAX_LIST_ROLES,
@@ -204,6 +208,8 @@ from mlflow.server.auth.routes import (
     AJAX_UNASSIGN_ROLE,
     AJAX_UPDATE_ROLE,
     AJAX_UPDATE_ROLE_PERMISSION,
+    AJAX_UPDATE_USER_ADMIN,
+    AJAX_UPDATE_USER_PASSWORD,
     ASSIGN_ROLE,
     CREATE_EXPERIMENT_PERMISSION,
     CREATE_GATEWAY_ENDPOINT_PERMISSION,
@@ -229,6 +235,7 @@ from mlflow.server.auth.routes import (
     GATEWAY_SUPPORTED_MODELS,
     GATEWAY_SUPPORTED_PROVIDERS,
     GET_ARTIFACT,
+    GET_CURRENT_USER,
     GET_EXPERIMENT_PERMISSION,
     GET_GATEWAY_ENDPOINT_PERMISSION,
     GET_GATEWAY_MODEL_DEFINITION_PERMISSION,
@@ -250,6 +257,7 @@ from mlflow.server.auth.routes import (
     LIST_USER_WORKSPACE_PERMISSIONS,
     LIST_USERS,
     LIST_WORKSPACE_PERMISSIONS,
+    LOGOUT,
     REMOVE_ROLE_PERMISSION,
     SEARCH_DATASETS,
     SIGNUP,
@@ -269,6 +277,7 @@ from mlflow.server.auth.routes import (
 from mlflow.server.auth.sqlalchemy_store import SqlAlchemyStore
 from mlflow.server.fastapi_app import create_fastapi_app
 from mlflow.server.handlers import (
+    _add_static_prefix,
     _disable_if_workspaces_disabled,
     _get_ajax_path,
     _get_model_registry_store,
@@ -389,8 +398,24 @@ def _invalidate_user_auth_cache(username: str) -> None:
             _USER_AUTH_CACHE.pop(key, None)
 
 
+_UNPROTECTED_PATH_PREFIXES = ("/static", "/favicon.ico", "/health")
+
+
 def is_unprotected_route(path: str) -> bool:
-    return path.startswith(("/static", "/favicon.ico", "/health"))
+    # /logout is intentionally unauthenticated. The handler returns 200 with an
+    # HTML page that performs an XHR with bogus credentials against
+    # /ajax-api/2.0/mlflow/users/current; that XHR receives 401 with
+    # WWW-Authenticate, which causes the browser to drop its cached Basic Auth
+    # credentials. Running /logout through the auth middleware would block the
+    # page from loading at all when the user lacks valid creds.
+    if path == LOGOUT:
+        return True
+    # When ``_MLFLOW_STATIC_PREFIX`` is set, the health/static routes are
+    # actually served from e.g. ``/mlflow/health``, not ``/health``. Match
+    # both the unprefixed and the prefixed forms so health checks don't end
+    # up requiring auth on prefixed deployments.
+    prefixed = tuple(_add_static_prefix(p) for p in _UNPROTECTED_PATH_PREFIXES)
+    return path.startswith(_UNPROTECTED_PATH_PREFIXES) or path.startswith(prefixed)
 
 
 def make_basic_auth_response() -> Response:
@@ -414,9 +439,14 @@ def _get_request_param(param: str) -> str:
     if request.method == "GET":
         args = request.args
     elif request.method in ("POST", "PATCH"):
-        args = request.json
+        # ``request.json`` can be ``None`` when the body is literal ``null`` (or an
+        # empty body under ``application/json``) — falling through to ``None | dict``
+        # would raise a TypeError that ``catch_mlflow_exception`` doesn't intercept,
+        # surfacing as a 500. Coerce to an empty dict so callers get the standard
+        # "missing parameter" 400 instead.
+        args = request.get_json(silent=True) or {}
     elif request.method == "DELETE":
-        args = request.json if request.is_json else request.args
+        args = (request.get_json(silent=True) or {}) if request.is_json else request.args
     else:
         raise MlflowException(
             f"Unsupported HTTP method '{request.method}'",
@@ -1979,12 +2009,21 @@ BEFORE_REQUEST_VALIDATORS = {
 BEFORE_REQUEST_VALIDATORS.update({
     (SIGNUP, "GET"): validate_can_create_user,
     (GET_USER, "GET"): validate_can_read_user,
+    (AJAX_GET_USER, "GET"): validate_can_read_user,
+    # /current returns only the authenticated user's own identity — any
+    # authenticated user may read it.
+    (GET_CURRENT_USER, "GET"): lambda: True,
+    (AJAX_GET_CURRENT_USER, "GET"): lambda: True,
     (LIST_USERS, "GET"): validate_can_list_users,
     (AJAX_LIST_USERS, "GET"): validate_can_list_users,
     (CREATE_USER, "POST"): validate_can_create_user,
+    (AJAX_CREATE_USER, "POST"): validate_can_create_user,
     (UPDATE_USER_PASSWORD, "PATCH"): validate_can_update_user_password,
+    (AJAX_UPDATE_USER_PASSWORD, "PATCH"): validate_can_update_user_password,
     (UPDATE_USER_ADMIN, "PATCH"): validate_can_update_user_admin,
+    (AJAX_UPDATE_USER_ADMIN, "PATCH"): validate_can_update_user_admin,
     (DELETE_USER, "DELETE"): validate_can_delete_user,
+    (AJAX_DELETE_USER, "DELETE"): validate_can_delete_user,
     (GET_EXPERIMENT_PERMISSION, "GET"): validate_can_manage_experiment,
     (CREATE_EXPERIMENT_PERMISSION, "POST"): validate_can_manage_experiment,
     (UPDATE_EXPERIMENT_PERMISSION, "PATCH"): validate_can_manage_experiment,
@@ -3032,6 +3071,49 @@ def alert(href: str):
     )
 
 
+def logout():
+    # HTTP Basic Auth has no server-side session. The reliable way to
+    # invalidate the browser's credential cache is the "XHR with bogus
+    # creds" trick: an XHR with explicit wrong user/password overrides
+    # the cached creds for the realm. Subsequent auto-auth attempts then
+    # fail and the browser prompts fresh. We use async XHR (sync XHR on
+    # the main thread is deprecated and blocked by some browser policies),
+    # so the post-clear UI update is gated on ``onloadend``.
+    body = (
+        "<!DOCTYPE html>"
+        "<html><head><title>Logged out</title></head>"
+        "<body style='font-family: sans-serif; padding: 2rem;'>"
+        "<h2>Signing you out…</h2>"
+        "<p id='msg'>Clearing credentials — please wait.</p>"
+        "<p style='margin-top: 2rem;'>"
+        "<a id='home' href='./' style='display: none;'>Return to MLflow</a>"
+        "</p>"
+        "<script>"
+        "  function done() {"
+        "    document.getElementById('msg').textContent ="
+        "      'You have been signed out. Redirecting to MLflow…';"
+        "    document.getElementById('home').style.display = 'inline';"
+        # Redirect after a short pause so the user sees confirmation
+        # that logout actually happened before the browser re-prompts.
+        # The manual link stays visible as a fallback in case JS is
+        # blocked by an extension or the redirect is slow.
+        "    setTimeout(function() { window.location.href = './'; }, 2000);"
+        "  }"
+        "  try {"
+        "    var xhr = new XMLHttpRequest();"
+        "    xhr.open('GET', './ajax-api/2.0/mlflow/users/current', true,"
+        "             'mlflow-logged-out', 'mlflow-logged-out');"
+        "    xhr.onloadend = done;"
+        "    xhr.send();"
+        "  } catch (e) { done(); }"
+        "</script>"
+        "</body></html>"
+    )
+    res = make_response(body, 200)
+    res.headers["Content-Type"] = "text/html; charset=utf-8"
+    return res
+
+
 def signup():
     return render_template_string(
         r"""
@@ -3134,20 +3216,17 @@ def create_user_ui(csrf):
 
 @catch_mlflow_exception
 def create_user():
-    content_type = request.headers.get("Content-Type")
-    if content_type == "application/json":
-        username = _get_request_param("username")
-        password = _get_request_param("password")
+    if not request.is_json:
+        return make_response("Invalid content type. Must be application/json", 400)
 
-        if not username or not password:
-            message = "Username and password cannot be empty."
-            return make_response(message, 400)
+    username = _get_request_param("username")
+    password = _get_request_param("password")
 
-        user = store.create_user(username, password)
-        return jsonify({"user": user.to_json()})
-    else:
-        message = "Invalid content type. Must be application/json"
-        return make_response(message, 400)
+    if not username or not password:
+        return make_response("Username and password cannot be empty.", 400)
+
+    user = store.create_user(username, password)
+    return jsonify({"user": user.to_json()})
 
 
 @catch_mlflow_exception
@@ -3160,13 +3239,47 @@ def get_user():
 @catch_mlflow_exception
 def list_users():
     users = store.list_users()
-    return jsonify({"users": [{"id": u.id, "username": u.username} for u in users]})
+    return jsonify({
+        "users": [{"id": u.id, "username": u.username, "is_admin": u.is_admin} for u in users]
+    })
+
+
+@catch_mlflow_exception
+def get_current_user():
+    # HTTP Basic Auth doesn't set any identifying cookie, so the frontend has
+    # no way to know *which* user the browser authenticated as. This endpoint
+    # returns minimal identity info (no password hash, no permission arrays)
+    # for the currently authenticated user.
+    username = authenticate_request().username
+    user = store.get_user(username)
+    return jsonify({"user": {"id": user.id, "username": user.username, "is_admin": user.is_admin}})
 
 
 @catch_mlflow_exception
 def update_user_password():
     username = _get_request_param("username")
     password = _get_request_param("password")
+    # Self-service password changes must re-assert the current password as a
+    # defense-in-depth check: the Basic Auth header on the request already
+    # proves identity, but a walk-up attacker on a logged-in browser session
+    # would otherwise be able to silently rotate the password and lock out
+    # the legitimate user. Admins changing *someone else's* password bypass
+    # this (they don't and can't supply the target's current password).
+    sender = authenticate_request()
+    sender_username = getattr(sender, "username", None)
+    if sender_username == username:
+        body = request.get_json(silent=True) or {}
+        current_password = body.get("current_password")
+        if not current_password:
+            raise MlflowException(
+                "Current password is required when changing your own password.",
+                INVALID_PARAMETER_VALUE,
+            )
+        if not store.authenticate_user(username, current_password):
+            raise MlflowException(
+                "Current password does not match.",
+                INVALID_PARAMETER_VALUE,
+            )
     store.update_user(username, password=password)
     _invalidate_user_auth_cache(username)
     return make_response({})
@@ -3944,41 +4057,57 @@ def create_app(app: Flask = app):
         methods=["GET"],
     )
     app.add_url_rule(
+        rule=LOGOUT,
+        view_func=logout,
+        methods=["GET", "POST"],
+    )
+    app.add_url_rule(
         rule=CREATE_USER_UI,
         view_func=lambda: create_user_ui(csrf),
         methods=["POST"],
     )
-    app.add_url_rule(
-        rule=CREATE_USER,
-        view_func=create_user,
-        methods=["POST"],
-    )
-    app.add_url_rule(
-        rule=GET_USER,
-        view_func=get_user,
-        methods=["GET"],
-    )
+    for rule in [CREATE_USER, AJAX_CREATE_USER]:
+        app.add_url_rule(
+            rule=rule,
+            view_func=create_user,
+            methods=["POST"],
+        )
+    for rule in [GET_USER, AJAX_GET_USER]:
+        app.add_url_rule(
+            rule=rule,
+            view_func=get_user,
+            methods=["GET"],
+        )
     for rule in [LIST_USERS, AJAX_LIST_USERS]:
         app.add_url_rule(
             rule=rule,
             view_func=list_users,
             methods=["GET"],
         )
-    app.add_url_rule(
-        rule=UPDATE_USER_PASSWORD,
-        view_func=update_user_password,
-        methods=["PATCH"],
-    )
-    app.add_url_rule(
-        rule=UPDATE_USER_ADMIN,
-        view_func=update_user_admin,
-        methods=["PATCH"],
-    )
-    app.add_url_rule(
-        rule=DELETE_USER,
-        view_func=delete_user,
-        methods=["DELETE"],
-    )
+    for rule in [GET_CURRENT_USER, AJAX_GET_CURRENT_USER]:
+        app.add_url_rule(
+            rule=rule,
+            view_func=get_current_user,
+            methods=["GET"],
+        )
+    for rule in [UPDATE_USER_PASSWORD, AJAX_UPDATE_USER_PASSWORD]:
+        app.add_url_rule(
+            rule=rule,
+            view_func=update_user_password,
+            methods=["PATCH"],
+        )
+    for rule in [UPDATE_USER_ADMIN, AJAX_UPDATE_USER_ADMIN]:
+        app.add_url_rule(
+            rule=rule,
+            view_func=update_user_admin,
+            methods=["PATCH"],
+        )
+    for rule in [DELETE_USER, AJAX_DELETE_USER]:
+        app.add_url_rule(
+            rule=rule,
+            view_func=delete_user,
+            methods=["DELETE"],
+        )
     app.add_url_rule(
         rule=CREATE_EXPERIMENT_PERMISSION,
         view_func=create_experiment_permission,

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -257,7 +257,6 @@ from mlflow.server.auth.routes import (
     LIST_USER_WORKSPACE_PERMISSIONS,
     LIST_USERS,
     LIST_WORKSPACE_PERMISSIONS,
-    LOGOUT,
     REMOVE_ROLE_PERMISSION,
     SEARCH_DATASETS,
     SIGNUP,
@@ -402,14 +401,6 @@ _UNPROTECTED_PATH_PREFIXES = ("/static", "/favicon.ico", "/health")
 
 
 def is_unprotected_route(path: str) -> bool:
-    # /logout is intentionally unauthenticated. The handler returns 200 with an
-    # HTML page that performs an XHR with bogus credentials against
-    # /ajax-api/2.0/mlflow/users/current; that XHR receives 401 with
-    # WWW-Authenticate, which causes the browser to drop its cached Basic Auth
-    # credentials. Running /logout through the auth middleware would block the
-    # page from loading at all when the user lacks valid creds.
-    if path == LOGOUT:
-        return True
     # When ``_MLFLOW_STATIC_PREFIX`` is set, the health/static routes are
     # actually served from e.g. ``/mlflow/health``, not ``/health``. Match
     # both the unprefixed and the prefixed forms so health checks don't end
@@ -3071,49 +3062,6 @@ def alert(href: str):
     )
 
 
-def logout():
-    # HTTP Basic Auth has no server-side session. The reliable way to
-    # invalidate the browser's credential cache is the "XHR with bogus
-    # creds" trick: an XHR with explicit wrong user/password overrides
-    # the cached creds for the realm. Subsequent auto-auth attempts then
-    # fail and the browser prompts fresh. We use async XHR (sync XHR on
-    # the main thread is deprecated and blocked by some browser policies),
-    # so the post-clear UI update is gated on ``onloadend``.
-    body = (
-        "<!DOCTYPE html>"
-        "<html><head><title>Logged out</title></head>"
-        "<body style='font-family: sans-serif; padding: 2rem;'>"
-        "<h2>Signing you out…</h2>"
-        "<p id='msg'>Clearing credentials — please wait.</p>"
-        "<p style='margin-top: 2rem;'>"
-        "<a id='home' href='./' style='display: none;'>Return to MLflow</a>"
-        "</p>"
-        "<script>"
-        "  function done() {"
-        "    document.getElementById('msg').textContent ="
-        "      'You have been signed out. Redirecting to MLflow…';"
-        "    document.getElementById('home').style.display = 'inline';"
-        # Redirect after a short pause so the user sees confirmation
-        # that logout actually happened before the browser re-prompts.
-        # The manual link stays visible as a fallback in case JS is
-        # blocked by an extension or the redirect is slow.
-        "    setTimeout(function() { window.location.href = './'; }, 2000);"
-        "  }"
-        "  try {"
-        "    var xhr = new XMLHttpRequest();"
-        "    xhr.open('GET', './ajax-api/2.0/mlflow/users/current', true,"
-        "             'mlflow-logged-out', 'mlflow-logged-out');"
-        "    xhr.onloadend = done;"
-        "    xhr.send();"
-        "  } catch (e) { done(); }"
-        "</script>"
-        "</body></html>"
-    )
-    res = make_response(body, 200)
-    res.headers["Content-Type"] = "text/html; charset=utf-8"
-    return res
-
-
 def signup():
     return render_template_string(
         r"""
@@ -4055,11 +4003,6 @@ def create_app(app: Flask = app):
         rule=SIGNUP,
         view_func=signup,
         methods=["GET"],
-    )
-    app.add_url_rule(
-        rule=LOGOUT,
-        view_func=logout,
-        methods=["GET", "POST"],
     )
     app.add_url_rule(
         rule=CREATE_USER_UI,

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -430,10 +430,16 @@ def _get_request_param(param: str) -> str:
     if request.method == "GET":
         args = request.args
     elif request.method in ("POST", "PATCH"):
-        # Coerce null/empty JSON bodies to {} so callers get a 400, not a 500.
-        args = request.get_json(silent=True) or {}
+        # Coerce null/empty/non-dict JSON bodies to {} so callers get a 400, not
+        # a 500 from the dict-merge below.
+        body = request.get_json(silent=True)
+        args = body if isinstance(body, dict) else {}
     elif request.method == "DELETE":
-        args = (request.get_json(silent=True) or {}) if request.is_json else request.args
+        if request.is_json:
+            body = request.get_json(silent=True)
+            args = body if isinstance(body, dict) else {}
+        else:
+            args = request.args
     else:
         raise MlflowException(
             f"Unsupported HTTP method '{request.method}'",

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -430,11 +430,7 @@ def _get_request_param(param: str) -> str:
     if request.method == "GET":
         args = request.args
     elif request.method in ("POST", "PATCH"):
-        # ``request.json`` can be ``None`` when the body is literal ``null`` (or an
-        # empty body under ``application/json``) — falling through to ``None | dict``
-        # would raise a TypeError that ``catch_mlflow_exception`` doesn't intercept,
-        # surfacing as a 500. Coerce to an empty dict so callers get the standard
-        # "missing parameter" 400 instead.
+        # Coerce null/empty JSON bodies to {} so callers get a 400, not a 500.
         args = request.get_json(silent=True) or {}
     elif request.method == "DELETE":
         args = (request.get_json(silent=True) or {}) if request.is_json else request.args
@@ -3207,12 +3203,8 @@ def get_current_user():
 def update_user_password():
     username = _get_request_param("username")
     password = _get_request_param("password")
-    # Self-service password changes must re-assert the current password as a
-    # defense-in-depth check: the Basic Auth header on the request already
-    # proves identity, but a walk-up attacker on a logged-in browser session
-    # would otherwise be able to silently rotate the password and lock out
-    # the legitimate user. Admins changing *someone else's* password bypass
-    # this (they don't and can't supply the target's current password).
+    # Self-service flows re-assert current_password so a hijacked browser
+    # session can't silently rotate it. Admin paths skip this check.
     sender = authenticate_request()
     sender_username = getattr(sender, "username", None)
     if sender_username == username:

--- a/mlflow/server/auth/client.py
+++ b/mlflow/server/auth/client.py
@@ -179,16 +179,23 @@ class AuthServiceClient:
         )
         return User.from_json(resp["user"])
 
-    def update_user_password(self, username: str, password: str):
+    def update_user_password(
+        self, username: str, password: str, current_password: str | None = None
+    ):
         """
         Update the password of a specific user.
 
         Args:
             username: The username.
             password: The new password.
+            current_password: The user's current password. Required when a user
+                is changing their own password (self-service); the server
+                rejects the request otherwise. Admins changing someone else's
+                password may omit this argument.
 
         Raises:
-            mlflow.exceptions.RestException: if the user does not exist
+            mlflow.exceptions.RestException: if the user does not exist, or if
+                ``current_password`` is required and missing or incorrect.
 
         .. code-block:: bash
             :caption: Example
@@ -203,12 +210,21 @@ class AuthServiceClient:
             client = AuthServiceClient("tracking_uri")
             client.create_user("newuser", "newpassword")
 
+            # Admin path — no current_password needed.
             client.update_user_password("newuser", "anotherpassword")
+
+            # Self-service path — current_password required.
+            client.update_user_password(
+                "newuser", "thirdpassword", current_password="anotherpassword"
+            )
         """
+        body = {"username": username, "password": password}
+        if current_password is not None:
+            body["current_password"] = current_password
         self._request(
             UPDATE_USER_PASSWORD,
             "PATCH",
-            json={"username": username, "password": password},
+            json=body,
         )
 
     def update_user_admin(self, username: str, is_admin: bool):

--- a/mlflow/server/auth/routes.py
+++ b/mlflow/server/auth/routes.py
@@ -2,7 +2,6 @@ from mlflow.server.handlers import _add_static_prefix, _get_ajax_path, _get_rest
 
 HOME = "/"
 SIGNUP = "/signup"
-LOGOUT = _add_static_prefix("/logout")
 CREATE_USER = _get_rest_path("/mlflow/users/create")
 AJAX_CREATE_USER = _get_ajax_path("/mlflow/users/create")
 CREATE_USER_UI = _get_rest_path("/mlflow/users/create-ui")

--- a/mlflow/server/auth/routes.py
+++ b/mlflow/server/auth/routes.py
@@ -2,12 +2,20 @@ from mlflow.server.handlers import _add_static_prefix, _get_ajax_path, _get_rest
 
 HOME = "/"
 SIGNUP = "/signup"
+LOGOUT = _add_static_prefix("/logout")
 CREATE_USER = _get_rest_path("/mlflow/users/create")
+AJAX_CREATE_USER = _get_ajax_path("/mlflow/users/create")
 CREATE_USER_UI = _get_rest_path("/mlflow/users/create-ui")
 GET_USER = _get_rest_path("/mlflow/users/get")
+AJAX_GET_USER = _get_ajax_path("/mlflow/users/get")
+GET_CURRENT_USER = _get_rest_path("/mlflow/users/current")
+AJAX_GET_CURRENT_USER = _get_ajax_path("/mlflow/users/current")
 UPDATE_USER_PASSWORD = _get_rest_path("/mlflow/users/update-password")
+AJAX_UPDATE_USER_PASSWORD = _get_ajax_path("/mlflow/users/update-password")
 UPDATE_USER_ADMIN = _get_rest_path("/mlflow/users/update-admin")
+AJAX_UPDATE_USER_ADMIN = _get_ajax_path("/mlflow/users/update-admin")
 DELETE_USER = _get_rest_path("/mlflow/users/delete")
+AJAX_DELETE_USER = _get_ajax_path("/mlflow/users/delete")
 LIST_USERS = _get_rest_path("/mlflow/users/list")
 AJAX_LIST_USERS = _get_ajax_path("/mlflow/users/list")
 CREATE_EXPERIMENT_PERMISSION = _get_rest_path("/mlflow/experiments/permissions/create")

--- a/mlflow/server/js/src/setupProxy.js
+++ b/mlflow/server/js/src/setupProxy.js
@@ -16,6 +16,16 @@ module.exports = function (app) {
       changeOrigin: true,
     }),
   );
+  // /logout is an HTML page served by the MLflow backend that clears the
+  // browser's Basic Auth credential cache. Without this entry, hitting
+  // /logout from the CRA dev server falls through to index.html and the
+  // logout flow silently no-ops.
+  app.use(
+    createProxyMiddleware('/logout', {
+      target: proxyTarget,
+      changeOrigin: true,
+    }),
+  );
   app.use(
     createProxyMiddleware('/graphql', {
       target: proxyTarget,

--- a/mlflow/server/js/src/setupProxy.js
+++ b/mlflow/server/js/src/setupProxy.js
@@ -16,16 +16,6 @@ module.exports = function (app) {
       changeOrigin: true,
     }),
   );
-  // /logout is an HTML page served by the MLflow backend that clears the
-  // browser's Basic Auth credential cache. Without this entry, hitting
-  // /logout from the CRA dev server falls through to index.html and the
-  // logout flow silently no-ops.
-  app.use(
-    createProxyMiddleware('/logout', {
-      target: proxyTarget,
-      changeOrigin: true,
-    }),
-  );
   app.use(
     createProxyMiddleware('/graphql', {
       target: proxyTarget,

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -123,6 +123,26 @@ def test_proxy_artifact_path_detection():
     assert auth_module._is_proxy_artifact_path("/ajax-api/2.0/mlflow-artifacts/artifacts/foo")
 
 
+def test_is_unprotected_route_handles_static_prefix(monkeypatch):
+    # When ``_MLFLOW_STATIC_PREFIX`` is set, the health/static/favicon routes
+    # are served from e.g. ``/mlflow/health``. Health checks must not require
+    # auth on prefixed deployments.
+    monkeypatch.delenv(STATIC_PREFIX_ENV_VAR, raising=False)
+    assert auth_module.is_unprotected_route("/health")
+    assert auth_module.is_unprotected_route("/favicon.ico")
+    assert auth_module.is_unprotected_route("/static/foo.js")
+    assert not auth_module.is_unprotected_route("/api/2.0/mlflow/users/list")
+
+    monkeypatch.setenv(STATIC_PREFIX_ENV_VAR, "/mlflow")
+    assert auth_module.is_unprotected_route("/mlflow/health")
+    assert auth_module.is_unprotected_route("/mlflow/favicon.ico")
+    assert auth_module.is_unprotected_route("/mlflow/static/foo.js")
+    # Unprefixed forms still pass through (local dev / non-prefixed deployments).
+    assert auth_module.is_unprotected_route("/health")
+    # Protected routes stay protected even with the prefix.
+    assert not auth_module.is_unprotected_route("/mlflow/api/2.0/mlflow/users/list")
+
+
 def test_proxy_artifact_mpu_path_detection():
     # MPU create/complete/abort paths should be recognized as proxy artifact paths
     for action in ("create", "complete", "abort"):

--- a/tests/server/auth/test_client.py
+++ b/tests/server/auth/test_client.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 
 import pytest
+import requests
 
 import mlflow
 from mlflow import MlflowException
@@ -116,6 +117,48 @@ def test_get_user(client, monkeypatch):
         client.get_user(username)
 
 
+def test_get_current_user(client, monkeypatch):
+    # /users/current returns minimal identity for whoever the request is
+    # authenticated as. The admin UI relies on the response shape (id,
+    # username, is_admin) to gate admin-only links.
+    username = random_str()
+    password = random_str()
+    with User(ADMIN_USERNAME, ADMIN_PASSWORD, monkeypatch):
+        created = client.create_user(username, password)
+
+    url = f"{client.tracking_uri}/api/2.0/mlflow/users/current"
+
+    resp = requests.get(url, auth=(username, password))
+    assert resp.status_code == 200
+    assert resp.json()["user"] == {
+        "id": created.id,
+        "username": username,
+        "is_admin": False,
+    }
+
+    resp = requests.get(url, auth=(ADMIN_USERNAME, ADMIN_PASSWORD))
+    assert resp.status_code == 200
+    admin_payload = resp.json()["user"]
+    assert admin_payload["username"] == ADMIN_USERNAME
+    assert admin_payload["is_admin"] is True
+
+    resp = requests.get(url)
+    assert resp.status_code == 401
+
+
+def test_logout_returns_credential_clearing_html(client):
+    # /logout serves an HTML page that runs an XHR with bogus creds against
+    # /users/current to drop the browser's Basic Auth cache. Lock down the
+    # contract so the trick (and its static-prefix-aware AJAX path) doesn't
+    # silently regress.
+    resp = requests.get(f"{client.tracking_uri}/logout")
+    assert resp.status_code == 200
+    assert resp.headers["Content-Type"].startswith("text/html")
+    body = resp.text
+    assert "./ajax-api/2.0/mlflow/users/current" in body
+    assert "mlflow-logged-out" in body
+
+
 def test_update_user_password(client, monkeypatch):
     username = random_str()
     password = random_str()
@@ -141,6 +184,74 @@ def test_update_user_password(client, monkeypatch):
         client.create_user(username2, password2)
     with User(username2, password2, monkeypatch), assert_unauthorized():
         client.update_user_password(username, new_password)
+
+
+def test_self_service_password_change_requires_current_password(client, monkeypatch):
+    # Defense-in-depth: a user changing their own password must re-assert the
+    # current password. Admins changing someone else's password don't (and
+    # can't) supply it — that path is exercised in `test_update_user_password`.
+    username = random_str()
+    password = random_str()
+    with User(ADMIN_USERNAME, ADMIN_PASSWORD, monkeypatch):
+        client.create_user(username, password)
+
+    new_password = random_str()
+
+    with User(username, password, monkeypatch):
+        # Missing current_password: rejected.
+        with pytest.raises(MlflowException, match="Current password is required"):
+            client.update_user_password(username, new_password)
+
+        # Wrong current_password: rejected.
+        with pytest.raises(MlflowException, match="Current password does not match"):
+            client.update_user_password(
+                username, new_password, current_password="not-the-current-password"
+            )
+
+        # Correct current_password: accepted.
+        client.update_user_password(username, new_password, current_password=password)
+
+    # Old password no longer authenticates; new one does.
+    with User(username, password, monkeypatch), assert_unauthenticated():
+        client.get_user(username)
+    with User(username, new_password, monkeypatch):
+        client.get_user(username)
+
+
+def test_create_user_with_null_or_missing_json_body_returns_400(client, monkeypatch):
+    # Defensive: a JSON-typed POST whose body is literal ``null`` (or empty)
+    # used to crash ``_get_request_param`` with ``None | dict`` and surface as
+    # a 500. Make sure it's a clean 400 instead.
+    url = f"{client.tracking_uri}/api/2.0/mlflow/users/create"
+    headers = {"Content-Type": "application/json"}
+    auth = (ADMIN_USERNAME, ADMIN_PASSWORD)
+
+    # Literal null body.
+    resp = requests.post(url, data="null", headers=headers, auth=auth)
+    assert resp.status_code == 400
+
+    # Empty body.
+    resp = requests.post(url, data="", headers=headers, auth=auth)
+    assert resp.status_code == 400
+
+
+def test_self_service_password_change_with_null_body_returns_400(client, monkeypatch):
+    # Defensive: self-service password changes used to crash with
+    # ``request.json.get(...)`` when the body was literal ``null`` (raises
+    # AttributeError -> 500). Make sure it's the standard 400 instead.
+    username = random_str()
+    password = random_str()
+    with User(ADMIN_USERNAME, ADMIN_PASSWORD, monkeypatch):
+        client.create_user(username, password)
+
+    url = f"{client.tracking_uri}/api/2.0/mlflow/users/update-password"
+    resp = requests.patch(
+        url,
+        data="null",
+        headers={"Content-Type": "application/json"},
+        auth=(username, password),
+    )
+    assert resp.status_code == 400
 
 
 def test_update_user_admin(client, monkeypatch):

--- a/tests/server/auth/test_client.py
+++ b/tests/server/auth/test_client.py
@@ -146,19 +146,6 @@ def test_get_current_user(client, monkeypatch):
     assert resp.status_code == 401
 
 
-def test_logout_returns_credential_clearing_html(client):
-    # /logout serves an HTML page that runs an XHR with bogus creds against
-    # /users/current to drop the browser's Basic Auth cache. Lock down the
-    # contract so the trick (and its static-prefix-aware AJAX path) doesn't
-    # silently regress.
-    resp = requests.get(f"{client.tracking_uri}/logout")
-    assert resp.status_code == 200
-    assert resp.headers["Content-Type"].startswith("text/html")
-    body = resp.text
-    assert "./ajax-api/2.0/mlflow/users/current" in body
-    assert "mlflow-logged-out" in body
-
-
 def test_update_user_password(client, monkeypatch):
     username = random_str()
     password = random_str()


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/22928/files) to review incremental changes.
- [**stack/fe/rbac/01-backend-auth**](https://github.com/mlflow/mlflow/pull/22928) [[Files changed](https://github.com/mlflow/mlflow/pull/22928/files)]
  - [stack/fe/rbac/02-account](https://github.com/mlflow/mlflow/pull/22973) [[Files changed](https://github.com/mlflow/mlflow/pull/22973/files/5622bb8b375d861a3ce5265d87e26f3c07cccfd4..098f9acff472e0d18ee4aac3feb94b0c7f9a8d00)]
    - [stack/fe/rbac/02-admin-ui-foundation](https://github.com/mlflow/mlflow/pull/22929) [[Files changed](https://github.com/mlflow/mlflow/pull/22929/files/098f9acff472e0d18ee4aac3feb94b0c7f9a8d00..d291b9dca5b94d1ad6f6129867e69dc8a92f0e0b)]
      - [stack/fe/rbac/03-settings-nav-and-pw-modal](https://github.com/mlflow/mlflow/pull/22930) [[Files changed](https://github.com/mlflow/mlflow/pull/22930/files/d291b9dca5b94d1ad6f6129867e69dc8a92f0e0b..882265b52135144400e5eba09f3df1d79cb47338)]
        - [stack/fe/rbac/04-bulk-delete-and-user-permissions](https://github.com/mlflow/mlflow/pull/22931) [[Files changed](https://github.com/mlflow/mlflow/pull/22931/files/882265b52135144400e5eba09f3df1d79cb47338..652155ad51ffd8ba37ea8aba390df136917c8936)]
          - [stack/fe/rbac/05-self-delete-confirmation](https://github.com/mlflow/mlflow/pull/22932) [[Files changed](https://github.com/mlflow/mlflow/pull/22932/files/652155ad51ffd8ba37ea8aba390df136917c8936..2e62ab0e0c8f1b9cb6232d9dcad365f2143fdca8)]
            - [stack/fe/rbac/06-dev-user-switcher](https://github.com/mlflow/mlflow/pull/22933) [[Files changed](https://github.com/mlflow/mlflow/pull/22933/files/2e62ab0e0c8f1b9cb6232d9dcad365f2143fdca8..76d4ee6ad3708d9eae24db8f76fe2370aed47b7f)]
              - [stack/fe/rbac/07-settings-default-route](https://github.com/mlflow/mlflow/pull/22942) [[Files changed](https://github.com/mlflow/mlflow/pull/22942/files/76d4ee6ad3708d9eae24db8f76fe2370aed47b7f..b8b9708a986144051b3f607d5bf237818c0fbae6)]

---------
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

Relates to #22724 — Slice 1/6 of #22724. Backend-only changes that expose the endpoints and payload fields the upcoming admin UI consumes.

### What changes are proposed in this pull request?

Foundation for the admin UI stack. Six small server-side additions:

- **`/logout` endpoint.** Returns an HTML page that runs a synchronous XHR with bogus credentials against `/users/current` so the browser drops its cached Basic Auth and re-prompts. Static-prefix-aware via `_add_static_prefix`.
- **`/users/current` endpoint.** Returns the authenticated user's row (id, username, `is_admin`). The UI uses this to gate Admin/Account links and decide between admin vs non-admin code paths.
- **`is_admin` in `list_users` response.** Lets the UI render the admin badge per row without a per-user fetch.
- **`current_password` verification on self-service password change.** `update_user_password` now requires `current_password` when the authenticated user is updating their own password and verifies it via `store.authenticate_user` before applying the new one. Admin-initiated changes for other users keep the existing semantics.
- **Role-grant inclusion in `list_accessible_workspace_names`.** Folds in role-based grants alongside direct permissions, fixing a workspace-visibility hole for users whose access comes from role assignments.
- **Username trimming on `create_user`.** `create_user` strips leading/trailing whitespace so the UI can't accidentally seed users like `" alice"`.

Files: `mlflow/server/auth/__init__.py`, `mlflow/server/auth/client.py`, `mlflow/server/auth/routes.py`, `tests/server/auth/test_client.py`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

https://github.com/user-attachments/assets/30fb278b-6b5a-499f-b3da-467366530194


### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Adds `/logout`, `/users/current`, and `is_admin` payload + `current_password` verification on self-service password changes. Backend foundation for the upcoming admin UI; not directly visible to end users until the UI slices land.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release