### PR TITLE
Fix trace API authorization vulnerability

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -88,6 +88,7 @@ from mlflow.protos.service_pb2 import (
     BatchGetTraces,
     CalculateTraceFilterCorrelation,
     CancelPromptOptimizationJob,
+    CreateAssessment,
     CreateExperiment,
     CreateGatewayBudgetPolicy,
     CreateGatewayEndpoint,
@@ -98,6 +99,7 @@ from mlflow.protos.service_pb2 import (
     CreatePromptOptimizationJob,
     CreateRun,
     CreateWorkspace,
+    DeleteAssessment,
     DeleteExperiment,
     DeleteExperimentTag,
     DeleteGatewayBudgetPolicy,
@@ -118,7 +120,9 @@ from mlflow.protos.service_pb2 import (
     DeleteTraceTagV3,
     DeleteWorkspace,
     DetachModelFromGatewayEndpoint,
+    EndTrace,
     FinalizeLoggedModel,
+    GetAssessmentRequest,
     GetExperiment,
     GetExperimentByName,
     GetGatewayEndpoint,
@@ -146,6 +150,7 @@ from mlflow.protos.service_pb2 import (
     LogMetric,
     LogModel,
     LogParam,
+    QueryTraceMetrics,
     RegisterScorer,
     RestoreExperiment,
     RestoreRun,
@@ -160,6 +165,9 @@ from mlflow.protos.service_pb2 import (
     SetTag,
     SetTraceTag,
     SetTraceTagV3,
+    StartTrace,
+    StartTraceV3,
+    UpdateAssessment,
     UpdateExperiment,
     UpdateGatewayBudgetPolicy,
     UpdateGatewayEndpoint,
@@ -1748,30 +1756,14 @@ def validate_can_read_model_version_artifact():
 
 
 def _get_permission_from_trace_request_id() -> Permission:
-    """
-    Get permission for trace artifacts.
-    Traces inherit permissions from their parent run/experiment.
-    """
     request_id = request.args.get("request_id")
     if not request_id:
         raise MlflowException(
             "Request must specify request_id parameter",
             INVALID_PARAMETER_VALUE,
         )
-    # Get the trace to find its experiment
     trace = _get_tracking_store().get_trace_info(request_id)
-    experiment_id = trace.experiment_id
-    username = authenticate_request().username
-    return _get_role_permission_or_default(
-        _role_permission_for(
-            username=username,
-            resource_type="experiment",
-            resource_key=experiment_id,
-            workspace_lookup_id=experiment_id,
-            workspace_fetcher=_get_tracking_store().get_experiment,
-            workspace_label="experiment",
-        ),
-    )
+    return _get_experiment_permission(trace.experiment_id, authenticate_request().username)
 
 
 def validate_can_read_trace_artifact():
@@ -1780,25 +1772,27 @@ def validate_can_read_trace_artifact():
 
 
 def _get_permission_from_trace(trace_id: str, username: str) -> Permission:
-    trace = _get_tracking_store().get_trace_info(trace_id)
+    try:
+        trace = _get_tracking_store().get_trace_info(trace_id)
+    except MlflowException as e:
+        if e.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST):
+            return NO_PERMISSIONS
+        raise
     return _get_experiment_permission(trace.experiment_id, username)
 
 
-# Traces: single-trace read (GetTraceInfo — deprecated, uses request_id path param)
 def validate_can_read_trace_by_request_id():
     return _get_permission_from_trace(
         _get_request_param("request_id"), authenticate_request().username
     ).can_read
 
 
-# Traces: single-trace read (GetTraceInfoV3 / GetTrace — use trace_id path/query param)
 def validate_can_read_trace_by_trace_id():
     return _get_permission_from_trace(
         _get_request_param("trace_id"), authenticate_request().username
     ).can_read
 
 
-# Traces: search by experiment_ids (SearchTraces — deprecated, GET with repeated params)
 def validate_can_search_traces():
     experiment_ids = request.args.to_dict(flat=False).get("experiment_ids", [])
     username = authenticate_request().username
@@ -1807,13 +1801,18 @@ def validate_can_search_traces():
     )
 
 
-# Traces: search by locations (SearchTracesV3 — locations is a list of TraceLocation objects)
 def validate_can_search_traces_v3():
     locations = (request.json or {}).get("locations", [])
+    # Only mlflow_experiment locations carry an experiment_id we can permission-check;
+    # inference_table and other future location types don't map to a local experiment so
+    # they are intentionally excluded and requests containing only those locations are
+    # denied (fail-closed) via the bool(experiment_ids) guard below.
     experiment_ids = [
-        loc["mlflow_experiment"]["experiment_id"]
+        eid
         for loc in locations
-        if isinstance(loc, dict) and "mlflow_experiment" in loc
+        if isinstance(loc, dict)
+        if isinstance(ml_exp := loc.get("mlflow_experiment"), dict)
+        if (eid := ml_exp.get("experiment_id"))
     ]
     username = authenticate_request().username
     return bool(experiment_ids) and all(
@@ -1821,7 +1820,6 @@ def validate_can_search_traces_v3():
     )
 
 
-# Traces: batch read by trace_ids (BatchGetTraces=GET, BatchGetTraceInfos=POST)
 def validate_can_batch_get_traces():
     if request.method == "GET":
         trace_ids = request.args.to_dict(flat=False).get("trace_ids", [])
@@ -1840,28 +1838,24 @@ def validate_can_batch_get_traces():
     )
 
 
-# Traces: delete by experiment_id (DeleteTraces / DeleteTracesV3)
 def validate_can_delete_traces():
     return _get_experiment_permission(
         _get_request_param("experiment_id"), authenticate_request().username
     ).can_delete
 
 
-# Traces: tag mutation by trace_id (SetTraceTagV3 / LinkPromptsToTrace)
 def validate_can_update_trace_by_trace_id():
     return _get_permission_from_trace(
         _get_request_param("trace_id"), authenticate_request().username
     ).can_update
 
 
-# Traces: tag mutation by request_id (SetTraceTag / DeleteTraceTag — deprecated)
 def validate_can_update_trace_by_request_id():
     return _get_permission_from_trace(
         _get_request_param("request_id"), authenticate_request().username
     ).can_update
 
 
-# Traces: read access check from JSON body experiment_ids (CalculateTraceFilterCorrelation)
 def validate_can_read_traces_by_experiment_ids():
     experiment_ids = (request.json or {}).get("experiment_ids", [])
     username = authenticate_request().username
@@ -1870,12 +1864,29 @@ def validate_can_read_traces_by_experiment_ids():
     )
 
 
-# Traces: link to run — UPDATE on run's experiment + READ on each trace's experiment
+def validate_can_start_trace_v3():
+    body = request.json or {}
+    match body:
+        case {
+            "trace": {
+                "trace_info": {"trace_location": {"mlflow_experiment": {"experiment_id": str(eid)}}}
+            }
+        } if eid:
+            return _get_experiment_permission(eid, authenticate_request().username).can_update
+        case _:
+            return False
+
+
 def validate_can_link_traces_to_run():
     tracking_store = _get_tracking_store()
     username = authenticate_request().username
     run_id = _get_request_param("run_id")
-    run = tracking_store.get_run(run_id)
+    try:
+        run = tracking_store.get_run(run_id)
+    except MlflowException as e:
+        if e.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST):
+            return False
+        raise
     if not _get_experiment_permission(run.info.experiment_id, username).can_update:
         return False
     trace_ids = (request.json or {}).get("trace_ids", [])
