### PR TITLE
Extract `show-versions` output in `analyze-ci` skill

### DIFF
--- a/.claude/skills/analyze-ci/SKILL.md
+++ b/.claude/skills/analyze-ci/SKILL.md
@@ -31,7 +31,10 @@ uv run --package skills skills analyze-ci '<job_url>' ['<job_url>' ...]
 uv run --package skills skills analyze-ci '<pr_url>' --debug
 ```
 
-Output: A concise failure summary with root cause, error messages, test names, and relevant log snippets.
+Output: A concise failure summary with root cause, error messages, test names, and relevant log snippets. Each job's output also includes:
+
+- `Raw log: <path>`: full unfiltered log cached locally for grepping.
+- `Package versions: <path>` (optional): file containing the `.github/actions/show-versions` action's output, written next to the raw log. Present only for jobs that run the action (e.g. cross-version tests). Useful for comparing package versions between two runs to find which packages changed.
 
 ## Examples
 

--- a/.claude/skills/analyze-ci/SKILL.md
+++ b/.claude/skills/analyze-ci/SKILL.md
@@ -34,7 +34,7 @@ uv run --package skills skills analyze-ci '<pr_url>' --debug
 Output: A concise failure summary with root cause, error messages, test names, and relevant log snippets. Each job's output also includes:
 
 - `Raw log: <path>`: full unfiltered log cached locally for grepping.
-- `Package versions: <path>` (optional): file containing the `.github/actions/show-versions` action's output, written next to the raw log. Present only for jobs that run the action (e.g. cross-version tests). Useful for comparing package versions between two runs to find which packages changed.
+- `Package versions: <path>` (optional): file containing the `.github/actions/show-versions` action's output, written next to the raw log. Present only for jobs that run the action (e.g. cross-version tests). Useful for diffing against another run.
 
 ## Examples
 

--- a/.claude/skills/analyze-ci/SKILL.md
+++ b/.claude/skills/analyze-ci/SKILL.md
@@ -34,7 +34,7 @@ uv run --package skills skills analyze-ci '<pr_url>' --debug
 Output: A concise failure summary with root cause, error messages, test names, and relevant log snippets. Each job's output also includes:
 
 - `Raw log: <path>`: full unfiltered log cached locally for grepping.
-- `Package versions: <path>` (optional): file containing the `.github/actions/show-versions` action's output, written next to the raw log. Present only for jobs that run the action (e.g. cross-version tests). Useful for diffing against another run.
+- `Package versions: <path>` (optional): file containing the `.github/actions/show-versions` action's output, written next to the raw log. Present only for jobs that run the action (e.g. cross-version tests). Useful for diffing against another run, or for reproducing the failure locally with matching package versions.
 
 ## Examples
 

--- a/.claude/skills/src/skills/commands/analyze_ci.py
+++ b/.claude/skills/src/skills/commands/analyze_ci.py
@@ -124,6 +124,7 @@ def extract_package_versions(log_path: Path) -> Path | None:
 
     captured: list[str] = []
     capturing = False
+    terminated = False
     with log_path.open("r", encoding="utf-8", errors="replace") as f:
         for line in f:
             line = line.rstrip("\r\n")
@@ -133,10 +134,11 @@ def extract_package_versions(log_path: Path) -> Path | None:
                     capturing = True
                 continue
             if content == PACKAGE_VERSIONS_END_MARKER:
+                terminated = True
                 break
-            captured.append(line)
+            captured.append(content)
 
-    if not captured:
+    if not terminated or not captured:
         return None
     with out_path.open("w", encoding="utf-8") as f:
         f.write("\n".join(captured) + "\n")

--- a/.claude/skills/src/skills/commands/analyze_ci.py
+++ b/.claude/skills/src/skills/commands/analyze_ci.py
@@ -31,6 +31,7 @@ class JobLogs:
     failed_step: str | None
     logs: str
     raw_log_path: Path
+    package_versions_path: Path | None
     conclusion: str | None
 
 
@@ -58,10 +59,9 @@ def prune_old_cached_logs() -> None:
     if not LOG_CACHE_DIR.exists():
         return
     cutoff = time.time() - LOG_CACHE_TTL_SECONDS
-    # Glob also catches partial `*.log.tmp` files left by interrupted downloads
-    for log_file in LOG_CACHE_DIR.rglob("*.log*"):
-        if log_file.stat().st_mtime < cutoff:
-            log_file.unlink()
+    for cached_file in LOG_CACHE_DIR.rglob("*"):
+        if cached_file.is_file() and cached_file.stat().st_mtime < cutoff:
+            cached_file.unlink()
     for run_dir in LOG_CACHE_DIR.iterdir():
         if run_dir.is_dir() and not any(run_dir.iterdir()):
             run_dir.rmdir()
@@ -109,6 +109,39 @@ def iter_step_lines(log_path: Path, failed_step: JobStep) -> Iterator[str]:
                 _, _, line = line.partition(" ")
             if in_range:
                 yield line
+
+
+PACKAGE_VERSIONS_BEGIN_MARKER = ">>> package versions"
+PACKAGE_VERSIONS_END_MARKER = "<<< package versions"
+
+
+def extract_package_versions(log_path: Path) -> Path | None:
+    """Save the show-versions action's package list block next to the raw log."""
+    out_path = log_path.with_suffix(".package-versions.txt")
+    if out_path.exists():
+        log(f"Using cached package versions at {out_path}")
+        return out_path
+
+    captured: list[str] = []
+    capturing = False
+    with log_path.open("r", encoding="utf-8", errors="replace") as f:
+        for line in f:
+            line = line.rstrip("\r\n")
+            content = TIMESTAMP_PATTERN.sub("", line)
+            if not capturing:
+                if content == PACKAGE_VERSIONS_BEGIN_MARKER:
+                    capturing = True
+                continue
+            if content == PACKAGE_VERSIONS_END_MARKER:
+                break
+            captured.append(line)
+
+    if not captured:
+        return None
+    with out_path.open("w", encoding="utf-8") as f:
+        f.write("\n".join(captured) + "\n")
+    log(f"Saved package versions to {out_path}")
+    return out_path
 
 
 ANSI_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
@@ -215,6 +248,7 @@ async def resolve_urls(client: GitHubClient, urls: list[str]) -> list[Job]:
 async def fetch_single_job_logs(client: GitHubClient, job: Job) -> JobLogs:
     log(f"Fetching logs for '{job.workflow_name} / {job.name}'")
     raw_log_path = await download_raw_log(client, job)
+    package_versions_path = extract_package_versions(raw_log_path)
 
     failed_step = next((s for s in job.steps if s.conclusion == "failure"), None)
     if not failed_step:
@@ -225,6 +259,7 @@ async def fetch_single_job_logs(client: GitHubClient, job: Job) -> JobLogs:
             failed_step=None,
             logs="",
             raw_log_path=raw_log_path,
+            package_versions_path=package_versions_path,
             conclusion=job.conclusion,
         )
     cleaned_logs = compact_logs(iter_step_lines(raw_log_path, failed_step))
@@ -237,6 +272,7 @@ async def fetch_single_job_logs(client: GitHubClient, job: Job) -> JobLogs:
         failed_step=failed_step.name,
         logs=truncated_logs,
         raw_log_path=raw_log_path,
+        package_versions_path=package_versions_path,
         conclusion=job.conclusion,
     )
 
@@ -282,6 +318,8 @@ async def analyze_single_job(job: JobLogs) -> AnalysisResult:
             f"Conclusion: {job.conclusion}\n\n"
             f"Job has no failure to analyze. Raw log cached at {job.raw_log_path}"
         )
+        if job.package_versions_path:
+            text = f"{text}\nPackage versions: {job.package_versions_path}"
         return AnalysisResult(text=text, total_cost_usd=None, usage=None)
 
     formatted_logs = format_single_job_for_analysis(job)
@@ -316,6 +354,8 @@ async def analyze_single_job(job: JobLogs) -> AnalysisResult:
     text = data.get("result", "")
     # Surface the raw log path so downstream agents can grep it for deeper analysis
     text = f"{text}\n\nRaw log: {job.raw_log_path}"
+    if job.package_versions_path:
+        text = f"{text}\nPackage versions: {job.package_versions_path}"
     return AnalysisResult(
         text=text,
         total_cost_usd=data.get("total_cost_usd"),

--- a/.github/actions/show-versions/action.yml
+++ b/.github/actions/show-versions/action.yml
@@ -15,5 +15,7 @@ runs:
         fi
         pip --disable-pip-version-check install aiohttp > /dev/null
         echo ">>> package versions"
-        python dev/show_package_release_dates.py
+        status=0
+        python dev/show_package_release_dates.py || status=$?
         echo "<<< package versions"
+        exit $status

--- a/.github/actions/show-versions/action.yml
+++ b/.github/actions/show-versions/action.yml
@@ -14,4 +14,6 @@ runs:
           fi
         fi
         pip --disable-pip-version-check install aiohttp > /dev/null
+        echo ">>> package versions"
         python dev/show_package_release_dates.py
+        echo "<<< package versions"


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22998

### What changes are proposed in this pull request?

Wraps the `show-versions` action's package list in `>>> package versions` / `<<< package versions` sentinels so `analyze-ci` can extract just that block to a `<job_id>.package-versions.txt` file next to the cached raw log. The path is surfaced in the skill's output.

The intent is to make it easy to compare package versions between two runs (e.g. last green vs. first failing run for a flavor) and find which packages changed, which is the fastest path to root-causing transitive-dep regressions in cross-version tests.

Touched files:

- `.github/actions/show-versions/action.yml`: emit explicit begin/end sentinels around the python script output.
- `.claude/skills/src/skills/commands/analyze_ci.py`: extract the sentinel-bracketed block to a sibling file in the cache dir; surface the path in the skill's output.
- `.claude/skills/analyze-ci/SKILL.md`: document the new `Package versions: <path>` output line.

### How is this PR tested?

- [x] Manual tests

Verified end-to-end against a real cross-version-tests job: the extractor produces a clean per-job `package-versions.txt` containing only the show-versions output, and the path is surfaced in the skill's summary.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release