### PR TITLE
Introduce LLM Playground UI

### DIFF
--- a/.github/actions/check-component-ids/componentId-registry.js
+++ b/.github/actions/check-component-ids/componentId-registry.js
@@ -1645,6 +1645,15 @@ module.exports = {
   "mlflow.overview.usage.trace_cost_over_time.item_selector": "",
   "mlflow.overview.usage.traces.view_traces_link": "",
 
+  // -- mlflow.playground --
+  "mlflow.playground.load_from_registry": "",
+  "mlflow.playground.output.error": "",
+  "mlflow.playground.prompt_input.content": "",
+  "mlflow.playground.prompt_input.remove": "",
+  "mlflow.playground.prompt_input.role": "",
+  "mlflow.playground.prompt_input.role_help": "",
+  "mlflow.playground.submit": "",
+
   // -- mlflow.prompts --
   "mlflow.prompts.chat_creator.add_after": "",
   "mlflow.prompts.chat_creator.content": "",
@@ -1807,6 +1816,8 @@ module.exports = {
   "mlflow.sidebar.home_tab_link": "",
   "mlflow.sidebar.logo_home_link": "",
   "mlflow.sidebar.models_tab_link": "",
+  "mlflow.sidebar.playground_new_tag": "",
+  "mlflow.sidebar.playground_tab_link": "",
   "mlflow.sidebar.prompts_tab_link": "",
   "mlflow.sidebar.settings_back_link": "",
   "mlflow.sidebar.settings_general_link": "",

--- a/docs/docs/genai/governance/ai-gateway/index.mdx
+++ b/docs/docs/genai/governance/ai-gateway/index.mdx
@@ -6,7 +6,7 @@ description: Manage multiple LLM providers through a single, secure endpoint. Ce
 import TilesGrid from "@site/src/components/TilesGrid";
 import TileCard from "@site/src/components/TileCard";
 import FeatureHighlights from "@site/src/components/FeatureHighlights";
-import { Shield, Globe, Zap, Users, Wrench, Play, GitBranch, BarChart3, Lock, DollarSign, Gauge, ShieldCheck } from "lucide-react";
+import { Shield, Globe, Zap, Users, Wrench, Play, GitBranch, BarChart3, Lock, DollarSign, Gauge, ShieldCheck, Sparkles } from "lucide-react";
 import GenAIDemoCard from "@site/src/content/genai_demo_card.mdx";
 
 # MLflow AI Gateway
@@ -75,6 +75,13 @@ MLflow AI Gateway also offers passthrough endpoints, enabling requests to be for
     description="Create, configure, and query AI model endpoints"
     href="./endpoints/create-and-manage"
     linkText="Configure endpoints →"
+  />
+  <TileCard
+    icon={Sparkles}
+    title="Playground"
+    description="Test endpoints and registered prompts interactively from the MLflow UI"
+    href="/genai/playground"
+    linkText="Open the Playground →"
   />
   <TileCard
     icon={GitBranch}

--- a/docs/docs/genai/playground.mdx
+++ b/docs/docs/genai/playground.mdx
@@ -1,0 +1,57 @@
+---
+title: Playground
+description: Interactively test AI Gateway endpoints and registered prompts from the MLflow UI without writing code.
+---
+
+# Playground
+
+The Playground is an in-browser UI for sending chat completion requests to your AI Gateway endpoints. Use it to spot-check an endpoint after configuration, iterate on a prompt before saving it to the registry, or replay a registered prompt against any endpoint without writing code.
+
+## Opening the Playground
+
+Click **Playground** in the sidebar. The page is available in any MLflow workspace where the AI Gateway is enabled.
+
+## Picking an endpoint
+
+The **Endpoint** dropdown lists every gateway endpoint visible in your workspace. The endpoint determines the provider, model, secret, and any guardrails or budget policies applied to the request — the Playground simply sends the conversation to whatever the endpoint resolves to.
+
+If the dropdown is empty, you have not created any endpoints yet. See [Create and Manage Endpoints](governance/ai-gateway/endpoints/create-and-manage.mdx).
+
+## Composing messages
+
+The right side of the page is a list of chat messages. Each message has:
+
+- **Role** — `system`, `user`, or `assistant`. The role tells the model who is "speaking":
+  - `system` — instructions or persona for the model (e.g. "You are a concise summarizer").
+  - `user` — what the human is asking. The typical input.
+  - `assistant` — a previous model reply. Useful for priming the model with example responses (few-shot prompting) or replaying a partial conversation.
+- **Content** — the message text. Supports multi-line input.
+
+Click **Add message** to append another turn. Use the X button on a card to remove it. **Submit** stays disabled until at least one message has non-empty content and an endpoint is selected.
+
+The Playground sends every message in the list as a single request — it does **not** automatically append the model's reply for follow-up turns. To continue a conversation, manually add the assistant's response and a new user message.
+
+## Loading a prompt from the registry
+
+Click **Load prompt from registry** to open a picker that lists all prompts in the [Prompt Registry](prompt-registry/index.mdx). Pick a prompt and a version, then click **Load** to populate the message list.
+
+- **Chat-typed prompts** load with their original message structure (system / user / assistant turns intact).
+- **Text-typed prompts** load as a single `user` message containing the prompt text.
+
+`{{ variable }}` placeholders are loaded literally — edit the messages inline to fill them before clicking Submit.
+
+## Reviewing the response
+
+After Submit, the **Output** panel renders the model's reply as Markdown (so code blocks, lists, and formatting come through). When the gateway returns token usage information, a footer shows prompt, completion, and total token counts.
+
+If the request fails — for example, the endpoint's secret is missing, a budget limit is exceeded, or a guardrail blocks the request — the error message is shown inline.
+
+## Limitations
+
+The current Playground is intentionally minimal. The following are not supported in the UI today:
+
+- **Streaming** responses — the full reply is rendered once the gateway finishes generating.
+- **Multi-turn loops** — the assistant reply is not appended automatically after Submit.
+- **Sampling parameters** — temperature, top_p, max_tokens, and similar knobs use the endpoint's defaults. To override them, query the endpoint directly with the [chat completions API](governance/ai-gateway/endpoints/query-endpoints.mdx).
+- **Tool / function calling** and **structured output**.
+- **Saving** — Playground sessions are not persisted. To capture a run, register the message list as a new prompt version in the [Prompt Registry](prompt-registry/index.mdx).

--- a/docs/docs/genai/prompt-registry/index.mdx
+++ b/docs/docs/genai/prompt-registry/index.mdx
@@ -41,6 +41,10 @@ import GenAIDemoCard from "@site/src/content/genai_demo_card.mdx";
   },
 ]} />
 
+:::tip Try prompts interactively
+Once a prompt is registered, you can load any version into the [Playground](/genai/playground) and run it against an AI Gateway endpoint without writing any code.
+:::
+
 ## Getting Started
 
 ### 1. Create a Prompt

