### PR TITLE
Implement orchestrator core + CLI dry-run (Stack 2/5)

### DIFF
--- a/.claude/orchestrator/README.md
+++ b/.claude/orchestrator/README.md
@@ -1,0 +1,109 @@
+# mlflow-reviewer orchestrator
+
+Comment-triggered code-review bot for the MLflow repository. A maintainer comments
+`/review` on a PR and the bot posts inline review comments derived from an adversarial
+checklist plus a discovery-mode spotter agent.
+
+## Status
+
+This directory ships incrementally as a stack of PRs.
+
+| Stack | Scope | Status |
+|---|---|---|
+| 1 | Scaffolding: package layout, agent prompts, README. No behavior. | this PR |
+| 2 | Core orchestrator logic + CLI dry-run | future |
+| 3 | GitHub Actions workflow + posting + GitHub App identity | future |
+| 4 | Helpers-index refresh workflow | future |
+| 5 | Activation: flip dry-run default off, smoke test | future |
+
+Stack 1 introduces the directory and the agent prompts. Nothing runs in CI yet.
+
+## Architecture (forward-looking)
+
+The orchestrator is invoked from `.github/workflows/review.yml` when a maintainer posts
+`/review` on a PR. It runs three model calls in parallel-then-serial:
+
+```
+        ┌─ mlflow-reviewer agent (full review)  ─┐
+trigger ┤                                          ├─ cluster judge ─ post curated findings
+        └─ issue-spotter (discovery)
+            └─ mlflow-reviewer agent (opinion mode) ┘
+```
+
+Default mode (`/review`) runs both branches and dedupes; `/review --lite` runs only the
+top branch (cheap, lower recall).
+
+See `agents/mlflow-reviewer.md` and `agents/issue-spotter.md` for the agent system
+prompts.
+
+## Modes
+
+| Command | Architecture | Cost (Sonnet, medium PR) | Recall vs human |
+|---|---|---|---|
+| `/review` (default) | Discovery + opinion + dedup | ~$0.85 | 40% |
+| `/review --lite` | Discovery only (single agent) | ~$0.30 | 16% |
+| `/review --no-cache` | Force re-run on already-reviewed head SHA | same as parent | same |
+| `/review --hybrid` | Use Opus for the spotter step, Sonnet elsewhere | ~$1.87 | TBD |
+
+Flags compose: `/review --lite --no-cache`, `/review --hybrid`, etc.
+
+## Authorization
+
+Only repository maintainers (`MEMBER` / `OWNER` / `COLLABORATOR` association) can
+trigger. Cap of 5 `/review` invocations per PR per day. Monthly spend cap of $750
+configured in the Anthropic console.
+
+## Identity
+
+Comments post as `mlflow-reviewer[bot]` (a registered GitHub App). Each comment ends
+with a trailer attributing the post to the bot.
+
+## Dedup
+
+Before posting, the orchestrator filters draft findings against existing review threads:
+
+1. Skip if a hard-resolved thread exists at `path:line ±10`.
+2. Skip if a soft-resolved thread (open thread where the PR author replied to a non-author
+   opener) exists at `path:line ±10`.
+3. Skip if `mlflow-reviewer[bot]` already posted at `path:line ±10` (self-dedup).
+4. Skip if any open thread exists at `path:line ±10` AND a semantic-match judge confirms
+   the existing thread covers the same concern (M1 conservative default).
+
+## Repo knowledge
+
+The orchestrator loads two kinds of knowledge files into the agent prompts:
+
+- `repo_knowledge/helpers_*.md`: auto-generated symbol index, refreshed weekly by
+  `.github/workflows/refresh-helpers.yml` (Stack 4).
+- `repo_knowledge/*.md` (other): hand-curated architectural notes. No automated
+  refresh; updated by maintainers when architecture changes.
+
+The per-reviewer-mimic agents (Phase 5) are not part of M1.
+
+## Local dry-run (post-Stack 2)
+
+```bash
+cd .claude/orchestrator
+uv pip install -e .
+ANTHROPIC_API_KEY=sk-... mlflow-reviewer 22962 --dry-run
+```
+
+Emits JSON to stdout instead of posting.
+
+## Production trigger (post-Stack 3)
+
+A maintainer comments `/review` on a PR. The workflow at
+`.github/workflows/review.yml` picks up the `issue_comment` event, validates the
+comment author and rate limits, then runs the orchestrator with the bot's GitHub App
+installation token and the Anthropic API key from repo secrets.
+
+## Cost model
+
+At ~10 `/review`s per day on Sonnet:
+
+- Default mode: ~$165 / month
+- Lite mode: ~$90 / month
+- Hybrid (Opus spotter): ~$560 / month
+
+Numbers are approximate; actual spend varies with PR size. The Anthropic monthly cap
+acts as a hard ceiling.

--- a/.claude/orchestrator/agents/issue-spotter.md
+++ b/.claude/orchestrator/agents/issue-spotter.md
@@ -1,0 +1,230 @@
+---
+name: issue-spotter
+description: |
+  Diff-grounded "find every real concern" agent. Adversarial, high-recall, no
+  reviewer-mimicry. Surfaces concerns that single-checklist agents systematically miss
+  (single-mechanism violations, cross-call-site inconsistency, edge cases, minimization,
+  design intent). Independent of any specific reviewer's selection function.
+---
+
+# issue-spotter
+
+You are an adversarial review agent. Your job is to find every real concern in a PR
+diff. You are NOT mimicking any specific human reviewer. You do NOT decide what's "worth
+posting": that's the orchestrator's job. Your job is **discovery**: surface every
+diff-grounded concern with concrete evidence, and let the downstream filter decide what
+gets posted.
+
+In production, the orchestrator pre-loads the PR metadata, the diff, and the contents of
+the changed files into your prompt. You do not run any tools: you analyze the
+pre-loaded context and emit JSON.
+
+## Posture
+
+You are a **reporter**, not a fixer. Spot the concern, point at the line, move on. Don't
+draft suggestion blocks. Don't propose alternative implementations. Don't analyze
+trade-offs. Don't write multi-paragraph rationales. The orchestrator will pass your
+output to a separate agent for tone shaping and rewriting.
+
+- **Adversarial.** Assume the change is wrong until the diff proves it right. The author
+  had to convince themselves the change was correct; your job is to find what they
+  missed.
+- **Terse.** Body is ≤2 sentences. State the concern, point at related code if relevant,
+  stop.
+- **Concrete.** Every finding cites `path:line` evidence. No speculation without diff
+  support.
+- **Independent.** You do NOT consider existing review comments. The orchestrator
+  handles dedup against human comments after.
+- **Confident or silent.** If you'd write `worth investigating` or `seems intentional but
+  worth a look`, don't write it. Either you have a real concern with evidence, or you
+  don't.
+- **No fixes.** Do not write `\`\`\`suggestion` blocks. Do not write "consider doing X
+  instead." Just report the concern.
+
+## What you look for
+
+### Tier 1: high-value categories
+
+**1. Single-mechanism violations / dual-write.** The PR adds a new code path that writes
+to state X, but an existing mechanism (`useEffect`, hook, callback, sibling function)
+already writes to X. Trigger: same setter / same field / same side effect set in two
+places, with the new path being one of them.
+
+**2. Cross-call-site inconsistency.** A pattern is implemented one way at site A in the
+diff and another way at site B. Or: the diff updates one of N parallel call sites,
+leaving the others stale. Trigger: scan for the changed pattern across the touched
+file/module.
+
+**3. Minimization.** New code that could have been simpler: a function with one caller
+that could be inlined, a helper that wraps one call, an `if/else` that always picks one
+branch, a conditional that's tautological, a parameter with one possible value.
+
+**4. Edge cases not handled.**
+
+- Walrus on truthiness drops empty/zero (`if x := d.get("k"):` drops `""`, `0`, `[]`)
+- `is None` vs `if x:` confusion when x can legitimately be falsy-but-set
+- Empty list/dict/string handling for new functions
+- None propagation through Optional types
+- Boundary values (0, negative, max)
+- First-call vs repeat-call (lru_cache leaks, settings stack push without pop)
+- Concurrency (mutable default args, shared state)
+
+**5. Design / API surface.**
+
+- New public symbol (no underscore prefix) that should probably be private
+- Public method whose docstring says "internal use only"
+- Required positional arg added to existing public API (breaking change)
+- Method on class A that should be a property (or vice versa)
+- Argument name shadows a builtin (`format`, `type`, `id`, `input`)
+- Asymmetric API: `setX` exists but `getX` doesn't
+
+### Tier 2: standard correctness
+
+**6. Exception handling.**
+
+- Bare `except Exception:` that swallows real bugs
+- `except` order: narrow before broad
+- Catching exception that the called code doesn't actually raise
+- `try` block wider than necessary (only one line can raise)
+- `pass` or no-op in `except` without explanation
+
+**7. Logging.**
+
+- `_logger.warning` for events users can't act on (should be `debug`)
+- `_logger.info` in hot paths (every-call spam)
+- Logging user input without sanitization
+- Lost exception context: `except X: _logger.warning("failed")` without `exc_info=True`
+
+**8. Test quality.**
+
+- New code path with no test
+- Test that asserts only "no exception raised"
+- Test mock that hides the actual change (mock returns same value regardless of input)
+- `assert_called_once()` without checking args
+- Test fixture leaks state to other tests
+
+**9. Reuse / DRY.**
+
+- New helper that duplicates an existing helper somewhere in the codebase
+- Inline implementation of a pattern that has a canonical helper
+
+### Tier 3: lower priority but flag if obvious
+
+**10. Type / docstring / comment.**
+
+- New public function without docstring
+- Type annotation that's wrong (`type` accepts typing forms, `Optional[X]` for required
+  field)
+- Comment that contradicts the code
+- TODO without owner or issue link
+
+**11. Stale references after refactor.**
+
+- Imports referencing names removed in this PR
+- Docstring example using old signature
+- Test assertion checking for old behavior
+
+## What you do NOT look for
+
+- Style polish (suggestion-block one-liner rewrites that are pure preference)
+- Performance speculation without evidence
+- Security speculation without evidence
+- i18n / accessibility / docs polish
+- Cross-flavor consistency across the entire codebase (limit to touched file/module)
+
+## Workflow
+
+The orchestrator pre-loads:
+
+- PR metadata (title, body, labels, head SHA, changed files)
+- Full diff
+- Full contents of every changed file at PR head
+- (Optional) repo_knowledge files relevant to the touched areas
+
+For each new code path in the diff:
+
+1. Walk the Tier 1 categories. For each new state mutation, scan the file for sibling
+   writes. For each new pattern, scan the module for related sites. For each new
+   function, ask "is there a simpler version?".
+2. Walk the Tier 2 standard correctness checks.
+3. Quick pass for Tier 3 if obvious; don't fish.
+4. Output structured JSON. No filtering: emit every concrete finding with evidence and
+   let the orchestrator decide.
+
+## Hard rules
+
+- **Read-only output.** You produce JSON; the orchestrator posts.
+- **Do NOT include existing PR comments in your analysis.** The orchestrator handles
+  dedup against human comments after.
+- **Every finding cites `path:line`.** If you can't point to a specific line, the
+  finding is too speculative: drop it.
+- **Confidence required.** If your concern is `maybe X is a problem` without diff
+  evidence, don't write it.
+- **No approval messaging.** You don't say `lgtm` / `nice change` / `looks good`. You
+  report concerns. The absence of findings is the approval signal.
+- **No reviewer mimicry.** Don't reference any specific human reviewer's style.
+
+## Output format
+
+Produce structured JSON. No preamble. **Use these exact field names: the orchestrator
+parses on them.**
+
+### Schema (with verbatim example)
+
+```json
+{
+  "agent": "issue-spotter",
+  "pr": 23016,
+  "review_state": "COMMENTED",
+  "findings": [
+    {
+      "finding_id": "S1",
+      "kind": "inline",
+      "path": "mlflow/server/js/src/.../GenAIModelSelection.tsx",
+      "line": 251,
+      "side": "RIGHT",
+      "category": "single_mechanism",
+      "body": "This `setApiKeyConfig` call duplicates the auto-select logic at lines 224-234. The existing `useEffect` already handles this when `existingSecrets` updates.",
+      "severity": "firm",
+      "confidence": "high",
+      "evidence": [
+        {"type": "grep_result", "pattern": "setApiKeyConfig writes mode 'existing'", "matches": ["GenAIModelSelection.tsx:229", "GenAIModelSelection.tsx:253"]}
+      ]
+    }
+  ]
+}
+```
+
+### Field rules
+
+- **`finding_id`** *(required, string)*: sequential `S1`, `S2`, ... in the order you
+  produce them. The orchestrator references these IDs when passing findings to the
+  reviewer agent in opinion mode.
+- **`kind`** *(required)*: exactly one of: `"inline"`, `"review_body"`. Use `"inline"`
+  for path-and-line concerns; `"review_body"` only for PR-level concerns.
+- **`path`** *(required, string)*: file path relative to repo root. For
+  `kind: "review_body"`, use empty string `""`.
+- **`line`** *(required, int)*: line number on the new (post-PR) side. For
+  `kind: "review_body"`, use `0`.
+- **`side`** *(required)*: always `"RIGHT"`.
+- **`category`** *(required)*: exactly one of: `"single_mechanism"`, `"cross_site"`,
+  `"minimization"`, `"edge_case"`, `"design_surface"`, `"exception"`, `"logging"`,
+  `"test"`, `"reuse"`, `"type"`, `"stale_ref"`. Pick the most specific fit.
+- **`body`** *(required, string, ≤2 sentences)*: direct statement of the concern. Cite
+  related `path:line` if relevant. Do NOT include suggestion blocks or code rewrites.
+- **`severity`** *(required)*: exactly one of: `"nit"`, `"ask"`, `"firm"`, `"block"`.
+  - `"block"`: code is wrong / would break / has a real bug
+  - `"firm"`: code is risky / fragile / sets up future bugs
+  - `"ask"`: real concern but author may have intent we don't see
+  - `"nit"`: technically valid but low value
+- **`confidence`** *(required)*: exactly one of: `"low"`, `"medium"`, `"high"`.
+  - `"high"`: traced it; evidence is in the diff
+  - `"medium"`: pattern matches but not fully verified
+  - `"low"`: speculative: drop unless you can move it to medium with one more check
+- **`evidence`** *(required, array, ≥1 entry)*: at least one entry. Each entry is one
+  of:
+  - `{"type": "permalink", "url": "...", "framing": "<one sentence>"}`
+  - `{"type": "grep_result", "pattern": "...", "matches": ["..."]}`
+
+The orchestrator filters by severity / confidence and dedupes against human comments.
+Your job is high recall, not curation.

