### PR TITLE
feat: add Astraflow (UCloud ModelVerse) provider support

### DIFF
--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -64,6 +64,8 @@ class Provider(str, Enum):
     OPENROUTER = "openrouter"
     OLLAMA = "ollama"
     VERTEX_AI = "vertex_ai"
+    ASTRAFLOW = "astraflow"
+    ASTRAFLOW_CN = "astraflow-cn"
     PORTKEY = "portkey"
 
     @classmethod

--- a/mlflow/gateway/provider_registry.py
+++ b/mlflow/gateway/provider_registry.py
@@ -58,6 +58,8 @@ def _register_default_providers(registry: ProviderRegistry):
     from mlflow.gateway.providers.palm import PaLMProvider
     from mlflow.gateway.providers.portkey import PortkeyProvider
     from mlflow.gateway.providers.togetherai import TogetherAIProvider
+    from mlflow.gateway.providers.astraflow import AstraflowProvider
+    from mlflow.gateway.providers.astraflow_cn import AstraflowCNProvider
     from mlflow.gateway.providers.vertex_ai import VertexAIProvider
     from mlflow.gateway.providers.xai import XAIProvider
 
@@ -87,6 +89,8 @@ def _register_default_providers(registry: ProviderRegistry):
     registry.register(Provider.TOGETHERAI, TogetherAIProvider)
     registry.register(Provider.VERTEX_AI, VertexAIProvider)
     registry.register(Provider.XAI, XAIProvider)
+    registry.register(Provider.ASTRAFLOW, AstraflowProvider)
+    registry.register(Provider.ASTRAFLOW_CN, AstraflowCNProvider)
 
 
 def _register_plugin_providers(registry: ProviderRegistry):

--- a/mlflow/gateway/providers/astraflow.py
+++ b/mlflow/gateway/providers/astraflow.py
@@ -1,0 +1,17 @@
+from mlflow.gateway.config import _OpenAICompatibleConfig
+from mlflow.gateway.providers.openai_compatible import OpenAICompatibleProvider
+
+
+class AstraflowProvider(OpenAICompatibleProvider):
+    """Provider for Astraflow (UCloud ModelVerse) — Global node (US/CA).
+
+    API base: https://api-us-ca.umodelverse.ai/v1
+    API key env var: ASTRAFLOW_API_KEY
+
+    Supports DeepSeek, Claude, GPT-4, and other models available on
+    the UCloud ModelVerse platform via an OpenAI-compatible API.
+    """
+
+    DISPLAY_NAME = "Astraflow"
+    CONFIG_TYPE = _OpenAICompatibleConfig
+    DEFAULT_API_BASE = "https://api-us-ca.umodelverse.ai/v1"

--- a/mlflow/gateway/providers/astraflow_cn.py
+++ b/mlflow/gateway/providers/astraflow_cn.py
@@ -1,0 +1,17 @@
+from mlflow.gateway.config import _OpenAICompatibleConfig
+from mlflow.gateway.providers.openai_compatible import OpenAICompatibleProvider
+
+
+class AstraflowCNProvider(OpenAICompatibleProvider):
+    """Provider for Astraflow CN (UCloud ModelVerse) — China node.
+
+    API base: https://api.modelverse.cn/v1
+    API key env var: ASTRAFLOW_CN_API_KEY
+
+    Supports DeepSeek, Claude, GPT-4, and other models available on
+    the UCloud ModelVerse platform via an OpenAI-compatible API.
+    """
+
+    DISPLAY_NAME = "Astraflow CN"
+    CONFIG_TYPE = _OpenAICompatibleConfig
+    DEFAULT_API_BASE = "https://api.modelverse.cn/v1"


### PR DESCRIPTION
## Summary

This PR adds support for **Astraflow (UCloud ModelVerse)** as an AI provider in the MLflow AI Gateway. ModelVerse is UCloud's OpenAI-compatible LLM aggregation platform supporting models such as DeepSeek, Claude, GPT-4, and more.

Two independent region nodes are registered as separate providers, consistent with how other providers with regional variants are handled:

| Provider name | Region | Base URL | API key env var |
|---|---|---|---|
| `astraflow` | Global (US/CA) | `https://api-us-ca.umodelverse.ai/v1` | `ASTRAFLOW_API_KEY` |
| `astraflow-cn` | China | `https://api.modelverse.cn/v1` | `ASTRAFLOW_CN_API_KEY` |

## Changes

- **`mlflow/gateway/config.py`** — Added `ASTRAFLOW` and `ASTRAFLOW_CN` entries to the `Provider` enum.
- **`mlflow/gateway/providers/astraflow.py`** — New provider file for the global (US/CA) node.
- **`mlflow/gateway/providers/astraflow_cn.py`** — New provider file for the China node.
- **`mlflow/gateway/provider_registry.py`** — Registered both providers in `_register_default_providers`.

## Usage Example

Configure your MLflow AI Gateway (`config.yaml`):

```yaml
endpoints:
  # Global node — recommended for international users
  - name: astraflow-chat
    endpoint_type: llm/v1/chat
    model:
      provider: astraflow
      name: claude-3-5-haiku-20241022
      config:
        api_key: $ASTRAFLOW_API_KEY

  # China node — recommended for users in China
  - name: astraflow-cn-chat
    endpoint_type: llm/v1/chat
    model:
      provider: astraflow-cn
      name: deepseek-ai/DeepSeek-V3
      config:
        api_key: $ASTRAFLOW_CN_API_KEY
```

Set the environment variables before starting the gateway:

```bash
export ASTRAFLOW_API_KEY="your-global-api-key"
export ASTRAFLOW_CN_API_KEY="your-cn-api-key"
export MLFLOW_GATEWAY_RESOLVE_API_KEY_FROM_ENV=true

mlflow gateway start --config-path config.yaml
```

## Implementation Notes

- Both providers extend `OpenAICompatibleProvider`, following the same pattern used by `OpenRouterProvider`, `XAIProvider`, and `DeepSeekProvider`.
- The implementation is minimal and idiomatic — only `DISPLAY_NAME`, `CONFIG_TYPE`, and `DEFAULT_API_BASE` are needed.
- `CONFIG_TYPE` uses the shared `_OpenAICompatibleConfig` which handles API key resolution (env var / file / literal) transparently.
- Both providers support chat completions, embeddings, and streaming out of the box.
