### PR TITLE
Fix gateway workspace context & add MCP run analysis tools

### DIFF
--- a/mlflow/genai/judges/adapters/gateway_adapter.py
+++ b/mlflow/genai/judges/adapters/gateway_adapter.py
@@ -15,6 +15,8 @@ from typing import TYPE_CHECKING, Any
 import pydantic
 
 from mlflow.utils.providers import _lookup_model_info
+from mlflow.utils.workspace_context import get_request_workspace
+from mlflow.utils.workspace_utils import WORKSPACE_HEADER_NAME
 
 if TYPE_CHECKING:
     from mlflow.entities.trace import Trace
@@ -297,6 +299,13 @@ def _invoke_via_gateway(
     Raises:
         MlflowException: If the provider is not supported or invocation fails.
     """
+    # Forward workspace context for gateway provider
+    if provider == "gateway":
+        workspace_headers = {}
+        if ws := get_request_workspace():
+            workspace_headers[WORKSPACE_HEADER_NAME] = ws
+        extra_headers = {**workspace_headers, **(extra_headers or {})}
+
     if isinstance(prompt, str):
         return score_model_on_payload(
             model_uri=model_uri,
@@ -523,6 +532,9 @@ class GatewayAdapter(BaseJudgeAdapter):
         # Tag gateway requests so the server can attribute traffic to the judge
         if provider == "gateway":
             headers[MLFLOW_GATEWAY_CALLER_HEADER] = GatewayCaller.JUDGE.value
+            # Forward workspace context when invoking gateway endpoints
+            if ws := get_request_workspace():
+                headers[WORKSPACE_HEADER_NAME] = ws
         if extra_headers:
             headers.update(extra_headers)
 

--- a/mlflow/mcp/server.py
+++ b/mlflow/mcp/server.py
@@ -10,6 +10,7 @@ import mlflow.deployments.cli as deployments_cli
 import mlflow.experiments
 import mlflow.models.cli as models_cli
 import mlflow.runs
+import mlflow.store.artifact.cli as artifacts_cli
 from mlflow.ai_commands.ai_command_utils import get_command_body, list_commands
 from mlflow.cli.scorers import commands as scorers_cli
 from mlflow.cli.traces import commands as traces_cli
@@ -24,8 +25,8 @@ from mlflow.mcp.decorator import get_mcp_tool_name
 MLFLOW_MCP_TOOLS = os.environ.get("MLFLOW_MCP_TOOLS", "genai")
 
 # Tool category mappings
-_GENAI_TOOLS = {"traces", "scorers", "experiments", "runs"}
-_ML_TOOLS = {"models", "deployments", "experiments", "runs"}
+_GENAI_TOOLS = {"traces", "scorers", "experiments", "runs", "artifacts"}
+_ML_TOOLS = {"models", "deployments", "experiments", "runs", "artifacts"}
 _ALL_TOOLS = _GENAI_TOOLS | _ML_TOOLS
 
 if TYPE_CHECKING:
@@ -228,6 +229,10 @@ def create_mcp() -> "FastMCP":
     # Run management tools (genai)
     if _is_tool_enabled("runs"):
         tools.extend(_collect_tools(mlflow.runs.commands.commands))
+
+    # Artifact management tools (genai & ml)
+    if _is_tool_enabled("artifacts"):
+        tools.extend(_collect_tools(artifacts_cli.commands.commands))
 
     # Model serving tools (ml)
     if _is_tool_enabled("models"):

--- a/mlflow/runs.py
+++ b/mlflow/runs.py
@@ -250,3 +250,230 @@ def link_traces(run_id: str, trace_ids: tuple[str, ...]) -> None:
         raise click.ClickException(f"Failed to link traces: {e.message}")
     except Exception as e:
         raise click.ClickException(f"Unexpected error linking traces: {e!s}")
+
+
+@commands.command("get-metric-history")
+@mlflow_mcp(tool_name="get_metric_history")
+@click.option(
+    "--run-id",
+    type=click.STRING,
+    required=True,
+    help="ID of the run to get metric history from.",
+)
+@click.option(
+    "--metric-key",
+    type=click.STRING,
+    required=True,
+    help="Name of the metric to retrieve history for.",
+)
+@click.option(
+    "--max-results",
+    type=click.INT,
+    help="Maximum number of metric history entries to return. If not specified, returns all entries.",
+)
+def get_metric_history(run_id: str, metric_key: str, max_results: int | None) -> None:
+    """
+    Get the full time series history of a metric for a run.
+
+    Returns a JSON array of metric history entries, each containing:
+    - step: The step number at which the metric was logged
+    - value: The metric value
+    - timestamp: Unix timestamp (milliseconds) when the metric was logged
+    """
+    try:
+        client = MlflowClient()
+        metric_history = client.get_metric_history(run_id, metric_key)
+
+        # Convert to list of dicts for JSON output
+        history_data = [
+            {
+                "step": metric.step,
+                "value": metric.value,
+                "timestamp": metric.timestamp,
+            }
+            for metric in metric_history
+        ]
+
+        # Apply max_results limit if specified
+        if max_results is not None and max_results > 0:
+            history_data = history_data[:max_results]
+
+        click.echo(json.dumps(history_data, indent=2))
+
+    except MlflowException as e:
+        raise click.ClickException(f"Failed to get metric history: {e.message}")
+    except Exception as e:
+        raise click.ClickException(f"Unexpected error getting metric history: {e!s}")
+
+
+@commands.command("search")
+@mlflow_mcp(tool_name="search_runs")
+@click.option(
+    "--experiment-ids",
+    type=click.STRING,
+    required=True,
+    help="Comma-separated list of experiment IDs to search within.",
+)
+@click.option(
+    "--filter",
+    "filter_string",
+    type=click.STRING,
+    default="",
+    help="Filter query string using MLflow's search syntax. "
+    "Examples: 'metrics.accuracy > 0.9', 'params.lr = \"1e-5\"', "
+    "'attributes.status = \"FINISHED\"'.",
+)
+@click.option(
+    "--order-by",
+    type=click.STRING,
+    multiple=True,
+    help="Order results by specified columns. Can be specified multiple times. "
+    "Format: 'column_name [ASC|DESC]'. Examples: 'metrics.accuracy DESC', 'start_time ASC'.",
+)
+@click.option(
+    "--max-results",
+    type=click.INT,
+    default=100,
+    help="Maximum number of runs to return. Default is 100.",
+)
+@click.option(
+    "--view-type",
+    type=click.Choice(["ACTIVE_ONLY", "DELETED_ONLY", "ALL"], case_sensitive=False),
+    default="ACTIVE_ONLY",
+    help="Type of runs to return. Options: ACTIVE_ONLY (default), DELETED_ONLY, or ALL.",
+)
+def search_runs(
+    experiment_ids: str,
+    filter_string: str,
+    order_by: tuple[str, ...],
+    max_results: int,
+    view_type: str,
+) -> None:
+    """
+    Search for runs matching specified criteria across experiments.
+
+    Returns a JSON array of runs with their parameters, metrics, and metadata.
+    Supports filtering, ordering, and pagination.
+    """
+    try:
+        client = MlflowClient()
+
+        # Parse experiment IDs
+        exp_ids = [exp_id.strip() for exp_id in experiment_ids.split(",") if exp_id.strip()]
+        if not exp_ids:
+            raise click.UsageError("At least one experiment ID must be provided.")
+
+        # Convert order_by tuple to list
+        order_by_list = list(order_by) if order_by else None
+
+        # Search runs
+        runs = client.search_runs(
+            experiment_ids=exp_ids,
+            filter_string=filter_string,
+            order_by=order_by_list,
+            max_results=max_results,
+            run_view_type=view_type.upper(),
+        )
+
+        # Convert runs to JSON-serializable format
+        runs_data = []
+        for run in runs:
+            run_dict = {
+                "run_id": run.info.run_id,
+                "experiment_id": run.info.experiment_id,
+                "status": run.info.status,
+                "start_time": run.info.start_time,
+                "end_time": run.info.end_time,
+                "run_name": run.info.run_name,
+                "metrics": {key: value for key, value in run.data.metrics.items()},
+                "params": {key: value for key, value in run.data.params.items()},
+                "tags": {key: value for key, value in run.data.tags.items()},
+            }
+            runs_data.append(run_dict)
+
+        click.echo(json.dumps(runs_data, indent=2))
+
+    except MlflowException as e:
+        raise click.ClickException(f"Failed to search runs: {e.message}")
+    except Exception as e:
+        raise click.ClickException(f"Unexpected error searching runs: {e!s}")
+
+
+@commands.command("compare")
+@mlflow_mcp(tool_name="compare_runs")
+@click.option(
+    "--run-ids",
+    type=click.STRING,
+    required=True,
+    help="Comma-separated list of run IDs to compare.",
+)
+@click.option(
+    "--metric-keys",
+    type=click.STRING,
+    help="Comma-separated list of metric keys to include. If not specified, includes all metrics.",
+)
+@click.option(
+    "--param-keys",
+    type=click.STRING,
+    help="Comma-separated list of parameter keys to include. If not specified, includes all parameters.",
+)
+def compare_runs(
+    run_ids: str,
+    metric_keys: str | None,
+    param_keys: str | None,
+) -> None:
+    """
+    Compare multiple runs side-by-side.
+
+    Returns a JSON object with run IDs as keys, each containing the run's
+    metrics and parameters for easy comparison.
+    """
+    try:
+        client = MlflowClient()
+
+        # Parse run IDs
+        run_id_list = [rid.strip() for rid in run_ids.split(",") if rid.strip()]
+        if not run_id_list:
+            raise click.UsageError("At least one run ID must be provided.")
+
+        # Parse metric and param keys if provided
+        metric_key_set = (
+            {key.strip() for key in metric_keys.split(",") if key.strip()}
+            if metric_keys
+            else None
+        )
+        param_key_set = (
+            {key.strip() for key in param_keys.split(",") if key.strip()} if param_keys else None
+        )
+
+        # Fetch runs and build comparison
+        comparison = {}
+        for run_id in run_id_list:
+            run = client.get_run(run_id)
+
+            # Filter metrics
+            if metric_key_set is not None:
+                metrics = {k: v for k, v in run.data.metrics.items() if k in metric_key_set}
+            else:
+                metrics = dict(run.data.metrics)
+
+            # Filter params
+            if param_key_set is not None:
+                params = {k: v for k, v in run.data.params.items() if k in param_key_set}
+            else:
+                params = dict(run.data.params)
+
+            comparison[run_id] = {
+                "run_name": run.info.run_name,
+                "status": run.info.status,
+                "metrics": metrics,
+                "params": params,
+            }
+
+        click.echo(json.dumps(comparison, indent=2))
+
+    except MlflowException as e:
+        raise click.ClickException(f"Failed to compare runs: {e.message}")
+    except Exception as e:
+        raise click.ClickException(f"Unexpected error comparing runs: {e!s}")
+

--- a/mlflow/store/artifact/cli.py
+++ b/mlflow/store/artifact/cli.py
@@ -3,6 +3,7 @@ import logging
 import click
 
 from mlflow.artifacts import download_artifacts as _download_artifacts
+from mlflow.mcp.decorator import mlflow_mcp
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.tracking import _get_store
 from mlflow.utils.proto_json_utils import message_to_json
@@ -67,6 +68,7 @@ def log_artifacts(local_dir, run_id, artifact_path):
 
 
 @commands.command("list")
+@mlflow_mcp(tool_name="list_artifacts")
 @click.option("--run-id", "-r", required=True, help="Run ID to be listed")
 @click.option(
     "--artifact-path",
@@ -92,6 +94,7 @@ def _file_infos_to_json(file_infos):
 
 
 @commands.command("download")
+@mlflow_mcp(tool_name="download_artifact")
 @click.option("--run-id", "-r", help="Run ID from which to download")
 @click.option(
     "--artifact-path",


### PR DESCRIPTION
## Related Issues/PRs

Closes #23001
Closes #23034

## What changes are proposed in this pull request?

This PR fixes two issues:

1. **Issue #23001**: Gateway adapter now forwards workspace context via X-MLFLOW-WORKSPACE header in both _invoke_and_handle_tools and _invoke_via_gateway methods
2. **Issue #23034**: Added MCP tools for run analysis (get-metric-history, search, compare commands) and exposed artifact commands via MCP

## How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests  
- [x] Manual tests

Manual testing: Verified all modified files compile successfully with py_compile.

## Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Does this PR require updating the MLflow Skills repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

## Release Notes

### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

**Bug fix**: Gateway adapter forwards workspace context when invoking judge endpoints (fixes #23001)

**Feature**: Added MCP run analysis tools: get_metric_history, search_runs, compare_runs, list_artifacts, download_artifact (fixes #23034)

## What component(s), interfaces, languages, and integrations does this PR affect?

### Components

- [x] area/tracking: Tracking Service, tracking client APIs, autologging
- [ ] area/models: MLmodel format, model serialization/deserialization, flavors
- [ ] area/model-registry: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] area/scoring: MLflow Model server, model deployment tools, Spark UDFs
- [ ] area/evaluation: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] area/gateway: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] area/prompts: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] area/tracing: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] area/projects: MLproject format, project running backends
- [ ] area/uiux: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] area/build: Build and test infrastructure for MLflow
- [ ] area/docs: MLflow documentation pages

## How should the PR be classified in the release notes? Choose one:

- [ ] rn/none - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] rn/breaking-change - The PR will be mentioned in the "Breaking Changes" section
- [x] rn/feature - A new user-facing feature worth mentioning in the release notes
- [ ] rn/bug-fix - A user-facing bug fix worth mentioning in the release notes
- [ ] rn/documentation - A user-facing documentation change worth mentioning in the release notes

## Is this PR a critical bugfix or security fix that should go into the next patch release?

### What is a minor/patch release?

Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.

Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
