### PR TITLE
Add multi-turn judge context primitives

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1448,6 +1448,24 @@ MLFLOW_ONLINE_SCORING_DEFAULT_SESSION_COMPLETION_BUFFER_SECONDS = _EnvironmentVa
 MLFLOW_JUDGE_MAX_ITERATIONS = _EnvironmentVariable("MLFLOW_JUDGE_MAX_ITERATIONS", int, 30)
 
 
+#: When evaluating a trace that belongs to a multi-turn session, this controls
+#: the maximum number of prior conversation turns to surface to single-turn LLM
+#: judges. Set to ``0`` to disable multi-turn context entirely (judges see only
+#: the current turn, matching the pre-multi-turn behavior).
+#: (default: ``10``)
+MLFLOW_JUDGE_MAX_PRIOR_TURNS = _EnvironmentVariable("MLFLOW_JUDGE_MAX_PRIOR_TURNS", int, 10)
+
+
+#: Optional token budget for the prior-conversation context block surfaced to
+#: single-turn LLM judges. When set, prior turns are dropped from the oldest
+#: end until the rendered block fits under this budget. Unset by default,
+#: meaning the only cap is :data:`MLFLOW_JUDGE_MAX_PRIOR_TURNS`.
+#: (default: unset)
+MLFLOW_JUDGE_PRIOR_TURNS_TOKEN_BUDGET = _EnvironmentVariable(
+    "MLFLOW_JUDGE_PRIOR_TURNS_TOKEN_BUDGET", int, None
+)
+
+
 #: Enable automatic run resumption for Serverless GPU Compute (SGC) jobs on Databricks.
 #: When enabled, MLflow will check for the SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID job
 #: parameter and automatically resume MLflow runs associated with that Databricks job run ID.

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1448,18 +1448,23 @@ MLFLOW_ONLINE_SCORING_DEFAULT_SESSION_COMPLETION_BUFFER_SECONDS = _EnvironmentVa
 MLFLOW_JUDGE_MAX_ITERATIONS = _EnvironmentVariable("MLFLOW_JUDGE_MAX_ITERATIONS", int, 30)
 
 
-#: When evaluating a trace that belongs to a multi-turn session, this controls
-#: the maximum number of prior conversation turns to surface to single-turn LLM
-#: judges. Set to ``0`` to disable multi-turn context entirely (judges see only
-#: the current turn, matching the pre-multi-turn behavior).
+#: When evaluating a trace that belongs to a multi-turn session, this caps the
+#: maximum number of prior conversation messages surfaced to single-turn LLM
+#: judges. The cap is applied to messages in the OpenAI-style conversation list
+#: (each user, assistant, or tool message counts individually — not as
+#: user/assistant turn pairs). Set to ``0`` to disable multi-turn context
+#: entirely (judges see only the current turn, matching the pre-multi-turn
+#: behavior).
 #: (default: ``10``)
 MLFLOW_JUDGE_MAX_PRIOR_TURNS = _EnvironmentVariable("MLFLOW_JUDGE_MAX_PRIOR_TURNS", int, 10)
 
 
