### PR TITLE
Surface Anthropic prompt-cache token counts in `mlflow.pydantic_ai.autolog`

### DIFF
--- a/mlflow/pydantic_ai/utils.py
+++ b/mlflow/pydantic_ai/utils.py
@@ -99,11 +99,16 @@ def parse_usage(result: Any) -> dict[str, int] | None:
         total_tokens = getattr(usage, "total_tokens", None)
         if total_tokens is None:
             total_tokens = input_tokens + output_tokens
-        return {
+        usage_dict = {
             TokenUsageKey.INPUT_TOKENS: input_tokens,
             TokenUsageKey.OUTPUT_TOKENS: output_tokens,
             TokenUsageKey.TOTAL_TOKENS: total_tokens,
         }
+        if cache_read := getattr(usage, "cache_read_tokens", 0):
+            usage_dict[TokenUsageKey.CACHE_READ_INPUT_TOKENS] = cache_read
+        if cache_write := getattr(usage, "cache_write_tokens", 0):
+            usage_dict[TokenUsageKey.CACHE_CREATION_INPUT_TOKENS] = cache_write
+        return usage_dict
     except Exception as e:
         _logger.debug("Failed to parse token usage from output: %s", e)
     return None

--- a/tests/pydantic_ai/test_utils.py
+++ b/tests/pydantic_ai/test_utils.py
@@ -1,0 +1,69 @@
+from mlflow.pydantic_ai.utils import parse_usage
+from mlflow.tracing.constant import TokenUsageKey
+
+
+class _FakeRunUsageWithCache:
+    input_tokens = 1500
+    output_tokens = 50
+    total_tokens = 1550
+    cache_read_tokens = 1200
+    cache_write_tokens = 300
+
+
+class _FakeRunUsageNoCache:
+    input_tokens = 1500
+    output_tokens = 50
+    total_tokens = 1550
+    cache_read_tokens = 0
+    cache_write_tokens = 0
+
+
+class _FakeRunUsageWithoutCacheAttrs:
+    input_tokens = 1500
+    output_tokens = 50
+    total_tokens = 1550
+
+
+class _FakeStreamedResult:
+    def __init__(self, usage):
+        self._usage = usage
+
+    def usage(self):
+        return self._usage
+
+
+class _FakeRunResult:
+    def __init__(self, usage):
+        self.usage = usage
+
+
+def test_parse_usage_emits_anthropic_cache_keys_when_populated():
+    assert parse_usage(_FakeRunResult(_FakeRunUsageWithCache())) == {
+        TokenUsageKey.INPUT_TOKENS: 1500,
+        TokenUsageKey.OUTPUT_TOKENS: 50,
+        TokenUsageKey.TOTAL_TOKENS: 1550,
+        TokenUsageKey.CACHE_READ_INPUT_TOKENS: 1200,
+        TokenUsageKey.CACHE_CREATION_INPUT_TOKENS: 300,
+    }
+
+
+def test_parse_usage_omits_cache_keys_when_zero():
+    assert parse_usage(_FakeRunResult(_FakeRunUsageNoCache())) == {
+        TokenUsageKey.INPUT_TOKENS: 1500,
+        TokenUsageKey.OUTPUT_TOKENS: 50,
+        TokenUsageKey.TOTAL_TOKENS: 1550,
+    }
+
+
+def test_parse_usage_streamed_result_callable_usage_path():
+    usage = parse_usage(_FakeStreamedResult(_FakeRunUsageWithCache()))
+    assert usage[TokenUsageKey.CACHE_READ_INPUT_TOKENS] == 1200
+    assert usage[TokenUsageKey.CACHE_CREATION_INPUT_TOKENS] == 300
+
+
+def test_parse_usage_skips_cache_keys_when_attrs_missing():
+    assert parse_usage(_FakeRunResult(_FakeRunUsageWithoutCacheAttrs())) == {
+        TokenUsageKey.INPUT_TOKENS: 1500,
+        TokenUsageKey.OUTPUT_TOKENS: 50,
+        TokenUsageKey.TOTAL_TOKENS: 1550,
+    }


### PR DESCRIPTION
### Related Issues/PRs

Closes #23002

### What changes are proposed in this pull request?

`mlflow.pydantic_ai.autolog._parse_usage` reads `input_tokens` / `output_tokens` / `total_tokens` off pydantic-ai's `RunUsage` but doesn't currently surface the Anthropic prompt-cache fields, even though pydantic-ai exposes them as `cache_read_tokens` / `cache_write_tokens`. The result is that the Usage breakdown panel in the trace UI renders `n/a` in the cache cells for any pydantic-ai run that exercises Anthropic prompt caching, while the equivalent run via `mlflow.anthropic.autolog` renders the cache numbers correctly.

This PR maps pydantic-ai's two cache fields onto the existing `TokenUsageKey.CACHE_READ_INPUT_TOKENS` / `TokenUsageKey.CACHE_CREATION_INPUT_TOKENS` keys when they're populated, mirroring the structure of [`mlflow.anthropic.autolog._parse_usage`](https://github.com/mlflow/mlflow/blob/master/mlflow/anthropic/autolog.py#L177-L196). One small wrinkle is that pydantic-ai's `RunUsage` already follows [genai-prices' `AbstractUsage` convention](https://github.com/pydantic/genai-prices/blob/main/genai_prices/types.py) where `input_tokens` includes both cached and uncached portions, so the post-hoc input/total normalization that `mlflow/anthropic/autolog.py` performs (after the cache fields are read) isn't applicable here — the totals are already correctly inclusive.

The cache fields are emitted only when truthy, so non-Anthropic / cache-disabled runs aren't polluted with `cache_*: 0` noise.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Four new unit tests in `tests/pydantic_ai/test_pydanticai_tracing.py` exercise `_parse_usage` directly:

1. Cache fields populated → `CACHE_*_INPUT_TOKENS` keys emitted with the expected values.
2. Cache fields zero → cache keys omitted entirely (no `cache_*: 0` noise).
3. `usage` exposed as a method (`StreamedRunResult` shape) → both code paths surface cache fields identically.
4. `cache_*` attributes missing on the usage object → `getattr` defaults keep the helper backwards-compatible.

> **Note for reviewers**: 4 unrelated tests in the same file (`test_agent_run_*_enable_disable_autolog*`) appear to currently be failing on `master` due to environment / version drift unrelated to this change. I verified by stashing this PR's diff and re-running them locally on top of the latest `master` — the same 4 fail. Happy to file a separate issue if useful.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. `mlflow.pydantic_ai.autolog` now surfaces Anthropic prompt-cache token counts (`cache_read_input_tokens`, `cache_creation_input_tokens`) on the `mlflow.chat.tokenUsage` span attribute, so the Usage breakdown panel in the trace UI renders the cache cells correctly for pydantic-ai runs that exercise Anthropic prompt caching.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
