### PR TITLE
Fix artifact text viewer crash on large files

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPage.tsx
@@ -41,6 +41,7 @@ import type { KeyValueEntity } from '../../../common/types';
 import { LazyShowArtifactMarkdownView } from './LazyShowArtifactMarkdownView';
 
 const MAX_PREVIEW_ARTIFACT_SIZE_MB = 50;
+const MAX_PREVIEW_TEXT_ARTIFACT_SIZE_MB = 10;
 
 type ShowArtifactPageProps = {
   runUuid: string;
@@ -114,6 +115,9 @@ class ShowArtifactPage extends Component<ShowArtifactPageProps> {
             />
           );
         } else if (TEXT_EXTENSIONS.has(normalizedExtension.toLowerCase())) {
+          if ((this.props.size || 0) > MAX_PREVIEW_TEXT_ARTIFACT_SIZE_MB * ONE_MB) {
+            return getFileTooLargeView(MAX_PREVIEW_TEXT_ARTIFACT_SIZE_MB);
+          }
           return <ShowArtifactTextView {...commonArtifactProps} size={this.props.size} />;
         } else if (MAP_EXTENSIONS.has(normalizedExtension.toLowerCase())) {
           return <LazyShowArtifactMapView {...commonArtifactProps} />;
@@ -159,7 +163,7 @@ const getSelectFileView = () => {
   );
 };
 
