### PR TITLE
Disable commit comments on tracing benchmark alerts

### DIFF
--- a/.github/workflows/tracing-benchmark.yml
+++ b/.github/workflows/tracing-benchmark.yml
@@ -63,7 +63,7 @@ jobs:
           benchmark-data-dir-path: dev/benchmarks/tracing
           auto-push: true
           alert-threshold: "200%"
-          comment-on-alert: true
+          comment-on-alert: false
           fail-on-alert: false
           summary-always: true
           max-items-in-chart: 500


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22602

### What changes are proposed in this pull request?

Set `comment-on-alert: false` in `.github/workflows/tracing-benchmark.yml` so `github-action-benchmark` stops posting commit comments when a benchmark regression exceeds the alert threshold (e.g. [this comment](https://github.com/mlflow/mlflow/commit/7686229ee4c11a3177426f3463664c3852f880ad#commitcomment-183651707)).

Alerts still appear in the workflow run summary via `summary-always: true`; only the commit-comment side effect is removed.

### How is this PR tested?

- [x] Manual tests

YAML-only change validated by inspection; the next master push to the workflow will exercise the path.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release