### PR TITLE
Fix assessment logging silently dropped in distributed tracing

### DIFF
--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -653,7 +653,9 @@ class TracingClient:
             )
             return assessment
 
-        # If the trace is the active trace, add the assessment to it in-memory
+        # If the trace is the active trace, add the assessment to it in-memory.
+        # Exception: remote (distributed) traces use a dummy in-memory entry that is discarded
+        # when the context exits, so assessments must be persisted directly to the backend.
         if trace_id == mlflow.get_active_trace_id():
             with InMemoryTraceManager.get_instance().get_trace(trace_id) as trace:
                 if trace is None:
@@ -661,6 +663,9 @@ class TracingClient:
                         f"Trace {trace_id} is active but not found in the in-memory buffer. "
                         "Something is wrong with trace handling. Skipping assessment logging."
                     )
+                    return assessment
+                if trace.is_remote_trace:
+                    return self.store.create_assessment(assessment)
                 trace.info.assessments.append(assessment)
             return assessment
         return self.store.create_assessment(assessment)

--- a/mlflow/tracing/distributed/__init__.py
+++ b/mlflow/tracing/distributed/__init__.py
@@ -138,6 +138,7 @@ def set_tracing_context_from_http_request_headers(headers: dict[str, str]):
 
     token = None
     otel_trace_id = None
+    registered_dummy_trace = False
     trace_manager = InMemoryTraceManager.get_instance()
     try:
         headers = dict(headers)
@@ -164,18 +165,26 @@ def set_tracing_context_from_http_request_headers(headers: dict[str, str]):
         otel_trace_id = span_context.trace_id
 
         trace_id = generate_mlflow_trace_id_from_otel_trace_id(otel_trace_id)
-        dummy_trace_info = TraceInfo(
-            trace_id=trace_id,
-            trace_location=None,
-            request_time=None,
-            state=TraceState.IN_PROGRESS,
-        )
 
-        trace_manager.register_trace(otel_trace_id, dummy_trace_info, is_remote_trace=True)
+        # Skip dummy registration if the trace already exists locally (e.g. same-process
+        # distributed tracing with a pending async export). Overwriting it would prevent
+        # the real trace from being exported to the backend.
+        with trace_manager.get_trace(trace_id) as existing_trace:
+            has_local_trace = existing_trace is not None and not existing_trace.is_remote_trace
+
+        if not has_local_trace:
+            dummy_trace_info = TraceInfo(
+                trace_id=trace_id,
+                trace_location=None,
+                request_time=None,
+                state=TraceState.IN_PROGRESS,
+            )
+            trace_manager.register_trace(otel_trace_id, dummy_trace_info, is_remote_trace=True)
+            registered_dummy_trace = True
 
         yield
     finally:
         if token is not None:
             get_context_api().detach(token)
-        if otel_trace_id is not None:
+        if otel_trace_id is not None and registered_dummy_trace:
             trace_manager.pop_trace(otel_trace_id)

--- a/tests/tracing/test_assessment.py
+++ b/tests/tracing/test_assessment.py
@@ -19,6 +19,7 @@ from mlflow.tracing.distributed import (
     get_tracing_context_headers_for_http_request,
     set_tracing_context_from_http_request_headers,
 )
