### PR TITLE
Fix: Artifacts not scaled to parent frame in comparison view (#20703)

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/components/EvaluationImageCellRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/components/EvaluationImageCellRenderer.tsx
@@ -57,6 +57,7 @@ export const EvaluationImageCellRenderer = ({ value }: EvaluationImageCellRender
             WebkitLineClamp: '7',
             width: '100%',
             height: '100%',
+            maxWidth: '100%',
           }}
         >
           <ImagePlot imageUrl={value.url} compressedImageUrl={value.compressed_url} />


### PR DESCRIPTION
## Summary

Fixes issue #20703: Artifacts (such as plots) are not scaled to their parent frame in the comparison view, causing a horizontal scrollbar that makes comparing plots/images inconvenient.

## Solution

Added `maxWidth: 100%` to the span element in `EvaluationImageCellRenderer.tsx` that wraps the `ImagePlot` component. This forces images to scale to the width of their parent frame.

## Changed file

- `mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/components/EvaluationImageCellRenderer.tsx`

## Before

Artifacts would overflow their container with a horizontal scrollbar.

## After

Artifacts now scale to fit their parent frame width.

---

Fixes #20703