### PR TITLE
feat: Add executor registry and startup validation

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1439,6 +1439,38 @@ MLFLOW_ONLINE_SCORING_DEFAULT_SESSION_COMPLETION_BUFFER_SECONDS = _EnvironmentVa
 #: (default: ``30``)
 MLFLOW_JUDGE_MAX_ITERATIONS = _EnvironmentVariable("MLFLOW_JUDGE_MAX_ITERATIONS", int, 30)
 
+#: Specifies the default job executor backend name.
+#: (default: ``"local"``)
+MLFLOW_JOB_DEFAULT_EXECUTOR_BACKEND = _EnvironmentVariable(
+    "MLFLOW_JOB_DEFAULT_EXECUTOR_BACKEND", str, "local"
+)
+
+#: Reserved for routing custom scorer jobs to a non-default backend. Validated
+#: at startup but not yet consulted by job submission until the executor router
+#: lands.
+MLFLOW_JOB_CUSTOM_SCORER_EXECUTOR_BACKEND = _EnvironmentVariable(
+    "MLFLOW_JOB_CUSTOM_SCORER_EXECUTOR_BACKEND", str, None
+)
+
+#: Default timeout in seconds applied by the executor framework when a job
+#: submission does not specify one explicitly.
+#: (default: ``3600.0``)
+MLFLOW_SERVER_JOB_DEFAULT_TIMEOUT = _EnvironmentVariable(
+    "MLFLOW_SERVER_JOB_DEFAULT_TIMEOUT", float, 3600.0
+)
+
+#: Time-to-live in seconds for the short-lived RUNNING job lease used by
+#: recovery logic.
+#: (default: ``60.0``)
+MLFLOW_SERVER_JOB_LEASE_TTL = _EnvironmentVariable("MLFLOW_SERVER_JOB_LEASE_TTL", float, 60.0)
+
+#: Retention window in seconds for terminal job rows managed by the executor
+#: framework.
+#: (default: ``86400.0``)
+MLFLOW_SERVER_COMPLETED_JOB_TTL = _EnvironmentVariable(
+    "MLFLOW_SERVER_COMPLETED_JOB_TTL", float, 86400.0
+)
+
 
 #: Enable automatic run resumption for Serverless GPU Compute (SGC) jobs on Databricks.
 #: When enabled, MLflow will check for the SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID job

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -457,6 +457,11 @@ def _run_server(
                 "Errors will be surfaced at job invocation time."
             )
 
+        if job_execution_enabled:
+            from mlflow.server.jobs.executor_registry import validate_executor_config
+
+            validate_executor_config()
+
     if app_name == "basic-auth" and job_execution_enabled:
         # Generate the token here (before forking uvicorn workers) so that all
         # worker processes and job subprocesses share the same token.

--- a/mlflow/server/jobs/__init__.py
+++ b/mlflow/server/jobs/__init__.py
@@ -65,6 +65,8 @@ class JobFunctionMetadata:
     transient_error_classes: list[type[Exception]] | None = None
     python_env: _PythonEnv | None = None
     exclusive: bool | list[str] = False
