### PR TITLE
Fix claude code tracing for plan mode

### DIFF
--- a/mlflow/claude_code/cli.py
+++ b/mlflow/claude_code/cli.py
@@ -5,7 +5,12 @@ from pathlib import Path
 import click
 
 from mlflow.claude_code.config import get_tracing_status, setup_environment_config
-from mlflow.claude_code.hooks import disable_tracing_hooks, setup_hooks_config, stop_hook_handler
+from mlflow.claude_code.hooks import (
+    disable_tracing_hooks,
+    exit_plan_mode_hook_handler,
+    setup_hooks_config,
+    stop_hook_handler,
+)
 
 
 @click.group("autolog")
@@ -176,3 +181,9 @@ def _show_setup_status(
 def stop_hook() -> None:
     """Hook handler invoked when a Claude Code conversation ends."""
     stop_hook_handler()
+
+
+@claude.command("exit-plan-mode-hook", hidden=True)
+def exit_plan_mode_hook() -> None:
+    """Hook handler invoked after ExitPlanMode tool use - traces the planning phase."""
+    exit_plan_mode_hook_handler()

--- a/mlflow/claude_code/hooks.py
+++ b/mlflow/claude_code/hooks.py
@@ -82,7 +82,10 @@ def upsert_hook(
 def setup_hooks_config(settings_path: Path) -> None:
     """Set up Claude Code hooks for MLflow tracing.
 
-    Creates or updates Stop hook that calls MLflow tracing handler.
+    Creates or updates two hooks:
+    - Stop hook: traces the execution phase at conversation end.
+    - PostToolUse ExitPlanMode hook: traces the planning phase when Plan mode is used.
+
     Updates existing MLflow hooks if found, otherwise adds new ones.
 
     Args:

--- a/mlflow/claude_code/hooks.py
+++ b/mlflow/claude_code/hooks.py
@@ -56,8 +56,8 @@ def upsert_hook(
 
     # Check if MLflow hook already exists and update it.
     # When a matcher is specified, only match groups with the same matcher value so
-    # that Stop and PostToolUse hooks don't collide even though they share the same
-    # MLFLOW_HOOK_IDENTIFIER prefix.
+    # that hooks registered under different matchers within the same hook type
+    # (e.g. ExitPlanMode vs other PostToolUse matchers) don't overwrite each other.
     hook_exists = False
     for hook_group in config[HOOK_FIELD_HOOKS][hook_type]:
         if HOOK_FIELD_HOOKS not in hook_group:
@@ -140,9 +140,7 @@ def disable_tracing_hooks(settings_path: Path) -> bool:
                 if len(filtered_hooks) < len(group[HOOK_FIELD_HOOKS]):
                     hooks_removed = True
                 if filtered_hooks:
-                    new_group: dict[str, Any] = {HOOK_FIELD_HOOKS: filtered_hooks}
-                    if "matcher" in group:
-                        new_group["matcher"] = group["matcher"]
+                    new_group = {**group, HOOK_FIELD_HOOKS: filtered_hooks}
                     filtered_groups.append(new_group)
             else:
                 filtered_groups.append(group)

--- a/mlflow/claude_code/hooks.py
+++ b/mlflow/claude_code/hooks.py
@@ -24,6 +24,7 @@ from mlflow.claude_code.tracing import (
     get_hook_response,
     get_logger,
     is_tracing_enabled,
+    process_planning_phase_transcript,
     process_transcript,
     read_hook_input,
     setup_mlflow,
@@ -34,13 +35,16 @@ from mlflow.claude_code.tracing import (
 # ============================================================================
 
 
-def upsert_hook(config: dict[str, Any], hook_type: str, subcommand: str) -> None:
+def upsert_hook(
+    config: dict[str, Any], hook_type: str, subcommand: str, matcher: str | None = None
+) -> None:
     """Insert or update a single MLflow hook in the configuration.
 
     Args:
         config: The hooks configuration dictionary to modify
         hook_type: The hook type (e.g., 'PostToolUse', 'Stop')
         subcommand: The CLI subcommand name (e.g., 'stop-hook')
+        matcher: Optional tool name matcher for PostToolUse hooks
     """
     if hook_type not in config[HOOK_FIELD_HOOKS]:
         config[HOOK_FIELD_HOOKS][hook_type] = []
@@ -50,20 +54,29 @@ def upsert_hook(config: dict[str, Any], hook_type: str, subcommand: str) -> None
 
     mlflow_hook = {"type": "command", HOOK_FIELD_COMMAND: hook_command}
 
-    # Check if MLflow hook already exists and update it
+    # Check if MLflow hook already exists and update it.
+    # When a matcher is specified, only match groups with the same matcher value so
+    # that Stop and PostToolUse hooks don't collide even though they share the same
+    # MLFLOW_HOOK_IDENTIFIER prefix.
     hook_exists = False
     for hook_group in config[HOOK_FIELD_HOOKS][hook_type]:
-        if HOOK_FIELD_HOOKS in hook_group:
-            for hook in hook_group[HOOK_FIELD_HOOKS]:
-                cmd = hook.get(HOOK_FIELD_COMMAND, "")
-                if MLFLOW_HOOK_IDENTIFIER in cmd or MLFLOW_LEGACY_HOOK_IDENTIFIER in cmd:
-                    hook.update(mlflow_hook)
-                    hook_exists = True
-                    break
+        if HOOK_FIELD_HOOKS not in hook_group:
+            continue
+        if hook_group.get("matcher") != matcher:
+            continue
+        for hook in hook_group[HOOK_FIELD_HOOKS]:
+            cmd = hook.get(HOOK_FIELD_COMMAND, "")
+            if MLFLOW_HOOK_IDENTIFIER in cmd or MLFLOW_LEGACY_HOOK_IDENTIFIER in cmd:
+                hook.update(mlflow_hook)
+                hook_exists = True
+                break
 
     # Add new hook if it doesn't exist
     if not hook_exists:
-        config[HOOK_FIELD_HOOKS][hook_type].append({HOOK_FIELD_HOOKS: [mlflow_hook]})
+        new_group: dict[str, Any] = {HOOK_FIELD_HOOKS: [mlflow_hook]}
+        if matcher is not None:
+            new_group["matcher"] = matcher
+        config[HOOK_FIELD_HOOKS][hook_type].append(new_group)
 
 
 def setup_hooks_config(settings_path: Path) -> None:
@@ -81,6 +94,7 @@ def setup_hooks_config(settings_path: Path) -> None:
         config[HOOK_FIELD_HOOKS] = {}
 
     upsert_hook(config, "Stop", "stop-hook")
+    upsert_hook(config, "PostToolUse", "exit-plan-mode-hook", matcher="ExitPlanMode")
 
     save_claude_config(settings_path, config)
 
@@ -106,9 +120,12 @@ def disable_tracing_hooks(settings_path: Path) -> bool:
     hooks_removed = False
     env_removed = False
 
-    # Remove MLflow hooks
-    if "Stop" in config.get(HOOK_FIELD_HOOKS, {}):
-        hook_groups = config[HOOK_FIELD_HOOKS]["Stop"]
+    # Remove MLflow hooks from all relevant hook types
+    for hook_type in ("Stop", "PostToolUse"):
+        if hook_type not in config.get(HOOK_FIELD_HOOKS, {}):
+            continue
+
+        hook_groups = config[HOOK_FIELD_HOOKS][hook_type]
         filtered_groups = []
 
         for group in hook_groups:
@@ -121,16 +138,19 @@ def disable_tracing_hooks(settings_path: Path) -> bool:
                 ]
 
                 if filtered_hooks:
-                    filtered_groups.append({HOOK_FIELD_HOOKS: filtered_hooks})
+                    new_group: dict[str, Any] = {HOOK_FIELD_HOOKS: filtered_hooks}
+                    if "matcher" in group:
+                        new_group["matcher"] = group["matcher"]
+                    filtered_groups.append(new_group)
                 else:
                     hooks_removed = True
             else:
                 filtered_groups.append(group)
 
         if filtered_groups:
-            config[HOOK_FIELD_HOOKS]["Stop"] = filtered_groups
+            config[HOOK_FIELD_HOOKS][hook_type] = filtered_groups
         else:
-            del config[HOOK_FIELD_HOOKS]["Stop"]
+            del config[HOOK_FIELD_HOOKS][hook_type]
             hooks_removed = True
 
     # Remove config variables
@@ -212,6 +232,60 @@ def stop_hook_handler() -> None:
 
     except Exception as e:
         get_logger().error("Error in Stop hook: %s", e, exc_info=True)
+        response = get_hook_response(error=str(e))
+        print(json.dumps(response))  # noqa: T201
+        sys.exit(1)
+
+
+def _process_exit_plan_mode_hook(
+    session_id: str | None, transcript_path: str | None
+) -> dict[str, Any]:
+    """Common logic for processing the PostToolUse ExitPlanMode hook.
+
+    Args:
+        session_id: Session identifier
+        transcript_path: Path to transcript file
+
+    Returns:
+        Hook response dictionary
+    """
+    get_logger().log(
+        CLAUDE_TRACING_LEVEL,
+        "ExitPlanMode hook: session=%s, transcript=%s",
+        session_id,
+        transcript_path,
+    )
+
+    trace = process_planning_phase_transcript(transcript_path, session_id)
+
+    if trace is not None:
+        return get_hook_response()
+    return get_hook_response(
+        error=(
+            "Failed to process planning phase transcript, please check"
+            " .claude/mlflow/claude_tracing.log for more details"
+        ),
+    )
+
+
+def exit_plan_mode_hook_handler() -> None:
+    """CLI hook handler for ExitPlanMode - processes planning phase and creates trace."""
+    if not is_tracing_enabled():
+        response = get_hook_response()
+        print(json.dumps(response))  # noqa: T201
+        return
+
+    try:
+        hook_data = read_hook_input()
+        session_id = hook_data.get("session_id")
+        transcript_path = hook_data.get("transcript_path")
+
+        setup_mlflow()
+        response = _process_exit_plan_mode_hook(session_id, transcript_path)
+        print(json.dumps(response))  # noqa: T201
+
+    except Exception as e:
+        get_logger().error("Error in ExitPlanMode hook: %s", e, exc_info=True)
         response = get_hook_response(error=str(e))
         print(json.dumps(response))  # noqa: T201
         sys.exit(1)

--- a/mlflow/claude_code/hooks.py
+++ b/mlflow/claude_code/hooks.py
@@ -137,13 +137,13 @@ def disable_tracing_hooks(settings_path: Path) -> bool:
                     and MLFLOW_LEGACY_HOOK_IDENTIFIER not in hook.get(HOOK_FIELD_COMMAND, "")
                 ]
 
+                if len(filtered_hooks) < len(group[HOOK_FIELD_HOOKS]):
+                    hooks_removed = True
                 if filtered_hooks:
                     new_group: dict[str, Any] = {HOOK_FIELD_HOOKS: filtered_hooks}
                     if "matcher" in group:
                         new_group["matcher"] = group["matcher"]
                     filtered_groups.append(new_group)
-                else:
-                    hooks_removed = True
             else:
                 filtered_groups.append(group)
 

--- a/mlflow/claude_code/tracing.py
+++ b/mlflow/claude_code/tracing.py
@@ -51,6 +51,7 @@ MESSAGE_FIELD_COMMAND_NAME = "commandName"
 MESSAGE_TYPE_QUEUE_OPERATION = "queue-operation"
 QUEUE_OPERATION_ENQUEUE = "enqueue"
 METADATA_KEY_CLAUDE_CODE_VERSION = "mlflow.claude_code_version"
+TOOL_EXIT_PLAN_MODE = "ExitPlanMode"
 
 # Custom logging level for Claude tracing
 CLAUDE_TRACING_LEVEL = logging.WARNING - 5
@@ -589,6 +590,61 @@ def find_final_assistant_response(transcript: list[dict[str, Any]], start_idx: i
 
 
 # ============================================================================
+# PLAN MODE HELPERS
+# ============================================================================
+
+
+def find_exit_plan_mode_index(
+    transcript: list[dict[str, Any]],
+) -> tuple[int, str] | None:
+    """Locate the ExitPlanMode approval result in the transcript.
+
+    Args:
+        transcript: List of conversation entries from Claude Code transcript
+
+    Returns:
+        Tuple of (boundary_idx, plan_text) where boundary_idx is the index of
+        the tool_result user entry if present, or the ExitPlanMode assistant
+        entry if the tool_result hasn't been written yet.
+        Returns None if ExitPlanMode is not present.
+    """
+    for i, entry in enumerate(transcript):
+        if entry.get(MESSAGE_FIELD_TYPE) != MESSAGE_TYPE_ASSISTANT:
+            continue
+        content = entry.get(MESSAGE_FIELD_MESSAGE, {}).get(MESSAGE_FIELD_CONTENT, [])
+        if not isinstance(content, list):
+            continue
+        epm_part = next(
+            (
+                p
+                for p in content
+                if isinstance(p, dict)
+                and p.get(MESSAGE_FIELD_TYPE) == CONTENT_TYPE_TOOL_USE
+                and p.get("name") == TOOL_EXIT_PLAN_MODE
+            ),
+            None,
+        )
+        if epm_part is None:
+            continue
+        plan_text = epm_part.get("input", {}).get("plan", "")
+        tool_use_id = epm_part.get("id", "")
+        for j in range(i + 1, len(transcript)):
+            result_content = (
+                transcript[j].get(MESSAGE_FIELD_MESSAGE, {}).get(MESSAGE_FIELD_CONTENT, [])
+            )
+            if isinstance(result_content, list) and any(
+                isinstance(p, dict)
+                and p.get(MESSAGE_FIELD_TYPE) == CONTENT_TYPE_TOOL_RESULT
+                and p.get("tool_use_id") == tool_use_id
+                for p in result_content
+            ):
+                return j, plan_text
+        # tool_result not yet written — fall back to the assistant entry.
+        return i, plan_text
+    return None
+
+
+# ============================================================================
 # MAIN TRANSCRIPT PROCESSING
 # ============================================================================
 
@@ -611,42 +667,64 @@ def process_transcript(
             get_logger().warning("Empty transcript, skipping")
             return None
 
-        last_user_idx = find_last_user_message_index(transcript)
-        if last_user_idx is None:
-            get_logger().warning("No user message found in transcript")
-            return None
+        # When the session used Plan mode, the Stop hook should only cover the
+        # execution phase (planning already got its own trace via the
+        # PostToolUse ExitPlanMode hook).  Detect the boundary and slice accordingly.
+        exec_start_idx = 0
+        prompt_override: str | None = None
+        exit_plan_mode_info = find_exit_plan_mode_index(transcript)
+        if exit_plan_mode_info is not None:
+            result_idx, plan_text = exit_plan_mode_info
+            exec_start_idx = result_idx + 1
+            prompt_override = plan_text
 
-        last_user_entry = transcript[last_user_idx]
-        last_user_prompt = last_user_entry.get(MESSAGE_FIELD_MESSAGE, {}).get(
-            MESSAGE_FIELD_CONTENT, ""
-        )
+        if prompt_override is not None:
+            # Execution-phase trace: use the approved plan text as the prompt
+            user_prompt_text = prompt_override
+            conv_start_ns = next(
+                (
+                    parse_timestamp_to_ns(e.get(MESSAGE_FIELD_TIMESTAMP))
+                    for e in transcript[exec_start_idx:]
+                    if e.get(MESSAGE_FIELD_TIMESTAMP)
+                ),
+                None,
+            )
+        else:
+            last_user_idx = find_last_user_message_index(transcript)
+            if last_user_idx is None:
+                get_logger().warning("No user message found in transcript")
+                return None
+            last_user_entry = transcript[last_user_idx]
+            last_user_prompt = last_user_entry.get(MESSAGE_FIELD_MESSAGE, {}).get(
+                MESSAGE_FIELD_CONTENT, ""
+            )
+            user_prompt_text = extract_text_content(last_user_prompt)
+            exec_start_idx = last_user_idx + 1
+            conv_start_ns = parse_timestamp_to_ns(last_user_entry.get(MESSAGE_FIELD_TIMESTAMP))
 
         if not session_id:
             session_id = f"claude-{datetime.now().strftime('%Y%m%d_%H%M%S')}"
 
         get_logger().log(CLAUDE_TRACING_LEVEL, "Creating MLflow trace for session: %s", session_id)
 
-        conv_start_ns = parse_timestamp_to_ns(last_user_entry.get(MESSAGE_FIELD_TIMESTAMP))
-
         parent_span = mlflow.start_span_no_context(
             name="claude_code_conversation",
-            inputs={"prompt": extract_text_content(last_user_prompt)},
+            inputs={"prompt": user_prompt_text},
             start_time_ns=conv_start_ns,
             span_type=SpanType.AGENT,
         )
 
         # Create spans for all assistant responses and tool uses
-        _create_llm_and_tool_spans(parent_span, transcript, last_user_idx + 1)
+        _create_llm_and_tool_spans(parent_span, transcript, exec_start_idx)
 
         # Update trace with preview content and end timing
-        final_response = find_final_assistant_response(transcript, last_user_idx + 1)
-        user_prompt_text = extract_text_content(last_user_prompt)
+        final_response = find_final_assistant_response(transcript, exec_start_idx)
 
         # Calculate end time based on last entry or use default duration
-        last_entry = transcript[-1] if transcript else last_user_entry
+        last_entry = transcript[-1] if transcript else transcript[exec_start_idx]
         conv_end_ns = parse_timestamp_to_ns(last_entry.get(MESSAGE_FIELD_TIMESTAMP))
-        if not conv_end_ns or conv_end_ns <= conv_start_ns:
-            conv_end_ns = conv_start_ns + int(10 * NANOSECONDS_PER_S)
+        if not conv_end_ns or (conv_start_ns and conv_end_ns <= conv_start_ns):
+            conv_end_ns = (conv_start_ns or 0) + int(10 * NANOSECONDS_PER_S)
 
         # Extract Claude Code version from transcript entries (CLI-only)
         claude_code_version = next(
@@ -664,6 +742,95 @@ def process_transcript(
 
     except Exception as e:
         get_logger().error("Error processing transcript: %s", e, exc_info=True)
+        return None
+
+
+def process_planning_phase_transcript(
+    transcript_path: str, session_id: str | None = None
+) -> mlflow.entities.Trace | None:
+    """Process the planning phase of a Plan mode session and create an MLflow trace.
+
+    Called by the PostToolUse ExitPlanMode hook.  Covers all conversation entries
+    from the original user prompt up to and including the ExitPlanMode approval,
+    and uses the approved plan text as the trace output.
+
+    Args:
+        transcript_path: Path to the Claude Code transcript.jsonl file
+        session_id: Optional session identifier
+
+    Returns:
+        MLflow trace object if successful, None if processing fails
+    """
+    try:
+        transcript = read_transcript(transcript_path)
+        if not transcript:
+            get_logger().warning("Empty transcript, skipping planning phase")
+            return None
+
+        exit_plan_mode_info = find_exit_plan_mode_index(transcript)
+        if exit_plan_mode_info is None:
+            get_logger().warning("No ExitPlanMode found, skipping planning phase trace")
+            return None
+
+        result_idx, plan_text = exit_plan_mode_info
+        planning_transcript = transcript[: result_idx + 1]
+
+        last_user_idx = find_last_user_message_index(planning_transcript)
+        if last_user_idx is None:
+            get_logger().warning("No user message found in planning phase")
+            return None
+
+        last_user_entry = planning_transcript[last_user_idx]
+        last_user_prompt = last_user_entry.get(MESSAGE_FIELD_MESSAGE, {}).get(
+            MESSAGE_FIELD_CONTENT, ""
+        )
+        user_prompt_text = extract_text_content(last_user_prompt)
+
+        if not session_id:
+            session_id = f"claude-{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+
+        get_logger().log(
+            CLAUDE_TRACING_LEVEL,
+            "Creating planning phase trace for session: %s",
+            session_id,
+        )
+
+        conv_start_ns = parse_timestamp_to_ns(last_user_entry.get(MESSAGE_FIELD_TIMESTAMP))
+
+        parent_span = mlflow.start_span_no_context(
+            name="claude_code_conversation",
+            inputs={"prompt": user_prompt_text},
+            start_time_ns=conv_start_ns,
+            span_type=SpanType.AGENT,
+        )
+
+        _create_llm_and_tool_spans(parent_span, planning_transcript, last_user_idx + 1)
+
+        # Use the approved plan text as the response preview
+        final_response = plan_text or find_final_assistant_response(
+            planning_transcript, last_user_idx + 1
+        )
+
+        last_entry = planning_transcript[-1]
+        conv_end_ns = parse_timestamp_to_ns(last_entry.get(MESSAGE_FIELD_TIMESTAMP))
+        if not conv_end_ns or conv_end_ns <= conv_start_ns:
+            conv_end_ns = conv_start_ns + int(10 * NANOSECONDS_PER_S)
+
+        claude_code_version = next(
+            (ver for entry in planning_transcript if (ver := entry.get("version"))), None
+        )
+
+        return _finalize_trace(
+            parent_span,
+            user_prompt_text,
+            final_response,
+            session_id,
+            conv_end_ns,
+            claude_code_version=claude_code_version,
+        )
+
+    except Exception as e:
+        get_logger().error("Error processing planning phase transcript: %s", e, exc_info=True)
         return None
 
 

--- a/mlflow/claude_code/tracing.py
+++ b/mlflow/claude_code/tracing.py
@@ -676,7 +676,7 @@ def process_transcript(
         if exit_plan_mode_info is not None:
             result_idx, plan_text = exit_plan_mode_info
             exec_start_idx = result_idx + 1
-            prompt_override = plan_text
+            prompt_override = plan_text or None
 
         if prompt_override is not None:
             # Execution-phase trace: use the approved plan text as the prompt
@@ -723,8 +723,8 @@ def process_transcript(
         # Calculate end time based on last entry or use default duration
         last_entry = transcript[-1] if transcript else transcript[exec_start_idx]
         conv_end_ns = parse_timestamp_to_ns(last_entry.get(MESSAGE_FIELD_TIMESTAMP))
-        if not conv_end_ns or (conv_start_ns and conv_end_ns <= conv_start_ns):
-            conv_end_ns = (conv_start_ns or 0) + int(10 * NANOSECONDS_PER_S)
+        if conv_start_ns and (not conv_end_ns or conv_end_ns <= conv_start_ns):
+            conv_end_ns = conv_start_ns + int(10 * NANOSECONDS_PER_S)
 
         # Extract Claude Code version from transcript entries (CLI-only)
         claude_code_version = next(
@@ -813,7 +813,7 @@ def process_planning_phase_transcript(
 
         last_entry = planning_transcript[-1]
         conv_end_ns = parse_timestamp_to_ns(last_entry.get(MESSAGE_FIELD_TIMESTAMP))
-        if not conv_end_ns or conv_end_ns <= conv_start_ns:
+        if conv_start_ns and (not conv_end_ns or conv_end_ns <= conv_start_ns):
             conv_end_ns = conv_start_ns + int(10 * NANOSECONDS_PER_S)
 
         claude_code_version = next(

--- a/mlflow/claude_code/tracing.py
+++ b/mlflow/claude_code/tracing.py
@@ -783,8 +783,11 @@ def process_planning_phase_transcript(
     """Process the planning phase of a Plan mode session and create an MLflow trace.
 
     Called by the PostToolUse ExitPlanMode hook.  Covers all conversation entries
-    from the original user prompt up to and including the ExitPlanMode approval,
-    and uses the approved plan text as the trace output.
+    from the last real user message (the plan-mode trigger prompt) up to and
+    including the ExitPlanMode boundary — either the tool_result approval entry
+    if it has been flushed to disk, or the ExitPlanMode assistant entry itself
+    if the hook fires before the result is written.  Uses the approved plan text
+    as the trace output.
 
     Args:
         transcript_path: Path to the Claude Code transcript.jsonl file

--- a/mlflow/claude_code/tracing.py
+++ b/mlflow/claude_code/tracing.py
@@ -424,8 +424,16 @@ def _set_token_usage_attribute(span, usage: dict[str, Any]) -> None:
 
 def _create_llm_and_tool_spans(
     parent_span, transcript: list[dict[str, Any]], start_idx: int
-) -> None:
-    """Create LLM and tool spans for assistant responses with proper timing."""
+) -> dict[str, int]:
+    """Create LLM and tool spans for assistant responses with proper timing.
+
+    Returns:
+        Accumulated raw token usage across all assistant responses.
+    """
+    total_usage: dict[str, int] = {}
+    has_llm_spans = False
+    last_model: str | None = None
+
     for i in range(start_idx, len(transcript)):
         entry = transcript[i]
         if entry.get(MESSAGE_FIELD_TYPE) != MESSAGE_TYPE_ASSISTANT:
@@ -442,13 +450,25 @@ def _create_llm_and_tool_spans(
         msg = entry.get(MESSAGE_FIELD_MESSAGE, {})
         content = msg.get(MESSAGE_FIELD_CONTENT, [])
         usage = msg.get("usage", {})
+        model = msg.get("model") or "unknown"
+
+        # Accumulate raw token counts from every assistant response so callers
+        # can surface total usage even when there are no LLM spans (e.g. plan mode).
+        for key in (
+            TokenUsageKey.INPUT_TOKENS,
+            TokenUsageKey.OUTPUT_TOKENS,
+            TokenUsageKey.CACHE_READ_INPUT_TOKENS,
+            TokenUsageKey.CACHE_CREATION_INPUT_TOKENS,
+        ):
+            if (val := usage.get(key)) is not None:
+                total_usage[key] = total_usage.get(key, 0) + val
 
         # First check if we have meaningful content to create a span for
         text_content, tool_uses = _extract_content_and_tools(content)
 
         # Only create LLM span if there's text content (no tools)
-        llm_span = None
         if text_content and text_content.strip() and not tool_uses:
+            has_llm_spans = True
             messages = _get_input_messages(transcript, i)
 
             llm_span = mlflow.start_span_no_context(
@@ -457,11 +477,11 @@ def _create_llm_and_tool_spans(
                 span_type=SpanType.LLM,
                 start_time_ns=timestamp_ns,
                 inputs={
-                    "model": msg.get("model", "unknown"),
+                    "model": model,
                     "messages": messages,
                 },
                 attributes={
-                    "model": msg.get("model", "unknown"),
+                    SpanAttributeKey.MODEL: model,
                     SpanAttributeKey.MESSAGE_FORMAT: "anthropic",
                 },
             )
@@ -479,6 +499,7 @@ def _create_llm_and_tool_spans(
 
         # Create tool spans with proportional timing and actual results
         if tool_uses:
+            last_model = model
             tool_results = _find_tool_results(transcript, i)
             tool_duration_ns = duration_ns // len(tool_uses)
 
@@ -501,6 +522,13 @@ def _create_llm_and_tool_spans(
 
                 tool_span.set_outputs({"result": tool_result})
                 tool_span.end(end_time_ns=tool_start_ns + tool_duration_ns)
+
+    if not has_llm_spans and total_usage:
+        _set_token_usage_attribute(parent_span, total_usage)
+        if last_model:
+            parent_span.set_attribute(SpanAttributeKey.MODEL, last_model)
+
+    return total_usage
 
 
 def _finalize_trace(
@@ -718,7 +746,7 @@ def process_transcript(
         )
 
         # Create spans for all assistant responses and tool uses
-        _create_llm_and_tool_spans(parent_span, transcript, exec_start_idx)
+        usage = _create_llm_and_tool_spans(parent_span, transcript, exec_start_idx)
 
         # Update trace with preview content and end timing
         final_response = find_final_assistant_response(transcript, exec_start_idx)
@@ -740,6 +768,7 @@ def process_transcript(
             final_response,
             session_id,
             conv_end_ns,
+            usage=usage or None,
             claude_code_version=claude_code_version,
         )
 
@@ -807,7 +836,7 @@ def process_planning_phase_transcript(
             span_type=SpanType.AGENT,
         )
 
-        _create_llm_and_tool_spans(parent_span, planning_transcript, last_user_idx + 1)
+        usage = _create_llm_and_tool_spans(parent_span, planning_transcript, last_user_idx + 1)
 
         # Use the approved plan text as the response preview
         final_response = plan_text or find_final_assistant_response(
@@ -829,6 +858,7 @@ def process_planning_phase_transcript(
             final_response,
             session_id,
             conv_end_ns,
+            usage=usage or None,
             claude_code_version=claude_code_version,
         )
 

--- a/mlflow/claude_code/tracing.py
+++ b/mlflow/claude_code/tracing.py
@@ -671,16 +671,15 @@ def process_transcript(
         # execution phase (planning already got its own trace via the
         # PostToolUse ExitPlanMode hook).  Detect the boundary and slice accordingly.
         exec_start_idx = 0
-        prompt_override: str | None = None
         exit_plan_mode_info = find_exit_plan_mode_index(transcript)
         if exit_plan_mode_info is not None:
             result_idx, plan_text = exit_plan_mode_info
+            # Always slice from after ExitPlanMode to avoid duplicating planning spans.
             exec_start_idx = result_idx + 1
-            prompt_override = plan_text or None
 
-        if prompt_override is not None:
+        if exit_plan_mode_info is not None and plan_text:
             # Execution-phase trace: use the approved plan text as the prompt
-            user_prompt_text = prompt_override
+            user_prompt_text = plan_text
             conv_start_ns = next(
                 (
                     parse_timestamp_to_ns(e.get(MESSAGE_FIELD_TIMESTAMP))
@@ -690,6 +689,9 @@ def process_transcript(
                 None,
             )
         else:
+            # No plan mode, or plan mode with empty plan text: fall back to the
+            # last real user message for the prompt, but keep exec_start_idx
+            # pointing past ExitPlanMode when plan mode was detected.
             last_user_idx = find_last_user_message_index(transcript)
             if last_user_idx is None:
                 get_logger().warning("No user message found in transcript")
@@ -699,7 +701,8 @@ def process_transcript(
                 MESSAGE_FIELD_CONTENT, ""
             )
             user_prompt_text = extract_text_content(last_user_prompt)
-            exec_start_idx = last_user_idx + 1
+            if exit_plan_mode_info is None:
+                exec_start_idx = last_user_idx + 1
             conv_start_ns = parse_timestamp_to_ns(last_user_entry.get(MESSAGE_FIELD_TIMESTAMP))
 
         if not session_id:

--- a/tests/claude_code/test_cli.py
+++ b/tests/claude_code/test_cli.py
@@ -111,3 +111,33 @@ def test_stop_hook_subcommand_is_routable(runner):
         result = runner.invoke(commands, ["claude", "stop-hook"])
         assert result.exit_code == 0
         mock_handler.assert_called_once()
+
+
+def test_upsert_hook_with_matcher():
+    config = {HOOK_FIELD_HOOKS: {}}
+    upsert_hook(config, "PostToolUse", "exit-plan-mode-hook", matcher="ExitPlanMode")
+
+    groups = config[HOOK_FIELD_HOOKS]["PostToolUse"]
+    assert len(groups) == 1
+    group = groups[0]
+    assert group.get("matcher") == "ExitPlanMode"
+    hook_command = group[HOOK_FIELD_HOOKS][0][HOOK_FIELD_COMMAND]
+    assert "mlflow autolog claude exit-plan-mode-hook" in hook_command
+
+
+def test_upsert_hook_stop_and_post_tool_use_are_independent():
+    config = {HOOK_FIELD_HOOKS: {}}
+    upsert_hook(config, "Stop", "stop-hook")
+    upsert_hook(config, "PostToolUse", "exit-plan-mode-hook", matcher="ExitPlanMode")
+
+    stop_cmd = config[HOOK_FIELD_HOOKS]["Stop"][0][HOOK_FIELD_HOOKS][0][HOOK_FIELD_COMMAND]
+    post_cmd = config[HOOK_FIELD_HOOKS]["PostToolUse"][0][HOOK_FIELD_HOOKS][0][HOOK_FIELD_COMMAND]
+    assert "stop-hook" in stop_cmd
+    assert "exit-plan-mode-hook" in post_cmd
+
+
+def test_exit_plan_mode_hook_subcommand_is_routable(runner):
+    with mock.patch("mlflow.claude_code.cli.exit_plan_mode_hook_handler") as mock_handler:
+        result = runner.invoke(commands, ["claude", "exit-plan-mode-hook"])
+        assert result.exit_code == 0
+        mock_handler.assert_called_once()

--- a/tests/claude_code/test_cli.py
+++ b/tests/claude_code/test_cli.py
@@ -7,7 +7,7 @@ from click.testing import CliRunner
 
 from mlflow.claude_code.cli import commands
 from mlflow.claude_code.config import HOOK_FIELD_COMMAND, HOOK_FIELD_HOOKS
-from mlflow.claude_code.hooks import upsert_hook
+from mlflow.claude_code.hooks import disable_tracing_hooks, upsert_hook
 
 
 @pytest.fixture
@@ -141,3 +141,32 @@ def test_exit_plan_mode_hook_subcommand_is_routable(runner):
         result = runner.invoke(commands, ["claude", "exit-plan-mode-hook"])
         assert result.exit_code == 0
         mock_handler.assert_called_once()
+
+
+def test_disable_tracing_hooks_partial_removal(tmp_path):
+    # A group that mixes MLflow and non-MLflow hooks should still report hooks_removed=True.
+    settings_path = tmp_path / "settings.json"
+    mlflow_cmd = "uv run mlflow autolog claude stop-hook"
+    other_cmd = "echo other-hook"
+    settings_path.write_text(
+        json.dumps({
+            "hooks": {
+                "Stop": [
+                    {
+                        "hooks": [
+                            {"type": "command", "command": mlflow_cmd},
+                            {"type": "command", "command": other_cmd},
+                        ]
+                    }
+                ]
+            }
+        })
+    )
+
+    removed = disable_tracing_hooks(settings_path)
+
+    assert removed
+    config = json.loads(settings_path.read_text())
+    remaining = config["hooks"]["Stop"][0]["hooks"]
+    assert len(remaining) == 1
+    assert remaining[0]["command"] == other_cmd

--- a/tests/claude_code/test_tracing.py
+++ b/tests/claude_code/test_tracing.py
@@ -1132,6 +1132,11 @@ def test_process_transcript_plan_mode_empty_plan_text(tmp_path):
     assert trace is not None
     root = next(s for s in trace.search_spans() if s.parent_id is None)
     assert root.inputs["prompt"] == "write a fun python script"
+    tool_spans = [s for s in trace.search_spans() if s.span_type == SpanType.TOOL]
+    tool_names = {s.name for s in tool_spans}
+    assert "tool_Write" in tool_names
+    assert "tool_AskUserQuestion" not in tool_names
+    assert "tool_ExitPlanMode" not in tool_names
 
 
 def test_process_transcript_plan_mode_execution_phase(tmp_path):

--- a/tests/claude_code/test_tracing.py
+++ b/tests/claude_code/test_tracing.py
@@ -1162,3 +1162,61 @@ def test_process_transcript_plan_mode_execution_phase(tmp_path):
     # Planning-phase tools must NOT appear in the execution trace
     assert "tool_AskUserQuestion" not in tool_names
     assert "tool_ExitPlanMode" not in tool_names
+
+
+def test_process_planning_phase_transcript_token_usage(tmp_path):
+    transcript = _make_plan_mode_transcript()
+    transcript[1]["message"]["usage"] = {"input_tokens": 100, "output_tokens": 20}
+    transcript[3]["message"]["usage"] = {"input_tokens": 80, "output_tokens": 15}
+
+    transcript_path = tmp_path / "plan_token_transcript.jsonl"
+    transcript_path.write_text("\n".join(json.dumps(e) for e in transcript) + "\n")
+
+    trace = process_planning_phase_transcript(str(transcript_path), "plan-token-session")
+    assert trace is not None
+
+    spans = list(trace.search_spans())
+    root_span = next(s for s in spans if s.parent_id is None)
+    assert root_span.get_attribute(SpanAttributeKey.CHAT_USAGE) == {
+        "input_tokens": 180,
+        "output_tokens": 35,
+        "total_tokens": 215,
+    }
+
+    assert trace.info.token_usage == {"input_tokens": 180, "output_tokens": 35, "total_tokens": 215}
+
+
+def test_process_transcript_no_token_double_count_with_llm_span(tmp_path):
+    transcript = _make_plan_mode_transcript()
+    transcript[5]["message"]["usage"] = {"input_tokens": 50, "output_tokens": 10}
+    transcript[7]["message"]["usage"] = {"input_tokens": 60, "output_tokens": 12}
+
+    transcript_path = tmp_path / "exec_token_transcript.jsonl"
+    transcript_path.write_text("\n".join(json.dumps(e) for e in transcript) + "\n")
+
+    trace = process_transcript(str(transcript_path), "exec-token-session")
+    assert trace is not None
+
+    spans = list(trace.search_spans())
+    llm_span = next(s for s in spans if s.span_type == SpanType.LLM)
+    assert llm_span.get_attribute(SpanAttributeKey.CHAT_USAGE) == {
+        "input_tokens": 60,
+        "output_tokens": 12,
+        "total_tokens": 72,
+    }
+
+    root_span = next(s for s in spans if s.parent_id is None)
+    assert root_span.get_attribute(SpanAttributeKey.CHAT_USAGE) is None
+
+    assert trace.info.token_usage == {"input_tokens": 60, "output_tokens": 12, "total_tokens": 72}
+
+
+def test_llm_span_has_model_attribute(mock_transcript_file_with_usage):
+    trace = process_transcript(mock_transcript_file_with_usage, "test-model-attr")
+    assert trace is not None
+
+    spans = list(trace.search_spans())
+    llm_spans = [s for s in spans if s.span_type == SpanType.LLM]
+    assert len(llm_spans) == 1
+
+    assert llm_spans[0].get_attribute(SpanAttributeKey.MODEL) == "claude-sonnet-4-20250514"

--- a/tests/claude_code/test_tracing.py
+++ b/tests/claude_code/test_tracing.py
@@ -18,9 +18,11 @@ import mlflow.claude_code.tracing as tracing_module
 from mlflow.claude_code.tracing import (
     CLAUDE_TRACING_LEVEL,
     METADATA_KEY_CLAUDE_CODE_VERSION,
+    find_exit_plan_mode_index,
     find_last_user_message_index,
     get_hook_response,
     parse_timestamp_to_ns,
+    process_planning_phase_transcript,
     process_sdk_messages,
     process_transcript,
     setup_logging,
@@ -903,3 +905,227 @@ def test_process_transcript_includes_steer_messages(tmp_path):
     steer_messages = [m for m in input_messages if m.get("content") == "also tell me about Java"]
     assert len(steer_messages) == 1
     assert steer_messages[0]["role"] == "user"
+
+
+def _make_plan_mode_transcript():
+    """Build a realistic Plan mode JSONL transcript.
+
+    Structure (text and tool_use are always separate entries, as Claude Code emits):
+      [0] user  — original prompt
+      [1] assistant — tool_use AskUserQuestion  (planning tool)
+      [2] user  — tool_result for AskUserQuestion
+      [3] assistant — tool_use ExitPlanMode  (signals end of planning)
+      [4] user  — tool_result for ExitPlanMode (user approval)
+      [5] assistant — tool_use Write  (execution)
+      [6] user  — tool_result for Write
+      [7] assistant — text  (final response)
+    """
+    return [
+        {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": "write a fun python script",
+            },
+            "timestamp": "2025-01-15T10:00:00.000Z",
+        },
+        # Planning: AskUserQuestion tool call
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "ask_1",
+                        "name": "AskUserQuestion",
+                        "input": {"question": "What kind of fun script?"},
+                    }
+                ],
+                "model": "claude-sonnet-4-20250514",
+            },
+            "timestamp": "2025-01-15T10:00:01.000Z",
+        },
+        {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "ask_1",
+                        "content": "Something with ASCII art.",
+                    }
+                ],
+            },
+            "timestamp": "2025-01-15T10:00:02.000Z",
+        },
+        # Planning ends: ExitPlanMode
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "epm_1",
+                        "name": "ExitPlanMode",
+                        "input": {"plan": "I will write fun.py with ASCII art."},
+                    }
+                ],
+                "model": "claude-sonnet-4-20250514",
+            },
+            "timestamp": "2025-01-15T10:00:03.000Z",
+        },
+        # User approves the plan
+        {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "epm_1",
+                        "content": "Plan approved.",
+                    }
+                ],
+            },
+            "timestamp": "2025-01-15T10:00:04.000Z",
+        },
+        # Execution: Write tool
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "write_1",
+                        "name": "Write",
+                        "input": {"file_path": "fun.py", "content": "print('( ^_^)/')"},
+                    }
+                ],
+                "model": "claude-sonnet-4-20250514",
+            },
+            "timestamp": "2025-01-15T10:00:05.000Z",
+        },
+        {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "write_1",
+                        "content": "File written successfully.",
+                    }
+                ],
+            },
+            "timestamp": "2025-01-15T10:00:06.000Z",
+        },
+        # Final text response
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Done! fun.py is ready."}],
+                "model": "claude-sonnet-4-20250514",
+            },
+            "timestamp": "2025-01-15T10:00:07.000Z",
+        },
+    ]
+
+
+def test_find_exit_plan_mode_index():
+    transcript = _make_plan_mode_transcript()
+    result = find_exit_plan_mode_index(transcript)
+
+    assert result is not None
+    result_idx, plan_text = result
+    assert transcript[result_idx]["type"] == "user"
+    assert plan_text == "I will write fun.py with ASCII art."
+
+
+def test_find_exit_plan_mode_index_no_tool_result_yet():
+    # Simulate what the transcript looks like when the PostToolUse hook fires
+    # before the tool_result entry is flushed to disk.
+    transcript = _make_plan_mode_transcript()[:4]  # stops right at the ExitPlanMode assistant entry
+
+    result = find_exit_plan_mode_index(transcript)
+    assert result is not None
+    boundary_idx, plan_text = result
+    # Should fall back to the assistant entry (index 3)
+    assert transcript[boundary_idx]["type"] == "assistant"
+    assert plan_text == "I will write fun.py with ASCII art."
+
+
+def test_find_exit_plan_mode_index_not_present():
+    transcript = [
+        {
+            "type": "user",
+            "message": {"role": "user", "content": "hello"},
+            "timestamp": "2025-01-15T10:00:00.000Z",
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Hi there!"}],
+            },
+            "timestamp": "2025-01-15T10:00:01.000Z",
+        },
+    ]
+    assert find_exit_plan_mode_index(transcript) is None
+
+
+@pytest.mark.parametrize("include_tool_result", [True, False])
+def test_process_planning_phase_transcript(tmp_path, include_tool_result):
+    # include_tool_result=False simulates the hook firing before the tool_result is flushed.
+    transcript = _make_plan_mode_transcript()
+    if not include_tool_result:
+        # Strip the tool_result entry (index 4) and everything after
+        transcript = transcript[:4]
+    transcript_path = tmp_path / "plan_mode_transcript.jsonl"
+    transcript_path.write_text("\n".join(json.dumps(e) for e in transcript) + "\n")
+
+    trace = process_planning_phase_transcript(str(transcript_path), "plan-session")
+    assert trace is not None
+
+    root = next(s for s in trace.search_spans() if s.parent_id is None)
+    # Input should be the original user prompt
+    assert root.inputs["prompt"] == "write a fun python script"
+    # Output should contain the plan text
+    assert "I will write fun.py with ASCII art." in root.outputs.get("response", "")
+
+    # Only planning-phase tool spans should appear (AskUserQuestion, ExitPlanMode)
+    tool_spans = [s for s in trace.search_spans() if s.span_type == SpanType.TOOL]
+    tool_names = {s.name for s in tool_spans}
+    assert "tool_AskUserQuestion" in tool_names
+    assert "tool_ExitPlanMode" in tool_names
+    # Execution-phase tools must NOT be in the planning trace
+    assert "tool_Write" not in tool_names
+
+
+def test_process_transcript_plan_mode_execution_phase(tmp_path):
+    # The Stop hook should only trace the execution phase when Plan mode was used.
+    transcript = _make_plan_mode_transcript()
+    transcript_path = tmp_path / "plan_mode_transcript.jsonl"
+    transcript_path.write_text("\n".join(json.dumps(e) for e in transcript) + "\n")
+
+    trace = process_transcript(str(transcript_path), "plan-session")
+    assert trace is not None
+
+    root = next(s for s in trace.search_spans() if s.parent_id is None)
+    # Root input should be the approved plan text, not the original user prompt
+    assert root.inputs["prompt"] == "I will write fun.py with ASCII art."
+
+    # The final text response should be the execution-phase response
+    assert "Done! fun.py is ready." in root.outputs.get("response", "")
+
+    # Only execution-phase spans should appear
+    tool_spans = [s for s in trace.search_spans() if s.span_type == SpanType.TOOL]
+    tool_names = {s.name for s in tool_spans}
+    assert "tool_Write" in tool_names
+    # Planning-phase tools must NOT appear in the execution trace
+    assert "tool_AskUserQuestion" not in tool_names
+    assert "tool_ExitPlanMode" not in tool_names

