### PR TITLE
Enable OpenCode tracing plugin to include reasoning/thinking content in the Span

### DIFF
--- a/libs/typescript/integrations/opencode/src/index.ts
+++ b/libs/typescript/integrations/opencode/src/index.ts
@@ -39,6 +39,7 @@ const MESSAGE_ROLE_USER = 'user';
 const MESSAGE_ROLE_ASSISTANT = 'assistant';
 const PART_TYPE_TEXT = 'text';
 const PART_TYPE_TOOL = 'tool';
+const PART_TYPE_REASONING = 'reasoning';
 
 // SDK initialization state
 let initialized = false;
@@ -302,14 +303,19 @@ function createLlmAndToolSpans(
     const createdNs = timestampToNs(timeInfo.created);
     const completedNs = timestampToNs(timeInfo.completed);
 
-    // Check for text and tool content
+    // Check for text, tool, and reasoning content
     const textParts = parts.filter((p) => p.type === PART_TYPE_TEXT);
     const toolParts = parts.filter((p) => p.type === PART_TYPE_TOOL);
+    const reasoningParts = parts.filter((p) => p.type === PART_TYPE_REASONING);
 
-    // Create LLM span for text responses
-    if (textParts.length > 0) {
+    // Create LLM span for text/reasoning responses
+    if (textParts.length > 0 || reasoningParts.length > 0) {
       const conversationMessages = reconstructConversationMessages(messages, i);
       const textContent = textParts.map((p) => p.text || '').join('\n');
+      const reasoningText =
+        reasoningParts.length > 0
+          ? reasoningParts.map((p) => p.text || '').join('\n\n')
+          : null;
 
       const llmSpan = startSpan({
         name: 'llm_call',
@@ -332,8 +338,12 @@ function createLlmAndToolSpans(
         llmSpan.setAttribute(SpanAttributeKey.TOKEN_USAGE, tokenUsage);
       }
 
+      const outputMessage: Record<string, unknown> = { role: 'assistant', content: textContent };
+      if (reasoningText) {
+        outputMessage.reasoning = reasoningText;
+      }
       llmSpan.setOutputs({
-        choices: [{ message: { role: 'assistant', content: textContent } }],
+        choices: [{ message: outputMessage }],
       });
       llmSpan.end({ endTimeNs: completedNs });
     }


### PR DESCRIPTION
### Related Issues/PRs

Closes #22956

### What changes are proposed in this pull request?

Add reasoning/thinking content support to the `@mlflow/opencode` tracing plugin. Currently the plugin drops `reasoning` message parts from OpenCode — only `text` and `tool` parts are processed.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Manually tested with OpenCode using OpenAI o-series and Claude models with extended thinking. Reasoning content appears in the MLflow trace UI under the collapsible "Reasoning" section on LLM spans.

### Thinking Visible in OpenCode

<img width="2256" height="912" alt="image" src="https://github.com/user-attachments/assets/b60de5b1-d941-4dbf-a519-498e4e5bdfab" />

### Current Mlflow Trace Viz
<img width="2954" height="1616" alt="image" src="https://github.com/user-attachments/assets/6ccb1d79-b749-4ead-8f17-476c5dff1a92" />



### After this PR
<img width="2990" height="1576" alt="image" src="https://github.com/user-attachments/assets/29ec908d-9fee-4dd0-bc60-a38d019ad531" />



### Does this PR require documentation update?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add reasoning/thinking content to LLM spans created by OpenCode tracing plugin.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

#### How should the PR be classified in the release notes?

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x ] I think so ..
- [] No

