### PR TITLE
Aggregate role-based grants in workspace-level permission checks

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -541,9 +541,21 @@ def _workspace_permission(
         return NO_PERMISSIONS
 
     try:
-        permission = store.get_workspace_permission(workspace_name, username)
-        if permission is not None:
-            return permission
+        # The effective workspace-level permission is the max of:
+        #   (a) ``workspace_permissions`` table entry (legacy, pre-RBAC)
+        #   (b) role-based grants where (resource_type='workspace',
+        #       resource_pattern='*') applied to this workspace
+        # Operators mid-migration may have both; resource-level checks already
+        # union role grants via ``_get_permission_from_store_or_default``, so
+        # the workspace-level path needs to do the same to stay consistent.
+        legacy = store.get_workspace_permission(workspace_name, username)
+        role = store.get_role_workspace_permission(workspace_name, username)
+        if legacy is not None and role is not None:
+            return get_permission(max_permission(legacy.name, role.name))
+        if legacy is not None:
+            return legacy
+        if role is not None:
+            return role
 
         if auth_config.grant_default_workspace_access and auth_config.default_permission:
             default_workspace, _ = get_default_workspace_optional(_get_workspace_store())

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -542,18 +542,24 @@ def _workspace_permission(
 
     try:
         # The effective workspace-level permission is the max of:
-        #   (a) ``workspace_permissions`` table entry (legacy, pre-RBAC)
+        #   (a) direct ``workspace_permissions`` row for this user/workspace
         #   (b) role-based grants where (resource_type='workspace',
         #       resource_pattern='*') applied to this workspace
-        # Operators mid-migration may have both; resource-level checks already
-        # union role grants via ``_get_permission_from_store_or_default``, so
-        # the workspace-level path needs to do the same to stay consistent.
-        legacy = store.get_workspace_permission(workspace_name, username)
+        # Both sources are first-class — direct grants are not deprecated by
+        # roles. Resource-level checks already union role grants via
+        # ``_get_permission_from_store_or_default``, so the workspace-level
+        # path needs to do the same to stay consistent.
+        direct = store.get_workspace_permission(workspace_name, username)
+        # MANAGE is the ceiling — a role grant can't raise it, so skip the
+        # extra DB round-trip in the common workspace-admin case. Mirrors
+        # the optimization in ``_get_permission_from_store_or_default``.
+        if direct is not None and direct.name == MANAGE.name:
+            return direct
         role = store.get_role_workspace_permission(workspace_name, username)
-        if legacy is not None and role is not None:
-            return get_permission(max_permission(legacy.name, role.name))
-        if legacy is not None:
-            return legacy
+        if direct is not None and role is not None:
+            return get_permission(max_permission(direct.name, role.name))
+        if direct is not None:
+            return direct
         if role is not None:
             return role
 

--- a/mlflow/server/auth/sqlalchemy_store.py
+++ b/mlflow/server/auth/sqlalchemy_store.py
@@ -446,14 +446,14 @@ class SqlAlchemyStore:
 
     def get_workspace_permission(self, workspace_name: str, username: str) -> Permission | None:
         """
-        Get the workspace permission for a user from the legacy
-        ``workspace_permissions`` table.
+        Get the **direct** workspace permission for a user — the row in the
+        ``workspace_permissions`` table, if any.
 
-        Does NOT include role-based grants — callers that need the full
-        authorization picture should also consult ``get_role_workspace_permission``
-        and ``max_permission``-merge the two. See
-        ``mlflow.server.auth.__init__._workspace_permission`` for the canonical
-        aggregation.
+        Does NOT include role-based grants. Callers that need the full
+        authorization picture should also consult
+        ``get_role_workspace_permission`` and ``max_permission``-merge the
+        two. See ``mlflow.server.auth.__init__._workspace_permission`` for
+        the canonical aggregation.
         """
         with self.ManagedSessionMaker() as session:
             user = self._get_user(session, username=username)
@@ -471,16 +471,15 @@ class SqlAlchemyStore:
         ``resource_pattern='*'``). Returns ``None`` when there are no such
         grants.
 
-        Complements ``get_workspace_permission``: that helper only reads the
-        legacy ``workspace_permissions`` table; this one only reads role
-        grants. Callers that need the effective workspace-level permission
-        should max-merge the two — pre-RBAC deployments only had legacy
-        grants, post-RBAC deployments increasingly use roles, and operators
-        mid-migration may have both.
+        Complements ``get_workspace_permission`` — that helper reads the
+        ``workspace_permissions`` table directly, this one reads role
+        grants. Both are first-class authorization sources; callers that
+        need the effective workspace-level permission should max-merge the
+        two.
         """
         with self.ManagedSessionMaker() as session:
             user = self._get_user(session, username=username)
-            rows = (
+            permissions = (
                 session
                 .query(SqlRolePermission.permission)
                 .join(SqlRole, SqlRole.id == SqlRolePermission.role_id)
@@ -491,12 +490,13 @@ class SqlAlchemyStore:
                     SqlRolePermission.resource_type == "workspace",
                     SqlRolePermission.resource_pattern == "*",
                 )
+                .distinct()
                 .all()
             )
-        if not rows:
+        if not permissions:
             return None
         best: str | None = None
-        for (perm,) in rows:
+        for (perm,) in permissions:
             best = perm if best is None else max_permission(best, perm)
         return get_permission(best)
 

--- a/mlflow/server/auth/sqlalchemy_store.py
+++ b/mlflow/server/auth/sqlalchemy_store.py
@@ -446,7 +446,14 @@ class SqlAlchemyStore:
 
     def get_workspace_permission(self, workspace_name: str, username: str) -> Permission | None:
         """
-        Get the workspace permission for a user.
+        Get the workspace permission for a user from the legacy
+        ``workspace_permissions`` table.
+
+        Does NOT include role-based grants — callers that need the full
+        authorization picture should also consult ``get_role_workspace_permission``
+        and ``max_permission``-merge the two. See
+        ``mlflow.server.auth.__init__._workspace_permission`` for the canonical
+        aggregation.
         """
         with self.ManagedSessionMaker() as session:
             user = self._get_user(session, username=username)
@@ -454,6 +461,44 @@ class SqlAlchemyStore:
             if entity is not None:
                 return get_permission(entity.permission)
         return None
+
+    def get_role_workspace_permission(
+        self, workspace_name: str, username: str
+    ) -> Permission | None:
+        """
+        Highest **role-based** permission ``username`` has on ``workspace_name``
+        where the role grant is workspace-wide (``resource_type='workspace'``,
+        ``resource_pattern='*'``). Returns ``None`` when there are no such
+        grants.
+
+        Complements ``get_workspace_permission``: that helper only reads the
+        legacy ``workspace_permissions`` table; this one only reads role
+        grants. Callers that need the effective workspace-level permission
+        should max-merge the two — pre-RBAC deployments only had legacy
+        grants, post-RBAC deployments increasingly use roles, and operators
+        mid-migration may have both.
+        """
+        with self.ManagedSessionMaker() as session:
+            user = self._get_user(session, username=username)
+            rows = (
+                session
+                .query(SqlRolePermission.permission)
+                .join(SqlRole, SqlRole.id == SqlRolePermission.role_id)
+                .join(SqlUserRoleAssignment, SqlRole.id == SqlUserRoleAssignment.role_id)
+                .filter(
+                    SqlUserRoleAssignment.user_id == user.id,
+                    SqlRole.workspace == workspace_name,
+                    SqlRolePermission.resource_type == "workspace",
+                    SqlRolePermission.resource_pattern == "*",
+                )
+                .all()
+            )
+        if not rows:
+            return None
+        best: str | None = None
+        for (perm,) in rows:
+            best = perm if best is None else max_permission(best, perm)
+        return get_permission(best)
 
     def create_scorer_permission(
         self, experiment_id: str, scorer_name: str, username: str, permission: str

--- a/tests/server/auth/test_auth_workspace.py
+++ b/tests/server/auth/test_auth_workspace.py
@@ -438,6 +438,9 @@ def test_workspace_permission_grants_default_access(monkeypatch):
         def get_workspace_permission(self, workspace_name, username):
             return None
 
+        def get_role_workspace_permission(self, workspace_name, username):
+            return None
+
         def list_accessible_workspace_names(self, username):
             return []
 
@@ -640,6 +643,56 @@ def test_experiment_validators_allow_manage_permission(workspace_permission_setu
         query_string={"experiment_name": "Primary Experiment"},
     ):
         assert auth_module.validate_can_read_experiment_by_name()
+
+    with workspace_context.WorkspaceContext("team-a"):
+        assert auth_module.validate_can_create_experiment()
+
+
+def test_experiment_validators_allow_role_based_workspace_manage(workspace_permission_setup):
+    # Grant MANAGE on the workspace via a role (with no legacy
+    # ``workspace_permissions`` row). Pre-fix this returned 403 — the
+    # workspace-level permission check only consulted the legacy table.
+    # ``_workspace_permission`` now max-merges role-based grants.
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+
+    # Drop the legacy grant the fixture installs so we exercise the role path
+    # in isolation.
+    store.delete_workspace_permission("team-a", username)
+    assert store.get_workspace_permission("team-a", username) is None
+
+    role = store.create_role(name="ws-admin", workspace="team-a")
+    store.add_role_permission(role.id, "workspace", "*", MANAGE.name)
+    user = store.get_user(username)
+    store.assign_role_to_user(user.id, role.id)
+
+    with auth_module.app.test_request_context(
+        "/api/2.0/mlflow/experiments/get", method="GET", query_string={"experiment_id": "exp-1"}
+    ):
+        assert auth_module.validate_can_read_experiment()
+        assert auth_module.validate_can_update_experiment()
+        assert auth_module.validate_can_delete_experiment()
+        assert auth_module.validate_can_manage_experiment()
+
+    with workspace_context.WorkspaceContext("team-a"):
+        assert auth_module.validate_can_create_experiment()
+
+
+def test_workspace_permission_max_merges_legacy_and_role(workspace_permission_setup):
+    # Operators mid-migration may have BOTH a legacy grant and a role grant.
+    # The effective permission must be the higher of the two — neither side
+    # should silently downgrade the other.
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+
+    # Legacy READ + role MANAGE → effective MANAGE.
+    store.delete_workspace_permission("team-a", username)
+    store.set_workspace_permission("team-a", username, READ.name)
+
+    role = store.create_role(name="ws-admin", workspace="team-a")
+    store.add_role_permission(role.id, "workspace", "*", MANAGE.name)
+    user = store.get_user(username)
+    store.assign_role_to_user(user.id, role.id)
 
     with workspace_context.WorkspaceContext("team-a"):
         assert auth_module.validate_can_create_experiment()

--- a/tests/server/auth/test_sqlalchemy_store_workspace.py
+++ b/tests/server/auth/test_sqlalchemy_store_workspace.py
@@ -51,6 +51,72 @@ def test_get_workspace_permission_precedence(store):
     assert perm == READ
 
 
+def test_get_role_workspace_permission_returns_none_when_no_role(store):
+    # No role assignment at all → None (callers fall back to legacy /
+    # default lookups).
+    username = random_str()
+    store.create_user(username, random_str())
+
+    assert store.get_role_workspace_permission("ws1", username) is None
+
+
+def test_get_role_workspace_permission_returns_workspace_wide_grant(store):
+    # Role with (resource_type='workspace', resource_pattern='*', MANAGE)
+    # in ws1 surfaces as a MANAGE grant for that workspace.
+    username = random_str()
+    user = store.create_user(username, random_str())
+
+    role = store.create_role(name="ws-admin", workspace="ws1")
+    store.add_role_permission(role.id, "workspace", "*", MANAGE.name)
+    store.assign_role_to_user(user.id, role.id)
+
+    assert store.get_role_workspace_permission("ws1", username) == MANAGE
+
+
+def test_get_role_workspace_permission_ignores_resource_specific_grants(store):
+    # A role with only resource-specific grants (e.g. experiment:* READ) must
+    # NOT register as a workspace-wide grant — that would over-promote a
+    # tab-scoped role into a workspace-level capability.
+    username = random_str()
+    user = store.create_user(username, random_str())
+
+    role = store.create_role(name="exp-reader", workspace="ws1")
+    store.add_role_permission(role.id, "experiment", "*", READ.name)
+    store.assign_role_to_user(user.id, role.id)
+
+    assert store.get_role_workspace_permission("ws1", username) is None
+
+
+def test_get_role_workspace_permission_takes_max_across_roles(store):
+    # Two roles in the same workspace with different workspace-wide
+    # permissions → the helper returns the higher of the two.
+    username = random_str()
+    user = store.create_user(username, random_str())
+
+    read_role = store.create_role(name="ws-reader", workspace="ws1")
+    store.add_role_permission(read_role.id, "workspace", "*", READ.name)
+    store.assign_role_to_user(user.id, read_role.id)
+
+    edit_role = store.create_role(name="ws-editor", workspace="ws1")
+    store.add_role_permission(edit_role.id, "workspace", "*", EDIT.name)
+    store.assign_role_to_user(user.id, edit_role.id)
+
+    assert store.get_role_workspace_permission("ws1", username) == EDIT
+
+
+def test_get_role_workspace_permission_scopes_to_requested_workspace(store):
+    # A workspace-wide role grant in ws1 must not leak into ws2's permission
+    # check — roles are bound to a single workspace.
+    username = random_str()
+    user = store.create_user(username, random_str())
+
+    role_ws1 = store.create_role(name="ws-admin", workspace="ws1")
+    store.add_role_permission(role_ws1.id, "workspace", "*", MANAGE.name)
+    store.assign_role_to_user(user.id, role_ws1.id)
+
+    assert store.get_role_workspace_permission("ws2", username) is None
+
+
 def test_list_workspace_permissions(store):
     workspace = "team-gamma"
     other_workspace = "team-delta"


### PR DESCRIPTION
### Related Issues/PRs

Sibling fix to #22864 (which closed the same class of bug for `list_accessible_workspace_names`). Surfaced while dogfooding the upcoming admin UI: granting `workspace:* → MANAGE` via a role didn't let the user create experiments / registered models / manage other workspace permissions, despite the role's intent.

### What changes are proposed in this pull request?

Workspace-level permission checks all bottleneck on `mlflow/server/auth/__init__.py:_workspace_permission`, which only consulted the legacy `workspace_permissions` table. A user granted MANAGE on a workspace via a role (`(resource_type='workspace', resource_pattern='*', permission=MANAGE)`) was therefore blocked from:

- `validate_can_create_experiment`
- `validate_can_create_registered_model`
- `validate_can_modify_workspace_permission`
- `validate_can_list_workspace_permissions`
- the gateway-endpoint USE check (`_validate_can_use_model_definitions_for_create`)
- the resource-permission workspace fallback

Resource-level checks (e.g. "can I read this experiment?") already aggregate role grants via `_get_permission_from_store_or_default(..., role_permission_func=...)`. Workspace-level "can I do X here?" checks did not.

Single-bottleneck fix:

1. **New store helper `SqlAlchemyStore.get_role_workspace_permission(workspace_name, username)`** — highest role-based permission a user has on a workspace where the role grant is workspace-wide. Mirrors the existing `_workspace_admin_workspaces` query shape, scoped to one workspace and unfiltered on permission level.

2. **`_workspace_permission`** now max-merges legacy + role-based permissions using `max_permission`. Operators mid-migration who have both keep the higher of the two.

Net diff: +180 / -4, all under `mlflow/server/auth/`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

New coverage:

- **Store-level** (`tests/server/auth/test_sqlalchemy_store_workspace.py`):
  - returns `None` when no role assignment
  - surfaces a `workspace:* → MANAGE` grant
  - ignores resource-specific grants (regression guard against accidentally promoting `experiment:*` roles into workspace-level capabilities)
  - takes max across multiple roles in the same workspace
  - scopes to the requested workspace (no cross-workspace leak)

- **Integration** (`tests/server/auth/test_auth_workspace.py`):
  - `test_experiment_validators_allow_role_based_workspace_manage` — role-only MANAGE unblocks read/update/delete/manage/create on experiments
  - `test_workspace_permission_max_merges_legacy_and_role` — legacy READ + role MANAGE → effective MANAGE

Full local run:
- `tests/server/auth/test_auth_workspace.py` — 130 passed
- `tests/server/auth/test_sqlalchemy_store{,_workspace,_rbac}.py` — 171 passed

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. RBAC workspace-level permissions granted via roles (e.g. `workspace:* → MANAGE`) are now correctly honored by experiment / registered-model creation, workspace permission management, and gateway endpoint creation. Previously these flows only consulted the legacy `workspace_permissions` table.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
