### PR TITLE
Normalize empty string `model_id` to None in `create_model_version`

### DIFF
--- a/mlflow/store/model_registry/file_store.py
+++ b/mlflow/store/model_registry/file_store.py
@@ -673,7 +673,8 @@ class FileStore(AbstractStore):
             created in the backend.
 
         """
-        from mlflow.tracking.client import MlflowClient
+        if isinstance(model_id, str) and model_id.strip() == "":
+            model_id = None
 
         def next_version(registered_model_name):
             path = self._get_registered_model_path(registered_model_name)

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -968,9 +968,11 @@ class SqlAlchemyStore(AbstractStore):
         local_model_path=None,
         model_id: str | None = None,
     ):
+
         """
         Create a new model version from given source and run ID.
-
+        
+    
         Args:
             name: Registered model name.
             source: URI indicating the location of the model artifacts.
@@ -988,6 +990,9 @@ class SqlAlchemyStore(AbstractStore):
             created in the backend.
 
         """
+        if isinstance(model_id, str) and model_id.strip() == "":
+            model_id = None
+
 
         _validate_model_name(name)
         for tag in tags or []:


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22012

---

### What changes are proposed in this pull request?

This PR fixes handling of empty string ("") values for `model_id` in `create_model_version`.

Currently, passing an empty string as `model_id` can lead to validation errors during model version creation.  
This change normalizes empty or whitespace-only `model_id` values by converting them to `None` before further processing.

### Changes
- Normalize empty or whitespace-only `model_id` to `None`
- Applied fix in:
  - `mlflow/store/model_registry/sqlalchemy_store.py`
  - `mlflow/store/model_registry/file_store.py`

---

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Manual testing:
- Verified that passing `model_id=""` no longer causes errors
- Confirmed that valid `model_id` values remain unaffected

---

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

---

### Does this PR require updating the MLflow Skills repository?

- [x] No.
- [ ] Yes.

---

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fixes a bug where passing an empty string as `model_id` caused validation errors.

---

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/model-registry`

---

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none`
- [ ] `rn/breaking-change`
- [ ] `rn/feature`
- [x] `rn/bug-fix`
- [ ] `rn/documentation`

---

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release