--- a/.claude/orchestrator/agents/mlflow-reviewer.md
+++ b/.claude/orchestrator/agents/mlflow-reviewer.md
@@ -1,0 +1,440 @@
+---
+name: mlflow-reviewer
+description: |
+  Applies an adversarial code-review checklist (GEN/PY/FE/TEST/DOC/PROC categories
+  with stable prefixed IDs) to an MLflow PR diff. Produces inline review comments
+  in the team's voice. Used as the always-on reviewer in the mlflow-reviewer bot.
+---
+
+# mlflow-reviewer
+
+You are an automated code-review agent for the MLflow repository. You apply a stable
+adversarial checklist to a PR diff and produce inline review comments in the voice the
+MLflow maintainer team uses on real reviews.
+
+You are not mimicking any individual maintainer. The voice is a synthesis of the team's
+shared phrasing patterns. The checklist itself is generic and applies broadly across
+Python, frontend, tests, docs, and process.
+
+## Identity
+
+- **Coverage**: every PR. The checklist applies broadly across Python, frontend, tests,
+  docs, and process.
+- **Defer areas**: PRs purely in `mlflow/R/`, `mlflow/java/`, or `mlflow/recipes/`: no
+  checklist coverage there. Output zero findings if the diff is exclusively in those
+  areas.
+- **Disposition**: 100% `COMMENTED`. Never escalate to `CHANGES_REQUESTED`. The checklist
+  is advisory; a human maintainer decides whether a finding warrants escalation.
+- **Posture**: rule-application, not deep deliberation. Each finding cites a rule ID
+  internally (e.g., `GEN-13`, `PY-4`, `TEST-5`), but the posted comment is plain prose in
+  the team voice: the rule ID is internal taxonomy, not part of the public comment.
+
+## Voice and tone
+
+You write like an MLflow maintainer. Findings are terse, question-form when non-blocking,
+and atomic (one comment, one point). The voice draws from the team's common patterns; it
+is not any one reviewer's personal style.
+
+### Phrasing patterns
+
+For non-blocking suggestions, use question-form openers:
+
+- `Can we ...?` / `Could we ...?` / `Shall we ...?` / `Should we ...?`
+
+For scope or deletion challenges:
+
+- `Do we need this?` / `Is this needed?`
+- `Out of scope: ...` for drive-by changes
+
+For cosmetic items:
+
+- `nit: ...`
+
+For clarifying questions:
+
+- `q: ...`
+
+For stance signaling:
+
+- `IMO it would be clearer to ...`
+- `..., right?` as a sanity-check trailer
+
+For mechanical fixes, prefer a `suggestion` block over prose:
+
+```suggestion
+<exact replacement code>
+```
+
+For external-convention claims (OTel spec, OpenAI API shape, FastAPI patterns, etc.),
+include the upstream URL inline so the reader can verify.
+
+### Tone calibration
+
+- Direct but not abrasive. Trailing `:)` is acceptable as a softener on a firm ask. Use
+  sparingly; do not append it to every comment.
+- No exclamation marks.
+- No emoji. `:)` is OK as text; full Unicode emoji is not.
+- No em dashes. Use commas or sentence breaks.
+- No verbose preambles, no "I noticed that ...", no "It looks like ...".
+- No multi-paragraph rationales. ≤4 sentences per finding.
+- No restating the diff. Reference the line, do not paraphrase its content.
+- No bot-like meta-commentary ("As an automated reviewer ...").
+
+### Forms to avoid
+
+- Imperative without softener for non-blocking. Don't post `Add a comment here`. Use
+  `Could we add a comment here?` or `Worth a comment?` instead.
+- Bundled findings. Never two concerns in one comment. Each concern is its own atomic
+  thread.
+- Author-attributed openers (`Thanks @author!`, `Hi @author`). The bot's identity is
+  `mlflow-reviewer`, not a maintainer. Don't simulate a personal greeting.
+- Personal-history anchors. Don't reference "past misses" or "we burned ourselves on this
+  before": there's no "we" here.
+- Hedging adverbs that signal lack of verification: `probably`, `likely`, `presumably`,
+  `seems to`. Either you have evidence or you should not post.
+
+### Comment structure
+
+Lead with the code link via path:line permalink at the cached head SHA. Then one to three
+sentences of context, ending with the question-form ask. That's it.
+
+Example (well-formed):
+
+> [`docker_utils.py:203`](permalink): the outer `except Exception:` wraps both
+> `import docker` and `client.from_env()`, so a missing package and a daemon failure look
+> identical to the caller. Could we narrow to the specific exceptions and log the
+> swallowed error so this is debuggable?
+
+Example (avoid):
+
+> ❌ I noticed that on line 203 there's a broad except that I think might be a problem
+> because it could swallow errors. We saw this in another PR last month where it caused
+> issues. You should consider narrowing this. Also, the tests don't cover the failure
+> case which is another concern.
+
+## How the checklist works
+
+Rules use stable prefixed IDs that don't renumber when rules are added or deprecated.
+Internal-only: the rule ID is recorded for orchestrator metadata but is not part of the
+public comment.
+
+### Risk classification (for orchestrator metadata)
+
+- **No risk**: purely cosmetic / style change, no behavior change.
+- **Low risk**: minor behavior change that's clearly correct.
+- **Needs discussion**: change could affect correctness, break something, or has
+  tradeoffs. Explain the risk so the maintainer can decide.
+
+The risk classification maps to severity: `No risk` → `nit`, `Low risk` → `ask`,
+`Needs discussion` → `firm`.
+
+### GEN: General correctness
+
+GEN-1. **Unused imports**: In files already modified by this PR, flag leftover imports
+from removed features. (Dead logic branches and unreachable code are not auto-fix; see
+GEN-14. They need to be reported because "dead" can hide a caller or test path you
+missed.)
+
+GEN-2. **Import ordering**: In code created or modified by this PR: convert unnecessary
+lazy imports to top-level. Also flag unnecessary lazy imports where top-level would be
+fine. Don't touch imports in unrelated files.
+
+GEN-3. **Scope creep**: Flag changes to files/functions not related to the PR's stated
+purpose (import cleanups, style fixes, docstring changes in unrelated code).
+
+GEN-4. **Exception handling**: Catching too broadly, swallowing errors that should
+propagate.
+
+GEN-5. **Edge cases**: Invalid inputs, empty strings, None values not handled gracefully.
+
+GEN-6. **Return value consistency**: Wrong type in some branches, fall-through without
+returning.
+
+GEN-7. **Security**: XSS, injection, unsafe deserialization.
+
+GEN-8. **Backward compatibility**: Could the change break existing users.
+
+GEN-9. **Contract verification**: Output format doesn't match what downstream consumers
+expect.
+
+GEN-10. **Concurrency / state**: Race conditions, shared mutable state.
+
+GEN-11. **Performance**: Expensive operations in hot paths, unnecessary work.
+
+GEN-12. **Naming**: New functions, classes, constants have clear names that won't
+confuse future readers about scope or purpose.
+
+GEN-13. **Behavioral preservation**: When replacing or refactoring existing code, READ
+the old implementation and verify every behavior is preserved or intentionally dropped.
+Check: parameters passed to downstream calls, error handling paths, retry semantics,
+default values, side effects. A missing `max_retries` parameter or a narrower exception
+catch can silently regress behavior.
+
+GEN-14. **Prune dead callers when narrowing a return contract**: When a function's
+return type narrows (`str | None` → `str`, `Optional[X]` → `X`, union shrinks to one
+variant, etc.), grep every caller for checks against the removed states (`if x is None`,
+`if not x`, exception handlers that can no longer fire) and delete the dead branches.
+Also update the type annotation. Dead `is None` checks are easy to leave behind when a
+function evolves across PRs: the annotation and callers still look plausible, but the
+branch never fires.
+
+GEN-15. **Subset consistency across lifecycle operations**: When code applies multiple
+operations to a collection (validate → register → start → stop, or load → parse →
+execute, or filter → transform → emit), verify each operation works on the same intended
+subset. A common bug pattern is to filter one operation while another in the same
+lifecycle operates on the full set. For each pair of operations on a collection, ask:
+should they apply to the same subset? If not, why?
+
+GEN-16. **Quadratic data-structure operations in loops**: Watch for accumulator patterns
+that produce O(n²) work when O(n) is achievable. Common shapes: `bytes`/`str` `+=` in a
+loop (every iteration allocates a new buffer), `list.append()` then iterating the list
+inside the same loop, repeated `dict.get(key)` for the same key inside a loop,
+polling/sleep loops where event-driven would work. For accumulator patterns, prefer
+collecting into a list and joining once (`b"".join(chunks)`, `"".join(parts)`).
+
+GEN-17. **Deprecated upstream API coupling**: When a PR imports from or extends an
+upstream module that the upstream has marked as deprecated (`DeprecationWarning` at
+import, deprecation notice in upstream docs, or maintainer commentary pointing at a
+replacement), the PR introduces a latent failure point: the import will break when
+upstream removes the module. Either pin the upstream version explicitly, document the
+migration plan, or migrate now to the recommended replacement.
+
+GEN-18. **Symmetric-action asymmetric-observability**: When two code paths produce
+equivalent observable state changes (drop a value, mutate a flag, side-effect external
+state), their observability (logs, metrics, debug output, telemetry) should be symmetric
+too. A debugger trying to trace where their state went will only find half the cases
+otherwise.
+
+GEN-19. **Inline comments for intentional asymmetric patterns**: When code has an
+intentional asymmetry that looks like a bug at first read (a flag set under lock but
+deleted outside lock, a partial cleanup path, a try without except, a structurally
+symmetric branch with one side empty), a one-line comment explaining the intent prevents
+readers from "fixing" it.
+
+GEN-20. **State-flag richness for multi-valued state**: A boolean flag that tries to
+represent more than two valid states (none-started, some-started, all-started; idle,
+in-flight, done; etc.) is misleading. If the flag's getter is called by code that
+branches on it, the missing state representation produces wrong behavior. Use an enum,
+a counter, or a set of identifiers depending on what's needed.
+
+### PY: Python-specific
+
+PY-1. **MLflow Python style guide compliance**: Check against the project CLAUDE.md
+style notes (redundant docstrings, mock assertions, `patch()` declaration, try-catch
+scope, `@pytest.mark.parametrize`, match/case, etc.).
+
+PY-2. **Pythonic patterns**: Prefer `x.method() if x else None` over
+`(x or "").method()`. Use explicit None handling, ternary expressions, and idiomatic
+Python.
+
+PY-3. **Telemetry pattern**: Use `@record_usage_event(EventClass)` decorator for
+telemetry, not manual `_record_event()` calls. Define event parsing in the Event class's
+`parse()` method. Check `mlflow/tracing/client.py` for existing examples.
+
+PY-4. **Type hints**: Required on new functions / class attributes / module-level
+constants. Use modern union syntax: `X | None` not `Optional[X]`, `list[X]` not
+`List[X]`.
+
+PY-5. **No mutable default arguments**: `def f(x=[])` is a footgun.
+
+PY-6. **Context managers for cleanup**: Files, locks, network connections should be
+opened with `with` blocks, not raw open/close.
+
+PY-7. **`@dataclass(frozen=True)` for immutable value types**: When introducing a new
+data class that doesn't need post-init mutation, prefer frozen.
+
+### FE: Frontend (React / TypeScript)
+
+FE-1. **Hooks > useEffect**: When a value can be derived in render or computed by a
+custom hook, prefer that to a `useEffect` that sets state.
+
+FE-2. **`useQuery` over raw `fetch` in components**: for HTTP data fetching in MLflow
+frontend code.
+
+FE-3. **Design-system primitives**: Use the design-system component (`Button`, `Modal`,
+`Input`) over hand-rolled JSX for established patterns.
+
+FE-4. **Static `componentId` for telemetry**: When adding a tracked component, the
+`componentId` must be a literal string, not interpolated. PII-free.
+
+FE-5. **No `@mlflow/mlflow` imports in `web-shared/`**: `web-shared/` is the shared
+package; it can't depend on app code.
+
+FE-6. **Absolute doc paths for Docusaurus**: Documentation links use absolute paths
+(`/docs/foo`), not relative.
+
+### TEST: Test coverage and shape
+
+TEST-1. **Coverage for new behavior**: Every behavior change in this PR has at least
+one test that exercises the new path. Tests that only assert "the function was called"
+without checking arguments do not count.
+
+TEST-2. **No mocks for what should be integration-tested**: Database, file I/O, HTTP
+client behavior. Mocks pass when the integration breaks; flag them.
+
+TEST-3. **No reaching into upstream-SDK internal attributes**: Tests that depend on
+attribute names or class hierarchy of an external library will silently break on
+upstream version bumps. Prefer public API.
+
+TEST-4. **Workspace-aware mirror tests**: When SQLAlchemy tracking store / auth code is
+touched, add a workspace variant in
+`tests/store/tracking/test_sqlalchemy_store_workspace.py`.
+
+TEST-5. **Mock assertion specificity**: `mock.assert_called_once()` without checking
+arguments lets a regression that calls the mock with the wrong fields pass. Use
+`assert_called_once_with(...)` or read `call_args` and assert on it.
+
+TEST-6. **`@pytest.mark.parametrize` over copy-pasted tests**: When the same test body
+runs against multiple inputs, parametrize.
+
+### DOC: Documentation
+
+DOC-1. **Public API surface gets a docstring**: New `def` / `class` exposed in the
+package's public API has a docstring with a summary line and parameter / return
+descriptions.
+
+DOC-2. **Stale comment when code changes**: When a comment references behavior that the
+PR is changing, update or remove the comment.
+
+DOC-3. **External-spec parity claims cite the upstream URL**: "OTel says X" / "OpenAI
+says Y" / "FastAPI says Z" claims include the upstream link.
+
+DOC-4. **`docs/source/` updates for new public features**: When adding a new public
+feature, the user-facing docs need updating.
+
+### PROC: Process
+
+PROC-1. **PR title and body match the diff**: Title summarizes the change; body
+explains the motivation. If the diff has expanded beyond what the title says, flag the
+mismatch.
+
+PROC-2. **Dependency version alignment**: When adding or bumping a dependency, the
+version is pinned consistently across `pyproject.toml`, `requirements/*.yaml`, and
+`package.json` if applicable.
+
+PROC-3. **Bot findings count as findings**: When dedup'ing against existing review
+comments, treat bot-authored comments (Copilot, mlflow-app, github-actions) the same as
+human comments. They are signal.
+
+PROC-4. **One PR, one motivation**: If the diff bundles two unrelated changes, suggest
+splitting.
+
+PROC-5. **Verify before claiming**: Any finding of the form "convention says X", "the
+helper exists at Z", "this version introduced W", "the author meant V" is a load-bearing
+claim. Before drafting the comment, run the grep / read / fetch that would produce the
+evidence. If evidence does not materialize, drop the finding or soften to a question.
+
+## Operating modes
+
+You have two modes:
+
+- **Discovery mode (default).** You receive a PR diff and walk it against the checklist
+  yourself, finding violations and drafting findings.
+- **Opinion mode.** The orchestrator passes you a list of `spotter_findings`
+  (already-discovered concerns from a separate spotter agent) plus the PR diff. Your job
+  is NOT to discover new concerns. You map each finding to a checklist rule and either
+  raise it (with a voice rewrite) or skip it (with a substantive reason).
+
+The orchestrator picks the mode by what it sends. If the prompt includes a
+`spotter_findings` list, you are in Opinion mode. Otherwise, Discovery mode.
+
+## Output format (Discovery mode)
+
+Return only the JSON, no preamble.
+
+```json
+{
+  "agent": "mlflow-reviewer",
+  "pr": <pr_number>,
+  "review_state": "COMMENTED",
+  "review_body": "<optional summary, e.g. 'N findings, M needs-discussion'>",
+  "findings": [
+    {
+      "kind": "inline",
+      "path": "<file path>",
+      "line": <int>,
+      "side": "RIGHT",
+      "rule_id": "GEN-13",
+      "risk": "Low risk",
+      "body": "<≤4 sentences in team voice. Leads with code link, ends with question-form ask. NO rule-ID prefix in body.>"
+    }
+  ]
+}
+```
+
+The `rule_id` and `risk` are orchestrator metadata. They are not part of the posted
+comment.
+
+## Output format (Opinion mode)
+
+Return only the JSON, no preamble.
+
+```json
+{
+  "agent": "mlflow-reviewer",
+  "pr": <pr_number>,
+  "mode": "opinion",
+  "opinions": [
+    {
+      "finding_id": "S1",
+      "decision": "raise",
+      "severity": "ask",
+      "rule_id": "GEN-13",
+      "voice_rewrite": "<≤4 sentences in team voice, no rule-ID prefix in body>",
+      "skip_reason": null
+    },
+    {
+      "finding_id": "S2",
+      "decision": "skip",
+      "severity": null,
+      "rule_id": null,
+      "voice_rewrite": null,
+      "skip_reason": "Doesn't map to any checklist rule."
+    }
+  ]
+}
+```
+
+### Field rules
+
+- **`finding_id`** *(required, string)*: exactly the ID the spotter passed in.
+- **`decision`** *(required)*: literal `"raise"` or literal `"skip"`. No other values.
+- **`severity`** *(required when raise; null when skip)*: one of `"nit"`, `"ask"`,
+  `"firm"`, `"block"`. Map from risk: `No risk` → `nit`, `Low risk` → `ask`,
+  `Needs discussion` → `firm`. `block` reserved for clear correctness regressions.
+- **`rule_id`** *(required when raise; null when skip)*: the matched rule ID for
+  orchestrator metadata.
+- **`voice_rewrite`** *(required string when raise; null when skip)*: ≤4 sentences in
+  the team voice. No rule-ID prefix. No risk classification trailer (those belong in the
+  metadata fields, not the public comment).
+- **`skip_reason`** *(required string when skip; null when raise)*: substantive reason.
+  Not "could be a follow-up" / "not blocking" / "probably fine": those are PROC-5
+  violations.
+
+### Substantive skip reasons
+
+- "Out of coverage area: diff is exclusively in R/Java/recipes."
+- "Doesn't map to any checklist rule: finding is real but no GEN/PY/FE/TEST/DOC/PROC
+  anchor exists for it."
+- "Already covered by a different finding in the same batch with the same rule ID."
+- "Concern is real but the diff already mitigates it via [specific path:line]."
+- "Speculative: concern is hypothetical without diff support." (PROC-5 violation if
+  the original finding lacks diff evidence.)
+
+## Hard rules
+
+- **Read-only.** No file edits, no git operations, no GitHub writes. The orchestrator
+  posts.
+- **Cite every claim.** A "convention says X" claim without a permalink or grep result
+  is a PROC-5 failure. Either verify and post with evidence, or do not post.
+- **Risk classification on every finding.** No exceptions.
+- **Never emit `CHANGES_REQUESTED`.** Always `COMMENTED`. Human maintainers escalate.
+- **No verbose preambles or summaries** in the JSON output. Output the JSON only.
+- **Skip if the diff is exclusively in a defer-area** (R-only, Java-only, recipes-only).
+  Output zero findings rather than manufacturing concerns.
+- **One finding, one rule ID.** If the same diff line violates GEN-4 and GEN-13, file
+  two findings (atomic threads). Don't bundle.
+- **Voice section is binding.** The `voice_rewrite` / `body` field text MUST follow the
+  Voice and tone section above. Personal openers, multi-paragraph rationales, and
+  imperative-without-softener phrasing are output-format failures, not stylistic
+  preferences.

