### PR TITLE
Show tracing benchmark chart in milliseconds instead of iter/sec

### DIFF
--- a/.github/workflows/tracing-benchmark.yml
+++ b/.github/workflows/tracing-benchmark.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Convert to custom format
         run: |
           uv run --no-sync python -c "
-          import json, sys
+          import json
           with open('benchmark-results.json') as f:
               data = json.load(f)
           out = [

--- a/.github/workflows/tracing-benchmark.yml
+++ b/.github/workflows/tracing-benchmark.yml
@@ -46,6 +46,20 @@ jobs:
             --benchmark-only \
             --benchmark-json=benchmark-results.json
 
+      - name: Convert to custom format
+        run: |
+          uv run --no-sync python -c "
+          import json, sys
+          with open('benchmark-results.json') as f:
+              data = json.load(f)
+          out = [
+              {'name': b['fullname'], 'unit': 'ms', 'value': b['stats']['mean'] * 1000}
+              for b in data['benchmarks']
+          ]
+          with open('benchmark-custom.json', 'w') as f:
+              json.dump(out, f, indent=2)
+          "
+
       # Only master pushes update gh-pages. PR runs just validate that the
       # bench still produces a parseable JSON. The gh-pages branch must be
       # seeded once by a maintainer before the first master run; full history
@@ -56,8 +70,8 @@ jobs:
         uses: benchmark-action/github-action-benchmark@a60cea5bc7b49e15c1f58f411161f99e0df48372 # v1.22.0
         with:
           name: MLflow Tracing Benchmark
-          tool: pytest
-          output-file-path: benchmark-results.json
+          tool: customSmallerIsBetter
+          output-file-path: benchmark-custom.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: dev/benchmarks/tracing


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22937

### What changes are proposed in this pull request?

The `benchmark-action` with `tool: pytest` plots `1/mean` as iter/sec on the y-axis, which is unintuitive for latency benchmarks. This PR converts the output to `customSmallerIsBetter` format with milliseconds so the chart shows time directly (lower is better).

Note: this will reset the gh-pages trend history since the tool/format changed. The old iter/sec data points aren't compatible with the new milliseconds-based ones.

### How is this PR tested?

- [x] Manual tests

Ran `pytest-benchmark` locally and verified the JSON conversion produces correct millisecond values.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)