-const getFileTooLargeView = () => {
+const getFileTooLargeView = (maxSizeMB: number = MAX_PREVIEW_ARTIFACT_SIZE_MB) => {
   return (
     <div css={{ flex: 1, display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
       <Empty
@@ -177,9 +181,9 @@ const getFileTooLargeView = () => {
         }
         description={
           <FormattedMessage
-            // eslint-disable-next-line formatjs/enforce-default-message
-            defaultMessage={`Maximum file size for preview: ${MAX_PREVIEW_ARTIFACT_SIZE_MB}MiB`}
+            defaultMessage="Maximum file size for preview: {maxSizeMB}MiB"
             description="Text to notify users of the maximum file size for which artifact previews are displayed"
+            values={{ maxSizeMB }}
           />
         }
       />

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactTextView.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactTextView.enzyme.test.tsx
@@ -9,6 +9,7 @@ import { describe, beforeEach, jest, test, expect } from '@jest/globals';
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 import ShowArtifactTextView, { prettifyArtifactText } from './ShowArtifactTextView';
+import { SyntaxHighlighterErrorBoundary } from './ShowArtifactTextView';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { mountWithIntl } from '../../../common/utils/TestUtils.enzyme';
 
@@ -146,5 +147,48 @@ describe('ShowArtifactTextView', () => {
   test('should leave invalid json untouched', () => {
     const outputText = prettifyArtifactText('json', '{"hello');
     expect(outputText).toBe('{"hello');
+  });
+
+  // eslint-disable-next-line jest/no-done-callback -- TODO(FEINF-1337)
+  test('should render large files as plain pre instead of SyntaxHighlighter', (done) => {
+    const largeText = 'x'.repeat(1024 * 1024 + 1);
+    const getArtifact = jest.fn(() => Promise.resolve(largeText));
+    const props = { path: 'big.json', runUuid: 'fakeUuid', getArtifact, experimentId: '123' };
+    wrapper = mountWithIntl(<ShowArtifactTextView {...props} />);
+    setImmediate(() => {
+      wrapper.update();
+      expect(wrapper.find('.mlflow-ShowArtifactPage').length).toBe(1);
+      expect(wrapper.find(SyntaxHighlighter).length).toBe(0);
+      expect(wrapper.find('pre').length).toBe(1);
+      done();
+    });
+  });
+});
+
+describe('SyntaxHighlighterErrorBoundary', () => {
+  test('should render children when no error occurs', () => {
+    const wrapper = mount(
+      <SyntaxHighlighterErrorBoundary fallback={<div id="fallback" />}>
+        <div id="child">content</div>
+      </SyntaxHighlighterErrorBoundary>,
+    );
+    expect(wrapper.find('#child').length).toBe(1);
+    expect(wrapper.find('#fallback').length).toBe(0);
+  });
+
+  test('should render fallback when child throws during render', () => {
+    const ThrowingComponent = () => {
+      throw new Error('render crash');
+    };
+    // Suppress expected error boundary console output
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const wrapper = mount(
+      <SyntaxHighlighterErrorBoundary fallback={<pre id="fallback">fallback text</pre>}>
+        <ThrowingComponent />
+      </SyntaxHighlighterErrorBoundary>,
+    );
+    expect(wrapper.find('#fallback').length).toBe(1);
+    expect(wrapper.find('#fallback').text()).toBe('fallback text');
+    spy.mockRestore();
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactTextView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactTextView.tsx
@@ -11,7 +11,43 @@ import { ArtifactViewErrorState } from './ArtifactViewErrorState';
 import type { LoggedModelArtifactViewerProps } from './ArtifactViewComponents.types';
 import { fetchArtifactUnified } from './utils/fetchArtifactUnified';
 
-const LARGE_ARTIFACT_SIZE = 100 * 1024;
+const LARGE_ARTIFACT_SIZE = 1024 * 1024;
+// Beyond this size, skip the syntax highlighter entirely and render as
+// plain text in a <pre> block. Prism creates a DOM node per token, so
+// multi-megabyte files can freeze the browser tab.
+const MAX_HIGHLIGHTER_SIZE = 1024 * 1024;
+
+type SyntaxHighlighterErrorBoundaryProps = {
+  fallback: React.ReactNode;
+  children: React.ReactNode;
+};
+
+type SyntaxHighlighterErrorBoundaryState = {
+  hasError: boolean;
+};
+
+/**
+ * Catches render errors from the syntax highlighter (e.g. files with
+ * problematic content or that are too large for Prism to tokenize) and
+ * falls back to a plain-text rendering instead of crashing the page.
+ */
+export class SyntaxHighlighterErrorBoundary extends Component<
+  SyntaxHighlighterErrorBoundaryProps,
+  SyntaxHighlighterErrorBoundaryState
+> {
+  state: SyntaxHighlighterErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback;
+    }
+    return this.props.children;
+  }
+}
 
 type Props = DesignSystemHocProps & {
   runUuid: string;
@@ -61,8 +97,10 @@ class ShowArtifactTextView extends Component<Props, State> {
     if (this.state.error) {
       return <ArtifactViewErrorState className="artifact-text-view-error" />;
     } else {
+      const textLength = this.state.text ? (this.state.text as string).length : 0;
+      const isVeryLargeFile = textLength > MAX_HIGHLIGHTER_SIZE;
       const isLargeFile = (this.props.size || 0) > LARGE_ARTIFACT_SIZE;
-      const language = isLargeFile ? 'text' : getLanguage(this.props.path);
+      const language = isLargeFile || isVeryLargeFile ? 'text' : getLanguage(this.props.path);
       const { theme } = this.props.designSystemThemeApi;
 
       const overrideStyles = {
@@ -78,14 +116,39 @@ class ShowArtifactTextView extends Component<Props, State> {
       };
       const renderedContent = this.state.text ? prettifyArtifactText(language, this.state.text) : this.state.text;
 
+      const plainTextFallback = (
+        <pre
+          style={{
+            ...overrideStyles,
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-all',
+            color: theme.colors.textPrimary,
+            backgroundColor: theme.colors.backgroundPrimary,
+            margin: 0,
+          }}
+        >
+          {renderedContent ?? ''}
+        </pre>
+      );
+
+      if (isVeryLargeFile) {
+        return (
+          <div className="mlflow-ShowArtifactPage">
+            <div className="text-area-border-box">{plainTextFallback}</div>
+          </div>
+        );
+      }
+
       const syntaxStyle = theme.isDarkMode ? darkStyle : style;
 
       return (
         <div className="mlflow-ShowArtifactPage">
           <div className="text-area-border-box">
-            <SyntaxHighlighter language={language} style={syntaxStyle} customStyle={overrideStyles}>
-              {renderedContent ?? ''}
-            </SyntaxHighlighter>
+            <SyntaxHighlighterErrorBoundary fallback={plainTextFallback}>
+              <SyntaxHighlighter language={language} style={syntaxStyle} customStyle={overrideStyles}>
+                {renderedContent ?? ''}
+              </SyntaxHighlighter>
+            </SyntaxHighlighterErrorBoundary>
           </div>
         </div>
       );


### PR DESCRIPTION
### Related Issues/PRs

Fixes #3384
Fixes #16066

### What changes are proposed in this pull request?

The Prism syntax highlighter in `ShowArtifactTextView` creates a DOM node for every token, which causes the browser to freeze or crash when rendering large text artifacts (e.g. JSON files > 2MB). The unhandled exception bubbles up to the top-level React error boundary, showing a generic "something went wrong" page instead of failing gracefully.

This is a long-standing issue reported by multiple users across #3384 and #16066.

**Changes:**

- **`SyntaxHighlighterErrorBoundary`**: New React error boundary wrapping the Prism `SyntaxHighlighter`. Catches any render failure (large files, problematic unicode, unexpected content) and falls back to a plain `<pre>` block instead of crashing the page.
- **`LARGE_ARTIFACT_SIZE` raised from 100KB to 1MB**: Syntax highlighting now works for moderately sized files. Testing shows Prism handles up to ~900KB of JSON without issues.
- **`MAX_HIGHLIGHTER_SIZE` (1MB)**: When fetched text content exceeds 1MB, the component skips Prism entirely and renders in a plain `<pre>` block.
- **`MAX_PREVIEW_TEXT_ARTIFACT_SIZE_MB` (10MB)**: Text-specific preview cap. Text files over 10MB show "file too large to preview" without being fetched. The existing 50MB general cap remains for other artifact types.
- **`getFileTooLargeView` parameterized**: Accepts a `maxSizeMB` parameter so the displayed message shows the correct limit.

**Rendering tiers:**

| File size | Behavior |
|-----------|----------|
| < 1MB | Full Prism syntax highlighting with language detection |
| 1MB - 10MB | Plain `<pre>` render (monospace, scrollable, no highlighting) |
| > 10MB | "File too large to preview" message (file not fetched) |
| Any size (Prism crash) | Error boundary catches, falls back to plain `<pre>` |

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New enzyme tests:
- Files over 1MB render `<pre>` instead of `SyntaxHighlighter`
- `SyntaxHighlighterErrorBoundary` renders children normally
- `SyntaxHighlighterErrorBoundary` renders fallback when child throws

Manual testing with JSON artifacts at 50KB, 500KB, 900KB, 1.1MB, 2MB, 4MB, 6MB, 8MB, 10MB, 12MB, and 16MB.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The MLflow artifact viewer no longer crashes when previewing large text files. Files under 1MB get full syntax highlighting, files between 1-10MB render as plain text, and files over 10MB show a "file too large" message.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release
