### PR TITLE
Fix nested array items being stripped from function tool schemas

### DIFF
--- a/mlflow/types/chat.py
+++ b/mlflow/types/chat.py
@@ -116,7 +116,11 @@ class ParamProperty(ParamType):
 
     description: str | None = None
     enum: list[str | int | float | bool] | None = None
-    items: ParamType | None = None
+    # Recursive type so nested arrays (e.g. list[list[str]]) preserve their inner
+    # `items` schema through Pydantic round-trips. If this were `ParamType`, the
+    # inner `items` field would be silently stripped and downstream providers
+    # would reject the schema with "array schema missing items".
+    items: ParamProperty | None = None
 
 
 class FunctionParams(BaseModel):

--- a/mlflow/types/llm.py
+++ b/mlflow/types/llm.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 import uuid
 from dataclasses import asdict, dataclass, field, fields

--- a/mlflow/types/llm.py
+++ b/mlflow/types/llm.py
@@ -280,12 +280,15 @@ class ParamProperty(ParamType):
 
     description: str | None = None
     enum: list[str] | None = None
-    items: ParamType | None = None
+    items: ParamProperty | None = None
 
     def __post_init__(self):
         self._validate_field("description", str, False)
         self._validate_list("enum", str, False)
-        self._convert_dataclass("items", ParamType, False)
+        # Convert recursively so nested arrays (e.g. list[list[str]]) preserve
+        # their inner `items` schema. If converted as `ParamType`, the inner
+        # `items` field would be silently dropped.
+        self._convert_dataclass("items", ParamProperty, False)
         super().__post_init__()
 
 

--- a/tests/gateway/schemas/test_chat.py
+++ b/tests/gateway/schemas/test_chat.py
@@ -90,6 +90,43 @@ def test_chat_request():
         chat.RequestPayload(**{})
 
 
+def test_chat_request_preserves_nested_array_items():
+    # Regression test for https://github.com/mlflow/mlflow/issues/23040.
+    # Nested array schemas (e.g. list[list[str]]) must round-trip through the
+    # request model without losing the inner `items` field; otherwise the
+    # gateway forwards a malformed schema and providers reject it with
+    # `array schema missing items`.
+    nested_items = {
+        "type": "array",
+        "items": {"type": "string"},
+    }
+    payload = chat.RequestPayload(**{
+        "messages": [{"role": "user", "content": "hi"}],
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "send",
+                    "description": "Send a message.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "buttons": {
+                                "type": "array",
+                                "items": nested_items,
+                            },
+                        },
+                    },
+                },
+            }
+        ],
+    })
+
+    dumped = payload.model_dump(exclude_none=True)
+    inner = dumped["tools"][0]["function"]["parameters"]["properties"]["buttons"]["items"]
+    assert inner == nested_items
+
+
 def test_chat_response():
     chat.ResponsePayload(**{
         "created": 100,


### PR DESCRIPTION
### Related Issues/PRs

Closes #23040

### What changes are proposed in this pull request?

`mlflow.types.chat.ParamProperty.items` was typed as `ParamType`, which only declares the `type` field. Because nested Pydantic models default to `extra="ignore"`, the inner `items` field of nested array schemas (e.g. `list[list[str]]`) was silently dropped on round-trip. The AI Gateway then forwarded a malformed schema to the provider, which OpenAI's strict-mode validator rejected with:

`Invalid schema for function '...': In context=('properties', '...', 'items'), array schema missing items.`

This PR makes `items` recursively typed as `ParamProperty` so nested arrays (and any inner `description` / `enum`) are preserved through Pydantic round-trips.

The same fix is applied to the dataclass-based `mlflow.types.llm.ParamProperty`, whose docstring already advertised `items: ParamProperty` even though the runtime type was `ParamType`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added a regression test in `tests/gateway/schemas/test_chat.py::test_chat_request_preserves_nested_array_items` that builds the exact reproducer from #23040 and asserts the inner `items` survives `model_dump`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed an AI Gateway validation bug where nested array schemas in function tool definitions (e.g. `list[list[str]]`) had their inner `items` silently stripped, causing downstream providers to reject the request with `array schema missing items`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release