### PR TITLE
Skip CI workflows for `.claude/**` changes

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -19,6 +19,7 @@ on:
       - ".github/workflows/preview-docs.yml"
       - "mlflow/server/js/**"
       - ".github/workflows/js.yml"
+      - ".claude/**"
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -14,6 +14,7 @@ on:
       - ".github/workflows/preview-docs.yml"
       - "mlflow/server/js/**"
       - ".github/workflows/js.yml"
+      - ".claude/**"
   workflow_dispatch:
     inputs:
       repository:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -14,6 +14,7 @@ on:
       - ".github/workflows/preview-docs.yml"
       - "mlflow/server/js/**"
       - ".github/workflows/js.yml"
+      - ".claude/**"
   schedule:
     # Run this action daily at 13:00 UTC
     - cron: "0 13 * * *"

--- a/.github/workflows/fs2db.yml
+++ b/.github/workflows/fs2db.yml
@@ -18,6 +18,7 @@ on:
       - ".github/workflows/preview-docs.yml"
       - "mlflow/server/js/**"
       - ".github/workflows/js.yml"
+      - ".claude/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -14,6 +14,7 @@ on:
       - ".github/workflows/preview-docs.yml"
       - "mlflow/server/js/**"
       - ".github/workflows/js.yml"
+      - ".claude/**"
   push:
     branches:
       - master

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -18,6 +18,7 @@ on:
       - ".github/workflows/preview-docs.yml"
       - "mlflow/server/js/**"
       - ".github/workflows/js.yml"
+      - ".claude/**"
   schedule:
     # Run this workflow daily at 13:00 UTC
     - cron: "0 13 * * *"

--- a/.github/workflows/tracing.yml
+++ b/.github/workflows/tracing.yml
@@ -14,6 +14,7 @@ on:
       - ".github/workflows/preview-docs.yml"
       - "mlflow/server/js/**"
       - ".github/workflows/js.yml"
+      - ".claude/**"
   push:
     branches:
       - master

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -14,6 +14,7 @@ on:
       - ".github/workflows/preview-docs.yml"
       - "mlflow/server/js/**"
       - ".github/workflows/js.yml"
+      - ".claude/**"
   push:
     branches:
       - master


### PR DESCRIPTION
### Related Issues/PRs

Relates to #N/A

### What changes are proposed in this pull request?

Add `.claude/**` to the `paths-ignore` list of the eight PR-triggered workflows. The `.claude/` directory holds Claude Code harness configuration and local developer skills (e.g. the `analyze-ci` skill) — none of which is part of the MLflow package or affects runtime behavior, so changes there shouldn't trigger the full test suite.

Workflows updated:
- `build-wheel.yml`
- `cross-version-tests.yml`
- `examples.yml`
- `fs2db.yml`
- `master.yml`
- `r.yml`
- `tracing.yml`
- `typescript.yml`

GitHub's `paths-ignore` skips a workflow only when *every* changed file matches an ignore pattern, so this is a no-op for any PR that also touches MLflow source.

### How is this PR tested?

- [x] Manual tests

Verified the YAML syntax is unchanged otherwise; the only diff is one new line per workflow.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release