### PR TITLE
Surface prior conversation context to RelevanceToQuery judge

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1448,6 +1448,24 @@ MLFLOW_ONLINE_SCORING_DEFAULT_SESSION_COMPLETION_BUFFER_SECONDS = _EnvironmentVa
 MLFLOW_JUDGE_MAX_ITERATIONS = _EnvironmentVariable("MLFLOW_JUDGE_MAX_ITERATIONS", int, 30)
 
 
+#: When evaluating a trace that belongs to a multi-turn session, this controls
+#: the maximum number of prior conversation turns to surface to single-turn LLM
+#: judges. Set to ``0`` to disable multi-turn context entirely (judges see only
+#: the current turn, matching the pre-multi-turn behavior).
+#: (default: ``10``)
+MLFLOW_JUDGE_MAX_PRIOR_TURNS = _EnvironmentVariable("MLFLOW_JUDGE_MAX_PRIOR_TURNS", int, 10)
+
+
+#: Optional token budget for the prior-conversation context block surfaced to
+#: single-turn LLM judges. When set, prior turns are dropped from the oldest
+#: end until the rendered block fits under this budget. Unset by default,
+#: meaning the only cap is :data:`MLFLOW_JUDGE_MAX_PRIOR_TURNS`.
+#: (default: unset)
+MLFLOW_JUDGE_PRIOR_TURNS_TOKEN_BUDGET = _EnvironmentVariable(
+    "MLFLOW_JUDGE_PRIOR_TURNS_TOKEN_BUDGET", int, None
+)
+
+
 #: Enable automatic run resumption for Serverless GPU Compute (SGC) jobs on Databricks.
 #: When enabled, MLflow will check for the SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID job
 #: parameter and automatically resume MLflow runs associated with that Databricks job run ID.

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1448,18 +1448,23 @@ MLFLOW_ONLINE_SCORING_DEFAULT_SESSION_COMPLETION_BUFFER_SECONDS = _EnvironmentVa
 MLFLOW_JUDGE_MAX_ITERATIONS = _EnvironmentVariable("MLFLOW_JUDGE_MAX_ITERATIONS", int, 30)
 
 
-#: When evaluating a trace that belongs to a multi-turn session, this controls
-#: the maximum number of prior conversation turns to surface to single-turn LLM
-#: judges. Set to ``0`` to disable multi-turn context entirely (judges see only
-#: the current turn, matching the pre-multi-turn behavior).
+#: When evaluating a trace that belongs to a multi-turn session, this caps the
+#: maximum number of prior conversation messages surfaced to single-turn LLM
+#: judges. The cap is applied to messages in the OpenAI-style conversation list
+#: (each user, assistant, or tool message counts individually — not as
+#: user/assistant turn pairs). Set to ``0`` to disable multi-turn context
+#: entirely (judges see only the current turn, matching the pre-multi-turn
+#: behavior).
 #: (default: ``10``)
 MLFLOW_JUDGE_MAX_PRIOR_TURNS = _EnvironmentVariable("MLFLOW_JUDGE_MAX_PRIOR_TURNS", int, 10)
 
 
