### PR TITLE
Fix #20479: PASS/FAIL does not have appropriate coloring

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/EvaluationsReviewAssessmentTag.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/EvaluationsReviewAssessmentTag.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect } from '@jest/globals';
+import { isAssessmentPassing } from './EvaluationsReviewAssessmentTag';
+import type { AssessmentInfo } from '../types';
+
+describe('isAssessmentPassing', () => {
+  const mockPassFailAssessment = { dtype: 'pass-fail' } as AssessmentInfo;
+  const mockBooleanAssessment = { dtype: 'boolean' } as AssessmentInfo;
+
+  it('should return true for YES and PASS values', () => {
+    expect(isAssessmentPassing(mockPassFailAssessment, 'yes')).toBe(true);
+    expect(isAssessmentPassing(mockPassFailAssessment, 'PASS')).toBe(true);
+  });
+
+  it('should return false for NO and FAIL values', () => {
+    expect(isAssessmentPassing(mockPassFailAssessment, 'no')).toBe(false);
+    expect(isAssessmentPassing(mockPassFailAssessment, 'FAIL')).toBe(false);
+  });
+
+  it('should return undefined for unrecognized values in pass-fail', () => {
+    expect(isAssessmentPassing(mockPassFailAssessment, 'maybe')).toBeUndefined();
+    expect(isAssessmentPassing(mockPassFailAssessment, null)).toBeUndefined();
+  });
+
+  it('should handle boolean dtypes correctly', () => {
+    expect(isAssessmentPassing(mockBooleanAssessment, true)).toBe(true);
+    expect(isAssessmentPassing(mockBooleanAssessment, false)).toBe(false);
+  });
+});

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/EvaluationsReviewAssessmentTag.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/EvaluationsReviewAssessmentTag.tsx
@@ -24,8 +24,11 @@ import { FormattedMessage, useIntl } from '@databricks/i18n';
 import {
   KnownEvaluationResultAssessmentValueLabel,
   KnownEvaluationResultAssessmentValueMapping,
+  normalizePassFailValue,
   getEvaluationResultAssessmentValue,
   hasBeenEditedByHuman,
+  isFailingValue,
+  isPassingValue,
   KnownEvaluationResultAssessmentStringValue,
   KnownEvaluationResultAssessmentValueMissingTooltip,
   ASSESSMENTS_DOC_LINKS,
@@ -46,9 +49,9 @@ export const isAssessmentPassing = (
 ) => {
   if (!isNil(assessmentValue)) {
     if (assessmentInfo.dtype === 'pass-fail') {
-      if (assessmentValue === KnownEvaluationResultAssessmentStringValue.YES) {
+      if (isPassingValue(assessmentValue)) {
         return true;
-      } else if (assessmentValue === KnownEvaluationResultAssessmentStringValue.NO) {
+      } else if (isFailingValue(assessmentValue)) {
         return false;
       }
     } else if (assessmentInfo.dtype === 'boolean') {
@@ -160,8 +163,13 @@ function getAssessmentTagDisplayValue(
       const knownMapping = KnownEvaluationResultAssessmentValueMapping[assessmentInfo.name];
 
       if (knownMapping) {
+        let lookupValue = KnownEvaluationResultAssessmentStringValue.YES;
+
+        if (value) {
+          lookupValue = normalizePassFailValue(value.toString()) as KnownEvaluationResultAssessmentStringValue;
+        }
         const messageDescriptor = value
-          ? (knownMapping[value.toString()] ?? knownMapping[KnownEvaluationResultAssessmentStringValue.YES])
+          ? (knownMapping[lookupValue] ?? knownMapping[KnownEvaluationResultAssessmentStringValue.YES])
           : knownMapping[KnownEvaluationResultAssessmentStringValue.YES];
         if (messageDescriptor) {
           tagText = <FormattedMessage {...messageDescriptor} values={{ value }} />;

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/GenAiEvaluationTracesReview.utils.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/GenAiEvaluationTracesReview.utils.test.ts
@@ -286,7 +286,17 @@ describe('EvaluationsReview utils', () => {
 
 describe('getAssessmentValueLabel', () => {
   const intl = I18nUtils.createIntlWithLocale();
-  const mockTheme = {} as ThemeType;
+  const mockTheme = {
+    isDarkMode: false,
+    colors: {
+      green400: '#green400',
+      green600: '#green600',
+      red400: '#red400',
+      red600: '#red600',
+      red200: '#red200',
+      red800: '#red800',
+    },
+  } as unknown as ThemeType;
 
   const createMockAssessmentInfo = (dtype: AssessmentInfo['dtype']): AssessmentInfo => ({
     name: 'test_assessment',
@@ -339,5 +349,28 @@ describe('getAssessmentValueLabel', () => {
     const stringAssessment = createMockAssessmentInfo('string');
     const result = getAssessmentValueLabel(intl, mockTheme, stringAssessment, 'custom_value');
     expect(result.content).toBe('custom_value');
+  });
+  it('should return "Pass" label and an icon for pass-fail dtype with YES or PASS value', () => {
+    const passFailAssessment = createMockAssessmentInfo('pass-fail');
+
+    const yesResult = getAssessmentValueLabel(intl, mockTheme, passFailAssessment, 'yes');
+    expect(yesResult.content).toBe('Pass');
+    expect(yesResult.icon).toBeDefined();
+
+    const passResult = getAssessmentValueLabel(intl, mockTheme, passFailAssessment, 'PASS');
+    expect(passResult.content).toBe('Pass');
+    expect(passResult.icon).toBeDefined();
+  });
+
+  it('should return "Fail" label and an icon for pass-fail dtype with NO or FAIL value', () => {
+    const passFailAssessment = createMockAssessmentInfo('pass-fail');
+
+    const noResult = getAssessmentValueLabel(intl, mockTheme, passFailAssessment, 'no');
+    expect(noResult.content).toBe('Fail');
+    expect(noResult.icon).toBeDefined();
+
+    const failResult = getAssessmentValueLabel(intl, mockTheme, passFailAssessment, 'FAIL');
+    expect(failResult.content).toBe('Fail');
+    expect(failResult.icon).toBeDefined();
   });
 });

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/GenAiEvaluationTracesReview.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/GenAiEvaluationTracesReview.utils.tsx
@@ -160,8 +160,38 @@ export const ASSESSMENTS_DOC_LINKS: Record<string, AssessmentLearnMoreLink> = {
 export enum KnownEvaluationResultAssessmentStringValue {
   YES = 'yes',
   NO = 'no',
+  PASS = 'PASS',
+  FAIL = 'FAIL',
   UNKNOWN = 'unknown',
 }
+
+export const normalizePassFailValue = (value: unknown): unknown => {
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  const normalizedValue = value.toUpperCase();
+  if (
+    normalizedValue === KnownEvaluationResultAssessmentStringValue.YES.toUpperCase() ||
+    normalizedValue === KnownEvaluationResultAssessmentStringValue.PASS
+  ) {
+    return KnownEvaluationResultAssessmentStringValue.YES;
+  }
+  if (
+    normalizedValue === KnownEvaluationResultAssessmentStringValue.NO.toUpperCase() ||
+    normalizedValue === KnownEvaluationResultAssessmentStringValue.FAIL
+  ) {
+    return KnownEvaluationResultAssessmentStringValue.NO;
+  }
+
+  return value;
+};
+
+export const isPassingValue = (value: unknown): boolean =>
+  normalizePassFailValue(value) === KnownEvaluationResultAssessmentStringValue.YES;
+
+export const isFailingValue = (value: unknown): boolean =>
+  normalizePassFailValue(value) === KnownEvaluationResultAssessmentStringValue.NO;
 
 export function getAssessmentValueLabel(
   intl: IntlShape,
@@ -179,7 +209,10 @@ export function getAssessmentValueLabel(
     };
   }
   if (assessmentInfo.dtype === 'pass-fail') {
-    if (value === KnownEvaluationResultAssessmentStringValue.YES) {
+    const normalizedPassFailValue = normalizePassFailValue(value);
+    const passFailStringValue = typeof normalizedPassFailValue === 'string' ? normalizedPassFailValue : String(value);
+
+    if (isPassingValue(normalizedPassFailValue)) {
       return {
         content: intl.formatMessage({
           defaultMessage: 'Pass',
@@ -189,7 +222,7 @@ export function getAssessmentValueLabel(
           <span
             css={{
               color: `${getEvaluationResultIconColor(theme, assessmentInfo, {
-                stringValue: KnownEvaluationResultAssessmentStringValue.YES,
+                stringValue: passFailStringValue,
               })} !important`,
               svg: {
                 width: '12px',
@@ -200,7 +233,7 @@ export function getAssessmentValueLabel(
             <CheckCircleIcon
               css={{
                 backgroundColor: getEvaluationResultAssessmentBackgroundColor(theme, assessmentInfo, {
-                  stringValue: KnownEvaluationResultAssessmentStringValue.YES,
+                  stringValue: passFailStringValue,
                 }),
                 borderRadius: '50%',
               }}
@@ -208,7 +241,7 @@ export function getAssessmentValueLabel(
           </span>
         ),
       };
-    } else if (value === KnownEvaluationResultAssessmentStringValue.NO) {
+    } else if (isFailingValue(normalizedPassFailValue)) {
       return {
         content: intl.formatMessage({
           defaultMessage: 'Fail',
@@ -218,7 +251,7 @@ export function getAssessmentValueLabel(
           <span
             css={{
               color: `${getEvaluationResultIconColor(theme, assessmentInfo, {
-                stringValue: KnownEvaluationResultAssessmentStringValue.NO,
+                stringValue: passFailStringValue,
               })} !important`,
               svg: {
                 width: '12px',
@@ -229,7 +262,7 @@ export function getAssessmentValueLabel(
             <XCircleIcon
               css={{
                 backgroundColor: getEvaluationResultAssessmentBackgroundColor(theme, assessmentInfo, {
-                  stringValue: KnownEvaluationResultAssessmentStringValue.NO,
+                  stringValue: passFailStringValue,
                 }),
                 borderRadius: '50%',
               }}

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/AggregationUtils.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/AggregationUtils.test.ts
@@ -1051,6 +1051,54 @@ describe('getBarChartData', () => {
       }),
     ]);
   });
+
+  it('normalizes PASS into yes and FAIL into no for pass-fail dtype', () => {
+    const mockAssessmentInfo = createMockAssessmentInfo('pass-fail', ['yes', 'no', 'PASS', 'FAIL']);
+
+    const displayInfoCounts: AssessmentAggregates = {
+      assessmentInfo: mockAssessmentInfo,
+      currentCounts: new Map([
+        ['yes', 2],
+        ['PASS', 1],
+        ['no', 1],
+        ['FAIL', 2],
+      ]),
+      currentNumRootCause: 0,
+      otherNumRootCause: 0,
+      assessmentFilters: [],
+    };
+
+    const result = getBarChartData(
+      intl,
+      mockTheme,
+      mockAssessmentInfo,
+      [],
+      jest.fn(),
+      displayInfoCounts,
+      'Current Run',
+    );
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        name: 'Pass',
+        current: expect.objectContaining({
+          value: 3,
+          fraction: 3 / 6,
+          tooltip: '3/6 for run "Current Run"',
+        }),
+        scoreChange: undefined,
+      }),
+      expect.objectContaining({
+        name: 'Fail',
+        current: expect.objectContaining({
+          value: 3,
+          fraction: 3 / 6,
+          tooltip: '3/6 for run "Current Run"',
+        }),
+        scoreChange: undefined,
+      }),
+    ]);
+  });
 });
 
 describe('getUniqueValueCountsBySourceId', () => {

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/AggregationUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/AggregationUtils.ts
@@ -12,9 +12,12 @@ import { DEFAULT_RUN_PLACEHOLDER_NAME } from './TraceUtils';
 import { isAssessmentPassing } from '../components/EvaluationsReviewAssessmentTag';
 import {
   ASSESSMENTS_DOC_LINKS,
+  normalizePassFailValue,
   DEFAULT_ASSESSMENTS_SORT_ORDER,
   getEvaluationResultAssessmentValue,
   getJudgeMetricsLink,
+  isFailingValue,
+  isPassingValue,
   KnownEvaluationResultAssessmentName,
   KnownEvaluationResultAssessmentStringValue,
   KnownEvaluationResultAssessmentValueDescription,
@@ -72,6 +75,8 @@ function getCustomMetricNameAndAssessment(assessmentPath: string): { metricName:
 const PASS_FAIL_VALUES: string[] = [
   KnownEvaluationResultAssessmentStringValue.YES,
   KnownEvaluationResultAssessmentStringValue.NO,
+  KnownEvaluationResultAssessmentStringValue.PASS,
+  KnownEvaluationResultAssessmentStringValue.FAIL,
 ];
 /**
  * Computes global metadata for each of the assessments.
@@ -590,16 +595,32 @@ export function getBarChartData(
 ): StackedBarchartItem[] {
   const showCompareData = displayInfoCounts.otherCounts !== undefined;
 
+  let currentCounts = displayInfoCounts.currentCounts;
+  let otherCounts = displayInfoCounts.otherCounts;
+  let keys = getBarChartKeys(assessmentInfo);
+
+  if (assessmentInfo.dtype === 'pass-fail') {
+    const mergeCounts = (counts?: AssessmentRunCounts): AssessmentRunCounts => {
+      return [...(counts?.entries() ?? [])].reduce<AssessmentRunCounts>((acc, [key, value]) => {
+        const mappedKey = normalizePassFailValue(key) as AssessmentValueType;
+        return acc.set(mappedKey, (acc.get(mappedKey) || 0) + value);
+      }, new Map());
+    };
+    currentCounts = mergeCounts(currentCounts);
+    otherCounts = mergeCounts(otherCounts);
+    keys = Array.from(new Set(keys.map((key) => normalizePassFailValue(key) as AssessmentValueType)));
+  }
+
   const barItems: StackedBarchartItem[] = [];
 
-  for (const value of getBarChartKeys(assessmentInfo)) {
-    const currentBarItem = displayInfoCounts.currentCounts
+  for (const value of keys) {
+    const currentBarItem = currentCounts
       ? getAssessmentBarChartValueBarItem(
           intl,
           assessmentInfo,
           assessmentFilters,
           value,
-          displayInfoCounts.currentCounts,
+          currentCounts,
           // For monitoring, there is no run name so we allow this to pass through.
           currentRunDisplayName || DEFAULT_RUN_PLACEHOLDER_NAME,
           toggleAssessmentFilter,
@@ -613,7 +634,7 @@ export function getBarChartData(
             assessmentInfo,
             assessmentFilters,
             value,
-            displayInfoCounts.otherCounts || new Map(),
+            otherCounts || new Map(),
             compareToRunDisplayName,
             toggleAssessmentFilter,
           )
@@ -680,12 +701,12 @@ function getAssessmentBarChartValueText(
   value: string | boolean | number | undefined,
 ): string {
   if (assessmentInfo.dtype === 'pass-fail') {
-    if (value === KnownEvaluationResultAssessmentStringValue.YES) {
+    if (isPassingValue(value)) {
       return intl.formatMessage({
         defaultMessage: 'Pass',
         description: 'The label for a passing asseessment above a bar-chart in the summary stats.',
       });
-    } else if (value === KnownEvaluationResultAssessmentStringValue.NO) {
+    } else if (isFailingValue(value)) {
       return intl.formatMessage({
         defaultMessage: 'Fail',
         description: 'The label for a failing asseessment above a bar-chart in the summary stats.',

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/Colors.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/Colors.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from '@jest/globals';
+import type { ThemeType } from '@databricks/design-system';
+import {
+  getEvaluationResultIconColor,
+  getEvaluationResultAssessmentBackgroundColor,
+  getEvaluationResultTextColor,
+  getAssessmentValueBarBackgroundColor,
+  PASS_BARCHART_BAR_COLOR,
+  FAIL_BARCHART_BAR_COLOR,
+} from './Colors';
+import type { AssessmentInfo } from '../types';
+
+describe('Colors utils - PASS/FAIL support', () => {
+  const mockTheme = {
+    isDarkMode: false,
+    colors: {
+      green600: 'mock-green-600',
+      red600: 'mock-red-600',
+      red200: 'mock-red-200',
+      grey400: 'mock-grey-400',
+      grey200: 'mock-grey-200',
+      textSecondary: 'mock-text-secondary',
+    },
+  } as unknown as ThemeType;
+
+  const mockAssessmentInfo = {
+    name: 'test_metric',
+    dtype: 'pass-fail',
+  } as AssessmentInfo;
+
+  describe('getEvaluationResultIconColor', () => {
+    it('should return green for YES and PASS', () => {
+      expect(getEvaluationResultIconColor(mockTheme, mockAssessmentInfo, { stringValue: 'yes' })).toBe(
+        'mock-green-600',
+      );
+      expect(getEvaluationResultIconColor(mockTheme, mockAssessmentInfo, { stringValue: 'PASS' })).toBe(
+        'mock-green-600',
+      );
+    });
+
+    it('should handle case-insensitive PASS/FAIL values', () => {
+      expect(getEvaluationResultIconColor(mockTheme, mockAssessmentInfo, { stringValue: 'pass' })).toBe(
+        'mock-green-600',
+      );
+      expect(getEvaluationResultIconColor(mockTheme, mockAssessmentInfo, { stringValue: 'fAiL' })).toBe('mock-red-600');
+    });
+
+    it('should return red for NO and FAIL', () => {
+      expect(getEvaluationResultIconColor(mockTheme, mockAssessmentInfo, { stringValue: 'no' })).toBe('mock-red-600');
+      expect(getEvaluationResultIconColor(mockTheme, mockAssessmentInfo, { stringValue: 'FAIL' })).toBe('mock-red-600');
+    });
+  });
+
+  describe('getEvaluationResultAssessmentBackgroundColor', () => {
+    const TAG_PASS_COLOR = '#02B30214';
+
+    it('should return PASS background color for YES and PASS', () => {
+      expect(getEvaluationResultAssessmentBackgroundColor(mockTheme, mockAssessmentInfo, { stringValue: 'yes' })).toBe(
+        TAG_PASS_COLOR,
+      );
+      expect(getEvaluationResultAssessmentBackgroundColor(mockTheme, mockAssessmentInfo, { stringValue: 'PASS' })).toBe(
+        TAG_PASS_COLOR,
+      );
+    });
+
+    it('should return FAIL background color for NO and FAIL', () => {
+      expect(getEvaluationResultAssessmentBackgroundColor(mockTheme, mockAssessmentInfo, { stringValue: 'no' })).toBe(
+        'mock-red-200',
+      );
+      expect(getEvaluationResultAssessmentBackgroundColor(mockTheme, mockAssessmentInfo, { stringValue: 'FAIL' })).toBe(
+        'mock-red-200',
+      );
+    });
+
+    it('should handle case-insensitive PASS/FAIL values', () => {
+      expect(getEvaluationResultAssessmentBackgroundColor(mockTheme, mockAssessmentInfo, { stringValue: 'PaSs' })).toBe(
+        TAG_PASS_COLOR,
+      );
+      expect(getEvaluationResultAssessmentBackgroundColor(mockTheme, mockAssessmentInfo, { stringValue: 'fail' })).toBe(
+        'mock-red-200',
+      );
+    });
+  });
+
+  describe('getEvaluationResultTextColor', () => {
+    it('should return green text for YES and PASS', () => {
+      expect(getEvaluationResultTextColor(mockTheme, mockAssessmentInfo, { stringValue: 'yes' })).toBe(
+        'mock-green-600',
+      );
+      expect(getEvaluationResultTextColor(mockTheme, mockAssessmentInfo, { stringValue: 'PASS' })).toBe(
+        'mock-green-600',
+      );
+    });
+
+    it('should return red text for NO and FAIL', () => {
+      expect(getEvaluationResultTextColor(mockTheme, mockAssessmentInfo, { stringValue: 'no' })).toBe('mock-red-600');
+      expect(getEvaluationResultTextColor(mockTheme, mockAssessmentInfo, { stringValue: 'FAIL' })).toBe('mock-red-600');
+    });
+
+    it('should handle case-insensitive PASS/FAIL values', () => {
+      expect(getEvaluationResultTextColor(mockTheme, mockAssessmentInfo, { stringValue: 'pass' })).toBe(
+        'mock-green-600',
+      );
+      expect(getEvaluationResultTextColor(mockTheme, mockAssessmentInfo, { stringValue: 'FaIl' })).toBe('mock-red-600');
+    });
+  });
+
+  describe('getAssessmentValueBarBackgroundColor', () => {
+    it('should return PASS bar chart color for YES and PASS', () => {
+      expect(getAssessmentValueBarBackgroundColor(mockTheme, mockAssessmentInfo, 'yes')).toBe(PASS_BARCHART_BAR_COLOR);
+      expect(getAssessmentValueBarBackgroundColor(mockTheme, mockAssessmentInfo, 'PASS')).toBe(PASS_BARCHART_BAR_COLOR);
+    });
+
+    it('should return FAIL bar chart color for NO and FAIL', () => {
+      expect(getAssessmentValueBarBackgroundColor(mockTheme, mockAssessmentInfo, 'no')).toBe(FAIL_BARCHART_BAR_COLOR);
+      expect(getAssessmentValueBarBackgroundColor(mockTheme, mockAssessmentInfo, 'FAIL')).toBe(FAIL_BARCHART_BAR_COLOR);
+    });
+
+    it('should handle case-insensitive PASS/FAIL values', () => {
+      expect(getAssessmentValueBarBackgroundColor(mockTheme, mockAssessmentInfo, 'pAsS')).toBe(PASS_BARCHART_BAR_COLOR);
+      expect(getAssessmentValueBarBackgroundColor(mockTheme, mockAssessmentInfo, 'fail')).toBe(FAIL_BARCHART_BAR_COLOR);
+    });
+  });
+});

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/Colors.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/Colors.ts
@@ -2,7 +2,7 @@ import { isNil } from 'lodash';
 
 import type { ThemeType } from '@databricks/design-system';
 
-import { KnownEvaluationResultAssessmentStringValue, withAlpha } from '../components/GenAiEvaluationTracesReview.utils';
+import { isFailingValue, isPassingValue, withAlpha } from '../components/GenAiEvaluationTracesReview.utils';
 import type { AssessmentInfo, AssessmentValueType, RunEvaluationResultAssessment } from '../types';
 
 // Taken from figma: https://www.figma.com/design/2B1KMp9x624WrxaASrSv9B/Tiles-UX?node-id=3205-87588&t=1MwrDNNRIOSODm4D-0
@@ -96,10 +96,10 @@ export const getEvaluationResultIconColor = (
 
   if (assessmentInfo.dtype === 'pass-fail') {
     // Return the color based on the assessment value
-    if (assessment?.stringValue === KnownEvaluationResultAssessmentStringValue.YES) {
+    if (isPassingValue(assessment?.stringValue)) {
       return theme.isDarkMode ? theme.colors.green400 : theme.colors.green600;
     }
-    if (assessment?.stringValue === KnownEvaluationResultAssessmentStringValue.NO) {
+    if (isFailingValue(assessment?.stringValue)) {
       return theme.isDarkMode ? theme.colors.red400 : theme.colors.red600;
     }
   }
@@ -122,10 +122,10 @@ export const getEvaluationResultAssessmentBackgroundColor = (
 
   if (assessmentInfo.dtype === 'pass-fail') {
     // Return the color based on the assessment value
-    if (assessment?.stringValue === KnownEvaluationResultAssessmentStringValue.YES) {
+    if (isPassingValue(assessment?.stringValue)) {
       return TAG_PASS_COLOR;
     }
-    if (assessment?.stringValue === KnownEvaluationResultAssessmentStringValue.NO) {
+    if (isFailingValue(assessment?.stringValue)) {
       return theme.isDarkMode ? withAlpha(theme.colors.red800, 0.6) : theme.colors.red200;
     }
     if (!iconOnly && assessment?.errorMessage) {
@@ -156,9 +156,9 @@ export const getEvaluationResultTextColor = (
 
   if (assessmentInfo.dtype === 'pass-fail') {
     // Return the color based on the assessment value
-    if (assessment?.stringValue === KnownEvaluationResultAssessmentStringValue.YES) {
+    if (isPassingValue(assessment?.stringValue)) {
       return theme.isDarkMode ? theme.colors.green400 : theme.colors.green600;
-    } else if (assessment?.stringValue === KnownEvaluationResultAssessmentStringValue.NO) {
+    } else if (isFailingValue(assessment?.stringValue)) {
       return theme.isDarkMode ? theme.colors.red400 : theme.colors.red600;
     } else {
       return theme.colors.textSecondary;
@@ -191,10 +191,10 @@ export const getAssessmentValueBarBackgroundColor = (
 
   if (assessmentInfo.dtype === 'pass-fail') {
     // Return the color based on the assessment value
-    if (assessmentValue === KnownEvaluationResultAssessmentStringValue.YES) {
+    if (isPassingValue(assessmentValue)) {
       return PASS_BARCHART_BAR_COLOR;
     }
-    if (assessmentValue === KnownEvaluationResultAssessmentStringValue.NO) {
+    if (isFailingValue(assessmentValue)) {
       return FAIL_BARCHART_BAR_COLOR;
     }
     return theme.isDarkMode ? theme.colors.grey800 : theme.colors.grey200;


### PR DESCRIPTION
Currently, the GenAI evaluations UI only has support for 'yes' and 'no' for pass-fail assessments. When models return 'PASS' or 'FAIL' the UI treats them as distinct categories, causing the bar char to fragment into redundant segments and lose theme styling.

This fix introduces a mapping layer that aggregates 'PASS' and 'FAIL' into a unified 'yes' and 'no' structure. This fix ensures correct theme colors are applied, accurate counts and prevents bar chart fragmentation. Test coverage was also added to ensure all this logic is correct.

<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #20479

### What changes are proposed in this pull request?

This pull request adds support for pass-fail assessments that return PASS and FAIL by normalizing them into the existing yes / no structure used by the GenAI evaluations UI. This prevents bar chart fragmentation and preserves the intended theme styling. Key changes include introducing the new normalizePassFailValue() function to map PASS to yes and FAIL to no and updating getBarChartData() to normalize pass-fail values before aggregating

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. It updates the GenAI evaluations UI to correctly handle PASS / FAIL pass-fail assessments, so the visible charts and labels change for users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
