### PR TITLE
Refactor trace archival helper utilities

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -12,7 +12,6 @@ import time
 import uuid
 from collections import defaultdict
 from dataclasses import dataclass, field
-from enum import Enum
 from functools import reduce
 from pathlib import PurePath
 from typing import Any, TypedDict, TypeVar
@@ -169,6 +168,15 @@ from mlflow.store.tracking.utils.sql_trace_metrics_utils import (
     query_metrics,
     validate_query_trace_metrics_params,
 )
+from mlflow.store.tracking.utils.trace_archival import (
+    _TRACE_ARCHIVAL_EXPERIMENT_ID_CHUNK_SIZE,
+    _ArchiveNowCleanupRequest,
+    _ArchiveNowRemainingState,
+    _ArchiveNowRequest,
+    _parse_experiment_trace_archival_retention_millis,
+    _parse_trace_archival_duration_millis,
+    _TraceArchiveCandidate,
+)
 from mlflow.store.workspace.abstract_store import ResolvedTraceArchivalConfig
 from mlflow.telemetry.events import UpdateIssueEvent
 from mlflow.telemetry.track import record_usage_event
@@ -226,7 +234,6 @@ from mlflow.utils.uri import (
     resolve_uri_if_local,
 )
 from mlflow.utils.validation import (
-    _parse_trace_archival_duration_config,
     _resolve_experiment_ids_and_locations,
     _validate_batch_log_data,
     _validate_batch_log_limits,
@@ -241,7 +248,6 @@ from mlflow.utils.validation import (
     _validate_run_id,
     _validate_tag,
     _validate_trace_archival_location,
-    _validate_trace_archival_retention_string,
     _validate_trace_tag,
 )
 from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME, WORKSPACES_DIR_NAME
@@ -266,84 +272,6 @@ class DatasetFilter(TypedDict, total=False):
 
     dataset_name: str
     dataset_digest: str
-
-
-_TRACE_ARCHIVAL_DURATION_MULTIPLIER_MILLIS = {
-    "m": 60 * 1000,
-    "h": 60 * 60 * 1000,
-    "d": 24 * 60 * 60 * 1000,
-}
-# Keep grouped experiment scans well below backend parameter limits (notably MSSQL's 2100).
-_TRACE_ARCHIVAL_EXPERIMENT_ID_CHUNK_SIZE = 1000
-
-
-class _ArchiveNowRemainingState(str, Enum):
-    DONE = "done"
-    ARCHIVABLE = "archivable"
-    TRANSIENT = "transient"
-    BLOCKED_UNMARKED = "blocked_unmarked"
-    TERMINAL_FAILURES_ONLY = "terminal_failures_only"
-
-
-@dataclass(frozen=True)
-class _ArchiveNowRequest:
-    older_than_millis: int | None
-
-    @classmethod
-    def from_tag_value(cls, value: str | None) -> _ArchiveNowRequest | None:
-        if value is None:
-            return None
-
-        try:
-            older_than = _parse_trace_archival_duration_config(
-                value,
-                duration_key="older_than",
-                allow_missing_duration=True,
-            )
-            return cls(older_than_millis=_parse_trace_archival_duration_millis(older_than))
-        except MlflowException:
-            _logger.warning(
-                "Ignoring malformed trace archive-now tag value: %r",
-                value,
-            )
-            return None
-
-
-@dataclass(frozen=True)
-class _ArchiveNowCleanupRequest:
-    experiment_id: str
-    raw_value: str
-    parsed_request: _ArchiveNowRequest
-
-
-@dataclass(frozen=True)
-class _TraceArchiveCandidate:
-    trace_id: str
-    experiment_id: str
-    timestamp_ms: int
-
-
-def _parse_trace_archival_duration_millis(value: str | None) -> int | None:
-    if value is None:
-        return None
-
-    trimmed = _validate_trace_archival_retention_string(value)
-    amount = trimmed[:-1]
-    unit = trimmed[-1]
-    return int(amount) * _TRACE_ARCHIVAL_DURATION_MULTIPLIER_MILLIS[unit]
-
-
-def _parse_experiment_trace_archival_retention_millis(value: str | None) -> int | None:
-    try:
-        duration = _parse_trace_archival_duration_config(
-            value,
-            duration_key="value",
-            expected_type="duration",
-        )
-        return _parse_trace_archival_duration_millis(duration)
-    except MlflowException:
-        _logger.warning("Ignoring invalid trace archival retention tag value: %r", value)
-        return None
 
 
 class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
@@ -5505,19 +5433,20 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         *,
         limit: int | None,
     ) -> list[_TraceArchiveCandidate]:
