### PR TITLE
Include reasoning content in OpenCode tracing spans

### DIFF
--- a/libs/typescript/integrations/opencode/src/index.ts
+++ b/libs/typescript/integrations/opencode/src/index.ts
@@ -39,6 +39,7 @@ const MESSAGE_ROLE_USER = 'user';
 const MESSAGE_ROLE_ASSISTANT = 'assistant';
 const PART_TYPE_TEXT = 'text';
 const PART_TYPE_TOOL = 'tool';
+const PART_TYPE_REASONING = 'reasoning';
 
 // SDK initialization state
 let initialized = false;
@@ -190,6 +191,18 @@ function extractAssistantResponse(messages: Message[]): string {
 }
 
 /**
+ * Extract reasoning text from assistant message parts.
+ */
+function extractReasoningText(parts: MessagePart[]): string | undefined {
+  const reasoningText = parts
+    .filter((p) => p.type === PART_TYPE_REASONING && p.text?.trim())
+    .map((p) => p.text?.trim() || '')
+    .join('\n\n');
+
+  return reasoningText || undefined;
+}
+
+/**
  * Find the index of the last user message
  */
 function findLastUserMessageIndex(messages: Message[]): number | null {
@@ -305,9 +318,10 @@ function createLlmAndToolSpans(
     // Check for text and tool content
     const textParts = parts.filter((p) => p.type === PART_TYPE_TEXT);
     const toolParts = parts.filter((p) => p.type === PART_TYPE_TOOL);
+    const reasoningText = extractReasoningText(parts);
 
     // Create LLM span for text responses
-    if (textParts.length > 0) {
+    if (textParts.length > 0 || reasoningText) {
       const conversationMessages = reconstructConversationMessages(messages, i);
       const textContent = textParts.map((p) => p.text || '').join('\n');
 
@@ -333,7 +347,15 @@ function createLlmAndToolSpans(
       }
 
       llmSpan.setOutputs({
-        choices: [{ message: { role: 'assistant', content: textContent } }],
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: textContent,
+              ...(reasoningText && { reasoning: reasoningText }),
+            },
+          },
+        ],
       });
       llmSpan.end({ endTimeNs: completedNs });
     }

--- a/libs/typescript/integrations/opencode/tests/index.test.ts
+++ b/libs/typescript/integrations/opencode/tests/index.test.ts
@@ -16,13 +16,6 @@ type EventParams = any;
 
 // Mock the @mlflow/core module
 jest.mock('@mlflow/core', () => {
-  const mockSpan = {
-    traceId: 'mock-trace-id',
-    setAttribute: jest.fn(),
-    setOutputs: jest.fn(),
-    end: jest.fn(),
-  };
-
   const mockTraceInfo = {
     requestPreview: '',
     responsePreview: '',
@@ -35,7 +28,12 @@ jest.mock('@mlflow/core', () => {
 
   return {
     init: jest.fn(),
-    startSpan: jest.fn(() => mockSpan),
+    startSpan: jest.fn(() => ({
+      traceId: 'mock-trace-id',
+      setAttribute: jest.fn(),
+      setOutputs: jest.fn(),
+      end: jest.fn(),
+    })),
     flushTraces: jest.fn().mockResolvedValue(undefined),
     SpanType: {
       LLM: 'LLM',
@@ -110,6 +108,7 @@ describe('MLflowTracingPlugin', () => {
         cache?: { read?: number; write?: number };
       };
       time?: { created?: number; completed?: number };
+      reasoningText?: string;
     },
   ) => ({
     info: {
@@ -119,7 +118,34 @@ describe('MLflowTracingPlugin', () => {
       tokens: options?.tokens || { input: 100, output: 50 },
       time: options?.time || { created: Date.now(), completed: Date.now() + 1000 },
     },
-    parts: [{ type: 'text', text }],
+    parts: [
+      ...(options?.reasoningText ? [{ type: 'reasoning', text: options.reasoningText }] : []),
+      { type: 'text', text },
+    ],
+  });
+
+  const createAssistantReasoningOnlyMessage = (
+    reasoningText: string,
+    options?: {
+      modelID?: string;
+      providerID?: string;
+      tokens?: {
+        input?: number;
+        output?: number;
+        reasoning?: number;
+        cache?: { read?: number; write?: number };
+      };
+      time?: { created?: number; completed?: number };
+    },
+  ) => ({
+    info: {
+      role: 'assistant',
+      modelID: options?.modelID || 'claude-3-opus',
+      providerID: options?.providerID || 'anthropic',
+      tokens: options?.tokens || { input: 100, output: 50, reasoning: 25 },
+      time: options?.time || { created: Date.now(), completed: Date.now() + 1000 },
+    },
+    parts: [{ type: 'reasoning', text: reasoningText }],
   });
 
   // Helper to create an assistant message with tool call
@@ -396,6 +422,65 @@ describe('MLflowTracingPlugin', () => {
           }),
         }),
       );
+    });
+
+    it('should attach reasoning content to LLM outputs when present', async () => {
+      const messages = [
+        createUserMessage('Solve this carefully'),
+        createAssistantTextMessage('The answer is 4.', {
+          reasoningText: 'I considered the arithmetic step by step.',
+        }),
+      ];
+
+      const mockClient = createMockClient({}, messages);
+      const hooks = await MLflowTracingPlugin(createPluginInput(mockClient));
+
+      await hooks.event!(createSessionIdleEvent('reasoning-session'));
+
+      const llmSpan = (mlflowTracing.startSpan as jest.Mock).mock.results[1].value;
+      expect(llmSpan.setOutputs).toHaveBeenCalledWith({
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'The answer is 4.',
+              reasoning: 'I considered the arithmetic step by step.',
+            },
+          },
+        ],
+      });
+    });
+
+    it('should create an LLM span for reasoning-only assistant messages', async () => {
+      const messages = [
+        createUserMessage('Think about this'),
+        createAssistantReasoningOnlyMessage('Let me work through the possibilities.'),
+      ];
+
+      const mockClient = createMockClient({}, messages);
+      const hooks = await MLflowTracingPlugin(createPluginInput(mockClient));
+
+      await hooks.event!(createSessionIdleEvent('reasoning-only-session'));
+
+      expect(mlflowTracing.startSpan).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'llm_call',
+          spanType: 'LLM',
+        }),
+      );
+
+      const llmSpan = (mlflowTracing.startSpan as jest.Mock).mock.results[1].value;
+      expect(llmSpan.setOutputs).toHaveBeenCalledWith({
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: '',
+              reasoning: 'Let me work through the possibilities.',
+            },
+          },
+        ],
+      });
     });
   });
 


### PR DESCRIPTION
### Related Issues/PRs

Closes #22956

### What changes are proposed in this pull request?

This updates the `@mlflow/opencode` tracing integration to preserve OpenCode `reasoning` message parts in LLM span outputs.

The plugin now:
- extracts reasoning text from assistant message parts,
- attaches that reasoning to the traced assistant message when text output is present, and
- still emits an LLM span when an assistant response contains reasoning without a text part so the trace UI can surface it.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Validation run:
- `npm run test:opencode`
- `npx eslint integrations/opencode/src integrations/opencode/tests --ext .ts`
- `npm run -C integrations/opencode build`

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the MLflow Skills repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

OpenCode tracing now records assistant reasoning/thinking content on LLM spans so it can be viewed in the trace UI.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

#### How should the PR be classified in the release notes?

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and should go into the next patch release. Please explain why this is critical.
- [x] This PR can wait until the next minor release.