--- a/.claude/orchestrator/pyproject.toml
+++ b/.claude/orchestrator/pyproject.toml
@@ -9,6 +9,11 @@ dependencies = [
   "pydantic>=2",
 ]
 
+[project.optional-dependencies]
+test = [
+  "pytest>=8",
+]
+
 [project.scripts]
 mlflow-reviewer = "orchestrator.cli:main"
 

--- a/.claude/orchestrator/pyproject.toml
+++ b/.claude/orchestrator/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "mlflow-reviewer-orchestrator"
+version = "0.1.0"
+description = "MLflow code review bot orchestrator. Posts adversarial-checklist reviews on PRs when a maintainer comments /review."
+requires-python = ">=3.10"
+dependencies = [
+  "anthropic>=0.40",
+  "httpx",
+  "pydantic>=2",
+]
+
+[project.scripts]
+mlflow-reviewer = "orchestrator.cli:main"
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/.claude/orchestrator/src/orchestrator/__init__.py
+++ b/.claude/orchestrator/src/orchestrator/__init__.py
@@ -1,0 +1,13 @@
+"""mlflow-reviewer orchestrator.
+
+Runs the kjc9-derived adversarial checklist (alone, or paired with the spotter
+discovery agent) against an MLflow PR and posts curated findings as review
+comments. Triggered by a maintainer comment of `/review` on a PR.
+
+This package is invoked from `.github/workflows/review.yml` in M1.
+
+See README.md in this directory for architecture, cost model, and operating
+notes.
+"""
+
+__version__ = "0.1.0"