-        def sort_key(candidate: _TraceArchiveCandidate) -> tuple[int, str]:
-            return candidate.timestamp_ms, candidate.trace_id
-
-        if limit is None:
-            return sorted([*existing_candidates, *new_candidates], key=sort_key)
-        if limit <= 0:
+        if limit is not None and limit <= 0:
             return []
-        if not existing_candidates:
-            return sorted(new_candidates, key=sort_key)[:limit]
-        if not new_candidates:
-            return sorted(existing_candidates, key=sort_key)[:limit]
 
-        return sorted([*existing_candidates, *new_candidates], key=sort_key)[:limit]
+        if not existing_candidates:
+            candidates = new_candidates
+        elif not new_candidates:
+            candidates = existing_candidates
+        else:
+            candidates = [*existing_candidates, *new_candidates]
+
+        sorted_candidates = sorted(
+            candidates, key=lambda candidate: (candidate.timestamp_ms, candidate.trace_id)
+        )
+        return sorted_candidates if limit is None else sorted_candidates[:limit]
 
     @staticmethod
     def _dedupe_trace_archive_candidates(

--- a/mlflow/store/tracking/utils/trace_archival.py
+++ b/mlflow/store/tracking/utils/trace_archival.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+
+from mlflow.exceptions import MlflowException
+from mlflow.utils.validation import (
+    _parse_trace_archival_duration_config,
+    _validate_trace_archival_retention_string,
+)
+
+_logger = logging.getLogger(__name__)
+
+_TRACE_ARCHIVAL_DURATION_MULTIPLIER_MILLIS = {
+    "m": 60 * 1000,
+    "h": 60 * 60 * 1000,
+    "d": 24 * 60 * 60 * 1000,
+}
+# Keep grouped experiment scans well below backend parameter limits (notably MSSQL's 2100).
+_TRACE_ARCHIVAL_EXPERIMENT_ID_CHUNK_SIZE = 1000
+
+
+class _ArchiveNowRemainingState(str, Enum):
+    DONE = "done"
+    ARCHIVABLE = "archivable"
+    TRANSIENT = "transient"
+    BLOCKED_UNMARKED = "blocked_unmarked"
+    TERMINAL_FAILURES_ONLY = "terminal_failures_only"
+
+
+@dataclass(frozen=True)
+class _ArchiveNowRequest:
+    older_than_millis: int | None
+
+    @classmethod
+    def from_tag_value(cls, value: str | None) -> _ArchiveNowRequest | None:
+        if value is None:
+            return None
+
+        try:
+            older_than = _parse_trace_archival_duration_config(
+                value,
+                duration_key="older_than",
+                allow_missing_duration=True,
+            )
+            return cls(older_than_millis=_parse_trace_archival_duration_millis(older_than))
+        except MlflowException:
+            _logger.warning(
+                "Ignoring malformed trace archive-now tag value: %r",
+                value,
+            )
+            return None
+
+
+@dataclass(frozen=True)
+class _ArchiveNowCleanupRequest:
+    experiment_id: str
+    raw_value: str
+    parsed_request: _ArchiveNowRequest
+
+
+@dataclass(frozen=True)
+class _TraceArchiveCandidate:
+    trace_id: str
+    experiment_id: str
+    timestamp_ms: int
+
+
+def _parse_trace_archival_duration_millis(value: str | None) -> int | None:
+    if value is None:
+        return None
+
+    trimmed = _validate_trace_archival_retention_string(value)
+    amount = trimmed[:-1]
+    unit = trimmed[-1]
+    return int(amount) * _TRACE_ARCHIVAL_DURATION_MULTIPLIER_MILLIS[unit]
+
+
+def _parse_experiment_trace_archival_retention_millis(value: str | None) -> int | None:
+    try:
+        duration = _parse_trace_archival_duration_config(
+            value,
+            duration_key="value",
+            expected_type="duration",
+        )
+        return _parse_trace_archival_duration_millis(duration)
+    except MlflowException:
+        _logger.warning("Ignoring invalid trace archival retention tag value: %r", value)
+        return None


### PR DESCRIPTION
### Related Issues/PRs
Addresses follow up comments from:  https://github.com/mlflow/mlflow/pull/22605

### What changes are proposed in this pull request?

Move trace archival planner helpers into a dedicated tracking utils module and inline the candidate sort lambda to address follow-up review feedback.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests


### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

