### PR TITLE
Activate NaiLaOpus posting + open to maintainer-authored fork PRs (Bridge 2/2)

### DIFF
--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -30,16 +30,27 @@ jobs:
     # `.github/policy.rego`'s require-explicit-permissions rule.
     permissions:
       contents: read
-    # The pull_request auto-trigger branch is commented out above; keep the
-    # comment-trigger gate here. The dropped branch required
-    # head.repo.full_name == github.repository (no fork PRs) and was
-    # restricted to MEMBER/COLLABORATOR/OWNER PR authors — both will need to
-    # be reinstated when the auto-trigger is re-enabled.
+    # Two layers of gating, both at the job level so that non-maintainer PRs
+    # never load the App-token secret or run any step at all (no observable
+    # side effects, no review burden on each step before a runtime gate):
+    #   1. Comment author must be a maintainer (prevents random users from
+    #      triggering the bot via `/review-v2`).
+    #   2. PR author must be a maintainer (prevents review of community-
+    #      authored PRs whose diff content could contain prompt-injection
+    #      attempts against the LLM).
+    # `issue_comment` payloads expose both associations directly, so we
+    # can do this check without an extra `gh api` step.
+    #
+    # The pull_request auto-trigger branch is commented out above; if
+    # re-enabled, the second branch of this `if:` will need to use
+    # `github.event.pull_request.head.repo.full_name == github.repository`
+    # (no fork PRs) and `github.event.pull_request.author_association`.
     if: |
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request != null &&
       startsWith(github.event.comment.body, '/review-v2') &&
-      contains(fromJSON('["MEMBER", "COLLABORATOR", "OWNER"]'), github.event.comment.author_association)
+      contains(fromJSON('["MEMBER", "COLLABORATOR", "OWNER"]'), github.event.comment.author_association) &&
+      contains(fromJSON('["MEMBER", "COLLABORATOR", "OWNER"]'), github.event.issue.author_association)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -89,31 +100,6 @@ jobs:
           orig=$(gh api "repos/$REPO/issues/comments/$COMMENT_ID" --jq .body)
           body=$(printf '%s\n\n---\n\n🚀 [NaiLaOpus running...](%s)' "$orig" "$run_url")
           gh api "repos/$REPO/issues/comments/$COMMENT_ID" -X PATCH -f body="$body" || true
-
-      - name: Reject fork PRs (comment-triggered only)
-        if: steps.ctx.outputs.trigger == 'comment'
-        env:
-          GH_TOKEN: ${{ steps.app_token.outputs.token }}
-          PR: ${{ steps.ctx.outputs.pr }}
-          REPO: ${{ github.repository }}
-          SERVER_URL: ${{ github.server_url }}
-          RUN_ID: ${{ github.run_id }}
-        run: |
-          # The issue_comment payload does not carry head_repo, so we fetch
-          # it here and refuse to run if the PR head is on a fork. The
-          # sparse-checkout above prevents fork code from executing on the
-          # runner, but the App-token + Anthropic key are still in scope, so
-          # we're being conservative for the bridge launch. Lifting this
-          # restriction (review.yml already allows fork PRs via the
-          # issue_comment path) is tracked as a followup, pending an
-          # explicit security review of the secret-exposure surface.
-          head_repo=$(gh api "repos/$REPO/pulls/$PR" --jq .head.repo.full_name)
-          if [ "$head_repo" != "$REPO" ]; then
-            run_url="$SERVER_URL/$REPO/actions/runs/$RUN_ID"
-            body=$(printf 'Refusing to run NaiLaOpus on fork PR (head=`%s`). See [run logs](%s).\n\n---\nPosted by `NaiLaOpus` (auto-generated).' "$head_repo" "$run_url")
-            gh api "repos/$REPO/issues/$PR/comments" -X POST -f body="$body" || true
-            exit 1
-          fi
 
       - name: Enforce per-PR daily rate limit
         env:
@@ -182,7 +168,7 @@ jobs:
           if echo "$BODY" | grep -q -- '--hybrid'; then flags="$flags --hybrid"; fi
           echo "flags=$flags" >> "$GITHUB_OUTPUT"
 
-      - name: Run NaiLaOpus (dry-run by default; Bridge 2 adds --no-dry-run to enable posting)
+      - name: Run NaiLaOpus
         env:
           # EXPERIMENTAL_ANTHROPIC_API_KEY isolates the bot's spend from
           # any other workflow on this repo that uses Anthropic (e.g. the
@@ -206,7 +192,7 @@ jobs:
         # from the orchestrator package without a separate `uv pip install`
         # step; uv caches the env between invocations.
         run: |
-          uv run --directory internal/nailaopus nailaopus "$PR" --repo "$REPO" --mlflow-tree "$GITHUB_WORKSPACE/mlflow" $FLAGS
+          uv run --directory internal/nailaopus nailaopus "$PR" --repo "$REPO" --mlflow-tree "$GITHUB_WORKSPACE/mlflow" --no-dry-run $FLAGS
 
       - name: React +1 on success (comment-triggered only)
         if: success() && steps.ctx.outputs.trigger == 'comment'


### PR DESCRIPTION
## 🥞 Stacked PR
- [stack/mlflow-reviewer-bridge/1-trigger](https://github.com/mlflow/mlflow/pull/23084) [MERGED]
  - [**stack/mlflow-reviewer-bridge/2-activate**](https://github.com/mlflow/mlflow/pull/23085)

---------

### Related Issues/PRs

Final PR of the M1 NaiLaOpus rollout. Stacks on Bridge 1/2 (#23084) plus the 4-PR `mlflow/internal` stack (#17-#20) and the anchor-quality follow-up (#22).

### What changes are proposed in this pull request?

Two changes, one file (`.github/workflows/nailaopus.yml`):

1. **Flip from dry-run to posting-enabled** by passing `--no-dry-run` to the `nailaopus` CLI. The bot now actually posts review comments instead of only emitting structured run JSON to stdout.

2. **Move the maintainer-author check from a runtime step to the job-level `if:` condition.** Trust model: we run on any PR (fork or non-fork) as long as both the comment author AND the PR author are maintainers (MEMBER/COLLABORATOR/OWNER). Both checks live in the job-level `if:` so that non-maintainer PRs never start the workflow at all — no App-token issuance, no step execution, no observable side effects.

   The previous design (runtime step that called `gh api ... pulls/$PR --jq .author_association` then posted a refusal comment) is removed entirely. `issue_comment` payloads already expose both `comment.author_association` and `issue.author_association` to the workflow context, so the check works at job-level without any extra API call.

   Per @harupy's review: "Can we move this in the job-level if condition to avoid **any interaction** with non-maintainer PRs like `review.yml`?" — done.

#### Coverage matrix

| PR origin | Pre-Bridge-2 | Post-Bridge-2 |
|---|---|---|
| Maintainer, pushed to `mlflow/mlflow` directly | Runs (dry-run) | Runs (posting) |
| Maintainer, pushed to their fork | Refused with comment | Runs (posting) |
| Community contributor on a fork | Refused with comment | Workflow does not start (silent skip) |

Community-authored PRs are deferred to a followup that adds output sanitization and an explicit security review of the prompt-injection surface.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Plan after merge:
- `/review-v2` on a recent maintainer-authored fork PR (e.g. mlflow/mlflow#23294, B-Step62) — workflow should start AND post review comments.
- `/review-v2` on a community-authored PR — workflow should not start at all (no run row appears in the Actions tab).

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

-- Claude-drafted, reviewed before posting.