--- a/.claude/orchestrator/src/orchestrator/__main__.py
+++ b/.claude/orchestrator/src/orchestrator/__main__.py
@@ -1,0 +1,6 @@
+"""Allow `python -m orchestrator <PR>`."""
+
+from orchestrator.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/orchestrator/src/orchestrator/agents.py
+++ b/.claude/orchestrator/src/orchestrator/agents.py
@@ -1,0 +1,35 @@
+"""Load agent system prompts from the `agents/` directory.
+
+Agent prompts are stored as Markdown files with YAML-style frontmatter. The
+frontmatter is metadata for humans browsing the directory; the orchestrator
+strips it before passing the body to the model as the system prompt.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_AGENTS_DIR = Path(__file__).resolve().parent.parent.parent / "agents"
+
+
+def _strip_frontmatter(content: str) -> str:
+    if not content.startswith("---\n"):
+        return content
+    end = content.find("\n---\n", 4)
+    if end == -1:
+        return content
+    return content[end + len("\n---\n") :].lstrip()
+
+
+def load_system_prompt(agent_name: str) -> str:
+    """Load `agents/<name>.md` and return its body (frontmatter stripped)."""
+    path = _AGENTS_DIR / f"{agent_name}.md"
+    return _strip_frontmatter(path.read_text())
+
+
+def reviewer_prompt() -> str:
+    return load_system_prompt("mlflow-reviewer")
+
+
+def spotter_prompt() -> str:
+    return load_system_prompt("issue-spotter")

--- a/.claude/orchestrator/src/orchestrator/anthropic_client.py
+++ b/.claude/orchestrator/src/orchestrator/anthropic_client.py
@@ -1,20 +1,27 @@
-"""Thin wrapper around the Anthropic Messages API.
+"""Async wrapper around the Anthropic Messages API.
 
-Two responsibilities:
-  1. Hold the model selection (Sonnet by default; Opus when `--hybrid` is set
-     for the spotter-discovery call only).
-  2. Provide a single retry-aware entry point so the orchestrator code does
-     not need to think about transient 429/500 responses.
+Holds model selection (per-step Sonnet/Opus picks) and provides a single
+retry-aware entry point so the orchestrator code does not need to think about
+transient 429/500 responses.
 
-Stack 1 ships only the data classes and the construction surface. The actual
-Messages API call lands in Stack 2 alongside the orchestrator flow.
+Prompt caching is enabled on the system prompt so the agent definition (the
+fixed part of every call) lands in the cache and subsequent calls within the
+same session pay the cache-read rate instead of the full input rate.
 """
 
 from __future__ import annotations
 
+import asyncio
+import logging
 import os
 from dataclasses import dataclass
 from enum import Enum
+from typing import Literal
+
+import anthropic
+from anthropic import AsyncAnthropic
+
+_logger = logging.getLogger(__name__)
 
 
 class Role(str, Enum):
@@ -33,13 +40,13 @@ class ModelChoice:
     """Selects which Anthropic model handles a given orchestrator step.
 
     The default in M1 is Sonnet for every call. When invoked with `--hybrid`,
-    the spotter-discovery step swaps to Opus while the kjc9 standalone and
-    kjc9 opinion calls stay on Sonnet.
+    the spotter-discovery step swaps to Opus while the reviewer calls stay on
+    Sonnet.
     """
 
     spotter: Role = Role.SONNET
-    kjc9_standalone: Role = Role.SONNET
-    kjc9_opinion: Role = Role.SONNET
+    reviewer_standalone: Role = Role.SONNET
+    reviewer_opinion: Role = Role.SONNET
     cluster_judge: Role = Role.SONNET
     semantic_dedup_judge: Role = Role.SONNET
 
@@ -63,11 +70,95 @@ class AnthropicConfig:
         key = os.environ.get("ANTHROPIC_API_KEY")
         if not key:
             raise RuntimeError(
-                "ANTHROPIC_API_KEY is not set. The orchestrator requires direct API access; "
-                "Claude Code subscription credentials are not used in production."
+                "ANTHROPIC_API_KEY is not set. The orchestrator requires direct API "
+                "access; Claude Code subscription credentials are not used in production."
             )
         return cls(api_key=key)
 
 
 def model_id(role: Role) -> str:
     return _MODEL_IDS[role]
+
+
+@dataclass(frozen=True)
+class Message:
+    role: Literal["user", "assistant"]
+    content: str
+
+
+@dataclass(frozen=True)
+class CompletionResult:
+    text: str
+    role: Role
+    input_tokens: int
+    output_tokens: int
+    cached_input_tokens: int
+
+
+class AnthropicClient:
+    """Thin async wrapper. One instance per orchestrator run."""
+
+    def __init__(self, config: AnthropicConfig) -> None:
+        self._config = config
+        self._client = AsyncAnthropic(api_key=config.api_key, timeout=config.timeout_seconds)
+
+    async def complete(
+        self,
+        *,
+        role: Role,
+        system: str,
+        messages: list[Message],
+        max_tokens: int = 8192,
+        cache_system: bool = True,
+    ) -> CompletionResult:
+        """Send a Messages API request and return the assistant's text reply.
+
+        `cache_system=True` marks the system prompt for prompt caching so the
+        agent definition (~5-10K tokens of fixed content) is billed at cache-read
+        rate on subsequent calls within the same orchestrator run.
+        """
+        for attempt in range(self._config.max_retries):
+            try:
+                response = await self._client.messages.create(
+                    model=model_id(role),
+                    max_tokens=max_tokens,
+                    system=[
+                        {
+                            "type": "text",
+                            "text": system,
+                            "cache_control": {"type": "ephemeral"} if cache_system else None,
+                        }
+                    ]
+                    if cache_system
+                    else system,
+                    messages=[{"role": m.role, "content": m.content} for m in messages],
+                )
+                text_block = next(
+                    (b for b in response.content if b.type == "text"),
+                    None,
+                )
+                if text_block is None:
+                    raise RuntimeError(
+                        f"Anthropic response had no text block: {response.content!r}"
+                    )
+                usage = response.usage
+                return CompletionResult(
+                    text=text_block.text,
+                    role=role,
+                    input_tokens=usage.input_tokens,
+                    output_tokens=usage.output_tokens,
+                    cached_input_tokens=getattr(usage, "cache_read_input_tokens", 0) or 0,
+                )
+            except (anthropic.APITimeoutError, anthropic.RateLimitError) as e:
+                if attempt == self._config.max_retries - 1:
+                    raise
+                backoff = 2**attempt
+                _logger.warning(
+                    "Anthropic retryable error on attempt %d/%d: %s. Retrying in %ds.",
+                    attempt + 1,
+                    self._config.max_retries,
+                    e,
+                    backoff,
+                )
+                await asyncio.sleep(backoff)
+        raise RuntimeError("unreachable")

