### PR TITLE
Fix `gateway_adapter` not forwarding workspace header to judge endpoints

### DIFF
--- a/mlflow/genai/judges/adapters/gateway_adapter.py
+++ b/mlflow/genai/judges/adapters/gateway_adapter.py
@@ -58,6 +58,8 @@ from mlflow.metrics.genai.model_utils import (
 )
 from mlflow.protos.databricks_pb2 import BAD_REQUEST, INTERNAL_ERROR, INVALID_PARAMETER_VALUE
 from mlflow.tracing.constant import AssessmentMetadataKey
+from mlflow.utils.workspace_context import get_request_workspace
+from mlflow.utils.workspace_utils import WORKSPACE_HEADER_NAME
 
 _logger = logging.getLogger(__name__)
 
@@ -297,6 +299,12 @@ def _invoke_via_gateway(
     Raises:
         MlflowException: If the provider is not supported or invocation fails.
     """
+    if provider == "gateway":
+        workspace_headers: dict[str, str] = {}
+        if ws := get_request_workspace():
+            workspace_headers[WORKSPACE_HEADER_NAME] = ws
+        extra_headers = {**workspace_headers, **(extra_headers or {})}
+
     if isinstance(prompt, str):
         return score_model_on_payload(
             model_uri=model_uri,
@@ -523,6 +531,8 @@ class GatewayAdapter(BaseJudgeAdapter):
         # Tag gateway requests so the server can attribute traffic to the judge
         if provider == "gateway":
             headers[MLFLOW_GATEWAY_CALLER_HEADER] = GatewayCaller.JUDGE.value
+            if ws := get_request_workspace():
+                headers[WORKSPACE_HEADER_NAME] = ws
         if extra_headers:
             headers.update(extra_headers)
 

--- a/tests/genai/judges/adapters/test_gateway_adapter.py
+++ b/tests/genai/judges/adapters/test_gateway_adapter.py
@@ -1144,7 +1144,7 @@ def test_invoke_and_handle_tools_forwards_workspace_header():
             "mlflow.genai.judges.adapters.gateway_adapter.send_chat_request",
             side_effect=capture_and_raise,
         ),
-        pytest.raises(MlflowException),
+        pytest.raises(MlflowException, match="stop"),
     ):
         adapter._invoke_and_handle_tools(
             provider="gateway",

--- a/tests/genai/judges/adapters/test_gateway_adapter.py
+++ b/tests/genai/judges/adapters/test_gateway_adapter.py
@@ -1075,4 +1075,83 @@ def test_invoke_with_tools_populates_output_fields(mock_trace):
 
     assert result.request_id == "req-123"
     assert result.num_prompt_tokens == 10
-    assert result.num_completion_tokens == 5
+
+
+# --- Workspace header forwarding tests ---
+
+
+def test_invoke_via_gateway_forwards_workspace_header():
+    with (
+        mock.patch(
+            "mlflow.genai.judges.adapters.gateway_adapter.get_request_workspace",
+            return_value="my-workspace",
+        ),
+        mock.patch(
+            "mlflow.genai.judges.adapters.gateway_adapter.score_model_on_payload",
+            return_value='{"result": "yes", "rationale": "ok"}',
+        ) as mock_score,
+    ):
+        _invoke_via_gateway(
+            model_uri="gateway:/my-endpoint",
+            provider="gateway",
+            prompt="Is this helpful?",
+        )
+
+    mock_score.assert_called_once()
+    assert mock_score.call_args[1]["extra_headers"]["X-MLFLOW-WORKSPACE"] == "my-workspace"
+
+
+def test_invoke_via_gateway_no_workspace_header_when_unset():
+    with (
+        mock.patch(
+            "mlflow.genai.judges.adapters.gateway_adapter.get_request_workspace",
+            return_value=None,
+        ),
+        mock.patch(
+            "mlflow.genai.judges.adapters.gateway_adapter.score_model_on_payload",
+            return_value='{"result": "yes", "rationale": "ok"}',
+        ) as mock_score,
+    ):
+        _invoke_via_gateway(
+            model_uri="gateway:/my-endpoint",
+            provider="gateway",
+            prompt="Is this helpful?",
+        )
+
+    mock_score.assert_called_once()
+    extra_headers = mock_score.call_args[1].get("extra_headers") or {}
+    assert "X-MLFLOW-WORKSPACE" not in extra_headers
+
+
+def test_invoke_and_handle_tools_forwards_workspace_header():
+    adapter = GatewayAdapter()
+    captured_headers = {}
+
+    def capture_and_raise(**kwargs):
+        captured_headers.update(kwargs.get("headers", {}))
+        raise MlflowException("stop")
+
+    with (
+        mock.patch(
+            "mlflow.genai.judges.adapters.gateway_adapter.get_request_workspace",
+            return_value="my-workspace",
+        ),
+        mock.patch(
+            "mlflow.genai.judges.adapters.gateway_adapter._get_provider_instance",
+            return_value=_mock_provider(),
+        ),
+        mock.patch(
+            "mlflow.genai.judges.adapters.gateway_adapter.send_chat_request",
+            side_effect=capture_and_raise,
+        ),
+        pytest.raises(MlflowException),
+    ):
+        adapter._invoke_and_handle_tools(
+            provider="gateway",
+            model_name="my-endpoint",
+            messages=[ChatMessage(role="user", content="evaluate this")],
+            trace=None,
+            num_retries=0,
+        )
+
+    assert captured_headers["X-MLFLOW-WORKSPACE"] == "my-workspace"


### PR DESCRIPTION
### Related Issues/PRs

Closes #23001

### What changes are proposed in this pull request?

When a judge evaluation job runs in a non-default workspace, the gateway adapter builds HTTP headers for gateway calls but never injects `X-MLFLOW-WORKSPACE`. The gateway resolves the endpoint against the default workspace instead of the job's workspace, causing a 404 for any workspace that doesn't have a duplicate endpoint in default.

Two code paths in `gateway_adapter.py` are fixed:

- **`_invoke_via_gateway`**: injects `X-MLFLOW-WORKSPACE` into `extra_headers` when the provider is `"gateway"` and a workspace is active.
- **`_invoke_and_handle_tools`**: injects `X-MLFLOW-WORKSPACE` into the headers dict alongside the existing `MLFLOW_GATEWAY_CALLER_HEADER` injection.

The workspace is read via `get_request_workspace()` which reads the `MLFLOW_WORKSPACE` env var already set correctly by the job runner subprocess.

### How is this PR tested?

Three new unit tests added to `tests/genai/judges/adapters/test_gateway_adapter.py`:

- `test_invoke_via_gateway_forwards_workspace_header` — verifies `X-MLFLOW-WORKSPACE` is added to `extra_headers` when workspace is set
- `test_invoke_via_gateway_no_workspace_header_when_unset` — verifies header is absent when no workspace is active
- `test_invoke_and_handle_tools_forwards_workspace_header` — verifies `X-MLFLOW-WORKSPACE` is added to headers in the tool-calling path

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

**Before** (404 — gateway endpoint not found because workspace header was missing):
<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/b0a86fb9-f029-4410-8ead-4a489a5f7367" />

**After** (assessments populated successfully after forwarding `X-MLFLOW-WORKSPACE`): 
<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/2787ca8f-31eb-4793-b90d-67c14aba4486" />

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release