### PR TITLE
Fix provider switch sometimes not auto-selecting first existing API key

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/GenAIModelSelection.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/GenAIModelSelection.test.tsx
@@ -42,6 +42,7 @@ describe('GenAIModelSelection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseApiKeyConfiguration.mockReturnValue({
+      allSecrets: [],
       existingSecrets: [],
       authModes: [],
       defaultAuthMode: '',
@@ -132,11 +133,13 @@ describe('GenAIModelSelection', () => {
 
   test('auto-selects first existing API key when secrets are available', async () => {
     mockEndpointQueryResult([]);
+    const secrets = [
+      { secret_id: 'secret-1', secret_name: 'My Key', provider: 'openai', masked_values: {} },
+      { secret_id: 'secret-2', secret_name: 'Other Key', provider: 'openai', masked_values: {} },
+    ];
     mockUseApiKeyConfiguration.mockReturnValue({
-      existingSecrets: [
-        { secret_id: 'secret-1', secret_name: 'My Key', provider: 'openai', masked_values: {} },
-        { secret_id: 'secret-2', secret_name: 'Other Key', provider: 'openai', masked_values: {} },
-      ],
+      allSecrets: secrets,
+      existingSecrets: secrets,
       authModes: [],
       defaultAuthMode: '',
       isLoadingProviderConfig: false,
@@ -195,8 +198,10 @@ describe('GenAIModelSelection', () => {
 
   test('does not auto-switch apiKeyConfig when readOnly is true', async () => {
     jest.mocked(useEndpointsQuery).mockReturnValue({ data: [], isLoading: false } as any);
+    const secrets = [{ secret_id: 'existing-secret', secret_name: 'My Key', provider: 'openai', masked_values: {} }];
     mockUseApiKeyConfiguration.mockReturnValue({
-      existingSecrets: [{ secret_id: 'existing-secret', secret_name: 'My Key', provider: 'openai', masked_values: {} }],
+      allSecrets: secrets,
+      existingSecrets: secrets,
       authModes: [],
       defaultAuthMode: '',
       isLoadingProviderConfig: false,
@@ -215,8 +220,10 @@ describe('GenAIModelSelection', () => {
 
   test('does not auto-switch apiKeyConfig when initialValues.apiKeyConfig is provided', async () => {
     jest.mocked(useEndpointsQuery).mockReturnValue({ data: [], isLoading: false } as any);
+    const secrets = [{ secret_id: 'existing-secret', secret_name: 'My Key', provider: 'openai', masked_values: {} }];
     mockUseApiKeyConfiguration.mockReturnValue({
-      existingSecrets: [{ secret_id: 'existing-secret', secret_name: 'My Key', provider: 'openai', masked_values: {} }],
+      allSecrets: secrets,
+      existingSecrets: secrets,
       authModes: [],
       defaultAuthMode: '',
       isLoadingProviderConfig: false,

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/GenAIModelSelection.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/GenAIModelSelection.test.tsx
@@ -155,6 +155,41 @@ describe('GenAIModelSelection', () => {
     });
   });
 
+  test('auto-selects first existing API key for new provider when switching providers', async () => {
+    mockEndpointQueryResult([]);
+    const allSecretsMultiProvider = [
+      { secret_id: 'openai-secret-1', secret_name: 'OpenAI Key', provider: 'openai', masked_values: {} },
+      { secret_id: 'anthropic-secret-1', secret_name: 'Anthropic Key 1', provider: 'anthropic', masked_values: {} },
+      { secret_id: 'anthropic-secret-2', secret_name: 'Anthropic Key 2', provider: 'anthropic', masked_values: {} },
+    ];
+    mockUseApiKeyConfiguration.mockReturnValue({
+      allSecrets: allSecretsMultiProvider,
+      existingSecrets: allSecretsMultiProvider.filter((s) => s.provider === 'openai'),
+      authModes: [],
+      defaultAuthMode: '',
+      isLoadingProviderConfig: false,
+    });
+
+    const ref = React.createRef<any>();
+    const { getByText } = renderWithDesignSystem(
+      <GenAIModelSelection {...defaultProps} ref={ref} showConfigureDirectly />,
+    );
+
+    await waitFor(() => {
+      expect(ref.current?.getValues().mode).toBe('direct');
+    });
+
+    // Open provider dropdown and switch to Anthropic
+    fireEvent.click(getByText('OpenAI'));
+    fireEvent.click(getByText('Anthropic'));
+
+    await waitFor(() => {
+      const config = ref.current?.getValues().apiKeyConfig;
+      expect(config.mode).toBe('existing');
+      expect(config.existingSecretId).toBe('anthropic-secret-1');
+    });
+  });
+
   test('hides endpoint dropdown when no endpoints exist', () => {
     mockEndpointQueryResult([]);
 

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/GenAIModelSelection.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/GenAIModelSelection.tsx
@@ -162,9 +162,11 @@ export const GenAIModelSelection = forwardRef<GenAIModelSelectionRef, GenAIModel
     // Track whether caller provided an initial apiKeyConfig to prevent auto-switching it
     const hasInitialApiKeyConfig = useRef(initialValues?.apiKeyConfig != null);
 
-    const { existingSecrets, authModes, defaultAuthMode, isLoadingProviderConfig } = useApiKeyConfiguration({
-      provider,
-    });
+    const { allSecrets, existingSecrets, authModes, defaultAuthMode, isLoadingProviderConfig } = useApiKeyConfiguration(
+      {
+        provider,
+      },
+    );
 
     // Build endpoint options for the dropdown
     const endpointOptions = useMemo(() => {
@@ -216,13 +218,13 @@ export const GenAIModelSelection = forwardRef<GenAIModelSelectionRef, GenAIModel
       [refetchEndpoints],
     );
 
-    // Update API key mode to 'existing' and auto-select first secret when secrets become available.
-    // Skip when readOnly or when initialValues.apiKeyConfig was provided to preserve round-trip fidelity.
+    // Auto-select the first existing secret when secrets load asynchronously (e.g. on initial mount
+    // or when the provider changes before the cache is populated). Skip when readOnly or when
+    // initialValues.apiKeyConfig was provided to preserve round-trip fidelity.
     useEffect(() => {
       if (readOnly || hasInitialApiKeyConfig.current) return;
       if (provider && existingSecrets.length > 0) {
         setApiKeyConfig((prev) => {
-          // Only update if currently in 'new' mode with no fields filled
           if (prev.mode === 'new' && Object.keys(prev.newSecret.secretFields).length === 0) {
             return { ...prev, mode: 'existing', existingSecretId: existingSecrets[0].secret_id };
           }
@@ -231,19 +233,30 @@ export const GenAIModelSelection = forwardRef<GenAIModelSelectionRef, GenAIModel
       }
     }, [readOnly, provider, existingSecrets]);
 
-    const handleProviderChange = useCallback((newProvider: string) => {
-      setProvider(newProvider);
-      const defaultModel = DEFAULT_MODEL_BY_PROVIDER[newProvider];
-      setModel(defaultModel ?? '');
-      setApiKeyConfig({
-        ...DEFAULT_API_KEY_CONFIG,
-        newSecret: {
-          ...DEFAULT_API_KEY_CONFIG.newSecret,
-          name: generateRandomName(newProvider),
-        },
-      });
-      setIsAdvancedSettingsExpanded(false);
-    }, []);
+    const handleProviderChange = useCallback(
+      (newProvider: string) => {
+        setProvider(newProvider);
+        const defaultModel = DEFAULT_MODEL_BY_PROVIDER[newProvider];
+        setModel(defaultModel ?? '');
+        // Set the correct mode synchronously from the cached secrets to avoid a race condition
+        // where a child effect overwrites the auto-selected 'existing' mode using a stale snapshot.
+        const newProviderSecrets = allSecrets.filter((s) => s.provider === newProvider);
+        const baseConfig = {
+          ...DEFAULT_API_KEY_CONFIG,
+          newSecret: {
+            ...DEFAULT_API_KEY_CONFIG.newSecret,
+            name: generateRandomName(newProvider),
+          },
+        };
+        setApiKeyConfig(
+          newProviderSecrets.length > 0
+            ? { ...baseConfig, mode: 'existing', existingSecretId: newProviderSecrets[0].secret_id }
+            : baseConfig,
+        );
+        setIsAdvancedSettingsExpanded(false);
+      },
+      [allSecrets],
+    );
 
     const reset = useCallback(() => {
       setMode(hasEndpoints ? 'endpoint' : 'direct');

--- a/mlflow/server/js/src/gateway/components/model-configuration/hooks/useApiKeyConfiguration.ts
+++ b/mlflow/server/js/src/gateway/components/model-configuration/hooks/useApiKeyConfiguration.ts
@@ -1,7 +1,6 @@
 import { useMemo, useCallback } from 'react';
 import { useSecretsQuery } from '../../../hooks/useSecretsQuery';
 import { useProviderConfigQuery } from '../../../hooks/useProviderConfigQuery';
-import type { ApiKeyConfiguration, NewSecretData } from '../types';
 import type { SecretInfo, AuthMode } from '../../../types';
 
 interface UseApiKeyConfigurationOptions {
@@ -9,6 +8,7 @@ interface UseApiKeyConfigurationOptions {
 }
 
 interface UseApiKeyConfigurationResult {
+  allSecrets: SecretInfo[];
   existingSecrets: SecretInfo[];
   isLoadingSecrets: boolean;
   authModes: AuthMode[];
@@ -47,6 +47,7 @@ export function useApiKeyConfiguration({ provider }: UseApiKeyConfigurationOptio
   );
 
   return {
+    allSecrets: allSecrets ?? [],
     existingSecrets,
     isLoadingSecrets,
     authModes,

--- a/mlflow/server/js/src/gateway/components/model-configuration/hooks/useApiKeyConfiguration.ts
+++ b/mlflow/server/js/src/gateway/components/model-configuration/hooks/useApiKeyConfiguration.ts
@@ -47,7 +47,7 @@ export function useApiKeyConfiguration({ provider }: UseApiKeyConfigurationOptio
   );
 
   return {
-    allSecrets: allSecrets ?? [],
+    allSecrets,
     existingSecrets,
     isLoadingSecrets,
     authModes,


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?
Fixing a provider-change race in Gen AI model selection: when the user switches provider, API key mode should follow cached secrets for the new provider immediately, instead of resetting to “new” and letting a later effect run with a stale existingSecrets list.

Before:

https://github.com/user-attachments/assets/2885a749-eca3-4870-a787-9bf2d36dba66

After:

https://github.com/user-attachments/assets/22bded41-7fa4-4b27-af56-75fe7523f0df

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [ ] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
