### PR TITLE
Enh/num format

### DIFF
--- a/mlflow/server/js/src/common/utils/Utils.tsx
+++ b/mlflow/server/js/src/common/utils/Utils.tsx
@@ -88,17 +88,36 @@ class Utils {
   static pipeLineStepNameTag = 'mlflow.pipeline.step.name';
 
   static formatMetric(value: any) {
-    if (value === 0) {
-      return '0';
-    } else if (Math.abs(value) < 1e-3) {
-      return value.toExponential(3).toString();
-    } else if (Math.abs(value) < 10) {
-      return (Math.round(value * 1000) / 1000).toString();
-    } else if (Math.abs(value) < 100) {
-      return (Math.round(value * 100) / 100).toString();
-    } else {
-      return (Math.round(value * 10) / 10).toString();
+    if (value === 0) return '0';
+    if (value == null || !isFinite(value)) return String(value);
+
+    const abs = Math.abs(value);
+    const exponent = Math.floor(Math.log10(abs));
+    const sign = value < 0 ? '-' : '';
+
+    const groupInt = (s: string) => s.replace(/\B(?=(\d{3})+(?!\d))/g, ' ');
+    const groupFrac = (s: string) => s.replace(/(\d{3})(?=\d)/g, '$1 ');
+    const fmt = (n: number, decimals: number) => {
+      const fixed = n.toFixed(decimals);
+      const dot = fixed.indexOf('.');
+      if (dot === -1) return groupInt(fixed);
+      return groupInt(fixed.slice(0, dot)) + '.' + groupFrac(fixed.slice(dot + 1));
+    };
+
+    if (exponent >= -4 && exponent <= 4) {
+      // Normal range: 4 sig figs anchored to this value's own magnitude.
+      // If the value is an integer, show no decimal places.
+      const decimals = Number.isInteger(value) ? 0 : Math.max(0, 3 - exponent);
+      return sign + fmt(abs, decimals);
     }
+
+    // Extreme range: scaled notation, e.g. "1.234×10⁻⁶"
+    const toSup = (n: number) => {
+      const map: Record<string, string> = {'0':'⁰','1':'¹','2':'²','3':'³','4':'⁴','5':'⁵','6':'⁶','7':'⁷','8':'⁸','9':'⁹','-':'⁻'};
+      return String(n).split('').map((c) => map[c] ?? c).join('');
+    };
+    const scaled = abs / Math.pow(10, exponent);
+    return sign + fmt(scaled, 3) + '×10' + toSup(exponent);
   }
 
   /**

--- a/mlflow/server/js/src/experiment-tracking/components/DetailsOverviewParamsTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/DetailsOverviewParamsTable.tsx
@@ -23,6 +23,8 @@ import type { Interpolation, Theme } from '@emotion/react';
 import { ExpandedJSONValueCell } from '@mlflow/mlflow/src/common/components/ExpandableCell';
 import { isUnstableNestedComponentsMigrated } from '../../common/utils/FeatureUtils';
 import { useExperimentTrackingDetailsPageLayoutStyles } from '../hooks/useExperimentTrackingDetailsPageLayoutStyles';
+import Utils from '../../common/utils/Utils';
+import { useSmartNumberFormattingEnabled } from './experiment-page/utils/useSmartNumberFormatting';
 
 type ParamsColumnDef = ColumnDef<KeyValueEntity> & {
   meta?: { styles?: Interpolation<Theme>; multiline?: boolean };
@@ -45,8 +47,13 @@ const ExpandableParamValueCell = ({
   autoExpandedRowsList: Record<string, boolean>;
 }) => {
   const { theme } = useDesignSystemTheme();
+  const smartFormatting = useSmartNumberFormattingEnabled();
   const cellRef = useRef<HTMLDivElement>(null);
   const [isOverflowing, setIsOverflowing] = useState(false);
+
+  // Format numeric param values when smart formatting is on
+  const isNumeric = typeof value === 'string' && value !== '' && value !== '-' && !isNaN(Number(value.trim()));
+  const displayValue = smartFormatting && isNumeric ? Utils.formatMetric(Number(value.trim())) : value;
 
   useEffect(() => {
     if (autoExpandedRowsList[name]) {
@@ -109,7 +116,7 @@ const ExpandableParamValueCell = ({
         }}
         ref={cellRef}
       >
-        {isExpanded ? <ExpandedJSONValueCell value={value} /> : value}
+        {isExpanded ? <ExpandedJSONValueCell value={value} /> : displayValue}
       </div>
     </div>
   );

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTable.tsx
@@ -222,6 +222,7 @@ export const ExperimentViewRunsTable = React.memo(
       onDatasetSelected,
       expandRows,
       runsHiddenMode: uiState.runsHiddenMode,
+      rowsData,
     });
 
     const gridSizeHandler = useCallback(

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/cells/ColumnHeaderCell.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/cells/ColumnHeaderCell.tsx
@@ -9,6 +9,8 @@ export interface ColumnHeaderCellProps {
     orderByKey: string;
     orderByAsc: boolean;
   };
+  /** Optional scale annotation shown below the column name, e.g. "×10⁻⁶" */
+  headerAnnotation?: string;
 }
 
 export const ColumnHeaderCell = ({
@@ -16,6 +18,7 @@ export const ColumnHeaderCell = ({
   canonicalSortKey,
   displayName,
   context: tableContext,
+  headerAnnotation,
 }: ColumnHeaderCellProps) => {
   const { orderByKey, orderByAsc } = tableContext || {};
   const updateSearchFacets = useUpdateExperimentPageSearchFacets();
@@ -68,14 +71,31 @@ export const ColumnHeaderCell = ({
         className={selectedCanonicalSortKey === orderByKey ? isOrderedByClassName : ''}
         onClick={enableSorting ? handleSortBy : undefined}
       >
-        <span data-testid={`sort-header-${displayName}`}>{displayName}</span>
-        {enableSorting && selectedCanonicalSortKey === orderByKey ? (
-          orderByAsc ? (
-            <SortAscendingIcon />
-          ) : (
-            <SortDescendingIcon />
-          )
-        ) : null}
+        <div css={{ display: 'flex', flexDirection: 'column', overflow: 'hidden', minWidth: 0 }}>
+          <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm, overflow: 'hidden' }}>
+            <span
+              data-testid={`sort-header-${displayName}`}
+              css={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+            >
+              {displayName}
+            </span>
+            {enableSorting && selectedCanonicalSortKey === orderByKey ? (
+              orderByAsc ? <SortAscendingIcon /> : <SortDescendingIcon />
+            ) : null}
+          </div>
+          {headerAnnotation && (
+            <span
+              css={{
+                fontSize: 10,
+                lineHeight: 1,
+                color: theme.colors.textSecondary,
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {headerAnnotation}
+            </span>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.column-utils.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.column-utils.tsx
@@ -45,6 +45,7 @@ import { AggregateMetricValueCell } from '../components/runs/cells/AggregateMetr
 import { type RUNS_VISIBILITY_MODE } from '../models/ExperimentPageUIState';
 import { useMediaQuery } from '@databricks/web-shared/hooks';
 import { customMetricBehaviorDefs } from './customMetricBehaviorUtils';
+import { computeColumnFormatSpec } from './metricColumnFormat';
 
 const cellClassIsOrderedBy = ({ colDef, context }: CellClassParams) => {
   return context.orderByKey === colDef.headerComponentParams?.canonicalSortKey;
@@ -160,6 +161,8 @@ export interface UseRunsColumnDefinitionsParams {
   allRunsHidden?: boolean;
   usingCustomVisibility?: boolean;
   runsHiddenMode?: RUNS_VISIBILITY_MODE;
+  /** All current row data, used to compute per-column number format specs. */
+  rowsData?: RunRowType[];
 }
 
 /**
@@ -249,6 +252,7 @@ export const useRunsColumnDefinitions = ({
   isComparingRuns,
   expandRows,
   runsHiddenMode,
+  rowsData,
 }: UseRunsColumnDefinitionsParams) => {
   const { theme } = useDesignSystemTheme();
 
@@ -460,6 +464,12 @@ export const useRunsColumnDefinitions = ({
           const displayName = customMetricColumnDef?.displayName ?? metricKey;
           const fieldName = createMetricFieldName(metricKey);
           const tooltip = getQualifiedEntityName(COLUMN_TYPES.METRICS, metricKey);
+
+          // Compute a column-aware format spec from all current row values.
+          // Falls back gracefully when rowsData is empty (e.g. before data loads).
+          const columnValues = (rowsData ?? []).map((row) => row[fieldName] as number | undefined | null);
+          const formatSpec = computeColumnFormatSpec(columnValues);
+
           return {
             headerName: displayName,
             colId: canonicalSortKey,
@@ -473,8 +483,9 @@ export const useRunsColumnDefinitions = ({
             sortable: true,
             headerComponentParams: {
               canonicalSortKey,
+              headerAnnotation: formatSpec.headerAnnotation,
             },
-            valueFormatter: customMetricColumnDef?.valueFormatter ?? (({ value }) => value !== undefined ? Utils.formatMetric(value) : ''),
+            valueFormatter: customMetricColumnDef?.valueFormatter ?? (({ value }) => formatSpec.format(value)),
             cellRendererSelector: ({ data: { groupParentInfo } }) =>
               groupParentInfo ? { component: 'AggregateMetricValueCell' } : undefined,
             cellClassRules: {
@@ -545,6 +556,7 @@ export const useRunsColumnDefinitions = ({
     onDatasetSelected,
     expandRows,
     usingCompactViewport,
+    rowsData,
   ]);
 
   const canonicalSortKeys = useMemo(

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.column-utils.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.column-utils.tsx
@@ -504,18 +504,40 @@ export const useRunsColumnDefinitions = ({
         groupId: COLUMN_TYPES.PARAMS,
         children: paramKeys.map((paramKey) => {
           const canonicalSortKey = makeCanonicalSortKey(COLUMN_TYPES.PARAMS, paramKey);
+          const fieldName = createParamFieldName(paramKey);
+
+          // Detect whether every non-empty value in this column is a valid number.
+          // We use Number() rather than parseFloat() so that "123abc" is rejected.
+          const rawValues = (rowsData ?? []).map((row) => row[fieldName]);
+          // '-' is the default placeholder for runs that don't have this param — exclude it
+          const nonEmpty = rawValues.filter((v): v is string => typeof v === 'string' && v !== '' && v !== '-');
+          const isNumericColumn =
+            nonEmpty.length > 0 && nonEmpty.every((v) => !isNaN(Number(v.trim())));
+
+          const numericFormatSpec = isNumericColumn
+            ? computeColumnFormatSpec(nonEmpty.map((v) => Number(v.trim())))
+            : null;
+
           return {
             colId: canonicalSortKey,
             headerName: paramKey,
             headerTooltip: getQualifiedEntityName(COLUMN_TYPES.PARAMS, paramKey),
-            field: createParamFieldName(paramKey),
-            tooltipField: createParamFieldName(paramKey),
+            field: fieldName,
+            tooltipField: fieldName,
             initialHide: true,
             initialWidth: 100,
             sortable: true,
             headerComponentParams: {
               canonicalSortKey,
+              headerAnnotation: numericFormatSpec?.headerAnnotation,
             },
+            ...(numericFormatSpec && {
+              valueFormatter: ({ value }) => {
+                if (value == null || value === '' || value === '-') return value ?? '';
+                const n = Number(String(value).trim());
+                return isNaN(n) ? String(value) : numericFormatSpec.format(n);
+              },
+            }),
             cellClassRules: {
               'is-previewable-cell': () => true,
               'is-ordered-by': cellClassIsOrderedBy,

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.column-utils.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.column-utils.tsx
@@ -46,6 +46,7 @@ import { type RUNS_VISIBILITY_MODE } from '../models/ExperimentPageUIState';
 import { useMediaQuery } from '@databricks/web-shared/hooks';
 import { customMetricBehaviorDefs } from './customMetricBehaviorUtils';
 import { computeColumnFormatSpec } from './metricColumnFormat';
+import { useSmartNumberFormattingEnabled } from './useSmartNumberFormatting';
 
 const cellClassIsOrderedBy = ({ colDef, context }: CellClassParams) => {
   return context.orderByKey === colDef.headerComponentParams?.canonicalSortKey;
@@ -255,6 +256,7 @@ export const useRunsColumnDefinitions = ({
   rowsData,
 }: UseRunsColumnDefinitionsParams) => {
   const { theme } = useDesignSystemTheme();
+  const smartFormatting = useSmartNumberFormattingEnabled();
 
   const cumulativeColumns = useCumulativeColumnKeys({
     metricKeyList,
@@ -468,7 +470,7 @@ export const useRunsColumnDefinitions = ({
           // Compute a column-aware format spec from all current row values.
           // Falls back gracefully when rowsData is empty (e.g. before data loads).
           const columnValues = (rowsData ?? []).map((row) => row[fieldName] as number | undefined | null);
-          const formatSpec = computeColumnFormatSpec(columnValues);
+          const formatSpec = smartFormatting ? computeColumnFormatSpec(columnValues) : null;
 
           return {
             headerName: displayName,
@@ -483,9 +485,9 @@ export const useRunsColumnDefinitions = ({
             sortable: true,
             headerComponentParams: {
               canonicalSortKey,
-              headerAnnotation: formatSpec.headerAnnotation,
+              headerAnnotation: formatSpec?.headerAnnotation,
             },
-            valueFormatter: customMetricColumnDef?.valueFormatter ?? (({ value }) => formatSpec.format(value)),
+            valueFormatter: customMetricColumnDef?.valueFormatter ?? (formatSpec ? ({ value }) => formatSpec.format(value) : undefined),
             cellRendererSelector: ({ data: { groupParentInfo } }) =>
               groupParentInfo ? { component: 'AggregateMetricValueCell' } : undefined,
             cellClassRules: {
@@ -514,7 +516,7 @@ export const useRunsColumnDefinitions = ({
           const isNumericColumn =
             nonEmpty.length > 0 && nonEmpty.every((v) => !isNaN(Number(v.trim())));
 
-          const numericFormatSpec = isNumericColumn
+          const numericFormatSpec = smartFormatting && isNumericColumn
             ? computeColumnFormatSpec(nonEmpty.map((v) => Number(v.trim())))
             : null;
 
@@ -579,6 +581,7 @@ export const useRunsColumnDefinitions = ({
     expandRows,
     usingCompactViewport,
     rowsData,
+    smartFormatting,
   ]);
 
   const canonicalSortKeys = useMemo(

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.column-utils.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.column-utils.tsx
@@ -474,7 +474,7 @@ export const useRunsColumnDefinitions = ({
             headerComponentParams: {
               canonicalSortKey,
             },
-            valueFormatter: customMetricColumnDef?.valueFormatter,
+            valueFormatter: customMetricColumnDef?.valueFormatter ?? (({ value }) => value !== undefined ? Utils.formatMetric(value) : ''),
             cellRendererSelector: ({ data: { groupParentInfo } }) =>
               groupParentInfo ? { component: 'AggregateMetricValueCell' } : undefined,
             cellClassRules: {

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/metricColumnFormat.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/metricColumnFormat.ts
@@ -1,0 +1,119 @@
+/**
+ * Column-aware metric number formatting.
+ *
+ * The core idea: all values in a metric column share one format spec, derived
+ * from the column's maximum absolute value. This keeps numbers visually comparable
+ * column-by-column without needing to inspect exponents per row.
+ *
+ * Formatting rules:
+ * - 4 significant figures, anchored to the largest value in the column
+ * - Digit groups separated by spaces on both sides of the decimal point
+ *   (e.g. "0.000 001 234", "1 234 567")
+ * - For "normal" magnitudes (|exponent| ≤ 6): plain decimal with space grouping
+ * - For extreme magnitudes: mantissa scaled to [1, 10) range, with a header
+ *   annotation ("×10ⁿ") indicating the shared exponent
+ * - Zero is always "0"
+ * - Negative values get a leading "−"
+ */
+
+/** Groups an integer string from the right in threes: "1234567" → "1 234 567" */
+function groupIntegerDigits(s: string): string {
+  return s.replace(/\B(?=(\d{3})+(?!\d))/g, ' ');
+}
+
+/** Groups a fractional digit string from the left in threes: "000001234" → "000 001 234" */
+function groupFractionalDigits(s: string): string {
+  return s.replace(/(\d{3})(?=\d)/g, '$1 ');
+}
+
+function formatNumber(abs: number, decimalPlaces: number): string {
+  const fixed = abs.toFixed(decimalPlaces);
+  const dotIndex = fixed.indexOf('.');
+  if (dotIndex === -1) {
+    return groupIntegerDigits(fixed);
+  }
+  const intPart = fixed.slice(0, dotIndex);
+  const fracPart = fixed.slice(dotIndex + 1);
+  return groupIntegerDigits(intPart) + '.' + groupFractionalDigits(fracPart);
+}
+
+function toSuperscript(n: number): string {
+  const map: Record<string, string> = {
+    '0': '⁰', '1': '¹', '2': '²', '3': '³', '4': '⁴',
+    '5': '⁵', '6': '⁶', '7': '⁷', '8': '⁸', '9': '⁹', '-': '⁻',
+  };
+  return String(n).split('').map((c) => map[c] ?? c).join('');
+}
+
+export interface ColumnFormatSpec {
+  /** Format a single cell value for display. Returns '' for null/undefined. */
+  format: (value: number | undefined | null) => string;
+  /**
+   * If set, render this string below the column name in the header.
+   * Indicates a shared scale factor, e.g. "×10⁻⁶".
+   */
+  headerAnnotation?: string;
+}
+
+/**
+ * Compute a format spec for a metric column from all its values.
+ *
+ * Pass the full list of values (including undefined/null for runs that don't
+ * have the metric). The returned spec should be reused for every cell in the
+ * column so all numbers are formatted consistently.
+ */
+export function computeColumnFormatSpec(values: (number | undefined | null)[]): ColumnFormatSpec {
+  const finite = values.filter((v): v is number => typeof v === 'number' && isFinite(v));
+
+  // Fallback for empty / all-undefined columns
+  if (finite.length === 0) {
+    return {
+      format: (v) => (v != null ? String(v) : ''),
+    };
+  }
+
+  const maxAbs = Math.max(...finite.map(Math.abs));
+
+  if (maxAbs === 0) {
+    return { format: (v) => (v != null ? '0' : '') };
+  }
+
+  const exponent = Math.floor(Math.log10(maxAbs));
+
+  if (exponent >= -4 && exponent <= 4) {
+    // Normal magnitude: fixed decimal, same number of places across the column.
+    // decimalPlaces chosen so the largest value shows 4 significant figures.
+    let decimalPlaces = Math.max(0, 3 - exponent);
+
+    // Drop to zero decimal places only if no value in the column actually has
+    // a fractional part at this precision — i.e. every value rounds to itself
+    // with zero decimals. This correctly handles zeros and whole-number columns.
+    if (decimalPlaces > 0 && finite.every((v) => parseFloat(v.toFixed(decimalPlaces)) === Math.round(v))) {
+      decimalPlaces = 0;
+    }
+
+    return {
+      format: (v) => {
+        if (v == null) return '';
+        if (!isFinite(v)) return String(v);
+        const formatted = formatNumber(Math.abs(v), decimalPlaces);
+        return v < 0 ? '-' + formatted : formatted;
+      },
+    };
+  }
+
+  // Extreme magnitude: scale to [1, 10) and annotate the header.
+  const scale = Math.pow(10, exponent);
+  const headerAnnotation = '×10' + toSuperscript(exponent);
+  return {
+    format: (v) => {
+      if (v == null) return '';
+      if (v === 0) return '0'; // zero has no magnitude to scale, always display as-is
+      if (!isFinite(v)) return String(v);
+      const scaled = Math.abs(v) / scale;
+      const formatted = formatNumber(scaled, 3);
+      return v < 0 ? '-' + formatted : formatted;
+    },
+    headerAnnotation,
+  };
+}

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/useSmartNumberFormatting.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/useSmartNumberFormatting.ts
@@ -1,0 +1,18 @@
+import { useLocalStorage } from '@databricks/web-shared/hooks';
+
+export const SMART_NUMBER_FORMATTING_KEY = 'mlflow.settings.smartNumberFormatting';
+export const SMART_NUMBER_FORMATTING_VERSION = 1;
+
+/**
+ * Returns whether column-aware smart number formatting is enabled.
+ * Reads from localStorage so it stays in sync with the Settings page toggle.
+ * Defaults to true (enabled).
+ */
+export const useSmartNumberFormattingEnabled = (): boolean => {
+  const [isEnabled] = useLocalStorage({
+    key: SMART_NUMBER_FORMATTING_KEY,
+    version: SMART_NUMBER_FORMATTING_VERSION,
+    initialValue: true,
+  });
+  return isEnabled ?? true;
+};

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewMetricsTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewMetricsTable.tsx
@@ -24,6 +24,8 @@ import { flexRender, getCoreRowModel } from '@tanstack/react-table';
 import type { UseGetRunQueryResponseRunInfo } from '../hooks/useGetRunQuery';
 import { isUndefined } from 'lodash';
 import { useExperimentTrackingDetailsPageLayoutStyles } from '../../../hooks/useExperimentTrackingDetailsPageLayoutStyles';
+import Utils from '../../../../common/utils/Utils';
+import { useSmartNumberFormattingEnabled } from '../../experiment-page/utils/useSmartNumberFormatting';
 
 const { systemMetricsLabel, modelMetricsLabel } = defineMessages({
   systemMetricsLabel: {
@@ -57,6 +59,7 @@ const RunViewMetricsTableSection = ({
   table: TableDef<MetricEntityWithLoggedModels>;
 }) => {
   const { theme } = useDesignSystemTheme();
+  const smartFormatting = useSmartNumberFormattingEnabled();
   const [{ column: keyColumn }, ...otherColumns] = table.getLeafHeaders();
 
   const valueColumn = otherColumns.find((column) => column.id === 'value')?.column;
@@ -104,7 +107,7 @@ const RunViewMetricsTableSection = ({
                 flex: valueColumn?.getCanResize() ? valueColumn.getSize() / 100 : undefined,
               }}
             >
-              {value.toString()}
+              {smartFormatting ? Utils.formatMetric(value) : value.toString()}
             </TableCell>
             {anyRowHasModels && (
               <TableCell

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsTooltipBody.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsTooltipBody.tsx
@@ -47,7 +47,7 @@ const createBarChartValuesBox = (cardConfig: RunsChartsBarCardConfig, activeRun:
       if (!metric) return null;
       const customMetricBehaviorDef = customMetricBehaviorDefs[metric.key];
       const displayName = customMetricBehaviorDef?.displayName ?? metric.key;
-      const displayValue = customMetricBehaviorDef?.valueFormatter({ value: metric.value }) ?? metric.value;
+      const displayValue = customMetricBehaviorDef?.valueFormatter({ value: metric.value }) ?? Utils.formatMetric(metric.value);
       return { displayName, displayValue };
     })
     .filter(Boolean);
@@ -75,9 +75,11 @@ const createScatterChartValuesBox = (cardConfig: RunsChartsScatterCardConfig, ac
   const xLabel = xaxis.key;
   const yLabel = yaxis.key;
 
-  const xValue = xaxis.type === 'METRIC' ? activeRun.metrics[xKey]?.value : activeRun.params[xKey]?.value;
+  const xRaw = xaxis.type === 'METRIC' ? activeRun.metrics[xKey]?.value : activeRun.params[xKey]?.value;
+  const yRaw = yaxis.type === 'METRIC' ? activeRun.metrics[yKey]?.value : activeRun.params[yKey]?.value;
 
-  const yValue = yaxis.type === 'METRIC' ? activeRun.metrics[yKey]?.value : activeRun.params[yKey]?.value;
+  const xValue = xaxis.type === 'METRIC' && xRaw !== undefined ? Utils.formatMetric(xRaw) : xRaw;
+  const yValue = yaxis.type === 'METRIC' && yRaw !== undefined ? Utils.formatMetric(yRaw) : yRaw;
 
   return (
     <>
@@ -101,11 +103,13 @@ const createContourChartValuesBox = (cardConfig: RunsChartsContourCardConfig, ac
   const yKey = yaxis.key;
   const zKey = zaxis.key;
 
-  const xValue = xaxis.type === 'METRIC' ? activeRun.metrics[xKey]?.value : activeRun.params[xKey]?.value;
+  const xRaw = xaxis.type === 'METRIC' ? activeRun.metrics[xKey]?.value : activeRun.params[xKey]?.value;
+  const yRaw = yaxis.type === 'METRIC' ? activeRun.metrics[yKey]?.value : activeRun.params[yKey]?.value;
+  const zRaw = zaxis.type === 'METRIC' ? activeRun.metrics[zKey]?.value : activeRun.params[zKey]?.value;
 
-  const yValue = yaxis.type === 'METRIC' ? activeRun.metrics[yKey]?.value : activeRun.params[yKey]?.value;
-
-  const zValue = zaxis.type === 'METRIC' ? activeRun.metrics[zKey]?.value : activeRun.params[zKey]?.value;
+  const xValue = xaxis.type === 'METRIC' && xRaw !== undefined ? Utils.formatMetric(xRaw) : xRaw;
+  const yValue = yaxis.type === 'METRIC' && yRaw !== undefined ? Utils.formatMetric(yRaw) : yRaw;
+  const zValue = zaxis.type === 'METRIC' && zRaw !== undefined ? Utils.formatMetric(zRaw) : zRaw;
 
   return (
     <>
@@ -170,7 +174,7 @@ const createLineChartValuesBox = (
         </div>
       )}
       <div css={styles.value}>
-        <strong>{metricKey}:</strong> {metricValue}
+        <strong>{metricKey}:</strong> {Utils.formatMetric(metricValue)}
       </div>
     </>
   );
@@ -198,7 +202,7 @@ const createParallelChartValuesBox = (
     if (metric) {
       return (
         <div key={metricKey}>
-          <strong>{metric.key}:</strong> {metric.value}
+          <strong>{metric.key}:</strong> {Utils.formatMetric(metric.value)}
         </div>
       );
     }

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsMetricsBarPlot.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsMetricsBarPlot.tsx
@@ -21,6 +21,7 @@ import RunsMetricsLegendWrapper from './RunsMetricsLegendWrapper';
 import { createChartImageDownloadHandler } from '../hooks/useChartImageDownloadHandler';
 import { customMetricBehaviorDefs } from '../../experiment-page/utils/customMetricBehaviorUtils';
 import { RunsChartCardLoadingPlaceholder } from './cards/ChartCard.common';
+import Utils from '../../../../common/utils/Utils';
 
 // We're not using params in bar plot
 export type BarPlotRunData = Omit<RunsChartsRunData, 'params' | 'tags' | 'images'>;
@@ -95,7 +96,7 @@ const Y_AXIS_PARAMS = {
   fixedrange: true,
 };
 
-const getFixedPointValue = (val: string | number, places = 2) => (typeof val === 'number' ? val.toFixed(places) : val);
+const getFixedPointValue = (val: string | number): string => (typeof val === 'number' ? Utils.formatMetric(val) : val);
 
 /**
  * Highlight function for multi-metric grouped bar charts.

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsMetricsLinePlot.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsMetricsLinePlot.tsx
@@ -6,6 +6,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
 import type { MetricEntity } from '../../../types';
 import { LazyPlot } from '../../LazyPlot';
+import { computeColumnFormatSpec, type ColumnFormatSpec } from '../../experiment-page/utils/metricColumnFormat';
 import { useMutableChartHoverCallback } from '../hooks/useMutableHoverCallback';
 import { highlightLineTraces, useRenderRunsChartTraceHighlight } from '../hooks/useRunsChartTraceHighlight';
 import type { RunsChartsRunData, RunsPlotsCommonProps } from './RunsCharts.common';
@@ -306,6 +307,8 @@ export interface RunsCompareMultipleTracesTooltipData {
   xAxisKey: RunsChartsLineChartXAxisType;
   xAxisKeyLabel: string;
   hoveredDataPoint?: RunsMetricsSingleTraceTooltipData;
+  /** Pre-computed format spec derived from all y-values in the chart (all steps/traces). */
+  formatSpec?: ColumnFormatSpec;
 }
 
 export interface RunsMetricsLinePlotProps extends RunsPlotsCommonProps {
@@ -779,6 +782,13 @@ export const RunsMetricsLinePlot = React.memo(
       [runsData, selectedMetricKeys, metricKey, yAxisKey, yAxisExpressions, getNodeLevelCustomLineStyle],
     );
 
+    // Compute a format spec from ALL y-values across every trace so the tooltip
+    // uses consistent formatting even at steps where every run happens to be 0.
+    const globalFormatSpec = useMemo(() => {
+      const allYValues = plotData.flatMap((trace) => trace.y ?? []) as (number | undefined | null)[];
+      return computeColumnFormatSpec(allYValues);
+    }, [plotData]);
+
     const {
       scanlineElement,
       initHandler,
@@ -797,6 +807,7 @@ export const RunsMetricsLinePlot = React.memo(
       xAxisScaleType: xAxisKey === RunsChartsLineChartXAxisType.STEP ? xAxisScaleType : 'linear',
       setHoveredPointIndex,
       positionInSection,
+      globalFormatSpec,
     });
 
     /**

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsMultipleTracesTooltipBody.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsMultipleTracesTooltipBody.tsx
@@ -1,6 +1,7 @@
 import { isUndefined } from 'lodash';
 import Utils from '../../../../common/utils/Utils';
 import { computeColumnFormatSpec } from '../../experiment-page/utils/metricColumnFormat';
+import { useSmartNumberFormattingEnabled } from '../../experiment-page/utils/useSmartNumberFormatting';
 
 import type { RunsCompareMultipleTracesTooltipData } from './RunsMetricsLinePlot';
 import React from 'react';
@@ -42,6 +43,7 @@ export const RunsMultipleTracesTooltipBody = ({ hoverData }: { hoverData: RunsCo
 
   const intl = useIntl();
   const { theme } = useDesignSystemTheme();
+  const smartFormatting = useSmartNumberFormattingEnabled();
 
   const hoveredTraceUuid = `${runUuid}.${metricEntity?.key}`;
   const displayedXValueLabel =
@@ -54,7 +56,9 @@ export const RunsMultipleTracesTooltipBody = ({ hoverData }: { hoverData: RunsCo
     // so that formatting is consistent even at steps where every visible value happens to be 0.
     // Fall back to computing from just the visible step's values when no global spec is available.
     const allValues = tooltipLegendItems.map((item) => item.value).filter((v): v is number => typeof v === 'number');
-    const formatSpec = hoverData.formatSpec ?? computeColumnFormatSpec(allValues);
+    const formatSpec = smartFormatting
+      ? (hoverData.formatSpec ?? computeColumnFormatSpec(allValues))
+      : null;
 
     return (
       <div>
@@ -80,7 +84,7 @@ export const RunsMultipleTracesTooltipBody = ({ hoverData }: { hoverData: RunsCo
             alignItems: 'center',
           }}
         >
-          {formatSpec.headerAnnotation && (
+          {formatSpec?.headerAnnotation && (
             <>
               <span />
               <span />
@@ -116,7 +120,7 @@ export const RunsMultipleTracesTooltipBody = ({ hoverData }: { hoverData: RunsCo
                       color: hoveredTraceUuid === uuid ? 'unset' : theme.colors.textPlaceholder,
                     }}
                   >
-                    {formatSpec.format(value)}
+                    {formatSpec ? formatSpec.format(value) : Utils.formatMetric(value)}
                   </span>
                 )}
               </div>

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsMultipleTracesTooltipBody.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsMultipleTracesTooltipBody.tsx
@@ -1,5 +1,6 @@
 import { isUndefined } from 'lodash';
 import Utils from '../../../../common/utils/Utils';
+import { computeColumnFormatSpec } from '../../experiment-page/utils/metricColumnFormat';
 
 import type { RunsCompareMultipleTracesTooltipData } from './RunsMetricsLinePlot';
 import React from 'react';
@@ -49,6 +50,12 @@ export const RunsMultipleTracesTooltipBody = ({ hoverData }: { hoverData: RunsCo
       : intl.formatMessage(getChartAxisLabelDescriptor(hoverData.xAxisKey));
 
   if (tooltipLegendItems) {
+    // Prefer the pre-computed spec (derived from ALL y-values in the chart, across all steps)
+    // so that formatting is consistent even at steps where every visible value happens to be 0.
+    // Fall back to computing from just the visible step's values when no global spec is available.
+    const allValues = tooltipLegendItems.map((item) => item.value).filter((v): v is number => typeof v === 'number');
+    const formatSpec = hoverData.formatSpec ?? computeColumnFormatSpec(allValues);
+
     return (
       <div>
         {!isUndefined(xValue) && (
@@ -73,6 +80,21 @@ export const RunsMultipleTracesTooltipBody = ({ hoverData }: { hoverData: RunsCo
             alignItems: 'center',
           }}
         >
+          {formatSpec.headerAnnotation && (
+            <>
+              <span />
+              <span />
+              <span
+                css={{
+                  fontSize: theme.typography.fontSizeSm,
+                  color: theme.colors.textSecondary,
+                  textAlign: 'right',
+                }}
+              >
+                {formatSpec.headerAnnotation}
+              </span>
+            </>
+          )}
           {tooltipLegendItems.map(({ displayName, color, uuid, value, dashStyle }) => (
             <React.Fragment key={uuid}>
               <TraceLabelColorIndicator color={color || 'transparent'} dashStyle={dashStyle} />
@@ -94,7 +116,7 @@ export const RunsMultipleTracesTooltipBody = ({ hoverData }: { hoverData: RunsCo
                       color: hoveredTraceUuid === uuid ? 'unset' : theme.colors.textPlaceholder,
                     }}
                   >
-                    {Utils.formatMetric(value)}
+                    {formatSpec.format(value)}
                   </span>
                 )}
               </div>

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsMultipleTracesTooltipBody.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsMultipleTracesTooltipBody.tsx
@@ -1,4 +1,5 @@
 import { isUndefined } from 'lodash';
+import Utils from '../../../../common/utils/Utils';
 
 import type { RunsCompareMultipleTracesTooltipData } from './RunsMetricsLinePlot';
 import React from 'react';
@@ -93,7 +94,7 @@ export const RunsMultipleTracesTooltipBody = ({ hoverData }: { hoverData: RunsCo
                       color: hoveredTraceUuid === uuid ? 'unset' : theme.colors.textPlaceholder,
                     }}
                   >
-                    {value}
+                    {Utils.formatMetric(value)}
                   </span>
                 )}
               </div>

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/hooks/useRunsChartsMultipleTracesTooltip.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/hooks/useRunsChartsMultipleTracesTooltip.tsx
@@ -9,6 +9,7 @@ import type {
 import { compact, isNumber, isString, isUndefined, orderBy, throttle, uniq } from 'lodash';
 import type { LegendLabelData } from '../components/RunsMetricsLegend';
 import type { RunsChartsLineChartXAxisType } from '../components/RunsCharts.common';
+import type { ColumnFormatSpec } from '../../experiment-page/utils/metricColumnFormat';
 
 // Plotly-specific selectors for finding particular elements of interest in the plot DOM structure
 const PLOTLY_SVG_SELECTOR = '.main-svg';
@@ -47,6 +48,7 @@ export const useRunsMultipleTracesTooltipData = ({
   setHoveredPointIndex,
   xAxisScaleType = 'linear',
   positionInSection = 0,
+  globalFormatSpec,
 }: Pick<RunsMetricsLinePlotProps, 'runsData' | 'onHover' | 'onUnhover'> & {
   plotData: LineChartTraceData[];
   legendLabelData: LegendLabelData[];
@@ -57,6 +59,7 @@ export const useRunsMultipleTracesTooltipData = ({
   setHoveredPointIndex: (value: number) => void;
   xAxisScaleType?: 'linear' | 'log';
   positionInSection?: number;
+  globalFormatSpec?: ColumnFormatSpec;
 }) => {
   // Save current boundaries/dimensions of the plot in the mutable ref object
   const chartBoundaries = useRef<{
@@ -102,6 +105,7 @@ export const useRunsMultipleTracesTooltipData = ({
   const immediatePlotData = useRef(plotData);
   const immediateXValuesData = useRef(visibleXValues);
   const immediateFigure = useRef(initializedFigure);
+  const immediateFormatSpec = useRef(globalFormatSpec);
 
   // Update the mutable ref objects when the input data changes
   immediateLegendLabelData.current = legendLabelData;
@@ -109,6 +113,7 @@ export const useRunsMultipleTracesTooltipData = ({
   immediatePlotData.current = plotData;
   immediateXValuesData.current = visibleXValues;
   immediateFigure.current = initializedFigure;
+  immediateFormatSpec.current = globalFormatSpec;
 
   // Setup the boundaries of the plot
   const setupBoundaries = useCallback((figure: Readonly<Figure>) => {
@@ -324,6 +329,7 @@ export const useRunsMultipleTracesTooltipData = ({
           xValue: closestXValue,
           xAxisKey,
           xAxisKeyLabel,
+          formatSpec: immediateFormatSpec.current,
         };
       },
       TOOLTIP_DATA_UPDATE_INTERVAL,

--- a/mlflow/server/js/src/settings/SettingsPage.tsx
+++ b/mlflow/server/js/src/settings/SettingsPage.tsx
@@ -7,6 +7,10 @@ import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react
 import { fetchEndpointRaw, HTTPMethods } from '../common/utils/FetchUtils';
 import { useLocation, useNavigate, useParams } from '../common/utils/RoutingUtils';
 import { useDarkThemeContext } from '../common/contexts/DarkThemeContext';
+import {
+  SMART_NUMBER_FORMATTING_KEY,
+  SMART_NUMBER_FORMATTING_VERSION,
+} from '../experiment-tracking/components/experiment-page/utils/useSmartNumberFormatting';
 import { ApiKeysPageInner } from '../gateway/pages/ApiKeysPage';
 import Routes from '../experiment-tracking/routes';
 import WebhooksSettings from './WebhooksSettings';
@@ -99,6 +103,12 @@ const SettingsPage = () => {
       });
     }
   }, [sectionParam, navigate, location.search, location.state]);
+
+  const [isSmartFormattingEnabled, setIsSmartFormattingEnabled] = useLocalStorage({
+    key: SMART_NUMBER_FORMATTING_KEY,
+    version: SMART_NUMBER_FORMATTING_VERSION,
+    initialValue: true,
+  });
 
   const [isTelemetryEnabled, setIsTelemetryEnabled] = useLocalStorage({
     key: TELEMETRY_ENABLED_STORAGE_KEY,
@@ -197,6 +207,32 @@ const SettingsPage = () => {
                   <FormattedMessage
                     defaultMessage="Select your theme preference between light and dark."
                     description="Description for the theme setting in the settings page"
+                  />
+                </Typography.Text>
+              </SettingsRow>
+              <SettingsRow
+                trailing={
+                  <Switch
+                    componentId="mlflow.settings.smartNumberFormatting.toggle-switch"
+                    checked={isSmartFormattingEnabled ?? true}
+                    onChange={setIsSmartFormattingEnabled}
+                    label={
+                      (isSmartFormattingEnabled ?? true)
+                        ? intl.formatMessage({ defaultMessage: 'On', description: 'Smart number formatting enabled label' })
+                        : intl.formatMessage({ defaultMessage: 'Off', description: 'Smart number formatting disabled label' })
+                    }
+                    activeLabel={intl.formatMessage({ defaultMessage: 'On', description: 'Smart number formatting enabled label' })}
+                    inactiveLabel={intl.formatMessage({ defaultMessage: 'Off', description: 'Smart number formatting disabled label' })}
+                  />
+                }
+              >
+                <Typography.Title level={4} withoutMargins>
+                  <FormattedMessage defaultMessage="Smart number formatting" description="Smart number formatting settings title" />
+                </Typography.Title>
+                <Typography.Text>
+                  <FormattedMessage
+                    defaultMessage="Format metric and parameter values column-aware, with consistent decimal places and space-grouped digits."
+                    description="Smart number formatting settings description"
                   />
                 </Typography.Text>
               </SettingsRow>


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Relates to #17150

### What changes are proposed in this pull request?

Introduce "smart number formatting" for run table view and chart tooltips which can be turned on or off from the settings menu.

The formatting is based on the following heuristics:
- Compute the column's max absolute value → derive an exponent (floor of log₁₀)
- For "normal" magnitudes (exponent in [−4, +4]): fixed decimal,
  `max(0, 3 − exponent)` decimal places, giving 4 significant figures on the
  largest value; all rows share the same decimal places so digits align
- If every value in the column is already a whole number at that precision,
  drop to zero decimal places
- For extreme magnitudes (exponent outside [−4, +4]): scale all values by 10ⁿ
  and show a `×10ⁿ` annotation in the column header (second line) or tooltip
  header
- Group digits with spaces: integer part from the right (`1 234 567`),
  fractional part from the left (`0.000 001 234`)
- Zero uses the same decimal places as the rest of the column (`0.000 0`),
  never special-cased to `"0"` in normal-magnitude columns
- Chart tooltips derive their format spec from all y-values across all traces
  and steps, so formatting stays consistent even at steps where every visible
  value happens to be zero

Formatting is also applied to parameters in the column view iff all values of the given parameter can be converted to float (or int), but note that this does not affect sorting so the sorting still looks wrong for parameters that are numerical. (I'd be happy to try to address that here but it is a separate problem not related to formatting.)

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Compare what this PR produces when smart formatting is on:
<img width="1465" height="862" alt="image" src="https://github.com/user-attachments/assets/b70ad7db-c418-4cfc-b844-bd664fdbcd74" />

To what the master branch does:
<img width="1465" height="862" alt="image" src="https://github.com/user-attachments/assets/697c3db1-bd4a-49c9-a5a7-804f362b1196" />

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Optional smart number formatting for column view and chart tooltips.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
