### PR TITLE
Improve archived trace read/delete handling and validate archival config resolution

### DIFF
--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -317,7 +317,7 @@ class AbstractStore(GatewayStoreMixin):
             raise MlflowException.invalid_parameter_value(
                 "Either `max_timestamp_millis` or `trace_ids` must be specified.",
             )
-        if max_timestamp_millis and trace_ids:
+        if max_timestamp_millis is not None and trace_ids:
             raise MlflowException.invalid_parameter_value(
                 "Only one of `max_timestamp_millis` and `trace_ids` can be specified.",
             )

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -81,6 +81,7 @@ from mlflow.entities.trace_metrics import (
 )
 from mlflow.entities.trace_state import TraceState
 from mlflow.entities.trace_status import TraceStatus
+from mlflow.entities.workspace import TraceArchivalConfig
 from mlflow.exceptions import (
     MlflowException,
     MlflowNotImplementedException,
@@ -251,6 +252,8 @@ from mlflow.utils.validation import (
     _validate_run_id,
     _validate_tag,
     _validate_trace_archival_location,
+    _validate_trace_archival_repository_support,
+    _validate_trace_archival_retention_string,
     _validate_trace_tag,
 )
 from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME, WORKSPACES_DIR_NAME
@@ -5456,7 +5459,18 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 "Trace archival config resolution returned no archival retention.",
                 error_code=INTERNAL_ERROR,
             )
-        self._validate_trace_archival_destination(trace_archival_config=trace_archival_config)
+        trace_archival_config = ResolvedTraceArchivalConfig(
+            config=TraceArchivalConfig(
+                location=_validate_trace_archival_repository_support(
+                    trace_archival_config.config.location,
+                    parameter_name="resolved_trace_archival_location",
+                ),
+                retention=_validate_trace_archival_retention_string(
+                    trace_archival_config.config.retention
+                ),
+            ),
+            append_workspace_prefix=trace_archival_config.append_workspace_prefix,
+        )
         broader_retention_millis = _parse_trace_archival_duration_millis(
             trace_archival_config.config.retention
         )
@@ -5621,30 +5635,6 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         patching the shared time utility.
         """
         return get_current_time_millis()
-
-    def _validate_trace_archival_destination(
-        self, *, trace_archival_config: ResolvedTraceArchivalConfig
-    ) -> None:
-        resolved_root = _validate_trace_archival_location(
-            trace_archival_config.config.location,
-            parameter_name="resolved_trace_archival_location",
-        )
-        if trace_archival_config.append_workspace_prefix and (
-            workspace_name := self._get_trace_archival_workspace_name()
-        ):
-            resolved_root = append_to_uri_path(resolved_root, WORKSPACES_DIR_NAME, workspace_name)
-
-        # Fail deterministic repository/config problems once per pass instead of misclassifying
-        # them as retryable per-trace archival errors.
-        get_artifact_repository(
-            append_to_uri_path(
-                resolved_root,
-                "0",
-                self.TRACE_FOLDER_NAME,
-                "preflight",
-                self.ARTIFACTS_FOLDER_NAME,
-            )
-        )
 
     def _get_trace_archival_workspace_name(self) -> str | None:
         """Return the workspace path segment for workspace-scoped archival roots."""

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -176,6 +176,9 @@ from mlflow.store.tracking.utils.trace_archival import (
     _parse_experiment_trace_archival_retention_millis,
     _parse_trace_archival_duration_millis,
     _TraceArchiveCandidate,
+    _TraceDeleteSelection,
+    _TraceReadSnapshot,
+    _TraceSpanSnapshot,
 )
 from mlflow.store.workspace.abstract_store import ResolvedTraceArchivalConfig
 from mlflow.telemetry.events import UpdateIssueEvent
@@ -4037,28 +4040,89 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         """
         with self.ManagedSessionMaker() as session:
             filters = [SqlTraceInfo.experiment_id == int(experiment_id)]
-            if max_timestamp_millis:
+            if max_timestamp_millis is not None:
                 filters.append(SqlTraceInfo.timestamp_ms <= max_timestamp_millis)
             if trace_ids:
                 filters.append(SqlTraceInfo.request_id.in_(trace_ids))
-            if max_traces:
+            if max_traces is not None:
                 limited_subquery = (
                     self
                     ._trace_query(session)
                     .with_entities(SqlTraceInfo.request_id)
                     .filter(*filters)
-                    .order_by(SqlTraceInfo.timestamp_ms)
+                    .order_by(SqlTraceInfo.timestamp_ms, SqlTraceInfo.request_id)
                     .limit(max_traces)
                     .subquery()
                 )
                 filters.append(SqlTraceInfo.request_id.in_(select(limited_subquery.c.request_id)))
 
