### PR TITLE
Fix Azure OpenAI streaming usage tracing

### DIFF
--- a/mlflow/openai/autolog.py
+++ b/mlflow/openai/autolog.py
@@ -381,11 +381,11 @@ def _process_last_chunk(
             output = None
         elif is_responses_api:
             output = _reconstruct_response_from_stream(output)
-        elif output[0].object in ["text_completion", "chat.completion.chunk"]:
+        elif completion_chunks := _filter_completion_stream_chunks(output):
             # Reconstruct a completion object from streaming chunks
-            output = _reconstruct_completion_from_stream(output)
+            output = _reconstruct_completion_from_stream(completion_chunks)
             # Set usage information on span if available
-            if usage := getattr(chunk, "usage", None):
+            if usage := _get_completion_stream_usage(completion_chunks):
                 usage_dict = {
                     TokenUsageKey.INPUT_TOKENS: usage.prompt_tokens,
                     TokenUsageKey.OUTPUT_TOKENS: usage.completion_tokens,
@@ -405,6 +405,21 @@ def _process_last_chunk(
         )
 
 
+def _filter_completion_stream_chunks(chunks: list[Any]) -> list[Any]:
+    return [
+        chunk
+        for chunk in chunks
+        if getattr(chunk, "object", None) in {"text_completion", "chat.completion.chunk"}
+    ]
+
+
+def _get_completion_stream_usage(chunks: list[Any]) -> Any:
+    for chunk in reversed(chunks):
+        if usage := getattr(chunk, "usage", None):
+            return usage
+    return None
+
+
 def _reconstruct_completion_from_stream(chunks: list[Any]) -> Any:
     """
     Reconstruct a completion object from streaming chunks.
@@ -412,6 +427,10 @@ def _reconstruct_completion_from_stream(chunks: list[Any]) -> Any:
     This preserves the structure and metadata that would be present in a non-streaming
     completion response, including ID, model, timestamps, usage, etc.
     """
+    chunks = _filter_completion_stream_chunks(chunks)
+    if not chunks:
+        return None
+
     if chunks[0].object == "text_completion":
         # Handling for the deprecated Completions API. Keep the legacy behavior for now.
         def _extract_content(chunk: Any) -> str:

--- a/tests/openai/mock_openai.py
+++ b/tests/openai/mock_openai.py
@@ -11,6 +11,7 @@ from mlflow.types.chat import ChatCompletionRequest
 
 EMPTY_CHOICES = "EMPTY_CHOICES"
 LIST_CONTENT = "LIST_CONTENT"
+AZURE_ANNOTATIONS = "AZURE_ANNOTATIONS"
 
 app = fastapi.FastAPI()
 
@@ -89,6 +90,34 @@ def _make_chat_stream_chunk_empty_choices():
     }
 
 
+def _make_chat_stream_annotation_chunk():
+    return {
+        "id": "",
+        "object": "",
+        "created": 0,
+        "model": "",
+        "system_fingerprint": None,
+        "choices": [],
+        "usage": None,
+    }
+
+
+def _make_chat_stream_usage_chunk():
+    return {
+        "id": "chatcmpl-123",
+        "object": "chat.completion.chunk",
+        "created": 1677652288,
+        "model": "gpt-4o-mini",
+        "system_fingerprint": "fp_44709d6fcb",
+        "choices": [],
+        "usage": {
+            "prompt_tokens": 9,
+            "completion_tokens": 12,
+            "total_tokens": 21,
+        },
+    }
+
+
 def _make_chat_stream_chunk_with_list_content(content_list, include_usage: bool = False):
     # Create a streaming chunk with list content (Databricks format).
     return {
@@ -132,6 +161,15 @@ async def chat_response_stream_empty_choices():
     yield _make_chat_stream_chunk("Hello")
 
 
+async def chat_response_stream_with_azure_annotations(include_usage: bool = False):
+    yield _make_chat_stream_annotation_chunk()
+    yield _make_chat_stream_chunk("Hello")
+    yield _make_chat_stream_chunk(" world")
+    if include_usage:
+        yield _make_chat_stream_usage_chunk()
+    yield _make_chat_stream_annotation_chunk()
+
+
 async def chat_response_stream_with_list_content(include_usage: bool = False):
     # Simulate Databricks streaming format with list content.
     yield _make_chat_stream_chunk_with_list_content(
@@ -149,6 +187,13 @@ async def chat(payload: ChatCompletionRequest):
         if EMPTY_CHOICES == payload.messages[0].content:
             content = (
                 f"data: {json.dumps(d)}\n\n" async for d in chat_response_stream_empty_choices()
+            )
+        elif AZURE_ANNOTATIONS == payload.messages[0].content:
+            content = (
+                f"data: {json.dumps(d)}\n\n"
+                async for d in chat_response_stream_with_azure_annotations(
+                    include_usage=(payload.stream_options or {}).get("include_usage", False)
+                )
             )
         elif LIST_CONTENT == payload.messages[0].content:
             content = (

--- a/tests/openai/test_openai_autolog.py
+++ b/tests/openai/test_openai_autolog.py
@@ -22,7 +22,7 @@ from mlflow.tracing.constant import (
 )
 from mlflow.version import IS_TRACING_SDK_ONLY
 
-from tests.openai.mock_openai import EMPTY_CHOICES, LIST_CONTENT
+from tests.openai.mock_openai import AZURE_ANNOTATIONS, EMPTY_CHOICES, LIST_CONTENT
 from tests.tracing.helper import get_traces, skip_when_testing_trace_sdk
 
 MOCK_TOOLS = [
@@ -439,6 +439,41 @@ async def test_chat_completions_streaming_empty_choices(client):
 
     trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
     assert trace.info.status == "OK"
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_streaming_ignores_azure_annotation_chunks(client):
+    mlflow.openai.autolog()
+    stream = client.chat.completions.create(
+        messages=[{"role": "user", "content": AZURE_ANNOTATIONS}],
+        model="gpt-4o-mini",
+        stream=True,
+        stream_options={"include_usage": True},
+    )
+
+    chunks = [chunk async for chunk in await stream] if client._is_async else list(stream)
+    assert chunks[0].object == ""
+    assert chunks[-1].object == ""
+
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+    assert trace is not None
+    assert trace.info.status == "OK"
+    assert trace.info.token_usage == {
+        TokenUsageKey.INPUT_TOKENS: 9,
+        TokenUsageKey.OUTPUT_TOKENS: 12,
+        TokenUsageKey.TOTAL_TOKENS: 21,
+    }
+
+    span = trace.data.spans[0]
+    assert span.outputs["id"] == "chatcmpl-123"
+    assert span.outputs["model"] == "gpt-4o-mini"
+    assert span.outputs["choices"][0]["message"]["content"] == "Hello world"
+    assert span.outputs["usage"]["prompt_tokens"] == 9
+    assert span.get_attribute(SpanAttributeKey.CHAT_USAGE) == {
+        TokenUsageKey.INPUT_TOKENS: 9,
+        TokenUsageKey.OUTPUT_TOKENS: 12,
+        TokenUsageKey.TOTAL_TOKENS: 21,
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Related Issues/PRs

Closes #23026

### What changes are proposed in this pull request?

Azure OpenAI Chat Completions streams can include annotation chunks whose `object` is an empty string. MLflow currently decides whether to reconstruct a streamed completion from `output[0].object` and reads usage only from the physical last chunk. A leading annotation chunk therefore bypasses completion reconstruction and `CHAT_USAGE`; a trailing annotation chunk can hide the usage chunk.

This PR filters streamed completion chunks before reconstruction and scans the filtered chunks from the end for usage. The Responses API path is unchanged.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Validation run locally:

- `uv run pytest tests/openai/test_openai_autolog.py::test_chat_completions_streaming_ignores_azure_annotation_chunks -q`
- `uv run pytest tests/openai/test_openai_autolog.py::test_chat_completions_autolog_streaming tests/openai/test_openai_autolog.py::test_chat_completions_streaming_empty_choices tests/openai/test_openai_autolog.py::test_chat_completions_streaming_ignores_azure_annotation_chunks tests/openai/test_openai_autolog.py::test_chat_completions_streaming_with_list_content tests/openai/test_openai_autolog.py::test_chat_completions_autolog_streaming_with_cached_tokens -q`
- `uv run ruff check mlflow/openai/autolog.py tests/openai/mock_openai.py tests/openai/test_openai_autolog.py`
- `uv run ruff format --check mlflow/openai/autolog.py tests/openai/mock_openai.py tests/openai/test_openai_autolog.py`

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I have updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixes OpenAI autologging so Azure OpenAI Chat Completions streams with annotation chunks correctly preserve reconstructed outputs and token usage.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