+    resource_requests: dict[str, str] | None = None
+    resource_limits: dict[str, str] | None = None
 
 
 def job(
@@ -74,6 +76,8 @@ def job(
     python_version: str | None = None,
     pip_requirements: list[str] | None = None,
     exclusive: bool | list[str] = False,
+    resource_requests: dict[str, str] | None = None,
+    resource_limits: dict[str, str] | None = None,
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """
     The decorator for the custom job function for setting max parallel workers that
@@ -92,6 +96,8 @@ def job(
         exclusive: (optional) If True, only one instance of this job with the same params
             can run at a time. If a list of parameter names is provided, only those
             parameters are considered when determining exclusivity. Default is False.
+        resource_requests: (optional) Resource requests metadata for executor backends.
+        resource_limits: (optional) Resource limits metadata for executor backends.
     """
     from mlflow.utils import PYTHON_VERSION
     from mlflow.utils.requirements_utils import _parse_requirements
@@ -129,6 +135,8 @@ def job(
             transient_error_classes=transient_error_classes,
             python_env=python_env,
             exclusive=exclusive,
+            resource_requests=resource_requests,
+            resource_limits=resource_limits,
         )
         return fn
 

--- a/mlflow/server/jobs/executor.py
+++ b/mlflow/server/jobs/executor.py
@@ -1,0 +1,139 @@
+"""Executor interface and supporting types for the job execution framework."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from mlflow.entities._job_status import JobStatus
+from mlflow.utils.environment import _PythonEnv
+
+
+@dataclass
+class JobExecutorConfig:
+    """Framework-level configuration shared across executor instances."""
+
+    retry_base_delay: float = 1.0
+    retry_max_delay: float = 60.0
+    max_retries: int = 3
+    default_timeout: float = 3600.0
+    job_lease_ttl: float = 60.0
+    completed_job_ttl: float = 86400.0
+
+
+@dataclass
+class JobResult:
+    """Result returned by an executor's ``wait_for_job()`` method."""
+
+    status: JobStatus
+    result: str | None = None
+    error_message: str | None = None
+    is_transient_error: bool = False
+
+
+@dataclass
+class JobExecutionContext:
+    """Execution metadata the framework passes to the selected backend."""
+
+    job_id: str
+    tracking_uri: str
+    gateway_uri: str | None = None
+    token: str | None = None
+    workspace: str | None = None
+
+
+@dataclass
+class JobRecoveryResult:
+    """Per-job recovery outcome returned by ``recover_jobs()``."""
+
+    job_id: str
+    action: Literal["reattach", "requeue", "fail"]
+    error_message: str | None = None
+
+
+class AbstractJobExecutor(ABC):
+    """Backend contract for job executor plugins."""
+
+    def __init__(self, config: JobExecutorConfig) -> None:
+        self._config = config
+
+    @property
+    def config(self) -> JobExecutorConfig:
+        """The executor's framework configuration."""
+        return self._config
+
+    def start_executor(self) -> None:
+        """Called during MLflow server startup.
+
+        Subclasses may override this to acquire background resources.
+        """
+
+    def stop_executor(self) -> None:
+        """Called during MLflow server shutdown for graceful cleanup.
+
+        Subclasses may override this to release background resources.
+        """
+
+    @abstractmethod
+    def submit_job(
+        self,
+        job_id: str,
+        job_name: str,
+        fn_fullname: str,
+        params: dict[str, Any],
+        context: JobExecutionContext,
+        python_env: _PythonEnv | None = None,
+        timeout: float | None = None,
+    ) -> None:
+        """Submit a job for execution.
+
+        Args:
+            job_id: Unique job identifier.
+            job_name: Static name of the decorated job function.
+            fn_fullname: Fully-qualified Python module path of the job function.
+            params: Job parameters (JSON-serialisable).
+            context: Execution metadata including tracking URI and auth.
+            python_env: Optional Python environment specification.
+            timeout: Optional per-job timeout in seconds.
+        """
+
+    @abstractmethod
+    def wait_for_job(self, job_id: str) -> JobResult:
+        """Block until the job reaches a terminal state.
+
+        Returns:
+            A ``JobResult`` with a terminal status.
+        """
+
+    @abstractmethod
+    def cancel_job(self, job_id: str) -> None:
+        """Request cancellation of backend work for the given job."""
+
+    @abstractmethod
+    def recover_jobs(self, unfinished_job_ids: list[str]) -> list[JobRecoveryResult]:
+        """Determine recovery action for jobs whose monitoring loop disappeared.
+
+        Args:
+            unfinished_job_ids: Job IDs that were in-flight when the previous
+                monitoring loop stopped.
+
+        Returns:
+            One ``JobRecoveryResult`` per job indicating whether to reattach,
+            requeue, or fail.
+        """
+
+    @property
+    def remote_execution(self) -> bool:
+        """Whether this executor runs jobs through the remote execution contract.
+
+        When ``True``, the framework generates scoped tokens and requires
+        Gateway-backed model URIs. Defaults to ``False``.
+        """
+        return False
+
+    def check_requirements(self) -> None:
+        """Optional fail-fast validation run during server startup.
+
+        Subclasses may override this to verify that external dependencies
+        are available (e.g. Docker daemon, Kubernetes API). Raise
+        ``MlflowException`` if requirements are not met.
+        """

--- a/mlflow/server/jobs/executor_registry.py
+++ b/mlflow/server/jobs/executor_registry.py
@@ -1,0 +1,218 @@
+"""Executor plugin discovery, registration, and validation."""
+
+import logging
+import threading
+import warnings
+
+from mlflow.exceptions import MlflowException
+from mlflow.server.jobs.executor import AbstractJobExecutor, JobExecutorConfig
+from mlflow.utils.plugins import get_entry_points
+
+_logger = logging.getLogger(__name__)
+
+ENTRY_POINT_GROUP = "mlflow.job_executors"
+DEFAULT_EXECUTOR_BACKEND = "local"
+
+_global_registry_lock = threading.Lock()
+
+
+class JobExecutorRegistry:
+    """Discovers, instantiates, validates, and manages executor backends."""
+
+    def __init__(self, config: JobExecutorConfig | None = None) -> None:
+        self._config = config or JobExecutorConfig()
+        self._executors: dict[str, AbstractJobExecutor] = {}
+
+    @property
+    def config(self) -> JobExecutorConfig:
+        """The shared executor configuration."""
+        return self._config
+
+    def discover_and_register(self) -> None:
+        """Load executor plugins from installed entry points.
+
+        Raises:
+            MlflowException: If two entry points declare the same backend name
+                or collide with an already-registered built-in.
+        """
+        discovered = get_entry_points(ENTRY_POINT_GROUP)
+
+        for ep in discovered:
+            # Built-in backends are not overridable by entry-point plugins.
+            if ep.name in self._executors:
+                raise MlflowException(
+                    f"Job executor backend name '{ep.name}' from entry point "
+                    f"'{ep.value}' conflicts with an already-registered backend."
+                )
+
+            try:
+                executor_cls = ep.load()
+            except Exception as exc:
+                warnings.warn(
+                    f"Failure attempting to register job executor '{ep.name}': {exc}",
+                    stacklevel=2,
+                )
+                continue
+
+            if not (
+                isinstance(executor_cls, type) and issubclass(executor_cls, AbstractJobExecutor)
+            ):
+                warnings.warn(
+                    f"Failure attempting to register job executor '{ep.name}': "
+                    f"entry point does not resolve to a subclass of AbstractJobExecutor.",
+                    stacklevel=2,
+                )
+                continue
+
+            try:
+                executor = executor_cls(self._config)
+            except Exception as exc:
+                warnings.warn(
+                    f"Failure attempting to register job executor '{ep.name}': "
+                    f"{type(exc).__name__}: {exc}",
+                    stacklevel=2,
+                )
+                continue
+
+            self._executors[ep.name] = executor
+            _logger.debug("Registered job executor backend '%s' from '%s'", ep.name, ep.value)
+
+        _logger.info(
+            "Available backends after discovery: %s",
+            ", ".join(sorted(self._executors)) or "(none)",
+        )
+
+    def register(self, name: str, executor: AbstractJobExecutor) -> None:
+        """Manually register an executor backend."""
+        if name in self._executors:
+            raise MlflowException(f"Job executor backend '{name}' is already registered.")
+        self._executors[name] = executor
+
+    def get(self, name: str) -> AbstractJobExecutor:
+        """Return the executor registered under the given backend name.
+
+        Raises:
+            MlflowException: If no executor is registered with that name.
+        """
+        if name not in self._executors:
+            available = ", ".join(sorted(self._executors)) or "(none)"
+            raise MlflowException(
+                f"No job executor backend registered with name '{name}'. "
+                f"Available backends: {available}"
+            )
+        return self._executors[name]
+
+    def get_registered_names(self) -> list[str]:
+        """Return all registered backend names in sorted order."""
+        return sorted(self._executors)
+
+    def validate_backends(self, *backend_names: str) -> None:
+        """Run fail-fast validation for the given configured backend names."""
+        for name in backend_names:
+            executor = self.get(name)
+            try:
+                executor.check_requirements()
+            except MlflowException:
+                raise
+            except Exception as e:
+                raise MlflowException(
+                    f"Requirements check failed for job executor backend '{name}': {e}"
+                ) from e
+            _logger.info("Job executor backend '%s' passed requirements check", name)
+
+
+_global_registry: JobExecutorRegistry | None = None
+
+
+def _register_default_executors(registry: JobExecutorRegistry) -> None:
+    """Register built-in executor backends."""
+    from mlflow.server.jobs.local_executor import LocalJobExecutor
+
+    registry.register(DEFAULT_EXECUTOR_BACKEND, LocalJobExecutor(registry.config))
+
+
+def _get_configured_backend_names() -> list[str]:
+    """Return the list of configured backend names from environment variables."""
+    from mlflow.environment_variables import (
+        MLFLOW_JOB_CUSTOM_SCORER_EXECUTOR_BACKEND,
+        MLFLOW_JOB_DEFAULT_EXECUTOR_BACKEND,
+    )
+
+    default_backend = MLFLOW_JOB_DEFAULT_EXECUTOR_BACKEND.get()
+    custom_scorer_backend = MLFLOW_JOB_CUSTOM_SCORER_EXECUTOR_BACKEND.get()
+
+    backends = [default_backend]
+    if custom_scorer_backend and custom_scorer_backend != default_backend:
+        backends.append(custom_scorer_backend)
+    return backends
+
+
+def _build_validated_registry() -> tuple[JobExecutorRegistry, list[str]]:
+    """Build a registry with built-ins, plugins, and validated backends."""
+    config = _build_executor_config_from_env()
+    registry = JobExecutorRegistry(config)
+    _register_default_executors(registry)
+    registry.discover_and_register()
+
+    backends = _get_configured_backend_names()
+    registry.validate_backends(*backends)
+    return registry, backends
+
+
+def get_executor_registry() -> JobExecutorRegistry:
+    """Return the global executor registry, creating it on first access.
+
+    On the first call in a given process the registry is built, built-in
+    backends are registered, entry-point plugins are discovered, and configured
+    backends are validated. Subsequent calls return the cached instance.
+    """
+    global _global_registry
+    if _global_registry is None:
+        with _global_registry_lock:
+            if _global_registry is None:
+                registry, _ = _build_validated_registry()
+                _global_registry = registry
+    return _global_registry
+
+
+def validate_executor_config() -> None:
+    """Validate configured executor backends and their requirements.
+
+    Intended to be called from ``_run_server()`` in the parent launcher
+    process for early fail-fast feedback. This builds a temporary registry,
+    registers built-in backends, discovers entry-point plugins, and validates
+    that configured backend names can be resolved and satisfy their runtime
+    requirements.
+    """
+    _build_validated_registry()
+
+
+def _build_executor_config_from_env() -> JobExecutorConfig:
+    """Build ``JobExecutorConfig`` from the current environment variables."""
+    from mlflow.environment_variables import (
+        MLFLOW_SERVER_COMPLETED_JOB_TTL,
+        MLFLOW_SERVER_JOB_DEFAULT_TIMEOUT,
+        MLFLOW_SERVER_JOB_LEASE_TTL,
+        MLFLOW_SERVER_JOB_TRANSIENT_ERROR_MAX_RETRIES,
+        MLFLOW_SERVER_JOB_TRANSIENT_ERROR_RETRY_BASE_DELAY,
+        MLFLOW_SERVER_JOB_TRANSIENT_ERROR_RETRY_MAX_DELAY,
+    )
+
+    return JobExecutorConfig(
+        retry_base_delay=MLFLOW_SERVER_JOB_TRANSIENT_ERROR_RETRY_BASE_DELAY.get(),
+        retry_max_delay=MLFLOW_SERVER_JOB_TRANSIENT_ERROR_RETRY_MAX_DELAY.get(),
+        max_retries=MLFLOW_SERVER_JOB_TRANSIENT_ERROR_MAX_RETRIES.get(),
+        default_timeout=MLFLOW_SERVER_JOB_DEFAULT_TIMEOUT.get(),
+        job_lease_ttl=MLFLOW_SERVER_JOB_LEASE_TTL.get(),
+        completed_job_ttl=MLFLOW_SERVER_COMPLETED_JOB_TTL.get(),
+    )
+
+
+def shutdown_executor_registry() -> None:
+    """Clear the global registry.
+
+    Safe to call even if the registry was never initialised.
+    """
+    global _global_registry
+    if _global_registry is not None:
+        _global_registry = None

--- a/mlflow/server/jobs/local_executor.py
+++ b/mlflow/server/jobs/local_executor.py
@@ -1,0 +1,44 @@
+"""Built-in local subprocess job executor."""
+
+from typing import Any
+
+from mlflow.server.jobs.executor import (
+    AbstractJobExecutor,
+    JobExecutionContext,
+    JobExecutorConfig,
+    JobRecoveryResult,
+    JobResult,
+)
+from mlflow.utils.environment import _PythonEnv
+
+
+class LocalJobExecutor(AbstractJobExecutor):
+    """Default executor that runs jobs as local subprocesses.
+
+    Args:
+        config: Framework-level executor configuration.
+    """
+
+    def __init__(self, config: JobExecutorConfig) -> None:
+        super().__init__(config)
+
+    def submit_job(
+        self,
+        job_id: str,
+        job_name: str,
+        fn_fullname: str,
+        params: dict[str, Any],
+        context: JobExecutionContext,
+        python_env: _PythonEnv | None = None,
+        timeout: float | None = None,
+    ) -> None:
+        raise NotImplementedError("LocalJobExecutor.submit_job() is not implemented yet.")
+
+    def wait_for_job(self, job_id: str) -> JobResult:
+        raise NotImplementedError("LocalJobExecutor.wait_for_job() is not implemented yet.")
+
+    def cancel_job(self, job_id: str) -> None:
+        raise NotImplementedError("LocalJobExecutor.cancel_job() is not implemented yet.")
+
+    def recover_jobs(self, unfinished_job_ids: list[str]) -> list[JobRecoveryResult]:
+        raise NotImplementedError("LocalJobExecutor.recover_jobs() is not implemented yet.")

--- a/tests/server/jobs/test_executor_registry.py
+++ b/tests/server/jobs/test_executor_registry.py
@@ -1,0 +1,297 @@
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from mlflow.entities._job_status import JobStatus
+from mlflow.exceptions import MlflowException
+from mlflow.server.jobs.executor import (
+    AbstractJobExecutor,
+    JobExecutionContext,
+    JobExecutorConfig,
+    JobRecoveryResult,
+    JobResult,
+)
+from mlflow.server.jobs.executor_registry import (
+    JobExecutorRegistry,
+    _build_executor_config_from_env,
+    _register_default_executors,
+    get_executor_registry,
+    shutdown_executor_registry,
+    validate_executor_config,
+)
+from mlflow.utils.environment import _PythonEnv
+
+
+class StubExecutor(AbstractJobExecutor):
+    """Minimal concrete executor for testing."""
+
+    def __init__(self, config: JobExecutorConfig) -> None:
+        super().__init__(config)
+
+    def submit_job(
+        self,
+        job_id: str,
+        job_name: str,
+        fn_fullname: str,
+        params: dict[str, Any],
+        context: JobExecutionContext,
+        python_env: _PythonEnv | None = None,
+        timeout: float | None = None,
+    ) -> None:
+        pass
+
+    def wait_for_job(self, job_id: str) -> JobResult:
+        return JobResult(status=JobStatus.SUCCEEDED)
+
+    def cancel_job(self, job_id: str) -> None:
+        pass
+
+    def recover_jobs(self, unfinished_job_ids: list[str]) -> list[JobRecoveryResult]:
+        return []
+
+
+class FailingRequirementsExecutor(StubExecutor):
+    """Executor whose check_requirements raises."""
+
+    def check_requirements(self) -> None:
+        raise MlflowException("Docker daemon is not running")
+
+
+# ---------------------------------------------------------------------------
+# JobExecutorRegistry unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_register_and_get():
+    registry = JobExecutorRegistry()
+    executor = StubExecutor(registry.config)
+    registry.register("test-backend", executor)
+
+    assert registry.get("test-backend") is executor
+    assert "test-backend" in registry.get_registered_names()
+
+
+def test_register_duplicate_name_raises():
+    registry = JobExecutorRegistry()
+    executor = StubExecutor(registry.config)
+    registry.register("dup", executor)
+
+    with pytest.raises(MlflowException, match="already registered"):
+        registry.register("dup", StubExecutor(registry.config))
+
+
+def test_get_unknown_name_raises():
+    registry = JobExecutorRegistry()
+
+    with pytest.raises(MlflowException, match="No job executor backend registered"):
+        registry.get("nonexistent")
+
+
+def test_get_unknown_name_lists_available():
+    registry = JobExecutorRegistry()
+    registry.register("alpha", StubExecutor(registry.config))
+
+    with pytest.raises(MlflowException, match="alpha"):
+        registry.get("nonexistent")
+
+
+def test_validate_backends_success():
+    registry = JobExecutorRegistry()
+    registry.register("local", StubExecutor(registry.config))
+
+    registry.validate_backends("local")
+
+
+def test_validate_backends_failing_requirements():
+    registry = JobExecutorRegistry()
+    registry.register("docker", FailingRequirementsExecutor(registry.config))
+
+    with pytest.raises(MlflowException, match="Docker daemon is not running"):
+        registry.validate_backends("docker")
+
+
+def test_validate_backends_unknown_name():
+    registry = JobExecutorRegistry()
+
+    with pytest.raises(MlflowException, match="No job executor backend registered"):
+        registry.validate_backends("missing")
+
+
+def test_get_registered_names_sorted():
+    registry = JobExecutorRegistry()
+    registry.register("zulu", StubExecutor(registry.config))
+    registry.register("alpha", StubExecutor(registry.config))
+
+    assert registry.get_registered_names() == ["alpha", "zulu"]
+
+
+def test_custom_config_propagated():
+    config = JobExecutorConfig(max_retries=10, default_timeout=7200.0)
+    registry = JobExecutorRegistry(config)
+    registry.register("test", StubExecutor(config))
+
+    assert registry.get("test").config.max_retries == 10
+    assert registry.get("test").config.default_timeout == 7200.0
+
+
+# ---------------------------------------------------------------------------
+# Built-in registration
+# ---------------------------------------------------------------------------
+
+
+def test_register_default_executors():
+    from mlflow.server.jobs.local_executor import LocalJobExecutor
+
+    registry = JobExecutorRegistry()
+    _register_default_executors(registry)
+
+    assert "local" in registry.get_registered_names()
+    assert isinstance(registry.get("local"), LocalJobExecutor)
+
+
+# ---------------------------------------------------------------------------
+# Entry-point discovery
+# ---------------------------------------------------------------------------
+
+
+def _make_entry_point(name: str, executor_cls: type):
+    """Create a mock entry point that loads to the given class."""
+    ep = mock.Mock()
+    ep.name = name
+    ep.value = f"{executor_cls.__module__}:{executor_cls.__qualname__}"
+    ep.load.return_value = executor_cls
+    return ep
+
+
+def test_discover_and_register_from_entry_points():
+    ep = _make_entry_point("remote", StubExecutor)
+
+    registry = JobExecutorRegistry()
+    with mock.patch("mlflow.server.jobs.executor_registry.get_entry_points", return_value=[ep]):
+        registry.discover_and_register()
+
+    assert "remote" in registry.get_registered_names()
+    assert isinstance(registry.get("remote"), StubExecutor)
+
+
+def test_discover_entry_point_conflicting_with_builtin_raises():
+    ep = _make_entry_point("local", StubExecutor)
+
+    registry = JobExecutorRegistry()
+    _register_default_executors(registry)
+
+    with mock.patch("mlflow.server.jobs.executor_registry.get_entry_points", return_value=[ep]):
+        with pytest.raises(MlflowException, match="conflicts with an already-registered"):
+            registry.discover_and_register()
+
+
+def test_discover_non_executor_class_skips_with_warning():
+    ep = _make_entry_point("bad", dict)
+
+    registry = JobExecutorRegistry()
+    with mock.patch("mlflow.server.jobs.executor_registry.get_entry_points", return_value=[ep]):
+        registry.discover_and_register()
+
+    assert "bad" not in registry.get_registered_names()
+
+
+def test_discover_import_failure_skips_with_warning():
+    ep = mock.Mock()
+    ep.name = "broken"
+    ep.value = "nonexistent.module:Cls"
+    ep.load.side_effect = ImportError("No module named 'nonexistent'")
+
+    registry = JobExecutorRegistry()
+    with mock.patch("mlflow.server.jobs.executor_registry.get_entry_points", return_value=[ep]):
+        registry.discover_and_register()
+
+    assert "broken" not in registry.get_registered_names()
+
+
+# ---------------------------------------------------------------------------
+# Config from environment
+# ---------------------------------------------------------------------------
+
+
+def test_build_executor_config_from_env(monkeypatch):
+    monkeypatch.setenv("MLFLOW_SERVER_JOB_TRANSIENT_ERROR_RETRY_BASE_DELAY", "2")
+    monkeypatch.setenv("MLFLOW_SERVER_JOB_TRANSIENT_ERROR_RETRY_MAX_DELAY", "30")
+    monkeypatch.setenv("MLFLOW_SERVER_JOB_TRANSIENT_ERROR_MAX_RETRIES", "7")
+    monkeypatch.setenv("MLFLOW_SERVER_JOB_DEFAULT_TIMEOUT", "120")
+    monkeypatch.setenv("MLFLOW_SERVER_JOB_LEASE_TTL", "45")
+    monkeypatch.setenv("MLFLOW_SERVER_COMPLETED_JOB_TTL", "600")
+
+    config = _build_executor_config_from_env()
+
+    assert config.retry_base_delay == 2
+    assert config.retry_max_delay == 30
+    assert config.max_retries == 7
+    assert config.default_timeout == 120
+    assert config.job_lease_ttl == 45
+    assert config.completed_job_ttl == 600
+
+
+# ---------------------------------------------------------------------------
+# Lazy global singleton
+# ---------------------------------------------------------------------------
+
+
+def test_get_executor_registry_lazy_init(monkeypatch):
+    import mlflow.server.jobs.executor_registry as mod
+
+    mod._global_registry = None
+    monkeypatch.setenv("MLFLOW_JOB_DEFAULT_EXECUTOR_BACKEND", "local")
+    monkeypatch.delenv("MLFLOW_JOB_CUSTOM_SCORER_EXECUTOR_BACKEND", raising=False)
+
+    with mock.patch("mlflow.server.jobs.executor_registry.get_entry_points", return_value=[]):
+        registry = get_executor_registry()
+
+    assert "local" in registry.get_registered_names()
+
+    # Second call returns the same cached instance
+    assert get_executor_registry() is registry
+
+    shutdown_executor_registry()
+
+
+def test_shutdown_executor_registry_is_idempotent():
+    shutdown_executor_registry()
+    shutdown_executor_registry()
+
+
+# ---------------------------------------------------------------------------
+# Early validation (called from _run_server)
+# ---------------------------------------------------------------------------
+
+
+def test_validate_executor_config_succeeds(monkeypatch):
+    monkeypatch.setenv("MLFLOW_JOB_DEFAULT_EXECUTOR_BACKEND", "local")
+    monkeypatch.delenv("MLFLOW_JOB_CUSTOM_SCORER_EXECUTOR_BACKEND", raising=False)
+
+    with mock.patch("mlflow.server.jobs.executor_registry.get_entry_points", return_value=[]):
+        validate_executor_config()
+
+
+def test_validate_executor_config_unknown_backend_raises(monkeypatch):
+    monkeypatch.setenv("MLFLOW_JOB_DEFAULT_EXECUTOR_BACKEND", "nonexistent")
+    monkeypatch.delenv("MLFLOW_JOB_CUSTOM_SCORER_EXECUTOR_BACKEND", raising=False)
+
+    with mock.patch("mlflow.server.jobs.executor_registry.get_entry_points", return_value=[]):
+        with pytest.raises(MlflowException, match="No job executor backend registered"):
+            validate_executor_config()
+
+
+# ---------------------------------------------------------------------------
+# AbstractJobExecutor defaults
+# ---------------------------------------------------------------------------
+
+
+def test_executor_remote_execution_defaults_to_false():
+    executor = StubExecutor(JobExecutorConfig())
+    assert executor.remote_execution is False
+
+
+def test_executor_check_requirements_default_is_noop():
+    executor = StubExecutor(JobExecutorConfig())
+    executor.check_requirements()


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Relates to https://github.com/mlflow/rfcs/pull/2

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

This PR adds the executor registry and startup validation layer for the job execution plugin framework https://github.com/mlflow/rfcs/pull/2.

It adds the `AbstractJobExecutor` interface and framework types `JobExecutorConfig`, `JobResult`, `JobExecutionContext`, `JobRecoveryResult`, `JobProgress`, a `JobExecutorRegistry` that registers built-in backends and loads external plugins from entry points, validation of configured backends, and executor-facing resource metadata on `JobFunctionMetadata`. A placeholder `LocalJobExecutor` is included too.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