--- a/docs/sidebarsGenAI.ts
+++ b/docs/sidebarsGenAI.ts
@@ -985,6 +985,12 @@ const sidebarsGenAI: SidebarsConfig = {
       },
     },
     {
+      type: 'doc',
+      id: 'playground',
+      label: 'Playground',
+      className: 'sidebar-top-level-category',
+    },
+    {
       type: 'category',
       label: 'AI Gateway',
       className: 'sidebar-top-level-category',

--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -7,6 +7,7 @@ import {
   GearIcon,
   HomeIcon,
   ModelsIcon,
+  PlayIcon,
   Tag,
   TextBoxIcon,
   Typography,
@@ -52,6 +53,8 @@ const isExperimentsActive = (location: Location) =>
   );
 const isModelsActive = (location: Location) => Boolean(matchPath('/models/*', location.pathname));
 const isPromptsActive = (location: Location) => Boolean(matchPath('/prompts/*', location.pathname));
+const isPlaygroundActive = (location: Location) =>
+  Boolean(matchPath({ path: '/playground', end: true }, location.pathname));
 const isGatewayActive = (location: Location) => Boolean(matchPath('/gateway/*', location.pathname));
 const isSettingsActive = (location: Location) =>
   Boolean(
@@ -225,6 +228,30 @@ export function MlflowSidebar({
                 shouldEnableWorkflowBasedNavigation() && isGatewayActive(location) ? (
                   <MlflowSidebarGatewayItems collapsed={!showSidebar} />
                 ) : undefined,
+            },
+          ]
+        : []),
+      ...(shouldShowGenAIFeatures(enableWorkflowBasedNavigation, workflowType) && !showNestedExperimentItems
+        ? [
+            {
+              key: 'playground',
+              icon: <PlayIcon />,
+              linkProps: {
+                to: ExperimentTrackingRoutes.playgroundPageRoute,
+                isActive: isPlaygroundActive,
+                children: (
+                  <>
+                    <FormattedMessage
+                      defaultMessage="Playground"
+                      description="Sidebar link for the LLM playground page"
+                    />
+                    <Tag componentId="mlflow.sidebar.playground_new_tag" color="turquoise" css={{ marginLeft: 'auto' }}>
+                      <FormattedMessage defaultMessage="New" description="Sidebar > Playground > New feature tag" />
+                    </Tag>
+                  </>
+                ),
+              },
+              componentId: 'mlflow.sidebar.playground_tab_link',
             },
           ]
         : []),

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/PlaygroundPage.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/PlaygroundPage.test.tsx
@@ -1,0 +1,99 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { render, renderHook, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { IntlProvider } from 'react-intl';
+import { DesignSystemProvider } from '@databricks/design-system';
+import { QueryClient, QueryClientProvider } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { testRoute, TestRouter } from '../../../common/utils/RoutingTestUtils';
+import { GatewayApi } from '../../../gateway/api';
+import { PlaygroundApi } from './api';
+import PlaygroundPage from './PlaygroundPage';
+import { useChatCompletionMutation } from './hooks/useChatCompletionMutation';
+
+const renderPlayground = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<PlaygroundPage />, {
+    wrapper: ({ children }) => (
+      <IntlProvider locale="en">
+        <DesignSystemProvider>
+          <QueryClientProvider client={queryClient}>
+            <TestRouter routes={[testRoute(<>{children}</>, '/'), testRoute(<div />, '*')]} initialEntries={['/']} />
+          </QueryClientProvider>
+        </DesignSystemProvider>
+      </IntlProvider>
+    ),
+  });
+};
+
+describe('PlaygroundPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(GatewayApi, 'listEndpoints').mockResolvedValue({
+      endpoints: [
+        {
+          endpoint_id: 'ep-1',
+          name: 'my-endpoint',
+          model_mappings: [],
+          created_at: 1700000000000,
+          last_updated_at: 1700000000000,
+        },
+      ],
+    });
+  });
+
+  it('renders the page header and the empty completion output by default', async () => {
+    renderPlayground();
+
+    await waitFor(() => {
+      expect(screen.getByText('Playground')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Submit a message to see the response here.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /submit/i })).toBeDisabled();
+  });
+
+  it('enables submit only when the message and endpoint are both present', async () => {
+    renderPlayground();
+
+    await waitFor(() => {
+      expect(screen.getByText('Playground')).toBeInTheDocument();
+    });
+
+    const submit = screen.getByRole('button', { name: /submit/i });
+    expect(submit).toBeDisabled();
+
+    const textarea = screen.getByPlaceholderText('Type a message');
+    await userEvent.type(textarea, 'Hello there');
+
+    // Endpoint is still empty, so submit stays disabled.
+    expect(submit).toBeDisabled();
+  });
+
+  it('exposes a hook that posts to the chat completions API', async () => {
+    const chatCompletionSpy = jest.spyOn(PlaygroundApi, 'chatCompletion').mockResolvedValue({
+      choices: [{ index: 0, message: { role: 'assistant', content: 'Hello back!' }, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 5, completion_tokens: 3, total_tokens: 8 },
+    });
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useChatCompletionMutation(), { wrapper });
+
+    result.current.mutate({
+      model: 'my-endpoint',
+      messages: [{ role: 'user', content: 'Hello there' }],
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(chatCompletionSpy).toHaveBeenCalledWith({
+      model: 'my-endpoint',
+      messages: [{ role: 'user', content: 'Hello there' }],
+    });
+    expect(result.current.data?.choices?.[0]?.message?.content).toBe('Hello back!');
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/PlaygroundPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/PlaygroundPage.tsx
@@ -1,0 +1,95 @@
+import { Button, PlayIcon, Spacer, useDesignSystemTheme } from '@databricks/design-system';
+import { useState } from 'react';
+import { FormattedMessage } from 'react-intl';
+import { ScrollablePageWrapper } from '../../../common/components/ScrollablePageWrapper';
+import ErrorUtils from '../../../common/utils/ErrorUtils';
+import { withErrorBoundary } from '../../../common/utils/withErrorBoundary';
+import { PageHeader } from '../../../shared/building_blocks/PageHeader';
+import { CompletionOutputPanel } from './components/CompletionOutputPanel';
+import { EndpointPicker } from './components/EndpointPicker';
+import { PromptInputPanel } from './components/PromptInputPanel';
+import { PromptRegistryPicker } from './components/PromptRegistryPicker';
+import { useChatCompletionMutation } from './hooks/useChatCompletionMutation';
+import type { ChatMessage } from './types';
+
+const PlaygroundPage = () => {
+  const { theme } = useDesignSystemTheme();
+  const [endpointName, setEndpointName] = useState<string>('');
+  const [messages, setMessages] = useState<ChatMessage[]>([{ role: 'user', content: '' }]);
+  const [showRegistryPicker, setShowRegistryPicker] = useState(false);
+
+  const { mutate, data, error, isLoading } = useChatCompletionMutation();
+
+  const canSubmit =
+    Boolean(endpointName) && messages.length > 0 && messages.some((m) => m.content.trim().length > 0) && !isLoading;
+
+  const handleSubmit = () => {
+    if (!canSubmit) {
+      return;
+    }
+    mutate({
+      model: endpointName,
+      messages,
+    });
+  };
+
+  return (
+    <ScrollablePageWrapper css={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
+      <PageHeader
+        title={<FormattedMessage defaultMessage="Playground" description="Title of the LLM playground page" />}
+        preview
+      />
+      <div
+        css={{
+          display: 'grid',
+          gridTemplateColumns: '320px 1fr',
+          gap: theme.spacing.lg,
+          flex: 1,
+          minHeight: 0,
+        }}
+      >
+        <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
+          <EndpointPicker value={endpointName} onChange={setEndpointName} />
+          <Button componentId="mlflow.playground.load_from_registry" onClick={() => setShowRegistryPicker(true)}>
+            <FormattedMessage
+              defaultMessage="Load prompt from registry"
+              description="Label for the button that opens the registered prompt picker on the playground page"
+            />
+          </Button>
+        </div>
+
+        <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md, minHeight: 0 }}>
+          <PromptInputPanel messages={messages} onChange={setMessages} />
+          <div css={{ display: 'flex', justifyContent: 'flex-end' }}>
+            <Button
+              componentId="mlflow.playground.submit"
+              type="primary"
+              icon={<PlayIcon />}
+              disabled={!canSubmit}
+              loading={isLoading}
+              onClick={handleSubmit}
+            >
+              <FormattedMessage
+                defaultMessage="Submit"
+                description="Label for the submit button on the playground page that runs the chat completion request"
+              />
+            </Button>
+          </div>
+          <Spacer size="sm" />
+          <CompletionOutputPanel response={data} error={error ?? undefined} isLoading={isLoading} />
+        </div>
+      </div>
+
+      <PromptRegistryPicker
+        visible={showRegistryPicker}
+        onCancel={() => setShowRegistryPicker(false)}
+        onLoad={(loadedMessages) => {
+          setMessages(loadedMessages.length > 0 ? loadedMessages : [{ role: 'user', content: '' }]);
+          setShowRegistryPicker(false);
+        }}
+      />
+    </ScrollablePageWrapper>
+  );
+};
+
+export default withErrorBoundary(ErrorUtils.mlflowServices.EXPERIMENTS, PlaygroundPage);

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/api.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/api.ts
@@ -1,0 +1,40 @@
+import { matchPredefinedError, UnknownError } from '@databricks/web-shared/errors';
+import { fetchEndpoint } from '../../../common/utils/FetchUtils';
+import type { ChatCompletionRequest, ChatCompletionResponse } from './types';
+
+const defaultErrorHandler = async ({
+  reject,
+  response,
+  err: originalError,
+}: {
+  reject: (cause: any) => void;
+  response: Response;
+  err: Error;
+}) => {
+  const predefinedError = matchPredefinedError(response);
+  const error = predefinedError instanceof UnknownError ? originalError : predefinedError;
+  if (response) {
+    try {
+      const body = await response.json();
+      const messageFromResponse = body?.message ?? body?.detail;
+      if (typeof messageFromResponse === 'string') {
+        error.message = messageFromResponse;
+      }
+    } catch {
+      // Keep original error message if extraction fails
+    }
+  }
+
+  reject(error);
+};
+
+export const PlaygroundApi = {
+  chatCompletion: (request: ChatCompletionRequest) => {
+    return fetchEndpoint({
+      relativeUrl: 'gateway/mlflow/v1/chat/completions',
+      method: 'POST',
+      body: JSON.stringify(request),
+      error: defaultErrorHandler,
+    }) as Promise<ChatCompletionResponse>;
+  },
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/components/CompletionOutputPanel.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/components/CompletionOutputPanel.tsx
@@ -1,0 +1,104 @@
+import { Alert, Empty, Spinner, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { GenAIMarkdownRenderer } from '@databricks/web-shared/genai-markdown-renderer';
+import { FormattedMessage } from 'react-intl';
+import type { ChatCompletionResponse } from '../types';
+
+interface Props {
+  response?: ChatCompletionResponse;
+  error?: Error;
+  isLoading: boolean;
+}
+
+const getCompletionContent = (response?: ChatCompletionResponse): string => {
+  if (!response) {
+    return '';
+  }
+  return response.choices?.[0]?.message?.content ?? '';
+};
+
+export const CompletionOutputPanel = ({ response, error, isLoading }: Props) => {
+  const { theme } = useDesignSystemTheme();
+  const completion = getCompletionContent(response);
+  const usage = response?.usage;
+
+  return (
+    <div
+      css={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: theme.spacing.sm,
+        flex: 1,
+        minHeight: 0,
+      }}
+    >
+      <Typography.Title level={4} withoutMargins>
+        <FormattedMessage
+          defaultMessage="Output"
+          description="Section header for the completion output panel on the playground page"
+        />
+      </Typography.Title>
+
+      <div
+        css={{
+          border: `1px solid ${theme.colors.border}`,
+          borderRadius: theme.general.borderRadiusBase,
+          padding: theme.spacing.md,
+          backgroundColor: theme.colors.backgroundSecondary,
+          minHeight: 200,
+          flex: 1,
+          overflow: 'auto',
+        }}
+      >
+        {isLoading ? (
+          <div css={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
+            <Spinner />
+          </div>
+        ) : error ? (
+          <Alert type="error" message={error.message} componentId="mlflow.playground.output.error" closable={false} />
+        ) : completion ? (
+          <GenAIMarkdownRenderer>{completion}</GenAIMarkdownRenderer>
+        ) : (
+          <div
+            css={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              height: '100%',
+              minHeight: 160,
+              '& > div': {
+                height: '100%',
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'center',
+                alignItems: 'center',
+              },
+            }}
+          >
+            <Empty
+              description={
+                <FormattedMessage
+                  defaultMessage="Submit a message to see the response here."
+                  description="Empty state for the playground completion output panel"
+                />
+              }
+            />
+          </div>
+        )}
+      </div>
+
+      {usage && (
+        <Typography.Hint>
+          <FormattedMessage
+            defaultMessage="Tokens — prompt: {prompt}, completion: {completion}, total: {total}"
+            description="Token usage footer on the playground completion output panel"
+            values={{
+              prompt: usage.prompt_tokens ?? '—',
+              completion: usage.completion_tokens ?? '—',
+              total: usage.total_tokens ?? '—',
+            }}
+          />
+        </Typography.Hint>
+      )}
+    </div>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/components/EndpointPicker.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/components/EndpointPicker.tsx
@@ -1,0 +1,74 @@
+import {
+  DialogCombobox,
+  DialogComboboxContent,
+  DialogComboboxOptionList,
+  DialogComboboxOptionListSearch,
+  DialogComboboxOptionListSelectItem,
+  DialogComboboxTrigger,
+  FormUI,
+} from '@databricks/design-system';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { useEndpointsQuery } from '../../../../gateway/hooks/useEndpointsQuery';
+
+const COMPONENT_ID = 'mlflow.playground.endpoint_picker';
+
+interface Props {
+  value?: string;
+  onChange: (endpointName: string) => void;
+}
+
+export const EndpointPicker = ({ value, onChange }: Props) => {
+  const intl = useIntl();
+  const { data: endpoints, isLoading, error } = useEndpointsQuery();
+
+  return (
+    <div>
+      <FormUI.Label htmlFor={COMPONENT_ID}>
+        <FormattedMessage
+          defaultMessage="Endpoint"
+          description="Label for the AI gateway endpoint picker on the playground page"
+        />
+      </FormUI.Label>
+      <DialogCombobox
+        componentId={COMPONENT_ID}
+        label={intl.formatMessage({
+          defaultMessage: 'Endpoint',
+          description: 'Label for the AI gateway endpoint picker on the playground page',
+        })}
+        modal={false}
+        value={value ? [value] : undefined}
+      >
+        <DialogComboboxTrigger
+          id={COMPONENT_ID}
+          css={{ width: '100%' }}
+          allowClear
+          placeholder={intl.formatMessage({
+            defaultMessage: 'Select a gateway endpoint',
+            description: 'Placeholder for the AI gateway endpoint picker on the playground page',
+          })}
+          withInlineLabel={false}
+          onClear={() => onChange('')}
+        />
+        <DialogComboboxContent loading={isLoading} maxHeight={400} matchTriggerWidth>
+          {!isLoading && (
+            <DialogComboboxOptionList>
+              <DialogComboboxOptionListSearch autoFocus>
+                {endpoints.map((endpoint) => (
+                  <DialogComboboxOptionListSelectItem
+                    value={endpoint.name}
+                    key={endpoint.endpoint_id}
+                    onChange={(name) => onChange(name)}
+                    checked={value === endpoint.name}
+                  >
+                    {endpoint.name}
+                  </DialogComboboxOptionListSelectItem>
+                ))}
+              </DialogComboboxOptionListSearch>
+            </DialogComboboxOptionList>
+          )}
+        </DialogComboboxContent>
+      </DialogCombobox>
+      {error && <FormUI.Message type="error" message={error.message} />}
+    </div>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/components/PromptInputPanel.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/components/PromptInputPanel.tsx
@@ -1,0 +1,176 @@
+import {
+  Button,
+  CloseIcon,
+  FormUI,
+  InfoSmallIcon,
+  Input,
+  PlusIcon,
+  Popover,
+  SegmentedControlButton,
+  SegmentedControlGroup,
+  Typography,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
+import { FormattedMessage, useIntl } from 'react-intl';
+import type { ChangeEvent } from 'react';
+import type { ChatMessage, ChatRole } from '../types';
+
+const { TextArea } = Input;
+
+const COMPONENT_ID = 'mlflow.playground.prompt_input';
+
+const ROLE_OPTIONS: ChatRole[] = ['system', 'user', 'assistant'];
+
+interface Props {
+  messages: ChatMessage[];
+  onChange: (messages: ChatMessage[]) => void;
+}
+
+export const PromptInputPanel = ({ messages, onChange }: Props) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+
+  const updateMessage = (index: number, patch: Partial<ChatMessage>) => {
+    onChange(messages.map((msg, i) => (i === index ? { ...msg, ...patch } : msg)));
+  };
+
+  const removeMessage = (index: number) => {
+    onChange(messages.filter((_, i) => i !== index));
+  };
+
+  const addMessage = () => {
+    onChange([...messages, { role: 'user', content: '' }]);
+  };
+
+  return (
+    <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
+      <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
+        <Typography.Title level={4} withoutMargins>
+          <FormattedMessage
+            defaultMessage="Messages"
+            description="Section header for the chat input on the playground page"
+          />
+        </Typography.Title>
+        <Popover.Root componentId="mlflow.playground.prompt_input.role_help">
+          <Popover.Trigger
+            aria-label={intl.formatMessage({
+              defaultMessage: 'About message roles',
+              description: 'Aria label for the info popover that explains chat roles on the playground page',
+            })}
+            css={{ border: 0, background: 'none', padding: 0, display: 'inline-flex', cursor: 'pointer' }}
+          >
+            <InfoSmallIcon />
+          </Popover.Trigger>
+          <Popover.Content align="start" css={{ maxWidth: 360 }}>
+            <Typography.Paragraph withoutMargins>
+              <FormattedMessage
+                defaultMessage="Each message has a role that tells the model who is speaking:"
+                description="Intro line for the playground role-selector help popover"
+              />
+            </Typography.Paragraph>
+            <ul css={{ margin: `${theme.spacing.xs}px 0 0`, paddingLeft: theme.spacing.lg }}>
+              <li>
+                <Typography.Text bold>system</Typography.Text>{' '}
+                <FormattedMessage
+                  defaultMessage="— instructions or persona for the model (e.g. {example})."
+                  description="Description of the system role in the playground role-selector help popover"
+                  values={{ example: <Typography.Text code>You are a helpful assistant</Typography.Text> }}
+                />
+              </li>
+              <li>
+                <Typography.Text bold>user</Typography.Text>{' '}
+                <FormattedMessage
+                  defaultMessage="— what the human is asking. This is the typical input."
+                  description="Description of the user role in the playground role-selector help popover"
+                />
+              </li>
+              <li>
+                <Typography.Text bold>assistant</Typography.Text>{' '}
+                <FormattedMessage
+                  defaultMessage="— what the model has previously said. Useful for priming with example responses."
+                  description="Description of the assistant role in the playground role-selector help popover"
+                />
+              </li>
+            </ul>
+            <Popover.Arrow />
+          </Popover.Content>
+        </Popover.Root>
+      </div>
+
+      {messages.length === 0 && (
+        <Typography.Hint>
+          <FormattedMessage
+            defaultMessage="Add a message to send to the endpoint, or load a prompt from the registry."
+            description="Empty-state hint for the playground messages panel"
+          />
+        </Typography.Hint>
+      )}
+
+      {messages.map((message, index) => (
+        <div
+          key={index}
+          css={{
+            border: `1px solid ${theme.colors.border}`,
+            borderRadius: theme.general.borderRadiusBase,
+            padding: theme.spacing.sm,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: theme.spacing.xs,
+          }}
+        >
+          <div css={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <SegmentedControlGroup
+              componentId="mlflow.playground.prompt_input.role"
+              name={`${COMPONENT_ID}.role.${index}`}
+              size="small"
+              value={message.role}
+              onChange={(event) => updateMessage(index, { role: event.target.value as ChatRole })}
+            >
+              {ROLE_OPTIONS.map((role) => (
+                <SegmentedControlButton key={role} value={role}>
+                  {role}
+                </SegmentedControlButton>
+              ))}
+            </SegmentedControlGroup>
+            <Button
+              componentId="mlflow.playground.prompt_input.remove"
+              size="small"
+              icon={<CloseIcon />}
+              aria-label={intl.formatMessage({
+                defaultMessage: 'Remove message',
+                description: 'Aria label for the button that removes a message from the playground messages panel',
+              })}
+              onClick={() => removeMessage(index)}
+            />
+          </div>
+          <FormUI.Label htmlFor={`${COMPONENT_ID}.content.${index}`} css={{ display: 'none' }}>
+            <FormattedMessage
+              defaultMessage="Message content"
+              description="Hidden label for the message content textarea on the playground page"
+            />
+          </FormUI.Label>
+          <TextArea
+            componentId="mlflow.playground.prompt_input.content"
+            id={`${COMPONENT_ID}.content.${index}`}
+            value={message.content}
+            onChange={(event: ChangeEvent<HTMLTextAreaElement>) =>
+              updateMessage(index, { content: event.target.value })
+            }
+            autoSize={{ minRows: 3, maxRows: 12 }}
+            placeholder={intl.formatMessage({
+              defaultMessage: 'Type a message',
+              description: 'Placeholder for a message textarea on the playground page',
+            })}
+          />
+        </div>
+      ))}
+
+      <Button componentId={`${COMPONENT_ID}.add`} icon={<PlusIcon />} onClick={addMessage}>
+        <FormattedMessage
+          defaultMessage="Add message"
+          description="Label for the button that appends a new chat message on the playground page"
+        />
+      </Button>
+    </div>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/components/PromptRegistryPicker.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/components/PromptRegistryPicker.tsx
@@ -1,0 +1,237 @@
+import {
+  Alert,
+  DialogCombobox,
+  DialogComboboxContent,
+  DialogComboboxOptionList,
+  DialogComboboxOptionListSearch,
+  DialogComboboxOptionListSelectItem,
+  DialogComboboxTrigger,
+  FormUI,
+  Modal,
+  Spacer,
+  Spinner,
+  Typography,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
+import { useMemo, useState } from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { usePromptDetailsQuery } from '../../prompts/hooks/usePromptDetailsQuery';
+import { usePromptsListQuery } from '../../prompts/hooks/usePromptsListQuery';
+import { getChatPromptMessagesFromValue, getPromptContentTagValue, isChatPrompt } from '../../prompts/utils';
+import type { ChatMessage } from '../types';
+
+interface Props {
+  visible: boolean;
+  onCancel: () => void;
+  onLoad: (messages: ChatMessage[]) => void;
+}
+
+const COMPONENT_ID = 'mlflow.playground.prompt_registry_picker';
+
+const buildMessagesFromVersion = (value: string | undefined, isChat: boolean): ChatMessage[] => {
+  if (!value) {
+    return [];
+  }
+  if (!isChat) {
+    return [{ role: 'user', content: value }];
+  }
+  const parsed = getChatPromptMessagesFromValue(value);
+  if (!parsed) {
+    return [{ role: 'user', content: value }];
+  }
+  return parsed.map((msg) => ({
+    role: (msg.role as ChatMessage['role']) ?? 'user',
+    content: msg.content,
+  }));
+};
+
+export const PromptRegistryPicker = ({ visible, onCancel, onLoad }: Props) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+  const [selectedPromptName, setSelectedPromptName] = useState<string | undefined>();
+  const [selectedVersion, setSelectedVersion] = useState<string | undefined>();
+
+  const { data: prompts, isLoading: isPromptsLoading, error: promptsError } = usePromptsListQuery();
+
+  const {
+    data: promptDetails,
+    isLoading: isDetailsLoading,
+    error: detailsError,
+  } = usePromptDetailsQuery({ promptName: selectedPromptName ?? '' }, { enabled: Boolean(selectedPromptName) });
+
+  const versions = useMemo(() => promptDetails?.versions ?? [], [promptDetails?.versions]);
+
+  const selectedVersionEntity = useMemo(
+    () => versions.find((v) => v.version === selectedVersion),
+    [versions, selectedVersion],
+  );
+
+  const handleLoad = () => {
+    if (!selectedVersionEntity) {
+      return;
+    }
+    const value = getPromptContentTagValue(selectedVersionEntity);
+    const messages = buildMessagesFromVersion(value, isChatPrompt(selectedVersionEntity));
+    onLoad(messages);
+  };
+
+  const reset = () => {
+    setSelectedPromptName(undefined);
+    setSelectedVersion(undefined);
+  };
+
+  const handleCancel = () => {
+    reset();
+    onCancel();
+  };
+
+  return (
+    <Modal
+      componentId={`${COMPONENT_ID}.modal`}
+      title={
+        <FormattedMessage
+          defaultMessage="Load prompt from registry"
+          description="Title for the modal that loads a registered prompt into the playground"
+        />
+      }
+      visible={visible}
+      onCancel={handleCancel}
+      okText={
+        <FormattedMessage
+          defaultMessage="Load"
+          description="Confirm button label for loading a registered prompt into the playground"
+        />
+      }
+      cancelText={
+        <FormattedMessage
+          defaultMessage="Cancel"
+          description="Cancel button label for the load-prompt modal on the playground page"
+        />
+      }
+      okButtonProps={{ disabled: !selectedVersionEntity }}
+      onOk={handleLoad}
+    >
+      <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
+        {promptsError && (
+          <Alert type="error" message={promptsError.message} componentId={`${COMPONENT_ID}.error`} closable={false} />
+        )}
+        <div>
+          <FormUI.Label htmlFor={`${COMPONENT_ID}.prompt`}>
+            <FormattedMessage
+              defaultMessage="Prompt"
+              description="Label for the prompt selector in the playground load-prompt modal"
+            />
+          </FormUI.Label>
+          <DialogCombobox
+            componentId={`${COMPONENT_ID}.prompt`}
+            label={intl.formatMessage({
+              defaultMessage: 'Prompt',
+              description: 'Label for the prompt selector in the playground load-prompt modal',
+            })}
+            modal={false}
+            value={selectedPromptName ? [selectedPromptName] : undefined}
+          >
+            <DialogComboboxTrigger
+              id={`${COMPONENT_ID}.prompt`}
+              css={{ width: '100%' }}
+              allowClear
+              placeholder={intl.formatMessage({
+                defaultMessage: 'Select a prompt',
+                description: 'Placeholder for the prompt selector in the playground load-prompt modal',
+              })}
+              withInlineLabel={false}
+              onClear={reset}
+            />
+            <DialogComboboxContent loading={isPromptsLoading} maxHeight={300} matchTriggerWidth>
+              {!isPromptsLoading && (
+                <DialogComboboxOptionList>
+                  <DialogComboboxOptionListSearch autoFocus>
+                    {(prompts ?? []).map((prompt) => (
+                      <DialogComboboxOptionListSelectItem
+                        value={prompt.name}
+                        key={prompt.name}
+                        onChange={(name) => {
+                          setSelectedPromptName(name);
+                          setSelectedVersion(undefined);
+                        }}
+                        checked={selectedPromptName === prompt.name}
+                      >
+                        {prompt.name}
+                      </DialogComboboxOptionListSelectItem>
+                    ))}
+                  </DialogComboboxOptionListSearch>
+                </DialogComboboxOptionList>
+              )}
+            </DialogComboboxContent>
+          </DialogCombobox>
+        </div>
+
+        {selectedPromptName && (
+          <div>
+            <FormUI.Label htmlFor={`${COMPONENT_ID}.version`}>
+              <FormattedMessage
+                defaultMessage="Version"
+                description="Label for the version selector in the playground load-prompt modal"
+              />
+            </FormUI.Label>
+            {isDetailsLoading ? (
+              <Spinner />
+            ) : detailsError ? (
+              <Alert
+                type="error"
+                message={detailsError.message}
+                componentId={`${COMPONENT_ID}.details_error`}
+                closable={false}
+              />
+            ) : (
+              <DialogCombobox
+                componentId={`${COMPONENT_ID}.version`}
+                label={intl.formatMessage({
+                  defaultMessage: 'Version',
+                  description: 'Label for the version selector in the playground load-prompt modal',
+                })}
+                modal={false}
+                value={selectedVersion ? [selectedVersion] : undefined}
+              >
+                <DialogComboboxTrigger
+                  id={`${COMPONENT_ID}.version`}
+                  css={{ width: '100%' }}
+                  allowClear
+                  placeholder={intl.formatMessage({
+                    defaultMessage: 'Select a version',
+                    description: 'Placeholder for the version selector in the playground load-prompt modal',
+                  })}
+                  withInlineLabel={false}
+                  onClear={() => setSelectedVersion(undefined)}
+                />
+                <DialogComboboxContent maxHeight={300} matchTriggerWidth>
+                  <DialogComboboxOptionList>
+                    {versions.map((version) => (
+                      <DialogComboboxOptionListSelectItem
+                        value={version.version ?? ''}
+                        key={version.version}
+                        onChange={(value) => setSelectedVersion(value)}
+                        checked={selectedVersion === version.version}
+                      >
+                        {version.version}
+                      </DialogComboboxOptionListSelectItem>
+                    ))}
+                  </DialogComboboxOptionList>
+                </DialogComboboxContent>
+              </DialogCombobox>
+            )}
+          </div>
+        )}
+
+        <Spacer size="sm" />
+        <Typography.Hint>
+          <FormattedMessage
+            defaultMessage="Variables in the prompt (e.g. {example}) will be loaded as-is. Edit the prompt before submitting to fill them in."
+            description="Helper text on the playground load-prompt modal explaining variable handling"
+            values={{ example: '{{name}}' }}
+          />
+        </Typography.Hint>
+      </div>
+    </Modal>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/hooks/useChatCompletionMutation.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/hooks/useChatCompletionMutation.tsx
@@ -1,0 +1,9 @@
+import { useMutation } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { PlaygroundApi } from '../api';
+import type { ChatCompletionRequest, ChatCompletionResponse } from '../types';
+
+export const useChatCompletionMutation = () => {
+  return useMutation<ChatCompletionResponse, Error, ChatCompletionRequest>({
+    mutationFn: (request) => PlaygroundApi.chatCompletion(request),
+  });
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/types.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/types.ts
@@ -1,0 +1,30 @@
+export type ChatRole = 'system' | 'user' | 'assistant';
+
+export interface ChatMessage {
+  role: ChatRole;
+  content: string;
+}
+
+export interface ChatCompletionRequest {
+  model: string;
+  messages: ChatMessage[];
+}
+
+export interface ChatCompletionUsage {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+}
+
+export interface ChatCompletionChoice {
+  index?: number;
+  message?: ChatMessage;
+  finish_reason?: string;
+}
+
+export interface ChatCompletionResponse {
+  id?: string;
+  model?: string;
+  choices: ChatCompletionChoice[];
+  usage?: ChatCompletionUsage;
+}

--- a/mlflow/server/js/src/experiment-tracking/route-defs.ts
+++ b/mlflow/server/js/src/experiment-tracking/route-defs.ts
@@ -3,6 +3,22 @@ import { createLazyRouteElement, DEFAULT_ASSISTANT_PROMPTS } from '../common/uti
 
 import { PageId, RoutePaths } from './routes';
 
+const getPlaygroundPageRouteDefs = () => [
+  {
+    path: RoutePaths.playgroundPage,
+    element: createLazyRouteElement(() => import('./pages/playground/PlaygroundPage')),
+    pageId: PageId.playgroundPage,
+    handle: {
+      getPageTitle: () => 'Playground',
+      getAssistantPrompts: () => [
+        'How do I test a prompt against an AI gateway endpoint?',
+        'How do I configure model parameters like temperature?',
+        'How do I load a prompt from the registry into the playground?',
+      ],
+    } satisfies RouteHandle,
+  },
+];
+
 const getPromptPagesRouteDefs = () => {
   return [
     {
@@ -369,4 +385,5 @@ export const getRouteDefs = () => [
     } satisfies RouteHandle,
   },
   ...getPromptPagesRouteDefs(),
+  ...getPlaygroundPageRouteDefs(),
 ];

--- a/mlflow/server/js/src/experiment-tracking/routes.ts
+++ b/mlflow/server/js/src/experiment-tracking/routes.ts
@@ -12,6 +12,7 @@ export enum PageId {
   settingsPage = 'mlflow.settings',
   promptsPage = 'mlflow.prompts',
   promptDetailsPage = 'mlflow.prompts.details',
+  playgroundPage = 'mlflow.playground',
   experimentPageTabbed = 'mlflow.experiment.details.tab',
   experimentLoggedModelDetailsPageTab = 'mlflow.logged-model.details.tab',
   experimentLoggedModelDetailsPage = 'mlflow.logged-model.details',
@@ -143,6 +144,9 @@ export class RoutePaths {
   }
   static get promptDetailsPage() {
     return createMLflowRoutePath('/prompts/:promptName');
+  }
+  static get playgroundPage() {
+    return createMLflowRoutePath('/playground');
   }
   static get settingsPage() {
     return createMLflowRoutePath('/settings');
@@ -348,6 +352,10 @@ class Routes {
       return generatePath(RoutePaths.experimentPageTabPromptDetails, { experimentId, promptName });
     }
     return generatePath(RoutePaths.promptDetailsPage, { promptName });
+  }
+
+  static get playgroundPageRoute() {
+    return RoutePaths.playgroundPage;
   }
 }
 

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -151,6 +151,10 @@
     "defaultMessage": "Expand graph",
     "description": "Tooltip for the button that expands the graph view"
   },
+  "//TrDV": {
+    "defaultMessage": "Output",
+    "description": "Section header for the completion output panel on the playground page"
+  },
   "/2InJv": {
     "defaultMessage": "Grounded",
     "description": "Evaluation results > grounded assessment > positive value label. Displayed if evaluation result is considered as grounded."
@@ -366,6 +370,10 @@
   "07nYAU": {
     "defaultMessage": "Compared IDs:",
     "description": "Label for the compared IDs section in the model trace explorer"
+  },
+  "084ch+": {
+    "defaultMessage": "Load",
+    "description": "Confirm button label for loading a registered prompt into the playground"
   },
   "08WP3h": {
     "defaultMessage": "Staging",
@@ -791,6 +799,10 @@
     "defaultMessage": "Compare",
     "description": "Compare evaluation runs action"
   },
+  "2ikLTU": {
+    "defaultMessage": "Type a message",
+    "description": "Placeholder for a message textarea on the playground page"
+  },
   "2kNo2y": {
     "defaultMessage": "Tool Error Rates",
     "description": "Title for the tool error rates section"
@@ -806,6 +818,10 @@
   "2oFAO4": {
     "defaultMessage": "Share",
     "description": "Text for share button on experiment view page header"
+  },
+  "2oNujF": {
+    "defaultMessage": "Prompt",
+    "description": "Section header for the single-message prompt input on the playground page"
   },
   "2pSaCv": {
     "defaultMessage": "Create new API key",
@@ -859,6 +875,10 @@
     "defaultMessage": "Rename",
     "description": "Text for rename button on the experiment view page header"
   },
+  "3MZ6H+": {
+    "defaultMessage": "Submit",
+    "description": "Label for the submit button on the playground page that runs the chat completion request"
+  },
   "3N1zOb": {
     "defaultMessage": "Disabled",
     "description": "Webhook disabled label"
@@ -866,6 +886,10 @@
   "3PBIB8": {
     "defaultMessage": "Appearance, product feedback, telemetry, and workspace demo data.",
     "description": "Settings content section subtitle for general preferences including demo data"
+  },
+  "3Q8nGH": {
+    "defaultMessage": "Playground",
+    "description": "Title of the LLM playground page"
   },
   "3Rb4sG": {
     "defaultMessage": "Delete",
@@ -1126,6 +1150,10 @@
   "5B5dhT": {
     "defaultMessage": "Validate the model before deployment",
     "description": "Heading text for validating the model before deploying it for serving"
+  },
+  "5Fq+ay": {
+    "defaultMessage": "Prompt",
+    "description": "Label for the prompt selector in the playground load-prompt modal"
   },
   "5GCYzy": {
     "defaultMessage": "Experiment Runs - Databricks",
@@ -2791,6 +2819,10 @@
     "defaultMessage": "Overview",
     "description": "Label for the overview tab on the logged model details page"
   },
+  "FBlbEZ": {
+    "defaultMessage": "Remove message",
+    "description": "Aria label for the button that removes a message from the playground messages panel"
+  },
   "FC9mcS": {
     "defaultMessage": "Parallel coordinates",
     "description": "Experiment tracking > runs charts > add chart menu > parallel coordinates"
@@ -3199,6 +3231,10 @@
     "defaultMessage": "Select All",
     "description": "Option to select all items in the item selector"
   },
+  "IADRYy": {
+    "defaultMessage": "Message content",
+    "description": "Hidden label for the message content textarea on the playground page"
+  },
   "IAyAgH": {
     "defaultMessage": "Move up",
     "description": "Experiment page > compare runs tab > chart header > move up option"
@@ -3502,6 +3538,10 @@
   "KGMbzq": {
     "defaultMessage": "Commit message:",
     "description": "A label for the commit message in the prompt details page"
+  },
+  "KGvWGW": {
+    "defaultMessage": "Endpoint",
+    "description": "Label for the AI gateway endpoint picker on the playground page"
   },
   "KIlp8v": {
     "defaultMessage": "No models selected",
@@ -4763,6 +4803,10 @@
     "defaultMessage": "Stage",
     "description": "Guardrail stage label"
   },
+  "SApqSU": {
+    "defaultMessage": "Cancel",
+    "description": "Cancel button label for the load-prompt modal on the playground page"
+  },
   "SAxj6I": {
     "defaultMessage": "Create budget policy",
     "description": "Gateway > Budgets page > Create budget policy button"
@@ -5046,6 +5090,10 @@
   "U3btBc": {
     "defaultMessage": "Examples:",
     "description": "Text header for examples of mlflow search syntax"
+  },
+  "U41a9m": {
+    "defaultMessage": "Messages",
+    "description": "Section header for the multi-message chat input on the playground page"
   },
   "U4ox5k": {
     "defaultMessage": "Experiments",
@@ -5454,6 +5502,10 @@
   "WP50re": {
     "defaultMessage": "Cancel",
     "description": "A label for the cancel button in the prompt creation modal in the prompt management UI"
+  },
+  "WPM8Ok": {
+    "defaultMessage": "Submit a message to see the response here.",
+    "description": "Empty state for the playground completion output panel"
   },
   "WQwCH6": {
     "defaultMessage": "Aliased versions",
@@ -6307,6 +6359,10 @@
     "defaultMessage": "Is the output semantically equivalent to the expected output?",
     "description": "Hint for Equivalence template"
   },
+  "bd6cTd": {
+    "defaultMessage": "Add a message to send to the endpoint, or load a prompt from the registry.",
+    "description": "Empty-state hint for the playground messages panel"
+  },
   "bdVsGZ": {
     "defaultMessage": "Collapse description",
     "description": "Aria label for button that collapses a long description"
@@ -6823,6 +6879,10 @@
     "defaultMessage": "Remove model",
     "description": "Tooltip for remove traffic split model button"
   },
+  "eYGERq": {
+    "defaultMessage": "Variables in the prompt (e.g. {example}) will be loaded as-is. Edit the prompt before submitting to fill them in.",
+    "description": "Helper text on the playground load-prompt modal explaining variable handling"
+  },
   "eYZ/ZL": {
     "defaultMessage": "Endpoints",
     "description": "Breadcrumb link to endpoints list"
@@ -7090,6 +7150,10 @@
   "gCCsKd": {
     "defaultMessage": "View starter code",
     "description": "Title for starter code card on endpoint overview"
+  },
+  "gF1WQp": {
+    "defaultMessage": "Add message",
+    "description": "Label for the button that appends a new chat message on the playground page"
   },
   "gFYM0j": {
     "defaultMessage": "Cancel",
@@ -7431,6 +7495,10 @@
     "defaultMessage": "Fit to view",
     "description": "Tooltip for the button that fits the graph to the viewport"
   },
+  "i6OY+u": {
+    "defaultMessage": "Prompt",
+    "description": "Hidden label for the prompt textarea on the playground page"
+  },
   "i7UTwK": {
     "defaultMessage": "Correctness assessment is missing. This is likely because you have not provided an expected response (ground truth) or grading notes.",
     "description": "Evaluation results > known type of evaluation result assessment > correctness assessment. Used to indicate if the result is correct in context of LLMs evaluation. Label displayed if user provided custom value, e.g. \"Correctness: mostly yes, have gaps\""
@@ -7502,6 +7570,10 @@
   "iT8ODo": {
     "defaultMessage": "Minimum",
     "description": "Experiment page > group by runs control > minimum aggregate function"
+  },
+  "iULNV4": {
+    "defaultMessage": "Type your prompt",
+    "description": "Placeholder for the single-message prompt textarea on the playground page"
   },
   "iVeCOa": {
     "defaultMessage": "My webhook",
@@ -7634,6 +7706,10 @@
   "jIrCsp": {
     "defaultMessage": "Knowledge retention",
     "description": "LLM template option"
+  },
+  "jLM00a": {
+    "defaultMessage": "Load prompt from registry",
+    "description": "Label for the button that opens the registered prompt picker on the playground page"
   },
   "jMUqD1": {
     "defaultMessage": "Safety",
@@ -8095,6 +8171,10 @@
     "defaultMessage": "Metrics ({length})",
     "description": "Run page > Overview > Metrics table > Section title"
   },
+  "m89k9z": {
+    "defaultMessage": "Select a prompt",
+    "description": "Placeholder for the prompt selector in the playground load-prompt modal"
+  },
   "m8ztHR": {
     "defaultMessage": "Edited {timeSince} by {source}.",
     "description": "Evaluation review > assessments > tooltip > edited by human"
@@ -8379,6 +8459,10 @@
     "defaultMessage": "Show all parent spans",
     "description": "Checkbox label for a setting that enables showing all parent spans in the trace explorer regardless of filter conditions."
   },
+  "nZow1J": {
+    "defaultMessage": "Tokens — prompt: {prompt}, completion: {completion}, total: {total}",
+    "description": "Token usage footer on the playground completion output panel"
+  },
   "naivho": {
     "defaultMessage": "of",
     "description": "Connector between list and element type"
@@ -8514,6 +8598,10 @@
   "oShuJS": {
     "defaultMessage": "Logged from",
     "description": "Label for the source (where it was logged from) of a logged model on the logged model details page. It can be e.g. a notebook or a file."
+  },
+  "oTRwYM": {
+    "defaultMessage": "Playground",
+    "description": "Sidebar link for the LLM playground page"
   },
   "oU/SPm": {
     "defaultMessage": "Add",
@@ -9903,6 +9991,10 @@
     "defaultMessage": "Runs",
     "description": "Label for the training runs tab in the MLflow experiment navbar"
   },
+  "x673Z5": {
+    "defaultMessage": "Version",
+    "description": "Label for the version selector in the playground load-prompt modal"
+  },
   "x6rkyu": {
     "defaultMessage": "Response",
     "description": "Evaluation review > Response section > title"
@@ -10043,6 +10135,10 @@
     "defaultMessage": "Logs",
     "description": "Tab label for trace logs"
   },
+  "xwYFYk": {
+    "defaultMessage": "Load prompt from registry",
+    "description": "Title for the modal that loads a registered prompt into the playground"
+  },
   "xyEaut": {
     "defaultMessage": "Add tags",
     "description": "Title for unified trace tag assignment modal"
@@ -10114,6 +10210,10 @@
   "yPdr5F": {
     "defaultMessage": "Does app's response directly address the user's input?",
     "description": "Hint for RelevanceToQuery template"
+  },
+  "yQjgCi": {
+    "defaultMessage": "Select a version",
+    "description": "Placeholder for the version selector in the playground load-prompt modal"
   },
   "yQkV88": {
     "defaultMessage": "No endpoints are using this key",
@@ -10246,6 +10346,10 @@
   "zEXwQL": {
     "defaultMessage": "Error",
     "description": "Label for an assessment with an error"
+  },
+  "zJUIKx": {
+    "defaultMessage": "Select a gateway endpoint",
+    "description": "Placeholder for the AI gateway endpoint picker on the playground page"
   },
   "zLTdCZ": {
     "defaultMessage": "Reviewed",


### PR DESCRIPTION
### Related Issues/PRs

Closes #22778

### What changes are proposed in this pull request?

Adds an in-browser **LLM Playground** to MLflow OSS so users can test AI Gateway endpoints — optionally seeded with prompts from the Prompt Registry — without leaving the UI or writing code.

**UI**

- New top-level page at `/playground` reachable from a new sidebar entry (with a "New" tag) placed adjacent to AI Gateway.
- Two-pane layout: endpoint picker + "Load prompt from registry" button on the left; message list + Submit + output on the right.
- Endpoint picker is populated from `GatewayApi.listEndpoints()`; the selected endpoint name is sent as the `model` field, letting the gateway route the call to whatever provider/model the endpoint resolves to.
- Message composer supports `system` / `user` / `assistant` roles per message, multi-line content, "Add message", and per-message remove. An info popover next to the section header explains the roles.
- Prompt Registry picker modal lets users load any registered prompt + version into the message list. Chat-typed prompts preserve their role structure; text-typed prompts load as a single user message. `{{ variable }}` placeholders are kept literal for the user to edit.
- Output panel renders responses through `GenAIMarkdownRenderer` (markdown, code blocks). Errors surface inline as an `Alert`. When the gateway returns usage, prompt/completion/total token counts are shown in a footer.

**Backend**

- No backend changes. Submit posts to the existing OpenAI-compatible `POST /gateway/mlflow/v1/chat/completions` route in `mlflow/server/gateway_api.py`.

**v1 scope (deliberate)**

- Single chat completion per submit (no auto-multi-turn loop).
- Non-streaming responses.
- No sampling-parameter panel (uses endpoint defaults).
- No persistence of playground sessions, no side-by-side comparison, no tool/function calling, no `{{ }}` variable-fill UI.

**Files**

- New module: `mlflow/server/js/src/experiment-tracking/pages/playground/` (page, components, hooks, API client, types, test).
- Route registration: `mlflow/server/js/src/experiment-tracking/{route-defs.ts,routes.ts}`.
- Sidebar entry: `mlflow/server/js/src/common/components/MlflowSidebar.tsx`.
- i18n strings: `mlflow/server/js/src/lang/default/en.json`.
- Local dev helper: `dev/seed-playground.py` (creates a sample Anthropic endpoint + sample prompt against a running dev server).
- Docs: `docs/docs/genai/playground.mdx` (new top-level page in the GenAI sidebar), with cross-links from `docs/docs/genai/governance/ai-gateway/index.mdx` and `docs/docs/genai/prompt-registry/index.mdx`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New tests in `PlaygroundPage.test.tsx`:
- Smoke render: page header + empty-state output.
- Submit-disabled guard: stays disabled until both an endpoint and a non-empty message are set.
- Hook integration: `useChatCompletionMutation` posts the expected payload and the response renders.

Pre-merge checks all green: `yarn lint`, `yarn prettier:check`, `yarn type-check`, `yarn i18n:check`, `yarn test --testPathPattern playground`.

Manual: ran `dev/run-dev-server.sh`, used `dev/seed-playground.py` to seed an Anthropic endpoint + a chat-typed registered prompt, then exercised the UI end-to-end (pick endpoint → compose messages → submit → markdown response with token counts → load registered prompt → re-submit).

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Instructions

A new `docs/docs/genai/playground.mdx` page covers opening the Playground, picking an endpoint, composing messages with role explanations, loading from the Prompt Registry, reviewing output, and the v1 limitations. The doc is registered as a top-level entry in `sidebarsGenAI.ts`, and cross-links are added from the AI Gateway intro (as a `TileCard`) and the Prompt Registry intro (as a `:::tip` callout) so it's discoverable from both flows.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

This PR adds a UI surface only. No public Python or REST API contracts change.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Adds a new **LLM Playground** page that lets you test AI Gateway endpoints and Prompt Registry prompts interactively from the MLflow UI.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