--- a/tests/claude_code/test_tracing.py
+++ b/tests/claude_code/test_tracing.py
@@ -1106,6 +1106,34 @@ def test_process_planning_phase_transcript(tmp_path, include_tool_result):
     assert "tool_Write" not in tool_names
 
 
+def test_process_planning_phase_transcript_missing_timestamp(tmp_path):
+    transcript = _make_plan_mode_transcript()[:4]
+    transcript[0].pop("timestamp", None)
+    transcript_path = tmp_path / "no_ts_transcript.jsonl"
+    transcript_path.write_text("\n".join(json.dumps(e) for e in transcript) + "\n")
+
+    trace = process_planning_phase_transcript(str(transcript_path), "no-ts-session")
+    assert trace is not None
+    root = next(s for s in trace.search_spans() if s.parent_id is None)
+    assert root.inputs["prompt"] == "write a fun python script"
+
+
+def test_process_transcript_plan_mode_empty_plan_text(tmp_path):
+    transcript = _make_plan_mode_transcript()
+    for entry in transcript:
+        if entry.get("type") == "assistant":
+            for part in entry.get("message", {}).get("content", []):
+                if isinstance(part, dict) and part.get("name") == "ExitPlanMode":
+                    part["input"]["plan"] = ""
+    transcript_path = tmp_path / "empty_plan_transcript.jsonl"
+    transcript_path.write_text("\n".join(json.dumps(e) for e in transcript) + "\n")
+
+    trace = process_transcript(str(transcript_path), "empty-plan-session")
+    assert trace is not None
+    root = next(s for s in trace.search_spans() if s.parent_id is None)
+    assert root.inputs["prompt"] == "write a fun python script"
+
+
 def test_process_transcript_plan_mode_execution_phase(tmp_path):
     # The Stop hook should only trace the execution phase when Plan mode was used.
     transcript = _make_plan_mode_transcript()


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #22831

### What changes are proposed in this pull request?
Fix plan mode tracing for claude code by supporting exit plan mode hook.
Verified the repro code in original issue, now the plan mode conversation is captured as a separate trace:
<img width="1030" height="525" alt="image" src="https://github.com/user-attachments/assets/8ca0a8b8-5f2c-4ce7-b3d6-0e0f6efcdcf8" />


<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [ ] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
