### PR TITLE
Add LLM Playground Scaffold

### DIFF
--- a/.github/actions/check-component-ids/componentId-registry.js
+++ b/.github/actions/check-component-ids/componentId-registry.js
@@ -1943,6 +1943,8 @@ module.exports = {
   "mlflow.sidebar.logout": "",
   "mlflow.sidebar.manage": "",
   "mlflow.sidebar.models_tab_link": "",
+  "mlflow.sidebar.playground_new_tag": "",
+  "mlflow.sidebar.playground_tab_link": "",
   "mlflow.sidebar.prompts_tab_link": "",
   "mlflow.sidebar.settings_back_link": "",
   "mlflow.sidebar.settings_general_link": "",

--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -9,6 +9,7 @@ import {
   GearIcon,
   HomeIcon,
   ModelsIcon,
+  PlayIcon,
   Tag,
   TextBoxIcon,
   Typography,
@@ -59,6 +60,7 @@ const isExperimentsActive = (location: Location) =>
   );
 const isModelsActive = (location: Location) => Boolean(matchPath('/models/*', location.pathname));
 const isPromptsActive = (location: Location) => Boolean(matchPath('/prompts/*', location.pathname));
+const isPlaygroundActive = (location: Location) => Boolean(matchPath('/playground/*', location.pathname));
 const isGatewayActive = (location: Location) => Boolean(matchPath('/gateway/*', location.pathname));
 const isSettingsActive = (location: Location) =>
   Boolean(
@@ -251,6 +253,27 @@ export function MlflowSidebar({
                 shouldEnableWorkflowBasedNavigation() && isGatewayActive(location) ? (
                   <MlflowSidebarGatewayItems collapsed={!showSidebar} />
                 ) : undefined,
+            },
+          ]
+        : []),
+      ...(shouldShowGenAIFeatures(enableWorkflowBasedNavigation, workflowType) && !showNestedExperimentItems
+        ? [
+            {
+              key: 'playground',
+              icon: <PlayIcon />,
+              linkProps: {
+                to: ExperimentTrackingRoutes.playgroundPageRoute,
+                isActive: isPlaygroundActive,
+                children: (
+                  <>
+                    <FormattedMessage defaultMessage="Playground" description="Sidebar link for playground tab" />
+                    <Tag componentId="mlflow.sidebar.playground_new_tag" color="turquoise" css={{ marginLeft: 'auto' }}>
+                      <FormattedMessage defaultMessage="New" description="Sidebar > Playground > New feature tag" />
+                    </Tag>
+                  </>
+                ),
+              },
+              componentId: 'mlflow.sidebar.playground_tab_link',
             },
           ]
         : []),

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/PlaygroundPage.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/PlaygroundPage.test.tsx
@@ -30,10 +30,9 @@ describe('PlaygroundPage', () => {
       expect(screen.getByText('Playground')).toBeInTheDocument();
     });
 
+    expect(screen.getByText('Playground coming soon')).toBeInTheDocument();
     expect(
-      screen.getByText(
-        "The Playground is being assembled. Soon you'll be able to test AI Gateway endpoints and registered prompts here.",
-      ),
+      screen.getByText("Soon you'll be able to test AI Gateway endpoints and registered prompts here."),
     ).toBeInTheDocument();
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/PlaygroundPage.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/PlaygroundPage.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from '@jest/globals';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { IntlProvider } from 'react-intl';
+import { DesignSystemProvider } from '@databricks/design-system';
+import { QueryClient, QueryClientProvider } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { testRoute, TestRouter } from '../../../common/utils/RoutingTestUtils';
+import PlaygroundPage from './PlaygroundPage';
+
+const renderPlayground = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<PlaygroundPage />, {
+    wrapper: ({ children }) => (
+      <IntlProvider locale="en">
+        <DesignSystemProvider>
+          <QueryClientProvider client={queryClient}>
+            <TestRouter routes={[testRoute(<>{children}</>, '/'), testRoute(<div />, '*')]} initialEntries={['/']} />
+          </QueryClientProvider>
+        </DesignSystemProvider>
+      </IntlProvider>
+    ),
+  });
+};
+
+describe('PlaygroundPage', () => {
+  it('renders the page header and the placeholder empty state', async () => {
+    renderPlayground();
+
+    await waitFor(() => {
+      expect(screen.getByText('Playground')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(
+        "The Playground is being assembled. Soon you'll be able to test AI Gateway endpoints and registered prompts here.",
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/PlaygroundPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/PlaygroundPage.tsx
@@ -28,32 +28,20 @@ const PlaygroundPage = () => {
         }
       />
       <Spacer shrinks={false} />
-      <div
-        css={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          height: '100%',
-          minHeight: 400,
-          width: '100%',
-          '& > div': {
-            height: '100%',
-            display: 'flex',
-            flexDirection: 'column',
-            justifyContent: 'center',
-            alignItems: 'center',
-          },
-        }}
-      >
-        <Empty
-          description={
-            <FormattedMessage
-              defaultMessage="The Playground is being assembled. Soon you'll be able to test AI Gateway endpoints and registered prompts here."
-              description="Placeholder description shown on the Playground page before its features are wired up"
-            />
-          }
-        />
-      </div>
+      <Empty
+        title={
+          <FormattedMessage
+            defaultMessage="Playground coming soon"
+            description="Title shown on the Playground page placeholder before its features are wired up"
+          />
+        }
+        description={
+          <FormattedMessage
+            defaultMessage="Soon you'll be able to test AI Gateway endpoints and registered prompts here."
+            description="Placeholder description shown on the Playground page before its features are wired up"
+          />
+        }
+      />
     </ScrollablePageWrapper>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/PlaygroundPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/PlaygroundPage.tsx
@@ -1,0 +1,61 @@
+import { Empty, Header, PlayIcon, Spacer, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage } from 'react-intl';
+import { ScrollablePageWrapper } from '../../../common/components/ScrollablePageWrapper';
+import ErrorUtils from '../../../common/utils/ErrorUtils';
+import { withErrorBoundary } from '../../../common/utils/withErrorBoundary';
+
+const PlaygroundPage = () => {
+  const { theme } = useDesignSystemTheme();
+
+  return (
+    <ScrollablePageWrapper css={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
+      <Spacer shrinks={false} />
+      <Header
+        title={
+          <span css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}>
+            <span
+              css={{
+                display: 'flex',
+                borderRadius: theme.borders.borderRadiusSm,
+                backgroundColor: theme.colors.backgroundSecondary,
+                padding: theme.spacing.sm,
+              }}
+            >
+              <PlayIcon />
+            </span>
+            <FormattedMessage defaultMessage="Playground" description="Title of the LLM playground page" />
+          </span>
+        }
+      />
+      <Spacer shrinks={false} />
+      <div
+        css={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          height: '100%',
+          minHeight: 400,
+          width: '100%',
+          '& > div': {
+            height: '100%',
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            alignItems: 'center',
+          },
+        }}
+      >
+        <Empty
+          description={
+            <FormattedMessage
+              defaultMessage="The Playground is being assembled. Soon you'll be able to test AI Gateway endpoints and registered prompts here."
+              description="Placeholder description shown on the Playground page before its features are wired up"
+            />
+          }
+        />
+      </div>
+    </ScrollablePageWrapper>
+  );
+};
+
+export default withErrorBoundary(ErrorUtils.mlflowServices.EXPERIMENTS, PlaygroundPage);

--- a/mlflow/server/js/src/experiment-tracking/route-defs.ts
+++ b/mlflow/server/js/src/experiment-tracking/route-defs.ts
@@ -3,6 +3,19 @@ import { createLazyRouteElement, DEFAULT_ASSISTANT_PROMPTS } from '../common/uti
 
 import { PageId, RoutePaths } from './routes';
 
+const getPlaygroundPageRouteDefs = () => {
+  return [
+    {
+      path: RoutePaths.playgroundPage,
+      element: createLazyRouteElement(() => import('./pages/playground/PlaygroundPage')),
+      pageId: PageId.playgroundPage,
+      handle: {
+        getPageTitle: () => 'Playground',
+      } satisfies RouteHandle,
+    },
+  ];
+};
+
 const getPromptPagesRouteDefs = () => {
   return [
     {
@@ -369,4 +382,5 @@ export const getRouteDefs = () => [
     } satisfies RouteHandle,
   },
   ...getPromptPagesRouteDefs(),
+  ...getPlaygroundPageRouteDefs(),
 ];

--- a/mlflow/server/js/src/experiment-tracking/routes.ts
+++ b/mlflow/server/js/src/experiment-tracking/routes.ts
@@ -12,6 +12,7 @@ export enum PageId {
   settingsPage = 'mlflow.settings',
   promptsPage = 'mlflow.prompts',
   promptDetailsPage = 'mlflow.prompts.details',
+  playgroundPage = 'mlflow.playground',
   experimentPageTabbed = 'mlflow.experiment.details.tab',
   experimentLoggedModelDetailsPageTab = 'mlflow.logged-model.details.tab',
   experimentLoggedModelDetailsPage = 'mlflow.logged-model.details',
@@ -143,6 +144,13 @@ export class RoutePaths {
   }
   static get promptDetailsPage() {
     return createMLflowRoutePath('/prompts/:promptName');
+  }
+  /**
+   * Route path for the LLM Playground page.
+   * Featured exclusively in open source MLflow.
+   */
+  static get playgroundPage() {
+    return createMLflowRoutePath('/playground');
   }
   static get settingsPage() {
     return createMLflowRoutePath('/settings');
@@ -348,6 +356,14 @@ class Routes {
       return generatePath(RoutePaths.experimentPageTabPromptDetails, { experimentId, promptName });
     }
     return generatePath(RoutePaths.promptDetailsPage, { promptName });
+  }
+
+  /**
+   * Route for the LLM Playground page.
+   * Featured exclusively in open source MLflow.
+   */
+  static get playgroundPageRoute() {
+    return RoutePaths.playgroundPage;
   }
 }
 

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -4355,6 +4355,10 @@
     "defaultMessage": "Scatter Plot",
     "description": "Tab pane title for scatterplots on the compare runs page"
   },
+  "OjUChs": {
+    "defaultMessage": "Playground coming soon",
+    "description": "Title shown on the Playground page placeholder before its features are wired up"
+  },
   "OjWQ39": {
     "defaultMessage": "Human feedback",
     "description": "Tooltip content for human feedback"
@@ -4746,10 +4750,6 @@
   "R6dCZ5": {
     "defaultMessage": "View your traces",
     "description": "Step 3 title for traces onboarding"
-  },
-  "R4Cwx7": {
-    "defaultMessage": "The Playground is being assembled. Soon you'll be able to test AI Gateway endpoints and registered prompts here.",
-    "description": "Placeholder description shown on the Playground page before its features are wired up"
   },
   "R7s1xC": {
     "defaultMessage": "Provider is required",
@@ -5867,10 +5867,6 @@
     "defaultMessage": "Scanning <tracesLink>{totalTraces} traces</tracesLink>, <issuesLink>{identifiedIssues} issues</issuesLink> identified so far",
     "description": "Issue detection progress > Progress summary while running"
   },
-  "Y/1i4Y": {
-    "defaultMessage": "{label}: {behavior}",
-    "description": "Helper text under the log-level slider explaining how the currently selected level filters the trace view."
-  },
   "Y+dLul": {
     "defaultMessage": "Choose your integration. Install the {code} package for automatic tracing, or use {trace} for custom functions.",
     "description": "Step 2 description for TypeScript traces onboarding"
@@ -5878,6 +5874,10 @@
   "Y+nCpQ": {
     "defaultMessage": "Pending",
     "description": "Label indicating this onboarding step is not yet completed"
+  },
+  "Y/1i4Y": {
+    "defaultMessage": "{label}: {behavior}",
+    "description": "Helper text under the log-level slider explaining how the currently selected level filters the trace view."
   },
   "Y1eg9D": {
     "defaultMessage": "In progress",
@@ -8262,6 +8262,10 @@
   "lQ2nDn": {
     "defaultMessage": "This assessment is produced by a custom metric.",
     "description": "Custom judge assessment description"
+  },
+  "lQq0YT": {
+    "defaultMessage": "Soon you'll be able to test AI Gateway endpoints and registered prompts here.",
+    "description": "Placeholder description shown on the Playground page before its features are wired up"
   },
   "lRO4km": {
     "defaultMessage": "Quality",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -887,6 +887,10 @@
     "defaultMessage": "Appearance, product feedback, telemetry, and workspace demo data.",
     "description": "Settings content section subtitle for general preferences including demo data"
   },
+  "3Q8nGH": {
+    "defaultMessage": "Playground",
+    "description": "Title of the LLM playground page"
+  },
   "3Rb4sG": {
     "defaultMessage": "Delete",
     "description": "String for the delete button to delete a particular experiment run"
@@ -3443,6 +3447,10 @@
     "defaultMessage": "Last 24 hours",
     "description": "Option for the start select dropdown to filter runs from the last 24 hours"
   },
+  "JD0saW": {
+    "defaultMessage": "New",
+    "description": "Sidebar > Playground > New feature tag"
+  },
   "JDpv0G": {
     "defaultMessage": "Operator",
     "description": "Tag filter input for operator field in the tags filter popover for experiments page search by tags"
@@ -4739,6 +4747,10 @@
     "defaultMessage": "View your traces",
     "description": "Step 3 title for traces onboarding"
   },
+  "R4Cwx7": {
+    "defaultMessage": "The Playground is being assembled. Soon you'll be able to test AI Gateway endpoints and registered prompts here.",
+    "description": "Placeholder description shown on the Playground page before its features are wired up"
+  },
   "R7s1xC": {
     "defaultMessage": "Provider is required",
     "description": "Error message when provider is not selected"
@@ -5718,6 +5730,10 @@
   "X3Uuiw": {
     "defaultMessage": "Off",
     "description": "Usage tracking disabled state"
+  },
+  "X3nbpN": {
+    "defaultMessage": "Playground",
+    "description": "Sidebar link for playground tab"
   },
   "X6P8tX": {
     "defaultMessage": "No models found",


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22778

This is **part 1 of a multi-PR split** of the LLM Playground feature. Subsequent PRs will add the gateway endpoint picker, single-turn chat, prompt registry integration, and multi-turn + sampling parameter support. Splitting was requested by @TomeHirata (the issue author) to make review more manageable.

### What changes are proposed in this pull request?

Introduces the **navigation plumbing** for a new LLM Playground page. The page is scoped intentionally to a placeholder so the route, sidebar entry, and lazy-loaded code-split can land and be reviewed in isolation before any chat or gateway behavior is wired up.

**Frontend** (`mlflow/server/js/src/`)
- `experiment-tracking/routes.ts` — adds `playgroundPage` to `PageId` and `RoutePaths`, plus a `playgroundPageRoute` getter on `Routes`. Path: `/playground`.
- `experiment-tracking/route-defs.ts` — registers a new `getPlaygroundPageRouteDefs()` that lazy-loads `PlaygroundPage` via `createLazyRouteElement`, and appends it to `getRouteDefs()`. Page title resolves to `Playground`.
- `experiment-tracking/pages/playground/PlaygroundPage.tsx` (new) — minimal page with the standard `Spacer + Header + Spacer` chrome (mirroring `PromptsPage.tsx`), a `<PlayIcon />` in a `backgroundSecondary` icon tile next to the title, and a centered `<Empty>` placeholder explaining that the playground is being assembled.
- `experiment-tracking/pages/playground/PlaygroundPage.test.tsx` (new) — smoke test asserting the header and the placeholder text both render.
- `common/components/MlflowSidebar.tsx` — adds a top-level **Playground** sidebar entry (with `<PlayIcon />` and a turquoise `New` tag) sitting between Prompts and AI Gateway, gated on the same GenAI features predicate as the surrounding entries.

<img width="1173" height="1042" alt="Screenshot 2026-05-01 at 5 33 53 PM" src="https://github.com/user-attachments/assets/c62cd73e-6ce2-41b8-81a1-57b8493e2dd3" />

<br/>

**Out of scope for this PR** (will land in subsequent parts of the split):
- Endpoint picker, chat input, chat completion submit, output rendering.
- Prompt registry "load from registry" integration.
- Sampling parameters (temperature / max_tokens / top_p) and multi-turn auto-append.
- User-facing documentation (`docs/docs/genai/playground.mdx`) and cross-links from the AI Gateway / Prompt Registry index pages — those land alongside the first PR that gives the page real functionality, so we don't ship a "coming soon" page on the public docs site.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

**New unit test** (`PlaygroundPage.test.tsx`, 1 case):
- Renders the page header ("Playground") and the placeholder empty-state copy.

**Verification gates** (all green from `mlflow/server/js`):
```
yarn lint
yarn prettier:check
yarn type-check
yarn i18n:check
yarn test PlaygroundPage
```
And `uv run pre-commit run --files <changed paths>` will pick up the auto-regenerated componentId registry for the new sidebar/page IDs.

**Manual** (against the local OSS dev server):
- Started the dev server, clicked the new **Playground** entry in the sidebar (with the turquoise `New` tag), confirmed the page renders the title with the play-icon tile to its left and the centered placeholder text, and that the title's vertical spacing matches the Prompts and Experiments pages.

### Does this PR require documentation update?

- [x] No.

(User-facing docs will land in the next PR alongside the first piece of real functionality, so the public docs site doesn't get a "coming soon" page.)

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. This PR introduces a new UI surface but no SDK or public API changes.

### Release Notes

#### Is this a user-facing change?

- [x] No.

(The page exists and is reachable from the sidebar, but its only content is a placeholder. The user-facing release-notes entry will live with the PR that ships the first usable functionality.)

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release
