### PR TITLE
[Chore] Tighten minimum version floors for dependencies with known CVEs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "databricks-sdk<1,>=0.20.0",
   "docker<8,>=4.0.0",
   "fastapi<1",
-  "gitpython<4,>=3.1.9",
+  "gitpython<4,>=3.1.47",
   "graphene<4",
   "gunicorn<26; platform_system != 'Windows'",
   "huey<3,>=2.5.4",
@@ -50,12 +50,12 @@ dependencies = [
   "opentelemetry-sdk<3,>=1.9.0",
   "packaging<27",
   "pandas<3",
-  "protobuf<8,>=3.12.0",
+  "protobuf<8,>=6.33.5",
   "pyarrow<24,>=4.0.0",
   "pydantic<3,>=2.0.0",
-  "python-dotenv<2,>=0.19.0",
+  "python-dotenv<2,>=1.2.2",
   "pyyaml<7,>=5.1",
-  "requests<3,>=2.17.3",
+  "requests<3,>=2.33.0",
   "scikit-learn<2",
   "scipy<2",
   "skops<1",
@@ -113,7 +113,7 @@ genai = [
   "uvicorn[standard]<1",
   "watchfiles<2",
 ]
-mcp = ["fastmcp<4,>=2.0.0", "click!=8.3.0"]
+mcp = ["fastmcp<4,>=3.2.0", "click!=8.3.0"]
 azure = ["azure-storage-blob>=12", "azure-identity>=1.6.1"]
 sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]


### PR DESCRIPTION
## Summary

Tightens minimum version floors for 5 dependencies with known CVEs:

| Dependency | Old | New | CVE |
|---|---|---|---|
| gitpython | >=3.1.9 | >=3.1.47 | GHSA-rpm5-65cw-6hj4, GHSA-x2qx-6953-8485 |
| protobuf | >=3.12.0 | >=6.33.5 | Multiple CVEs |
| python-dotenv | >=0.19.0 | >=1.2.2 | GHSA-mf9w-mj56-hr94 |
| requests | >=2.17.3 | >=2.33.0 | GHSA-gc5v-m9x4-r6x2 |
| fastmcp | >=2.0.0 | >=3.2.0 | GHSA-rww4-4w9c-7733, GHSA-m8x7-r2rg-vh5g, GHSA-vv7q-7jx5-f767 |

Closes #23061