### PR TITLE
Upgrade trace graph view to honor node boundaries from agent frameworks

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/graph-view/GraphView.workflow.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/graph-view/GraphView.workflow.test.ts
@@ -31,13 +31,10 @@ describe('computeWorkflowLayout', () => {
 
   it('consolidates spans with same type and name under non-agent parents', () => {
     // Root (CHAIN) -> [tool1, tool2] both named "search"
-    const root = makeSpan(
-      { title: 'root', type: 'UNKNOWN', start: 0 },
-      [
-        makeSpan({ title: 'search', type: 'TOOL', key: 's1', start: 10 }),
-        makeSpan({ title: 'search', type: 'TOOL', key: 's2', start: 20 }),
-      ],
-    );
+    const root = makeSpan({ title: 'root', type: 'UNKNOWN', start: 0 }, [
+      makeSpan({ title: 'search', type: 'TOOL', key: 's1', start: 10 }),
+      makeSpan({ title: 'search', type: 'TOOL', key: 's2', start: 20 }),
+    ]);
 
     const layout = computeWorkflowLayout(root);
     // "search" spans should be consolidated into one node
@@ -48,19 +45,14 @@ describe('computeWorkflowLayout', () => {
 
   it('separates spans with same name under different AGENT parents', () => {
     // Root -> [AgentA, AgentB] each with a child "llm"
-    const root = makeSpan(
-      { title: 'orchestrator', type: 'UNKNOWN', start: 0 },
-      [
-        makeSpan(
-          { title: 'agent_a', type: 'AGENT', key: 'a', start: 10 },
-          [makeSpan({ title: 'llm', type: 'LLM', key: 'llm1', start: 15 })],
-        ),
-        makeSpan(
-          { title: 'agent_b', type: 'AGENT', key: 'b', start: 20 },
-          [makeSpan({ title: 'llm', type: 'LLM', key: 'llm2', start: 25 })],
-        ),
-      ],
-    );
+    const root = makeSpan({ title: 'orchestrator', type: 'UNKNOWN', start: 0 }, [
+      makeSpan({ title: 'agent_a', type: 'AGENT', key: 'a', start: 10 }, [
+        makeSpan({ title: 'llm', type: 'LLM', key: 'llm1', start: 15 }),
+      ]),
+      makeSpan({ title: 'agent_b', type: 'AGENT', key: 'b', start: 20 }, [
+        makeSpan({ title: 'llm', type: 'LLM', key: 'llm2', start: 25 }),
+      ]),
+    ]);
 
     const layout = computeWorkflowLayout(root);
     // "llm" under agent_a and agent_b should be separate nodes
@@ -72,18 +64,12 @@ describe('computeWorkflowLayout', () => {
 
   it('consolidates spans under same AGENT parent', () => {
     // Root -> Agent -> [llm1, llm2] both named "llm"
-    const root = makeSpan(
-      { title: 'root', type: 'UNKNOWN', start: 0 },
-      [
-        makeSpan(
-          { title: 'my_agent', type: 'AGENT', key: 'agent', start: 10 },
-          [
-            makeSpan({ title: 'llm', type: 'LLM', key: 'llm1', start: 15 }),
-            makeSpan({ title: 'llm', type: 'LLM', key: 'llm2', start: 20 }),
-          ],
-        ),
-      ],
-    );
+    const root = makeSpan({ title: 'root', type: 'UNKNOWN', start: 0 }, [
+      makeSpan({ title: 'my_agent', type: 'AGENT', key: 'agent', start: 10 }, [
+        makeSpan({ title: 'llm', type: 'LLM', key: 'llm1', start: 15 }),
+        makeSpan({ title: 'llm', type: 'LLM', key: 'llm2', start: 20 }),
+      ]),
+    ]);
 
     const layout = computeWorkflowLayout(root);
     const llmNodes = layout.nodes.filter((n) => n.displayName === 'llm');
@@ -93,38 +79,121 @@ describe('computeWorkflowLayout', () => {
 
   it('separates spans under different CHAIN parents', () => {
     // Root -> [ChainA, ChainB] each with "parse"
-    const root = makeSpan(
-      { title: 'root', type: 'UNKNOWN', start: 0 },
-      [
-        makeSpan(
-          { title: 'chain_a', type: 'CHAIN', key: 'ca', start: 10 },
-          [makeSpan({ title: 'parse', type: 'PARSER', key: 'p1', start: 15 })],
-        ),
-        makeSpan(
-          { title: 'chain_b', type: 'CHAIN', key: 'cb', start: 20 },
-          [makeSpan({ title: 'parse', type: 'PARSER', key: 'p2', start: 25 })],
-        ),
-      ],
-    );
+    const root = makeSpan({ title: 'root', type: 'UNKNOWN', start: 0 }, [
+      makeSpan({ title: 'chain_a', type: 'CHAIN', key: 'ca', start: 10 }, [
+        makeSpan({ title: 'parse', type: 'PARSER', key: 'p1', start: 15 }),
+      ]),
+      makeSpan({ title: 'chain_b', type: 'CHAIN', key: 'cb', start: 20 }, [
+        makeSpan({ title: 'parse', type: 'PARSER', key: 'p2', start: 25 }),
+      ]),
+    ]);
 
     const layout = computeWorkflowLayout(root);
     const parseNodes = layout.nodes.filter((n) => n.displayName === 'parse');
     expect(parseNodes).toHaveLength(2);
   });
 
+  it('separates spans under different WORKFLOW parents', () => {
+    // Root -> [WorkflowA, WorkflowB] each with "llm"
+    const root = makeSpan({ title: 'root', type: 'UNKNOWN', start: 0 }, [
+      makeSpan({ title: 'workflow_a', type: 'WORKFLOW', key: 'wa', start: 10 }, [
+        makeSpan({ title: 'llm', type: 'LLM', key: 'llm1', start: 15 }),
+      ]),
+      makeSpan({ title: 'workflow_b', type: 'WORKFLOW', key: 'wb', start: 20 }, [
+        makeSpan({ title: 'llm', type: 'LLM', key: 'llm2', start: 25 }),
+      ]),
+    ]);
+
+    const layout = computeWorkflowLayout(root);
+    const llmNodes = layout.nodes.filter((n) => n.displayName === 'llm');
+    expect(llmNodes).toHaveLength(2);
+  });
+
+  it('separates spans under different TASK parents', () => {
+    // Root -> [TaskA, TaskB] each with "tool"
+    const root = makeSpan({ title: 'root', type: 'UNKNOWN', start: 0 }, [
+      makeSpan({ title: 'task_a', type: 'TASK', key: 'ta', start: 10 }, [
+        makeSpan({ title: 'tool', type: 'TOOL', key: 't1', start: 15 }),
+      ]),
+      makeSpan({ title: 'task_b', type: 'TASK', key: 'tb', start: 20 }, [
+        makeSpan({ title: 'tool', type: 'TOOL', key: 't2', start: 25 }),
+      ]),
+    ]);
+
+    const layout = computeWorkflowLayout(root);
+    const toolNodes = layout.nodes.filter((n) => n.displayName === 'tool');
+    expect(toolNodes).toHaveLength(2);
+  });
+
+  it('treats span with entity.name attribute as a boundary', () => {
+    // Root -> [CustomA (has entity.name), CustomB (has entity.name)] each with "llm"
+    // Even though type is not AGENT/CHAIN, entity.name signals a framework boundary
+    const root = makeSpan({ title: 'root', type: 'UNKNOWN', start: 0 }, [
+      makeSpan(
+        {
+          title: 'voltagent_a',
+          type: 'UNKNOWN',
+          key: 'va',
+          start: 10,
+          attributes: { 'entity.name': 'agent-alpha' },
+        },
+        [makeSpan({ title: 'llm', type: 'LLM', key: 'llm1', start: 15 })],
+      ),
+      makeSpan(
+        {
+          title: 'voltagent_b',
+          type: 'UNKNOWN',
+          key: 'vb',
+          start: 20,
+          attributes: { 'entity.name': 'agent-beta' },
+        },
+        [makeSpan({ title: 'llm', type: 'LLM', key: 'llm2', start: 25 })],
+      ),
+    ]);
+
+    const layout = computeWorkflowLayout(root);
+    const llmNodes = layout.nodes.filter((n) => n.displayName === 'llm');
+    expect(llmNodes).toHaveLength(2);
+  });
+
+  it('treats span with openinference.span.kind attribute as a boundary', () => {
+    const root = makeSpan({ title: 'root', type: 'UNKNOWN', start: 0 }, [
+      makeSpan(
+        {
+          title: 'node_a',
+          type: 'UNKNOWN',
+          key: 'na',
+          start: 10,
+          attributes: { 'openinference.span.kind': 'AGENT' },
+        },
+        [makeSpan({ title: 'embed', type: 'EMBEDDING', key: 'e1', start: 15 })],
+      ),
+      makeSpan(
+        {
+          title: 'node_b',
+          type: 'UNKNOWN',
+          key: 'nb',
+          start: 20,
+          attributes: { 'openinference.span.kind': 'AGENT' },
+        },
+        [makeSpan({ title: 'embed', type: 'EMBEDDING', key: 'e2', start: 25 })],
+      ),
+    ]);
+
+    const layout = computeWorkflowLayout(root);
+    const embedNodes = layout.nodes.filter((n) => n.displayName === 'embed');
+    expect(embedNodes).toHaveLength(2);
+  });
+
   it('handles nested agents correctly', () => {
     // Root (AGENT) -> SubAgent (AGENT) -> llm
     // Root (AGENT) -> llm
-    const root = makeSpan(
-      { title: 'root_agent', type: 'AGENT', start: 0 },
-      [
-        makeSpan({ title: 'llm', type: 'LLM', key: 'llm_root', start: 5 }),
-        makeSpan(
-          { title: 'sub_agent', type: 'AGENT', key: 'sub', start: 10 },
-          [makeSpan({ title: 'llm', type: 'LLM', key: 'llm_sub', start: 15 })],
-        ),
-      ],
-    );
+    const root = makeSpan({ title: 'root_agent', type: 'AGENT', start: 0 }, [
+      makeSpan({ title: 'llm', type: 'LLM', key: 'llm_root', start: 5 }),
+      makeSpan({ title: 'sub_agent', type: 'AGENT', key: 'sub', start: 10 }, [
+        makeSpan({ title: 'llm', type: 'LLM', key: 'llm_sub', start: 15 }),
+      ]),
+    ]);
 
     const layout = computeWorkflowLayout(root);
     const llmNodes = layout.nodes.filter((n) => n.displayName === 'llm');

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/graph-view/GraphView.workflow.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/graph-view/GraphView.workflow.test.ts
@@ -200,4 +200,53 @@ describe('computeWorkflowLayout', () => {
     // llm under root_agent and llm under sub_agent should be separate
     expect(llmNodes).toHaveLength(2);
   });
+
+  it('separates children under same-named sibling AGENT parents', () => {
+    // Root -> [AgentA, AgentB] both named "subagent" with different keys
+    // Each has a child "llm" — they should NOT be merged
+    const root = makeSpan({ title: 'orchestrator', type: 'UNKNOWN', start: 0 }, [
+      makeSpan({ title: 'subagent', type: 'AGENT', key: 'agent-1', start: 10 }, [
+        makeSpan({ title: 'llm', type: 'LLM', key: 'llm1', start: 15 }),
+      ]),
+      makeSpan({ title: 'subagent', type: 'AGENT', key: 'agent-2', start: 20 }, [
+        makeSpan({ title: 'llm', type: 'LLM', key: 'llm2', start: 25 }),
+      ]),
+    ]);
+
+    const layout = computeWorkflowLayout(root);
+    const llmNodes = layout.nodes.filter((n) => n.displayName === 'llm');
+    expect(llmNodes).toHaveLength(2);
+    expect(llmNodes[0].count).toBe(1);
+    expect(llmNodes[1].count).toBe(1);
+  });
+
+  it('separates children under same-named boundaries with different attribute values', () => {
+    // Two boundaries with same type/name but different entity.name values
+    const root = makeSpan({ title: 'root', type: 'UNKNOWN', start: 0 }, [
+      makeSpan(
+        {
+          title: 'worker',
+          type: 'UNKNOWN',
+          key: 'w1',
+          start: 10,
+          attributes: { 'entity.name': 'worker-alpha' },
+        },
+        [makeSpan({ title: 'llm', type: 'LLM', key: 'llm1', start: 15 })],
+      ),
+      makeSpan(
+        {
+          title: 'worker',
+          type: 'UNKNOWN',
+          key: 'w2',
+          start: 20,
+          attributes: { 'entity.name': 'worker-beta' },
+        },
+        [makeSpan({ title: 'llm', type: 'LLM', key: 'llm2', start: 25 })],
+      ),
+    ]);
+
+    const layout = computeWorkflowLayout(root);
+    const llmNodes = layout.nodes.filter((n) => n.displayName === 'llm');
+    expect(llmNodes).toHaveLength(2);
+  });
 });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/graph-view/GraphView.workflow.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/graph-view/GraphView.workflow.test.ts
@@ -1,0 +1,134 @@
+import type { ModelTraceSpanNode } from '../ModelTrace.types';
+import { computeWorkflowLayout } from './GraphView.workflow';
+
+/**
+ * Helper to create a minimal ModelTraceSpanNode for testing.
+ */
+function makeSpan(
+  overrides: Partial<ModelTraceSpanNode> & { title: string; type?: string },
+  children?: ModelTraceSpanNode[],
+): ModelTraceSpanNode {
+  return {
+    key: overrides.key ?? overrides.title,
+    title: overrides.title,
+    type: overrides.type,
+    start: overrides.start ?? 0,
+    end: overrides.end ?? 100,
+    icon: null as any,
+    assessments: [],
+    traceId: 'test-trace',
+    children: children ?? undefined,
+    ...overrides,
+  } as ModelTraceSpanNode;
+}
+
+describe('computeWorkflowLayout', () => {
+  it('returns empty layout for null root', () => {
+    const layout = computeWorkflowLayout(null);
+    expect(layout.nodes).toHaveLength(0);
+    expect(layout.edges).toHaveLength(0);
+  });
+
+  it('consolidates spans with same type and name under non-agent parents', () => {
+    // Root (CHAIN) -> [tool1, tool2] both named "search"
+    const root = makeSpan(
+      { title: 'root', type: 'UNKNOWN', start: 0 },
+      [
+        makeSpan({ title: 'search', type: 'TOOL', key: 's1', start: 10 }),
+        makeSpan({ title: 'search', type: 'TOOL', key: 's2', start: 20 }),
+      ],
+    );
+
+    const layout = computeWorkflowLayout(root);
+    // "search" spans should be consolidated into one node
+    const searchNodes = layout.nodes.filter((n) => n.displayName === 'search');
+    expect(searchNodes).toHaveLength(1);
+    expect(searchNodes[0].count).toBe(2);
+  });
+
+  it('separates spans with same name under different AGENT parents', () => {
+    // Root -> [AgentA, AgentB] each with a child "llm"
+    const root = makeSpan(
+      { title: 'orchestrator', type: 'UNKNOWN', start: 0 },
+      [
+        makeSpan(
+          { title: 'agent_a', type: 'AGENT', key: 'a', start: 10 },
+          [makeSpan({ title: 'llm', type: 'LLM', key: 'llm1', start: 15 })],
+        ),
+        makeSpan(
+          { title: 'agent_b', type: 'AGENT', key: 'b', start: 20 },
+          [makeSpan({ title: 'llm', type: 'LLM', key: 'llm2', start: 25 })],
+        ),
+      ],
+    );
+
+    const layout = computeWorkflowLayout(root);
+    // "llm" under agent_a and agent_b should be separate nodes
+    const llmNodes = layout.nodes.filter((n) => n.displayName === 'llm');
+    expect(llmNodes).toHaveLength(2);
+    expect(llmNodes[0].count).toBe(1);
+    expect(llmNodes[1].count).toBe(1);
+  });
+
+  it('consolidates spans under same AGENT parent', () => {
+    // Root -> Agent -> [llm1, llm2] both named "llm"
+    const root = makeSpan(
+      { title: 'root', type: 'UNKNOWN', start: 0 },
+      [
+        makeSpan(
+          { title: 'my_agent', type: 'AGENT', key: 'agent', start: 10 },
+          [
+            makeSpan({ title: 'llm', type: 'LLM', key: 'llm1', start: 15 }),
+            makeSpan({ title: 'llm', type: 'LLM', key: 'llm2', start: 20 }),
+          ],
+        ),
+      ],
+    );
+
+    const layout = computeWorkflowLayout(root);
+    const llmNodes = layout.nodes.filter((n) => n.displayName === 'llm');
+    expect(llmNodes).toHaveLength(1);
+    expect(llmNodes[0].count).toBe(2);
+  });
+
+  it('separates spans under different CHAIN parents', () => {
+    // Root -> [ChainA, ChainB] each with "parse"
+    const root = makeSpan(
+      { title: 'root', type: 'UNKNOWN', start: 0 },
+      [
+        makeSpan(
+          { title: 'chain_a', type: 'CHAIN', key: 'ca', start: 10 },
+          [makeSpan({ title: 'parse', type: 'PARSER', key: 'p1', start: 15 })],
+        ),
+        makeSpan(
+          { title: 'chain_b', type: 'CHAIN', key: 'cb', start: 20 },
+          [makeSpan({ title: 'parse', type: 'PARSER', key: 'p2', start: 25 })],
+        ),
+      ],
+    );
+
+    const layout = computeWorkflowLayout(root);
+    const parseNodes = layout.nodes.filter((n) => n.displayName === 'parse');
+    expect(parseNodes).toHaveLength(2);
+  });
+
+  it('handles nested agents correctly', () => {
+    // Root (AGENT) -> SubAgent (AGENT) -> llm
+    // Root (AGENT) -> llm
+    const root = makeSpan(
+      { title: 'root_agent', type: 'AGENT', start: 0 },
+      [
+        makeSpan({ title: 'llm', type: 'LLM', key: 'llm_root', start: 5 }),
+        makeSpan(
+          { title: 'sub_agent', type: 'AGENT', key: 'sub', start: 10 },
+          [makeSpan({ title: 'llm', type: 'LLM', key: 'llm_sub', start: 15 })],
+        ),
+      ],
+    );
+
+    const layout = computeWorkflowLayout(root);
+    const llmNodes = layout.nodes.filter((n) => n.displayName === 'llm');
+    // llm under root_agent and llm under sub_agent should be separate
+    expect(llmNodes).toHaveLength(2);
+  });
+});

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/graph-view/GraphView.workflow.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/graph-view/GraphView.workflow.ts
@@ -26,10 +26,16 @@ function flattenSpans(root: ModelTraceSpanNode): ModelTraceSpanNode[] {
 }
 
 /**
- * Gets the aggregation key for a span using its type and name.
+ * Span types that represent agent/node boundaries in agent frameworks.
+ * Spans under different parents of these types should NOT be consolidated.
+ */
+const NODE_BOUNDARY_TYPES = new Set(['AGENT', 'CHAIN']);
+
+/**
+ * Gets the base aggregation key for a span using its type and name.
  * Including type prevents unrelated operations with the same name from merging.
  */
-function getAggregationKey(span: ModelTraceSpanNode): string {
+function getBaseAggregationKey(span: ModelTraceSpanNode): string {
   return `${span.type ?? 'UNKNOWN'}::${span.title ?? 'Unknown'}`;
 }
 
@@ -339,6 +345,37 @@ function buildWorkflowGraph(
   rootNode: ModelTraceSpanNode,
   config: GraphLayoutConfig,
 ): { nodes: WorkflowNode[]; edges: WorkflowEdge[]; rootNodeId: string } | null {
+  // Walk the tree to compute parent-scoped aggregation keys.
+  // This ensures spans with the same name under different agent nodes
+  // are NOT consolidated into a single graph node.
+  const spanKeyMap = new Map<ModelTraceSpanNode, string>();
+
+  function assignKeys(node: ModelTraceSpanNode, scopeKey: string | null): void {
+    // If there's a scoping ancestor (AGENT/CHAIN), prefix this span's key
+    // so that identically named spans under different agents stay separate.
+    const key = scopeKey !== null ? `${scopeKey}/${getBaseAggregationKey(node)}` : getBaseAggregationKey(node);
+
+    spanKeyMap.set(node, key);
+
+    if (node.children) {
+      // If this node is an agent boundary, it becomes the new scope for children.
+      // Otherwise, pass through the current scope unchanged.
+      const childScope = NODE_BOUNDARY_TYPES.has(node.type ?? '') ? key : scopeKey;
+      for (const child of node.children) {
+        assignKeys(child, childScope);
+      }
+    }
+  }
+
+  const rootKey = getBaseAggregationKey(rootNode);
+  spanKeyMap.set(rootNode, rootKey);
+  if (rootNode.children) {
+    const rootScope = NODE_BOUNDARY_TYPES.has(rootNode.type ?? '') ? rootKey : null;
+    for (const child of rootNode.children) {
+      assignKeys(child, rootScope);
+    }
+  }
+
   // Flatten all spans
   const spans = flattenSpans(rootNode);
 
@@ -349,10 +386,10 @@ function buildWorkflowGraph(
   // Sort by start time to get execution order
   spans.sort((a, b) => a.start - b.start);
 
-  // Group spans by name (aggregation key)
+  // Group spans by their scoped aggregation key
   const nodeGroups = new Map<string, ModelTraceSpanNode[]>();
   for (const span of spans) {
-    const key = getAggregationKey(span);
+    const key = spanKeyMap.get(span) ?? getBaseAggregationKey(span);
     if (!nodeGroups.has(key)) {
       nodeGroups.set(key, []);
     }
@@ -383,7 +420,7 @@ function buildWorkflowGraph(
   const edgeMap = new Map<string, WorkflowEdge>();
 
   function buildEdgesFromHierarchy(node: ModelTraceSpanNode, parentKey: string | null): void {
-    const currentKey = getAggregationKey(node);
+    const currentKey = spanKeyMap.get(node) ?? getBaseAggregationKey(node);
 
     if (parentKey !== null && currentKey !== parentKey) {
       const edgeId = `${parentKey}->${currentKey}`;
@@ -433,7 +470,7 @@ function buildWorkflowGraph(
   return {
     nodes: workflowNodes,
     edges: Array.from(edgeMap.values()),
-    rootNodeId: getAggregationKey(rootNode),
+    rootNodeId: rootKey,
   };
 }
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/graph-view/GraphView.workflow.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/graph-view/GraphView.workflow.ts
@@ -26,10 +26,49 @@ function flattenSpans(root: ModelTraceSpanNode): ModelTraceSpanNode[] {
 }
 
 /**
- * Span types that represent agent/node boundaries in agent frameworks.
+ * Span types that represent node boundaries in agent frameworks.
  * Spans under different parents of these types should NOT be consolidated.
+ *
+ * This set covers the standard MLflow span types that denote logical grouping:
+ * - AGENT, CHAIN: core multi-step orchestration types
+ * - WORKFLOW, TASK: used by frameworks (e.g., CrewAI, LangGraph) for
+ *   higher-level orchestration nodes
+ *
+ * Framework-specific span kinds (e.g., VoltAgent's entity.type, OpenInference's
+ * openinference.span.kind) are translated to these standard MLflow types by
+ * the backend's OTel schema translators before reaching the frontend.
  */
-const NODE_BOUNDARY_TYPES = new Set(['AGENT', 'CHAIN']);
+const NODE_BOUNDARY_TYPES = new Set(['AGENT', 'CHAIN', 'WORKFLOW', 'TASK']);
+
+/**
+ * Span attribute keys that frameworks use to signal agent/node identity.
+ * If a span carries any of these attributes, it is treated as a node boundary
+ * regardless of its type — this honors the framework's native boundary signal.
+ */
+const BOUNDARY_ATTRIBUTE_KEYS = [
+  'entity.name', // VoltAgent, Gemini CLI
+  'openinference.span.kind', // Arize / OpenInference
+  'graph.node.id', // Arize explicit graph annotations
+];
+
+/**
+ * Checks whether a span represents a node boundary — either by its type
+ * or by framework-specific attributes that signal agent/node identity.
+ */
+function isNodeBoundary(span: ModelTraceSpanNode): boolean {
+  if (NODE_BOUNDARY_TYPES.has(span.type ?? '')) {
+    return true;
+  }
+  const attrs = span.attributes;
+  if (attrs && !Array.isArray(attrs)) {
+    for (const key of BOUNDARY_ATTRIBUTE_KEYS) {
+      if (attrs[key] != null) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
 
 /**
  * Gets the base aggregation key for a span using its type and name.
@@ -358,9 +397,9 @@ function buildWorkflowGraph(
     spanKeyMap.set(node, key);
 
     if (node.children) {
-      // If this node is an agent boundary, it becomes the new scope for children.
-      // Otherwise, pass through the current scope unchanged.
-      const childScope = NODE_BOUNDARY_TYPES.has(node.type ?? '') ? key : scopeKey;
+      // If this node is a framework-defined boundary, it becomes the new scope
+      // for children. Otherwise, pass through the current scope unchanged.
+      const childScope = isNodeBoundary(node) ? key : scopeKey;
       for (const child of node.children) {
         assignKeys(child, childScope);
       }
@@ -370,7 +409,7 @@ function buildWorkflowGraph(
   const rootKey = getBaseAggregationKey(rootNode);
   spanKeyMap.set(rootNode, rootKey);
   if (rootNode.children) {
-    const rootScope = NODE_BOUNDARY_TYPES.has(rootNode.type ?? '') ? rootKey : null;
+    const rootScope = isNodeBoundary(rootNode) ? rootKey : null;
     for (const child of rootNode.children) {
       assignKeys(child, rootScope);
     }

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/graph-view/GraphView.workflow.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/graph-view/GraphView.workflow.ts
@@ -79,6 +79,25 @@ function getBaseAggregationKey(span: ModelTraceSpanNode): string {
 }
 
 /**
+ * Gets a unique scope key for a boundary node. Uses boundary attribute values
+ * (e.g. entity.name, graph.node.id) when available for semantic identity,
+ * falling back to the span's unique key (span ID) to guarantee uniqueness.
+ * This prevents same-named sibling boundary nodes from sharing a scope.
+ */
+function getBoundaryScopeKey(span: ModelTraceSpanNode): string {
+  const attrs = span.attributes;
+  if (attrs && !Array.isArray(attrs)) {
+    for (const attrKey of BOUNDARY_ATTRIBUTE_KEYS) {
+      const val = attrs[attrKey];
+      if (val != null) {
+        return `${getBaseAggregationKey(span)}[${String(val)}]`;
+      }
+    }
+  }
+  return `${getBaseAggregationKey(span)}[${span.key}]`;
+}
+
+/**
  * Detects cycles via iterative DFS and marks cycle-causing edges as back-edges.
  * Uses the standard white/gray/black coloring: an edge to a gray (in-stack)
  * node is a back-edge. After this runs, the remaining forward edges form a DAG.
@@ -398,8 +417,9 @@ function buildWorkflowGraph(
 
     if (node.children) {
       // If this node is a framework-defined boundary, it becomes the new scope
-      // for children. Otherwise, pass through the current scope unchanged.
-      const childScope = isNodeBoundary(node) ? key : scopeKey;
+      // for children. Uses a unique scope key (incorporating span ID or boundary
+      // attributes) so same-named sibling boundaries create distinct scopes.
+      const childScope = isNodeBoundary(node) ? getBoundaryScopeKey(node) : scopeKey;
       for (const child of node.children) {
         assignKeys(child, childScope);
       }
@@ -409,7 +429,7 @@ function buildWorkflowGraph(
   const rootKey = getBaseAggregationKey(rootNode);
   spanKeyMap.set(rootNode, rootKey);
   if (rootNode.children) {
-    const rootScope = isNodeBoundary(rootNode) ? rootKey : null;
+    const rootScope = isNodeBoundary(rootNode) ? getBoundaryScopeKey(rootNode) : null;
     for (const child of rootNode.children) {
       assignKeys(child, rootScope);
     }


### PR DESCRIPTION
### Related Issues/PRs

Closes #22752

### What changes are proposed in this pull request?

The trace graph view aggregates spans by `type::name`, which loses parent context when the span tree is flattened. This causes spans with the same name under different agent nodes (e.g., two subagents each calling "llm") to merge into a single graph node.

This PR introduces improvements to honor framework-native node boundaries:

1. **Expanded boundary types**: `NODE_BOUNDARY_TYPES` now includes `WORKFLOW` and `TASK` in addition to `AGENT` and `CHAIN`, covering frameworks like CrewAI and LangGraph.

2. **Attribute-based boundary detection**: A new `isNodeBoundary()` function checks for framework-specific attributes (`entity.name`, `openinference.span.kind`, `graph.node.id`) that signal agent/node identity, regardless of span type. This honors boundaries from VoltAgent, OpenInference, Arize, and Gemini CLI.

3. **Unique scope keys for same-named boundaries**: A new `getBoundaryScopeKey()` function uses boundary attribute values or the span's unique key (span ID) to create distinct scopes, preventing children under same-named sibling boundary nodes from being incorrectly merged.

Key changes in `GraphView.workflow.ts`:
- Add `BOUNDARY_ATTRIBUTE_KEYS` for framework-native boundary signal detection
- Add `isNodeBoundary()` to unify type-based and attribute-based boundary checks
- Add `getBoundaryScopeKey()` to guarantee unique scopes for same-named boundaries
- Update `assignKeys()` and root scope logic to use these new functions

### Screenshots

#### Test case 1: Nested agents

A root agent calls an LLM directly, and also delegates to a sub-agent which calls its own LLM. Both LLM spans have the same name `"llm"`, but belong to different agent scopes.

```
Input span tree:
root_agent (AGENT)
├── llm (LLM)           ← called by root_agent
└── sub_agent (AGENT)
    └── llm (LLM)       ← called by sub_agent
```

| Before (master) | After (this PR) |
|---|---|
| <img width="255" height="400" alt="nested-agent(before)" src="https://github.com/user-attachments/assets/bc7a89c0-fc39-4f1c-989a-b3164a4bea79" /> | <img width="430" height="364" alt="nested-agent(after)" src="https://github.com/user-attachments/assets/ffb4fdab-69cf-46e9-b8c8-32a1f64cf241" /> |

**Before:** The two `llm` spans are merged into a single graph node with count ×2, losing the information about which agent invoked which LLM.
**After:** Two separate `llm` nodes are shown, each correctly associated with its parent agent boundary.

#### Test case 2: Same-named sibling agents

An orchestrator agent spawns two worker agents with the same name `"worker_agent"`, each of which calls its own LLM. This tests that even when boundary nodes themselves share the same name, their children are still kept separate.

```
Input span tree:
orchestrator (AGENT)
├── worker_agent (AGENT)    ← first worker (span ID: abc)
│   └── llm (LLM)
└── worker_agent (AGENT)    ← second worker (span ID: def)
    └── llm (LLM)
```

| Before (master) | After (this PR) |
|---|---|
| <img width="281" height="451" alt="same-name-agent(before)" src="https://github.com/user-attachments/assets/3c8a17bc-913e-49ee-8fe9-d36c4b99bd5d" /> | <img width="506" height="412" alt="same-name-agent(after)" src="https://github.com/user-attachments/assets/64d5a2ef-e8b8-4eee-aeaf-c9762ffd88f8" /> |

**Before:** Both `llm` spans are merged into one node (×2), as the same-named `worker_agent` parents produce identical scope keys.
**After:** Two separate `llm` nodes are shown. The `getBoundaryScopeKey()` function uses each boundary's unique span ID to create distinct scopes, even when the boundary names are identical.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Test file `GraphView.workflow.test.ts` with 12 test cases:
- Returns empty layout for null root
- Consolidates spans with same type and name under non-agent parents (backward compat)
- Separates spans with same name under different AGENT parents
- Consolidates spans under same AGENT parent
- Separates spans under different CHAIN parents
- Separates spans under different WORKFLOW parents
- Separates spans under different TASK parents
- Treats span with `entity.name` attribute as a boundary (VoltAgent/Gemini CLI)
- Treats span with `openinference.span.kind` attribute as a boundary (Arize/OpenInference)
- Handles nested agents correctly
- Separates children under same-named sibling AGENT parents
- Separates children under same-named boundaries with different attribute values

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The trace graph view now correctly separates spans that belong to different agent nodes, honoring the node boundaries defined by agent frameworks such as LangGraph, CrewAI, VoltAgent, and OpenInference.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release

