### PR TITLE
Restore expandable max height of params/metrics boxes on run details page

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewOverview.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewOverview.tsx
@@ -377,6 +377,8 @@ export const RunViewOverview = ({
         </>
       )}
       {!usingSidebarLayout && <Spacer />}
+      {/* Add a spacer so the page doesn't jump when searching params / metrics */}
+      <div css={{ height: 500 }} />
     </DetailsPageLayout>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/hooks/useExperimentTrackingDetailsPageLayoutStyles.tsx
+++ b/mlflow/server/js/src/experiment-tracking/hooks/useExperimentTrackingDetailsPageLayoutStyles.tsx
@@ -11,7 +11,9 @@ export const useExperimentTrackingDetailsPageLayoutStyles = () => {
 
   const detailsPageTableStyles = useMemo<Interpolation<Theme>>(
     () => ({
-      height: 200,
+      minHeight: 200,
+      maxHeight: 500,
+      height: 'min-content',
       overflow: 'hidden',
       '& > div': {
         ...getBottomOnlyShadowScrollStyles(theme),


### PR DESCRIPTION
### Related Issues/PRs

Relates to #18306 (regression of that fix), reported in https://github.com/mlflow/mlflow/pull/18306#issuecomment-4339986643.

### What changes are proposed in this pull request?

The internal UI sync in #20789 inadvertently reverted the params/metrics box height fix from #18306, sending the boxes back to a fixed `height: 200px` (only ~5 rows). This regression first shipped in v3.11.0 and is still present on master.

This PR re-applies #18306's diff verbatim:

- `useExperimentTrackingDetailsPageLayoutStyles.tsx`: replace the hard-coded `height: 200` with `minHeight: 200`, `maxHeight: 500`, `height: 'min-content'` so the tables can grow when there are many params/metrics.
- `RunViewOverview.tsx`: re-add the 500px bottom spacer so the page does not jump while filtering.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

The change is a pure CSS revert-of-revert that mirrors #18306, which was previously verified manually (videos in #18306). Visually, on the run details overview page, the params and metrics tables now expand up to 500px when there are many entries, instead of being stuck at 200px.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release