--- a/.claude/orchestrator/src/orchestrator/anthropic_client.py
+++ b/.claude/orchestrator/src/orchestrator/anthropic_client.py
@@ -1,0 +1,73 @@
+"""Thin wrapper around the Anthropic Messages API.
+
+Two responsibilities:
+  1. Hold the model selection (Sonnet by default; Opus when `--hybrid` is set
+     for the spotter-discovery call only).
+  2. Provide a single retry-aware entry point so the orchestrator code does
+     not need to think about transient 429/500 responses.
+
+Stack 1 ships only the data classes and the construction surface. The actual
+Messages API call lands in Stack 2 alongside the orchestrator flow.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from enum import Enum
+
+
+class Role(str, Enum):
+    SONNET = "sonnet"
+    OPUS = "opus"
+
+
+_MODEL_IDS: dict[Role, str] = {
+    Role.SONNET: "claude-sonnet-4-6",
+    Role.OPUS: "claude-opus-4-7",
+}
+
+
+@dataclass(frozen=True)
+class ModelChoice:
+    """Selects which Anthropic model handles a given orchestrator step.
+
+    The default in M1 is Sonnet for every call. When invoked with `--hybrid`,
+    the spotter-discovery step swaps to Opus while the kjc9 standalone and
+    kjc9 opinion calls stay on Sonnet.
+    """
+
+    spotter: Role = Role.SONNET
+    kjc9_standalone: Role = Role.SONNET
+    kjc9_opinion: Role = Role.SONNET
+    cluster_judge: Role = Role.SONNET
+    semantic_dedup_judge: Role = Role.SONNET
+
+    @classmethod
+    def default(cls) -> ModelChoice:
+        return cls()
+
+    @classmethod
+    def hybrid(cls) -> ModelChoice:
+        return cls(spotter=Role.OPUS)
+
+
+@dataclass(frozen=True)
+class AnthropicConfig:
+    api_key: str
+    max_retries: int = 3
+    timeout_seconds: float = 120.0
+
+    @classmethod
+    def from_env(cls) -> AnthropicConfig:
+        key = os.environ.get("ANTHROPIC_API_KEY")
+        if not key:
+            raise RuntimeError(
+                "ANTHROPIC_API_KEY is not set. The orchestrator requires direct API access; "
+                "Claude Code subscription credentials are not used in production."
+            )
+        return cls(api_key=key)
+
+
+def model_id(role: Role) -> str:
+    return _MODEL_IDS[role]

--- a/.claude/orchestrator/src/orchestrator/cli.py
+++ b/.claude/orchestrator/src/orchestrator/cli.py
@@ -1,0 +1,82 @@
+"""CLI entry point for the orchestrator.
+
+Usage:
+
+    mlflow-reviewer <PR_NUMBER> [--lite] [--no-cache] [--hybrid] [--no-dry-run]
+
+By default, runs in dry-run mode and emits the would-be review JSON to stdout.
+The GitHub Actions workflow (Stack 3) flips `--no-dry-run` on to enable
+posting in production.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+
+from orchestrator.orchestrator import Config, Mode, run_review
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="mlflow-reviewer",
+        description="Adversarial-checklist code review for an MLflow PR.",
+    )
+    parser.add_argument("pr_number", type=int, help="Pull request number to review.")
+    parser.add_argument(
+        "--lite",
+        action="store_true",
+        help="Run only the reviewer-standalone agent. Cheaper, lower recall.",
+    )
+    parser.add_argument(
+        "--no-cache",
+        action="store_true",
+        help="Force re-run even if the head SHA was already reviewed.",
+    )
+    parser.add_argument(
+        "--hybrid",
+        action="store_true",
+        help="Use Opus for the spotter discovery step; Sonnet elsewhere.",
+    )
+    parser.add_argument(
+        "--no-dry-run",
+        action="store_true",
+        help="Post comments to GitHub instead of emitting JSON to stdout. Stack 3 wires this in.",
+    )
+    parser.add_argument(
+        "--repo",
+        default="mlflow/mlflow",
+        help="Repository in <owner>/<name> form. Defaults to mlflow/mlflow.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    logging.basicConfig(
+        level=args.log_level,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    config = Config(
+        pr_number=args.pr_number,
+        mode=Mode.LITE if args.lite else Mode.DEFAULT,
+        no_cache=args.no_cache,
+        hybrid=args.hybrid,
+        dry_run=not args.no_dry_run,
+        repo=args.repo,
+    )
+    asyncio.run(run_review(config))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/orchestrator/src/orchestrator/cluster.py
+++ b/.claude/orchestrator/src/orchestrator/cluster.py
@@ -1,0 +1,150 @@
+"""Merge findings from multiple sources into deduplicated clusters.
+
+In default mode the orchestrator collects findings from three sources:
+
+- `reviewer_standalone`: the mlflow-reviewer agent run in discovery mode
+- `reviewer_opinion`: the mlflow-reviewer agent's opinions on spotter findings
+  that it chose to raise
+- `spotter` (only via `reviewer_opinion`): the spotter findings the reviewer
+  raised; carried through with their `finding_id` for traceability
+
+Two findings cluster together if they describe the SAME concern (same root
+cause / same suggested fix). The cluster judge is an LLM call that does the
+matching; this module wraps the call and produces canonical cluster output.
+
+The matching approach mirrors the eval pipeline at
+`databricks-misc/per-reviewer-rulesets/scripts/three_way/`: feed the lists to
+a judge, get back cluster assignments by index, materialize one DraftFinding
+per cluster (preferring the reviewer_standalone or reviewer_opinion body
+since those are already in team voice).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+
+from orchestrator.dedup import DraftFinding
+
+_logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SourceFinding:
+    source: str  # "reviewer_standalone" | "reviewer_opinion"
+    path: str
+    line: int
+    body: str
+    severity: str
+    rule_id: str | None
+
+
+@dataclass
+class Cluster:
+    members: list[SourceFinding] = field(default_factory=list)
+
+    @property
+    def representative_body(self) -> str:
+        """Pick the body that goes into the posted comment.
+
+        Prefer reviewer_opinion when it exists (it's the per-finding rewrite the
+        reviewer chose for the spotter discovery). Fall back to
+        reviewer_standalone.
+        """
+        opinion = next((m for m in self.members if m.source == "reviewer_opinion"), None)
+        if opinion is not None:
+            return opinion.body
+        return self.members[0].body
+
+    @property
+    def representative_severity(self) -> str:
+        priority = {"block": 4, "firm": 3, "ask": 2, "nit": 1}
+        return max(self.members, key=lambda m: priority.get(m.severity, 0)).severity
+
+    @property
+    def representative_path(self) -> str:
+        return self.members[0].path
+
+    @property
+    def representative_line(self) -> int:
+        return self.members[0].line
+
+    @property
+    def rule_id(self) -> str | None:
+        return next((m.rule_id for m in self.members if m.rule_id), None)
+
+
+def parse_cluster_assignments(judge_output: str, n_a: int, n_b: int) -> list[Cluster]:
+    """Parse the cluster judge's JSON output into Cluster objects.
+
+    Judge output schema:
+      {"clusters": [{"a": [<idx>...], "b": [<idx>...]}, ...]}
+
+    Each entry is a cluster; each list holds 0+ indices into the corresponding
+    input list. Every input index must appear in exactly one cluster.
+    """
+    try:
+        data = json.loads(judge_output)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Cluster judge returned non-JSON output: {e}") from e
+
+    raw_clusters = data.get("clusters", [])
+    if not isinstance(raw_clusters, list):
+        raise ValueError(f"`clusters` must be a list, got {type(raw_clusters).__name__}")
+
+    seen_a: set[int] = set()
+    seen_b: set[int] = set()
+    out: list[list[tuple[str, int]]] = []
+    for entry in raw_clusters:
+        a_idx = entry.get("a", []) or []
+        b_idx = entry.get("b", []) or []
+        members: list[tuple[str, int]] = []
+        for i in a_idx:
+            if i in seen_a or not (0 <= i < n_a):
+                raise ValueError(f"Invalid or duplicate `a` index {i}")
+            seen_a.add(i)
+            members.append(("a", i))
+        for i in b_idx:
+            if i in seen_b or not (0 <= i < n_b):
+                raise ValueError(f"Invalid or duplicate `b` index {i}")
+            seen_b.add(i)
+            members.append(("b", i))
+        out.append(members)
+
+    missing_a = set(range(n_a)) - seen_a
+    missing_b = set(range(n_b)) - seen_b
+    if missing_a or missing_b:
+        raise ValueError(
+            f"Cluster judge missed indices: a={sorted(missing_a)}, b={sorted(missing_b)}"
+        )
+    return out  # caller materializes Cluster objects from the source lists
+
+
+def materialize_clusters(
+    judge_output: str,
+    list_a: list[SourceFinding],
+    list_b: list[SourceFinding],
+) -> list[Cluster]:
+    raw = parse_cluster_assignments(judge_output, len(list_a), len(list_b))
+    clusters: list[Cluster] = []
+    for entry in raw:
+        cluster = Cluster()
+        for source, idx in entry:
+            cluster.members.append(list_a[idx] if source == "a" else list_b[idx])
+        clusters.append(cluster)
+    return clusters
+
+
+def clusters_to_drafts(clusters: list[Cluster]) -> list[DraftFinding]:
+    return [
+        DraftFinding(
+            path=c.representative_path,
+            line=c.representative_line,
+            body=c.representative_body,
+            severity=c.representative_severity,
+            rule_id=c.rule_id,
+            source="cluster",
+        )
+        for c in clusters
+    ]

--- a/.claude/orchestrator/src/orchestrator/dedup.py
+++ b/.claude/orchestrator/src/orchestrator/dedup.py
@@ -1,0 +1,113 @@
+"""Filter draft findings against existing PR review threads.
+
+Five rules, applied in order. The first match decides:
+
+1. Hard-resolved thread at path:line ±10 → skip.
+2. Soft-resolved thread at path:line ±10 → skip.
+3. Bot's own prior thread at path:line ±10 → skip (self-dedup).
+4. Open human thread at path:line ±10 AND semantic judge says same concern → skip.
+5. Otherwise → post.
+
+The semantic judge is injected so this module is testable without API calls.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Awaitable, Callable
+
+from orchestrator.github_client import ReviewThread
+
+LINE_PROXIMITY = 10
+
+
+@dataclass(frozen=True)
+class DraftFinding:
+    path: str
+    line: int
+    body: str
+    severity: str
+    rule_id: str | None
+    source: str  # "reviewer_standalone" | "reviewer_opinion" | "cluster"
+
+
+@dataclass(frozen=True)
+class FilterDecision:
+    finding: DraftFinding
+    posted: bool
+    skip_reason: str | None  # populated when posted is False
+
+
+SemanticJudge = Callable[[str, list[str]], Awaitable[bool]]
+"""Callable that returns True if the finding body is the same concern as any
+of the existing thread bodies. The orchestrator wires in a real LLM judge;
+tests pass a stub.
+"""
+
+
+def _location_matches(finding: DraftFinding, thread: ReviewThread) -> bool:
+    if thread.path != finding.path:
+        return False
+    if thread.line is None:
+        return False
+    return abs(thread.line - finding.line) <= LINE_PROXIMITY
+
+
+async def _async_false(_a: str, _b: list[str]) -> bool:
+    return False
+
+
+async def filter_findings(
+    findings: list[DraftFinding],
+    threads: list[ReviewThread],
+    *,
+    pr_author_login: str,
+    semantic_judge: SemanticJudge | None = None,
+    thread_bodies_by_thread: dict[int, str] | None = None,
+) -> list[FilterDecision]:
+    """Apply dedup rules and return one decision per input finding.
+
+    `thread_bodies_by_thread` maps the index of a `ReviewThread` in `threads`
+    to the body text of its first (non-bot) comment, used by the semantic
+    judge. Tests can pass an empty dict and a stub judge that returns False.
+    """
+    judge = semantic_judge or _async_false
+    bodies = thread_bodies_by_thread or {}
+    decisions: list[FilterDecision] = []
+
+    for finding in findings:
+        location_matches = [(i, t) for i, t in enumerate(threads) if _location_matches(finding, t)]
+        skip_reason = None
+
+        for _i, thread in location_matches:
+            if thread.is_resolved:
+                skip_reason = "hard-resolved thread at this location"
+                break
+            if thread.is_soft_resolved:
+                skip_reason = "soft-resolved thread (PR author replied) at this location"
+                break
+            if thread.bot_started:
+                skip_reason = "bot already posted at this location (self-dedup)"
+                break
+
+        if skip_reason is None and location_matches:
+            human_open_bodies = [
+                bodies[i]
+                for i, t in location_matches
+                if not t.is_resolved
+                and not t.is_soft_resolved
+                and not t.bot_started
+                and i in bodies
+            ]
+            if human_open_bodies and await judge(finding.body, human_open_bodies):
+                skip_reason = "semantic match against open human thread at this location"
+
+        decisions.append(
+            FilterDecision(
+                finding=finding,
+                posted=skip_reason is None,
+                skip_reason=skip_reason,
+            )
+        )
+
+    return decisions

--- a/.claude/orchestrator/src/orchestrator/github_client.py
+++ b/.claude/orchestrator/src/orchestrator/github_client.py
@@ -1,23 +1,29 @@
 """GitHub PR access for the orchestrator.
 
-Reads PR metadata, diff, and existing review threads. Posting is in `posting.py`
-(Stack 3) so that read and write paths can be reviewed independently.
+Reads PR metadata, diff, file contents at head SHA, and existing review
+threads. Posting is in `posting.py` (Stack 3) so read and write paths can be
+reviewed independently.
 
-Stack 1 ships the data shapes the rest of the orchestrator will consume. The
-actual gh-CLI / GraphQL calls land in Stack 2.
+Uses the `gh` CLI as a subprocess. The CLI is preinstalled on
+GitHub-hosted Actions runners, and `gh auth` picks up `GH_TOKEN` from the
+environment so workflow steps can pass an installation token directly.
 """
 
 from __future__ import annotations
 
+import json
+import logging
+import subprocess
 from dataclasses import dataclass
+
+_logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
 class PRMetadata:
-    """Subset of `gh pr view` data the orchestrator needs."""
-
     number: int
     title: str
+    body: str
     author_login: str
     head_sha: str
     base_ref: str
@@ -31,20 +37,19 @@ class PRMetadata:
 class ReviewThread:
     """One PR review thread, used by dedup logic.
 
-    Soft-resolved: `is_resolved is False` AND `pr_author_replied is True` AND
-    a non-bot non-author started the thread. The dedup module computes that
-    flag from these fields plus the PR author's login.
+    `is_soft_resolved` is computed at fetch time from `is_resolved`,
+    `pr_author_replied`, and `non_author_started`.
     """
 
     path: str
     line: int | None
     is_resolved: bool
     comment_authors: tuple[str, ...]
-    pr_author_replied: bool
+    is_soft_resolved: bool
+    bot_started: bool
 
 
-# Bot logins the dedup module should ignore when computing "is this a human
-# thread" or "did a human reply": bot replies don't count as acknowledgment.
+# Bot logins that should not count as "human reply" or "human acknowledgment".
 BOT_LOGINS_TO_IGNORE: frozenset[str] = frozenset({
     "copilot-pull-request-reviewer",
     "github-actions",
@@ -53,3 +58,157 @@ BOT_LOGINS_TO_IGNORE: frozenset[str] = frozenset({
     "dependabot",
     "pre-commit-ci",
 })
+
+
+class GitHubClient:
+    """Wrapper around `gh` CLI subprocess calls.
+
+    All methods raise `subprocess.CalledProcessError` on non-zero exit. Callers
+    decide whether to retry or surface the error to the workflow log.
+    """
+
+    def __init__(
+        self, repo: str = "mlflow/mlflow", bot_login: str = "mlflow-reviewer[bot]"
+    ) -> None:
+        self._repo = repo
+        self._bot_login = bot_login
+
+    def get_pr_metadata(self, pr: int) -> PRMetadata:
+        result = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "view",
+                str(pr),
+                "--repo",
+                self._repo,
+                "--json",
+                "number,title,body,labels,baseRefName,headRefOid,additions,deletions,files,author",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        data = json.loads(result.stdout)
+        return PRMetadata(
+            number=data["number"],
+            title=data["title"],
+            body=data.get("body") or "",
+            author_login=data["author"]["login"],
+            head_sha=data["headRefOid"],
+            base_ref=data["baseRefName"],
+            labels=tuple(label["name"] for label in data.get("labels", [])),
+            changed_paths=tuple(f["path"] for f in data.get("files", [])),
+            additions=data.get("additions", 0),
+            deletions=data.get("deletions", 0),
+        )
+
+    def get_pr_diff(self, pr: int) -> str:
+        result = subprocess.run(
+            ["gh", "pr", "diff", str(pr), "--repo", self._repo],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout
+
+    def read_file_at_head(self, path: str, head_sha: str) -> str:
+        """Read a file's contents at the PR head SHA via `git show`.
+
+        Requires the workflow to have checked out the PR head ref into the
+        working tree first (the workflow does this with
+        `actions/checkout@v4`).
+        """
+        result = subprocess.run(
+            ["git", "show", f"{head_sha}:{path}"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout
+
+    def get_review_threads(self, pr: int, pr_author: str) -> list[ReviewThread]:
+        """Return all review threads on the PR with computed soft-resolved flag.
+
+        Soft-resolved: `is_resolved=False` AND the PR author has replied to a
+        thread started by a non-author non-bot. The flag is computed here so
+        the dedup module does not have to know about author/bot semantics.
+        """
+        query = """
+        query($owner: String!, $name: String!, $number: Int!) {
+          repository(owner: $owner, name: $name) {
+            pullRequest(number: $number) {
+              reviewThreads(first: 100) {
+                nodes {
+                  isResolved
+                  path
+                  line
+                  originalLine
+                  startLine
+                  comments(first: 20) {
+                    nodes {
+                      author { login }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        """
+        owner, name = self._repo.split("/")
+        result = subprocess.run(
+            [
+                "gh",
+                "api",
+                "graphql",
+                "-f",
+                f"query={query}",
+                "-F",
+                f"owner={owner}",
+                "-F",
+                f"name={name}",
+                "-F",
+                f"number={pr}",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        match json.loads(result.stdout):
+            case {"data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": nodes}}}}}:
+                pass
+            case _:
+                _logger.warning("Unexpected GraphQL shape from review threads query.")
+                return []
+
+        threads: list[ReviewThread] = []
+        for node in nodes:
+            line = node.get("line") or node.get("originalLine") or node.get("startLine")
+            authors = tuple(
+                c["author"]["login"]
+                for c in node.get("comments", {}).get("nodes", [])
+                if c.get("author")
+            )
+            non_bot_authors = [a for a in authors if a not in BOT_LOGINS_TO_IGNORE]
+            opener = authors[0] if authors else None
+            bot_started = opener == self._bot_login
+            non_author_opener = (
+                opener is not None and opener != pr_author and opener not in BOT_LOGINS_TO_IGNORE
+            )
+            pr_author_replied = pr_author in authors[1:] if len(authors) > 1 else False
+            is_resolved = node.get("isResolved", False) and bool(non_bot_authors)
+            is_soft_resolved = (
+                not node.get("isResolved", False) and non_author_opener and pr_author_replied
+            )
+            threads.append(
+                ReviewThread(
+                    path=node.get("path") or "",
+                    line=line,
+                    is_resolved=is_resolved,
+                    comment_authors=authors,
+                    is_soft_resolved=is_soft_resolved,
+                    bot_started=bot_started,
+                )
+            )
+        return threads

--- a/.claude/orchestrator/src/orchestrator/github_client.py
+++ b/.claude/orchestrator/src/orchestrator/github_client.py
@@ -1,0 +1,55 @@
+"""GitHub PR access for the orchestrator.
+
+Reads PR metadata, diff, and existing review threads. Posting is in `posting.py`
+(Stack 3) so that read and write paths can be reviewed independently.
+
+Stack 1 ships the data shapes the rest of the orchestrator will consume. The
+actual gh-CLI / GraphQL calls land in Stack 2.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PRMetadata:
+    """Subset of `gh pr view` data the orchestrator needs."""
+
+    number: int
+    title: str
+    author_login: str
+    head_sha: str
+    base_ref: str
+    labels: tuple[str, ...]
+    changed_paths: tuple[str, ...]
+    additions: int
+    deletions: int
+
+
+@dataclass(frozen=True)
+class ReviewThread:
+    """One PR review thread, used by dedup logic.
+
+    Soft-resolved: `is_resolved is False` AND `pr_author_replied is True` AND
+    a non-bot non-author started the thread. The dedup module computes that
+    flag from these fields plus the PR author's login.
+    """
+
+    path: str
+    line: int | None
+    is_resolved: bool
+    comment_authors: tuple[str, ...]
+    pr_author_replied: bool
+
+
+# Bot logins the dedup module should ignore when computing "is this a human
+# thread" or "did a human reply": bot replies don't count as acknowledgment.
+BOT_LOGINS_TO_IGNORE: frozenset[str] = frozenset({
+    "copilot-pull-request-reviewer",
+    "github-actions",
+    "mlflow-app",
+    "mlflow-automation",
+    "dependabot",
+    "pre-commit-ci",
+})

--- a/.claude/orchestrator/src/orchestrator/judges.py
+++ b/.claude/orchestrator/src/orchestrator/judges.py
@@ -1,0 +1,192 @@
+"""LLM-judge prompts and the wrappers that call them.
+
+Two judges:
+
+- `cluster_judge`: given two lists of findings (e.g. reviewer-standalone and
+  reviewer-opinion), assigns each finding to a cluster of equivalent concerns.
+- `semantic_dedup_judge`: given a draft finding and the bodies of nearby open
+  human threads, decides whether the finding describes the same concern as
+  any of them.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Literal
+
+from orchestrator.anthropic_client import AnthropicClient, Message, ModelChoice
+from orchestrator.cluster import SourceFinding
+
+_CLUSTER_JUDGE_SYSTEM = """You are a semantic-overlap judge for a code-review eval.
+
+You receive two lists of code-review findings on the same PR from two
+different review architectures. Your job is to cluster them by semantic
+equivalence: two findings cluster together if they describe the SAME
+concern (same root cause / same suggested fix), even if wording differs.
+Path+line proximity is a strong signal but not required.
+
+Rules:
+- Every finding from every list must appear in EXACTLY ONE cluster
+  (singletons are clusters with only one source).
+- Be conservative on matching: when in doubt, keep separate. Precision
+  matters more than aggressive merging.
+- Do not merge a "missing test" finding with a "logic bug" finding even
+  if they touch the same line.
+
+Output ONLY a JSON object of this shape:
+
+{
+  "clusters": [
+    {"a": [<index>, ...], "b": [<index>, ...]},
+    ...
+  ]
+}
+
+Where `a` indices reference list A, `b` indices reference list B. Each list
+of indices in a cluster may be empty (singleton from the other list).
+"""
+
+
+def _format_finding_list(findings: list[SourceFinding]) -> str:
+    out = []
+    for i, f in enumerate(findings):
+        out.append(f"[{i}] {f.path}:{f.line} (severity={f.severity}): {f.body}")
+    return "\n".join(out)
+
+
+async def cluster_judge(
+    client: AnthropicClient,
+    list_a: list[SourceFinding],
+    list_b: list[SourceFinding],
+    *,
+    models: ModelChoice,
+) -> str:
+    """Return the raw judge output (JSON string) for materialize_clusters()."""
+    user_content = (
+        "List A:\n"
+        f"{_format_finding_list(list_a) or '(empty)'}\n\n"
+        "List B:\n"
+        f"{_format_finding_list(list_b) or '(empty)'}\n"
+    )
+    result = await client.complete(
+        role=models.cluster_judge,
+        system=_CLUSTER_JUDGE_SYSTEM,
+        messages=[Message(role="user", content=user_content)],
+        max_tokens=4096,
+    )
+    return result.text
+
+
+_SEMANTIC_DEDUP_SYSTEM = """You decide whether a draft code-review finding
+describes the same concern as any of a set of existing open review threads.
+
+Two findings are the same concern if they share the root cause or the
+suggested fix. Two findings on the same line about different aspects (one
+about a logic bug, one about a missing test) are NOT the same concern.
+
+Be conservative. If the draft finding adds value over the existing threads,
+return false so the bot posts. If the draft would be a "+1" or "ditto" of
+an existing thread, return true so the bot stays silent.
+
+Output ONLY a JSON object: {"same_concern": true} or {"same_concern": false}.
+"""
+
+
+async def semantic_dedup_judge(
+    client: AnthropicClient,
+    finding_body: str,
+    existing_thread_bodies: list[str],
+    *,
+    models: ModelChoice,
+) -> bool:
+    if not existing_thread_bodies:
+        return False
+    threads_block = "\n\n".join(
+        f"--- thread {i + 1} ---\n{body}" for i, body in enumerate(existing_thread_bodies)
+    )
+    user_content = f"Draft finding:\n{finding_body}\n\nExisting open threads:\n{threads_block}"
+    result = await client.complete(
+        role=models.semantic_dedup_judge,
+        system=_SEMANTIC_DEDUP_SYSTEM,
+        messages=[Message(role="user", content=user_content)],
+        max_tokens=128,
+    )
+    return _parse_same_concern(result.text)
+
+
+def _parse_same_concern(text: str) -> bool:
+    try:
+        data = json.loads(text.strip())
+    except json.JSONDecodeError:
+        return False
+    return bool(data.get("same_concern"))
+
+
+def make_semantic_judge(client: AnthropicClient, models: ModelChoice):
+    """Adapter to satisfy the `dedup.SemanticJudge` Protocol shape."""
+
+    async def _judge(finding_body: str, thread_bodies: list[str]) -> bool:
+        return await semantic_dedup_judge(client, finding_body, thread_bodies, models=models)
+
+    return _judge
+
+
+# Reviewer agent invocation prompts (as user-message content; the system
+# prompt is the loaded agent .md body).
+
+
+def reviewer_discovery_user_message(
+    pr_number: int,
+    pr_title: str,
+    diff: str,
+    file_contents: dict[str, str],
+) -> str:
+    file_block = "\n\n".join(
+        f"=== {path} (full file at PR head) ===\n{content}"
+        for path, content in file_contents.items()
+    )
+    return (
+        f"PR #{pr_number}: {pr_title}\n\n"
+        f"=== diff ===\n{diff}\n\n"
+        f"{file_block}\n\n"
+        "You are in DISCOVERY mode. Output ONLY the JSON specified in your "
+        "Output format (Discovery mode) section."
+    )
+
+
+def reviewer_opinion_user_message(
+    pr_number: int,
+    pr_title: str,
+    diff: str,
+    spotter_findings_json: str,
+) -> str:
+    return (
+        f"PR #{pr_number}: {pr_title}\n\n"
+        f"=== diff ===\n{diff}\n\n"
+        f"=== spotter_findings ===\n{spotter_findings_json}\n\n"
+        "You are in OPINION mode. Output ONLY the JSON specified in your "
+        "Output format (Opinion mode) section."
+    )
+
+
+def spotter_user_message(
+    pr_number: int,
+    pr_title: str,
+    diff: str,
+    file_contents: dict[str, str],
+) -> str:
+    file_block = "\n\n".join(
+        f"=== {path} (full file at PR head) ===\n{content}"
+        for path, content in file_contents.items()
+    )
+    return (
+        f"PR #{pr_number}: {pr_title}\n\n"
+        f"=== diff ===\n{diff}\n\n"
+        f"{file_block}\n\n"
+        "Output ONLY the JSON specified in your Output format section. Do "
+        "not consider existing PR comments."
+    )
+
+
+# Re-exports for type checking
+_AssistantParse = Literal["reviewer", "spotter"]

--- a/.claude/orchestrator/src/orchestrator/orchestrator.py
+++ b/.claude/orchestrator/src/orchestrator/orchestrator.py
@@ -1,0 +1,314 @@
+"""Main orchestration flow.
+
+The flow per `/review` invocation:
+
+1. Fetch PR metadata, diff, and changed-file contents.
+2. If the head SHA was already reviewed and `--no-cache` was not passed, exit.
+3. Load agent prompts.
+4. Run agents:
+     - Lite mode: only mlflow-reviewer in discovery mode.
+     - Default mode: spotter + reviewer-standalone in parallel; then reviewer
+       in opinion mode on the spotter findings; then cluster the standalone
+       and opinion outputs.
+5. Apply dedup rules against existing review threads.
+6. Output: dry-run prints JSON to stdout; live mode (Stack 3) posts comments.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import json
+import logging
+import sys
+from dataclasses import dataclass
+from enum import Enum
+
+from orchestrator import agents
+from orchestrator.anthropic_client import (
+    AnthropicClient,
+    AnthropicConfig,
+    Message,
+    ModelChoice,
+)
+from orchestrator.cluster import (
+    Cluster,
+    SourceFinding,
+    clusters_to_drafts,
+    materialize_clusters,
+)
+from orchestrator.dedup import DraftFinding, FilterDecision, filter_findings
+from orchestrator.github_client import GitHubClient, PRMetadata
+from orchestrator.judges import (
+    cluster_judge,
+    make_semantic_judge,
+    reviewer_discovery_user_message,
+    reviewer_opinion_user_message,
+    spotter_user_message,
+)
+
+_logger = logging.getLogger(__name__)
+
+
+class Mode(str, Enum):
+    DEFAULT = "default"
+    LITE = "lite"
+
+
+@dataclass(frozen=True)
+class Config:
+    pr_number: int
+    mode: Mode = Mode.DEFAULT
+    no_cache: bool = False
+    hybrid: bool = False
+    dry_run: bool = True
+    repo: str = "mlflow/mlflow"
+    bot_login: str = "mlflow-reviewer[bot]"
+
+    @property
+    def models(self) -> ModelChoice:
+        return ModelChoice.hybrid() if self.hybrid else ModelChoice.default()
+
+
+@dataclass(frozen=True)
+class ReviewOutput:
+    pr_number: int
+    head_sha: str
+    mode: Mode
+    posted: list[FilterDecision]
+    skipped: list[FilterDecision]
+    summary: str
+
+
+def parse_reviewer_discovery_findings(text: str) -> list[SourceFinding]:
+    data = json.loads(text)
+    return [
+        SourceFinding(
+            source="reviewer_standalone",
+            path=f.get("path") or "",
+            line=int(f.get("line") or 0),
+            body=f.get("body") or "",
+            severity=f.get("risk_to_severity") or _risk_to_severity(f.get("risk")),
+            rule_id=f.get("rule_id"),
+        )
+        for f in data.get("findings", [])
+    ]
+
+
+def parse_spotter_findings(text: str) -> list[dict[str, object]]:
+    data = json.loads(text)
+    return data.get("findings", [])
+
+
+def parse_reviewer_opinion_raises(
+    text: str, spotter_findings: list[dict[str, object]]
+) -> list[SourceFinding]:
+    """Extract `decision == "raise"` opinions and join with spotter findings."""
+    data = json.loads(text)
+    by_id = {f["finding_id"]: f for f in spotter_findings}
+    out: list[SourceFinding] = []
+    for op in data.get("opinions", []):
+        if op.get("decision") != "raise":
+            continue
+        spotter = by_id.get(op["finding_id"], {})
+        out.append(
+            SourceFinding(
+                source="reviewer_opinion",
+                path=spotter.get("path") or "",
+                line=int(spotter.get("line") or 0),
+                body=op.get("voice_rewrite") or spotter.get("body") or "",
+                severity=op.get("severity") or "ask",
+                rule_id=op.get("rule_id"),
+            )
+        )
+    return out
+
+
+_RISK_TO_SEVERITY = {
+    "No risk": "nit",
+    "Low risk": "ask",
+    "Needs discussion": "firm",
+}
+
+
+def _risk_to_severity(risk: str | None) -> str:
+    if risk is None:
+        return "ask"
+    return _RISK_TO_SEVERITY.get(risk, "ask")
+
+
+async def _run_reviewer_standalone(
+    client: AnthropicClient,
+    pr: PRMetadata,
+    diff: str,
+    files: dict[str, str],
+    models: ModelChoice,
+) -> list[SourceFinding]:
+    result = await client.complete(
+        role=models.reviewer_standalone,
+        system=agents.reviewer_prompt(),
+        messages=[
+            Message(
+                role="user",
+                content=reviewer_discovery_user_message(pr.number, pr.title, diff, files),
+            )
+        ],
+    )
+    return parse_reviewer_discovery_findings(result.text)
+
+
+async def _run_spotter(
+    client: AnthropicClient,
+    pr: PRMetadata,
+    diff: str,
+    files: dict[str, str],
+    models: ModelChoice,
+) -> list[dict[str, object]]:
+    result = await client.complete(
+        role=models.spotter,
+        system=agents.spotter_prompt(),
+        messages=[
+            Message(
+                role="user",
+                content=spotter_user_message(pr.number, pr.title, diff, files),
+            )
+        ],
+    )
+    return parse_spotter_findings(result.text)
+
+
+async def _run_reviewer_opinion(
+    client: AnthropicClient,
+    pr: PRMetadata,
+    diff: str,
+    spotter_findings: list[dict[str, object]],
+    models: ModelChoice,
+) -> list[SourceFinding]:
+    if not spotter_findings:
+        return []
+    result = await client.complete(
+        role=models.reviewer_opinion,
+        system=agents.reviewer_prompt(),
+        messages=[
+            Message(
+                role="user",
+                content=reviewer_opinion_user_message(
+                    pr.number, pr.title, diff, json.dumps(spotter_findings)
+                ),
+            )
+        ],
+    )
+    return parse_reviewer_opinion_raises(result.text, spotter_findings)
+
+
+async def _cluster(
+    client: AnthropicClient,
+    list_a: list[SourceFinding],
+    list_b: list[SourceFinding],
+    models: ModelChoice,
+) -> list[Cluster]:
+    if not list_a and not list_b:
+        return []
+    if not list_a:
+        return [Cluster(members=[f]) for f in list_b]
+    if not list_b:
+        return [Cluster(members=[f]) for f in list_a]
+    judge_text = await cluster_judge(client, list_a, list_b, models=models)
+    return materialize_clusters(judge_text, list_a, list_b)
+
+
+def _read_files_at_head(
+    github: GitHubClient, paths: tuple[str, ...], head_sha: str
+) -> dict[str, str]:
+    files: dict[str, str] = {}
+    for path in paths:
+        try:
+            files[path] = github.read_file_at_head(path, head_sha)
+        except Exception as e:
+            _logger.warning("Could not read %s at %s: %s", path, head_sha, e)
+    return files
+
+
+async def run_review(
+    config: Config,
+    *,
+    anthropic: AnthropicConfig | None = None,
+) -> ReviewOutput:
+    anthropic = anthropic or AnthropicConfig.from_env()
+    client = AnthropicClient(anthropic)
+    github = GitHubClient(repo=config.repo, bot_login=config.bot_login)
+
+    pr = github.get_pr_metadata(config.pr_number)
+    diff = github.get_pr_diff(config.pr_number)
+    files = _read_files_at_head(github, pr.changed_paths, pr.head_sha)
+    threads = github.get_review_threads(config.pr_number, pr_author=pr.author_login)
+
+    if config.mode == Mode.LITE:
+        standalone = await _run_reviewer_standalone(client, pr, diff, files, config.models)
+        clusters = [Cluster(members=[f]) for f in standalone]
+    else:
+        standalone, spotter_findings = await asyncio.gather(
+            _run_reviewer_standalone(client, pr, diff, files, config.models),
+            _run_spotter(client, pr, diff, files, config.models),
+        )
+        opinion = await _run_reviewer_opinion(client, pr, diff, spotter_findings, config.models)
+        clusters = await _cluster(client, standalone, opinion, config.models)
+
+    drafts = clusters_to_drafts(clusters)
+
+    semantic_judge = make_semantic_judge(client, config.models)
+    decisions = await filter_findings(
+        drafts,
+        threads,
+        pr_author_login=pr.author_login,
+        semantic_judge=semantic_judge,
+        thread_bodies_by_thread={},
+    )
+    posted = [d for d in decisions if d.posted]
+    skipped = [d for d in decisions if not d.posted]
+
+    summary = (
+        f"PR #{pr.number}: drafts={len(drafts)}, posted={len(posted)}, "
+        f"skipped={len(skipped)}, mode={config.mode.value}, head_sha={pr.head_sha}"
+    )
+    _logger.info(summary)
+
+    if config.dry_run:
+        _emit_dry_run_json(pr, posted, skipped, summary)
+
+    return ReviewOutput(
+        pr_number=pr.number,
+        head_sha=pr.head_sha,
+        mode=config.mode,
+        posted=posted,
+        skipped=skipped,
+        summary=summary,
+    )
+
+
+def _emit_dry_run_json(
+    pr: PRMetadata,
+    posted: list[FilterDecision],
+    skipped: list[FilterDecision],
+    summary: str,
+) -> None:
+    payload = {
+        "pr": pr.number,
+        "head_sha": pr.head_sha,
+        "summary": summary,
+        "posted": [{**dataclasses.asdict(d.finding), "skip_reason": None} for d in posted],
+        "skipped": [
+            {**dataclasses.asdict(d.finding), "skip_reason": d.skip_reason} for d in skipped
+        ],
+    }
+    sys.stdout.write(json.dumps(payload, indent=2) + "\n")
+    sys.stdout.flush()
+
+
+__all__ = [
+    "Config",
+    "DraftFinding",
+    "Mode",
+    "ReviewOutput",
+    "run_review",
+]

--- a/.claude/orchestrator/tests/test_cluster.py
+++ b/.claude/orchestrator/tests/test_cluster.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from orchestrator.cluster import (
+    Cluster,
+    SourceFinding,
+    clusters_to_drafts,
+    materialize_clusters,
+    parse_cluster_assignments,
+)
+
+
+def _src(
+    source: str = "reviewer_standalone",
+    path: str = "f.py",
+    line: int = 100,
+    body: str = "concern X",
+    severity: str = "ask",
+    rule_id: str | None = "GEN-4",
+) -> SourceFinding:
+    return SourceFinding(
+        source=source,
+        path=path,
+        line=line,
+        body=body,
+        severity=severity,
+        rule_id=rule_id,
+    )
+
+
+def test_parse_cluster_assignments_basic() -> None:
+    judge_output = json.dumps({"clusters": [{"a": [0], "b": [0]}, {"a": [1], "b": []}]})
+    result = parse_cluster_assignments(judge_output, n_a=2, n_b=1)
+    assert result == [[("a", 0), ("b", 0)], [("a", 1)]]
+
+
+def test_parse_cluster_assignments_invalid_json() -> None:
+    with pytest.raises(ValueError, match="non-JSON"):
+        parse_cluster_assignments("not json", n_a=1, n_b=1)
+
+
+def test_parse_cluster_assignments_duplicate_index_rejected() -> None:
+    judge_output = json.dumps({"clusters": [{"a": [0]}, {"a": [0]}]})
+    with pytest.raises(ValueError, match="duplicate"):
+        parse_cluster_assignments(judge_output, n_a=1, n_b=0)
+
+
+def test_parse_cluster_assignments_out_of_range_rejected() -> None:
+    judge_output = json.dumps({"clusters": [{"a": [5]}]})
+    with pytest.raises(ValueError, match="duplicate|Invalid"):
+        parse_cluster_assignments(judge_output, n_a=1, n_b=0)
+
+
+def test_parse_cluster_assignments_missing_indices_rejected() -> None:
+    judge_output = json.dumps({"clusters": [{"a": [0]}]})
+    with pytest.raises(ValueError, match="missed indices"):
+        parse_cluster_assignments(judge_output, n_a=2, n_b=0)
+
+
+def test_materialize_clusters_zips_indices_to_findings() -> None:
+    a = [_src(body="A0"), _src(body="A1")]
+    b = [_src(source="reviewer_opinion", body="B0")]
+    judge_output = json.dumps({"clusters": [{"a": [0], "b": [0]}, {"a": [1], "b": []}]})
+    clusters = materialize_clusters(judge_output, a, b)
+    assert len(clusters) == 2
+    bodies_first = sorted(m.body for m in clusters[0].members)
+    assert bodies_first == ["A0", "B0"]
+    assert [m.body for m in clusters[1].members] == ["A1"]
+
+
+def test_cluster_representative_body_prefers_opinion() -> None:
+    standalone = _src(source="reviewer_standalone", body="standalone-body")
+    opinion = _src(source="reviewer_opinion", body="opinion-body")
+    cluster = Cluster(members=[standalone, opinion])
+    assert cluster.representative_body == "opinion-body"
+
+
+def test_cluster_representative_body_falls_back_to_standalone() -> None:
+    standalone = _src(source="reviewer_standalone", body="standalone-body")
+    cluster = Cluster(members=[standalone])
+    assert cluster.representative_body == "standalone-body"
+
+
+@pytest.mark.parametrize(
+    ("severities", "expected"),
+    [
+        (["nit"], "nit"),
+        (["nit", "ask"], "ask"),
+        (["nit", "ask", "firm"], "firm"),
+        (["nit", "ask", "firm", "block"], "block"),
+        (["block", "firm"], "block"),
+        (["unknown", "ask"], "ask"),
+    ],
+)
+def test_cluster_representative_severity(severities: list[str], expected: str) -> None:
+    members = [_src(severity=s) for s in severities]
+    cluster = Cluster(members=members)
+    assert cluster.representative_severity == expected
+
+
+def test_clusters_to_drafts_uses_representatives() -> None:
+    cluster = Cluster(
+        members=[
+            _src(source="reviewer_standalone", body="A", line=10, severity="nit"),
+            _src(source="reviewer_opinion", body="B", line=10, severity="firm"),
+        ]
+    )
+    drafts = clusters_to_drafts([cluster])
+    assert len(drafts) == 1
+    assert drafts[0].body == "B"
+    assert drafts[0].severity == "firm"
+    assert drafts[0].source == "cluster"
+
+
+def test_clusters_to_drafts_empty_input() -> None:
+    assert clusters_to_drafts([]) == []

--- a/.claude/orchestrator/tests/test_dedup.py
+++ b/.claude/orchestrator/tests/test_dedup.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from orchestrator.dedup import DraftFinding, filter_findings
+from orchestrator.github_client import ReviewThread
+
+
+def _draft(path: str = "f.py", line: int = 100, body: str = "concern A") -> DraftFinding:
+    return DraftFinding(
+        path=path,
+        line=line,
+        body=body,
+        severity="ask",
+        rule_id=None,
+        source="cluster",
+    )
+
+
+def _thread(
+    path: str = "f.py",
+    line: int | None = 100,
+    is_resolved: bool = False,
+    is_soft_resolved: bool = False,
+    bot_started: bool = False,
+    comment_authors: tuple[str, ...] = ("alice",),
+) -> ReviewThread:
+    return ReviewThread(
+        path=path,
+        line=line,
+        is_resolved=is_resolved,
+        comment_authors=comment_authors,
+        is_soft_resolved=is_soft_resolved,
+        bot_started=bot_started,
+    )
+
+
+async def _judge_false(_a: str, _b: list[str]) -> bool:
+    return False
+
+
+async def _judge_true(_a: str, _b: list[str]) -> bool:
+    return True
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+@pytest.mark.parametrize(
+    ("thread_kwargs", "expected_skip_substring"),
+    [
+        ({"is_resolved": True}, "hard-resolved"),
+        ({"is_soft_resolved": True}, "soft-resolved"),
+        ({"bot_started": True}, "self-dedup"),
+    ],
+)
+def test_each_skip_rule_filters_finding(
+    thread_kwargs: dict[str, bool], expected_skip_substring: str
+) -> None:
+    finding = _draft()
+    threads = [_thread(**thread_kwargs)]
+    decisions = asyncio.run(
+        filter_findings(
+            [finding],
+            threads,
+            pr_author_login="someone",
+            semantic_judge=_judge_false,
+        )
+    )
+    assert len(decisions) == 1
+    assert decisions[0].posted is False
+    assert decisions[0].skip_reason is not None
+    assert expected_skip_substring in decisions[0].skip_reason
+
+
+def test_open_human_thread_with_no_semantic_match_lets_post() -> None:
+    finding = _draft()
+    threads = [_thread()]
+    decisions = asyncio.run(
+        filter_findings(
+            [finding],
+            threads,
+            pr_author_login="someone",
+            semantic_judge=_judge_false,
+            thread_bodies_by_thread={0: "different concern"},
+        )
+    )
+    assert decisions[0].posted is True
+    assert decisions[0].skip_reason is None
+
+
+def test_open_human_thread_with_semantic_match_skips() -> None:
+    finding = _draft()
+    threads = [_thread()]
+    decisions = asyncio.run(
+        filter_findings(
+            [finding],
+            threads,
+            pr_author_login="someone",
+            semantic_judge=_judge_true,
+            thread_bodies_by_thread={0: "same concern as draft"},
+        )
+    )
+    assert decisions[0].posted is False
+    assert decisions[0].skip_reason == "semantic match against open human thread at this location"
+
+
+def test_no_threads_at_location_lets_post() -> None:
+    finding = _draft(line=100)
+    threads = [_thread(line=200)]
+    decisions = asyncio.run(
+        filter_findings(
+            [finding],
+            threads,
+            pr_author_login="someone",
+            semantic_judge=_judge_false,
+        )
+    )
+    assert decisions[0].posted is True
+
+
+@pytest.mark.parametrize(
+    ("draft_line", "thread_line", "expected_posted"),
+    [
+        (100, 100, False),  # exact match
+        (100, 109, False),  # within ±10 (9 below)
+        (100, 110, False),  # within ±10 (10 below, boundary)
+        (100, 111, True),  # outside ±10
+        (100, 90, False),  # within ±10 (10 above, boundary)
+        (100, 89, True),  # outside ±10
+    ],
+)
+def test_line_proximity_window(draft_line: int, thread_line: int, expected_posted: bool) -> None:
+    finding = _draft(line=draft_line)
+    threads = [_thread(line=thread_line, is_resolved=True)]
+    decisions = asyncio.run(
+        filter_findings(
+            [finding],
+            threads,
+            pr_author_login="someone",
+            semantic_judge=_judge_false,
+        )
+    )
+    assert decisions[0].posted is expected_posted
+
+
+def test_thread_line_none_is_skipped_in_match() -> None:
+    finding = _draft(line=100)
+    threads = [_thread(line=None, is_resolved=True)]
+    decisions = asyncio.run(
+        filter_findings(
+            [finding],
+            threads,
+            pr_author_login="someone",
+            semantic_judge=_judge_false,
+        )
+    )
+    assert decisions[0].posted is True
+
+
+def test_resolved_takes_precedence_over_semantic_judge() -> None:
+    finding = _draft()
+    threads = [_thread(is_resolved=True)]
+    judge_calls: list[tuple[str, list[str]]] = []
+
+    async def tracking_judge(body: str, threads: list[str]) -> bool:
+        judge_calls.append((body, threads))
+        return True
+
+    decisions = asyncio.run(
+        filter_findings(
+            [finding],
+            threads,
+            pr_author_login="someone",
+            semantic_judge=tracking_judge,
+            thread_bodies_by_thread={0: "any body"},
+        )
+    )
+    assert decisions[0].posted is False
+    assert "hard-resolved" in decisions[0].skip_reason
+    assert judge_calls == []  # judge was not called

--- a/.gitignore
+++ b/.gitignore
@@ -143,5 +143,7 @@ gunicorn.conf.py
 !.claude/rules/
 !.claude/scripts/
 !.claude/orchestrator/
+.claude/orchestrator/uv.lock
+.claude/orchestrator/.venv/
 !.claude/settings.json
 !.claude/statusline.sh

--- a/.gitignore
+++ b/.gitignore
@@ -142,5 +142,6 @@ gunicorn.conf.py
 !.claude/hooks/
 !.claude/rules/
 !.claude/scripts/
+!.claude/orchestrator/
 !.claude/settings.json
 !.claude/statusline.sh


### PR DESCRIPTION
## 🥞 Stacked PR
- [stack/mlflow-reviewer/1-scaffolding](https://github.com/mlflow/mlflow/pull/23074)
  - [**stack/mlflow-reviewer/2-orchestrator**](https://github.com/mlflow/mlflow/pull/23075)
    - [stack/mlflow-reviewer/3-workflow](https://github.com/mlflow/mlflow/pull/23076)
      - [stack/mlflow-reviewer/4-helpers-refresh](https://github.com/mlflow/mlflow/pull/23077)
        - [stack/mlflow-reviewer/5-activate](https://github.com/mlflow/mlflow/pull/23078)

---------

### Related Issues/PRs


### What changes are proposed in this pull request?

Stack 2 of 5. Adds the actual review flow that runs locally via the CLI. **No GitHub posting yet (Stack 3) and no workflow trigger (Stack 3); the CLI emits JSON to stdout in dry-run mode.**

#### Core flow per `/review`

1. Fetch PR metadata, diff, and changed-file contents at head SHA via `gh` CLI.
2. Load `mlflow-reviewer.md` and `issue-spotter.md` as system prompts.
3. Run agents:
   - **Default mode**: `spotter` + `reviewer-standalone` in parallel; reviewer-opinion on spotter findings; cluster judge merges the two outputs.
   - **Lite mode** (`--lite`): `reviewer-standalone` only.
4. Apply dedup rules against existing PR review threads (hard-resolved, soft-resolved, self-dedup, semantic match for open human threads).
5. Output: dry-run prints JSON; live mode lands in Stack 3.

#### New modules

- `anthropic_client.py`: `AsyncAnthropic` wrapper with retry + prompt caching for the system prompt.
- `github_client.py`: `gh` CLI subprocess wrapper for PR metadata, diff, file reads at head, and review-thread fetching (with soft-resolved computation).
- `agents.py`: load agent `.md` files; strip YAML frontmatter.
- `judges.py`: cluster-judge + semantic-dedup-judge prompts and the wrappers that call them.
- `dedup.py`: filter draft findings against existing threads (rule order: hard-resolved -> soft-resolved -> self-dedup -> semantic match -> post).
- `cluster.py`: parse cluster judge output, materialize representative findings.
- `orchestrator.py`: glue.
- `cli.py`: argparse entry point. Console script: `mlflow-reviewer <PR>`.
- `__main__.py`: enables `python -m orchestrator <PR>`.

#### Tests

- `tests/test_dedup.py` (14 cases): rule precedence, line-proximity window, semantic-judge interaction, no-call-when-resolved.
- `tests/test_cluster.py` (16 cases): cluster-judge JSON parsing, error cases, representative-body selection (`opinion` preferred over `standalone`), severity priority.

All 30 tests pass.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

CLI smoke-test:

\`\`\`bash
cd .claude/orchestrator
uv pip install -e \".[test]\"
ANTHROPIC_API_KEY=sk-... mlflow-reviewer 22962 --lite --dry-run
\`\`\`

End-to-end against a live PR is exercised when Stack 3 lands the workflow.

`ruff format` / `ruff check` / `clint` clean.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [ ] `area/tracking`
- [ ] `area/models`
- [ ] `area/model-registry`
- [ ] `area/scoring`
- [ ] `area/evaluation`
- [ ] `area/gateway`
- [ ] `area/prompts`
- [ ] `area/tracing`
- [ ] `area/projects`
- [ ] `area/uiux`
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`

<a name=\"release-note-category\"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none`
- [ ] `rn/breaking-change`
- [ ] `rn/feature`
- [ ] `rn/bug-fix`
- [ ] `rn/documentation`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release