### PR TITLE
Fix SensitiveQueryParamFilter over-redacting generic `signature` query params

### DIFF
--- a/mlflow/utils/logging_utils.py
+++ b/mlflow/utils/logging_utils.py
@@ -121,13 +121,17 @@ class SuppressLogFilter(logging.Filter):
 # Cloud storage presigned URLs (AWS S3, GCS, Azure SAS) embed credentials in
 # query parameters. urllib3 logs the full target URL on connection retries
 # (e.g. when DNS resolution fails), which leaks those credentials to stderr.
+# Only include provider-specific parameter names to avoid false positives on
+# generic names like "sig" or "Signature" that appear in non-cloud URLs.
 _SENSITIVE_QUERY_PARAM_NAMES = (
+    # AWS S3 presigned URL parameters
     "X-Amz-Signature",
     "X-Amz-Security-Token",
     "X-Amz-Credential",
+    # GCS presigned URL parameters
     "X-Goog-Signature",
     "X-Goog-Credential",
-    "Signature",
+    # Azure SAS token parameters
     "sig",
 )
 
@@ -145,8 +149,9 @@ class SensitiveQueryParamFilter(logging.Filter):
     """
     Logging filter that masks cloud storage credentials embedded in URL query
     strings. Attached to urllib3 to avoid leaking presigned URL credentials
-    (X-Amz-Signature, X-Amz-Security-Token, X-Amz-Credential, ...) when
-    urllib3 logs full URLs on connection failures or retries.
+    (X-Amz-Signature, X-Amz-Security-Token, X-Amz-Credential, X-Goog-Signature,
+    X-Goog-Credential, sig) when urllib3 logs full URLs on connection failures
+    or retries.
     """
 
     def filter(self, record: logging.LogRecord) -> bool:

--- a/tests/utils/test_logging_utils.py
+++ b/tests/utils/test_logging_utils.py
@@ -212,6 +212,15 @@ assert logging.getLogger("mlflow").isEnabledFor({expected_level})
             "just a normal log message without credentials",
         ),
         ("path?foo=bar&baz=qux", "path?foo=bar&baz=qux"),
+        # Generic "Signature" and "signature" params on non-cloud URLs must NOT be redacted.
+        (
+            "https://api.example.com/webhook?signature=abc123&nonce=xyz",
+            "https://api.example.com/webhook?signature=abc123&nonce=xyz",
+        ),
+        (
+            "https://api.example.com/v1/verify?Signature=deadbeef&timestamp=12345",
+            "https://api.example.com/v1/verify?Signature=deadbeef&timestamp=12345",
+        ),
     ],
 )
 def test_redact_sensitive_query_params(message: str, expected: str):


### PR DESCRIPTION
### Related Issues/PRs

Closes #23058

### What changes are proposed in this pull request?

Removes `"Signature"` from `_SENSITIVE_QUERY_PARAM_NAMES` in `mlflow/utils/logging_utils.py`.

The `SensitiveQueryParamFilter` (added in #22995) included the bare string `"Signature"` alongside provider-specific names like `X-Amz-Signature` and `X-Goog-Signature`. Because the regex is case-insensitive, any URL containing `?signature=` was redacted — including non-cloud endpoints (webhooks, OAuth callbacks, custom APIs) that use `signature` as a legitimate query parameter name.

No cloud storage provider uses `Signature` as a query parameter name:
- AWS S3 uses `X-Amz-Signature` (already in the list)
- GCS uses `X-Goog-Signature` (already in the list)
- Azure SAS uses `sig` (already in the list)

The docstring on `SensitiveQueryParamFilter` is updated to enumerate the exact parameter names that are redacted.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Two new parametrized cases are added to `test_redact_sensitive_query_params`:
- `https://api.example.com/webhook?signature=abc123&nonce=xyz` → unchanged (no longer over-redacted)
- `https://api.example.com/v1/verify?Signature=deadbeef&timestamp=12345` → unchanged (no longer over-redacted)

All existing cases (AWS S3, GCS, Azure SAS, plain messages) continue to pass.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`SensitiveQueryParamFilter` no longer redacts the value of generic `?signature=` query parameters on non-cloud URLs. Cloud storage presigned URL credentials (AWS `X-Amz-Signature`, GCS `X-Goog-Signature`, Azure SAS `sig`) are still redacted.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release