+from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.version import IS_TRACING_SDK_ONLY
 
 _HUMAN_ASSESSMENT_SOURCE = AssessmentSource(
@@ -984,8 +985,7 @@ def test_log_multiple_assessment_types(trace_id):
     assert assessments_by_type["issue"].issue_id == "iss-11111"
 
 
-def test_log_feedback_in_distributed_trace_persists_to_backend():
-    # Simulate a root endpoint: start and complete a trace, capture propagation headers
+def test_log_feedback_in_distributed_trace_same_process():
     captured_headers = {}
 
     @mlflow.trace(name="root")
@@ -995,7 +995,54 @@ def test_log_feedback_in_distributed_trace_persists_to_backend():
 
     root()
 
-    # Simulate a child endpoint: restore distributed context and log feedback
+    root_trace_id = mlflow.get_last_active_trace_id()
+    assert root_trace_id is not None
+    tm = InMemoryTraceManager.get_instance()
+    with tm.get_trace(root_trace_id) as t:
+        assert t is not None
+        assert not t.is_remote_trace
+
+    with set_tracing_context_from_http_request_headers(captured_headers):
+
+        @mlflow.trace(name="child")
+        def child():
+            trace_id = mlflow.get_active_trace_id()
+            return mlflow.log_feedback(
+                trace_id=trace_id,
+                name="child_was_called",
+                value="yes",
+            )
+
+        child()
+
+    with tm.get_trace(root_trace_id) as t:
+        assert t is not None
+        assert len(t.info.assessments) == 1
+        assert t.info.assessments[0].name == "child_was_called"
+
+    mlflow.flush_trace_async_logging()
+    trace = mlflow.get_trace(root_trace_id)
+    assert len(trace.info.assessments) == 1
+    assert trace.info.assessments[0].name == "child_was_called"
+    assert trace.info.assessments[0].feedback.value == "yes"
+
+
+def test_log_feedback_in_distributed_trace_cross_process():
+    captured_headers = {}
+
+    @mlflow.trace(name="root")
+    def root():
+        nonlocal captured_headers
+        captured_headers = get_tracing_context_headers_for_http_request()
+
+    root()
+    mlflow.flush_trace_async_logging()
+
+    root_trace_id = mlflow.get_last_active_trace_id()
+    tm = InMemoryTraceManager.get_instance()
+    with tm.get_trace(root_trace_id) as t:
+        assert t is None
+
     with mock.patch.object(TracingClient, "store") as mock_store:
         mock_assessment = mock.MagicMock()
         mock_assessment.assessment_id = "a-test-assessment-id"
@@ -1014,6 +1061,5 @@ def test_log_feedback_in_distributed_trace_persists_to_backend():
 
             result = child()
 
-        # The assessment must be persisted via the store, not dropped silently
         mock_store.create_assessment.assert_called_once()
         assert result.assessment_id == "a-test-assessment-id"

--- a/tests/tracing/test_assessment.py
+++ b/tests/tracing/test_assessment.py
@@ -6,7 +6,6 @@ import pytest
 import mlflow
 from mlflow.entities.assessment import (
     AssessmentError,
-    AssessmentSource,
     Expectation,
     Feedback,
     IssueReference,
@@ -14,7 +13,6 @@ from mlflow.entities.assessment import (
 from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
 from mlflow.entities.issue import IssueStatus
 from mlflow.exceptions import MlflowException
-from mlflow.tracing.client import TracingClient
 from mlflow.tracing.distributed import (
     get_tracing_context_headers_for_http_request,
     set_tracing_context_from_http_request_headers,
@@ -1043,11 +1041,12 @@ def test_log_feedback_in_distributed_trace_cross_process():
     with tm.get_trace(root_trace_id) as t:
         assert t is None
 
-    with mock.patch.object(TracingClient, "store") as mock_store:
-        mock_assessment = mock.MagicMock()
-        mock_assessment.assessment_id = "a-test-assessment-id"
-        mock_store.create_assessment.return_value = mock_assessment
+    mock_store = mock.MagicMock()
+    mock_assessment = mock.MagicMock()
+    mock_assessment.assessment_id = "a-test-assessment-id"
+    mock_store.create_assessment.return_value = mock_assessment
 
+    with mock.patch("mlflow.tracing.client._get_store", return_value=mock_store):
         with set_tracing_context_from_http_request_headers(captured_headers):
 
             @mlflow.trace(name="child")

--- a/tests/tracing/test_assessment.py
+++ b/tests/tracing/test_assessment.py
@@ -985,20 +985,21 @@ def test_log_multiple_assessment_types(trace_id):
 
 def test_log_feedback_in_distributed_trace_same_process():
     captured_headers = {}
+    tm = InMemoryTraceManager.get_instance()
 
     @mlflow.trace(name="root")
     def root():
         nonlocal captured_headers
         captured_headers = get_tracing_context_headers_for_http_request()
+        trace_id = mlflow.get_active_trace_id()
+        with tm.get_trace(trace_id) as t:
+            assert t is not None
+            assert not t.is_remote_trace
 
     root()
 
     root_trace_id = mlflow.get_last_active_trace_id()
     assert root_trace_id is not None
-    tm = InMemoryTraceManager.get_instance()
-    with tm.get_trace(root_trace_id) as t:
-        assert t is not None
-        assert not t.is_remote_trace
 
     with set_tracing_context_from_http_request_headers(captured_headers):
 
@@ -1061,4 +1062,31 @@ def test_log_feedback_in_distributed_trace_cross_process():
             result = child()
 
         mock_store.create_assessment.assert_called_once()
+        called_assessment = mock_store.create_assessment.call_args[0][0]
+        assert called_assessment.name == "child_was_called"
+        assert called_assessment.feedback.value == "yes"
         assert result.assessment_id == "a-test-assessment-id"
+
+
+def test_log_assessment_active_trace_not_in_memory():
+    null_cm = mock.MagicMock()
+    null_cm.__enter__.return_value = None
+    null_cm.__exit__.return_value = False
+
+    mock_store = mock.MagicMock()
+
+    with mlflow.start_span(name="root"):
+        with (
+            mock.patch.object(
+                InMemoryTraceManager.get_instance(), "get_trace", return_value=null_cm
+            ),
+            mock.patch("mlflow.tracing.client._get_store", return_value=mock_store),
+        ):
+            result = mlflow.log_feedback(
+                trace_id=mlflow.get_active_trace_id(),
+                name="test_feedback",
+                value=1.0,
+            )
+            mock_store.create_assessment.assert_not_called()
+            assert result is not None
+            assert result.assessment_id is None

--- a/tests/tracing/test_assessment.py
+++ b/tests/tracing/test_assessment.py
@@ -1014,11 +1014,6 @@ def test_log_feedback_in_distributed_trace_same_process():
 
         child()
 
-    with tm.get_trace(root_trace_id) as t:
-        assert t is not None
-        assert len(t.info.assessments) == 1
-        assert t.info.assessments[0].name == "child_was_called"
-
     mlflow.flush_trace_async_logging()
     trace = mlflow.get_trace(root_trace_id)
     assert len(trace.info.assessments) == 1

--- a/tests/tracing/test_assessment.py
+++ b/tests/tracing/test_assessment.py
@@ -1,4 +1,5 @@
 import os
+from unittest import mock
 
 import pytest
 
@@ -13,6 +14,11 @@ from mlflow.entities.assessment import (
 from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
 from mlflow.entities.issue import IssueStatus
 from mlflow.exceptions import MlflowException
+from mlflow.tracing.client import TracingClient
+from mlflow.tracing.distributed import (
+    get_tracing_context_headers_for_http_request,
+    set_tracing_context_from_http_request_headers,
+)
 from mlflow.version import IS_TRACING_SDK_ONLY
 
 _HUMAN_ASSESSMENT_SOURCE = AssessmentSource(
@@ -976,3 +982,38 @@ def test_log_multiple_assessment_types(trace_id):
     assert assessments_by_type["issue"].name == "iss-11111"
     assert assessments_by_type["issue"].issue_name == "data_quality_issue"
     assert assessments_by_type["issue"].issue_id == "iss-11111"
+
+
+def test_log_feedback_in_distributed_trace_persists_to_backend():
+    # Simulate a root endpoint: start and complete a trace, capture propagation headers
+    captured_headers = {}
+
+    @mlflow.trace(name="root")
+    def root():
+        nonlocal captured_headers
+        captured_headers = get_tracing_context_headers_for_http_request()
+
+    root()
+
+    # Simulate a child endpoint: restore distributed context and log feedback
+    with mock.patch.object(TracingClient, "store") as mock_store:
+        mock_assessment = mock.MagicMock()
+        mock_assessment.assessment_id = "a-test-assessment-id"
+        mock_store.create_assessment.return_value = mock_assessment
+
+        with set_tracing_context_from_http_request_headers(captured_headers):
+
+            @mlflow.trace(name="child")
+            def child():
+                trace_id = mlflow.get_active_trace_id()
+                return mlflow.log_feedback(
+                    trace_id=trace_id,
+                    name="child_was_called",
+                    value="yes",
+                )
+
+            result = child()
+
+        # The assessment must be persisted via the store, not dropped silently
+        mock_store.create_assessment.assert_called_once()
+        assert result.assessment_id == "a-test-assessment-id"


### PR DESCRIPTION
### Related Issues/PRs

Closes #22938

### What changes are proposed in this pull request?

When `mlflow.log_feedback` (or `log_assessment`) is called inside a distributed (remote) child span context, the assessment was silently dropped instead of being persisted to the backend.

**Root cause:** `log_assessment` checks `if trace_id == mlflow.get_active_trace_id()` and, when true, adds the assessment to the in-memory trace. However, in a distributed tracing scenario the in-memory trace is a *dummy remote trace* (`is_remote_trace=True`) registered by `set_tracing_context_from_http_request_headers`. This dummy trace is discarded when the context manager exits, taking the assessment with it — and `assessment_id` is never populated.

**Fix:** When the in-memory trace is found but has `is_remote_trace=True`, fall through to `self.store.create_assessment(assessment)` to persist directly to the backend. Also fixed a latent `AttributeError` when `trace is None` (missing `return` before `trace.info.assessments.append`).

### How is this PR tested?

- [x] New unit/integration tests

Added `test_log_feedback_in_distributed_trace_persists_to_backend` in `tests/tracing/test_assessment.py` which simulates the root→child distributed tracing flow and asserts `store.create_assessment` is called (not silently dropped).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. `mlflow.log_feedback` / `mlflow.log_assessment` called inside a distributed tracing child span context now correctly persists the assessment to the backend instead of silently dropping it.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release