### PR TITLE
Fix `triage` workflow `fromJSON` failure on empty result

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -156,7 +156,7 @@ jobs:
           && contains(github.event.issue.labels.*.name, 'area/uiux')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COMMENT: ${{ fromJSON(steps.triage.outputs.result).comment }}
+          COMMENT: ${{ fromJSON(steps.triage.outputs.result || '{"comment":""}').comment }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "$COMMENT


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22975

### What changes are proposed in this pull request?

The `Comment and label if info needed` step in `.github/workflows/triage.yml` set its `COMMENT` env via `${{ fromJSON(steps.triage.outputs.result).comment }}`. When the prior `Triage issue` step is skipped (e.g., the issue isn't labeled `bug`), `steps.triage.outputs.result` is empty, and `fromJSON("")` fails with:

```
Error reading JToken from JsonReader. Path '', line 0, position 0.
```

Add a fallback default object so the expression evaluates safely when the prior step produced no output. The `if:` guard still short-circuits and prevents the step from actually running.

See: https://github.com/mlflow/mlflow/actions/runs/25085643686/job/73500484286

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release