### PR TITLE
[UI] Restore visible label on trace assessments pane toggle

### DIFF
--- a/.github/actions/check-component-ids/componentId-registry.js
+++ b/.github/actions/check-component-ids/componentId-registry.js
@@ -1907,7 +1907,6 @@ module.exports = {
   "shared.model-trace-explorer.assessment-value-number-input": "",
   "shared.model-trace-explorer.assessment-value-string-input": "",
   "shared.model-trace-explorer.assessments-pane-toggle": "",
-  "shared.model-trace-explorer.assessments-pane-toggle-tooltip": "",
   "shared.model-trace-explorer.attachment-audio-play": "",
   "shared.model-trace-explorer.attachment-download": "",
   "shared.model-trace-explorer.attachment-image-preview": "",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -4483,10 +4483,6 @@
     "defaultMessage": "Total",
     "description": "Label for total token usage"
   },
-  "QK9qFL": {
-    "defaultMessage": "Hide assessments",
-    "description": "Label for the button to hide the assessments pane"
-  },
   "QMCliz": {
     "defaultMessage": "Measure and compare LLM quality with built-in and custom scorers.",
     "description": "Feature card summary for evaluation"

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentPaneToggle.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentPaneToggle.tsx
@@ -1,38 +1,29 @@
-import { SidebarExpandIcon, Button, SidebarCollapseIcon, Tooltip } from '@databricks/design-system';
-import { useIntl } from '@databricks/i18n';
+import { Button, SidebarCollapseIcon } from '@databricks/design-system';
+import { FormattedMessage } from '@databricks/i18n';
 
 import { useModelTraceExplorerViewState } from '../ModelTraceExplorerViewStateContext';
 
 export const AssessmentPaneToggle = () => {
   const { assessmentsPaneExpanded, setAssessmentsPaneExpanded, assessmentsPaneEnabled } =
     useModelTraceExplorerViewState();
-  const intl = useIntl();
-
-  const label = assessmentsPaneExpanded
-    ? intl.formatMessage({
-        defaultMessage: 'Hide assessments',
-        description: 'Label for the button to hide the assessments pane',
-      })
-    : intl.formatMessage({
-        defaultMessage: 'Show assessments',
-        description: 'Label for the button to show the assessments pane',
-      });
 
   if (assessmentsPaneExpanded) {
     return null;
   }
 
   return (
-    <Tooltip componentId="shared.model-trace-explorer.assessments-pane-toggle-tooltip" content={label}>
-      <Button
-        disabled={!assessmentsPaneEnabled}
-        type="primary"
-        componentId="shared.model-trace-explorer.assessments-pane-toggle"
-        size="small"
-        icon={assessmentsPaneExpanded ? <SidebarExpandIcon /> : <SidebarCollapseIcon />}
-        onClick={() => setAssessmentsPaneExpanded?.(!assessmentsPaneExpanded)}
-        aria-label={label}
+    <Button
+      disabled={!assessmentsPaneEnabled}
+      type="primary"
+      componentId="shared.model-trace-explorer.assessments-pane-toggle"
+      size="small"
+      icon={<SidebarCollapseIcon />}
+      onClick={() => setAssessmentsPaneExpanded?.(true)}
+    >
+      <FormattedMessage
+        defaultMessage="Show assessments"
+        description="Label for the button to show the assessments pane"
       />
-    </Tooltip>
+    </Button>
   );
 };


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22697

### What changes are proposed in this pull request?

Restores the visible "Show assessments" label on the primary button that opens the assessments pane in the trace detail view.

PR #22697 ("MLflow UI Sync") replaced the labeled blue primary button with an icon-only button + tooltip. With only the icon visible, it is hard to discover where the assessments panel is — especially for users who haven't seen the trace UI before. This change restores the `FormattedMessage` child on the `Button` so the label renders again.

While reverting, I also dropped the now-unreachable `Hide assessments` branch in `AssessmentPaneToggle.tsx`: the component early-returns when `assessmentsPaneExpanded` is true, so the hide-state code path was dead.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

`yarn type-check`, `yarn lint`, `yarn prettier:check`, and `yarn i18n:check` all pass.

### Does this PR require documentation update?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Restores the visible "Show assessments" label on the trace detail view's assessments pane toggle button.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release