### PR TITLE
Restructure `pr-review` skill instructions with explicit review dimensions

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -52,7 +52,7 @@ Run the `fetch-diff` skill to fetch the PR diff for the identified PR.
 
 **Apply additional filtering** from user instructions if provided (e.g., focus on specific issues or areas).
 
-Carefully examine **only the changed lines** (added, modified, or deleted) in the diff. Ignore unchanged/context lines and pre-existing code; they are not in scope, even if they look suboptimal.
+You may read unchanged/context lines to understand the change, but only file findings against the changed lines (added, modified, or deleted). Pre-existing code is not in scope, even if it looks suboptimal.
 
 Evaluate the changed code across these dimensions:
 
@@ -84,7 +84,7 @@ Then:
 
 ### 5. Add Review Comments
 
-For each finding, use the `add-review-comment` skill. One comment per issue, anchored to the most relevant changed line.
+For each finding, use the `add-review-comment` skill. One comment per distinct finding, anchored to the most relevant changed line. For repeated identical issues, leave a single representative comment rather than flagging every instance.
 
 Every comment MUST use this exact format: `<emoji> **<severity>:** <description>`
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -7,7 +7,7 @@ description: Review a GitHub pull request, add review comments for issues found,
 
 # Review Pull Request
 
-Automatically review a GitHub pull request and provide feedback on code quality, style guide violations, and potential bugs. Approves the PR if no significant issues are found.
+Automatically review a GitHub pull request across correctness, security, edge cases, efficiency, readability, test coverage, and style. Approves the PR when there are no findings or only MODERATE/NIT findings.
 
 ## Usage
 
@@ -92,7 +92,7 @@ Keep comments constructive and specific: state the problem, why it matters, and 
 
 ### 6. Approve the PR
 
