### PR TITLE
Add UC traces upsell message for set_experiment calls on Databricks

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1475,6 +1475,13 @@ MLFLOW_SERVER_ENABLE_GRAPHQL_AUTH = _BooleanEnvironmentVariable(
     "MLFLOW_SERVER_ENABLE_GRAPHQL_AUTH", True
 )
 
+#: Whether to show the Unity Catalog trace upsell message when calling set_experiment
+#: on a Databricks-backed experiment without a UC trace destination.
+#: (default: ``True``)
+_MLFLOW_ENABLE_UC_TRACE_UPSELL = _BooleanEnvironmentVariable(
+    "_MLFLOW_ENABLE_UC_TRACE_UPSELL", True
+)
+
 
 #: Specifies whether to allow unsafe pickle deserialization for loading model
 MLFLOW_ALLOW_PICKLE_DESERIALIZATION = _BooleanEnvironmentVariable(

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1478,9 +1478,7 @@ MLFLOW_SERVER_ENABLE_GRAPHQL_AUTH = _BooleanEnvironmentVariable(
 #: Whether to show the Unity Catalog trace upsell message when calling set_experiment
 #: on a Databricks-backed experiment without a UC trace destination.
 #: (default: ``True``)
-_MLFLOW_ENABLE_UC_TRACE_UPSELL = _BooleanEnvironmentVariable(
-    "_MLFLOW_ENABLE_UC_TRACE_UPSELL", True
-)
+_MLFLOW_ENABLE_UC_TRACE_UPSELL = _BooleanEnvironmentVariable("_MLFLOW_ENABLE_UC_TRACE_UPSELL", True)
 
 
 #: Specifies whether to allow unsafe pickle deserialization for loading model

--- a/mlflow/tracking/_uc_upsell.py
+++ b/mlflow/tracking/_uc_upsell.py
@@ -1,0 +1,25 @@
+from mlflow.utils.logging_utils import eprint
+
+_BOLD_ORANGE = "\033[1;38;5;208m"
+_LIGHT_BLUE = "\033[94m"
+_RESET = "\033[0m"
+
+
+def show_existing_experiment_upsell():
+    doc_url = "https://docs.databricks.com/aws/en/mlflow3/genai/tracing/migrate-traces-to-uc"
+    eprint(
+        f"{_BOLD_ORANGE}If you are using MLflow Tracing, you can migrate your traces "
+        f"to Unity Catalog for unlimited storage, fine-grained access controls, "
+        f"and queryability from notebooks, SQL, and dashboards. "
+        f"{_LIGHT_BLUE}Learn more: {doc_url}{_RESET}"
+    )
+
+
+def show_new_experiment_upsell():
+    doc_url = "https://docs.databricks.com/aws/en/mlflow3/genai/tracing/trace-unity-catalog"
+    eprint(
+        f"{_BOLD_ORANGE}If you are using MLflow Tracing, consider storing your "
+        f"traces in Unity Catalog for unlimited storage (no 100,000 trace limit), "
+        f"fine-grained access controls, and queryability from notebooks, SQL, "
+        f"and dashboards. {_LIGHT_BLUE}Learn more: {doc_url}{_RESET}"
+    )

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -37,6 +37,7 @@ from mlflow.entities.trace_location import UnityCatalog
 from mlflow.environment_variables import (
     _MLFLOW_ACTIVE_MODEL_ID,
     _MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS,
+    _MLFLOW_ENABLE_UC_TRACE_UPSELL,
     MLFLOW_ACTIVE_MODEL_ID,
     MLFLOW_ENABLE_ASYNC_LOGGING,
     MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING,
@@ -241,6 +242,15 @@ def set_experiment(
                 error_code=INVALID_PARAMETER_VALUE,
             )
 
+    if (
+        _MLFLOW_ENABLE_UC_TRACE_UPSELL.get()
+        and not is_newly_created
+        and trace_location is None
+        and is_databricks_uri(_resolve_tracking_uri())
+        and MLFLOW_EXPERIMENT_DATABRICKS_TRACE_DESTINATION_PATH not in experiment.tags
+    ):
+        _show_uc_upsell_message()
+
     if trace_location is not None and trace_location.table_prefix is None:
         trace_location = UnityCatalog(
             catalog_name=trace_location.catalog_name,
@@ -287,6 +297,20 @@ def _sync_trace_destination_and_provider(
         provider.reset()
 
     _MLFLOW_TRACE_USER_DESTINATION.set(resolved_location)
+
+
+def _show_uc_upsell_message():
+    from mlflow.utils.logging_utils import eprint
+
+    yellow_bold = "\033[1;33m"
+    cyan = "\033[36m"
+    reset = "\033[0m"
+    doc_url = "https://docs.databricks.com/TODO"
+    eprint(
+        f"{yellow_bold}Migrate your traces to Unity Catalog for unlimited storage, "
+        f"fine-grained access controls, and queryability from notebooks, SQL, and "
+        f"dashboards. {cyan}Learn more: {doc_url}{reset}"
+    )
 
 
 def _resolve_experiment_to_trace_location(

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -59,6 +59,7 @@ from mlflow.tracing.provider import (
 )
 from mlflow.tracking._tracking_service.client import TrackingServiceClient
 from mlflow.tracking._tracking_service.utils import _resolve_tracking_uri
+from mlflow.tracking._uc_upsell import show_existing_experiment_upsell, show_new_experiment_upsell
 from mlflow.utils import get_results_from_paginated_fn
 from mlflow.utils.annotations import experimental
 from mlflow.utils.async_logging.run_operations import RunOperations
@@ -244,12 +245,14 @@ def set_experiment(
 
     if (
         _MLFLOW_ENABLE_UC_TRACE_UPSELL.get()
-        and not is_newly_created
         and trace_location is None
         and is_databricks_uri(_resolve_tracking_uri())
         and MLFLOW_EXPERIMENT_DATABRICKS_TRACE_DESTINATION_PATH not in experiment.tags
     ):
-        _show_uc_upsell_message()
+        if is_newly_created:
+            show_new_experiment_upsell()
+        else:
+            show_existing_experiment_upsell()
 
     if trace_location is not None and trace_location.table_prefix is None:
         trace_location = UnityCatalog(
@@ -297,20 +300,6 @@ def _sync_trace_destination_and_provider(
         provider.reset()
 
     _MLFLOW_TRACE_USER_DESTINATION.set(resolved_location)
-
-
-def _show_uc_upsell_message():
-    from mlflow.utils.logging_utils import eprint
-
-    yellow_bold = "\033[1;33m"
-    cyan = "\033[36m"
-    reset = "\033[0m"
-    doc_url = "https://docs.databricks.com/TODO"
-    eprint(
-        f"{yellow_bold}Migrate your traces to Unity Catalog for unlimited storage, "
-        f"fine-grained access controls, and queryability from notebooks, SQL, and "
-        f"dashboards. {cyan}Learn more: {doc_url}{reset}"
-    )
 
 
 def _resolve_experiment_to_trace_location(

--- a/tests/tracking/fluent/test_set_experiment_trace_location.py
+++ b/tests/tracking/fluent/test_set_experiment_trace_location.py
@@ -7,6 +7,7 @@ from mlflow.entities import Experiment
 from mlflow.entities.experiment_tag import ExperimentTag
 from mlflow.entities.trace_location import UnityCatalog
 from mlflow.exceptions import MlflowException
+from mlflow.tracking._uc_upsell import show_existing_experiment_upsell, show_new_experiment_upsell
 from mlflow.tracking.fluent import (
     _resolve_experiment_to_trace_location,
     _sync_trace_destination_and_provider,
@@ -377,19 +378,31 @@ def test_sync_fresh_session_without_location_is_noop(_clean_tracing_state):
     assert not prov.once._done
 
 
-def test_show_uc_upsell_message_outputs_expected_content():
-    from mlflow.tracking.fluent import _show_uc_upsell_message
-
-    with mock.patch("mlflow.utils.logging_utils.eprint") as mock_eprint:
-        _show_uc_upsell_message()
+def test_show_uc_upsell_message_existing_experiment():
+    with mock.patch("mlflow.tracking._uc_upsell.eprint") as mock_eprint:
+        show_existing_experiment_upsell()
         mock_eprint.assert_called_once_with(
-            "\033[1;33mMigrate your traces to Unity Catalog for unlimited storage, "
-            "fine-grained access controls, and queryability from notebooks, SQL, and "
-            "dashboards. \033[36mLearn more: https://docs.databricks.com/TODO\033[0m"
+            "\033[1;38;5;208mIf you are using MLflow Tracing, you can migrate your traces "
+            "to Unity Catalog for unlimited storage, fine-grained access controls, "
+            "and queryability from notebooks, SQL, and dashboards. "
+            "\033[94mLearn more: https://docs.databricks.com/aws/en/mlflow3/genai/tracing/migrate-traces-to-uc\033[0m"
         )
 
 
-def test_uc_upsell_shown_for_existing_non_uc_experiment_on_databricks():
+def test_show_uc_upsell_message_new_experiment():
+    with mock.patch("mlflow.tracking._uc_upsell.eprint") as mock_eprint:
+        show_new_experiment_upsell()
+        mock_eprint.assert_called_once_with(
+            "\033[1;38;5;208mIf you are using MLflow Tracing, consider storing your "
+            "traces in Unity Catalog for unlimited storage (no 100,000 trace limit), "
+            "fine-grained access controls, and queryability from notebooks, SQL, "
+            "and dashboards. \033[94mLearn more: "
+            "https://docs.databricks.com/aws/en/mlflow3/genai/tracing/trace-unity-catalog"
+            "\033[0m"
+        )
+
+
+def test_uc_upsell_existing_shown_for_existing_non_uc_experiment_on_databricks():
     exp = _experiment()
     with (
         mock.patch("mlflow.tracking.fluent.TrackingServiceClient") as mock_client_cls,
@@ -400,12 +413,40 @@ def test_uc_upsell_shown_for_existing_non_uc_experiment_on_databricks():
         mock.patch("mlflow.tracking.fluent._sync_trace_destination_and_provider"),
         mock.patch("mlflow.tracking.fluent._resolve_tracking_uri", return_value="databricks"),
         mock.patch("mlflow.tracking.fluent.is_databricks_uri", return_value=True),
-        mock.patch("mlflow.utils.logging_utils.eprint") as mock_eprint,
+        mock.patch("mlflow.tracking._uc_upsell.eprint") as mock_eprint,
     ):
         mock_client_cls.return_value.get_experiment_by_name.return_value = exp
         mlflow.set_experiment("test-experiment")
+        mock_eprint.assert_called_once_with(
+            "\033[1;38;5;208mIf you are using MLflow Tracing, you can migrate your traces "
+            "to Unity Catalog for unlimited storage, fine-grained access controls, "
+            "and queryability from notebooks, SQL, and dashboards. "
+            "\033[94mLearn more: https://docs.databricks.com/aws/en/mlflow3/genai/tracing/migrate-traces-to-uc\033[0m"
+        )
+
+
+def test_uc_upsell_new_shown_for_newly_created_experiment_on_databricks():
+    exp = _experiment()
+    with (
+        mock.patch("mlflow.tracking.fluent.TrackingServiceClient") as mock_client_cls,
+        mock.patch(
+            "mlflow.tracking.fluent._resolve_experiment_to_trace_location",
+            return_value=None,
+        ),
+        mock.patch("mlflow.tracking.fluent._sync_trace_destination_and_provider"),
+        mock.patch("mlflow.tracking.fluent._resolve_tracking_uri", return_value="databricks"),
+        mock.patch("mlflow.tracking.fluent.is_databricks_uri", return_value=True),
+        mock.patch("mlflow.tracking._uc_upsell.eprint") as mock_eprint,
+    ):
+        client = mock_client_cls.return_value
+        client.get_experiment_by_name.return_value = None
+        client.create_experiment.return_value = "123"
+        client.get_experiment.return_value = exp
+        mlflow.set_experiment("test-experiment")
         mock_eprint.assert_called_once()
-        assert "Unity Catalog" in mock_eprint.call_args[0][0]
+        message = mock_eprint.call_args[0][0]
+        assert "If you are using MLflow Tracing" in message
+        assert "consider storing your traces in Unity Catalog" in message
 
 
 def test_uc_upsell_not_shown_when_experiment_has_uc_tag():
@@ -421,7 +462,7 @@ def test_uc_upsell_not_shown_when_experiment_has_uc_tag():
         mock.patch("mlflow.tracking.fluent._sync_trace_destination_and_provider"),
         mock.patch("mlflow.tracking.fluent._resolve_tracking_uri", return_value="databricks"),
         mock.patch("mlflow.tracking.fluent.is_databricks_uri", return_value=True),
-        mock.patch("mlflow.utils.logging_utils.eprint") as mock_eprint,
+        mock.patch("mlflow.tracking._uc_upsell.eprint") as mock_eprint,
     ):
         mock_client_cls.return_value.get_experiment_by_name.return_value = exp
         mlflow.set_experiment("test-experiment")

--- a/tests/tracking/fluent/test_set_experiment_trace_location.py
+++ b/tests/tracking/fluent/test_set_experiment_trace_location.py
@@ -375,3 +375,57 @@ def test_sync_fresh_session_without_location_is_noop(_clean_tracing_state):
 
     assert destination_registry.get() is None
     assert not prov.once._done
+
+
+# --- UC upsell message tests ---
+
+
+def test_show_uc_upsell_message_outputs_expected_content():
+    from mlflow.tracking.fluent import _show_uc_upsell_message
+
+    with mock.patch("mlflow.utils.logging_utils.eprint") as mock_eprint:
+        _show_uc_upsell_message()
+        mock_eprint.assert_called_once_with(
+            "\033[1;33mMigrate your traces to Unity Catalog for unlimited storage, "
+            "fine-grained access controls, and queryability from notebooks, SQL, and "
+            "dashboards. \033[36mLearn more: https://docs.databricks.com/TODO\033[0m"
+        )
+
+
+def test_uc_upsell_shown_for_existing_non_uc_experiment_on_databricks():
+    exp = _experiment()
+    with (
+        mock.patch("mlflow.tracking.fluent.TrackingServiceClient") as mock_client_cls,
+        mock.patch(
+            "mlflow.tracking.fluent._resolve_experiment_to_trace_location",
+            return_value=None,
+        ),
+        mock.patch("mlflow.tracking.fluent._sync_trace_destination_and_provider"),
+        mock.patch("mlflow.tracking.fluent._resolve_tracking_uri", return_value="databricks"),
+        mock.patch("mlflow.tracking.fluent.is_databricks_uri", return_value=True),
+        mock.patch("mlflow.utils.logging_utils.eprint") as mock_eprint,
+    ):
+        mock_client_cls.return_value.get_experiment_by_name.return_value = exp
+        mlflow.set_experiment("test-experiment")
+        mock_eprint.assert_called_once()
+        assert "Unity Catalog" in mock_eprint.call_args[0][0]
+
+
+def test_uc_upsell_not_shown_when_experiment_has_uc_tag():
+    exp = _experiment(
+        tags={MLFLOW_EXPERIMENT_DATABRICKS_TRACE_DESTINATION_PATH: "catalog.schema.prefix"}
+    )
+    with (
+        mock.patch("mlflow.tracking.fluent.TrackingServiceClient") as mock_client_cls,
+        mock.patch(
+            "mlflow.tracking.fluent._resolve_experiment_to_trace_location",
+            return_value=None,
+        ),
+        mock.patch("mlflow.tracking.fluent._sync_trace_destination_and_provider"),
+        mock.patch("mlflow.tracking.fluent._resolve_tracking_uri", return_value="databricks"),
+        mock.patch("mlflow.tracking.fluent.is_databricks_uri", return_value=True),
+        mock.patch("mlflow.utils.logging_utils.eprint") as mock_eprint,
+    ):
+        mock_client_cls.return_value.get_experiment_by_name.return_value = exp
+        mlflow.set_experiment("test-experiment")
+        mock_eprint.assert_not_called()

--- a/tests/tracking/fluent/test_set_experiment_trace_location.py
+++ b/tests/tracking/fluent/test_set_experiment_trace_location.py
@@ -377,9 +377,6 @@ def test_sync_fresh_session_without_location_is_noop(_clean_tracing_state):
     assert not prov.once._done
 
 
-# --- UC upsell message tests ---
-
-
 def test_show_uc_upsell_message_outputs_expected_content():
     from mlflow.tracking.fluent import _show_uc_upsell_message
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to UC trace migration initiative

### What changes are proposed in this pull request?

When `mlflow.set_experiment()` is called on Databricks with an experiment that does **not** have a Unity Catalog trace destination configured, a colored upsell message is printed to stderr encouraging migration to UC traces.

**Two scenarios with different messages:**

1. **Existing experiment without UC** — "Migrate your traces to Unity Catalog for unlimited storage, fine-grained access controls, and queryability from notebooks, SQL, and dashboards."

2. **Newly created experiment** — "Store your traces in Unity Catalog..." with a code snippet showing how to call `set_experiment` with `trace_location=UnityCatalog(...)` and a link to the docs.

**Conditions for showing the message (all must be true):**
- Tracking URI is Databricks (`is_databricks_uri`)
- No `trace_location` parameter was provided
- The experiment has no `MLFLOW_EXPERIMENT_DATABRICKS_TRACE_DESTINATION_PATH` tag
- The `_MLFLOW_ENABLE_UC_TRACE_UPSELL` env var is not set to `false`

**Files changed:**
- `mlflow/environment_variables.py` — Added `_MLFLOW_ENABLE_UC_TRACE_UPSELL` internal boolean env var (default: `True`) for easy toggling from Databricks
- `mlflow/tracking/_uc_upsell.py` — New module containing upsell message functions (`show_existing_experiment_upsell`, `show_new_experiment_upsell`)
- `mlflow/tracking/fluent.py` — Added upsell condition check in `set_experiment`, imports from `_uc_upsell`
- `tests/tracking/fluent/test_set_experiment_trace_location.py` — Added 5 tests: message content for both scenarios, positive integration tests for both, and negative test

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests

Verified on a Databricks notebook that:
1. OSS (non-Databricks) `set_experiment` does NOT show the message
2. Databricks `set_experiment` on a newly created experiment shows the "Store your traces" message with code snippet
3. Databricks `set_experiment` on an existing non-UC experiment shows the "Migrate your traces" message
4. Databricks `set_experiment` on an experiment with UC tag does NOT show the message

**OSS set_experiment**
<img width="711" height="448" alt="Screenshot 2026-05-01 at 4 27 21 PM" src="https://github.com/user-attachments/assets/e0add55c-5748-4f4d-bc7b-3da659e220fe" />

**databricks set_experiment: existing MySQL experiment**
<img width="939" height="361" alt="image" src="https://github.com/user-attachments/assets/4ea00747-fc4a-4a40-a22c-ba78263a40a6" />


**databricks set_experiment: new MySQL experiment**
<img width="943" height="313" alt="image" src="https://github.com/user-attachments/assets/ba20580c-9c7a-4a99-939f-aae0ccb9fc82" />

**databricks set_experiment: existing UC experiment**
<img width="913" height="630" alt="Screenshot 2026-05-01 at 4 44 32 PM" src="https://github.com/user-attachments/assets/b0765a6e-6b17-4efd-ac30-075e9e2e1dee" />

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. When using Databricks, `mlflow.set_experiment()` now shows an informational message encouraging migration to Unity Catalog traces for experiments without a UC trace destination configured.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release