### PR TITLE
Use `TaskContext.artifactDir` to get the correct unpacked artifacts directory

### DIFF
--- a/mlflow/pyfunc/dbconnect_artifact_cache.py
+++ b/mlflow/pyfunc/dbconnect_artifact_cache.py
@@ -114,8 +114,8 @@ class DBConnectArtifactCache:
 
         if session_id := os.environ.get("DB_SESSION_UUID"):
             task_context = TaskContext.get()
-            if hasattr(task_context, "artifact_dir"):
-                return os.path.join(task_context.artifact_dir(), "archives", archive_file_name)
+            if hasattr(task_context, "artifactDir"):
+                return os.path.join(task_context.artifactDir(), "archives", archive_file_name)
 
             return (
                 f"/local_disk0/.ephemeral_nfs/artifacts/{session_id}/archives/{archive_file_name}"

--- a/mlflow/pyfunc/dbconnect_artifact_cache.py
+++ b/mlflow/pyfunc/dbconnect_artifact_cache.py
@@ -106,11 +106,17 @@ class DBConnectArtifactCache:
         Get unpacked artifact directory path, you can only call this method
         inside Databricks Connect spark UDF sandbox.
         """
+        from pyspark.taskcontext import TaskContext
+
         if cache_key not in self._cache:
             raise RuntimeError(f"The artifact '{cache_key}' does not exist.")
         archive_file_name = self._cache[cache_key]
 
         if session_id := os.environ.get("DB_SESSION_UUID"):
+            task_context = TaskContext.get()
+            if hasattr(task_context, "artifact_dir"):
+                return os.path.join(task_context.artifact_dir(), "archives", archive_file_name)
+
             return (
                 f"/local_disk0/.ephemeral_nfs/artifacts/{session_id}/archives/{archive_file_name}"
             )


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

In current `DBConnectArtifactCache.get_unpacked_artifact_dir` implementation, if the Spark Cluster is configured with multiple drivers, `DBConnectArtifactCache.get_unpacked_artifact_dir` might return incorrect result.
In latest runtime version, a new Spark API `TaskContext.artifactDir` was introduced to fetch the correct artifact path for all cases. This PR updates MLflow code to use the API `TaskContext.artifactDir` if it exists.

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Manually tests:

```
%pip install git+https://github.com/WeichenXu123/mlflow.git@fix-artifact-cache
%restart_python

%sh
echo "hello" > file1.txt && echo "world" > file2.txt && tar -czf /tmp/archive1.tar.gz file1.txt file2.txt

from mlflow.pyfunc.dbconnect_artifact_cache import DBConnectArtifactCache

dbcache = DBConnectArtifactCache.get_or_create(spark)
dbcache.add_artifact_archive("arc1", "/tmp/archive1.tar.gz")

import pandas as pd
from pyspark.sql.functions import pandas_udf

from pyspark.sql.types import IntegerType
@pandas_udf("string")
def slen(s: pd.Series) -> pd.Series:
    artifact_dir = dbcache.get_unpacked_artifact_dir("arc1")
    return pd.Series([artifact_dir] * len(s))
  

df = spark.createDataFrame(
  [[1, "a string"]],
  "long_col long, string_col string")

import os

# It should list the correct file list in the archive file.
os.listdir(df.select(slen("string_col")).head()[0])
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