-#: Optional token budget for the prior-conversation context block surfaced to
-#: single-turn LLM judges. When set, prior turns are dropped from the oldest
-#: end until the rendered block fits under this budget. Unset by default,
-#: meaning the only cap is :data:`MLFLOW_JUDGE_MAX_PRIOR_TURNS`.
+#: Optional token budget that consumers may apply to the prior-conversation
+#: context block when surfacing it to single-turn LLM judges. The intended
+#: contract is "drop oldest messages first until the rendered block fits under
+#: this budget". This PR adds the env var only — the consumer that enforces
+#: it lands in a follow-up. Unset by default, meaning the only cap is
+#: :data:`MLFLOW_JUDGE_MAX_PRIOR_TURNS`.
 #: (default: unset)
 MLFLOW_JUDGE_PRIOR_TURNS_TOKEN_BUDGET = _EnvironmentVariable(
     "MLFLOW_JUDGE_PRIOR_TURNS_TOKEN_BUDGET", int, None

--- a/mlflow/genai/evaluation/harness.py
+++ b/mlflow/genai/evaluation/harness.py
@@ -414,16 +414,11 @@ class _ScoreSubmitter:
         self._single_turn_scorers = single_turn_scorers
         self._multi_turn_scorers = multi_turn_scorers
         self._session_groups = session_groups
-        # Build a trace_id → session traces lookup once so single-turn
-        # scorers can be supplied with their session context. Items without
-        # a trace, or whose trace doesn't belong to a session group, are
-        # absent from the map and fall back to ``session=None``.
-        self._trace_to_session: dict[str, list[Trace]] = {}
-        for items in session_groups.values():
-            session_traces = [item.trace for item in items if item.trace is not None]
-            for item in items:
-                if item.trace is not None:
-                    self._trace_to_session[item.trace.info.trace_id] = session_traces
+        # The trace_id → session traces lookup is rebuilt on every
+        # ``submit()`` rather than cached, because predict_fn flows
+        # populate ``EvalItem.trace`` incrementally — caching the first
+        # build would freeze a partial map. Rebuilding is O(n) per submit,
+        # acceptable for typical eval sizes.
         self._run_id = run_id
         self._max_retries = max_retries
         self._limiter = _make_rate_limiter(
@@ -451,12 +446,32 @@ class _ScoreSubmitter:
     def shutdown(self) -> None:
         self._pool.shutdown(wait=False, cancel_futures=True)
 
+    def _build_trace_to_session(self) -> dict[str, list[Trace]]:
+        """
+        Build the trace_id → session traces lookup from the current state of
+        ``self._eval_items``. Called per ``submit()`` because predict_fn
+        flows populate ``EvalItem.trace`` incrementally — a cached map would
+        miss traces produced after the first call.
+        """
+        # ``_session_groups`` was computed before predict_fn ran, so for
+        # predict_fn flows it would be empty here. Recompute from the
+        # latest ``_eval_items`` instead.
+        from mlflow.genai.evaluation.session_utils import group_traces_by_session
+
+        mapping: dict[str, list[Trace]] = {}
+        for items in group_traces_by_session(self._eval_items).values():
+            session_traces = [item.trace for item in items if item.trace is not None]
+            for item in items:
+                if item.trace is not None:
+                    mapping[item.trace.info.trace_id] = session_traces
+        return mapping
+
     def submit(self, idx: int) -> Future:
         """Submit a score task for eval item *idx* and return the future."""
         _logger.debug(f"Predict completed for item {idx}, submitting score")
         eval_item = self._eval_items[idx]
         session_traces = (
-            self._trace_to_session.get(eval_item.trace.info.trace_id)
+            self._build_trace_to_session().get(eval_item.trace.info.trace_id)
             if eval_item.trace is not None
             else None
         )

--- a/mlflow/genai/evaluation/harness.py
+++ b/mlflow/genai/evaluation/harness.py
@@ -414,6 +414,16 @@ class _ScoreSubmitter:
         self._single_turn_scorers = single_turn_scorers
         self._multi_turn_scorers = multi_turn_scorers
         self._session_groups = session_groups
+        # Build a trace_id → session traces lookup once so single-turn
+        # scorers can be supplied with their session context. Items without
+        # a trace, or whose trace doesn't belong to a session group, are
+        # absent from the map and fall back to ``session=None``.
+        self._trace_to_session: dict[str, list[Trace]] = {}
+        for items in session_groups.values():
+            session_traces = [item.trace for item in items if item.trace is not None]
+            for item in items:
+                if item.trace is not None:
+                    self._trace_to_session[item.trace.info.trace_id] = session_traces
         self._run_id = run_id
         self._max_retries = max_retries
         self._limiter = _make_rate_limiter(
@@ -444,13 +454,20 @@ class _ScoreSubmitter:
     def submit(self, idx: int) -> Future:
         """Submit a score task for eval item *idx* and return the future."""
         _logger.debug(f"Predict completed for item {idx}, submitting score")
+        eval_item = self._eval_items[idx]
+        session_traces = (
+            self._trace_to_session.get(eval_item.trace.info.trace_id)
+            if eval_item.trace is not None
+            else None
+        )
         future = self._pool.submit(
             self._timed_score,
-            self._eval_items[idx],
+            eval_item,
             self._single_turn_scorers,
             self._run_id,
             self._limiter,
             self._max_retries,
+            session_traces,
         )
         self._score_futures_to_eval_id[future] = idx
         return future
@@ -640,8 +657,19 @@ def run(
     experiment_id = mlflow.get_run(run_id).info.experiment_id
 
     single_turn_scorers, multi_turn_scorers = classify_scorers(scorers)
-    session_groups = group_traces_by_session(eval_items) if multi_turn_scorers else {}
-    total_tasks = (len(eval_items) if single_turn_scorers else 0) + len(session_groups)
+    # Compute session_groups whenever any scorers are present: multi-turn
+    # scorers need them as before, and single-turn scorers may use them to
+    # surface prior conversation context to LLM judges (Scorer.run() filters
+    # the kwarg by signature, so scorers that don't opt in are unaffected).
+    session_groups = (
+        group_traces_by_session(eval_items) if (single_turn_scorers or multi_turn_scorers) else {}
+    )
+    # ``total_tasks`` only counts multi-turn session groups, not the
+    # single-turn-with-session lookups, since the latter are not separate
+    # progress-bar units.
+    total_tasks = (len(eval_items) if single_turn_scorers else 0) + (
+        len(session_groups) if multi_turn_scorers else 0
+    )
 
     progress_bar = (
         tqdm(
@@ -720,7 +748,11 @@ def run(
     mlflow.log_metrics(aggregated_metrics)
 
     try:
-        emit_metric_usage_event(scorers, len(eval_items), len(session_groups), aggregated_metrics)
+        # The session-group count reported here measures multi-turn scorer
+        # invocations, so it should be 0 when no multi-turn scorers ran even
+        # if session_groups was populated for single-turn context lookup.
+        emitted_session_count = len(session_groups) if multi_turn_scorers else 0
+        emit_metric_usage_event(scorers, len(eval_items), emitted_session_count, aggregated_metrics)
     except Exception as e:
         _logger.debug(f"Failed to emit metric usage event: {e}", exc_info=True)
 
@@ -801,6 +833,7 @@ def _run_score(
     run_id: str | None,
     scorer_rate_limiter: RateLimiter,
     max_retries: int = 0,
+    session: list[Trace] | None = None,
 ) -> EvalResult:
     if run_id:
         ctx = context.get_context()
@@ -812,6 +845,7 @@ def _run_score(
             scorers=scorers,
             rate_limiter=scorer_rate_limiter,
             max_retries=max_retries,
+            session=session,
         )
     eval_result.assessments.extend(_get_new_expectations(eval_item))
 
@@ -836,12 +870,19 @@ def _run_score(
     return eval_result
 
 
-def _invoke_scorer(scorer_func: Callable[..., Any], eval_item: EvalItem):
+def _invoke_scorer(
+    scorer_func: Callable[..., Any],
+    eval_item: EvalItem,
+    session: list[Trace] | None = None,
+):
+    # ``Scorer.run()`` filters by signature, so passing ``session`` here is
+    # safe for scorers that don't declare it — they simply won't receive it.
     return scorer_func(
         inputs=eval_item.inputs,
         outputs=eval_item.outputs,
         expectations=eval_item.expectations,
         trace=eval_item.trace,
+        session=session,
     )
 
 
@@ -851,6 +892,7 @@ def _compute_eval_scores(
     scorers: list[Scorer],
     rate_limiter: RateLimiter = NoOpRateLimiter(),
     max_retries: int = 0,
+    session: list[Trace] | None = None,
 ) -> EvalResult:
     if not scorers:
         return EvalResult(eval_item=eval_item, assessments=[], scorer_stats={})
@@ -867,7 +909,9 @@ def _compute_eval_scores(
                 )
 
             value = call_with_retry(
-                lambda: _invoke_scorer(scorer_func, eval_item), rate_limiter, max_retries
+                lambda: _invoke_scorer(scorer_func, eval_item, session=session),
+                rate_limiter,
+                max_retries,
             )
             feedbacks = standardize_scorer_value(scorer.name, value)
 

--- a/mlflow/genai/judges/builtin.py
+++ b/mlflow/genai/judges/builtin.py
@@ -65,7 +65,12 @@ def requires_databricks_agents(func):
 
 @format_docstring(_MODEL_API_DOC)
 def is_context_relevant(
-    *, request: str, context: Any, name: str | None = None, model: str | None = None
+    *,
+    request: str,
+    context: Any,
+    name: str | None = None,
+    model: str | None = None,
+    prior_conversation: list[dict[str, str]] | None = None,
 ) -> Feedback:
     """
     LLM judge determines whether the given context is relevant to the input request.
@@ -76,6 +81,13 @@ def is_context_relevant(
             Supports any JSON-serializable object.
         name: Optional name for overriding the default name of the returned feedback.
         model: {{ model }}
+        prior_conversation: Optional list of OpenAI-style messages
+            (``[{"role": ..., "content": ...}]``) representing prior turns of
+            a multi-turn conversation. When provided, the judge sees the
+            history when deciding relevance — useful when the request is a
+            short continuation (e.g. ``"yes"``) that only makes sense in
+            context. The Databricks judge model does not currently accept
+            this parameter and ignores it.
 
     Returns:
         A :py:class:`mlflow.entities.assessment.Feedback~` object with a "yes" or "no" value
@@ -114,13 +126,15 @@ def is_context_relevant(
     if model == "databricks":
         from databricks.agents.evals.judges import relevance_to_query
 
+        # The Databricks judge does not currently accept prior conversation
+        # context; multi-turn support there will be plumbed in a follow-up.
         feedback = relevance_to_query(
             request=request,
             response=str(context),
             assessment_name=assessment_name,
         )
     else:
-        prompt = get_prompt(request, str(context))
+        prompt = get_prompt(request, str(context), prior_conversation=prior_conversation)
         feedback = invoke_judge_model(
             model, prompt, assessment_name=assessment_name, use_case=USE_CASE_BUILTIN_JUDGE
         )

--- a/mlflow/genai/judges/prompts/relevance_to_query.py
+++ b/mlflow/genai/judges/prompts/relevance_to_query.py
@@ -1,3 +1,4 @@
+from mlflow.genai.judges.utils.multi_turn import render_prior_conversation_block
 from mlflow.genai.prompts.utils import format_prompt
 
 # NB: User-facing name for the is_context_relevant assessment.
@@ -28,9 +29,18 @@ RELEVANCE_TO_QUERY_PROMPT = (
 )
 
 
-def get_prompt(request: str, context: str) -> str:
-    return format_prompt(
-        RELEVANCE_TO_QUERY_PROMPT,
-        input=request,
-        output=context,
-    )
+def get_prompt(
+    request: str,
+    context: str,
+    prior_conversation: list[dict[str, str]] | None = None,
+) -> str:
+    """
+    Render the relevance-to-query judge prompt.
+
+    When ``prior_conversation`` is empty or None this returns the same string
+    as before multi-turn support was added — that's by design so single-turn
+    evaluations are byte-for-byte unchanged. When non-empty, a conversation
+    history block is prepended ahead of the question/answer.
+    """
+    rendered = format_prompt(RELEVANCE_TO_QUERY_PROMPT, input=request, output=context)
+    return render_prior_conversation_block(prior_conversation or []) + rendered

--- a/mlflow/genai/judges/utils/multi_turn.py
+++ b/mlflow/genai/judges/utils/multi_turn.py
@@ -1,0 +1,89 @@
+"""
+Helpers for surfacing prior conversation context to single-turn LLM judges.
+
+The prior conversation is supplied as an OpenAI-style message list
+(``[{"role": ..., "content": ...}]``) — the same shape returned by
+``mlflow.genai.utils.trace_utils.extract_prior_turns``. Truncation here is
+purely cap enforcement: turn count first, then optional token budget.
+Token estimation uses a 4-chars-per-token heuristic, which is sufficient for
+budget-protection purposes and avoids pulling in a tokenizer dependency.
+"""
+
+from mlflow.environment_variables import (
+    MLFLOW_JUDGE_MAX_PRIOR_TURNS,
+    MLFLOW_JUDGE_PRIOR_TURNS_TOKEN_BUDGET,
+)
+
+_PRIOR_CONVERSATION_HEADER = (
+    "Below is the prior conversation history that led up to the current turn. "
+    "Use it as context when evaluating the answer below — for example, when the "
+    'user\'s input is a continuation ("yes", "tell me more") that only makes '
+    "sense given earlier turns."
+)
+_CHARS_PER_TOKEN = 4
+
+
+def _estimate_tokens(text: str) -> int:
+    return max(1, len(text) // _CHARS_PER_TOKEN)
+
+
+def truncate_prior_conversation(
+    messages: list[dict[str, str]],
+    *,
+    max_turns: int | None = None,
+    token_budget: int | None = None,
+) -> list[dict[str, str]]:
+    """
+    Apply turn-count and token-budget caps to a prior conversation, dropping
+    the oldest messages first.
+
+    Args:
+        messages: Conversation messages in chronological order.
+        max_turns: Maximum number of messages to keep. ``None`` reads
+            :data:`mlflow.environment_variables.MLFLOW_JUDGE_MAX_PRIOR_TURNS`.
+            ``0`` returns an empty list.
+        token_budget: Maximum estimated tokens for the kept messages. ``None``
+            reads :data:`mlflow.environment_variables.MLFLOW_JUDGE_PRIOR_TURNS_TOKEN_BUDGET`,
+            which is unset by default and means "no token cap".
+    """
+    if not messages:
+        return []
+
+    if max_turns is None:
+        max_turns = MLFLOW_JUDGE_MAX_PRIOR_TURNS.get()
+    if max_turns <= 0:
+        return []
+    truncated = messages[-max_turns:]
+
+    if token_budget is None:
+        token_budget = MLFLOW_JUDGE_PRIOR_TURNS_TOKEN_BUDGET.get()
+    if token_budget is None:
+        return truncated
+
+    # Drop oldest turns until under budget. Always keep at least one message
+    # if the budget cannot accommodate even that — a too-small budget is a
+    # configuration issue and silently dropping all context would hide it.
+    total = sum(_estimate_tokens(m.get("content", "")) for m in truncated)
+    while len(truncated) > 1 and total > token_budget:
+        dropped = truncated.pop(0)
+        total -= _estimate_tokens(dropped.get("content", ""))
+    return truncated
+
+
+def render_prior_conversation_block(messages: list[dict[str, str]]) -> str:
+    """
+    Render the prior conversation as a prompt prefix, or an empty string if
+    the list is empty. The empty-string return is load-bearing: callers
+    concatenate this with their existing prompt template and rely on it
+    producing byte-for-byte the original prompt when there is no prior
+    context. Do not change the empty-case return value.
+    """
+    if not messages:
+        return ""
+    rendered_turns = "\n".join(
+        f"[{message.get('role', 'unknown')}]: {message.get('content', '')}" for message in messages
+    )
+    return (
+        f"{_PRIOR_CONVERSATION_HEADER}\n\n"
+        f"<prior_conversation>\n{rendered_turns}\n</prior_conversation>\n\n"
+    )

--- a/mlflow/genai/judges/utils/multi_turn.py
+++ b/mlflow/genai/judges/utils/multi_turn.py
@@ -24,7 +24,10 @@ _CHARS_PER_TOKEN = 4
 
 
 def _estimate_tokens(text: str) -> int:
-    return max(1, len(text) // _CHARS_PER_TOKEN)
+    # Ceiling division: 5-7 chars round up to 2 tokens, not 1. Conservative
+    # estimate ensures the budget is honored rather than slightly overshot
+    # by short messages.
+    return max(1, (len(text) + _CHARS_PER_TOKEN - 1) // _CHARS_PER_TOKEN)
 
 
 def truncate_prior_conversation(

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -80,6 +80,7 @@ from mlflow.genai.judges.utils import (
     get_default_model,
     invoke_judge_model,
 )
+from mlflow.genai.judges.utils.multi_turn import truncate_prior_conversation
 from mlflow.genai.scorers.base import (
     _SERIALIZATION_VERSION,
     Scorer,
@@ -93,6 +94,7 @@ from mlflow.genai.scorers.scorer_utils import (
 )
 from mlflow.genai.utils.trace_utils import (
     extract_available_tools_from_trace,
+    extract_prior_turns,
     extract_request_from_trace,
     extract_response_from_trace,
     extract_retrieval_context_from_trace,
@@ -1544,6 +1546,7 @@ class RelevanceToQuery(BuiltInScorer):
         inputs: dict[str, Any] | None = None,
         outputs: Any | None = None,
         trace: Trace | None = None,
+        session: list[Trace] | None = None,
     ) -> Feedback:
         """
         Evaluate relevance to the user's query.
@@ -1560,6 +1563,14 @@ class RelevanceToQuery(BuiltInScorer):
                 Optional when trace is provided.
             trace: MLflow trace object containing the execution to evaluate. When provided,
                 inputs and outputs will be automatically extracted from the trace.
+            session: Optional list of traces from the same multi-turn session. When supplied
+                alongside ``trace``, the judge sees prior turns when assessing relevance —
+                this is what lets the judge correctly score continuations like ``"yes"`` that
+                only make sense with earlier context. Capped by
+                :data:`mlflow.environment_variables.MLFLOW_JUDGE_MAX_PRIOR_TURNS` and optionally
+                by :data:`MLFLOW_JUDGE_PRIOR_TURNS_TOKEN_BUDGET`. The eval harness populates
+                this automatically for traces tagged with a session id; ignored when ``trace``
+                is not supplied.
 
         Returns:
             An :py:class:`mlflow.entities.assessment.Feedback~` object with a boolean value
@@ -1568,10 +1579,19 @@ class RelevanceToQuery(BuiltInScorer):
         fields = resolve_scorer_fields(trace, self, inputs, outputs, model=self.model)
         _validate_required_fields(fields, self, "RelevanceToQuery scorer")
 
-        # Use the existing scorer implementation with extracted/provided fields
+        prior_conversation: list[dict[str, str]] | None = None
+        if trace is not None and session:
+            full_prior = extract_prior_turns(session, trace)
+            truncated = truncate_prior_conversation(full_prior)
+            prior_conversation = truncated or None
+
         request = parse_inputs_to_str(fields.inputs)
         feedback = judges.is_context_relevant(
-            request=request, context=fields.outputs, name=self.name, model=self.model
+            request=request,
+            context=fields.outputs,
+            name=self.name,
+            model=self.model,
+            prior_conversation=prior_conversation,
         )
         return _sanitize_scorer_feedback(feedback)
 

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -1568,9 +1568,9 @@ class RelevanceToQuery(BuiltInScorer):
                 this is what lets the judge correctly score continuations like ``"yes"`` that
                 only make sense with earlier context. Capped by
                 :data:`mlflow.environment_variables.MLFLOW_JUDGE_MAX_PRIOR_TURNS` and optionally
-                by :data:`MLFLOW_JUDGE_PRIOR_TURNS_TOKEN_BUDGET`. The eval harness populates
-                this automatically for traces tagged with a session id; ignored when ``trace``
-                is not supplied.
+                by :data:`mlflow.environment_variables.MLFLOW_JUDGE_PRIOR_TURNS_TOKEN_BUDGET`.
+                The eval harness populates this automatically for traces tagged with a session
+                id; ignored when ``trace`` is not supplied.
 
         Returns:
             An :py:class:`mlflow.entities.assessment.Feedback~` object with a boolean value

--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -413,6 +413,43 @@ def resolve_conversation_from_session(
     return conversation
 
 
+def extract_prior_turns(
+    session: list[Trace],
+    current_trace: Trace,
+    *,
+    include_tool_calls: bool = False,
+) -> list[dict[str, str]]:
+    """
+    Extract conversation history from session traces that occurred strictly
+    before ``current_trace``. Used by single-turn LLM judges to obtain the
+    prior context for a turn embedded in a multi-turn session.
+
+    A trace is considered "prior" if its ``timestamp_ms`` is strictly less
+    than the current trace's ``timestamp_ms`` and it is not the current trace
+    itself. Same-millisecond ties are excluded to avoid races between the
+    current turn's own spans and other concurrent traces.
+
+    Args:
+        session: List of traces from the same session. The current trace may
+            or may not be a member of this list — it is filtered out either way.
+        current_trace: The trace whose prior context we want.
+        include_tool_calls: Forwarded to ``resolve_conversation_from_session``.
+
+    Returns:
+        Conversation messages from prior turns in chronological order, in the
+        format ``[{"role": "user"|"assistant"|"tool", "content": str}]``.
+        Empty list if there are no prior turns.
+    """
+    current_id = current_trace.info.trace_id
+    current_ts = current_trace.info.timestamp_ms
+    prior = [
+        trace
+        for trace in session
+        if trace.info.trace_id != current_id and trace.info.timestamp_ms < current_ts
+    ]
+    return resolve_conversation_from_session(prior, include_tool_calls=include_tool_calls)
+
+
 def resolve_expectations_from_trace(
     expectations: dict[str, Any] | None,
     trace: Trace,

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -1200,6 +1200,47 @@ def test_evaluate_with_mixed_single_turn_and_multi_turn_scorers(server_config):
             assert a.value in (2.0, 3.0)
 
 
+def test_evaluate_threads_session_to_single_turn_scorers_when_session_id_present(server_config):
+    """
+    Single-turn scorers that declare a ``session`` kwarg should receive the
+    list of traces from the same multi-turn session, so they can derive prior
+    conversation context. Scorers that don't declare ``session`` are
+    unaffected by ``Scorer.run()``'s signature filtering.
+    """
+    received_sessions: dict[str, list[Trace]] = {}
+
+    class SessionAwareScorer(mlflow.genai.Scorer):
+        def __init__(self):
+            super().__init__(name="session_aware")
+
+        def __call__(self, *, trace, session=None, **kwargs):
+            received_sessions[trace.info.trace_id] = list(session) if session else []
+            return 1
+
+    @mlflow.trace(span_type=SpanType.CHAT_MODEL)
+    def model(question, session_id):
+        mlflow.update_current_trace(metadata={"mlflow.trace.session": session_id})
+        return f"Answer to: {question}"
+
+    mlflow.set_experiment("multi_turn_session_thread_test")
+    with mlflow.start_run() as run:
+        # Two sessions, three turns each.
+        for q in ["A1", "A2", "A3"]:
+            model(q, session_id="thread_session_a")
+        for q in ["B1", "B2", "B3"]:
+            model(q, session_id="thread_session_b")
+
+        traces = mlflow.search_traces(
+            locations=[run.info.experiment_id], filter_string=f'run_id = "{run.info.run_id}"'
+        )
+        mlflow.genai.evaluate(data=traces, scorers=[SessionAwareScorer()])
+
+    # Every trace should have received its full session group (3 traces each).
+    assert len(received_sessions) == 6
+    for session_traces in received_sessions.values():
+        assert len(session_traces) == 3
+
+
 def test_evaluate_with_evaluation_dataset_and_session_level_scorers():
     # Define a session-level scorer
     class ConversationLengthScorer(mlflow.genai.Scorer):

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -1241,6 +1241,51 @@ def test_evaluate_threads_session_to_single_turn_scorers_when_session_id_present
         assert len(session_traces) == 3
 
 
+def test_evaluate_threads_session_to_single_turn_scorers_with_predict_fn(server_config):
+    """
+    For evaluation flows that go through ``predict_fn``, ``EvalItem.trace`` is
+    populated by ``_run_predict`` *after* the ScoreSubmitter is constructed.
+    The session lookup must be built lazily so single-turn scorers still
+    receive their session context — building eagerly at construction time
+    would leave the map empty for these flows.
+    """
+    received_sessions: dict[str, list[Trace]] = {}
+
+    class SessionAwareScorer(mlflow.genai.Scorer):
+        def __init__(self):
+            super().__init__(name="session_aware_predict")
+
+        def __call__(self, *, trace, session=None, **kwargs):
+            received_sessions[trace.info.trace_id] = list(session) if session else []
+            return 1
+
+    @mlflow.trace(span_type=SpanType.CHAT_MODEL)
+    def model(question, session_id):
+        mlflow.update_current_trace(metadata={"mlflow.trace.session": session_id})
+        return f"Answer to: {question}"
+
+    mlflow.set_experiment("multi_turn_session_predict_fn_test")
+    with mlflow.start_run():
+        # Drive evaluation through predict_fn so traces are produced inside
+        # the harness rather than supplied up front.
+        data = [
+            {"inputs": {"question": "P1", "session_id": "predict_session_a"}},
+            {"inputs": {"question": "P2", "session_id": "predict_session_a"}},
+            {"inputs": {"question": "P3", "session_id": "predict_session_b"}},
+        ]
+        mlflow.genai.evaluate(data=data, predict_fn=model, scorers=[SessionAwareScorer()])
+
+    # Every item must receive a non-empty session. If the lookup were built
+    # eagerly at construction (before predict_fn populates traces) every
+    # session would be [], regressing this test. Exact sizes depend on
+    # predict parallelism — session_a items see 1 or 2 depending on whether
+    # both predicts have completed yet — so we only assert the bounds:
+    # each item sees ≥ 1 trace, and never more than its session membership.
+    assert len(received_sessions) == 3
+    for session in received_sessions.values():
+        assert 1 <= len(session) <= 2
+
+
 def test_evaluate_with_evaluation_dataset_and_session_level_scorers():
     # Define a session-level scorer
     class ConversationLengthScorer(mlflow.genai.Scorer):

--- a/tests/genai/judges/test_builtin.py
+++ b/tests/genai/judges/test_builtin.py
@@ -274,6 +274,62 @@ def test_is_context_relevant_oss():
     assert "Paris is the capital of France." in prompt
 
 
+@pytest.mark.parametrize("prior", [None, []])
+def test_is_context_relevant_prompt_unchanged_when_prior_conversation_is_absent(prior):
+    """
+    Regression test: the rendered prompt must be byte-for-byte identical to
+    the legacy single-turn prompt when no prior conversation is supplied.
+    Single-turn evaluation behavior MUST NOT change as a side effect of
+    adding multi-turn support.
+    """
+    from mlflow.genai.judges.prompts.relevance_to_query import (
+        RELEVANCE_TO_QUERY_PROMPT,
+        get_prompt,
+    )
+    from mlflow.genai.prompts.utils import format_prompt
+
+    expected = format_prompt(
+        RELEVANCE_TO_QUERY_PROMPT,
+        input="What is the capital of France?",
+        output="Paris.",
+    )
+    actual = get_prompt(
+        "What is the capital of France?",
+        "Paris.",
+        prior_conversation=prior,
+    )
+    assert actual == expected
+
+
+def test_is_context_relevant_oss_with_prior_conversation():
+    mock_content = json.dumps({
+        "result": "yes",
+        "rationale": "Let's think step by step. 'Yes' continues the prior NFL question.",
+    })
+
+    prior = [
+        {"role": "user", "content": "Tell me about upcoming NFL games"},
+        {"role": "assistant", "content": "Here's some info. Would you like more details?"},
+    ]
+
+    with _mock_score(mock_content) as mock_score:
+        feedback = judges.is_context_relevant(
+            request="Yes",
+            context="Here are the detailed NFL game schedules for this weekend.",
+            prior_conversation=prior,
+        )
+
+    assert feedback.value == CategoricalRating.YES
+
+    mock_score.assert_called_once()
+    prompt = mock_score.call_args.kwargs["payload"]
+    # The prior conversation block should appear ahead of the question/answer.
+    assert "<prior_conversation>" in prompt
+    assert "[user]: Tell me about upcoming NFL games" in prompt
+    assert "[assistant]: Here's some info. Would you like more details?" in prompt
+    assert prompt.index("</prior_conversation>") < prompt.index("<question>")
+
+
 def test_is_correct_oss():
     mock_content = json.dumps({
         "result": "yes",

--- a/tests/genai/judges/test_multi_turn.py
+++ b/tests/genai/judges/test_multi_turn.py
@@ -1,0 +1,125 @@
+import pytest
+
+from mlflow.genai.judges.utils.multi_turn import (
+    render_prior_conversation_block,
+    truncate_prior_conversation,
+)
+
+
+def _msg(role: str, content: str) -> dict[str, str]:
+    return {"role": role, "content": content}
+
+
+_FOUR_TURN_CONVERSATION = [
+    _msg("user", "hello"),
+    _msg("assistant", "hi"),
+    _msg("user", "how are you?"),
+    _msg("assistant", "good"),
+]
+
+
+def test_truncate_returns_empty_for_empty_input():
+    assert truncate_prior_conversation([]) == []
+
+
+def test_truncate_returns_empty_when_max_turns_is_zero():
+    assert truncate_prior_conversation(_FOUR_TURN_CONVERSATION, max_turns=0) == []
+
+
+def test_truncate_keeps_only_last_n_messages_when_max_turns_lt_total():
+    result = truncate_prior_conversation(_FOUR_TURN_CONVERSATION, max_turns=2)
+    assert result == _FOUR_TURN_CONVERSATION[-2:]
+
+
+def test_truncate_returns_all_when_max_turns_ge_total():
+    assert (
+        truncate_prior_conversation(_FOUR_TURN_CONVERSATION, max_turns=10)
+        == _FOUR_TURN_CONVERSATION
+    )
+
+
+def test_truncate_no_token_cap_when_token_budget_is_none():
+    long_msg = _msg("user", "x" * 10_000)
+    # Without a budget, the long message survives even with a generous max_turns.
+    assert truncate_prior_conversation([long_msg], max_turns=5, token_budget=None) == [long_msg]
+
+
+def test_truncate_drops_oldest_until_under_token_budget():
+    msgs = [
+        _msg("user", "a" * 800),  # ~200 tokens
+        _msg("assistant", "b" * 800),  # ~200 tokens
+        _msg("user", "c" * 800),  # ~200 tokens
+    ]
+    # Budget of ~250 tokens should keep just the last message.
+    result = truncate_prior_conversation(msgs, max_turns=10, token_budget=250)
+    assert result == msgs[-1:]
+
+
+def test_truncate_keeps_at_least_one_message_when_budget_is_unrealistically_small():
+    # A budget too small to fit even one message still keeps the last one
+    # so the user notices the misconfiguration rather than getting silently
+    # blank context.
+    msg = _msg("user", "x" * 5000)
+    result = truncate_prior_conversation([msg, msg], max_turns=10, token_budget=1)
+    assert len(result) == 1
+
+
+def test_truncate_max_turns_applied_before_token_budget():
+    msgs = [
+        _msg("user", "old"),
+        _msg("user", "x" * 800),
+        _msg("user", "y" * 800),
+    ]
+    # max_turns first chops to last two, token budget then trims one more.
+    result = truncate_prior_conversation(msgs, max_turns=2, token_budget=250)
+    assert result == msgs[-1:]
+
+
+@pytest.mark.parametrize(
+    ("env_max_turns", "expected_count"),
+    [
+        ("0", 0),
+        ("1", 1),
+        ("2", 2),
+        ("10", 4),
+    ],
+)
+def test_truncate_reads_max_turns_from_env_when_not_passed(
+    monkeypatch, env_max_turns, expected_count
+):
+    monkeypatch.setenv("MLFLOW_JUDGE_MAX_PRIOR_TURNS", env_max_turns)
+    result = truncate_prior_conversation(_FOUR_TURN_CONVERSATION)
+    assert len(result) == expected_count
+
+
+def test_truncate_reads_token_budget_from_env_when_not_passed(monkeypatch):
+    monkeypatch.setenv("MLFLOW_JUDGE_PRIOR_TURNS_TOKEN_BUDGET", "200")
+    # Each message is ~200 tokens; budget should drop the oldest.
+    msgs = [
+        _msg("user", "a" * 800),
+        _msg("user", "b" * 800),
+    ]
+    result = truncate_prior_conversation(msgs, max_turns=10)
+    assert len(result) == 1
+
+
+def test_render_empty_messages_returns_empty_string():
+    # Load-bearing: the empty case must produce "" (no header, no tag wrapper)
+    # so the existing prompt template remains byte-for-byte unchanged when
+    # there is no prior conversation.
+    assert render_prior_conversation_block([]) == ""
+
+
+def test_render_includes_header_and_role_prefixed_messages():
+    rendered = render_prior_conversation_block(_FOUR_TURN_CONVERSATION)
+    assert "<prior_conversation>" in rendered
+    assert "</prior_conversation>" in rendered
+    assert "[user]: hello" in rendered
+    assert "[assistant]: hi" in rendered
+    assert "[user]: how are you?" in rendered
+    assert "[assistant]: good" in rendered
+
+
+def test_rendered_block_ends_with_blank_line_separator():
+    rendered = render_prior_conversation_block(_FOUR_TURN_CONVERSATION)
+    assert rendered.endswith("\n\n")

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -9,6 +9,7 @@ from mlflow.entities.assessment import Feedback
 from mlflow.entities.assessment_error import AssessmentError
 from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
 from mlflow.entities.span import SpanType
+from mlflow.entities.trace import Trace
 from mlflow.exceptions import MlflowException
 from mlflow.genai.judges.base import JudgeField
 from mlflow.genai.judges.builtin import CategoricalRating
@@ -458,6 +459,7 @@ def test_relevance_to_query():
         context="answer",
         name="relevance_to_query",
         model=None,
+        prior_conversation=None,
     )
 
     # 2. Test with custom model parameter
@@ -473,6 +475,7 @@ def test_relevance_to_query():
         context="answer",
         name="custom_relevance",
         model="openai:/gpt-4.1-mini",
+        prior_conversation=None,
     )
 
 
@@ -846,6 +849,96 @@ def test_relevance_to_query_with_trace():
         assert result.name == "relevance_to_query"
         assert result.value == CategoricalRating.YES
         mock_is_context_relevant.assert_called_once()
+
+
+def _make_chat_session_traces(session_id: str, turns: list[tuple[str, str]]) -> list[Trace]:
+    """
+    Build session traces using the OpenAI-style ``messages`` input shape so
+    ``parse_inputs_to_str`` returns clean user content rather than a stringified
+    dict.
+    """
+    traces = []
+    for user_msg, assistant_msg in turns:
+        with mlflow.start_span(name="turn") as span:
+            span.set_inputs({"messages": [{"role": "user", "content": user_msg}]})
+            span.set_outputs(assistant_msg)
+            mlflow.update_current_trace(metadata={"mlflow.trace.session": session_id})
+        traces.append(mlflow.get_trace(span.trace_id))
+    return traces
+
+
+def test_relevance_to_query_passes_prior_conversation_to_judge_when_session_supplied():
+    """
+    When evaluating turn N of a multi-turn session, ``RelevanceToQuery``
+    should derive the prior conversation from the supplied ``session`` and
+    forward it to ``is_context_relevant``.
+    """
+    session_traces = _make_chat_session_traces(
+        "test_relevance_session",
+        [
+            ("Tell me about upcoming NFL games", "Want more detail?"),
+            ("Yes", "Here are the schedules..."),
+        ],
+    )
+
+    with patch("mlflow.genai.judges.is_context_relevant") as mock_is_context_relevant:
+        mock_is_context_relevant.return_value = Feedback(
+            name="relevance_to_query", value="yes", rationale="continuation of prior turn"
+        )
+
+        scorer = RelevanceToQuery()
+        result = scorer(trace=session_traces[1], session=session_traces)
+
+    assert result.value == CategoricalRating.YES
+    mock_is_context_relevant.assert_called_once()
+    kwargs = mock_is_context_relevant.call_args.kwargs
+    prior = kwargs["prior_conversation"]
+    assert prior == [
+        {"role": "user", "content": "Tell me about upcoming NFL games"},
+        {"role": "assistant", "content": "Want more detail?"},
+    ]
+
+
+def test_relevance_to_query_omits_prior_conversation_for_first_turn_in_session():
+    """
+    When the current trace is the first turn in its session, there is no
+    prior conversation — ``prior_conversation`` should be ``None``, not an
+    empty list, so ``is_context_relevant`` renders the legacy single-turn
+    prompt unchanged.
+    """
+    session_traces = _make_chat_session_traces(
+        "test_relevance_first_turn",
+        [("Hello", "Hi there"), ("How are you?", "Good")],
+    )
+
+    with patch("mlflow.genai.judges.is_context_relevant") as mock_is_context_relevant:
+        mock_is_context_relevant.return_value = Feedback(
+            name="relevance_to_query", value="yes", rationale="ok"
+        )
+
+        scorer = RelevanceToQuery()
+        scorer(trace=session_traces[0], session=session_traces)
+
+    kwargs = mock_is_context_relevant.call_args.kwargs
+    assert kwargs["prior_conversation"] is None
+
+
+def test_relevance_to_query_does_not_pass_prior_conversation_when_session_is_none():
+    """
+    Calling the scorer without a session must produce the same call shape
+    as before multi-turn support was added: ``prior_conversation=None``.
+    """
+    with patch("mlflow.genai.judges.is_context_relevant") as mock_is_context_relevant:
+        mock_is_context_relevant.return_value = Feedback(
+            name="relevance_to_query", value="yes", rationale="ok"
+        )
+
+        trace = create_simple_trace()
+        scorer = RelevanceToQuery()
+        scorer(trace=trace)
+
+    kwargs = mock_is_context_relevant.call_args.kwargs
+    assert kwargs["prior_conversation"] is None
 
 
 @databricks_only

--- a/tests/genai/scorers/test_serialization.py
+++ b/tests/genai/scorers/test_serialization.py
@@ -361,6 +361,7 @@ def test_builtin_scorer_round_trip():
         ),
         name="relevance_to_query",
         model=None,
+        prior_conversation=None,
     )
 
     assert isinstance(result, Feedback)

--- a/tests/genai/utils/test_trace_utils.py
+++ b/tests/genai/utils/test_trace_utils.py
@@ -32,6 +32,7 @@ from mlflow.genai.utils.trace_utils import (
     extract_expectations_from_trace,
     extract_inputs_from_trace,
     extract_outputs_from_trace,
+    extract_prior_turns,
     extract_request_from_trace,
     extract_response_from_trace,
     extract_retrieval_context_from_trace,
@@ -1030,6 +1031,85 @@ def test_resolve_conversation_from_session_with_tool_calls():
 
 def test_resolve_conversation_from_session_empty():
     assert resolve_conversation_from_session([]) == []
+
+
+def _make_session_traces(session_id: str, turns: list[tuple[str, str]]) -> list[Trace]:
+    traces: list[Trace] = []
+    for user_msg, assistant_msg in turns:
+        with mlflow.start_span(name="turn") as span:
+            span.set_inputs({"messages": [{"role": "user", "content": user_msg}]})
+            span.set_outputs(assistant_msg)
+            mlflow.update_current_trace(metadata={"mlflow.trace.session": session_id})
+        traces.append(mlflow.get_trace(span.trace_id))
+    return traces
+
+
+def test_extract_prior_turns_returns_only_strictly_earlier_traces():
+    traces = _make_session_traces(
+        "session_extract_prior",
+        [("hello", "hi"), ("how are you?", "good"), ("tell me a joke", "knock knock")],
+    )
+
+    # Looking at the third turn, prior = first two turns, in order.
+    prior = extract_prior_turns(traces, traces[2])
+    assert prior == [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+        {"role": "user", "content": "how are you?"},
+        {"role": "assistant", "content": "good"},
+    ]
+
+
+def test_extract_prior_turns_excludes_current_trace_even_if_in_session_list():
+    traces = _make_session_traces("session_self_exclude", [("u1", "a1"), ("u2", "a2")])
+
+    # Pass the full session including the current trace; helper must filter it out.
+    prior = extract_prior_turns(traces, traces[1])
+    assert prior == [
+        {"role": "user", "content": "u1"},
+        {"role": "assistant", "content": "a1"},
+    ]
+
+
+def test_extract_prior_turns_returns_empty_for_first_turn():
+    traces = _make_session_traces("session_first_turn", [("u1", "a1"), ("u2", "a2")])
+
+    assert extract_prior_turns(traces, traces[0]) == []
+
+
+def test_extract_prior_turns_returns_empty_when_session_is_empty():
+    # Synthesize a single trace not part of any session list.
+    traces = _make_session_traces("session_alone", [("u1", "a1")])
+
+    assert extract_prior_turns([], traces[0]) == []
+
+
+def test_extract_prior_turns_forwards_include_tool_calls():
+    session_id = "session_with_tools"
+    traces: list[Trace] = []
+
+    with mlflow.start_span(name="turn_0") as root_span:
+        root_span.set_inputs({"messages": [{"role": "user", "content": "Get AAPL price"}]})
+        with mlflow.start_span(name="get_stock_price", span_type=SpanType.TOOL) as tool_span:
+            tool_span.set_inputs({"symbol": "AAPL"})
+            tool_span.set_outputs({"price": 150})
+        root_span.set_outputs("AAPL is $150.")
+        mlflow.update_current_trace(metadata={"mlflow.trace.session": session_id})
+    traces.append(mlflow.get_trace(root_span.trace_id))
+
+    with mlflow.start_span(name="turn_1") as span:
+        span.set_inputs({"messages": [{"role": "user", "content": "Thanks"}]})
+        span.set_outputs("You're welcome.")
+        mlflow.update_current_trace(metadata={"mlflow.trace.session": session_id})
+    traces.append(mlflow.get_trace(span.trace_id))
+
+    # Without tool calls, prior context is just user/assistant messages.
+    prior = extract_prior_turns(traces, traces[1])
+    assert [m["role"] for m in prior] == ["user", "assistant"]
+
+    # With tool calls, the TOOL span message appears between user and assistant.
+    prior_with_tools = extract_prior_turns(traces, traces[1], include_tool_calls=True)
+    assert [m["role"] for m in prior_with_tools] == ["user", "tool", "assistant"]
 
 
 @pytest.mark.parametrize("include_timing", [True, False])

--- a/tests/genai/utils/test_trace_utils.py
+++ b/tests/genai/utils/test_trace_utils.py
@@ -1035,12 +1035,18 @@ def test_resolve_conversation_from_session_empty():
 
 def _make_session_traces(session_id: str, turns: list[tuple[str, str]]) -> list[Trace]:
     traces: list[Trace] = []
-    for user_msg, assistant_msg in turns:
+    for i, (user_msg, assistant_msg) in enumerate(turns):
         with mlflow.start_span(name="turn") as span:
             span.set_inputs({"messages": [{"role": "user", "content": user_msg}]})
             span.set_outputs(assistant_msg)
             mlflow.update_current_trace(metadata={"mlflow.trace.session": session_id})
-        traces.append(mlflow.get_trace(span.trace_id))
+        trace = mlflow.get_trace(span.trace_id)
+        # Force a deterministic, monotonically increasing timestamp so the
+        # strict-less-than filter in extract_prior_turns is exercised
+        # reliably even when traces complete in the same wall-clock
+        # millisecond (which can happen in tight test loops).
+        trace.info.timestamp_ms = i + 1
+        traces.append(trace)
     return traces
 
 


### PR DESCRIPTION
## 🥞 Stacked PR
- [stack/judge-multiturn/1-foundation](https://github.com/mlflow/mlflow/pull/22984)
  - [**stack/judge-multiturn/2-pilot**](https://github.com/mlflow/mlflow/pull/22985)
    - (follow-ups planned — see "Remaining work" below)

---------
### Related Issues/PRs

Pilot for fixing single-turn LLM judges that produce false negatives on multi-turn conversations. Builds on the primitives added in #22984.

### What changes are proposed in this pull request?

When a user replies `"Yes"` to the agent's `"Would you like more details?"`, today's `RelevanceToQuery` judge sees only `(input="Yes", output="Here's NFL info...")` in isolation and reports the response irrelevant. This PR threads the prior conversation history into the judge prompt for `RelevanceToQuery` so the judgment reflects the actual context.

The end-to-end wiring (one judge as a pilot):

1. **`mlflow/genai/judges/utils/multi_turn.py` (new)** — adds `truncate_prior_conversation` (caps by turn count, then optionally by token budget; oldest-first drop) and `render_prior_conversation_block` (renders a prompt prefix, or `""` when there is no prior context — load-bearing for the empty-state regression).

2. **`mlflow/genai/judges/prompts/relevance_to_query.py`** — `get_prompt` gains an optional `prior_conversation` kwarg. When empty/None, the rendered prompt is byte-for-byte identical to the legacy single-turn form.

3. **`mlflow/genai/judges/builtin.py`** — `is_context_relevant` accepts `prior_conversation` and threads it to `get_prompt`. The Databricks-model code path is left unchanged for now (multi-turn for that path is a follow-up).

4. **`mlflow/genai/scorers/builtin_scorers.py`** — `RelevanceToQuery.__call__` gains an optional `session: list[Trace]` kwarg. When supplied with a `trace`, it derives prior conversation via `extract_prior_turns` (from the foundation PR), applies `truncate_prior_conversation`, and forwards to `is_context_relevant`.

5. **`mlflow/genai/evaluation/harness.py`** — `_ScoreSubmitter` builds a `trace_id → session-traces` lookup at construction and passes `session=...` to single-turn scorers. `Scorer.run()` already filters kwargs by signature so scorers that don't declare `session` are unaffected. `session_groups` is now computed whenever any scorers are present (previously only when multi-turn scorers existed); the telemetry usage event still reports session-group counts only when multi-turn scorers actually ran.

### Behavior summary

| Scenario | Behavior |
|---|---|
| Trace without a session id | Identical prompt, identical verdict (no behavior change) |
| `MLFLOW_JUDGE_MAX_PRIOR_TURNS=0` | Identical to today (escape hatch / opt-out) |
| Session of length 1 (only the current turn) | Identical to today — `extract_prior_turns` returns `[]` and the prompt's empty-state branch fires |
| Multi-turn session | Prior turns surfaced to the judge, capped at default 10 turns. Token budget unset by default (only the turn cap applies). |

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

- **Empty-state regression test** in `tests/genai/judges/test_builtin.py`: asserts `get_prompt(..., prior_conversation=None)` is byte-for-byte equal to the legacy `format_prompt(...)` output. Pins the no-op invariant for single-turn evaluation.
- **16 helper tests** in `tests/genai/judges/test_multi_turn.py` covering `truncate_prior_conversation` (turn caps, token budget, env-var defaults, oldest-first drop, minimum-one-message guard) and `render_prior_conversation_block` (empty case, role-prefixed rendering, separator).
- **Judge-level multi-turn case** in `test_builtin.py`: confirms the prior-conversation block reaches the LLM prompt ahead of the question/answer.
- **Scorer-level cases** in `tests/genai/scorers/test_builtin_scorers.py`: session supplied → `prior_conversation` populated; first-turn-in-session → `prior_conversation=None`; no-session → `prior_conversation=None`.
- **Harness-level case** in `tests/genai/evaluate/test_evaluation.py`: confirms `session` is threaded into single-turn scorers that declare it for traces tagged with a session id.

### Remaining work (follow-up stacks)

Once the design here is validated in review:

1. Roll the same pattern out to the other single-turn builtin judges: `ToolCallCorrectness`, `ToolCallEfficiency`, `RetrievalGroundedness`, `Groundedness`, `Safety`. Mostly mechanical given the pilot's pattern.
2. Plumb `prior_conversation` through the custom-judge entry points (`make_judge`, `custom_prompt_judge`) so user-authored judges can opt in via a `{{conversation}}`-style template slot.
3. Migration / "multi-turn evaluation" docs page covering the env vars, the opt-out, the token-cost story, and a re-baseline note for users with hard-coded score thresholds in CI.
4. Multi-turn support for the Databricks judge model path in `is_context_relevant` (needs a separate API surface).

### Open design questions for this review

- **Default `MAX_PRIOR_TURNS = 10`.** Picked as a starting point pending empirical token data. Easy to tune.
- **Token budget unset by default.** Per offline discussion: setting `MLFLOW_JUDGE_PRIOR_TURNS_TOKEN_BUDGET` honors it; not setting it means the only cap is the turn count.
- **Truncation policy: oldest-first drop.** Matches the GenAI convention of prioritizing recent context.
- **Default-on when session id is present.** The gate is implicit — traces without a session id render the legacy prompt unchanged, so users with single-turn-only data have zero migration friction.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

User-facing docs (the migration guide noted in "Remaining work") will land with the rollout PR. The pilot's behavior change is currently opt-in via session-id presence.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