-            return (
+            selected_traces = self._select_archived_traces_for_delete(
+                session=session,
+                filters=filters,
+            )
+            deleted = (
                 self
                 ._trace_query(session, for_update_or_delete=True)
                 .filter(and_(*filters))
-                .delete(synchronize_session="fetch")
+                .delete(synchronize_session=False)
             )
+
+        self._delete_archived_trace_payloads(selected_traces)
+        return deleted
+
+    def _select_archived_traces_for_delete(
+        self,
+        *,
+        session: Session,
+        filters: list[ColumnElement[bool]],
+    ) -> list[_TraceDeleteSelection]:
+        spans_location_tag = aliased(SqlTraceTag)
+        archive_location_tag = aliased(SqlTraceTag)
+        rows = (
+            self
+            ._trace_query(session, for_update_or_delete=True)
+            .outerjoin(
+                spans_location_tag,
+                and_(
+                    spans_location_tag.request_id == SqlTraceInfo.request_id,
+                    spans_location_tag.key == TraceTagKey.SPANS_LOCATION,
+                ),
+            )
+            .outerjoin(
+                archive_location_tag,
+                and_(
+                    archive_location_tag.request_id == SqlTraceInfo.request_id,
+                    archive_location_tag.key == TraceTagKey.ARCHIVE_LOCATION,
+                ),
+            )
+            .with_entities(SqlTraceInfo.request_id, archive_location_tag.value)
+            .filter(and_(*filters), spans_location_tag.value == SpansLocation.ARCHIVE_REPO.value)
+            .all()
+        )
+        return [
+            _TraceDeleteSelection(
+                trace_id=trace_id,
+                archived_artifact_uri=archived_artifact_uri,
+            )
+            for trace_id, archived_artifact_uri in rows
+        ]
+
+    def _delete_archived_trace_payloads(
+        self, selected_traces: list[_TraceDeleteSelection]
+    ) -> None:
+        for selected_trace in selected_traces:
+            if selected_trace.archived_artifact_uri is None:
+                continue
+            try:
+                get_artifact_repository(selected_trace.archived_artifact_uri).delete_artifacts(
+                    TRACE_ARCHIVAL_FILENAME
+                )
+            except Exception:
+                _logger.warning(
+                    "Failed to clean up archived payload for deleted trace %s.",
+                    selected_trace.trace_id,
+                    exc_info=True,
+                )
 
     def create_assessment(self, assessment: Assessment) -> Assessment:
         """
@@ -5068,7 +5132,6 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 self
                 ._trace_query(session)
                 .options(
-                    joinedload(SqlTraceInfo.spans),
                     selectinload(SqlTraceInfo.tags),
                     selectinload(SqlTraceInfo.request_metadata),
                     selectinload(SqlTraceInfo.assessments),
@@ -5077,18 +5140,43 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 .one_or_none()
             )
 
-            if sql_trace_info:
-                trace_info = sql_trace_info.to_mlflow_entity()
-                spans = self._get_spans_with_trace_info(
-                    trace_info, sql_trace_info.spans, allow_partial=allow_partial
-                )
-                if allow_partial or spans:
-                    return Trace(info=trace_info, data=TraceData(spans=spans))
-            else:
+            if sql_trace_info is None:
                 raise MlflowException(
                     message=f"Trace with ID {trace_id} is not found.",
                     error_code=RESOURCE_DOES_NOT_EXIST,
                 )
+
+            trace_info = sql_trace_info.to_mlflow_entity()
+            span_snapshots = []
+            traces_with_cleared_payloads: set[str] = set()
+            if (
+                trace_info.tags.get(TraceTagKey.SPANS_LOCATION)
+                == SpansLocation.TRACKING_STORE.value
+            ):
+                tracking_store_span_snapshots, traces_with_cleared_payloads = (
+                    self._load_tracking_store_span_snapshots(session, [trace_id])
+                )
+                span_snapshots = tracking_store_span_snapshots.get(trace_id, [])
+            trace_snapshot = _TraceReadSnapshot(
+                trace_info=trace_info,
+                spans=span_snapshots,
+            )
+
+        # If archival finalized after we read trace_info but before we loaded spans, reread
+        # metadata so archived traces dispatch to archive storage instead of empty DB payloads.
+        trace_snapshot = self._refresh_transitioning_trace_snapshot(
+            trace_snapshot,
+            traces_with_cleared_payloads=traces_with_cleared_payloads,
+        )
+
+        spans = self._get_spans_with_trace_info(
+            trace_snapshot.trace_info,
+            trace_snapshot.spans,
+            allow_partial=allow_partial,
+        )
+        if allow_partial or spans:
+            return Trace(info=trace_snapshot.trace_info, data=TraceData(spans=spans))
+        return None
 
     def batch_get_traces(self, trace_ids: list[str], location: str | None = None) -> list[Trace]:
         """
@@ -5109,12 +5197,12 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             value=SqlTraceInfo.request_id,
         )
         with self.ManagedSessionMaker() as session:
