### PR TITLE
Cache raw logs for successful jobs in `analyze-ci` skill

### DIFF
--- a/.claude/skills/analyze-ci/SKILL.md
+++ b/.claude/skills/analyze-ci/SKILL.md
@@ -24,7 +24,8 @@ uv run --package skills skills analyze-ci '<pr_url>'
 # Analyze all failed jobs in a workflow run
 uv run --package skills skills analyze-ci '<run_url>'
 
-# Analyze specific job URLs directly
+# Analyze specific job URLs directly.
+# Analysis runs only for failed jobs. Raw logs are always cached.
 uv run --package skills skills analyze-ci '<job_url>' ['<job_url>' ...]
 
 # Show debug info (tokens and costs)

--- a/.claude/skills/analyze-ci/SKILL.md
+++ b/.claude/skills/analyze-ci/SKILL.md
@@ -24,8 +24,7 @@ uv run --package skills skills analyze-ci '<pr_url>'
 # Analyze all failed jobs in a workflow run
 uv run --package skills skills analyze-ci '<run_url>'
 
-# Analyze specific job URLs directly.
-# Analysis runs only for failed jobs. Raw logs are always cached.
+# Analyze specific job URLs directly
 uv run --package skills skills analyze-ci '<job_url>' ['<job_url>' ...]
 
 # Show debug info (tokens and costs)

--- a/.claude/skills/src/skills/commands/analyze_ci.py
+++ b/.claude/skills/src/skills/commands/analyze_ci.py
@@ -31,6 +31,7 @@ class JobLogs:
     failed_step: str | None
     logs: str
     raw_log_path: Path
+    conclusion: str | None
 
 
 @dataclass
@@ -213,11 +214,19 @@ async def resolve_urls(client: GitHubClient, urls: list[str]) -> list[Job]:
 
 async def fetch_single_job_logs(client: GitHubClient, job: Job) -> JobLogs:
     log(f"Fetching logs for '{job.workflow_name} / {job.name}'")
+    raw_log_path = await download_raw_log(client, job)
 
     failed_step = next((s for s in job.steps if s.conclusion == "failure"), None)
     if not failed_step:
-        raise ValueError(f"No failed step found for job {job.id}")
-    raw_log_path = await download_raw_log(client, job)
+        return JobLogs(
+            workflow_name=job.workflow_name,
+            job_name=job.name,
+            job_url=job.html_url,
+            failed_step=None,
+            logs="",
+            raw_log_path=raw_log_path,
+            conclusion=job.conclusion,
+        )
     cleaned_logs = compact_logs(iter_step_lines(raw_log_path, failed_step))
     truncated_logs = truncate_logs(cleaned_logs)
 
@@ -228,6 +237,7 @@ async def fetch_single_job_logs(client: GitHubClient, job: Job) -> JobLogs:
         failed_step=failed_step.name,
         logs=truncated_logs,
         raw_log_path=raw_log_path,
+        conclusion=job.conclusion,
     )
 
 
@@ -265,6 +275,15 @@ def format_single_job_for_analysis(job: JobLogs) -> str:
 
 
 async def analyze_single_job(job: JobLogs) -> AnalysisResult:
+    if job.failed_step is None:
+        text = (
+            f"## {job.workflow_name} / {job.job_name}\n"
+            f"URL: {job.job_url}\n"
+            f"Conclusion: {job.conclusion}\n\n"
+            f"Job has no failure to analyze. Raw log cached at {job.raw_log_path}"
+        )
+        return AnalysisResult(text=text, total_cost_usd=None, usage=None)
+
     formatted_logs = format_single_job_for_analysis(job)
     prompt = f"Analyze this CI failure:\n\n{formatted_logs}"
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22988

### What changes are proposed in this pull request?

When a job URL is passed directly to `analyze-ci`, the skill previously raised `ValueError("No failed step found for job <id>")` for any job that did not have a failing step (e.g. a successful, cancelled, or in-progress job), bailing out before the raw log was downloaded. This made the skill unusable as a raw-log fetcher for green runs.

This PR:

- Downloads the raw log first, so the cache always populates regardless of conclusion.
- For jobs without a failed step, returns a short "no failure to analyze" summary instead of crashing.
- Records the job's `conclusion` on `JobLogs` and surfaces it in the summary.

PR-URL and run-URL input paths still filter to failed jobs upstream, so this graceful path only triggers when a specific job URL is passed.

### How is this PR tested?

- [x] Manual tests

Ran `analyze-ci` against:

1. A failing job URL: still produces a normal failure analysis.
2. A successful job URL: prints the new summary and caches the raw log.
3. The same successful job URL again: hits the cache (`Using cached raw log at ...`).

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Instructions

Updated `.claude/skills/analyze-ci/SKILL.md` to mention the new behavior in the usage block.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release