### PR TITLE
fix: preserve ParamSchema when type hint inference returns params=None

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -3315,9 +3315,19 @@ def save_model(
         saved_example = _save_example(mlflow_model, input_example, path)
 
     if signature_from_type_hints:
-        if signature and signature_from_type_hints != signature:
-            # TODO: drop this support and raise exception in the next minor release since this
-            # is a behavior change
+        # TODO: drop this support and raise exception in the next minor release since this
+        # is a behavior change
+        if signature_from_type_hints.params is None and signature.params is not None:
+            signature_from_type_hints.params = signature.params
+            _logger.warning(
+                "Provided signature does not match the signature inferred from the Python model's "
+                "`predict` function type hint. Signature inferred from type hint will be used "
+                "for inputs and outputs:\n"
+                f"{signature_from_type_hints}\nSince params cannot be inferred from type hints, "
+                "the provided params schema has been preserved.\n",
+                extra={"color": "red"},
+            )
+        else:
             _logger.warning(
                 "Provided signature does not match the signature inferred from the Python model's "
                 "`predict` function type hint. Signature inferred from type hint will be used:\n"

--- a/tests/pyfunc/test_preserve_params_schema.py
+++ b/tests/pyfunc/test_preserve_params_schema.py
@@ -1,0 +1,54 @@
+import pytest
+
+import mlflow
+from mlflow.models import ModelSignature
+from mlflow.types.schema import ColSpec, ParamSchema, ParamSpec, Schema
+
+
+@pytest.fixture(autouse=True)
+def mock_log_model_with_pip_requirements():
+    from unittest import mock
+
+    original_log_model = mlflow.pyfunc.log_model
+
+    def patched_log_model(*args, **kwargs):
+        kwargs.setdefault("pip_requirements", [])
+        return original_log_model(*args, **kwargs)
+
+    with mock.patch("mlflow.pyfunc.log_model", patched_log_model):
+        yield
+
+
+def test_log_model_preserves_user_params_schema_when_type_hint_inference_returns_none():
+    """
+    Regression test for https://github.com/mlflow/mlflow/issues/14908
+    """
+
+    class MyModel(mlflow.pyfunc.PythonModel):
+        def predict(
+            self,
+            context,
+            model_input: list[str],
+            params: dict[str, str] | None = None,
+        ) -> list[str]:
+            return model_input
+
+    signature = ModelSignature(
+        inputs=Schema([ColSpec(type="string")]),
+        outputs=Schema([ColSpec(type="string")]),
+        params=ParamSchema([ParamSpec(name="k", dtype="long", default=1)]),
+    )
+
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(
+            name="test_model",
+            python_model=MyModel(),
+            signature=signature,
+        )
+
+    assert model_info.signature.params is not None
+    assert model_info.signature.params == signature.params
+
+    loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
+    result = loaded_model.predict(["test"], params={"k": 1})
+    assert result == ["test"]


### PR DESCRIPTION
When logging a PythonModel with type hints and a manually provided ModelSignature containing a ParamSchema, MLflow's type hint inference would overwrite the user's signature with one where params=None, causing params to be silently dropped at inference time.

<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Relates to #14908

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
This fix preserves the user's ParamSchema when the inferred signature has params=None but the user provided a ParamSchema explicitly.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Params provided by the user in a defined ParamSchema are maintained instead of being overwritten by inferred params=None. 
#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
