### PR TITLE
Redact presigned URL credentials in urllib3 retry logs

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -57,7 +57,7 @@ from mlflow import tracing  # noqa: F401
 from mlflow.environment_variables import MLFLOW_CONFIGURE_LOGGING
 from mlflow.exceptions import MlflowException
 from mlflow.utils.lazy_load import LazyLoader
-from mlflow.utils.logging_utils import _configure_mlflow_loggers
+from mlflow.utils.logging_utils import _configure_mlflow_loggers, _install_sensitive_query_param_filter
 
 # Lazily load mlflow flavors to avoid excessive dependencies.
 anthropic = LazyLoader("mlflow.anthropic", globals(), "mlflow.anthropic")
@@ -160,6 +160,8 @@ if TYPE_CHECKING:
         transformers,
         xgboost,
     )
+
+_install_sensitive_query_param_filter()
 
 if MLFLOW_CONFIGURE_LOGGING.get() is True:
     _configure_mlflow_loggers(root_module_name=__name__)

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -57,7 +57,10 @@ from mlflow import tracing  # noqa: F401
 from mlflow.environment_variables import MLFLOW_CONFIGURE_LOGGING
 from mlflow.exceptions import MlflowException
 from mlflow.utils.lazy_load import LazyLoader
-from mlflow.utils.logging_utils import _configure_mlflow_loggers, _install_sensitive_query_param_filter
+from mlflow.utils.logging_utils import (
+    _configure_mlflow_loggers,
+    _install_sensitive_query_param_filter,
+)
 
 # Lazily load mlflow flavors to avoid excessive dependencies.
 anthropic = LazyLoader("mlflow.anthropic", globals(), "mlflow.anthropic")

--- a/mlflow/utils/logging_utils.py
+++ b/mlflow/utils/logging_utils.py
@@ -118,6 +118,49 @@ class SuppressLogFilter(logging.Filter):
         return super().filter(record)
 
 
+# Cloud storage presigned URLs (AWS S3, GCS, Azure SAS) embed credentials in
+# query parameters. urllib3 logs the full target URL on connection retries
+# (e.g. when DNS resolution fails), which leaks those credentials to stderr.
+_SENSITIVE_QUERY_PARAM_NAMES = (
+    "X-Amz-Signature",
+    "X-Amz-Security-Token",
+    "X-Amz-Credential",
+    "X-Goog-Signature",
+    "X-Goog-Credential",
+    "Signature",
+    "sig",
+)
+
+_SENSITIVE_QUERY_PARAM_PATTERN = re.compile(
+    r"\b(" + "|".join(re.escape(p) for p in _SENSITIVE_QUERY_PARAM_NAMES) + r")=[^&\s'\"]+",
+    re.IGNORECASE,
+)
+
+
+def _redact_sensitive_query_params(message: str) -> str:
+    return _SENSITIVE_QUERY_PARAM_PATTERN.sub(lambda m: f"{m.group(1)}=[REDACTED]", message)
+
+
+class SensitiveQueryParamFilter(logging.Filter):
+    """
+    Logging filter that masks cloud storage credentials embedded in URL query
+    strings. Attached to urllib3 to avoid leaking presigned URL credentials
+    (X-Amz-Signature, X-Amz-Security-Token, X-Amz-Credential, ...) when
+    urllib3 logs full URLs on connection failures or retries.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            message = record.getMessage()
+        except Exception:
+            return True
+        redacted = _redact_sensitive_query_params(message)
+        if redacted != message:
+            record.msg = redacted
+            record.args = None
+        return True
+
+
 def _configure_mlflow_loggers(root_module_name):
     log_level = (MLFLOW_LOGGING_LEVEL.get() or "INFO").upper()
     # For alembic, use WARNING minimum to reduce noise, but respect higher levels
@@ -169,6 +212,19 @@ def _configure_mlflow_loggers(root_module_name):
             }
         },
     })
+
+    _install_sensitive_query_param_filter()
+
+
+def _install_sensitive_query_param_filter() -> None:
+    """
+    Attach SensitiveQueryParamFilter to urllib3.connectionpool. urllib3 logs
+    full target URLs (with presigned-URL credentials in query params) on
+    connection retries, which can leak credentials to stderr. Idempotent.
+    """
+    urllib3_logger = logging.getLogger("urllib3.connectionpool")
+    if not any(isinstance(f, SensitiveQueryParamFilter) for f in urllib3_logger.filters):
+        urllib3_logger.addFilter(SensitiveQueryParamFilter())
 
 
 def eprint(*args, **kwargs):

--- a/mlflow/utils/logging_utils.py
+++ b/mlflow/utils/logging_utils.py
@@ -213,8 +213,6 @@ def _configure_mlflow_loggers(root_module_name):
         },
     })
 
-    _install_sensitive_query_param_filter()
-
 
 def _install_sensitive_query_param_filter() -> None:
     """

--- a/tests/utils/test_logging_utils.py
+++ b/tests/utils/test_logging_utils.py
@@ -10,7 +10,13 @@ import pytest
 
 import mlflow
 from mlflow.utils import logging_utils
-from mlflow.utils.logging_utils import LOGGING_LINE_FORMAT, eprint, suppress_logs
+from mlflow.utils.logging_utils import (
+    LOGGING_LINE_FORMAT,
+    SensitiveQueryParamFilter,
+    _redact_sensitive_query_params,
+    eprint,
+    suppress_logs,
+)
 
 logger = logging.getLogger(mlflow.__name__)
 
@@ -179,6 +185,70 @@ assert logging.getLogger("mlflow").isEnabledFor({expected_level})
         ],
         env=os.environ.copy() | {env_var_name: value},
     )