-#: Optional token budget for the prior-conversation context block surfaced to
-#: single-turn LLM judges. When set, prior turns are dropped from the oldest
-#: end until the rendered block fits under this budget. Unset by default,
-#: meaning the only cap is :data:`MLFLOW_JUDGE_MAX_PRIOR_TURNS`.
+#: Optional token budget that consumers may apply to the prior-conversation
+#: context block when surfacing it to single-turn LLM judges. The intended
+#: contract is "drop oldest messages first until the rendered block fits under
+#: this budget". This PR adds the env var only — the consumer that enforces
+#: it lands in a follow-up. Unset by default, meaning the only cap is
+#: :data:`MLFLOW_JUDGE_MAX_PRIOR_TURNS`.
 #: (default: unset)
 MLFLOW_JUDGE_PRIOR_TURNS_TOKEN_BUDGET = _EnvironmentVariable(
     "MLFLOW_JUDGE_PRIOR_TURNS_TOKEN_BUDGET", int, None

--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -413,6 +413,43 @@ def resolve_conversation_from_session(
     return conversation
 
 
+def extract_prior_turns(
+    session: list[Trace],
+    current_trace: Trace,
+    *,
+    include_tool_calls: bool = False,
+) -> list[dict[str, str]]:
+    """
+    Extract conversation history from session traces that occurred strictly
+    before ``current_trace``. Used by single-turn LLM judges to obtain the
+    prior context for a turn embedded in a multi-turn session.
+
+    A trace is considered "prior" if its ``timestamp_ms`` is strictly less
+    than the current trace's ``timestamp_ms`` and it is not the current trace
+    itself. Same-millisecond ties are excluded to avoid races between the
+    current turn's own spans and other concurrent traces.
+
+    Args:
+        session: List of traces from the same session. The current trace may
+            or may not be a member of this list — it is filtered out either way.
+        current_trace: The trace whose prior context we want.
+        include_tool_calls: Forwarded to ``resolve_conversation_from_session``.
+
+    Returns:
+        Conversation messages from prior turns in chronological order, in the
+        format ``[{"role": "user"|"assistant"|"tool", "content": str}]``.
+        Empty list if there are no prior turns.
+    """
+    current_id = current_trace.info.trace_id
+    current_ts = current_trace.info.timestamp_ms
+    prior = [
+        trace
+        for trace in session
+        if trace.info.trace_id != current_id and trace.info.timestamp_ms < current_ts
+    ]
+    return resolve_conversation_from_session(prior, include_tool_calls=include_tool_calls)
+
+
 def resolve_expectations_from_trace(
     expectations: dict[str, Any] | None,
     trace: Trace,

--- a/tests/genai/utils/test_trace_utils.py
+++ b/tests/genai/utils/test_trace_utils.py
@@ -32,6 +32,7 @@ from mlflow.genai.utils.trace_utils import (
     extract_expectations_from_trace,
     extract_inputs_from_trace,
     extract_outputs_from_trace,
+    extract_prior_turns,
     extract_request_from_trace,
     extract_response_from_trace,
     extract_retrieval_context_from_trace,
@@ -1030,6 +1031,85 @@ def test_resolve_conversation_from_session_with_tool_calls():
 
 def test_resolve_conversation_from_session_empty():
     assert resolve_conversation_from_session([]) == []
+
+
+def _make_session_traces(session_id: str, turns: list[tuple[str, str]]) -> list[Trace]:
+    traces: list[Trace] = []
+    for user_msg, assistant_msg in turns:
+        with mlflow.start_span(name="turn") as span:
+            span.set_inputs({"messages": [{"role": "user", "content": user_msg}]})
+            span.set_outputs(assistant_msg)
+            mlflow.update_current_trace(metadata={"mlflow.trace.session": session_id})
+        traces.append(mlflow.get_trace(span.trace_id))
+    return traces
+
+
+def test_extract_prior_turns_returns_only_strictly_earlier_traces():
+    traces = _make_session_traces(
+        "session_extract_prior",
+        [("hello", "hi"), ("how are you?", "good"), ("tell me a joke", "knock knock")],
+    )
+
+    # Looking at the third turn, prior = first two turns, in order.
+    prior = extract_prior_turns(traces, traces[2])
+    assert prior == [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+        {"role": "user", "content": "how are you?"},
+        {"role": "assistant", "content": "good"},
+    ]
+
+
+def test_extract_prior_turns_excludes_current_trace_even_if_in_session_list():
+    traces = _make_session_traces("session_self_exclude", [("u1", "a1"), ("u2", "a2")])
+
+    # Pass the full session including the current trace; helper must filter it out.
+    prior = extract_prior_turns(traces, traces[1])
+    assert prior == [
+        {"role": "user", "content": "u1"},
+        {"role": "assistant", "content": "a1"},
+    ]
+
+
+def test_extract_prior_turns_returns_empty_for_first_turn():
+    traces = _make_session_traces("session_first_turn", [("u1", "a1"), ("u2", "a2")])
+
+    assert extract_prior_turns(traces, traces[0]) == []
+
+
+def test_extract_prior_turns_returns_empty_when_session_is_empty():
+    # Synthesize a single trace not part of any session list.
+    traces = _make_session_traces("session_alone", [("u1", "a1")])
+
+    assert extract_prior_turns([], traces[0]) == []
+
+
+def test_extract_prior_turns_forwards_include_tool_calls():
+    session_id = "session_with_tools"
+    traces: list[Trace] = []
+
+    with mlflow.start_span(name="turn_0") as root_span:
+        root_span.set_inputs({"messages": [{"role": "user", "content": "Get AAPL price"}]})
+        with mlflow.start_span(name="get_stock_price", span_type=SpanType.TOOL) as tool_span:
+            tool_span.set_inputs({"symbol": "AAPL"})
+            tool_span.set_outputs({"price": 150})
+        root_span.set_outputs("AAPL is $150.")
+        mlflow.update_current_trace(metadata={"mlflow.trace.session": session_id})
+    traces.append(mlflow.get_trace(root_span.trace_id))
+
+    with mlflow.start_span(name="turn_1") as span:
+        span.set_inputs({"messages": [{"role": "user", "content": "Thanks"}]})
+        span.set_outputs("You're welcome.")
+        mlflow.update_current_trace(metadata={"mlflow.trace.session": session_id})
+    traces.append(mlflow.get_trace(span.trace_id))
+
+    # Without tool calls, prior context is just user/assistant messages.
+    prior = extract_prior_turns(traces, traces[1])
+    assert [m["role"] for m in prior] == ["user", "assistant"]
+
+    # With tool calls, the TOOL span message appears between user and assistant.
+    prior_with_tools = extract_prior_turns(traces, traces[1], include_tool_calls=True)
+    assert [m["role"] for m in prior_with_tools] == ["user", "tool", "assistant"]
 
 
 @pytest.mark.parametrize("include_timing", [True, False])

--- a/tests/genai/utils/test_trace_utils.py
+++ b/tests/genai/utils/test_trace_utils.py
@@ -1035,12 +1035,18 @@ def test_resolve_conversation_from_session_empty():
 
 def _make_session_traces(session_id: str, turns: list[tuple[str, str]]) -> list[Trace]:
     traces: list[Trace] = []
-    for user_msg, assistant_msg in turns:
+    for i, (user_msg, assistant_msg) in enumerate(turns):
         with mlflow.start_span(name="turn") as span:
             span.set_inputs({"messages": [{"role": "user", "content": user_msg}]})
             span.set_outputs(assistant_msg)
             mlflow.update_current_trace(metadata={"mlflow.trace.session": session_id})
-        traces.append(mlflow.get_trace(span.trace_id))
+        trace = mlflow.get_trace(span.trace_id)
+        # Force a deterministic, monotonically increasing timestamp so the
+        # strict-less-than filter in extract_prior_turns is exercised
+        # reliably even when traces complete in the same wall-clock
+        # millisecond (which can happen in tight test loops).
+        trace.info.timestamp_ms = i + 1
+        traces.append(trace)
     return traces
 
 


### PR DESCRIPTION
## 🥞 Stacked PR
- [**stack/judge-multiturn/1-foundation**](https://github.com/mlflow/mlflow/pull/22984)
  - [stack/judge-multiturn/2-pilot](https://github.com/mlflow/mlflow/pull/22985)

---------
### Related Issues/PRs

Foundation for fixing single-turn LLM judges that produce false negatives on multi-turn conversations. The single-turn judges (`RelevanceToQuery`, `ToolCallCorrectness`, etc.) currently see only the root span of one trace and have zero visibility into prior turns of the same session — so when a user says `"Yes"` in response to the agent's `"Would you like more details?"`, the judge looks at `(input="Yes", output="...NFL info...")` in isolation and reports the response as irrelevant or the tool call as unwarranted.

This PR adds the data-extraction primitives. The follow-up stack-2 PR consumes them in `RelevanceToQuery` as a pilot (signature change, prompt template update, harness wiring, regression tests).

### What changes are proposed in this pull request?

Two pure additions, both inert until consumed:

1. **`extract_prior_turns(session, current_trace)`** in `mlflow/genai/utils/trace_utils.py` — filters a session list to traces strictly earlier than `current_trace` (by `timestamp_ms`, with a self-exclusion safety check) and delegates to the existing `resolve_conversation_from_session()` helper for message formatting. Returns the prior conversation in chronological order, no truncation. Truncation is a separate concern owned by the consumer.

2. **Two environment variables** in `mlflow/environment_variables.py`:
   - `MLFLOW_JUDGE_MAX_PRIOR_TURNS` (int, default `10`) — caps how many prior turns are surfaced to single-turn judges. Setting `0` disables multi-turn context entirely and reproduces today's behavior exactly.
   - `MLFLOW_JUDGE_PRIOR_TURNS_TOKEN_BUDGET` (int, unset by default) — optional token budget consumers can apply on top.

Neither helper is wired into any scorer or judge yet — that lives in the next stack PR.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

5 new pytest tests in `tests/genai/utils/test_trace_utils.py` covering:
- strict-less-than timestamp filtering returns prior turns in chronological order
- the current trace is excluded even when it appears in the session list
- empty result for the first turn of a session
- empty result for an empty session list
- `include_tool_calls` parameter is forwarded through to `resolve_conversation_from_session`

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

User-facing docs land with stack 2 (the pilot consumer). This PR adds internal helpers only.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