@@ -1887,7 +1898,9 @@ def validate_can_link_traces_to_run():
         if e.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST):
             return False
         raise
-    return all(_get_experiment_permission(eid, username).can_read for eid in trace_experiment_ids)
+    return bool(trace_experiment_ids) and all(
+        _get_experiment_permission(eid, username).can_read for eid in trace_experiment_ids
+    )
 
 
 def validate_can_read_metric_history_bulk(run_ids=None):
@@ -2089,6 +2102,9 @@ BEFORE_REQUEST_HANDLERS = {
     CancelPromptOptimizationJob: validate_can_update_prompt_optimization_job,
     DeletePromptOptimizationJob: validate_can_delete_prompt_optimization_job,
     # Routes for traces
+    StartTrace: validate_can_update_experiment,
+    StartTraceV3: validate_can_start_trace_v3,
+    EndTrace: validate_can_update_trace_by_request_id,
     GetTraceInfo: validate_can_read_trace_by_request_id,
     GetTraceInfoV3: validate_can_read_trace_by_trace_id,
     GetTrace: validate_can_read_trace_by_trace_id,
@@ -2105,6 +2121,11 @@ BEFORE_REQUEST_HANDLERS = {
     LinkTracesToRun: validate_can_link_traces_to_run,
     LinkPromptsToTrace: validate_can_update_trace_by_trace_id,
     CalculateTraceFilterCorrelation: validate_can_read_traces_by_experiment_ids,
+    QueryTraceMetrics: validate_can_read_traces_by_experiment_ids,
+    CreateAssessment: validate_can_update_trace_by_trace_id,
+    GetAssessmentRequest: validate_can_read_trace_by_trace_id,
+    UpdateAssessment: validate_can_update_trace_by_trace_id,
+    DeleteAssessment: validate_can_update_trace_by_trace_id,
     # Workspace routes
     ListWorkspaces: None,
     CreateWorkspace: sender_is_admin,
@@ -2423,8 +2444,9 @@ def _find_validator(req: Request) -> Callable[[], bool] | None:
         return validator
 
     # Trace routes with path parameters (e.g. /mlflow/traces/<request_id>/tags).
+    # Unknown paths under this prefix are denied (fail-closed) rather than skipped.
     if "/mlflow/traces/" in req.path:
-        return next(
+        validator = next(
             (
                 v
                 for (pat, method), v in TRACE_PARAMETERIZED_BEFORE_REQUEST_VALIDATORS.items()
@@ -2432,6 +2454,7 @@ def _find_validator(req: Request) -> Callable[[], bool] | None:
             ),
             None,
         )
+        return validator if validator is not None else lambda: False
 
     # Workspace permission routes use parameterized path matching (e.g., workspace_name).
     # Only check these when workspaces are enabled to avoid unnecessary regex matching.

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -84,6 +84,9 @@ from mlflow.protos.model_registry_pb2 import (
 )
 from mlflow.protos.service_pb2 import (
     AttachModelToGatewayEndpoint,
+    BatchGetTraceInfos,
+    BatchGetTraces,
+    CalculateTraceFilterCorrelation,
     CancelPromptOptimizationJob,
     CreateExperiment,
     CreateGatewayBudgetPolicy,
@@ -109,6 +112,10 @@ from mlflow.protos.service_pb2 import (
     DeleteRun,
     DeleteScorer,
     DeleteTag,
+    DeleteTraces,
+    DeleteTracesV3,
+    DeleteTraceTag,
+    DeleteTraceTagV3,
     DeleteWorkspace,
     DetachModelFromGatewayEndpoint,
     FinalizeLoggedModel,
@@ -122,7 +129,12 @@ from mlflow.protos.service_pb2 import (
     GetPromptOptimizationJob,
     GetRun,
     GetScorer,
+    GetTrace,
+    GetTraceInfo,
+    GetTraceInfoV3,
     GetWorkspace,
+    LinkPromptsToTrace,
+    LinkTracesToRun,
     ListArtifacts,
     ListGatewayEndpointBindings,
     ListLoggedModelArtifacts,
@@ -140,10 +152,14 @@ from mlflow.protos.service_pb2 import (
     SearchExperiments,
     SearchLoggedModels,
     SearchPromptOptimizationJobs,
+    SearchTraces,
+    SearchTracesV3,
     SetExperimentTag,
     SetGatewayEndpointTag,
     SetLoggedModelTags,
     SetTag,
+    SetTraceTag,
+    SetTraceTagV3,
     UpdateExperiment,
     UpdateGatewayBudgetPolicy,
     UpdateGatewayEndpoint,
@@ -1763,6 +1779,117 @@ def validate_can_read_trace_artifact():
     return _get_permission_from_trace_request_id().can_read
 
 
+def _get_permission_from_trace(trace_id: str, username: str) -> Permission:
+    trace = _get_tracking_store().get_trace_info(trace_id)
+    return _get_experiment_permission(trace.experiment_id, username)
+
+
+# Traces: single-trace read (GetTraceInfo — deprecated, uses request_id path param)
+def validate_can_read_trace_by_request_id():
+    return _get_permission_from_trace(
+        _get_request_param("request_id"), authenticate_request().username
+    ).can_read
+
+
+# Traces: single-trace read (GetTraceInfoV3 / GetTrace — use trace_id path/query param)
+def validate_can_read_trace_by_trace_id():
+    return _get_permission_from_trace(
+        _get_request_param("trace_id"), authenticate_request().username
+    ).can_read
+
+
+# Traces: search by experiment_ids (SearchTraces — deprecated, GET with repeated params)
+def validate_can_search_traces():
+    experiment_ids = request.args.to_dict(flat=False).get("experiment_ids", [])
+    username = authenticate_request().username
+    return bool(experiment_ids) and all(
+        _get_experiment_permission(eid, username).can_read for eid in experiment_ids
+    )
+
+
+# Traces: search by locations (SearchTracesV3 — locations is a list of TraceLocation objects)
+def validate_can_search_traces_v3():
+    locations = (request.json or {}).get("locations", [])
+    experiment_ids = [
+        loc["mlflow_experiment"]["experiment_id"]
+        for loc in locations
+        if isinstance(loc, dict) and "mlflow_experiment" in loc
+    ]
+    username = authenticate_request().username
+    return bool(experiment_ids) and all(
+        _get_experiment_permission(eid, username).can_read for eid in experiment_ids
+    )
+
+
+# Traces: batch read by trace_ids (BatchGetTraces=GET, BatchGetTraceInfos=POST)
+def validate_can_batch_get_traces():
+    if request.method == "GET":
+        trace_ids = request.args.to_dict(flat=False).get("trace_ids", [])
+    else:
+        trace_ids = (request.json or {}).get("trace_ids", [])
+    username = authenticate_request().username
+    tracking_store = _get_tracking_store()
+    try:
+        experiment_ids = {tracking_store.get_trace_info(tid).experiment_id for tid in trace_ids}
+    except MlflowException as e:
+        if e.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST):
+            return False
+        raise
+    return bool(experiment_ids) and all(
+        _get_experiment_permission(eid, username).can_read for eid in experiment_ids
+    )
+
+
+# Traces: delete by experiment_id (DeleteTraces / DeleteTracesV3)
+def validate_can_delete_traces():
+    return _get_experiment_permission(
+        _get_request_param("experiment_id"), authenticate_request().username
+    ).can_delete
+
+
+# Traces: tag mutation by trace_id (SetTraceTagV3 / LinkPromptsToTrace)
+def validate_can_update_trace_by_trace_id():
+    return _get_permission_from_trace(
+        _get_request_param("trace_id"), authenticate_request().username
+    ).can_update
+
+
+# Traces: tag mutation by request_id (SetTraceTag / DeleteTraceTag — deprecated)
+def validate_can_update_trace_by_request_id():
+    return _get_permission_from_trace(
+        _get_request_param("request_id"), authenticate_request().username
+    ).can_update
+
+
+# Traces: read access check from JSON body experiment_ids (CalculateTraceFilterCorrelation)
+def validate_can_read_traces_by_experiment_ids():
+    experiment_ids = (request.json or {}).get("experiment_ids", [])
+    username = authenticate_request().username
+    return bool(experiment_ids) and all(
+        _get_experiment_permission(eid, username).can_read for eid in experiment_ids
+    )
+
+
+# Traces: link to run — UPDATE on run's experiment + READ on each trace's experiment
+def validate_can_link_traces_to_run():
+    tracking_store = _get_tracking_store()
+    username = authenticate_request().username
+    run_id = _get_request_param("run_id")
+    run = tracking_store.get_run(run_id)
+    if not _get_experiment_permission(run.info.experiment_id, username).can_update:
+        return False
+    trace_ids = (request.json or {}).get("trace_ids", [])
+    try:
+        trace_experiment_ids = {
+            tracking_store.get_trace_info(tid).experiment_id for tid in trace_ids
+        }
+    except MlflowException as e:
+        if e.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST):
+            return False
+        raise
+    return all(_get_experiment_permission(eid, username).can_read for eid in trace_experiment_ids)
+
+
 def validate_can_read_metric_history_bulk(run_ids=None):
     """Checks READ permission on all requested runs.
 
@@ -1961,6 +2088,23 @@ BEFORE_REQUEST_HANDLERS = {
     SearchPromptOptimizationJobs: validate_can_read_experiment,
     CancelPromptOptimizationJob: validate_can_update_prompt_optimization_job,
     DeletePromptOptimizationJob: validate_can_delete_prompt_optimization_job,
+    # Routes for traces
+    GetTraceInfo: validate_can_read_trace_by_request_id,
+    GetTraceInfoV3: validate_can_read_trace_by_trace_id,
+    GetTrace: validate_can_read_trace_by_trace_id,
+    SearchTraces: validate_can_search_traces,
+    SearchTracesV3: validate_can_search_traces_v3,
+    BatchGetTraces: validate_can_batch_get_traces,
+    BatchGetTraceInfos: validate_can_batch_get_traces,
+    DeleteTraces: validate_can_delete_traces,
+    DeleteTracesV3: validate_can_delete_traces,
+    SetTraceTag: validate_can_update_trace_by_request_id,
+    SetTraceTagV3: validate_can_update_trace_by_trace_id,
+    DeleteTraceTag: validate_can_update_trace_by_request_id,
+    DeleteTraceTagV3: validate_can_update_trace_by_trace_id,
+    LinkTracesToRun: validate_can_link_traces_to_run,
+    LinkPromptsToTrace: validate_can_update_trace_by_trace_id,
+    CalculateTraceFilterCorrelation: validate_can_read_traces_by_experiment_ids,
     # Workspace routes
     ListWorkspaces: None,
     CreateWorkspace: sender_is_admin,
@@ -2112,6 +2256,15 @@ WORKSPACE_PARAMETERIZED_BEFORE_REQUEST_VALIDATORS = {
     (_re_compile_path(path), method): handler
     for (path, method), handler in BEFORE_REQUEST_VALIDATORS.items()
     if "<" in path and "/workspaces/" in path
+}
+
+# Trace endpoints with path parameters (e.g. /mlflow/traces/<request_id>/tags) require
+# regex matching — the BEFORE_REQUEST_VALIDATORS exact-match lookup won't find them when
+# the real request path contains an actual trace/request ID instead of the template name.
+TRACE_PARAMETERIZED_BEFORE_REQUEST_VALIDATORS = {
+    (_re_compile_path(path), method): handler
+    for (path, method), handler in BEFORE_REQUEST_VALIDATORS.items()
+    if "<" in path and "/mlflow/traces/" in path
 }
 
 LOGGED_MODEL_BEFORE_REQUEST_HANDLERS = {
@@ -2268,6 +2421,17 @@ def _find_validator(req: Request) -> Callable[[], bool] | None:
 
     if validator := BEFORE_REQUEST_VALIDATORS.get((req.path, req.method)):
         return validator
+
+    # Trace routes with path parameters (e.g. /mlflow/traces/<request_id>/tags).
+    if "/mlflow/traces/" in req.path:
+        return next(
+            (
+                v
+                for (pat, method), v in TRACE_PARAMETERIZED_BEFORE_REQUEST_VALIDATORS.items()
+                if pat.fullmatch(req.path) and method == req.method
+            ),
+            None,
+        )
 
     # Workspace permission routes use parameterized path matching (e.g., workspace_name).
     # Only check these when workspaces are enabled to avoid unnecessary regex matching.

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -3487,7 +3487,7 @@ def test_trace_search_permission(client, monkeypatch):
         params={"experiment_ids": [experiment_id]},
         auth=(user1, password1),
     )
-    assert resp.status_code != 403
+    assert resp.status_code == 200
 
     # user2 is denied
     resp = requests.get(
@@ -3508,7 +3508,7 @@ def test_trace_search_permission(client, monkeypatch):
         params={"experiment_ids": [experiment_id]},
         auth=(user2, password2),
     )
-    assert resp.status_code != 403
+    assert resp.status_code == 200
 
 
 def test_trace_delete_permission(client, monkeypatch):
@@ -3533,7 +3533,7 @@ def test_trace_delete_permission(client, monkeypatch):
     assert delete_traces((user2, password2)).status_code == 403
 
     # user1 (MANAGE) can delete
-    assert delete_traces((user1, password1)).status_code != 403
+    assert delete_traces((user1, password1)).status_code == 200
 
     # Upgrade user2 to MANAGE; now allowed
     requests.patch(
@@ -3541,7 +3541,7 @@ def test_trace_delete_permission(client, monkeypatch):
         json={"experiment_id": experiment_id, "username": user2, "permission": "MANAGE"},
         auth=(user1, password1),
     ).raise_for_status()
-    assert delete_traces((user2, password2)).status_code != 403
+    assert delete_traces((user2, password2)).status_code == 200
 
 
 def test_trace_tag_permission(client, monkeypatch):
@@ -3581,8 +3581,8 @@ def test_trace_tag_permission(client, monkeypatch):
         json={"experiment_id": experiment_id, "username": user2, "permission": "EDIT"},
         auth=(user1, password1),
     ).raise_for_status()
-    assert set_tag((user2, password2)).status_code != 403
-    assert delete_tag((user2, password2)).status_code != 403
+    assert set_tag((user2, password2)).status_code == 200
+    assert delete_tag((user2, password2)).status_code == 200
 
 
 def test_trace_get_info_permission(client, monkeypatch):
@@ -3608,7 +3608,7 @@ def test_trace_get_info_permission(client, monkeypatch):
     assert get_info((user2, password2)).status_code == 403
 
     # user1 can read
-    assert get_info((user1, password1)).status_code != 403
+    assert get_info((user1, password1)).status_code == 200
 
     # Grant READ; user2 can now read
     requests.patch(
@@ -3616,4 +3616,134 @@ def test_trace_get_info_permission(client, monkeypatch):
         json={"experiment_id": experiment_id, "username": user2, "permission": "READ"},
         auth=(user1, password1),
     ).raise_for_status()
-    assert get_info((user2, password2)).status_code != 403
+    assert get_info((user2, password2)).status_code == 200
+
+
+def test_trace_get_v3_permission(client, monkeypatch):
+    user1, password1 = create_user(client.tracking_uri)
+    user2, password2 = create_user(client.tracking_uri)
+
+    with User(user1, password1, monkeypatch):
+        experiment_id = client.create_experiment("trace_get_v3_test")
+
+    trace_id = _create_trace(client.tracking_uri, experiment_id, (user1, password1))
+
+    _grant_experiment_permission(
+        client.tracking_uri, experiment_id, user2, "NO_PERMISSIONS", (user1, password1)
+    )
+
+    def get_trace_v3(auth):
+        return requests.get(
+            url=client.tracking_uri + f"/api/3.0/mlflow/traces/{trace_id}",
+            auth=auth,
+        )
+
+    assert get_trace_v3((user2, password2)).status_code == 403
+    assert get_trace_v3((user1, password1)).status_code == 200
+
+    requests.patch(
+        url=client.tracking_uri + "/api/2.0/mlflow/experiments/permissions/update",
+        json={"experiment_id": experiment_id, "username": user2, "permission": "READ"},
+        auth=(user1, password1),
+    ).raise_for_status()
+    assert get_trace_v3((user2, password2)).status_code == 200
+
+
+def test_trace_batch_get_permission(client, monkeypatch):
+    user1, password1 = create_user(client.tracking_uri)
+    user2, password2 = create_user(client.tracking_uri)
+
+    with User(user1, password1, monkeypatch):
+        experiment_id = client.create_experiment("trace_batch_get_test")
+
+    trace_id = _create_trace(client.tracking_uri, experiment_id, (user1, password1))
+
+    _grant_experiment_permission(
+        client.tracking_uri, experiment_id, user2, "NO_PERMISSIONS", (user1, password1)
+    )
+
+    def batch_get(auth):
+        return requests.post(
+            url=client.tracking_uri + "/api/3.0/mlflow/traces/batchGetInfos",
+            json={"trace_ids": [trace_id]},
+            auth=auth,
+        )
+
+    assert batch_get((user2, password2)).status_code == 403
+    assert batch_get((user1, password1)).status_code == 200
+
+    requests.patch(
+        url=client.tracking_uri + "/api/2.0/mlflow/experiments/permissions/update",
+        json={"experiment_id": experiment_id, "username": user2, "permission": "READ"},
+        auth=(user1, password1),
+    ).raise_for_status()
+    assert batch_get((user2, password2)).status_code == 200
+
+
+def test_trace_link_to_run_permission(client, monkeypatch):
+    user1, password1 = create_user(client.tracking_uri)
+    user2, password2 = create_user(client.tracking_uri)
+
+    with User(user1, password1, monkeypatch):
+        exp_a = client.create_experiment("link_test_exp_a")
+        exp_b = client.create_experiment("link_test_exp_b")
+
+    trace_id = _create_trace(client.tracking_uri, exp_b, (user1, password1))
+
+    with User(user1, password1, monkeypatch):
+        run = client.create_run(exp_a)
+    run_id = run.info.run_id
+
+    # user2: UPDATE on exp_a but NO_PERMISSIONS on exp_b → denied (can't read traces in B)
+    _grant_experiment_permission(client.tracking_uri, exp_a, user2, "EDIT", (user1, password1))
+    _grant_experiment_permission(
+        client.tracking_uri, exp_b, user2, "NO_PERMISSIONS", (user1, password1)
+    )
+
+    def link(auth):
+        return requests.post(
+            url=client.tracking_uri + "/api/2.0/mlflow/traces/link-to-run",
+            json={"trace_ids": [trace_id], "run_id": run_id},
+            auth=auth,
+        )
+
+    assert link((user2, password2)).status_code == 403
+
+    # Grant READ on exp_b → now allowed
+    requests.patch(
+        url=client.tracking_uri + "/api/2.0/mlflow/experiments/permissions/update",
+        json={"experiment_id": exp_b, "username": user2, "permission": "READ"},
+        auth=(user1, password1),
+    ).raise_for_status()
+    assert link((user2, password2)).status_code == 200
+
+
+def test_trace_search_v3_permission(client, monkeypatch):
+    user1, password1 = create_user(client.tracking_uri)
+    user2, password2 = create_user(client.tracking_uri)
+
+    with User(user1, password1, monkeypatch):
+        experiment_id = client.create_experiment("trace_search_v3_test")
+
+    _grant_experiment_permission(
+        client.tracking_uri, experiment_id, user2, "NO_PERMISSIONS", (user1, password1)
+    )
+
+    def search_v3(auth):
+        return requests.post(
+            url=client.tracking_uri + "/api/3.0/mlflow/traces/search",
+            json={
+                "locations": [{"mlflow_experiment": {"experiment_id": experiment_id}}],
+            },
+            auth=auth,
+        )
+
+    assert search_v3((user2, password2)).status_code == 403
+    assert search_v3((user1, password1)).status_code == 200
+
+    requests.patch(
+        url=client.tracking_uri + "/api/2.0/mlflow/experiments/permissions/update",
+        json={"experiment_id": experiment_id, "username": user2, "permission": "READ"},
+        auth=(user1, password1),
+    ).raise_for_status()
+    assert search_v3((user2, password2)).status_code == 200

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -3470,6 +3470,11 @@ def _grant_experiment_permission(
     )
 
 
+@pytest.mark.parametrize(
+    "client",
+    [{"MLFLOW_AUTH_CONFIG_PATH": "tests/server/auth/fixtures/no_permission_auth.ini"}],
+    indirect=True,
+)
 def test_trace_search_permission(client, monkeypatch):
     user1, password1 = create_user(client.tracking_uri)
     user2, password2 = create_user(client.tracking_uri)
@@ -3477,9 +3482,7 @@ def test_trace_search_permission(client, monkeypatch):
     with User(user1, password1, monkeypatch):
         experiment_id = client.create_experiment("trace_search_test")
 
-    _grant_experiment_permission(
-        client.tracking_uri, experiment_id, user2, "NO_PERMISSIONS", (user1, password1)
-    )
+    # user2 has no grant; default_permission=NO_PERMISSIONS denies access
 
     # user1 can search traces
     resp = requests.get(
@@ -3498,11 +3501,9 @@ def test_trace_search_permission(client, monkeypatch):
     assert resp.status_code == 403
 
     # Grant READ; user2 can now search
-    requests.patch(
-        url=client.tracking_uri + "/api/2.0/mlflow/experiments/permissions/update",
-        json={"experiment_id": experiment_id, "username": user2, "permission": "READ"},
-        auth=(user1, password1),
-    ).raise_for_status()
+    _grant_experiment_permission(
+        client.tracking_uri, experiment_id, user2, "READ", (user1, password1)
+    )
     resp = requests.get(
         url=client.tracking_uri + "/api/2.0/mlflow/traces",
         params={"experiment_ids": [experiment_id]},
@@ -3585,6 +3586,11 @@ def test_trace_tag_permission(client, monkeypatch):
     assert delete_tag((user2, password2)).status_code == 200
 
 
+@pytest.mark.parametrize(
+    "client",
+    [{"MLFLOW_AUTH_CONFIG_PATH": "tests/server/auth/fixtures/no_permission_auth.ini"}],
+    indirect=True,
+)
 def test_trace_get_info_permission(client, monkeypatch):
     user1, password1 = create_user(client.tracking_uri)
     user2, password2 = create_user(client.tracking_uri)
@@ -3594,9 +3600,7 @@ def test_trace_get_info_permission(client, monkeypatch):
 
     request_id = _create_trace(client.tracking_uri, experiment_id, (user1, password1))
 
-    _grant_experiment_permission(
-        client.tracking_uri, experiment_id, user2, "NO_PERMISSIONS", (user1, password1)
-    )
+    # user2 has no grant; default_permission=NO_PERMISSIONS denies access
 
     def get_info(auth):
         return requests.get(
@@ -3604,21 +3608,24 @@ def test_trace_get_info_permission(client, monkeypatch):
             auth=auth,
         )
 
-    # user2 with NO_PERMISSIONS is denied
+    # user2 with no grant is denied
     assert get_info((user2, password2)).status_code == 403
 
     # user1 can read
     assert get_info((user1, password1)).status_code == 200
 
     # Grant READ; user2 can now read
-    requests.patch(
-        url=client.tracking_uri + "/api/2.0/mlflow/experiments/permissions/update",
-        json={"experiment_id": experiment_id, "username": user2, "permission": "READ"},
-        auth=(user1, password1),
-    ).raise_for_status()
+    _grant_experiment_permission(
+        client.tracking_uri, experiment_id, user2, "READ", (user1, password1)
+    )
     assert get_info((user2, password2)).status_code == 200
 
 
+@pytest.mark.parametrize(
+    "client",
+    [{"MLFLOW_AUTH_CONFIG_PATH": "tests/server/auth/fixtures/no_permission_auth.ini"}],
+    indirect=True,
+)
 def test_trace_get_v3_permission(client, monkeypatch):
     user1, password1 = create_user(client.tracking_uri)
     user2, password2 = create_user(client.tracking_uri)
@@ -3628,9 +3635,7 @@ def test_trace_get_v3_permission(client, monkeypatch):
 
     trace_id = _create_trace(client.tracking_uri, experiment_id, (user1, password1))
 
-    _grant_experiment_permission(
-        client.tracking_uri, experiment_id, user2, "NO_PERMISSIONS", (user1, password1)
-    )
+    # user2 has no grant; default_permission=NO_PERMISSIONS denies access
 
     def get_trace_v3(auth):
         return requests.get(
@@ -3641,14 +3646,17 @@ def test_trace_get_v3_permission(client, monkeypatch):
     assert get_trace_v3((user2, password2)).status_code == 403
     assert get_trace_v3((user1, password1)).status_code == 200
 
-    requests.patch(
-        url=client.tracking_uri + "/api/2.0/mlflow/experiments/permissions/update",
-        json={"experiment_id": experiment_id, "username": user2, "permission": "READ"},
-        auth=(user1, password1),
-    ).raise_for_status()
+    _grant_experiment_permission(
+        client.tracking_uri, experiment_id, user2, "READ", (user1, password1)
+    )
     assert get_trace_v3((user2, password2)).status_code == 200
 
 
+@pytest.mark.parametrize(
+    "client",
+    [{"MLFLOW_AUTH_CONFIG_PATH": "tests/server/auth/fixtures/no_permission_auth.ini"}],
+    indirect=True,
+)
 def test_trace_batch_get_permission(client, monkeypatch):
     user1, password1 = create_user(client.tracking_uri)
     user2, password2 = create_user(client.tracking_uri)
@@ -3658,9 +3666,7 @@ def test_trace_batch_get_permission(client, monkeypatch):
 
     trace_id = _create_trace(client.tracking_uri, experiment_id, (user1, password1))
 
-    _grant_experiment_permission(
-        client.tracking_uri, experiment_id, user2, "NO_PERMISSIONS", (user1, password1)
-    )
+    # user2 has no grant; default_permission=NO_PERMISSIONS denies access
 
     def batch_get(auth):
         return requests.post(
@@ -3672,14 +3678,17 @@ def test_trace_batch_get_permission(client, monkeypatch):
     assert batch_get((user2, password2)).status_code == 403
     assert batch_get((user1, password1)).status_code == 200
 
-    requests.patch(
-        url=client.tracking_uri + "/api/2.0/mlflow/experiments/permissions/update",
-        json={"experiment_id": experiment_id, "username": user2, "permission": "READ"},
-        auth=(user1, password1),
-    ).raise_for_status()
+    _grant_experiment_permission(
+        client.tracking_uri, experiment_id, user2, "READ", (user1, password1)
+    )
     assert batch_get((user2, password2)).status_code == 200
 
 
+@pytest.mark.parametrize(
+    "client",
+    [{"MLFLOW_AUTH_CONFIG_PATH": "tests/server/auth/fixtures/no_permission_auth.ini"}],
+    indirect=True,
+)
 def test_trace_link_to_run_permission(client, monkeypatch):
     user1, password1 = create_user(client.tracking_uri)
     user2, password2 = create_user(client.tracking_uri)
@@ -3694,11 +3703,9 @@ def test_trace_link_to_run_permission(client, monkeypatch):
         run = client.create_run(exp_a)
     run_id = run.info.run_id
 
-    # user2: UPDATE on exp_a but NO_PERMISSIONS on exp_b → denied (can't read traces in B)
+    # user2: UPDATE on exp_a but no grant on exp_b → denied (can't read traces in B)
+    # default_permission=NO_PERMISSIONS means absence of a grant on exp_b is a deny
     _grant_experiment_permission(client.tracking_uri, exp_a, user2, "EDIT", (user1, password1))
-    _grant_experiment_permission(
-        client.tracking_uri, exp_b, user2, "NO_PERMISSIONS", (user1, password1)
-    )
 
     def link(auth):
         return requests.post(
@@ -3710,14 +3717,17 @@ def test_trace_link_to_run_permission(client, monkeypatch):
     assert link((user2, password2)).status_code == 403
 
     # Grant READ on exp_b → now allowed
-    requests.patch(
-        url=client.tracking_uri + "/api/2.0/mlflow/experiments/permissions/update",
-        json={"experiment_id": exp_b, "username": user2, "permission": "READ"},
-        auth=(user1, password1),
-    ).raise_for_status()
+    _grant_experiment_permission(
+        client.tracking_uri, exp_b, user2, "READ", (user1, password1)
+    )
     assert link((user2, password2)).status_code == 200
 
 
+@pytest.mark.parametrize(
+    "client",
+    [{"MLFLOW_AUTH_CONFIG_PATH": "tests/server/auth/fixtures/no_permission_auth.ini"}],
+    indirect=True,
+)
 def test_trace_search_v3_permission(client, monkeypatch):
     user1, password1 = create_user(client.tracking_uri)
     user2, password2 = create_user(client.tracking_uri)
@@ -3725,9 +3735,7 @@ def test_trace_search_v3_permission(client, monkeypatch):
     with User(user1, password1, monkeypatch):
         experiment_id = client.create_experiment("trace_search_v3_test")
 
-    _grant_experiment_permission(
-        client.tracking_uri, experiment_id, user2, "NO_PERMISSIONS", (user1, password1)
-    )
+    # user2 has no grant; default_permission=NO_PERMISSIONS denies access
 
     def search_v3(auth):
         return requests.post(
@@ -3741,9 +3749,7 @@ def test_trace_search_v3_permission(client, monkeypatch):
     assert search_v3((user2, password2)).status_code == 403
     assert search_v3((user1, password1)).status_code == 200
 
-    requests.patch(
-        url=client.tracking_uri + "/api/2.0/mlflow/experiments/permissions/update",
-        json={"experiment_id": experiment_id, "username": user2, "permission": "READ"},
-        auth=(user1, password1),
-    ).raise_for_status()
+    _grant_experiment_permission(
+        client.tracking_uri, experiment_id, user2, "READ", (user1, password1)
+    )
     assert search_v3((user2, password2)).status_code == 200

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -3435,3 +3435,185 @@ def test_invalidate_user_auth_cache_drops_only_matching_username(
     _authenticate_fastapi_request(_make_request("/x", f"Basic {alice_alt}"))
     _authenticate_fastapi_request(_make_request("/x", f"Basic {bob}"))
     assert mock_auth_store.authenticate_user.call_count == 5
+
+
+def _create_trace(tracking_uri: str, experiment_id: str, auth: tuple[str, str]) -> str:
+    """Create a trace and return its request_id."""
+    resp = requests.post(
+        url=tracking_uri + "/api/2.0/mlflow/traces",
+        json={
+            "experiment_id": experiment_id,
+            "timestamp_ms": int(time.time() * 1000),
+            "execution_time_ms": 10,
+            "status": "OK",
+            "request_metadata": [],
+            "tags": [],
+        },
+        auth=auth,
+    )
+    resp.raise_for_status()
+    return resp.json()["trace_info"]["request_id"]
+
+
+def _grant_experiment_permission(
+    tracking_uri: str, experiment_id: str, username: str, permission: str, auth: tuple[str, str]
+) -> None:
+    _send_rest_tracking_post_request(
+        tracking_uri,
+        "/api/2.0/mlflow/experiments/permissions/create",
+        json_payload={
+            "experiment_id": experiment_id,
+            "username": username,
+            "permission": permission,
+        },
+        auth=auth,
+    )
+
+
+def test_trace_search_permission(client, monkeypatch):
+    user1, password1 = create_user(client.tracking_uri)
+    user2, password2 = create_user(client.tracking_uri)
+
+    with User(user1, password1, monkeypatch):
+        experiment_id = client.create_experiment("trace_search_test")
+
+    _grant_experiment_permission(
+        client.tracking_uri, experiment_id, user2, "NO_PERMISSIONS", (user1, password1)
+    )
+
+    # user1 can search traces
+    resp = requests.get(
+        url=client.tracking_uri + "/api/2.0/mlflow/traces",
+        params={"experiment_ids": [experiment_id]},
+        auth=(user1, password1),
+    )
+    assert resp.status_code != 403
+
+    # user2 is denied
+    resp = requests.get(
+        url=client.tracking_uri + "/api/2.0/mlflow/traces",
+        params={"experiment_ids": [experiment_id]},
+        auth=(user2, password2),
+    )
+    assert resp.status_code == 403
+
+    # Grant READ; user2 can now search
+    requests.patch(
+        url=client.tracking_uri + "/api/2.0/mlflow/experiments/permissions/update",
+        json={"experiment_id": experiment_id, "username": user2, "permission": "READ"},
+        auth=(user1, password1),
+    ).raise_for_status()
+    resp = requests.get(
+        url=client.tracking_uri + "/api/2.0/mlflow/traces",
+        params={"experiment_ids": [experiment_id]},
+        auth=(user2, password2),
+    )
+    assert resp.status_code != 403
+
+
+def test_trace_delete_permission(client, monkeypatch):
+    user1, password1 = create_user(client.tracking_uri)
+    user2, password2 = create_user(client.tracking_uri)
+
+    with User(user1, password1, monkeypatch):
+        experiment_id = client.create_experiment("trace_delete_test")
+
+    _grant_experiment_permission(
+        client.tracking_uri, experiment_id, user2, "READ", (user1, password1)
+    )
+
+    def delete_traces(auth):
+        return requests.post(
+            url=client.tracking_uri + "/api/2.0/mlflow/traces/delete-traces",
+            json={"experiment_id": experiment_id, "max_timestamp_millis": 9999999999999},
+            auth=auth,
+        )
+
+    # user2 with READ is denied
+    assert delete_traces((user2, password2)).status_code == 403
+
+    # user1 (MANAGE) can delete
+    assert delete_traces((user1, password1)).status_code != 403
+
+    # Upgrade user2 to MANAGE; now allowed
+    requests.patch(
+        url=client.tracking_uri + "/api/2.0/mlflow/experiments/permissions/update",
+        json={"experiment_id": experiment_id, "username": user2, "permission": "MANAGE"},
+        auth=(user1, password1),
+    ).raise_for_status()
+    assert delete_traces((user2, password2)).status_code != 403
+
+
+def test_trace_tag_permission(client, monkeypatch):
+    user1, password1 = create_user(client.tracking_uri)
+    user2, password2 = create_user(client.tracking_uri)
+
+    with User(user1, password1, monkeypatch):
+        experiment_id = client.create_experiment("trace_tag_test")
+
+    request_id = _create_trace(client.tracking_uri, experiment_id, (user1, password1))
+
+    _grant_experiment_permission(
+        client.tracking_uri, experiment_id, user2, "READ", (user1, password1)
+    )
+
+    def set_tag(auth):
+        return requests.patch(
+            url=client.tracking_uri + f"/api/2.0/mlflow/traces/{request_id}/tags",
+            json={"key": "env", "value": "test"},
+            auth=auth,
+        )
+
+    def delete_tag(auth):
+        return requests.delete(
+            url=client.tracking_uri + f"/api/2.0/mlflow/traces/{request_id}/tags",
+            json={"key": "env"},
+            auth=auth,
+        )
+
+    # READ is not enough for tag mutation
+    assert set_tag((user2, password2)).status_code == 403
+    assert delete_tag((user2, password2)).status_code == 403
+
+    # Upgrade to EDIT; tag operations now allowed
+    requests.patch(
+        url=client.tracking_uri + "/api/2.0/mlflow/experiments/permissions/update",
+        json={"experiment_id": experiment_id, "username": user2, "permission": "EDIT"},
+        auth=(user1, password1),
+    ).raise_for_status()
+    assert set_tag((user2, password2)).status_code != 403
+    assert delete_tag((user2, password2)).status_code != 403
+
+
+def test_trace_get_info_permission(client, monkeypatch):
+    user1, password1 = create_user(client.tracking_uri)
+    user2, password2 = create_user(client.tracking_uri)
+
+    with User(user1, password1, monkeypatch):
+        experiment_id = client.create_experiment("trace_get_info_test")
+
+    request_id = _create_trace(client.tracking_uri, experiment_id, (user1, password1))
+
+    _grant_experiment_permission(
+        client.tracking_uri, experiment_id, user2, "NO_PERMISSIONS", (user1, password1)
+    )
+
+    def get_info(auth):
+        return requests.get(
+            url=client.tracking_uri + f"/api/2.0/mlflow/traces/{request_id}/info",
+            auth=auth,
+        )
+
+    # user2 with NO_PERMISSIONS is denied
+    assert get_info((user2, password2)).status_code == 403
+
+    # user1 can read
+    assert get_info((user1, password1)).status_code != 403
+
+    # Grant READ; user2 can now read
+    requests.patch(
+        url=client.tracking_uri + "/api/2.0/mlflow/experiments/permissions/update",
+        json={"experiment_id": experiment_id, "username": user2, "permission": "READ"},
+        auth=(user1, password1),
+    ).raise_for_status()
+    assert get_info((user2, password2)).status_code != 403

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -3717,9 +3717,7 @@ def test_trace_link_to_run_permission(client, monkeypatch):
     assert link((user2, password2)).status_code == 403
 
     # Grant READ on exp_b → now allowed
-    _grant_experiment_permission(
-        client.tracking_uri, exp_b, user2, "READ", (user1, password1)
-    )
+    _grant_experiment_permission(client.tracking_uri, exp_b, user2, "READ", (user1, password1))
     assert link((user2, password2)).status_code == 200
 
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #hunter-report

### What changes are proposed in this pull request?

Register authorization validators for all trace API endpoints to prevent unauthorized access and modification of traces from experiments users don't have permission on.

**Issue:** When MLflow runs with authentication enabled (`--app-name basic-auth`), the trace API endpoints were missing authorization checks in `_before_request()`. This allowed any authenticated user to:
- Search and read traces (containing LLM prompts, responses, and function arguments)
- Delete traces (destroying audit logs)
- Modify trace tags
- Link traces to runs

**Root cause:** The existing `BEFORE_REQUEST_HANDLERS` dict lacked entries for all trace endpoint protobuf classes, so `_find_validator()` returned `None` for those routes and authorization was skipped.


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests


### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

**Security fix:** Fixed authorization vulnerability in trace API endpoints. Trace operations (read, delete, modify tags) now require proper experiment-level permissions. Previously, any authenticated user could access and modify traces from experiments they didn't have permission on.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release