-Approve the PR when there are no issues or only minor issues, but **only if the PR author has the `admin` or `maintain` role**.
+Approve the PR when there are no findings or only MODERATE/NIT findings, but **only if the PR author has the `admin` or `maintain` role**.
 
 First, check the PR author's role:
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -78,9 +78,9 @@ Classify each finding by severity (matches `.github/instructions/code-review.ins
 
 Then:
 
-- **No findings** → skip to step 6 (approve)
-- **Only MODERATE/NIT findings** → step 5 (add comments), then step 6 (approve)
-- **Any CRITICAL finding** → step 5 (add comments); do NOT approve
+- **No findings** -> skip to step 6 (approve)
+- **Only MODERATE/NIT findings** -> step 5 (add comments), then step 6 (approve)
+- **Any CRITICAL finding** -> step 5 (add comments); do NOT approve
 
 ### 5. Add Review Comments
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -48,29 +48,41 @@ The current local branch may not be the PR branch being reviewed. Always rely on
 
 Run the `fetch-diff` skill to fetch the PR diff for the identified PR.
 
-### 3. Review Changed Lines
+### 3. In-Depth Analysis
 
-**Apply additional filtering** from user instructions if provided (e.g., focus on specific issues or areas)
+**Apply additional filtering** from user instructions if provided (e.g., focus on specific issues or areas).
 
-Carefully examine **only the changed lines** (added, modified, or deleted) in the diff for:
+Carefully examine **only the changed lines** (added, modified, or deleted) in the diff. Ignore unchanged/context lines and pre-existing code; they are not in scope, even if they look suboptimal.
 
-- Style guide violations (see `.claude/rules/` for language-specific rules)
-- Potential bugs and code quality issues
-- Common mistakes
+Evaluate the changed code across these dimensions:
 
-**Workspace awareness reminder**: If the diff touches the SQLAlchemy tracking store or other tracking persistence layers, verify that workspace-aware behavior remains intact and that new functionality includes matching workspace-aware tests (for example, additions in `tests/store/tracking/test_sqlalchemy_store_workspace.py`).
+- **Correctness**: logic errors, off-by-one, incorrect API usage, broken invariants, regressions in behavior
+- **Security**: injection, unsafe deserialization, secret leakage, missing authz/authn, unsafe defaults
+- **Edge cases**: None/empty/zero inputs, concurrency, error paths, retries, large/unicode inputs
+- **Efficiency**: needless N+1 queries, redundant work in hot paths, allocations in tight loops
+- **Readability & maintainability**: unclear names, dead code, premature abstractions, comments that restate the code
+- **Test coverage**: new behavior lacks tests, tests assert on the wrong thing, mocks hide real failures
+- **Style guide**: see `.claude/rules/` for language-specific rules and `CLAUDE.md` for repo conventions
 
-**Important**: Ignore unchanged/context lines and pre-existing code.
+**Workspace awareness reminder**: If the diff touches the SQLAlchemy tracking store or other tracking persistence layers, verify workspace-aware behavior remains intact and that new functionality includes matching workspace-aware tests (e.g., additions in `tests/store/tracking/test_sqlalchemy_store_workspace.py`).
 
 ### 4. Decision Point
 
-- If **no issues found** → Skip to step 6 (approve)
-- If **only minor issues found** (e.g., style nits, suggestions) → Continue to step 5 (add review comments), then step 6 (approve)
-- If **significant issues found** (e.g., bugs, logic errors, security) → Continue to step 5 (add review comments), do NOT approve
+Classify each finding by severity:
+
+- **Critical**: bugs, logic errors, security issues, data loss risk, broken public API, missing tests for new behavior
+- **Improvement**: non-blocking quality concerns where the code works but could be clearer or safer
+- **Nitpick**: pure style/preference; prefix the comment with `nit:` so the author can ignore it
+
+Then:
+
+- **No findings** → skip to step 6 (approve)
+- **Only improvements/nitpicks** → step 5 (add comments), then step 6 (approve)
+- **Any critical finding** → step 5 (add comments); do NOT approve
 
 ### 5. Add Review Comments
 
-For each issue found, use the `add-review-comment` skill to post review comments.
+For each finding, use the `add-review-comment` skill. One comment per issue, anchored to the most relevant changed line. Keep comments constructive and specific: state the problem, why it matters, and a concrete suggestion when possible. Prefix nitpicks with `nit:`.
 
 ### 6. Approve the PR
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -68,21 +68,27 @@ Evaluate the changed code across these dimensions:
 
 ### 4. Decision Point
 
-Classify each finding by severity:
+Classify each finding by severity (matches `.github/instructions/code-review.instructions.md`):
 
-- **Critical**: bugs, logic errors, security issues, data loss risk, broken public API, missing tests for new behavior
-- **Improvement**: non-blocking quality concerns where the code works but could be clearer or safer
-- **Nitpick**: pure style/preference; prefix the comment with `nit:` so the author can ignore it
+| Severity | Emoji | Use for                                                                          |
+| -------- | ----- | -------------------------------------------------------------------------------- |
+| CRITICAL | 🔴    | bugs, logic errors, security issues, data loss risk, broken public API           |
+| MODERATE | 🟡    | non-blocking quality concerns where the code works but could be clearer or safer |
+| NIT      | 🟢    | pure style/preference the author can ignore                                      |
 
 Then:
 
 - **No findings** → skip to step 6 (approve)
-- **Only improvements/nitpicks** → step 5 (add comments), then step 6 (approve)
-- **Any critical finding** → step 5 (add comments); do NOT approve
+- **Only MODERATE/NIT findings** → step 5 (add comments), then step 6 (approve)
+- **Any CRITICAL finding** → step 5 (add comments); do NOT approve
 
 ### 5. Add Review Comments
 
-For each finding, use the `add-review-comment` skill. One comment per issue, anchored to the most relevant changed line. Keep comments constructive and specific: state the problem, why it matters, and a concrete suggestion when possible. Prefix nitpicks with `nit:`.
+For each finding, use the `add-review-comment` skill. One comment per issue, anchored to the most relevant changed line.
+
+Every comment MUST use this exact format: `<emoji> **<severity>:** <description>`
+
+Keep comments constructive and specific: state the problem, why it matters, and a concrete suggestion when possible.
 
 ### 6. Approve the PR
 


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Refines `.claude/skills/pr-review/SKILL.md`:

- Renames step 3 to **In-Depth Analysis** and replaces the loose "style/bugs/common mistakes" checklist with explicit review dimensions (correctness, security, edge cases, efficiency, readability/maintainability, test coverage, style guide).
- Adds a severity table in step 4 — **CRITICAL (🔴) / MODERATE (🟡) / NIT (🟢)** — that matches `.github/instructions/code-review.instructions.md`, so this skill and the Copilot reviewer produce consistent comment style.
- Mandates the comment format `<emoji> **<severity>:** <description>` in step 5, allows grouping repeated identical issues into a single representative comment, and clarifies that reviewers may read context lines for understanding while still scoping findings to changed lines.
- Updates the skill body description and the step 6 approve gate to use the new severity terminology instead of the old "minor/significant issues" wording.

Skill behavior is otherwise unchanged: same auto-detection, same `fetch-diff` dependency, same author-role gate before approving.

### How is this PR tested?

- [x] Manual tests

Reviewed the rendered markdown locally; pre-commit (prettier, etc.) ran clean.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release