### PR TITLE
Fix: Artifacts not scaled to parent frame in comparison view

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/components/EvaluationImageCellRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/components/EvaluationImageCellRenderer.tsx
@@ -57,6 +57,7 @@ export const EvaluationImageCellRenderer = ({ value }: EvaluationImageCellRender
             WebkitLineClamp: '7',
             width: '100%',
             height: '100%',
+            maxWidth: '100%',
           }}
         >
           <ImagePlot imageUrl={value.url} compressedImageUrl={value.compressed_url} />


### PR DESCRIPTION
### Related Issues/PRs

Closes #20703

### What changes are proposed in this pull request?

Add `max-width: 100%` to the image span in `EvaluationImageCellRenderer.tsx` to prevent images from overflowing their container in the comparison view.

### How is this PR tested?


- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.


### Does this PR require updating the MLflow Skills repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?


- [x] Yes. Fixes a UI bug where images in the comparison view overflow and show a horizontal scrollbar.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [ ] `area/tracking`
- [ ] `area/models`
- [ ] `area/model-registry`
- [ ] `area/scoring`
- [x] `area/evaluation`
- [ ] `area/gateway`
- [ ] `area/prompts`
- [ ] `area/other`
