### PR TITLE
DOC Add XGBoost autolog code example consistent with other frameworks

### DIFF
--- a/docs/docs/classic-ml/tracking/autolog/index.mdx
+++ b/docs/docs/classic-ml/tracking/autolog/index.mdx
@@ -198,7 +198,7 @@ Autologging captures the following information:
   </tbody>
 </Table>
 
-If early stopping is activated, metrics at the best iteration will be logged as an extra step/iteration.
+If early stopping is activated, metrics at the best iteration will be logged as an extra step/iteration
 
 ### Paddle \{#autolog-paddle}
 
@@ -499,3 +499,30 @@ Autologging captures the following information:
 </Table>
 
 If early stopping is activated, metrics at the best iteration will be logged as an extra step/iteration.
+
+As an example, try running the [XGBoost example](https://github.com/mlflow/mlflow/blob/master/examples/xgboost/xgboost_native/train.py).
+
+```python
+import mlflow
+import xgboost as xgb
+from sklearn import datasets
+from sklearn.model_selection import train_test_split
+
+mlflow.xgboost.autolog()
+
+iris = datasets.load_iris()
+X_train, X_test, y_train, y_test = train_test_split(
+    iris.data, iris.target, test_size=0.2, random_state=42
+)
+
+dtrain = xgb.DMatrix(X_train, label=y_train)
+params = {
+    "objective": "multi:softprob",
+    "num_class": 3,
+    "learning_rate": 0.3,
+    "eval_metric": "mlogloss",
+}
+
+with mlflow.start_run():
+    xgb.train(params, dtrain, num_boost_round=20)
+```


### PR DESCRIPTION
The XGBoost section in the autologging docs was missing a usage example, while every other major framework (Keras, sklearn, LightGBM, Statsmodels, etc.) has one. This PR adds a short code snippet showing `mlflow.xgboost.autolog()` with `xgb.train()`, consistent with the existing pattern in the file. The example is based on the code in `examples/xgboost/xgboost_native/train.py`.

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Added a usage example to the XGBoost section of the autologging docs, following the same pattern as sklearn and other frameworks already in the file.

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Examples

### Does this PR require updating the MLflow Skills repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Adds a missing code example to the XGBoost autologging documentation, making it consistent with other supported frameworks.

#### What component(s) does this PR affect?

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/docs`: MLflow documentation pages

#### How should the PR be classified in the release notes?

- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix?

- [x] This PR can wait for the next minor release
