### PR TITLE
Pin `lightning==2.6.1` to mitigate transient PyPI resolution failure

### DIFF
--- a/requirements/doc-requirements.txt
+++ b/requirements/doc-requirements.txt
@@ -12,7 +12,8 @@ ipython!=8.7.0
 keras
 torch>=1.11.0
 torchvision>=0.12.0
-lightning>=1.8.1
+# Tactical pin (see requirements/torch.txt) - revert to ``lightning>=1.8.1`` once PyPI is healthy.
+lightning==2.6.1
 scrapy
 ipywidgets>=8.1.1
 # incremental==24.7.0 requires setuptools>=61.0, which causes https://github.com/mlflow/mlflow/issues/8635

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -9,7 +9,8 @@ tensorboard
 # Required by mlflow.pytorch
 torch>=1.11.0
 torchvision>=0.12.0
-lightning>=1.8.1
+# Tactical pin (see requirements/torch.txt) - revert to ``lightning>=1.8.1`` once PyPI is healthy.
+lightning==2.6.1
 # Required by mlflow.xgboost
 xgboost>=0.82
 # Required by mlflow.lightgbm

--- a/requirements/torch.txt
+++ b/requirements/torch.txt
@@ -2,4 +2,9 @@
 # once https://download.pytorch.org/whl/cpu is accessible again.
 torch>=1.11.0
 torchvision>=0.12.0,!=0.24.0
-lightning>=1.8.1
+# Tactical pin: PyPI's `lightning` index has been intermittently returning
+# empty results since ~2026-04-30 13:39 UTC, breaking `uv pip install` with
+# "no versions of lightning". 2.6.1 is the version master's last successful
+# CI run resolved. Relax this back to `lightning>=1.8.1` once the upstream
+# index is healthy.
+lightning==2.6.1


### PR DESCRIPTION
### Related Issues/PRs

Relates to ongoing CI breakage on every open PR.

### What changes are proposed in this pull request?

PyPI's `lightning` index has been intermittently returning empty results since ~2026-04-30 13:39 UTC, breaking `uv pip install -r requirements/torch.txt` with `No solution found ... no versions of lightning ... unsatisfiable` across many open PRs. The same `requirements/torch.txt` resolved cleanly in master's last green run earlier the same morning (which used `lightning==2.6.1`), so the requirement file itself is fine - it's an upstream-index hiccup interacting with `UV_EXCLUDE_NEWER=P14D`.

This pins `lightning==2.6.1` (the exact version master last successfully resolved) in the three places `lightning>=1.8.1` previously appeared:
- `requirements/torch.txt` (used by `docs.yml` build)
- `requirements/extra-ml-requirements.txt` (used by master test workflow on PRs)
- `requirements/doc-requirements.txt` (used by docs)

The pin is intentionally tactical / surgical: it skips the resolver's version-selection step that's currently failing without restricting any in-practice flexibility (master already converged on 2.6.1). The `requirements/torch.txt` comment includes a TODO to revert once the upstream index is healthy.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Claude.