-            # Load traces and their spans in one go
+            # Load trace metadata first; DB-backed span rows are fetched separately only for traces
+            # that still read from the tracking store.
             sql_trace_infos = (
                 self
                 ._trace_query(session)
                 .options(
-                    joinedload(SqlTraceInfo.spans),
                     selectinload(SqlTraceInfo.tags),
                     selectinload(SqlTraceInfo.request_metadata),
                     selectinload(SqlTraceInfo.assessments),
@@ -5123,18 +5211,45 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 .order_by(order_case)
                 .all()
             )
+            trace_infos = [sql_trace_info.to_mlflow_entity() for sql_trace_info in sql_trace_infos]
+            tracking_store_trace_ids = [
+                trace_info.trace_id
+                for trace_info in trace_infos
+                if trace_info.tags.get(TraceTagKey.SPANS_LOCATION)
+                == SpansLocation.TRACKING_STORE.value
+            ]
+            tracking_store_span_snapshots, traces_with_cleared_payloads = (
+                self._load_tracking_store_span_snapshots(session, tracking_store_trace_ids)
+            )
+            trace_snapshots = [
+                _TraceReadSnapshot(
+                    trace_info=trace_info,
+                    spans=tracking_store_span_snapshots.get(trace_info.trace_id, []),
+                )
+                for trace_info in trace_infos
+            ]
 
-            traces = []
-            for sql_trace_info in sql_trace_infos:
-                trace_info = sql_trace_info.to_mlflow_entity()
-                # batch_get_traces is depended by search_traces, so we need to return
-                # complete traces only
-                if spans := self._get_spans_with_trace_info(
-                    trace_info, sql_trace_info.spans, allow_partial=False
-                ):
-                    traces.append(Trace(info=trace_info, data=TraceData(spans=spans)))
+        # If archival finalized after we read trace_info but before we loaded spans, reread
+        # metadata so archived traces dispatch to archive storage instead of empty DB payloads.
+        trace_snapshots = [
+            self._refresh_transitioning_trace_snapshot(
+                trace_snapshot,
+                traces_with_cleared_payloads=traces_with_cleared_payloads,
+            )
+            for trace_snapshot in trace_snapshots
+        ]
 
-            return traces
+        traces = []
+        for trace_snapshot in trace_snapshots:
+            trace_info = trace_snapshot.trace_info
+            # batch_get_traces is depended by search_traces, so we need to return
+            # complete traces only.
+            if spans := self._get_spans_with_trace_info(
+                trace_info, trace_snapshot.spans, allow_partial=False
+            ):
+                traces.append(Trace(info=trace_info, data=TraceData(spans=spans)))
+
+        return traces
 
     def batch_get_trace_infos(
         self, trace_ids: list[str], location: str | None = None
@@ -6137,7 +6252,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         return _ArchiveNowRemainingState.TERMINAL_FAILURES_ONLY
 
     def _get_spans_with_trace_info(
-        self, trace_info: TraceInfo, spans: list[SqlSpan], allow_partial: bool = True
+        self, trace_info: TraceInfo, spans: list[_TraceSpanSnapshot], allow_partial: bool = True
     ) -> list[Span] | None:
         spans_location = trace_info.tags.get(TraceTagKey.SPANS_LOCATION)
         if spans_location == SpansLocation.ARCHIVE_REPO.value:
@@ -6149,12 +6264,12 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         if spans_location != SpansLocation.TRACKING_STORE.value:
             raise MlflowTracingException("Trace data not stored in tracking store")
 
-        sql_spans = sorted(
+        span_snapshots = sorted(
             spans,
-            key=lambda s: (
+            key=lambda span: (
                 # Root spans come first, then sort by start time
-                0 if s.parent_span_id is None else 1,
-                s.start_time_unix_nano,
+                0 if span.parent_span_id is None else 1,
+                span.start_time_unix_nano,
             ),
         )
         # check whether all spans are logged before returning if not allow partial
@@ -6163,17 +6278,83 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         ):
             trace_stats = json.loads(trace_stats)
             num_spans = trace_stats.get(TraceSizeStatsKey.NUM_SPANS, 0)
-            if len(sql_spans) < num_spans:
+            if len(span_snapshots) < num_spans:
                 _logger.debug(
                     f"Trace {trace_info.trace_id} is not fully exported yet, "
-                    f"expecting {num_spans} spans but got {len(sql_spans)}"
+                    f"expecting {num_spans} spans but got {len(span_snapshots)}"
                 )
                 return
 
         return [
-            Span.from_dict(translate_loaded_span(json.loads(sql_span.content)))
-            for sql_span in sql_spans
+            Span.from_dict(translate_loaded_span(json.loads(span.content)))
+            for span in span_snapshots
         ]
+
+    def _load_tracking_store_span_snapshots(
+        self, session: Session, trace_ids: Iterable[str]
+    ) -> tuple[dict[str, list[_TraceSpanSnapshot]], set[str]]:
+        trace_ids = list(dict.fromkeys(trace_ids))
+        if not trace_ids:
+            return {}, set()
+
+        span_snapshots_by_trace_id: dict[str, list[_TraceSpanSnapshot]] = defaultdict(list)
+        traces_with_cleared_payloads: set[str] = set()
+        rows = (
+            session.query(
+                SqlSpan.trace_id,
+                SqlSpan.content,
+                SqlSpan.parent_span_id,
+                SqlSpan.start_time_unix_nano,
+            )
+            .filter(SqlSpan.trace_id.in_(trace_ids))
+            .all()
+        )
+        for trace_id, content, parent_span_id, start_time_unix_nano in rows:
+            if content == "":
+                traces_with_cleared_payloads.add(trace_id)
+                continue
+            span_snapshots_by_trace_id[trace_id].append(
+                _TraceSpanSnapshot(
+                    content=content,
+                    parent_span_id=parent_span_id,
+                    start_time_unix_nano=start_time_unix_nano,
+                )
+            )
+        return span_snapshots_by_trace_id, traces_with_cleared_payloads
+
+    def _refresh_transitioning_trace_snapshot(
+        self,
+        trace_snapshot: _TraceReadSnapshot,
+        *,
+        traces_with_cleared_payloads: set[str],
+    ) -> _TraceReadSnapshot:
+        """
+        Refresh a DB-backed read snapshot when archival may have finalized mid-read.
+
+        A trace can be observed as TRACKING_STORE in the initial metadata read, then have its
+        span payloads cleared and its tags flipped to ARCHIVE_REPO before the span rows are
+        loaded. When that happens, reread the trace metadata and return an archive-backed
+        snapshot so the caller can fetch spans from the archive repository instead of treating
+        the cleared DB rows as missing data.
+        """
+        trace_info = trace_snapshot.trace_info
+        if (
+            trace_info.tags.get(TraceTagKey.SPANS_LOCATION) != SpansLocation.TRACKING_STORE.value
+            or trace_info.trace_id not in traces_with_cleared_payloads
+        ):
+            return trace_snapshot
+
+        refreshed_trace_info = self.get_trace_info(trace_info.trace_id)
+        if (
+            refreshed_trace_info.tags.get(TraceTagKey.SPANS_LOCATION)
+            == SpansLocation.TRACKING_STORE.value
+        ):
+            return trace_snapshot
+
+        return _TraceReadSnapshot(
+            trace_info=refreshed_trace_info,
+            spans=[],
+        )
 
     #######################################################################################
     # Entity Association Methods

--- a/mlflow/store/tracking/utils/trace_archival.py
+++ b/mlflow/store/tracking/utils/trace_archival.py
@@ -4,6 +4,7 @@ import logging
 from dataclasses import dataclass
 from enum import Enum
 
+from mlflow.entities import TraceInfo
 from mlflow.exceptions import MlflowException
 from mlflow.utils.validation import (
     _parse_trace_archival_duration_config,
@@ -65,6 +66,25 @@ class _TraceArchiveCandidate:
     trace_id: str
     experiment_id: str
     timestamp_ms: int
+
+
+@dataclass(frozen=True)
+class _TraceDeleteSelection:
+    trace_id: str
+    archived_artifact_uri: str | None = None
+
+
+@dataclass(frozen=True)
+class _TraceSpanSnapshot:
+    content: str
+    parent_span_id: int | None
+    start_time_unix_nano: int
+
+
+@dataclass(frozen=True)
+class _TraceReadSnapshot:
+    trace_info: TraceInfo
+    spans: list[_TraceSpanSnapshot]
 
 
 def _parse_trace_archival_duration_millis(value: str | None) -> int | None:

--- a/mlflow/store/workspace/sqlalchemy_store.py
+++ b/mlflow/store/workspace/sqlalchemy_store.py
@@ -37,6 +37,10 @@ from mlflow.store.workspace.abstract_store import (
 )
 from mlflow.store.workspace.dbmodels import SqlWorkspace
 from mlflow.utils.uri import extract_db_type_from_uri
+from mlflow.utils.validation import (
+    _validate_trace_archival_repository_support,
+    _validate_trace_archival_retention_string,
+)
 from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
 
 _logger = logging.getLogger(__name__)
@@ -99,14 +103,27 @@ class SqlAlchemyStore(AbstractStore):
 
     def create_workspace(self, workspace: Workspace) -> Workspace:
         WorkspaceNameValidator.validate(workspace.name)
+        trace_archival_location = (
+            _validate_trace_archival_repository_support(
+                workspace.trace_archival_location,
+                parameter_name="trace_archival_location",
+            )
+            if workspace.trace_archival_location
+            else None
+        )
+        trace_archival_retention = (
+            _validate_trace_archival_retention_string(workspace.trace_archival_retention)
+            if workspace.trace_archival_retention
+            else None
+        )
         with self.ManagedSessionMaker() as session:
             try:
                 entity = SqlWorkspace(
                     name=workspace.name,
                     description=workspace.description,
                     default_artifact_root=workspace.default_artifact_root or None,
-                    trace_archival_location=workspace.trace_archival_location or None,
-                    trace_archival_retention=workspace.trace_archival_retention or None,
+                    trace_archival_location=trace_archival_location,
+                    trace_archival_retention=trace_archival_retention,
                 )
                 session.add(entity)
                 session.flush()
@@ -129,6 +146,18 @@ class SqlAlchemyStore(AbstractStore):
         return workspace_entity
 
     def update_workspace(self, workspace: Workspace) -> Workspace:
+        trace_archival_location = None
+        trace_archival_retention = None
+        if workspace.trace_archival_location:
+            trace_archival_location = _validate_trace_archival_repository_support(
+                workspace.trace_archival_location,
+                parameter_name="trace_archival_location",
+            )
+        if workspace.trace_archival_retention:
+            trace_archival_retention = _validate_trace_archival_retention_string(
+                workspace.trace_archival_retention
+            )
+
         with self.ManagedSessionMaker() as session:
             entity = self._get_workspace(session, workspace.name)
             if workspace.description is not None:
@@ -138,9 +167,9 @@ class SqlAlchemyStore(AbstractStore):
                 # value
                 entity.default_artifact_root = workspace.default_artifact_root or None
             if workspace.trace_archival_location is not None:
-                entity.trace_archival_location = workspace.trace_archival_location or None
+                entity.trace_archival_location = trace_archival_location
             if workspace.trace_archival_retention is not None:
-                entity.trace_archival_retention = workspace.trace_archival_retention or None
+                entity.trace_archival_retention = trace_archival_retention
             session.flush()
 
             _logger.info("Updated workspace '%s'", workspace.name)

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -195,8 +195,36 @@ def _validate_trace_archival_location(value: Any, *, parameter_name: str | None 
         raise MlflowException.invalid_parameter_value(
             "Trace archival location cannot use the proxy-only `mlflow-artifacts:` scheme."
         )
-
     return trimmed
+
+
+def _validate_trace_archival_repository_support(
+    value: Any, *, parameter_name: str | None = None
+) -> str:
+    location = _validate_trace_archival_location(value, parameter_name=parameter_name)
+    parameter_name = parameter_name or "trace_archival_location"
+
+    # Imported lazily to avoid a module import cycle with artifact repository validation helpers.
+    from mlflow.store.artifact.artifact_repo import ArtifactRepository
+    from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
+    from mlflow.store.artifact.databricks_artifact_repo import DatabricksArtifactRepository
+    from mlflow.store.artifact.dbfs_artifact_repo import DbfsRestArtifactRepository
+
+    artifact_repo = get_artifact_repository(location)
+    if isinstance(artifact_repo, DatabricksArtifactRepository):
+        raise MlflowException.invalid_parameter_value(
+            f"Invalid value for '{parameter_name}'. Trace archival location {location!r} "
+            "resolves to a Databricks trace artifact repository that does not support "
+            "archived trace reads."
+        )
+    if isinstance(artifact_repo, DbfsRestArtifactRepository) or (
+        type(artifact_repo).delete_artifacts is ArtifactRepository.delete_artifacts
+    ):
+        raise MlflowException.invalid_parameter_value(
+            f"Invalid value for '{parameter_name}'. Trace archival location {location!r} "
+            "resolves to an artifact repository that does not support deleting archived payloads."
+        )
+    return location
 
 
 def _parse_trace_archival_duration_config(

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store.py
@@ -15554,6 +15554,62 @@ def test_archive_traces_rejects_unregistered_archive_scheme_before_processing_ca
         )
 
 
+def test_archive_traces_rejects_unsupported_default_root_repository(store: SqlAlchemyStore):
+    class UnsupportedArchiveRepo(ArtifactRepository):
+        def log_artifact(self, local_file, artifact_path=None):
+            raise NotImplementedError
+
+        def list_artifacts(self, path=None):
+            raise NotImplementedError
+
+    with mock.patch(
+        "mlflow.store.artifact.artifact_repository_registry.get_artifact_repository",
+        return_value=UnsupportedArchiveRepo("dbfs:/archive/default"),
+    ):
+        with pytest.raises(
+            MlflowException,
+            match="does not support deleting archived payloads",
+        ) as exc_info:
+            store.archive_traces(
+                default_trace_archival_location="dbfs:/archive/default",
+                default_retention="1d",
+            )
+    assert exc_info.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+
+def test_archive_traces_rejects_unsupported_resolved_root_override(store: SqlAlchemyStore):
+    class UnsupportedArchiveRepo(ArtifactRepository):
+        def log_artifact(self, local_file, artifact_path=None):
+            raise NotImplementedError
+
+        def list_artifacts(self, path=None):
+            raise NotImplementedError
+
+    with (
+        mock.patch.object(
+            store,
+            "resolve_trace_archival_config",
+            return_value=ResolvedTraceArchivalConfig(
+                config=TraceArchivalConfig(location="dbfs:/archive/override", retention="1d"),
+                append_workspace_prefix=False,
+            ),
+        ),
+        mock.patch(
+            "mlflow.store.artifact.artifact_repository_registry.get_artifact_repository",
+            return_value=UnsupportedArchiveRepo("dbfs:/archive/override"),
+        ),
+    ):
+        with pytest.raises(
+            MlflowException,
+            match="resolved_trace_archival_location",
+        ) as exc_info:
+            store.archive_traces(
+                default_trace_archival_location="s3://archive/default",
+                default_retention="1d",
+            )
+    assert exc_info.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+
 def test_archive_traces_raises_when_default_retention_exceeds_max_length(
     store: SqlAlchemyStore,
 ):

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store.py
@@ -75,6 +75,7 @@ from mlflow.protos.databricks_pb2 import (
     TEMPORARILY_UNAVAILABLE,
     ErrorCode,
 )
+from mlflow.store.artifact.artifact_repo import ArtifactRepository
 from mlflow.store.db.db_types import MSSQL, MYSQL, POSTGRES, SQLITE
 from mlflow.store.db.utils import (
     _get_latest_schema_revision,
@@ -8128,6 +8129,17 @@ def test_delete_traces_with_max_timestamp(store):
     assert len(traces) == 0
 
 
+def test_delete_traces_with_zero_timestamp_cutoff(store):
+    exp1 = store.create_experiment("exp-zero-cutoff")
+    _create_trace(store, "tr-zero", exp1, request_time=0)
+    _create_trace(store, "tr-one", exp1, request_time=1)
+
+    deleted = store.delete_traces(exp1, max_timestamp_millis=0)
+    assert deleted == 1
+    traces, _ = store.search_traces([exp1])
+    assert [trace.trace_id for trace in traces] == ["tr-one"]
+
+
 def test_delete_traces_with_max_count(store):
     exp1 = store.create_experiment("exp1")
     for i in range(10):
@@ -14694,7 +14706,9 @@ def test_archive_traces_archives_db_backed_trace_payloads(
         assert len(archived_trace_data.spans) == 1
         assert archived_trace_data.spans[0].name == "test_span"
         assert store.get_trace(old_trace_id).data.spans[0].name == "test_span"
-        assert store.batch_get_traces([old_trace_id])[0].data.spans[0].name == "test_span"
+        batched_traces = store.batch_get_traces([old_trace_id, new_trace_id])
+        assert [trace.info.trace_id for trace in batched_traces] == [old_trace_id, new_trace_id]
+        assert [trace.data.spans[0].name for trace in batched_traces] == ["test_span", "test_span"]
 
         assert (
             _archive_traces(
@@ -14705,6 +14719,560 @@ def test_archive_traces_archives_db_backed_trace_payloads(
             )
             == 0
         )
+
+
+def test_archived_trace_downloads_happen_after_session_close(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("archive-read-session-boundary")
+    trace_id = "tr-archive-session-boundary"
+    now_millis = 18 * 24 * 60 * 60 * 1000
+    request_time = now_millis - 2 * 24 * 60 * 60 * 1000
+
+    _create_trace(store, trace_id, exp_id, request_time=request_time)
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                trace_id,
+                span_id=311,
+                start_ns=request_time * 1_000_000,
+                end_ns=(request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        assert (
+            _archive_traces(
+                store,
+                default_trace_archival_location=archive_root.as_uri(),
+                default_retention="1d",
+                now_millis=now_millis,
+            )
+            == 1
+        )
+
+        from mlflow.store.artifact.artifact_repo import ArtifactRepository
+
+        original_managed_session_maker = store.ManagedSessionMaker
+        original_download_archived_trace_data = ArtifactRepository.download_archived_trace_data
+        inside_session = False
+
+        @contextlib.contextmanager
+        def tracked_managed_session_maker():
+            nonlocal inside_session
+            with original_managed_session_maker() as session:
+                inside_session = True
+                try:
+                    yield session
+                finally:
+                    inside_session = False
+
+        def assert_session_closed_during_download(self):
+            assert not inside_session
+            return original_download_archived_trace_data(self)
+
+        with (
+            mock.patch.object(
+                store,
+                "ManagedSessionMaker",
+                tracked_managed_session_maker,
+            ),
+            mock.patch.object(
+                ArtifactRepository,
+                "download_archived_trace_data",
+                new=assert_session_closed_during_download,
+            ),
+        ):
+            assert store.get_trace(trace_id).info.trace_id == trace_id
+            assert [trace.info.trace_id for trace in store.batch_get_traces([trace_id])] == [
+                trace_id
+            ]
+
+
+def test_archived_trace_reads_recover_when_metadata_still_points_to_tracking_store(
+    store: SqlAlchemyStore,
+):
+    exp_id = store.create_experiment("archive-read-transition-fallback")
+    trace_id = "tr-archive-read-transition-fallback"
+    now_millis = 24 * 24 * 60 * 60 * 1000
+    request_time = now_millis - 2 * 24 * 60 * 60 * 1000
+
+    _create_trace(store, trace_id, exp_id, request_time=request_time)
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                trace_id,
+                span_id=511,
+                start_ns=request_time * 1_000_000,
+                end_ns=(request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        assert (
+            _archive_traces(
+                store,
+                default_trace_archival_location=archive_root.as_uri(),
+                default_retention="1d",
+                now_millis=now_millis,
+            )
+            == 1
+        )
+
+        original_to_mlflow_entity = SqlTraceInfo.to_mlflow_entity
+
+        def stale_first_trace_read(self):
+            trace_info = original_to_mlflow_entity(self)
+            if self.request_id == trace_id and stale_first_trace_read.remaining > 0:
+                stale_first_trace_read.remaining -= 1
+                trace_info.tags[TraceTagKey.SPANS_LOCATION] = SpansLocation.TRACKING_STORE.value
+            return trace_info
+
+        stale_first_trace_read.remaining = 1
+        with mock.patch.object(SqlTraceInfo, "to_mlflow_entity", new=stale_first_trace_read):
+            trace = store.get_trace(trace_id)
+        assert trace.info.tags[TraceTagKey.SPANS_LOCATION] == SpansLocation.ARCHIVE_REPO.value
+        assert [span.name for span in trace.data.spans] == ["test_span"]
+
+        stale_first_trace_read.remaining = 1
+        with mock.patch.object(SqlTraceInfo, "to_mlflow_entity", new=stale_first_trace_read):
+            traces = store.batch_get_traces([trace_id])
+        assert [trace.info.tags[TraceTagKey.SPANS_LOCATION] for trace in traces] == [
+            SpansLocation.ARCHIVE_REPO.value
+        ]
+        assert [span.name for span in traces[0].data.spans] == ["test_span"]
+
+
+def test_archived_trace_reads_skip_tracking_store_span_queries(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("archive-read-no-span-query")
+    trace_id = "tr-archive-read-no-span-query"
+    now_millis = 18 * 24 * 60 * 60 * 1000
+    request_time = now_millis - 2 * 24 * 60 * 60 * 1000
+
+    _create_trace(store, trace_id, exp_id, request_time=request_time)
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                trace_id,
+                span_id=511,
+                start_ns=request_time * 1_000_000,
+                end_ns=(request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        assert (
+            _archive_traces(
+                store,
+                default_trace_archival_location=archive_root.as_uri(),
+                default_retention="1d",
+                now_millis=now_millis,
+            )
+            == 1
+        )
+
+        span_statements = []
+
+        def capture_statement(_conn, _cursor, statement, _parameters, _context, _executemany):
+            if re.search(r"\b(from|join)\s+spans\b", statement, re.IGNORECASE):
+                span_statements.append(statement)
+
+        sqlalchemy.event.listen(store.engine, "before_cursor_execute", capture_statement)
+        try:
+            assert store.get_trace(trace_id).info.trace_id == trace_id
+            assert [trace.info.trace_id for trace in store.batch_get_traces([trace_id])] == [
+                trace_id
+            ]
+        finally:
+            sqlalchemy.event.remove(store.engine, "before_cursor_execute", capture_statement)
+
+    assert span_statements == []
+
+
+def test_search_traces_respects_archived_trace_filter_semantics(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("archive-search-semantics")
+    archived_trace_id = "tr-archive-search-archived"
+    fresh_trace_id = "tr-archive-search-fresh"
+    now_millis = 22 * 24 * 60 * 60 * 1000
+    archived_request_time = now_millis - 2 * 24 * 60 * 60 * 1000
+    fresh_request_time = now_millis - 60 * 60 * 1000
+
+    _create_trace(
+        store,
+        archived_trace_id,
+        exp_id,
+        request_time=archived_request_time,
+        tags={"group": "archive-search"},
+    )
+    _create_trace(
+        store,
+        fresh_trace_id,
+        exp_id,
+        request_time=fresh_request_time,
+        tags={"group": "archive-search"},
+    )
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span_with_content(
+                archived_trace_id,
+                name="shared_span",
+                span_id=411,
+                span_type="LLM",
+                start_ns=archived_request_time * 1_000_000,
+                end_ns=(archived_request_time + 1_000) * 1_000_000,
+                custom_attributes={"model": "gpt-4"},
+            )
+        ],
+    )
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span_with_content(
+                fresh_trace_id,
+                name="shared_span",
+                span_id=412,
+                span_type="LLM",
+                start_ns=fresh_request_time * 1_000_000,
+                end_ns=(fresh_request_time + 1_000) * 1_000_000,
+                custom_attributes={"model": "gpt-4"},
+            )
+        ],
+    )
+
+    with TempDir() as tmp:
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        assert (
+            _archive_traces(
+                store,
+                default_trace_archival_location=archive_root.as_uri(),
+                default_retention="1d",
+                now_millis=now_millis,
+            )
+            == 1
+        )
+
+        traces, _ = store.search_traces([exp_id], filter_string='tags.group = "archive-search"')
+        assert {trace.trace_id for trace in traces} == {archived_trace_id, fresh_trace_id}
+
+        traces, _ = store.search_traces([exp_id], filter_string='span.name = "shared_span"')
+        assert {trace.trace_id for trace in traces} == {archived_trace_id, fresh_trace_id}
+
+        traces, _ = store.search_traces(
+            [exp_id], filter_string='span.attributes.model LIKE "%gpt-4%"'
+        )
+        assert {trace.trace_id for trace in traces} == {fresh_trace_id}
+
+        traces, _ = store.search_traces([exp_id], filter_string='trace.text LIKE "%gpt-4%"')
+        assert {trace.trace_id for trace in traces} == {fresh_trace_id}
+
+
+def test_delete_traces_cleans_up_archived_payloads(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("archive-delete-cleanup")
+    trace_id = "tr-archive-delete-cleanup"
+    now_millis = 26 * 24 * 60 * 60 * 1000
+    request_time = now_millis - 2 * 24 * 60 * 60 * 1000
+
+    _create_trace(store, trace_id, exp_id, request_time=request_time)
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                trace_id,
+                span_id=511,
+                start_ns=request_time * 1_000_000,
+                end_ns=(request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+
+    with TempDir() as tmp:
+        from mlflow.tracing.otel.otel_archival import TRACE_ARCHIVAL_FILENAME
+
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        assert (
+            _archive_traces(
+                store,
+                default_trace_archival_location=archive_root.as_uri(),
+                default_retention="1d",
+                now_millis=now_millis,
+            )
+            == 1
+        )
+
+        trace_info = store.get_trace_info(trace_id)
+        archive_payload_path = (
+            Path(local_file_uri_to_path(trace_info.tags[TraceTagKey.ARCHIVE_LOCATION]))
+            / TRACE_ARCHIVAL_FILENAME
+        )
+        assert archive_payload_path.is_file()
+
+        assert store.delete_traces(exp_id, trace_ids=[trace_id]) == 1
+        assert not archive_payload_path.exists()
+
+
+def test_delete_traces_keeps_db_delete_when_archived_cleanup_fails(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("archive-delete-best-effort")
+    trace_id = "tr-archive-delete-best-effort"
+    now_millis = 27 * 24 * 60 * 60 * 1000
+    request_time = now_millis - 2 * 24 * 60 * 60 * 1000
+
+    _create_trace(store, trace_id, exp_id, request_time=request_time)
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                trace_id,
+                span_id=611,
+                start_ns=request_time * 1_000_000,
+                end_ns=(request_time + 1_000) * 1_000_000,
+            )
+        ],
+    )
+
+    with TempDir() as tmp:
+        from mlflow.tracing.otel.otel_archival import TRACE_ARCHIVAL_FILENAME
+
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        assert (
+            _archive_traces(
+                store,
+                default_trace_archival_location=archive_root.as_uri(),
+                default_retention="1d",
+                now_millis=now_millis,
+            )
+            == 1
+        )
+
+        trace_info = store.get_trace_info(trace_id)
+        archive_payload_path = (
+            Path(local_file_uri_to_path(trace_info.tags[TraceTagKey.ARCHIVE_LOCATION]))
+            / TRACE_ARCHIVAL_FILENAME
+        )
+        assert archive_payload_path.is_file()
+
+        failing_artifact_repo = mock.Mock()
+        failing_artifact_repo.delete_artifacts.side_effect = RuntimeError("boom")
+        with mock.patch(
+            "mlflow.store.tracking.sqlalchemy_store.get_artifact_repository",
+            return_value=failing_artifact_repo,
+        ):
+            assert store.delete_traces(exp_id, trace_ids=[trace_id]) == 1
+
+        traces, _ = store.search_traces([exp_id])
+        assert traces == []
+        assert archive_payload_path.is_file()
+
+
+def test_delete_traces_cleans_up_archived_payloads_with_bounded_ties(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("archive-delete-bounded-ties")
+    old_trace_id = "tr-archive-delete-a"
+    other_trace_id = "tr-archive-delete-b"
+    now_millis = 29 * 24 * 60 * 60 * 1000
+    request_time = now_millis - 2 * 24 * 60 * 60 * 1000
+
+    for trace_id, span_id in [(old_trace_id, 811), (other_trace_id, 812)]:
+        _create_trace(store, trace_id, exp_id, request_time=request_time)
+        store.log_spans(
+            exp_id,
+            [
+                create_test_span(
+                    trace_id,
+                    span_id=span_id,
+                    start_ns=request_time * 1_000_000,
+                    end_ns=(request_time + 1_000) * 1_000_000,
+                )
+            ],
+        )
+
+    with TempDir() as tmp:
+        from mlflow.tracing.otel.otel_archival import TRACE_ARCHIVAL_FILENAME
+
+        archive_root = Path(tmp.path("archive"))
+        archive_root.mkdir()
+        assert (
+            _archive_traces(
+                store,
+                default_trace_archival_location=archive_root.as_uri(),
+                default_retention="1d",
+                now_millis=now_millis,
+            )
+            == 2
+        )
+
+        old_payload_path = (
+            Path(
+                local_file_uri_to_path(
+                    store.get_trace_info(old_trace_id).tags[TraceTagKey.ARCHIVE_LOCATION]
+                )
+            )
+            / TRACE_ARCHIVAL_FILENAME
+        )
+        other_payload_path = (
+            Path(
+                local_file_uri_to_path(
+                    store.get_trace_info(other_trace_id).tags[TraceTagKey.ARCHIVE_LOCATION]
+                )
+            )
+            / TRACE_ARCHIVAL_FILENAME
+        )
+        assert old_payload_path.is_file()
+        assert other_payload_path.is_file()
+
+        assert store.delete_traces(exp_id, max_timestamp_millis=now_millis, max_traces=1) == 1
+
+        traces, _ = store.search_traces([exp_id])
+        assert [trace.trace_id for trace in traces] == [other_trace_id]
+        assert not old_payload_path.exists()
+        assert other_payload_path.is_file()
+
+
+def test_delete_traces_cleans_up_workspace_archived_payloads(
+    store: SqlAlchemyStore, workspaces_enabled: bool
+):
+    if not workspaces_enabled:
+        pytest.skip("Workspace archive cleanup behavior only applies when workspaces are enabled.")
+
+    workspace_store = store._get_workspace_provider_instance()
+    exp_id = store.create_experiment("archive-workspace-delete-cleanup")
+    trace_id = "tr-workspace-delete-cleanup"
+    now_millis = 31 * 24 * 60 * 60 * 1000
+    request_time = now_millis - 2 * 24 * 60 * 60 * 1000
+
+    with TempDir() as tmp:
+        from mlflow.tracing.otel.otel_archival import TRACE_ARCHIVAL_FILENAME
+
+        server_archive_root = Path(tmp.path("server-archive"))
+        workspace_artifact_root = Path(tmp.path("workspace-artifacts"))
+        workspace_archive_root = Path(tmp.path("workspace-archive"))
+        server_archive_root.mkdir()
+        workspace_artifact_root.mkdir()
+        workspace_archive_root.mkdir()
+        workspace_store.update_workspace(
+            Workspace(
+                name=DEFAULT_WORKSPACE_NAME,
+                default_artifact_root=workspace_artifact_root.as_uri(),
+                trace_archival_location=workspace_archive_root.as_uri(),
+            )
+        )
+
+        _create_trace(store, trace_id, exp_id, request_time=request_time)
+        store.log_spans(
+            exp_id,
+            [
+                create_test_span(
+                    trace_id,
+                    span_id=813,
+                    start_ns=request_time * 1_000_000,
+                    end_ns=(request_time + 1_000) * 1_000_000,
+                )
+            ],
+        )
+
+        assert (
+            _archive_traces(
+                store,
+                default_trace_archival_location=server_archive_root.as_uri(),
+                default_retention="1d",
+                now_millis=now_millis,
+            )
+            == 1
+        )
+
+        trace_info = store.get_trace_info(trace_id)
+        expected_workspace_archive_uri = append_to_uri_path(
+            workspace_archive_root.as_uri(),
+            exp_id,
+            SqlAlchemyStore.TRACE_FOLDER_NAME,
+            trace_id,
+            SqlAlchemyStore.ARTIFACTS_FOLDER_NAME,
+        )
+        assert trace_info.tags[TraceTagKey.ARCHIVE_LOCATION] == expected_workspace_archive_uri
+
+        archive_payload_path = (
+            Path(local_file_uri_to_path(trace_info.tags[TraceTagKey.ARCHIVE_LOCATION]))
+            / TRACE_ARCHIVAL_FILENAME
+        )
+        assert archive_payload_path.is_file()
+
+        assert store.delete_traces(exp_id, trace_ids=[trace_id]) == 1
+        assert not archive_payload_path.exists()
+
+
+def test_delete_traces_workspace_cleanup_selection_respects_active_workspace(
+    store: SqlAlchemyStore, workspaces_enabled: bool
+):
+    if not workspaces_enabled:
+        pytest.skip("Workspace cleanup scoping only applies when workspaces are enabled.")
+
+    workspace_store = store._get_workspace_provider_instance()
+    workspace_store.create_workspace(Workspace(name="team-b", description="other workspace"))
+
+    trace_id = "tr-workspace-delete-scope"
+    now_millis = 33 * 24 * 60 * 60 * 1000
+    request_time = now_millis - 2 * 24 * 60 * 60 * 1000
+
+    with TempDir() as tmp:
+        from mlflow.tracing.otel.otel_archival import TRACE_ARCHIVAL_FILENAME
+
+        default_archive_root = Path(tmp.path("default-archive"))
+        team_b_archive_root = Path(tmp.path("team-b-archive"))
+        default_archive_root.mkdir()
+        team_b_archive_root.mkdir()
+        workspace_store.update_workspace(
+            Workspace(name="team-b", trace_archival_location=team_b_archive_root.as_uri())
+        )
+
+        with WorkspaceContext("team-b"):
+            exp_id = store.create_experiment("archive-workspace-delete-scope")
+            _create_trace(store, trace_id, exp_id, request_time=request_time)
+            store.log_spans(
+                exp_id,
+                [
+                    create_test_span(
+                        trace_id,
+                        span_id=911,
+                        start_ns=request_time * 1_000_000,
+                        end_ns=(request_time + 1_000) * 1_000_000,
+                    )
+                ],
+            )
+
+            assert (
+                _archive_traces(
+                    store,
+                    default_trace_archival_location=default_archive_root.as_uri(),
+                    default_retention="1d",
+                    now_millis=now_millis,
+                )
+                == 1
+            )
+            archived_trace_info = store.get_trace_info(trace_id)
+
+        archive_payload_path = (
+            Path(local_file_uri_to_path(archived_trace_info.tags[TraceTagKey.ARCHIVE_LOCATION]))
+            / TRACE_ARCHIVAL_FILENAME
+        )
+        assert archive_payload_path.is_file()
+
+        assert store.delete_traces(exp_id, trace_ids=[trace_id]) == 0
+        assert archive_payload_path.is_file()
+
+        with WorkspaceContext("team-b"):
+            assert store.get_trace_info(trace_id).trace_id == trace_id
 
 
 def test_batch_get_traces_raises_for_archived_traces_with_missing_payload(

--- a/tests/store/workspace/test_sqlalchemy_store.py
+++ b/tests/store/workspace/test_sqlalchemy_store.py
@@ -1,9 +1,12 @@
+from unittest import mock
+
 import pytest
 import sqlalchemy as sa
 from sqlalchemy.exc import IntegrityError
 
 from mlflow.entities.workspace import Workspace, WorkspaceDeletionMode
 from mlflow.exceptions import MlflowException
+from mlflow.store.artifact.artifact_repo import ArtifactRepository
 from mlflow.store.workspace.dbmodels.models import SqlWorkspace
 from mlflow.store.workspace.sqlalchemy_store import SqlAlchemyStore
 from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
@@ -107,6 +110,59 @@ def test_create_workspace_invalid_name_raises(workspace_store):
     assert exc.value.error_code == "INVALID_PARAMETER_VALUE"
 
 
+def test_create_workspace_invalid_trace_archival_location_raises(workspace_store):
+    with pytest.raises(MlflowException, match="proxy-only `mlflow-artifacts:` scheme") as exc:
+        workspace_store.create_workspace(
+            Workspace(
+                name="team-a",
+                description=None,
+                trace_archival_location="mlflow-artifacts:/archive/team-a",
+            )
+        )
+    assert exc.value.error_code == "INVALID_PARAMETER_VALUE"
+
+
+def test_create_workspace_unsupported_trace_archival_location_raises(workspace_store):
+    class UnsupportedArchiveRepo(ArtifactRepository):
+        def log_artifact(self, local_file, artifact_path=None):
+            raise NotImplementedError
+
+        def log_artifacts(self, local_dir, artifact_path=None):
+            raise NotImplementedError
+
+        def list_artifacts(self, path=None):
+            raise NotImplementedError
+
+    with mock.patch(
+        "mlflow.store.artifact.artifact_repository_registry.get_artifact_repository",
+        return_value=UnsupportedArchiveRepo("dbfs:/archive/team-a"),
+    ):
+        with pytest.raises(
+            MlflowException,
+            match="does not support deleting archived payloads",
+        ) as exc:
+            workspace_store.create_workspace(
+                Workspace(
+                    name="team-a",
+                    description=None,
+                    trace_archival_location="dbfs:/archive/team-a",
+                )
+            )
+    assert exc.value.error_code == "INVALID_PARAMETER_VALUE"
+
+
+def test_create_workspace_invalid_trace_archival_retention_raises(workspace_store):
+    with pytest.raises(MlflowException, match="Trace archival retention must") as exc:
+        workspace_store.create_workspace(
+            Workspace(
+                name="team-a",
+                description=None,
+                trace_archival_retention="thirty-days",
+            )
+        )
+    assert exc.value.error_code == "INVALID_PARAMETER_VALUE"
+
+
 def test_update_workspace_changes_description(workspace_store):
     workspace_store.create_workspace(Workspace(name="team-a", description="old"))
 
@@ -153,6 +209,43 @@ def test_update_workspace_sets_trace_archival_location(workspace_store):
     assert fetched.trace_archival_location == "s3://archive/team-a"
 
 
+def test_update_workspace_invalid_trace_archival_location_raises(workspace_store):
+    workspace_store.create_workspace(Workspace(name="team-a", description="old"))
+
+    with pytest.raises(MlflowException, match="proxy-only `mlflow-artifacts:` scheme") as exc:
+        workspace_store.update_workspace(
+            Workspace(name="team-a", trace_archival_location="mlflow-artifacts:/archive/team-a")
+        )
+    assert exc.value.error_code == "INVALID_PARAMETER_VALUE"
+
+
+def test_update_workspace_unsupported_trace_archival_location_raises(workspace_store):
+    class UnsupportedArchiveRepo(ArtifactRepository):
+        def log_artifact(self, local_file, artifact_path=None):
+            raise NotImplementedError
+
+        def log_artifacts(self, local_dir, artifact_path=None):
+            raise NotImplementedError
+
+        def list_artifacts(self, path=None):
+            raise NotImplementedError
+
+    workspace_store.create_workspace(Workspace(name="team-a", description="old"))
+
+    with mock.patch(
+        "mlflow.store.artifact.artifact_repository_registry.get_artifact_repository",
+        return_value=UnsupportedArchiveRepo("dbfs:/archive/team-a"),
+    ):
+        with pytest.raises(
+            MlflowException,
+            match="does not support deleting archived payloads",
+        ) as exc:
+            workspace_store.update_workspace(
+                Workspace(name="team-a", trace_archival_location="dbfs:/archive/team-a")
+            )
+    assert exc.value.error_code == "INVALID_PARAMETER_VALUE"
+
+
 def test_update_workspace_can_clear_trace_archival_location(workspace_store):
     workspace_store.create_workspace(
         Workspace(
@@ -177,6 +270,16 @@ def test_update_workspace_sets_trace_archival_retention(workspace_store):
     assert updated.trace_archival_retention == "14d"
     fetched = workspace_store.get_workspace("team-a")
     assert fetched.trace_archival_retention == "14d"
+
+
+def test_update_workspace_invalid_trace_archival_retention_raises(workspace_store):
+    workspace_store.create_workspace(Workspace(name="team-a", description="old"))
+
+    with pytest.raises(MlflowException, match="Trace archival retention must") as exc:
+        workspace_store.update_workspace(
+            Workspace(name="team-a", trace_archival_retention="thirty-days")
+        )
+    assert exc.value.error_code == "INVALID_PARAMETER_VALUE"
 
 
 def test_update_workspace_can_clear_trace_archival_retention(workspace_store):


### PR DESCRIPTION

### Related Issues/PRs

Relates to https://github.com/mlflow/rfcs/blob/main/rfcs/0001-trace-archival/0001-trace-archival.md


### What changes are proposed in this pull request?

This PR adds retrieval and additional validation semantics to SQLAlchemy trace archival behavior. It improves archived trace retrieval and delete semantics by making transition-time reads more robust and cleaning up archived payloads when traces are deleted. It also adds stricter validation for resolved trace archival configuration so unsupported archive roots and malformed retention values fail early, with focused regression coverage for both tracking and workspace paths.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests



### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

Documentation updates will come in follow up PRs. 

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [] Yes. Give a description of this change to be included in the release notes for MLflow users.

It is somewhat user facing, but the changes are mostly transparent. 

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
