### PR TITLE
Fix artifact image scaling in run comparison

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactImageView.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactImageView.enzyme.test.tsx
@@ -48,4 +48,34 @@ describe('ShowArtifactImageView', () => {
       done();
     });
   });
+
+  // eslint-disable-next-line jest/no-done-callback -- TODO(FEINF-1337)
+  test('should constrain image preview to its parent width', (done) => {
+    const getArtifact = jest.fn(() => Promise.resolve(new ArrayBuffer(8)));
+    wrapper = mount(<ShowArtifactImageView {...minimalProps} getArtifact={getArtifact} />);
+
+    setImmediate(() => {
+      try {
+        wrapper.update();
+        const image = wrapper.find('img[src="blob:abc-12345"]').at(0);
+        const imageWrapper = image.parent();
+
+        expect(imageWrapper.prop('css')).toEqual(
+          expect.objectContaining({
+            display: 'block',
+            width: '100%',
+          }),
+        );
+        expect(image.prop('css')).toEqual(
+          expect.objectContaining({
+            display: 'block',
+            maxWidth: '100%',
+          }),
+        );
+        done();
+      } catch (error) {
+        done(error);
+      }
+    });
+  });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactImageView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactImageView.tsx
@@ -86,13 +86,17 @@ const ShowArtifactImageView = ({
 const classNames = {
   imageOuterContainer: {
     padding: '10px',
-    overflow: 'scroll',
+    overflow: 'auto',
     // Let's keep images (esp. transparent PNGs) on the white background regardless of the theme
     background: 'white',
     minHeight: '100%',
   },
-  imageWrapper: { display: 'inline-block' },
+  imageWrapper: {
+    display: 'block',
+    width: '100%',
+  },
   image: {
+    display: 'block',
     maxWidth: '100%',
     height: 'auto',
     cursor: 'pointer',


### PR DESCRIPTION
### Related Issues/PRs

Closes #20703

### What changes are proposed in this pull request?

This fixes image previews in the run comparison artifact view so image artifacts scale to the width of their preview cell instead of forcing horizontal scrolling.

The image wrapper now fills the parent container, and the image is rendered as a block with `maxWidth: '100%'` so the preview is constrained by the parent frame.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added coverage to `ShowArtifactImageView.enzyme.test.tsx` for the image wrapper and image sizing styles.

Ran:

```text
node .\yarn\releases\yarn-4.12.0.cjs test src/experiment-tracking/components/artifact-view-components/ShowArtifactImageView.enzyme.test.tsx --watchAll=false --runInBand
```

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Image artifacts in the run comparison view now scale to their preview cell width, improving side by side artifact comparison.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release