+
+
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        (
+            "Retrying after broken: /path?X-Amz-Security-Token=ABC&"
+            "X-Amz-Credential=KEY%2F20260414%2Fap-northeast-1%2Fs3%2Faws4_request&"
+            "X-Amz-Date=20260414T154032Z&X-Amz-Signature=DEADBEEF",
+            "Retrying after broken: /path?X-Amz-Security-Token=[REDACTED]&"
+            "X-Amz-Credential=[REDACTED]&"
+            "X-Amz-Date=20260414T154032Z&X-Amz-Signature=[REDACTED]",
+        ),
+        (
+            "https://store.googleapis.com/o?X-Goog-Signature=ZZZ&X-Goog-Credential=YYY",
+            "https://store.googleapis.com/o?X-Goog-Signature=[REDACTED]&"
+            "X-Goog-Credential=[REDACTED]",
+        ),
+        (
+            "https://store.blob.core.windows.net/c/b?sig=AAA&se=2026-04-14T16%3A40%3A32Z",
+            "https://store.blob.core.windows.net/c/b?sig=[REDACTED]&se=2026-04-14T16%3A40%3A32Z",
+        ),
+        (
+            "just a normal log message without credentials",
+            "just a normal log message without credentials",
+        ),
+        ("path?foo=bar&baz=qux", "path?foo=bar&baz=qux"),
+    ],
+)
+def test_redact_sensitive_query_params(message: str, expected: str):
+    assert _redact_sensitive_query_params(message) == expected
+
+
+def test_sensitive_query_param_filter_rewrites_record_message():
+    capture_stream = StringIO()
+    logger = logging.getLogger(f"test_urllib3_{uuid.uuid4().hex}")
+    logger.addHandler(logging.StreamHandler(capture_stream))
+    logger.addFilter(SensitiveQueryParamFilter())
+    logger.setLevel(logging.WARNING)
+
+    logger.warning(
+        "Retrying (%r) after connection broken by %r: %s",
+        "Retry(total=1)",
+        "NameResolutionError(...)",
+        "/tokyo-prod/artifacts/traces.json"
+        "?X-Amz-Security-Token=SECRET_TOKEN"
+        "&X-Amz-Algorithm=AWS4-HMAC-SHA256"
+        "&X-Amz-Signature=SECRET_SIGNATURE"
+        "&X-Amz-Credential=SECRET_CREDENTIAL",
+    )
+
+    output = capture_stream.getvalue()
+    assert "X-Amz-Security-Token=[REDACTED]" in output
+    assert "X-Amz-Signature=[REDACTED]" in output
+    assert "X-Amz-Credential=[REDACTED]" in output
+    assert "X-Amz-Algorithm=AWS4-HMAC-SHA256" in output
+    assert "SECRET_TOKEN" not in output
+    assert "SECRET_SIGNATURE" not in output
+    assert "SECRET_CREDENTIAL" not in output
+
+
+def test_sensitive_query_param_filter_installed_on_urllib3_connectionpool():
+    urllib3_logger = logging.getLogger("urllib3.connectionpool")
+    assert any(isinstance(f, SensitiveQueryParamFilter) for f in urllib3_logger.filters)
 
 
 @pytest.mark.parametrize("configure_logging", ["0", "1"])


### PR DESCRIPTION
### Related Issues/PRs

Relates to custom report.

### What changes are proposed in this pull request?

When a trace artifact upload fails with a network error (e.g. `NameResolutionError` because the target S3 host cannot be DNS-resolved from the current network), urllib3 logs the retry warning with the full target URL. For Databricks-managed presigned URLs that URL contains credentials in the query string:

```
[urllib3.connectionpool][WARNING]: Retrying (...) after connection broken by 'NameResolutionError(...)':
/.../traces.json?X-Amz-Security-Token=XXX&X-Amz-Algorithm=AWS4-HMAC-SHA256&...&X-Amz-Credential=ZZZ&X-Amz-Signature=CCCCC
```

`X-Amz-Security-Token`, `X-Amz-Credential`, and `X-Amz-Signature` (and the GCS / Azure SAS analogues) are credentials and should not be written to stderr.

This PR adds a `logging.Filter` (`SensitiveQueryParamFilter`) that rewrites log records to mask the values of those parameters (`[REDACTED]`) while preserving the rest of the message. The filter is attached to `urllib3.connectionpool` from `_configure_mlflow_loggers`, which is the logger that emits the leaky retry warning. Non-credential parameters (`X-Amz-Date`, `X-Amz-Expires`, `X-Amz-Algorithm`, `X-Amz-SignedHeaders`, `se`, ...) are left untouched.

Covered providers:
- AWS S3 SigV4: `X-Amz-Signature`, `X-Amz-Security-Token`, `X-Amz-Credential`
- GCS V4 signed URLs: `X-Goog-Signature`, `X-Goog-Credential`
- Azure SAS: `sig`, generic `Signature`

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests

New unit tests in `tests/utils/test_logging_utils.py`:
- `test_redact_sensitive_query_params` — parametrized over AWS / GCS / Azure SAS / benign messages.
- `test_sensitive_query_param_filter_rewrites_record_message` — drives an actual log record through the filter (with `%s`-style args mimicking urllib3) and verifies the captured stream contains `[REDACTED]` and not the raw secret values.
- `test_sensitive_query_param_filter_installed_on_urllib3_connectionpool` — asserts that importing mlflow attaches the filter to the urllib3 logger.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. MLflow now masks credential-bearing query parameters (`X-Amz-Signature`, `X-Amz-Security-Token`, `X-Amz-Credential`, `X-Goog-Signature`, `X-Goog-Credential`, Azure SAS `sig`) in `urllib3.connectionpool` retry warnings, so cloud-storage presigned URL credentials are no longer printed to stderr when a connection error occurs during artifact upload/download.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release

This pull request was AI-assisted by Isaac.