### PR TITLE
Open `/admin` to workspace managers (scoped per their workspace)

### DIFF
--- a/.github/actions/check-component-ids/componentId-registry.js
+++ b/.github/actions/check-component-ids/componentId-registry.js
@@ -40,14 +40,10 @@ module.exports = {
   "codegen_mlflow_app_src_common_hooks_useeditkeyvaluetagsmodal.tsx_309": "",
   "codegen_mlflow_app_src_common_hooks_useeditkeyvaluetagsmodal.tsx_316": "",
   "codegen_mlflow_app_src_common_hooks_useeditkeyvaluetagsmodal.tsx_324": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_artifact-view-components_showartifactloggedtableview.tsx_181":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_artifact-view-components_showartifactloggedtableview.tsx_223":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_artifact-view-components_showartifactloggedtableview.tsx_315":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_artifact-view-components_showartifactloggedtableview.tsx_331":
-    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_artifact-view-components_showartifactloggedtableview.tsx_181": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_artifact-view-components_showartifactloggedtableview.tsx_223": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_artifact-view-components_showartifactloggedtableview.tsx_315": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_artifact-view-components_showartifactloggedtableview.tsx_331": "",
   "codegen_mlflow_app_src_experiment-tracking_components_artifactview.tsx_288": "",
   "codegen_mlflow_app_src_experiment-tracking_components_artifactview.tsx_337": "",
   "codegen_mlflow_app_src_experiment-tracking_components_comparerunbox.tsx_46": "",
@@ -57,254 +53,130 @@ module.exports = {
   "codegen_mlflow_app_src_experiment-tracking_components_comparerunview.tsx_570": "",
   "codegen_mlflow_app_src_experiment-tracking_components_comparerunview.tsx_581": "",
   "codegen_mlflow_app_src_experiment-tracking_components_comparerunview.tsx_592": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationcellevaluatebutton.tsx_59":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationcreatepromptrunoutput.tsx_144":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationcreatepromptrunoutput.tsx_85":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationcreatepromptrunoutput.tsx_99":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadercellrenderer.tsx_112":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadercellrenderer.tsx_118":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadercellrenderer.tsx_143":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadercellrenderer.tsx_150":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheaderdatasetindicator.tsx_37":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheaderdatasetindicator.tsx_49":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheaderdatasetindicator.tsx_51":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheaderdatasetindicator.tsx_66":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadermodelindicator.tsx_107":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadermodelindicator.tsx_115":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationtableactionscellrenderer.tsx_37":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationtableactionscolumnrenderer.tsx_22":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_createnotebookrunmodal.tsx_111":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_createnotebookrunmodal.tsx_117":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactcompareview.tsx_358":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactcompareview.tsx_414":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactcompareview.tsx_433":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactcompareview.tsx_465":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactviewemptystate.tsx_48":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptparameters.tsx_107":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptparameters.tsx_28":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptparameters.tsx_39":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_541":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_589":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_596":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_597":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_638":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_678":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_694":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_695":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_736":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodalexamples.tsx_42":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodalexamples.tsx_48":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodalexamples.tsx_90":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_hooks_useevaluationaddnewinputsmodal.tsx_57":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_hooks_useevaluationaddnewinputsmodal.tsx_99":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_hooks_useevaluationartifactwriteback.tsx_102":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_hooks_useevaluationartifactwriteback.tsx_110":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewassessmentssection.tsx_149":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewassessmentupsertform.tsx_124":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewassessmentupsertform.tsx_160":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewretrievalsection.tsx_30":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewretrievalsection.tsx_32":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_evaluationsoverview.tsx_576":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_experimentviewdescriptionnotes.tsx_114":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_experimentviewdescriptionnotes.tsx_120":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_experimentviewdescriptionnotes.tsx_126":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_experimentviewdescriptionnotes.tsx_141":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_experimentviewnotes.tsx_57":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_header_experimentgetsharelinkmodal.tsx_101":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_header_experimentgetsharelinkmodal.tsx_115":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_header_experimentviewheadersharebutton.tsx_44":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_172":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_184":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_49":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_56":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_75":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_groupparentcellrenderer.tsx_109":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_groupparentcellrenderer.tsx_136":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_loadmorerowrenderer.tsx_20":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_modelscellrenderer.tsx_49":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_rowactionsheadercellrenderer.tsx_52":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_runnamecellrenderer.tsx_46":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetdrawer.tsx_206":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetdrawer.tsx_81":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetlink.tsx_19_1":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetlink.tsx_19_2":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetschema.tsx_92":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetschematable.tsx_57":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetschematable.tsx_58":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetsourceurl.tsx_34":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetwithcontext.tsx_41":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscolumnselector.tsx_300":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscolumnselector.tsx_315":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrols.tsx_175":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactions.tsx_110":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactions.tsx_117":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactions.tsx_126":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactions.tsx_136":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactionsaddnewtagmodal.tsx_34":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactionsaddnewtagmodal.tsx_51":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactionsaddnewtagmodal.tsx_78":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactionsselecttags.tsx_162":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_184":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_201":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_211":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_217":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_248":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_289":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_329":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_338":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_362":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_382":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_402":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_403":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_415":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_461":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_469":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_time_button":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsemptytable.tsx_35":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_168":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_191":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_233":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_244":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_280":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_302":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_306":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_314":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_330":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_342":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_349":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_426":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_436":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunssortselectorv2.tsx_137":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunssortselectorv2.tsx_151":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunssortselectorv2.tsx_97":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunstableaddcolumncta.tsx_218":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_runssearchautocomplete.tsx_212":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_runssearchautocomplete.tsx_236":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_runssearchautocomplete.tsx_310":
-    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationcellevaluatebutton.tsx_59": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationcreatepromptrunoutput.tsx_144": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationcreatepromptrunoutput.tsx_85": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationcreatepromptrunoutput.tsx_99": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadercellrenderer.tsx_112": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadercellrenderer.tsx_118": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadercellrenderer.tsx_143": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadercellrenderer.tsx_150": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheaderdatasetindicator.tsx_37": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheaderdatasetindicator.tsx_49": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheaderdatasetindicator.tsx_51": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheaderdatasetindicator.tsx_66": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadermodelindicator.tsx_107": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadermodelindicator.tsx_115": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationtableactionscellrenderer.tsx_37": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationtableactionscolumnrenderer.tsx_22": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_createnotebookrunmodal.tsx_111": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_createnotebookrunmodal.tsx_117": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactcompareview.tsx_358": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactcompareview.tsx_414": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactcompareview.tsx_433": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactcompareview.tsx_465": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactviewemptystate.tsx_48": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptparameters.tsx_107": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptparameters.tsx_28": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptparameters.tsx_39": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_541": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_589": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_596": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_597": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_638": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_678": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_694": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_695": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_736": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodalexamples.tsx_42": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodalexamples.tsx_48": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodalexamples.tsx_90": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_hooks_useevaluationaddnewinputsmodal.tsx_57": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_hooks_useevaluationaddnewinputsmodal.tsx_99": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_hooks_useevaluationartifactwriteback.tsx_102": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_hooks_useevaluationartifactwriteback.tsx_110": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewassessmentssection.tsx_149": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewassessmentupsertform.tsx_124": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewassessmentupsertform.tsx_160": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewretrievalsection.tsx_30": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewretrievalsection.tsx_32": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_evaluationsoverview.tsx_576": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_experimentviewdescriptionnotes.tsx_114": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_experimentviewdescriptionnotes.tsx_120": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_experimentviewdescriptionnotes.tsx_126": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_experimentviewdescriptionnotes.tsx_141": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_experimentviewnotes.tsx_57": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_header_experimentgetsharelinkmodal.tsx_101": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_header_experimentgetsharelinkmodal.tsx_115": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_header_experimentviewheadersharebutton.tsx_44": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_172": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_184": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_49": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_56": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_75": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_groupparentcellrenderer.tsx_109": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_groupparentcellrenderer.tsx_136": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_loadmorerowrenderer.tsx_20": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_modelscellrenderer.tsx_49": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_rowactionsheadercellrenderer.tsx_52": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_runnamecellrenderer.tsx_46": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetdrawer.tsx_206": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetdrawer.tsx_81": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetlink.tsx_19_1": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetlink.tsx_19_2": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetschema.tsx_92": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetschematable.tsx_57": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetschematable.tsx_58": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetsourceurl.tsx_34": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetwithcontext.tsx_41": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscolumnselector.tsx_300": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscolumnselector.tsx_315": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrols.tsx_175": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactions.tsx_110": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactions.tsx_117": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactions.tsx_126": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactions.tsx_136": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactionsaddnewtagmodal.tsx_34": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactionsaddnewtagmodal.tsx_51": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactionsaddnewtagmodal.tsx_78": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactionsselecttags.tsx_162": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_184": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_201": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_211": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_217": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_248": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_289": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_329": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_338": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_362": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_382": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_402": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_403": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_415": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_461": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_469": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_time_button": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsemptytable.tsx_35": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_168": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_191": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_233": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_244": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_280": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_302": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_306": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_314": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_330": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_342": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_349": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_426": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_436": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunssortselectorv2.tsx_137": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunssortselectorv2.tsx_151": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunssortselectorv2.tsx_97": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunstableaddcolumncta.tsx_218": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_runssearchautocomplete.tsx_212": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_runssearchautocomplete.tsx_236": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_runssearchautocomplete.tsx_310": "",
   "codegen_mlflow_app_src_experiment-tracking_components_metricchartsaccordion.tsx_82": "",
   "codegen_mlflow_app_src_experiment-tracking_components_metricsplotcontrols.tsx_120": "",
   "codegen_mlflow_app_src_experiment-tracking_components_metricsplotcontrols.tsx_154": "",
@@ -314,184 +186,96 @@ module.exports = {
   "codegen_mlflow_app_src_experiment-tracking_components_modals_createexperimentform.tsx_71": "",
   "codegen_mlflow_app_src_experiment-tracking_components_modals_getlinkmodal.tsx_21": "",
   "codegen_mlflow_app_src_experiment-tracking_components_modals_renameform.tsx_69": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_parallelcoordinatesplotcontrols.tsx_84":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewdatasetbox.tsx_16":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewdatasetbox.tsx_70":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewdatasetbox.tsx_81":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewdescriptionbox.tsx_46":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewmetricstable.tsx_186":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewmetricstable.tsx_312":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewparamstable.tsx_213":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewparamstable.tsx_244":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewparamstable.tsx_74":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewregisteredmodelsbox.tsx_40":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewsourcebox.tsx_48":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewstatusbox.tsx_81":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_195":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_231":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_50":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_58":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_80":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_89":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_90":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewmetricchartsv2.tsx_244":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_262":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_288":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_291":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_298":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_316":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_324":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_334":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_340":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_344":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_350":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_runschartsparallelchartcard.tsx_293":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_runschartsparallelchartcard.tsx_300":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_charts_imagegridmultiplekeyplot.tsx_44":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_charts_imagegridmultiplekeyplot.tsx_52":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfiguredifferencechart.tsx_129":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfiguredifferencechart.tsx_138":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfiguredifferencechart.tsx_157":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfiguredifferencechart.tsx_98":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigureimagechart.tsx_84":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_436":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_474":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_494":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_524":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_628":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_682":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_703":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_716":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_747":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_838":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_112":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_126":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_42":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_56":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_70":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_84":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_98":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsconfiguremodal.tsx_232":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsconfiguremodal.tsx_296":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsfilterinput.tsx_30":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsfullscreenmodal.tsx_53":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_118":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_44":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_68":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_78":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_88":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsnodatafoundindicator.tsx_31":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsyaxismetricandexpressionselector.tsx_122":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsyaxismetricandexpressionselector.tsx_221":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_220":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_321":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_327":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_333":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_351":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_hooks_userunschartstooltip.stories.tsx_42":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_cards_chartcard.common.tsx_158":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_runscompareaddchartmenu.tsx_19":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_runscomparetooltipbody.tsx_259":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_runscomparetooltipbody.tsx_282":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_runscomparetooltipbody.tsx_302":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_sections_runscomparesectionaccordion.tsx_405":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_sections_runscomparesectionheader.tsx_246":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_sections_runscomparesectionheader.tsx_251":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_sections_runscomparesectionheader.tsx_288":
-    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_parallelcoordinatesplotcontrols.tsx_84": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewdatasetbox.tsx_16": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewdatasetbox.tsx_70": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewdatasetbox.tsx_81": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewdescriptionbox.tsx_46": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewmetricstable.tsx_186": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewmetricstable.tsx_312": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewparamstable.tsx_213": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewparamstable.tsx_244": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewparamstable.tsx_74": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewregisteredmodelsbox.tsx_40": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewsourcebox.tsx_48": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewstatusbox.tsx_81": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_195": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_231": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_50": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_58": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_80": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_89": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_90": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewmetricchartsv2.tsx_244": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_262": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_288": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_291": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_298": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_316": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_324": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_334": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_340": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_344": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_350": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_runschartsparallelchartcard.tsx_293": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_runschartsparallelchartcard.tsx_300": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_charts_imagegridmultiplekeyplot.tsx_44": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_charts_imagegridmultiplekeyplot.tsx_52": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfiguredifferencechart.tsx_129": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfiguredifferencechart.tsx_138": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfiguredifferencechart.tsx_157": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfiguredifferencechart.tsx_98": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigureimagechart.tsx_84": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_436": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_474": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_494": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_524": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_628": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_682": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_703": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_716": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_747": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_838": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_112": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_126": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_42": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_56": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_70": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_84": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_98": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsconfiguremodal.tsx_232": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsconfiguremodal.tsx_296": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsfilterinput.tsx_30": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsfullscreenmodal.tsx_53": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_118": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_44": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_68": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_78": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_88": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsnodatafoundindicator.tsx_31": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsyaxismetricandexpressionselector.tsx_122": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsyaxismetricandexpressionselector.tsx_221": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_220": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_321": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_327": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_333": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_351": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_hooks_userunschartstooltip.stories.tsx_42": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_cards_chartcard.common.tsx_158": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_runscompareaddchartmenu.tsx_19": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_runscomparetooltipbody.tsx_259": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_runscomparetooltipbody.tsx_282": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_runscomparetooltipbody.tsx_302": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_sections_runscomparesectionaccordion.tsx_405": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_sections_runscomparesectionheader.tsx_246": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_sections_runscomparesectionheader.tsx_251": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_sections_runscomparesectionheader.tsx_288": "",
   "codegen_mlflow_app_src_model-registry_components_CreateModelButton.tsx_28": "",
-  "codegen_mlflow_app_src_model-registry_components_aliases_modelstablealiasedversionscell.tsx_47":
-    "",
-  "codegen_mlflow_app_src_model-registry_components_aliases_modelstablealiasedversionscell.tsx_57":
-    "",
+  "codegen_mlflow_app_src_model-registry_components_aliases_modelstablealiasedversionscell.tsx_47": "",
+  "codegen_mlflow_app_src_model-registry_components_aliases_modelstablealiasedversionscell.tsx_57": "",
   "codegen_mlflow_app_src_model-registry_components_aliases_modelversionaliastag.tsx_23": "",
-  "codegen_mlflow_app_src_model-registry_components_aliases_modelversiontablealiasescell.tsx_30":
-    "",
-  "codegen_mlflow_app_src_model-registry_components_aliases_modelversiontablealiasescell.tsx_41":
-    "",
+  "codegen_mlflow_app_src_model-registry_components_aliases_modelversiontablealiasescell.tsx_30": "",
+  "codegen_mlflow_app_src_model-registry_components_aliases_modelversiontablealiasescell.tsx_41": "",
   "codegen_mlflow_app_src_model-registry_components_aliases_modelversionviewaliaseditor.tsx_29": "",
   "codegen_mlflow_app_src_model-registry_components_aliases_modelversionviewaliaseditor.tsx_37": "",
   "codegen_mlflow_app_src_model-registry_components_createmodelform.tsx_62": "",
@@ -534,88 +318,49 @@ module.exports = {
   "codegen_mlflow_app_src_shared_building_blocks_copybox.tsx_18": "",
   "codegen_mlflow_app_src_shared_building_blocks_pageheader.tsx_54": "",
   "codegen_mlflow_app_src_shared_building_blocks_previewbadge.tsx_14": "",
-  codegen_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_cancel:
-    "",
-  codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_121:
-    "",
-  codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_130:
-    "",
-  codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_141:
-    "",
-  codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_157:
-    "",
-  codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_207:
-    "",
-  codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_timeline_tree_timelinetreefilterbutton_111:
-    "",
-  codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_timeline_tree_timelinetreefilterbutton_83:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_common_hooks_usetagassignmentmodal_115: "",
-  codegen_no_dynamic_mlflow_web_js_src_common_hooks_usetagassignmentmodal_82: "",
-  codegen_no_dynamic_mlflow_web_js_src_common_hooks_usetagassignmentmodal_91: "",
-  codegen_no_dynamic_mlflow_web_js_src_common_hooks_usetagassignmentmodal_99: "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_evaluations_evaluationruncompareselector_112:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_evaluations_evaluationruncompareselector_190:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_experiment_page_components_experimentlistviewtagsfilter_69:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_experiment_page_components_experimentlistviewtagsfilter_87:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_experiment_page_components_experimentlistviewtagsfilter_96:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_experiment_page_components_header_experimentviewheaderkindselector_113:
-    "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_traces_quickstart_tracetablequickstart.utils_366":
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_evaluation_runs_experimentevaluationrunstablecellrenderers_284:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_page_tabs_side_nav_experimentpagesidenavsection_93:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_customcodescorerformrenderer_152:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_customcodescorerformrenderer_209:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_deletescorermodalrenderer_28:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_deletescorermodalrenderer_46:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_178:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_224:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_234:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_263:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_271:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_316:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_52:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_106:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_123:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_179:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_41:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_45:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_85:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scoreremptystaterenderer_59:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorerformrenderer_140:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorerformrenderer_293:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorerformrenderer_298:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorermodalrenderer_29:
-    "",
+  "codegen_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_cancel": "",
+  "codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_121": "",
+  "codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_130": "",
+  "codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_141": "",
+  "codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_157": "",
+  "codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_207": "",
+  "codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_timeline_tree_timelinetreefilterbutton_111": "",
+  "codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_timeline_tree_timelinetreefilterbutton_83": "",
+  "codegen_no_dynamic_mlflow_web_js_src_common_hooks_usetagassignmentmodal_115": "",
+  "codegen_no_dynamic_mlflow_web_js_src_common_hooks_usetagassignmentmodal_82": "",
+  "codegen_no_dynamic_mlflow_web_js_src_common_hooks_usetagassignmentmodal_91": "",
+  "codegen_no_dynamic_mlflow_web_js_src_common_hooks_usetagassignmentmodal_99": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_evaluations_evaluationruncompareselector_112": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_evaluations_evaluationruncompareselector_190": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_experiment_page_components_experimentlistviewtagsfilter_69": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_experiment_page_components_experimentlistviewtagsfilter_87": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_experiment_page_components_experimentlistviewtagsfilter_96": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_experiment_page_components_header_experimentviewheaderkindselector_113": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_traces_quickstart_tracetablequickstart.utils_366": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_evaluation_runs_experimentevaluationrunstablecellrenderers_284": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_page_tabs_side_nav_experimentpagesidenavsection_93": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_customcodescorerformrenderer_152": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_customcodescorerformrenderer_209": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_deletescorermodalrenderer_28": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_deletescorermodalrenderer_46": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_178": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_224": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_234": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_263": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_271": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_316": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_52": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_106": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_123": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_179": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_41": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_45": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_85": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scoreremptystaterenderer_59": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorerformrenderer_140": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorerformrenderer_293": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorerformrenderer_298": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorermodalrenderer_29": "",
   "codegen_web-shared_src_copy_copyactionbutton.tsx_17": "",
   "codegen_web-shared_src_snippet_actions_snippetactionbutton.tsx_26": "",
   "codegen_web-shared_src_snippet_actions_snippetactionbutton.tsx_33": "",
@@ -624,7 +369,7 @@ module.exports = {
   // -- Other --
   "TagAssignmentKey.Default.Input": "",
   "TagAssignmentValue.Default.Input": "",
-  account: "",
+  "account": "",
   "account.change_password_button": "",
   "account.change_password_modal": "",
   "account.change_password_modal.error": "",
@@ -753,7 +498,7 @@ module.exports = {
   "admin.users.select_row": "",
   "admin.users.username_header": "",
   "admin.users.username_link": "",
-  cancel: "",
+  "cancel": "",
   "categorical-aggregate-chart-more-items": "",
   "databricks-experiment-tracking-prompt-edit-tags-button": "",
   "delete-run-modal": "",
@@ -770,7 +515,7 @@ module.exports = {
   "eval-tab.delete_traces-modal": "",
   "experiment-evaluation-monitoring-end-date-picker": "",
   "experiment-evaluation-monitoring-start-date-picker": "",
-  fullscreen_button_chartcard: "",
+  "fullscreen_button_chartcard": "",
   "genai.util.markdown-copy-code-block": "",
   "graph-view-span-navigator-next": "",
   "graph-view-span-navigator-prev": "",
@@ -784,7 +529,7 @@ module.exports = {
   "graph-view-toolbar.zoom-out-button": "",
   "mlflow_header.toggle_sidebar_button": "",
   "open-modal": "",
-  promptType: "",
+  "promptType": "",
   "storybook.long-form.description": "",
   "storybook.long-form.model": "",
   "storybook.long-form.name": "",
@@ -794,7 +539,7 @@ module.exports = {
   "web-shared.genai-traces-table.evaluations-review-assessment.tooltip": "",
   "web-shared.genai-traces-table.key-value-tag.full-view-tooltip": "",
   "web-shared.time-ago": "",
-  workspace_selector: "",
+  "workspace_selector": "",
   "workspace_selector.tooltip": "",
 
   // -- mlflow.artifact_view --
@@ -1603,11 +1348,14 @@ module.exports = {
   "mlflow.home.workspaces.edit_modal": "",
   "mlflow.home.workspaces.error": "",
   "mlflow.home.workspaces.last_used_badge": "",
+  "mlflow.home.workspaces.manage_link": "",
+  "mlflow.home.workspaces.manage_tooltip": "",
   "mlflow.home.workspaces.pagination": "",
   "mlflow.home.workspaces.retry": "",
   "mlflow.home.workspaces.workspace_link": "",
   "mlflow.home.workspaces_table.header.artifact_root": "",
   "mlflow.home.workspaces_table.header.description": "",
+  "mlflow.home.workspaces_table.header.manage": "",
   "mlflow.home.workspaces_table.header.name": "",
 
   // -- mlflow.issue-detection --
@@ -1861,8 +1609,7 @@ module.exports = {
   "mlflow.run_details.header.register-model-button.tooltip": "",
   "mlflow.run_details.header.register_model_from_logged_model.button": "",
   "mlflow.run_details.header.register_model_from_logged_model.dropdown_menu_item": "",
-  "mlflow.run_details.header.register_model_from_logged_model.dropdown_menu_item.view_model_button":
-    "",
+  "mlflow.run_details.header.register_model_from_logged_model.dropdown_menu_item.view_model_button": "",
   "mlflow.run_details.overview.child_runs.load_more_button": "",
   "mlflow.run_details.overview.source.commit_hash": "",
   "mlflow.run_details.overview.source.commit_hash_popover": "",
@@ -2144,4 +1891,5 @@ module.exports = {
   "shared.model-trace-explorer.trace-too-large.force-display-button": "",
   "shared.model-trace-explorer.view-mode-toggle": "",
   "shared.model-trace-explorer.workflow-node-tooltip": "",
+
 };

--- a/.github/actions/check-component-ids/componentId-registry.js
+++ b/.github/actions/check-component-ids/componentId-registry.js
@@ -40,10 +40,14 @@ module.exports = {
   "codegen_mlflow_app_src_common_hooks_useeditkeyvaluetagsmodal.tsx_309": "",
   "codegen_mlflow_app_src_common_hooks_useeditkeyvaluetagsmodal.tsx_316": "",
   "codegen_mlflow_app_src_common_hooks_useeditkeyvaluetagsmodal.tsx_324": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_artifact-view-components_showartifactloggedtableview.tsx_181": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_artifact-view-components_showartifactloggedtableview.tsx_223": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_artifact-view-components_showartifactloggedtableview.tsx_315": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_artifact-view-components_showartifactloggedtableview.tsx_331": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_artifact-view-components_showartifactloggedtableview.tsx_181":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_artifact-view-components_showartifactloggedtableview.tsx_223":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_artifact-view-components_showartifactloggedtableview.tsx_315":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_artifact-view-components_showartifactloggedtableview.tsx_331":
+    "",
   "codegen_mlflow_app_src_experiment-tracking_components_artifactview.tsx_288": "",
   "codegen_mlflow_app_src_experiment-tracking_components_artifactview.tsx_337": "",
   "codegen_mlflow_app_src_experiment-tracking_components_comparerunbox.tsx_46": "",
@@ -53,130 +57,254 @@ module.exports = {
   "codegen_mlflow_app_src_experiment-tracking_components_comparerunview.tsx_570": "",
   "codegen_mlflow_app_src_experiment-tracking_components_comparerunview.tsx_581": "",
   "codegen_mlflow_app_src_experiment-tracking_components_comparerunview.tsx_592": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationcellevaluatebutton.tsx_59": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationcreatepromptrunoutput.tsx_144": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationcreatepromptrunoutput.tsx_85": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationcreatepromptrunoutput.tsx_99": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadercellrenderer.tsx_112": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadercellrenderer.tsx_118": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadercellrenderer.tsx_143": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadercellrenderer.tsx_150": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheaderdatasetindicator.tsx_37": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheaderdatasetindicator.tsx_49": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheaderdatasetindicator.tsx_51": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheaderdatasetindicator.tsx_66": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadermodelindicator.tsx_107": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadermodelindicator.tsx_115": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationtableactionscellrenderer.tsx_37": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationtableactionscolumnrenderer.tsx_22": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_createnotebookrunmodal.tsx_111": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_createnotebookrunmodal.tsx_117": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactcompareview.tsx_358": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactcompareview.tsx_414": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactcompareview.tsx_433": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactcompareview.tsx_465": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactviewemptystate.tsx_48": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptparameters.tsx_107": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptparameters.tsx_28": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptparameters.tsx_39": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_541": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_589": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_596": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_597": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_638": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_678": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_694": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_695": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_736": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodalexamples.tsx_42": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodalexamples.tsx_48": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodalexamples.tsx_90": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_hooks_useevaluationaddnewinputsmodal.tsx_57": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_hooks_useevaluationaddnewinputsmodal.tsx_99": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_hooks_useevaluationartifactwriteback.tsx_102": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_hooks_useevaluationartifactwriteback.tsx_110": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewassessmentssection.tsx_149": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewassessmentupsertform.tsx_124": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewassessmentupsertform.tsx_160": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewretrievalsection.tsx_30": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewretrievalsection.tsx_32": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_evaluationsoverview.tsx_576": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_experimentviewdescriptionnotes.tsx_114": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_experimentviewdescriptionnotes.tsx_120": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_experimentviewdescriptionnotes.tsx_126": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_experimentviewdescriptionnotes.tsx_141": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_experimentviewnotes.tsx_57": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_header_experimentgetsharelinkmodal.tsx_101": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_header_experimentgetsharelinkmodal.tsx_115": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_header_experimentviewheadersharebutton.tsx_44": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_172": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_184": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_49": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_56": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_75": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_groupparentcellrenderer.tsx_109": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_groupparentcellrenderer.tsx_136": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_loadmorerowrenderer.tsx_20": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_modelscellrenderer.tsx_49": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_rowactionsheadercellrenderer.tsx_52": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_runnamecellrenderer.tsx_46": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetdrawer.tsx_206": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetdrawer.tsx_81": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetlink.tsx_19_1": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetlink.tsx_19_2": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetschema.tsx_92": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetschematable.tsx_57": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetschematable.tsx_58": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetsourceurl.tsx_34": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetwithcontext.tsx_41": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscolumnselector.tsx_300": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscolumnselector.tsx_315": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrols.tsx_175": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactions.tsx_110": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactions.tsx_117": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactions.tsx_126": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactions.tsx_136": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactionsaddnewtagmodal.tsx_34": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactionsaddnewtagmodal.tsx_51": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactionsaddnewtagmodal.tsx_78": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactionsselecttags.tsx_162": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_184": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_201": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_211": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_217": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_248": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_289": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_329": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_338": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_362": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_382": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_402": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_403": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_415": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_461": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_469": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_time_button": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsemptytable.tsx_35": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_168": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_191": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_233": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_244": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_280": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_302": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_306": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_314": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_330": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_342": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_349": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_426": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_436": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunssortselectorv2.tsx_137": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunssortselectorv2.tsx_151": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunssortselectorv2.tsx_97": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunstableaddcolumncta.tsx_218": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_runssearchautocomplete.tsx_212": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_runssearchautocomplete.tsx_236": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_runssearchautocomplete.tsx_310": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationcellevaluatebutton.tsx_59":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationcreatepromptrunoutput.tsx_144":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationcreatepromptrunoutput.tsx_85":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationcreatepromptrunoutput.tsx_99":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadercellrenderer.tsx_112":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadercellrenderer.tsx_118":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadercellrenderer.tsx_143":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadercellrenderer.tsx_150":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheaderdatasetindicator.tsx_37":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheaderdatasetindicator.tsx_49":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheaderdatasetindicator.tsx_51":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheaderdatasetindicator.tsx_66":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadermodelindicator.tsx_107":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadermodelindicator.tsx_115":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationtableactionscellrenderer.tsx_37":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationtableactionscolumnrenderer.tsx_22":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_createnotebookrunmodal.tsx_111":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_createnotebookrunmodal.tsx_117":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactcompareview.tsx_358":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactcompareview.tsx_414":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactcompareview.tsx_433":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactcompareview.tsx_465":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactviewemptystate.tsx_48":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptparameters.tsx_107":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptparameters.tsx_28":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptparameters.tsx_39":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_541":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_589":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_596":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_597":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_638":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_678":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_694":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_695":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_736":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodalexamples.tsx_42":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodalexamples.tsx_48":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodalexamples.tsx_90":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_hooks_useevaluationaddnewinputsmodal.tsx_57":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_hooks_useevaluationaddnewinputsmodal.tsx_99":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_hooks_useevaluationartifactwriteback.tsx_102":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_hooks_useevaluationartifactwriteback.tsx_110":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewassessmentssection.tsx_149":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewassessmentupsertform.tsx_124":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewassessmentupsertform.tsx_160":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewretrievalsection.tsx_30":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewretrievalsection.tsx_32":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_evaluationsoverview.tsx_576":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_experimentviewdescriptionnotes.tsx_114":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_experimentviewdescriptionnotes.tsx_120":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_experimentviewdescriptionnotes.tsx_126":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_experimentviewdescriptionnotes.tsx_141":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_experimentviewnotes.tsx_57":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_header_experimentgetsharelinkmodal.tsx_101":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_header_experimentgetsharelinkmodal.tsx_115":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_header_experimentviewheadersharebutton.tsx_44":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_172":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_184":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_49":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_56":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_75":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_groupparentcellrenderer.tsx_109":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_groupparentcellrenderer.tsx_136":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_loadmorerowrenderer.tsx_20":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_modelscellrenderer.tsx_49":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_rowactionsheadercellrenderer.tsx_52":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_runnamecellrenderer.tsx_46":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetdrawer.tsx_206":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetdrawer.tsx_81":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetlink.tsx_19_1":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetlink.tsx_19_2":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetschema.tsx_92":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetschematable.tsx_57":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetschematable.tsx_58":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetsourceurl.tsx_34":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetwithcontext.tsx_41":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscolumnselector.tsx_300":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscolumnselector.tsx_315":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrols.tsx_175":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactions.tsx_110":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactions.tsx_117":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactions.tsx_126":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactions.tsx_136":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactionsaddnewtagmodal.tsx_34":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactionsaddnewtagmodal.tsx_51":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactionsaddnewtagmodal.tsx_78":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactionsselecttags.tsx_162":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_184":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_201":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_211":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_217":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_248":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_289":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_329":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_338":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_362":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_382":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_402":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_403":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_415":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_461":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_469":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_time_button":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsemptytable.tsx_35":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_168":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_191":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_233":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_244":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_280":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_302":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_306":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_314":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_330":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_342":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_349":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_426":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_436":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunssortselectorv2.tsx_137":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunssortselectorv2.tsx_151":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunssortselectorv2.tsx_97":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunstableaddcolumncta.tsx_218":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_runssearchautocomplete.tsx_212":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_runssearchautocomplete.tsx_236":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_runssearchautocomplete.tsx_310":
+    "",
   "codegen_mlflow_app_src_experiment-tracking_components_metricchartsaccordion.tsx_82": "",
   "codegen_mlflow_app_src_experiment-tracking_components_metricsplotcontrols.tsx_120": "",
   "codegen_mlflow_app_src_experiment-tracking_components_metricsplotcontrols.tsx_154": "",
@@ -186,96 +314,184 @@ module.exports = {
   "codegen_mlflow_app_src_experiment-tracking_components_modals_createexperimentform.tsx_71": "",
   "codegen_mlflow_app_src_experiment-tracking_components_modals_getlinkmodal.tsx_21": "",
   "codegen_mlflow_app_src_experiment-tracking_components_modals_renameform.tsx_69": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_parallelcoordinatesplotcontrols.tsx_84": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewdatasetbox.tsx_16": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewdatasetbox.tsx_70": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewdatasetbox.tsx_81": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewdescriptionbox.tsx_46": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewmetricstable.tsx_186": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewmetricstable.tsx_312": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewparamstable.tsx_213": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewparamstable.tsx_244": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewparamstable.tsx_74": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewregisteredmodelsbox.tsx_40": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewsourcebox.tsx_48": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewstatusbox.tsx_81": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_195": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_231": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_50": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_58": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_80": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_89": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_90": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewmetricchartsv2.tsx_244": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_262": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_288": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_291": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_298": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_316": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_324": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_334": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_340": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_344": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_350": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_runschartsparallelchartcard.tsx_293": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_runschartsparallelchartcard.tsx_300": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_charts_imagegridmultiplekeyplot.tsx_44": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_charts_imagegridmultiplekeyplot.tsx_52": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfiguredifferencechart.tsx_129": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfiguredifferencechart.tsx_138": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfiguredifferencechart.tsx_157": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfiguredifferencechart.tsx_98": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigureimagechart.tsx_84": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_436": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_474": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_494": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_524": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_628": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_682": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_703": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_716": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_747": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_838": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_112": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_126": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_42": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_56": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_70": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_84": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_98": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsconfiguremodal.tsx_232": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsconfiguremodal.tsx_296": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsfilterinput.tsx_30": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsfullscreenmodal.tsx_53": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_118": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_44": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_68": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_78": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_88": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsnodatafoundindicator.tsx_31": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsyaxismetricandexpressionselector.tsx_122": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsyaxismetricandexpressionselector.tsx_221": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_220": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_321": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_327": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_333": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_351": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_hooks_userunschartstooltip.stories.tsx_42": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_cards_chartcard.common.tsx_158": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_runscompareaddchartmenu.tsx_19": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_runscomparetooltipbody.tsx_259": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_runscomparetooltipbody.tsx_282": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_runscomparetooltipbody.tsx_302": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_sections_runscomparesectionaccordion.tsx_405": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_sections_runscomparesectionheader.tsx_246": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_sections_runscomparesectionheader.tsx_251": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_sections_runscomparesectionheader.tsx_288": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_parallelcoordinatesplotcontrols.tsx_84":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewdatasetbox.tsx_16":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewdatasetbox.tsx_70":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewdatasetbox.tsx_81":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewdescriptionbox.tsx_46":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewmetricstable.tsx_186":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewmetricstable.tsx_312":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewparamstable.tsx_213":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewparamstable.tsx_244":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewparamstable.tsx_74":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewregisteredmodelsbox.tsx_40":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewsourcebox.tsx_48":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewstatusbox.tsx_81":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_195":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_231":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_50":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_58":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_80":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_89":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_90":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewmetricchartsv2.tsx_244":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_262":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_288":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_291":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_298":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_316":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_324":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_334":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_340":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_344":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_350":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_runschartsparallelchartcard.tsx_293":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_runschartsparallelchartcard.tsx_300":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_charts_imagegridmultiplekeyplot.tsx_44":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_charts_imagegridmultiplekeyplot.tsx_52":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfiguredifferencechart.tsx_129":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfiguredifferencechart.tsx_138":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfiguredifferencechart.tsx_157":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfiguredifferencechart.tsx_98":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigureimagechart.tsx_84":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_436":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_474":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_494":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_524":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_628":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_682":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_703":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_716":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_747":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_838":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_112":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_126":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_42":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_56":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_70":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_84":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_98":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsconfiguremodal.tsx_232":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsconfiguremodal.tsx_296":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsfilterinput.tsx_30":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsfullscreenmodal.tsx_53":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_118":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_44":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_68":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_78":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_88":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsnodatafoundindicator.tsx_31":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsyaxismetricandexpressionselector.tsx_122":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsyaxismetricandexpressionselector.tsx_221":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_220":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_321":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_327":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_333":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_351":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_hooks_userunschartstooltip.stories.tsx_42":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_cards_chartcard.common.tsx_158":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_runscompareaddchartmenu.tsx_19":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_runscomparetooltipbody.tsx_259":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_runscomparetooltipbody.tsx_282":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_runscomparetooltipbody.tsx_302":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_sections_runscomparesectionaccordion.tsx_405":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_sections_runscomparesectionheader.tsx_246":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_sections_runscomparesectionheader.tsx_251":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_sections_runscomparesectionheader.tsx_288":
+    "",
   "codegen_mlflow_app_src_model-registry_components_CreateModelButton.tsx_28": "",
-  "codegen_mlflow_app_src_model-registry_components_aliases_modelstablealiasedversionscell.tsx_47": "",
-  "codegen_mlflow_app_src_model-registry_components_aliases_modelstablealiasedversionscell.tsx_57": "",
+  "codegen_mlflow_app_src_model-registry_components_aliases_modelstablealiasedversionscell.tsx_47":
+    "",
+  "codegen_mlflow_app_src_model-registry_components_aliases_modelstablealiasedversionscell.tsx_57":
+    "",
   "codegen_mlflow_app_src_model-registry_components_aliases_modelversionaliastag.tsx_23": "",
-  "codegen_mlflow_app_src_model-registry_components_aliases_modelversiontablealiasescell.tsx_30": "",
-  "codegen_mlflow_app_src_model-registry_components_aliases_modelversiontablealiasescell.tsx_41": "",
+  "codegen_mlflow_app_src_model-registry_components_aliases_modelversiontablealiasescell.tsx_30":
+    "",
+  "codegen_mlflow_app_src_model-registry_components_aliases_modelversiontablealiasescell.tsx_41":
+    "",
   "codegen_mlflow_app_src_model-registry_components_aliases_modelversionviewaliaseditor.tsx_29": "",
   "codegen_mlflow_app_src_model-registry_components_aliases_modelversionviewaliaseditor.tsx_37": "",
   "codegen_mlflow_app_src_model-registry_components_createmodelform.tsx_62": "",
@@ -318,49 +534,88 @@ module.exports = {
   "codegen_mlflow_app_src_shared_building_blocks_copybox.tsx_18": "",
   "codegen_mlflow_app_src_shared_building_blocks_pageheader.tsx_54": "",
   "codegen_mlflow_app_src_shared_building_blocks_previewbadge.tsx_14": "",
-  "codegen_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_cancel": "",
-  "codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_121": "",
-  "codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_130": "",
-  "codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_141": "",
-  "codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_157": "",
-  "codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_207": "",
-  "codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_timeline_tree_timelinetreefilterbutton_111": "",
-  "codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_timeline_tree_timelinetreefilterbutton_83": "",
-  "codegen_no_dynamic_mlflow_web_js_src_common_hooks_usetagassignmentmodal_115": "",
-  "codegen_no_dynamic_mlflow_web_js_src_common_hooks_usetagassignmentmodal_82": "",
-  "codegen_no_dynamic_mlflow_web_js_src_common_hooks_usetagassignmentmodal_91": "",
-  "codegen_no_dynamic_mlflow_web_js_src_common_hooks_usetagassignmentmodal_99": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_evaluations_evaluationruncompareselector_112": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_evaluations_evaluationruncompareselector_190": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_experiment_page_components_experimentlistviewtagsfilter_69": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_experiment_page_components_experimentlistviewtagsfilter_87": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_experiment_page_components_experimentlistviewtagsfilter_96": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_experiment_page_components_header_experimentviewheaderkindselector_113": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_traces_quickstart_tracetablequickstart.utils_366": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_evaluation_runs_experimentevaluationrunstablecellrenderers_284": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_page_tabs_side_nav_experimentpagesidenavsection_93": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_customcodescorerformrenderer_152": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_customcodescorerformrenderer_209": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_deletescorermodalrenderer_28": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_deletescorermodalrenderer_46": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_178": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_224": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_234": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_263": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_271": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_316": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_52": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_106": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_123": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_179": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_41": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_45": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_85": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scoreremptystaterenderer_59": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorerformrenderer_140": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorerformrenderer_293": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorerformrenderer_298": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorermodalrenderer_29": "",
+  codegen_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_cancel:
+    "",
+  codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_121:
+    "",
+  codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_130:
+    "",
+  codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_141:
+    "",
+  codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_157:
+    "",
+  codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_207:
+    "",
+  codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_timeline_tree_timelinetreefilterbutton_111:
+    "",
+  codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_timeline_tree_timelinetreefilterbutton_83:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_common_hooks_usetagassignmentmodal_115: "",
+  codegen_no_dynamic_mlflow_web_js_src_common_hooks_usetagassignmentmodal_82: "",
+  codegen_no_dynamic_mlflow_web_js_src_common_hooks_usetagassignmentmodal_91: "",
+  codegen_no_dynamic_mlflow_web_js_src_common_hooks_usetagassignmentmodal_99: "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_evaluations_evaluationruncompareselector_112:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_evaluations_evaluationruncompareselector_190:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_experiment_page_components_experimentlistviewtagsfilter_69:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_experiment_page_components_experimentlistviewtagsfilter_87:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_experiment_page_components_experimentlistviewtagsfilter_96:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_experiment_page_components_header_experimentviewheaderkindselector_113:
+    "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_traces_quickstart_tracetablequickstart.utils_366":
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_evaluation_runs_experimentevaluationrunstablecellrenderers_284:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_page_tabs_side_nav_experimentpagesidenavsection_93:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_customcodescorerformrenderer_152:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_customcodescorerformrenderer_209:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_deletescorermodalrenderer_28:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_deletescorermodalrenderer_46:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_178:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_224:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_234:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_263:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_271:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_316:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_52:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_106:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_123:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_179:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_41:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_45:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_85:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scoreremptystaterenderer_59:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorerformrenderer_140:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorerformrenderer_293:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorerformrenderer_298:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorermodalrenderer_29:
+    "",
   "codegen_web-shared_src_copy_copyactionbutton.tsx_17": "",
   "codegen_web-shared_src_snippet_actions_snippetactionbutton.tsx_26": "",
   "codegen_web-shared_src_snippet_actions_snippetactionbutton.tsx_33": "",
@@ -369,7 +624,7 @@ module.exports = {
   // -- Other --
   "TagAssignmentKey.Default.Input": "",
   "TagAssignmentValue.Default.Input": "",
-  "account": "",
+  account: "",
   "account.change_password_button": "",
   "account.change_password_modal": "",
   "account.change_password_modal.error": "",
@@ -498,7 +753,7 @@ module.exports = {
   "admin.users.select_row": "",
   "admin.users.username_header": "",
   "admin.users.username_link": "",
-  "cancel": "",
+  cancel: "",
   "categorical-aggregate-chart-more-items": "",
   "databricks-experiment-tracking-prompt-edit-tags-button": "",
   "delete-run-modal": "",
@@ -515,7 +770,7 @@ module.exports = {
   "eval-tab.delete_traces-modal": "",
   "experiment-evaluation-monitoring-end-date-picker": "",
   "experiment-evaluation-monitoring-start-date-picker": "",
-  "fullscreen_button_chartcard": "",
+  fullscreen_button_chartcard: "",
   "genai.util.markdown-copy-code-block": "",
   "graph-view-span-navigator-next": "",
   "graph-view-span-navigator-prev": "",
@@ -529,7 +784,7 @@ module.exports = {
   "graph-view-toolbar.zoom-out-button": "",
   "mlflow_header.toggle_sidebar_button": "",
   "open-modal": "",
-  "promptType": "",
+  promptType: "",
   "storybook.long-form.description": "",
   "storybook.long-form.model": "",
   "storybook.long-form.name": "",
@@ -539,7 +794,7 @@ module.exports = {
   "web-shared.genai-traces-table.evaluations-review-assessment.tooltip": "",
   "web-shared.genai-traces-table.key-value-tag.full-view-tooltip": "",
   "web-shared.time-ago": "",
-  "workspace_selector": "",
+  workspace_selector: "",
   "workspace_selector.tooltip": "",
 
   // -- mlflow.artifact_view --
@@ -1609,7 +1864,8 @@ module.exports = {
   "mlflow.run_details.header.register-model-button.tooltip": "",
   "mlflow.run_details.header.register_model_from_logged_model.button": "",
   "mlflow.run_details.header.register_model_from_logged_model.dropdown_menu_item": "",
-  "mlflow.run_details.header.register_model_from_logged_model.dropdown_menu_item.view_model_button": "",
+  "mlflow.run_details.header.register_model_from_logged_model.dropdown_menu_item.view_model_button":
+    "",
   "mlflow.run_details.overview.child_runs.load_more_button": "",
   "mlflow.run_details.overview.source.commit_hash": "",
   "mlflow.run_details.overview.source.commit_hash_popover": "",
@@ -1891,5 +2147,4 @@ module.exports = {
   "shared.model-trace-explorer.trace-too-large.force-display-button": "",
   "shared.model-trace-explorer.view-mode-toggle": "",
   "shared.model-trace-explorer.workflow-node-tooltip": "",
-
 };

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -1348,20 +1348,20 @@ def validate_can_view_roles():
 
 def validate_can_list_roles():
     """
-    Authorization for the ``/mlflow/roles/list`` endpoint. The endpoint accepts an
-    optional ``workspace`` param: if provided, returns roles in that workspace; if
-    omitted, returns all roles across workspaces. Non-admins must scope the request to
-    a workspace where they hold a role; only super admins can list across workspaces.
+    Authorization for the ``/mlflow/roles/list`` endpoint. The endpoint accepts a
+    repeated ``workspace`` query param: zero workspaces lists across the system
+    (admin-only), one or more scopes the listing to those workspaces. Non-admins
+    must hold a role in *every* workspace they request; only super admins can list
+    unscoped.
     """
     username = authenticate_request().username
     user = store.get_user(username)
     if user.is_admin:
         return True
-    params = _request_params()
-    workspace = params.get("workspace")
-    if not isinstance(workspace, str) or not workspace.strip():
+    workspaces = [w for w in request.args.getlist("workspace") if isinstance(w, str) and w.strip()]
+    if not workspaces:
         return False
-    return store.user_has_any_role_in_workspace(user.id, workspace)
+    return all(store.user_has_any_role_in_workspace(user.id, w) for w in workspaces)
 
 
 def validate_can_view_user_roles():
@@ -1468,10 +1468,8 @@ def validate_can_read_user():
 def validate_can_list_users():
     # Workspace admins are allowed: the payload has no per-workspace data, and
     # they need all usernames to assign outsiders to roles in workspaces they manage.
-    username = authenticate_request().username
-    user = store.get_user(username)
-    if user.is_admin:
-        return True
+    # (Super admins short-circuit in ``_before_request`` and never reach this validator.)
+    user = store.get_user(authenticate_request().username)
     return bool(store.list_workspace_admin_workspaces(user.id))
 
 
@@ -1479,10 +1477,8 @@ def validate_can_create_user():
     # Workspace admins may need to seed an account before assigning it a role
     # in a workspace they manage; creating a user grants no access on its own.
     # Deletion stays super-admin-only (see ``validate_can_delete_user``).
-    username = authenticate_request().username
-    user = store.get_user(username)
-    if user.is_admin:
-        return True
+    # (Super admins short-circuit in ``_before_request`` and never reach this validator.)
+    user = store.get_user(authenticate_request().username)
     return bool(store.list_workspace_admin_workspaces(user.id))
 
 
@@ -2445,18 +2441,20 @@ def get_role():
 
 @catch_mlflow_exception
 def list_roles():
-    # Optional ``workspace`` scopes the listing. When omitted, fall back to cross-
+    # Repeated ``workspace`` scopes the listing. When omitted, fall back to cross-
     # workspace listing (admin-only — enforced by validate_can_list_roles).
-    params = _request_params()
-    workspace = params.get("workspace")
-    if workspace is None:
-        roles = store.list_all_roles()
-    else:
-        if not isinstance(workspace, str) or not workspace.strip():
+    workspaces = request.args.getlist("workspace")
+    for w in workspaces:
+        if not isinstance(w, str) or not w.strip():
             raise MlflowException.invalid_parameter_value(
                 "Parameter 'workspace' must be a non-empty string when provided."
             )
-        roles = store.list_roles(workspace)
+    if not workspaces:
+        roles = store.list_all_roles()
+    elif len(workspaces) == 1:
+        roles = store.list_roles(workspaces[0])
+    else:
+        roles = store.list_roles_in_workspaces(workspaces)
     return jsonify({"roles": [r.to_json() for r in roles]})
 
 

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -1466,14 +1466,8 @@ def validate_can_read_user():
 
 
 def validate_can_list_users():
-    """
-    Authorization for the ``/mlflow/users/list`` endpoint. Platform admins always
-    pass (handled by ``_before_request``). Workspace admins (users holding
-    ``(workspace, *, MANAGE)`` in at least one workspace) are also allowed: the
-    ``users`` payload (``id``, ``username``, ``is_admin``) carries no per-workspace
-    data, and workspace admins need to see all usernames so they can assign
-    outside users to roles in the workspaces they manage.
-    """
+    # Workspace admins are allowed: the payload has no per-workspace data, and
+    # they need all usernames to assign outsiders to roles in workspaces they manage.
     username = authenticate_request().username
     user = store.get_user(username)
     if user.is_admin:
@@ -1482,15 +1476,9 @@ def validate_can_list_users():
 
 
 def validate_can_create_user():
-    """
-    Authorization for the ``/mlflow/users/create`` endpoint. Platform admins
-    always pass (handled by ``_before_request``). Workspace admins are also
-    allowed: they may need to add a user before assigning that user a role
-    in one of the workspaces they manage. Creating a user does not by itself
-    grant the new account any access — they have no roles or permissions
-    until an authorized requester explicitly assigns them. Deletion stays
-    platform-admin-only (see ``validate_can_delete_user``).
-    """
+    # Workspace admins may need to seed an account before assigning it a role
+    # in a workspace they manage; creating a user grants no access on its own.
+    # Deletion stays super-admin-only (see ``validate_can_delete_user``).
     username = authenticate_request().username
     user = store.get_user(username)
     if user.is_admin:

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -3218,10 +3218,32 @@ def get_user():
 
 @catch_mlflow_exception
 def list_users():
-    users = store.list_users()
-    return jsonify({
-        "users": [{"id": u.id, "username": u.username, "is_admin": u.is_admin} for u in users]
-    })
+    # Eager-load each user's roles in one batch so the admin Users tab doesn't
+    # have to fan out per-user requests. Per-user roles are scoped to what the
+    # caller is allowed to see, mirroring ``list_user_roles``:
+    # - super admin / self → every role
+    # - workspace admin → roles in workspaces they administer
+    users_with_roles = store.list_users_with_roles()
+    requester = authenticate_request().username
+    requester_user = store.get_user(requester)
+    admin_workspaces: set[str] | None = (
+        None
+        if requester_user.is_admin
+        else store.list_workspace_admin_workspaces(requester_user.id)
+    )
+    response_users = []
+    for u, roles in users_with_roles:
+        if admin_workspaces is None or u.username == requester:
+            visible_roles = roles
+        else:
+            visible_roles = [r for r in roles if r.workspace in admin_workspaces]
+        response_users.append({
+            "id": u.id,
+            "username": u.username,
+            "is_admin": u.is_admin,
+            "roles": [r.to_json() for r in visible_roles],
+        })
+    return jsonify({"users": response_users})
 
 
 @catch_mlflow_exception

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -1466,8 +1466,19 @@ def validate_can_read_user():
 
 
 def validate_can_list_users():
-    # only admins can list all users, but admins won't reach this validator
-    return False
+    """
+    Authorization for the ``/mlflow/users/list`` endpoint. Platform admins always
+    pass (handled by ``_before_request``). Workspace admins (users holding
+    ``(workspace, *, MANAGE)`` in at least one workspace) are also allowed: the
+    ``users`` payload (``id``, ``username``, ``is_admin``) carries no per-workspace
+    data, and workspace admins need to see all usernames so they can assign
+    outside users to roles in the workspaces they manage.
+    """
+    username = authenticate_request().username
+    user = store.get_user(username)
+    if user.is_admin:
+        return True
+    return bool(store.list_workspace_admin_workspaces(user.id))
 
 
 def validate_can_create_user():

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -1358,10 +1358,14 @@ def validate_can_list_roles():
     user = store.get_user(username)
     if user.is_admin:
         return True
-    workspaces = [w for w in request.args.getlist("workspace") if isinstance(w, str) and w.strip()]
-    if not workspaces:
+    requested = {
+        w.strip() for w in request.args.getlist("workspace") if isinstance(w, str) and w.strip()
+    }
+    if not requested:
         return False
-    return all(store.user_has_any_role_in_workspace(user.id, w) for w in workspaces)
+    # Single batch query — avoids N round-trips when multiple workspaces are
+    # requested and dedups duplicates implicitly via the set.
+    return requested <= store.list_user_present_workspaces(user.id)
 
 
 def validate_can_view_user_roles():
@@ -2449,12 +2453,7 @@ def list_roles():
             raise MlflowException.invalid_parameter_value(
                 "Parameter 'workspace' must be a non-empty string when provided."
             )
-    if not workspaces:
-        roles = store.list_all_roles()
-    elif len(workspaces) == 1:
-        roles = store.list_roles(workspaces[0])
-    else:
-        roles = store.list_roles_in_workspaces(workspaces)
+    roles = store.list_roles(workspaces) if workspaces else store.list_roles()
     return jsonify({"roles": [r.to_json() for r in roles]})
 
 

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -1482,8 +1482,20 @@ def validate_can_list_users():
 
 
 def validate_can_create_user():
-    # only admins can create user, but admins won't reach this validator
-    return False
+    """
+    Authorization for the ``/mlflow/users/create`` endpoint. Platform admins
+    always pass (handled by ``_before_request``). Workspace admins are also
+    allowed: they may need to add a user before assigning that user a role
+    in one of the workspaces they manage. Creating a user does not by itself
+    grant the new account any access — they have no roles or permissions
+    until an authorized requester explicitly assigns them. Deletion stays
+    platform-admin-only (see ``validate_can_delete_user``).
+    """
+    username = authenticate_request().username
+    user = store.get_user(username)
+    if user.is_admin:
+        return True
+    return bool(store.list_workspace_admin_workspaces(user.id))
 
 
 def validate_can_update_user_password():

--- a/mlflow/server/auth/sqlalchemy_store.py
+++ b/mlflow/server/auth/sqlalchemy_store.py
@@ -1,4 +1,5 @@
 import re
+from collections.abc import Iterable
 from urllib.parse import quote, unquote
 
 from sqlalchemy import and_, or_, select, text
@@ -1553,6 +1554,22 @@ class SqlAlchemyStore:
                 .query(SqlRole)
                 .options(selectinload(SqlRole.permissions))
                 .filter(SqlRole.workspace == workspace)
+                .all()
+            )
+            return [r.to_mlflow_entity() for r in roles]
+
+    def list_roles_in_workspaces(self, workspaces: Iterable[str]) -> list[Role]:
+        # Empty input returns nothing — callers must use ``list_all_roles`` for
+        # the unscoped admin path.
+        names = list(workspaces)
+        if not names:
+            return []
+        with self.ManagedSessionMaker() as session:
+            roles = (
+                session
+                .query(SqlRole)
+                .options(selectinload(SqlRole.permissions))
+                .filter(SqlRole.workspace.in_(names))
                 .all()
             )
             return [r.to_mlflow_entity() for r in roles]

--- a/mlflow/server/auth/sqlalchemy_store.py
+++ b/mlflow/server/auth/sqlalchemy_store.py
@@ -161,6 +161,28 @@ class SqlAlchemyStore:
             users = session.query(SqlUser).all()
             return [u.to_mlflow_entity() for u in users]
 
+    def list_users_with_roles(self) -> list[tuple[User, list[Role]]]:
+        """
+        Return every user paired with their role assignments. Eager-loads
+        assignments / roles / role-permissions in batched queries so the admin
+        Users tab can render per-user role info without N per-row requests.
+        """
+        with self.ManagedSessionMaker() as session:
+            users = (
+                session
+                .query(SqlUser)
+                .options(
+                    selectinload(SqlUser.user_role_assignments)
+                    .selectinload(SqlUserRoleAssignment.role)
+                    .selectinload(SqlRole.permissions)
+                )
+                .all()
+            )
+            return [
+                (u.to_mlflow_entity(), [a.role.to_mlflow_entity() for a in u.user_role_assignments])
+                for u in users
+            ]
+
     def update_user(
         self, username: str, password: str | None = None, is_admin: bool | None = None
     ) -> User:

--- a/mlflow/server/auth/sqlalchemy_store.py
+++ b/mlflow/server/auth/sqlalchemy_store.py
@@ -1547,20 +1547,14 @@ class SqlAlchemyStore:
         with self.ManagedSessionMaker() as session:
             return self._get_role_by_name(session, workspace, name).to_mlflow_entity()
 
-    def list_roles(self, workspace: str) -> list[Role]:
-        with self.ManagedSessionMaker() as session:
-            roles = (
-                session
-                .query(SqlRole)
-                .options(selectinload(SqlRole.permissions))
-                .filter(SqlRole.workspace == workspace)
-                .all()
-            )
-            return [r.to_mlflow_entity() for r in roles]
-
-    def list_roles_in_workspaces(self, workspaces: Iterable[str]) -> list[Role]:
-        # Empty input returns nothing — callers must use ``list_all_roles`` for
-        # the unscoped admin path.
+    def list_roles(self, workspaces: Iterable[str] | None = None) -> list[Role]:
+        # ``None`` lists every role across the system (admin path); an explicit
+        # iterable scopes the listing to those workspaces. An empty iterable is
+        # interpreted literally and returns no roles.
+        if workspaces is None:
+            with self.ManagedSessionMaker() as session:
+                roles = session.query(SqlRole).options(selectinload(SqlRole.permissions)).all()
+                return [r.to_mlflow_entity() for r in roles]
         names = list(workspaces)
         if not names:
             return []
@@ -1572,11 +1566,6 @@ class SqlAlchemyStore:
                 .filter(SqlRole.workspace.in_(names))
                 .all()
             )
-            return [r.to_mlflow_entity() for r in roles]
-
-    def list_all_roles(self) -> list[Role]:
-        with self.ManagedSessionMaker() as session:
-            roles = session.query(SqlRole).options(selectinload(SqlRole.permissions)).all()
             return [r.to_mlflow_entity() for r in roles]
 
     def update_role(
@@ -1811,6 +1800,15 @@ class SqlAlchemyStore:
                 .first()
                 is not None
             )
+
+    def list_user_present_workspaces(self, user_id: int) -> set[str]:
+        """
+        Return every workspace where the user has at least one role assignment.
+        Bulk membership check used by validators that need to authorize a request
+        spanning multiple workspaces in a single query.
+        """
+        with self.ManagedSessionMaker() as session:
+            return self._user_present_workspaces(session, user_id)
 
     def list_role_users(self, role_id: int) -> list[UserRoleAssignment]:
         with self.ManagedSessionMaker() as session:

--- a/mlflow/server/js/src/account/hooks.test.tsx
+++ b/mlflow/server/js/src/account/hooks.test.tsx
@@ -136,8 +136,7 @@ describe('useUserRolesQuery (gated on truthy username)', () => {
 });
 
 describe('useCurrentUserIsWorkspaceAdmin', () => {
-  // A workspace-admin role carries (resource_type='workspace',
-  // resource_pattern='*', permission='MANAGE') in its permissions list.
+  // (workspace, *, MANAGE) → workspace-admin role.
   const wsAdminRole = {
     id: 1,
     name: 'wp-admin-foo',
@@ -154,7 +153,6 @@ describe('useCurrentUserIsWorkspaceAdmin', () => {
   };
 
   it('returns false while the queries are still loading', () => {
-    // Pending current-user promise: rolesData stays absent.
     mockedApi.getCurrentUser.mockReturnValueOnce(new Promise(() => {}));
     const { result } = renderHook(() => useCurrentUserIsWorkspaceAdmin(), {
       wrapper: makeWrapper(),
@@ -187,7 +185,6 @@ describe('useCurrentUserIsWorkspaceAdmin', () => {
     const { result } = renderHook(() => useCurrentUserIsWorkspaceAdmin(), {
       wrapper: makeWrapper(),
     });
-    // Wait for the role-list query to settle, then assert the derived value.
     await waitFor(() => expect(mockedApi.listUserRoles).toHaveBeenCalledTimes(1));
     expect(result.current).toBe(false);
   });
@@ -236,9 +233,6 @@ describe('useCurrentUserAdminWorkspaces', () => {
       is_basic_auth: true,
     });
     mockedApi.listUserRoles.mockResolvedValueOnce({
-      // Mix of admin roles in two workspaces and a non-admin role —
-      // ``foo-member`` should not pull ``foo`` into the set on its own,
-      // but ``admin-foo`` does. Only the admin grant matters per workspace.
       roles: [adminFooRole, memberRole, adminBarRole],
     });
 

--- a/mlflow/server/js/src/account/hooks.test.tsx
+++ b/mlflow/server/js/src/account/hooks.test.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from '@databricks/web-shared/query-c
 
 import { AccountApi } from './api';
 import {
+  useCurrentUserAdminWorkspaces,
   useCurrentUserIsWorkspaceAdmin,
   useCurrentUserQuery,
   useIsAuthAvailable,
@@ -203,5 +204,71 @@ describe('useCurrentUserIsWorkspaceAdmin', () => {
     });
     await waitFor(() => expect(mockedApi.listUserRoles).toHaveBeenCalledTimes(1));
     expect(result.current).toBe(false);
+  });
+});
+
+describe('useCurrentUserAdminWorkspaces', () => {
+  const adminFooRole = {
+    id: 1,
+    name: 'admin-foo',
+    workspace: 'foo',
+    description: '',
+    permissions: [{ id: 10, role_id: 1, resource_type: 'workspace', resource_pattern: '*', permission: 'MANAGE' }],
+  };
+  const adminBarRole = {
+    id: 2,
+    name: 'admin-bar',
+    workspace: 'bar',
+    description: '',
+    permissions: [{ id: 20, role_id: 2, resource_type: 'workspace', resource_pattern: '*', permission: 'MANAGE' }],
+  };
+  const memberRole = {
+    id: 3,
+    name: 'foo-member',
+    workspace: 'foo',
+    description: '',
+    permissions: [{ id: 30, role_id: 3, resource_type: 'experiment', resource_pattern: '*', permission: 'READ' }],
+  };
+
+  it('returns the set of workspaces where the user is a workspace admin', async () => {
+    mockedApi.getCurrentUser.mockResolvedValueOnce({
+      user: { id: 1, username: 'pat', is_admin: false },
+      is_basic_auth: true,
+    });
+    mockedApi.listUserRoles.mockResolvedValueOnce({
+      // Mix of admin roles in two workspaces and a non-admin role —
+      // ``foo-member`` should not pull ``foo`` into the set on its own,
+      // but ``admin-foo`` does. Only the admin grant matters per workspace.
+      roles: [adminFooRole, memberRole, adminBarRole],
+    });
+
+    const { result } = renderHook(() => useCurrentUserAdminWorkspaces(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.size).toBe(2));
+    expect(result.current.has('foo')).toBe(true);
+    expect(result.current.has('bar')).toBe(true);
+  });
+
+  it('returns an empty set when the user has only non-admin roles', async () => {
+    mockedApi.getCurrentUser.mockResolvedValueOnce({
+      user: { id: 1, username: 'pat', is_admin: false },
+      is_basic_auth: true,
+    });
+    mockedApi.listUserRoles.mockResolvedValueOnce({ roles: [memberRole] });
+
+    const { result } = renderHook(() => useCurrentUserAdminWorkspaces(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(mockedApi.listUserRoles).toHaveBeenCalledTimes(1));
+    expect(result.current.size).toBe(0);
+  });
+
+  it('returns an empty set while the queries are still loading', () => {
+    mockedApi.getCurrentUser.mockReturnValueOnce(new Promise(() => {}));
+    const { result } = renderHook(() => useCurrentUserAdminWorkspaces(), {
+      wrapper: makeWrapper(),
+    });
+    expect(result.current.size).toBe(0);
   });
 });

--- a/mlflow/server/js/src/account/hooks.test.tsx
+++ b/mlflow/server/js/src/account/hooks.test.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from '@databricks/web-shared/query-c
 
 import { AccountApi } from './api';
 import {
+  useCurrentUserIsWorkspaceAdmin,
   useCurrentUserQuery,
   useIsAuthAvailable,
   useIsBasicAuth,
@@ -130,5 +131,77 @@ describe('useUserRolesQuery (gated on truthy username)', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(mockedApi.listUserRoles).toHaveBeenCalledWith('pat');
+  });
+});
+
+describe('useCurrentUserIsWorkspaceAdmin', () => {
+  // A workspace-admin role carries (resource_type='workspace',
+  // resource_pattern='*', permission='MANAGE') in its permissions list.
+  const wsAdminRole = {
+    id: 1,
+    name: 'wp-admin-foo',
+    workspace: 'foo',
+    description: '',
+    permissions: [{ id: 10, role_id: 1, resource_type: 'workspace', resource_pattern: '*', permission: 'MANAGE' }],
+  };
+  const memberRole = {
+    id: 2,
+    name: 'foo-member',
+    workspace: 'foo',
+    description: '',
+    permissions: [{ id: 11, role_id: 2, resource_type: 'experiment', resource_pattern: '*', permission: 'READ' }],
+  };
+
+  it('returns false while the queries are still loading', () => {
+    // Pending current-user promise: rolesData stays absent.
+    mockedApi.getCurrentUser.mockReturnValueOnce(new Promise(() => {}));
+    const { result } = renderHook(() => useCurrentUserIsWorkspaceAdmin(), {
+      wrapper: makeWrapper(),
+    });
+    expect(result.current).toBe(false);
+    expect(mockedApi.listUserRoles).not.toHaveBeenCalled();
+  });
+
+  it('returns true when the user has at least one workspace-admin role', async () => {
+    mockedApi.getCurrentUser.mockResolvedValueOnce({
+      user: { id: 1, username: 'pat', is_admin: false },
+      is_basic_auth: true,
+    });
+    mockedApi.listUserRoles.mockResolvedValueOnce({ roles: [memberRole, wsAdminRole] });
+
+    const { result } = renderHook(() => useCurrentUserIsWorkspaceAdmin(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current).toBe(true));
+    expect(mockedApi.listUserRoles).toHaveBeenCalledWith('pat');
+  });
+
+  it('returns false when the user holds only non-admin roles', async () => {
+    mockedApi.getCurrentUser.mockResolvedValueOnce({
+      user: { id: 1, username: 'pat', is_admin: false },
+      is_basic_auth: true,
+    });
+    mockedApi.listUserRoles.mockResolvedValueOnce({ roles: [memberRole] });
+
+    const { result } = renderHook(() => useCurrentUserIsWorkspaceAdmin(), {
+      wrapper: makeWrapper(),
+    });
+    // Wait for the role-list query to settle, then assert the derived value.
+    await waitFor(() => expect(mockedApi.listUserRoles).toHaveBeenCalledTimes(1));
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when the user has no roles at all', async () => {
+    mockedApi.getCurrentUser.mockResolvedValueOnce({
+      user: { id: 1, username: 'pat', is_admin: false },
+      is_basic_auth: true,
+    });
+    mockedApi.listUserRoles.mockResolvedValueOnce({ roles: [] });
+
+    const { result } = renderHook(() => useCurrentUserIsWorkspaceAdmin(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(mockedApi.listUserRoles).toHaveBeenCalledTimes(1));
+    expect(result.current).toBe(false);
   });
 });

--- a/mlflow/server/js/src/account/hooks.test.tsx
+++ b/mlflow/server/js/src/account/hooks.test.tsx
@@ -258,6 +258,21 @@ describe('useCurrentUserAdminWorkspaces', () => {
     expect(result.current.size).toBe(0);
   });
 
+  it('skips listUserRoles for platform admins (they short-circuit elsewhere)', async () => {
+    mockedApi.getCurrentUser.mockResolvedValueOnce({
+      user: { id: 1, username: 'admin', is_admin: true },
+      is_basic_auth: true,
+    });
+
+    const { result } = renderHook(() => useCurrentUserAdminWorkspaces(), {
+      wrapper: makeWrapper(),
+    });
+    // Wait for currentUserQuery to resolve, then assert no roles fetch fired.
+    await waitFor(() => expect(mockedApi.getCurrentUser).toHaveBeenCalled());
+    expect(mockedApi.listUserRoles).not.toHaveBeenCalled();
+    expect(result.current.size).toBe(0);
+  });
+
   it('returns an empty set while the queries are still loading', () => {
     mockedApi.getCurrentUser.mockReturnValueOnce(new Promise(() => {}));
     const { result } = renderHook(() => useCurrentUserAdminWorkspaces(), {

--- a/mlflow/server/js/src/account/hooks.ts
+++ b/mlflow/server/js/src/account/hooks.ts
@@ -30,7 +30,11 @@ export const useCurrentUserIsAdmin = () => {
 export const useCurrentUserAdminWorkspaces = (): Set<string> => {
   const { data: currentUser } = useCurrentUserQuery();
   const username = currentUser?.user?.username ?? '';
-  const { data: rolesData } = useUserRolesQuery(username);
+  // Platform admins short-circuit on ``is_admin`` everywhere; their
+  // workspace-admin set is unused. Skip the fetch to save a request per page load.
+  const { data: rolesData } = useUserRolesQuery(username, {
+    enabled: !currentUser?.user?.is_admin,
+  });
 
   const computed = useMemo(() => {
     if (!rolesData) {

--- a/mlflow/server/js/src/account/hooks.ts
+++ b/mlflow/server/js/src/account/hooks.ts
@@ -19,17 +19,35 @@ export const useCurrentUserIsAdmin = () => {
 };
 
 /**
- * True when the current user holds a workspace-admin role
- * (``(workspace, *, MANAGE)``) in at least one workspace. Composes
- * existing self-authorized queries; no new endpoint required. Returns
- * false while the queries are still loading so auth-gated UI doesn't
- * flash visible before we know the answer.
+ * The set of workspaces in which the current user holds a workspace-admin
+ * role (``(workspace, *, MANAGE)``). Mirrors the backend
+ * ``store.list_workspace_admin_workspaces``. Composes self-authorized
+ * queries — no admin-only endpoint required. Returns an empty set while
+ * the underlying queries are still loading so auth-gated UI doesn't flash
+ * visible before we know the answer.
  */
-export const useCurrentUserIsWorkspaceAdmin = (): boolean => {
+export const useCurrentUserAdminWorkspaces = (): Set<string> => {
   const { data: currentUser } = useCurrentUserQuery();
   const username = currentUser?.user?.username ?? '';
   const { data: rolesData } = useUserRolesQuery(username);
-  return useMemo(() => (rolesData?.roles ?? []).some(isWorkspaceAdminRole), [rolesData]);
+  return useMemo(() => {
+    const result = new Set<string>();
+    for (const role of rolesData?.roles ?? []) {
+      if (isWorkspaceAdminRole(role)) {
+        result.add(role.workspace);
+      }
+    }
+    return result;
+  }, [rolesData]);
+};
+
+/**
+ * True when the current user is a workspace admin in at least one
+ * workspace. Thin wrapper over ``useCurrentUserAdminWorkspaces`` for
+ * call sites that only need the boolean.
+ */
+export const useCurrentUserIsWorkspaceAdmin = (): boolean => {
+  return useCurrentUserAdminWorkspaces().size > 0;
 };
 
 /**

--- a/mlflow/server/js/src/account/hooks.ts
+++ b/mlflow/server/js/src/account/hooks.ts
@@ -19,23 +19,13 @@ export const useCurrentUserIsAdmin = () => {
 };
 
 /**
- * The set of workspaces in which the current user holds a workspace-admin
- * role (``(workspace, *, MANAGE)``). Mirrors the backend
- * ``store.list_workspace_admin_workspaces``. Composes self-authorized
- * queries — no admin-only endpoint required.
+ * Workspaces in which the current user holds ``(workspace, *, MANAGE)``.
  *
- * ``WorkspaceSelector`` blanket-invalidates the query cache after a
- * workspace switch, so this hook can briefly observe ``rolesData ===
- * undefined`` while the refetch is in-flight. Without protection that
- * would flip ``canManage`` to false in the sidebar and flicker the
- * Manage entry off and back on. We hold the last computed set in a ref
- * and reuse it whenever ``rolesData`` is missing, so the UI gate stays
- * stable across refetches.
- *
- * Identity changes (e.g. dev-user-switcher swapping the Basic Auth
- * cookie without a full reload) reset the cached set so we never serve a
- * previous user's admin-workspace set during the new user's first
- * refetch.
+ * Holds the last computed set in a ref so the gate stays stable across
+ * the cache invalidation ``WorkspaceSelector`` triggers on workspace
+ * switch (without it the Manage entry flickers off and back on). Resets
+ * on username change so a dev-user-switcher cookie swap can't briefly
+ * serve the previous identity's set during the new user's first refetch.
  */
 export const useCurrentUserAdminWorkspaces = (): Set<string> => {
   const { data: currentUser } = useCurrentUserQuery();
@@ -59,9 +49,6 @@ export const useCurrentUserAdminWorkspaces = (): Set<string> => {
   const lastUsername = useRef(username);
   useEffect(() => {
     if (lastUsername.current !== username) {
-      // Identity changed — drop the stale set before any new role-list
-      // refetch lands so we don't briefly show the previous user's
-      // admin-workspace gate.
       previous.current = new Set();
       lastUsername.current = username;
     }
@@ -73,11 +60,6 @@ export const useCurrentUserAdminWorkspaces = (): Set<string> => {
   return computed ?? previous.current;
 };
 
-/**
- * True when the current user is a workspace admin in at least one
- * workspace. Thin wrapper over ``useCurrentUserAdminWorkspaces`` for
- * call sites that only need the boolean.
- */
 export const useCurrentUserIsWorkspaceAdmin = (): boolean => {
   return useCurrentUserAdminWorkspaces().size > 0;
 };
@@ -121,10 +103,7 @@ export const useUserRolesQuery = (username: string, options: { enabled?: boolean
     queryFn: () => AccountApi.listUserRoles(username),
     retry: false,
     refetchOnWindowFocus: false,
-    // Default-on. Callers pass ``enabled: false`` to skip the request when
-    // they know it would be wasted (e.g. the AdminPage Users tab skipping
-    // per-row fetches for workspace managers — many would 403, and the
-    // visible cell collapses to ``—`` anyway).
+    // Callers pass ``enabled: false`` to skip a fetch they know will 403.
     enabled: Boolean(username) && options.enabled !== false,
   });
 };

--- a/mlflow/server/js/src/account/hooks.ts
+++ b/mlflow/server/js/src/account/hooks.ts
@@ -31,6 +31,11 @@ export const useCurrentUserIsAdmin = () => {
  * Manage entry off and back on. We hold the last computed set in a ref
  * and reuse it whenever ``rolesData`` is missing, so the UI gate stays
  * stable across refetches.
+ *
+ * Identity changes (e.g. dev-user-switcher swapping the Basic Auth
+ * cookie without a full reload) reset the cached set so we never serve a
+ * previous user's admin-workspace set during the new user's first
+ * refetch.
  */
 export const useCurrentUserAdminWorkspaces = (): Set<string> => {
   const { data: currentUser } = useCurrentUserQuery();
@@ -51,11 +56,19 @@ export const useCurrentUserAdminWorkspaces = (): Set<string> => {
   }, [rolesData]);
 
   const previous = useRef<Set<string>>(new Set());
+  const lastUsername = useRef(username);
   useEffect(() => {
+    if (lastUsername.current !== username) {
+      // Identity changed — drop the stale set before any new role-list
+      // refetch lands so we don't briefly show the previous user's
+      // admin-workspace gate.
+      previous.current = new Set();
+      lastUsername.current = username;
+    }
     if (computed) {
       previous.current = computed;
     }
-  }, [computed]);
+  }, [computed, username]);
 
   return computed ?? previous.current;
 };
@@ -102,13 +115,17 @@ export const useUpdatePassword = () => {
   });
 };
 
-export const useUserRolesQuery = (username: string) => {
+export const useUserRolesQuery = (username: string, options: { enabled?: boolean } = {}) => {
   return useQuery({
     queryKey: AccountQueryKeys.userRoles(username),
     queryFn: () => AccountApi.listUserRoles(username),
     retry: false,
     refetchOnWindowFocus: false,
-    enabled: Boolean(username),
+    // Default-on. Callers pass ``enabled: false`` to skip the request when
+    // they know it would be wasted (e.g. the AdminPage Users tab skipping
+    // per-row fetches for workspace managers — many would 403, and the
+    // visible cell collapses to ``—`` anyway).
+    enabled: Boolean(username) && options.enabled !== false,
   });
 };
 

--- a/mlflow/server/js/src/account/hooks.ts
+++ b/mlflow/server/js/src/account/hooks.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useMutation, useQuery } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
 import { AccountApi } from './api';
 import { isWorkspaceAdminRole } from './types';
@@ -22,23 +22,42 @@ export const useCurrentUserIsAdmin = () => {
  * The set of workspaces in which the current user holds a workspace-admin
  * role (``(workspace, *, MANAGE)``). Mirrors the backend
  * ``store.list_workspace_admin_workspaces``. Composes self-authorized
- * queries — no admin-only endpoint required. Returns an empty set while
- * the underlying queries are still loading so auth-gated UI doesn't flash
- * visible before we know the answer.
+ * queries — no admin-only endpoint required.
+ *
+ * ``WorkspaceSelector`` blanket-invalidates the query cache after a
+ * workspace switch, so this hook can briefly observe ``rolesData ===
+ * undefined`` while the refetch is in-flight. Without protection that
+ * would flip ``canManage`` to false in the sidebar and flicker the
+ * Manage entry off and back on. We hold the last computed set in a ref
+ * and reuse it whenever ``rolesData`` is missing, so the UI gate stays
+ * stable across refetches.
  */
 export const useCurrentUserAdminWorkspaces = (): Set<string> => {
   const { data: currentUser } = useCurrentUserQuery();
   const username = currentUser?.user?.username ?? '';
   const { data: rolesData } = useUserRolesQuery(username);
-  return useMemo(() => {
+
+  const computed = useMemo(() => {
+    if (!rolesData) {
+      return null;
+    }
     const result = new Set<string>();
-    for (const role of rolesData?.roles ?? []) {
+    for (const role of rolesData.roles ?? []) {
       if (isWorkspaceAdminRole(role)) {
         result.add(role.workspace);
       }
     }
     return result;
   }, [rolesData]);
+
+  const previous = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    if (computed) {
+      previous.current = computed;
+    }
+  }, [computed]);
+
+  return computed ?? previous.current;
 };
 
 /**

--- a/mlflow/server/js/src/account/hooks.ts
+++ b/mlflow/server/js/src/account/hooks.ts
@@ -1,5 +1,7 @@
+import { useMemo } from 'react';
 import { useMutation, useQuery } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
 import { AccountApi } from './api';
+import { isWorkspaceAdminRole } from './types';
 import type { UpdatePasswordRequest } from './types';
 
 export const useCurrentUserQuery = () => {
@@ -14,6 +16,20 @@ export const useCurrentUserQuery = () => {
 export const useCurrentUserIsAdmin = () => {
   const { data } = useCurrentUserQuery();
   return Boolean(data?.user?.is_admin);
+};
+
+/**
+ * True when the current user holds a workspace-admin role
+ * (``(workspace, *, MANAGE)``) in at least one workspace. Composes
+ * existing self-authorized queries; no new endpoint required. Returns
+ * false while the queries are still loading so auth-gated UI doesn't
+ * flash visible before we know the answer.
+ */
+export const useCurrentUserIsWorkspaceAdmin = (): boolean => {
+  const { data: currentUser } = useCurrentUserQuery();
+  const username = currentUser?.user?.username ?? '';
+  const { data: rolesData } = useUserRolesQuery(username);
+  return useMemo(() => (rolesData?.roles ?? []).some(isWorkspaceAdminRole), [rolesData]);
 };
 
 /**

--- a/mlflow/server/js/src/account/types.ts
+++ b/mlflow/server/js/src/account/types.ts
@@ -2,6 +2,13 @@ export interface User {
   id: number;
   username: string;
   is_admin: boolean;
+  /**
+   * Roles the requester is authorized to see for this user. The backend
+   * scopes the list per-requester (admin sees every role; workspace
+   * managers see only roles in workspaces they administer). Optional so
+   * older callers / fixtures that don't populate it stay valid.
+   */
+  roles?: Role[];
 }
 
 export interface RolePermission {

--- a/mlflow/server/js/src/admin/api.ts
+++ b/mlflow/server/js/src/admin/api.ts
@@ -65,10 +65,11 @@ export const AdminApi = {
     }) as Promise<RoleResponse>;
   },
 
-  listRoles: (workspace?: string) => {
+  listRoles: (workspaces?: string | readonly string[]) => {
     const params = new URLSearchParams();
-    if (workspace) {
-      params.append('workspace', workspace);
+    const list = workspaces === undefined ? [] : typeof workspaces === 'string' ? [workspaces] : workspaces;
+    for (const w of list) {
+      if (w) params.append('workspace', w);
     }
     // Drop the trailing ``?`` when there are no params - the unconditional
     // ``join('?')`` produced ``.../list?`` which clutters logs and breaks

--- a/mlflow/server/js/src/admin/components/CreateUserModal.tsx
+++ b/mlflow/server/js/src/admin/components/CreateUserModal.tsx
@@ -93,6 +93,9 @@ export const CreateUserModal = ({ open, onClose }: CreateUserModalProps) => {
         }
       }
       queryClient.invalidateQueries({ queryKey: AccountQueryKeys.userRoles(trimmedUsername) });
+      // The Admin Users tab eager-loads each user's roles via
+      // ``useUsersQuery``; invalidate so the new assignments show up.
+      queryClient.invalidateQueries({ queryKey: AdminQueryKeys.users });
       for (const roleId of roleValue.roleIds) {
         queryClient.invalidateQueries({ queryKey: AdminQueryKeys.roleUsers(roleId) });
       }

--- a/mlflow/server/js/src/admin/components/EditAccessModal.tsx
+++ b/mlflow/server/js/src/admin/components/EditAccessModal.tsx
@@ -15,16 +15,17 @@ import { LongFormSection } from '../../common/components/long-form/LongFormSecti
 import { AdminApi } from '../api';
 import {
   AdminQueryKeys,
+  useCurrentUserAdminWorkspaces,
   useCurrentUserIsAdmin,
   useGrantUserPermission,
   useRevokeUserPermission,
+  useRolesInWorkspacesQuery,
   useRolesQuery,
   useUserPermissionsQuery,
   useUserRolesQuery,
   useUsersQuery,
 } from '../hooks';
 import { AccountQueryKeys } from '../../account/hooks';
-import { useActiveWorkspace } from '../../workspaces/utils/WorkspaceUtils';
 import { RoleAssignmentForm, ROLE_ASSIGNMENT_DEFAULT, type RoleAssignmentValue } from './RoleAssignmentForm';
 import { type DirectGrantResourceType } from './DirectPermissionForm';
 import { DirectPermissionsSection, type StagedDirectPermission } from './DirectPermissionsSection';
@@ -73,14 +74,14 @@ export const EditAccessModal = ({ open, onClose, username, onCreateRoleForAllOfT
   const { data: rolesData, isLoading: rolesLoading } = useUserRolesQuery(username);
   const { data: directPermsData, isLoading: directPermsLoading } = useUserPermissionsQuery(username);
   const { data: usersData, isLoading: usersLoading } = useUsersQuery();
-  // Roles list is needed for the Review step's name lookup (the form uses
-  // the dropdown's own label, but the Review step renders by id).
-  // Workspace admins must pass a workspace; suppress when none is active
-  // to avoid a guaranteed 403.
-  const activeWorkspace = useActiveWorkspace();
-  const rolesListWorkspace = isCurrentUserAdmin ? undefined : (activeWorkspace ?? undefined);
-  const rolesListEnabled = isCurrentUserAdmin || Boolean(activeWorkspace);
-  const { data: rolesListData } = useRolesQuery(rolesListWorkspace, { enabled: rolesListEnabled });
+  // Roles list for the Review step's name lookup (the form uses the
+  // dropdown's own label, but the Review step renders by id). Platform
+  // admins fetch unscoped; workspace managers fan out across the
+  // workspaces they administer.
+  const adminWorkspaces = useCurrentUserAdminWorkspaces();
+  const adminRolesQuery = useRolesQuery(undefined, { enabled: isCurrentUserAdmin });
+  const workspaceRolesQuery = useRolesInWorkspacesQuery(isCurrentUserAdmin ? new Set<string>() : adminWorkspaces);
+  const rolesListData = isCurrentUserAdmin ? adminRolesQuery.data : workspaceRolesQuery.data;
 
   const currentRoleIds = useMemo<number[]>(() => (rolesData?.roles ?? []).map((r) => r.id), [rolesData]);
   const currentDirectPerms = useMemo<StagedDirectPermission[]>(

--- a/mlflow/server/js/src/admin/components/EditAccessModal.tsx
+++ b/mlflow/server/js/src/admin/components/EditAccessModal.tsx
@@ -19,7 +19,6 @@ import {
   useCurrentUserIsAdmin,
   useGrantUserPermission,
   useRevokeUserPermission,
-  useRolesInWorkspacesQuery,
   useRolesQuery,
   useUserPermissionsQuery,
   useUserRolesQuery,
@@ -76,12 +75,14 @@ export const EditAccessModal = ({ open, onClose, username, onCreateRoleForAllOfT
   const { data: usersData, isLoading: usersLoading } = useUsersQuery();
   // Roles list for the Review step's name lookup (the form uses the
   // dropdown's own label, but the Review step renders by id). Platform
-  // admins fetch unscoped; workspace managers fan out across the
-  // workspaces they administer.
+  // admins fetch unscoped; workspace managers pass the list of workspaces
+  // they administer.
   const adminWorkspaces = useCurrentUserAdminWorkspaces();
-  const adminRolesQuery = useRolesQuery(undefined, { enabled: isCurrentUserAdmin });
-  const workspaceRolesQuery = useRolesInWorkspacesQuery(isCurrentUserAdmin ? new Set<string>() : adminWorkspaces);
-  const rolesListData = isCurrentUserAdmin ? adminRolesQuery.data : workspaceRolesQuery.data;
+  const rolesListWorkspaces = useMemo(
+    () => (isCurrentUserAdmin ? undefined : Array.from(adminWorkspaces)),
+    [isCurrentUserAdmin, adminWorkspaces],
+  );
+  const { data: rolesListData } = useRolesQuery(rolesListWorkspaces);
 
   const currentRoleIds = useMemo<number[]>(() => (rolesData?.roles ?? []).map((r) => r.id), [rolesData]);
   const currentDirectPerms = useMemo<StagedDirectPermission[]>(

--- a/mlflow/server/js/src/admin/components/EditAccessModal.tsx
+++ b/mlflow/server/js/src/admin/components/EditAccessModal.tsx
@@ -213,6 +213,9 @@ export const EditAccessModal = ({ open, onClose, username, onCreateRoleForAllOfT
     }
     if (roleIdsTouched.size > 0) {
       queryClient.invalidateQueries({ queryKey: AccountQueryKeys.userRoles(username) });
+      // The Admin Users tab eager-loads each user's roles via
+      // ``useUsersQuery``; invalidate so the per-row Roles cell refreshes.
+      queryClient.invalidateQueries({ queryKey: AdminQueryKeys.users });
       for (const roleId of roleIdsTouched) {
         queryClient.invalidateQueries({ queryKey: AdminQueryKeys.roleUsers(roleId) });
       }

--- a/mlflow/server/js/src/admin/components/EditAccessModal.tsx
+++ b/mlflow/server/js/src/admin/components/EditAccessModal.tsx
@@ -24,6 +24,7 @@ import {
   useUsersQuery,
 } from '../hooks';
 import { AccountQueryKeys } from '../../account/hooks';
+import { useActiveWorkspace } from '../../workspaces/utils/WorkspaceUtils';
 import { RoleAssignmentForm, ROLE_ASSIGNMENT_DEFAULT, type RoleAssignmentValue } from './RoleAssignmentForm';
 import { type DirectGrantResourceType } from './DirectPermissionForm';
 import { DirectPermissionsSection, type StagedDirectPermission } from './DirectPermissionsSection';
@@ -74,7 +75,12 @@ export const EditAccessModal = ({ open, onClose, username, onCreateRoleForAllOfT
   const { data: usersData, isLoading: usersLoading } = useUsersQuery();
   // Roles list is needed for the Review step's name lookup (the form uses
   // the dropdown's own label, but the Review step renders by id).
-  const { data: rolesListData } = useRolesQuery(undefined);
+  // Workspace admins must pass a workspace; suppress when none is active
+  // to avoid a guaranteed 403.
+  const activeWorkspace = useActiveWorkspace();
+  const rolesListWorkspace = isCurrentUserAdmin ? undefined : (activeWorkspace ?? undefined);
+  const rolesListEnabled = isCurrentUserAdmin || Boolean(activeWorkspace);
+  const { data: rolesListData } = useRolesQuery(rolesListWorkspace, { enabled: rolesListEnabled });
 
   const currentRoleIds = useMemo<number[]>(() => (rolesData?.roles ?? []).map((r) => r.id), [rolesData]);
   const currentDirectPerms = useMemo<StagedDirectPermission[]>(

--- a/mlflow/server/js/src/admin/components/EditAccessModal.tsx
+++ b/mlflow/server/js/src/admin/components/EditAccessModal.tsx
@@ -15,7 +15,6 @@ import { LongFormSection } from '../../common/components/long-form/LongFormSecti
 import { AdminApi } from '../api';
 import {
   AdminQueryKeys,
-  useCurrentUserAdminWorkspaces,
   useCurrentUserIsAdmin,
   useGrantUserPermission,
   useRevokeUserPermission,
@@ -25,6 +24,7 @@ import {
   useUsersQuery,
 } from '../hooks';
 import { AccountQueryKeys } from '../../account/hooks';
+import { useActiveWorkspace } from '../../workspaces/utils/WorkspaceUtils';
 import { RoleAssignmentForm, ROLE_ASSIGNMENT_DEFAULT, type RoleAssignmentValue } from './RoleAssignmentForm';
 import { type DirectGrantResourceType } from './DirectPermissionForm';
 import { DirectPermissionsSection, type StagedDirectPermission } from './DirectPermissionsSection';
@@ -75,14 +75,12 @@ export const EditAccessModal = ({ open, onClose, username, onCreateRoleForAllOfT
   const { data: usersData, isLoading: usersLoading } = useUsersQuery();
   // Roles list for the Review step's name lookup (the form uses the
   // dropdown's own label, but the Review step renders by id). Platform
-  // admins fetch unscoped; workspace managers pass the list of workspaces
-  // they administer.
-  const adminWorkspaces = useCurrentUserAdminWorkspaces();
-  const rolesListWorkspaces = useMemo(
-    () => (isCurrentUserAdmin ? undefined : Array.from(adminWorkspaces)),
-    [isCurrentUserAdmin, adminWorkspaces],
-  );
-  const { data: rolesListData } = useRolesQuery(rolesListWorkspaces);
+  // admins fetch unscoped; workspace managers pass the active workspace.
+  // Suppress when none is active to avoid a guaranteed 403.
+  const activeWorkspace = useActiveWorkspace();
+  const rolesListWorkspace = isCurrentUserAdmin ? undefined : (activeWorkspace ?? undefined);
+  const rolesListEnabled = isCurrentUserAdmin || Boolean(activeWorkspace);
+  const { data: rolesListData } = useRolesQuery(rolesListWorkspace, { enabled: rolesListEnabled });
 
   const currentRoleIds = useMemo<number[]>(() => (rolesData?.roles ?? []).map((r) => r.id), [rolesData]);
   const currentDirectPerms = useMemo<StagedDirectPermission[]>(

--- a/mlflow/server/js/src/admin/components/RoleAssignmentForm.tsx
+++ b/mlflow/server/js/src/admin/components/RoleAssignmentForm.tsx
@@ -11,7 +11,8 @@ import {
   useDesignSystemTheme,
 } from '@databricks/design-system';
 import { FieldLabel } from './FieldLabel';
-import { useCurrentUserAdminWorkspaces, useCurrentUserIsAdmin, useRolesQuery } from '../hooks';
+import { useCurrentUserIsAdmin, useRolesQuery } from '../hooks';
+import { useActiveWorkspace } from '../../workspaces/utils/WorkspaceUtils';
 import type { Role } from '../types';
 
 export interface RoleAssignmentValue {
@@ -40,16 +41,13 @@ const formatRoleLabel = (role: Role): string =>
 export const RoleAssignmentForm = ({ value, onChange, disabled }: RoleAssignmentFormProps) => {
   const { theme } = useDesignSystemTheme();
   const [search, setSearch] = useState('');
-  // Platform admins fetch unscoped (every workspace); workspace managers
-  // pass the list of workspaces they administer.
+  // Per-workspace scope: platform admins fetch unscoped; workspace
+  // managers pass the active workspace. Suppress when none is active.
   const isAdmin = useCurrentUserIsAdmin();
-  const adminWorkspaces = useCurrentUserAdminWorkspaces();
-  const queryWorkspaces = useMemo(
-    () => (isAdmin ? undefined : Array.from(adminWorkspaces)),
-    [isAdmin, adminWorkspaces],
-  );
-  const queryEnabled = isAdmin || adminWorkspaces.size > 0;
-  const { data: rolesData, isLoading, error } = useRolesQuery(queryWorkspaces);
+  const activeWorkspace = useActiveWorkspace();
+  const queryWorkspace = isAdmin ? undefined : (activeWorkspace ?? undefined);
+  const queryEnabled = isAdmin || Boolean(activeWorkspace);
+  const { data: rolesData, isLoading, error } = useRolesQuery(queryWorkspace, { enabled: queryEnabled });
   const roles = useMemo(() => rolesData?.roles ?? [], [rolesData]);
 
   // Pin "default" workspace's roles first; sort the rest alphabetically
@@ -91,7 +89,9 @@ export const RoleAssignmentForm = ({ value, onChange, disabled }: RoleAssignment
       <div>
         <FieldLabel>Roles</FieldLabel>
         {!queryEnabled ? (
-          <Typography.Text color="secondary">No roles available.</Typography.Text>
+          <Typography.Text color="secondary">
+            Select a workspace from the workspace selector to choose roles.
+          </Typography.Text>
         ) : isLoading ? (
           <div css={{ padding: theme.spacing.sm }}>
             <Spinner size="small" />

--- a/mlflow/server/js/src/admin/components/RoleAssignmentForm.tsx
+++ b/mlflow/server/js/src/admin/components/RoleAssignmentForm.tsx
@@ -11,12 +11,7 @@ import {
   useDesignSystemTheme,
 } from '@databricks/design-system';
 import { FieldLabel } from './FieldLabel';
-import {
-  useCurrentUserAdminWorkspaces,
-  useCurrentUserIsAdmin,
-  useRolesInWorkspacesQuery,
-  useRolesQuery,
-} from '../hooks';
+import { useCurrentUserAdminWorkspaces, useCurrentUserIsAdmin, useRolesQuery } from '../hooks';
 import type { Role } from '../types';
 
 export interface RoleAssignmentValue {
@@ -46,15 +41,15 @@ export const RoleAssignmentForm = ({ value, onChange, disabled }: RoleAssignment
   const { theme } = useDesignSystemTheme();
   const [search, setSearch] = useState('');
   // Platform admins fetch unscoped (every workspace); workspace managers
-  // fan out to one query per workspace they administer and merge.
+  // pass the list of workspaces they administer.
   const isAdmin = useCurrentUserIsAdmin();
   const adminWorkspaces = useCurrentUserAdminWorkspaces();
-  const adminRolesQuery = useRolesQuery(undefined, { enabled: isAdmin });
-  const workspaceRolesQuery = useRolesInWorkspacesQuery(isAdmin ? new Set<string>() : adminWorkspaces);
-  const rolesData = isAdmin ? adminRolesQuery.data : workspaceRolesQuery.data;
-  const isLoading = isAdmin ? adminRolesQuery.isLoading : workspaceRolesQuery.isLoading;
-  const error = isAdmin ? adminRolesQuery.error : workspaceRolesQuery.error;
+  const queryWorkspaces = useMemo(
+    () => (isAdmin ? undefined : Array.from(adminWorkspaces)),
+    [isAdmin, adminWorkspaces],
+  );
   const queryEnabled = isAdmin || adminWorkspaces.size > 0;
+  const { data: rolesData, isLoading, error } = useRolesQuery(queryWorkspaces);
   const roles = useMemo(() => rolesData?.roles ?? [], [rolesData]);
 
   // Pin "default" workspace's roles first; sort the rest alphabetically

--- a/mlflow/server/js/src/admin/components/RoleAssignmentForm.tsx
+++ b/mlflow/server/js/src/admin/components/RoleAssignmentForm.tsx
@@ -47,7 +47,7 @@ export const RoleAssignmentForm = ({ value, onChange, disabled }: RoleAssignment
   const activeWorkspace = useActiveWorkspace();
   const queryWorkspace = isAdmin ? undefined : (activeWorkspace ?? undefined);
   const queryEnabled = isAdmin || Boolean(activeWorkspace);
-  const { data: rolesData, isLoading } = useRolesQuery(queryWorkspace, { enabled: queryEnabled });
+  const { data: rolesData, isLoading, error } = useRolesQuery(queryWorkspace, { enabled: queryEnabled });
   const roles = useMemo(() => rolesData?.roles ?? [], [rolesData]);
 
   // Pin "default" workspace's roles first; sort the rest alphabetically
@@ -88,10 +88,16 @@ export const RoleAssignmentForm = ({ value, onChange, disabled }: RoleAssignment
     <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
       <div>
         <FieldLabel>Roles</FieldLabel>
-        {isLoading ? (
+        {!queryEnabled ? (
+          <Typography.Text color="secondary">
+            Select a workspace from the workspace selector to choose roles.
+          </Typography.Text>
+        ) : isLoading ? (
           <div css={{ padding: theme.spacing.sm }}>
             <Spinner size="small" />
           </div>
+        ) : error ? (
+          <Typography.Text color="error">Failed to load roles for this workspace.</Typography.Text>
         ) : roles.length === 0 ? (
           <Typography.Text color="secondary">No roles available. Create a role first.</Typography.Text>
         ) : (

--- a/mlflow/server/js/src/admin/components/RoleAssignmentForm.tsx
+++ b/mlflow/server/js/src/admin/components/RoleAssignmentForm.tsx
@@ -11,7 +11,8 @@ import {
   useDesignSystemTheme,
 } from '@databricks/design-system';
 import { FieldLabel } from './FieldLabel';
-import { useRolesQuery } from '../hooks';
+import { useCurrentUserIsAdmin, useRolesQuery } from '../hooks';
+import { useActiveWorkspace } from '../../workspaces/utils/WorkspaceUtils';
 import type { Role } from '../types';
 
 export interface RoleAssignmentValue {
@@ -40,8 +41,15 @@ const formatRoleLabel = (role: Role): string =>
 export const RoleAssignmentForm = ({ value, onChange, disabled }: RoleAssignmentFormProps) => {
   const { theme } = useDesignSystemTheme();
   const [search, setSearch] = useState('');
-  // Pass undefined to fetch roles across every workspace.
-  const { data: rolesData, isLoading } = useRolesQuery(undefined);
+  // Platform admins fetch roles across every workspace; workspace admins
+  // are scoped to a single workspace by ``validate_can_list_roles`` and
+  // pass the active workspace explicitly. When neither applies (no active
+  // workspace yet), suppress the request — it would 403 anyway.
+  const isAdmin = useCurrentUserIsAdmin();
+  const activeWorkspace = useActiveWorkspace();
+  const queryWorkspace = isAdmin ? undefined : (activeWorkspace ?? undefined);
+  const queryEnabled = isAdmin || Boolean(activeWorkspace);
+  const { data: rolesData, isLoading } = useRolesQuery(queryWorkspace, { enabled: queryEnabled });
   const roles = useMemo(() => rolesData?.roles ?? [], [rolesData]);
 
   // Pin "default" workspace's roles first; sort the rest alphabetically

--- a/mlflow/server/js/src/admin/components/RoleAssignmentForm.tsx
+++ b/mlflow/server/js/src/admin/components/RoleAssignmentForm.tsx
@@ -41,10 +41,8 @@ const formatRoleLabel = (role: Role): string =>
 export const RoleAssignmentForm = ({ value, onChange, disabled }: RoleAssignmentFormProps) => {
   const { theme } = useDesignSystemTheme();
   const [search, setSearch] = useState('');
-  // Platform admins fetch roles across every workspace; workspace admins
-  // are scoped to a single workspace by ``validate_can_list_roles`` and
-  // pass the active workspace explicitly. When neither applies (no active
-  // workspace yet), suppress the request — it would 403 anyway.
+  // Workspace admins must pass a workspace; suppress when none is active
+  // to avoid a guaranteed 403.
   const isAdmin = useCurrentUserIsAdmin();
   const activeWorkspace = useActiveWorkspace();
   const queryWorkspace = isAdmin ? undefined : (activeWorkspace ?? undefined);

--- a/mlflow/server/js/src/admin/components/RoleAssignmentForm.tsx
+++ b/mlflow/server/js/src/admin/components/RoleAssignmentForm.tsx
@@ -11,8 +11,12 @@ import {
   useDesignSystemTheme,
 } from '@databricks/design-system';
 import { FieldLabel } from './FieldLabel';
-import { useCurrentUserIsAdmin, useRolesQuery } from '../hooks';
-import { useActiveWorkspace } from '../../workspaces/utils/WorkspaceUtils';
+import {
+  useCurrentUserAdminWorkspaces,
+  useCurrentUserIsAdmin,
+  useRolesInWorkspacesQuery,
+  useRolesQuery,
+} from '../hooks';
 import type { Role } from '../types';
 
 export interface RoleAssignmentValue {
@@ -41,13 +45,16 @@ const formatRoleLabel = (role: Role): string =>
 export const RoleAssignmentForm = ({ value, onChange, disabled }: RoleAssignmentFormProps) => {
   const { theme } = useDesignSystemTheme();
   const [search, setSearch] = useState('');
-  // Workspace admins must pass a workspace; suppress when none is active
-  // to avoid a guaranteed 403.
+  // Platform admins fetch unscoped (every workspace); workspace managers
+  // fan out to one query per workspace they administer and merge.
   const isAdmin = useCurrentUserIsAdmin();
-  const activeWorkspace = useActiveWorkspace();
-  const queryWorkspace = isAdmin ? undefined : (activeWorkspace ?? undefined);
-  const queryEnabled = isAdmin || Boolean(activeWorkspace);
-  const { data: rolesData, isLoading, error } = useRolesQuery(queryWorkspace, { enabled: queryEnabled });
+  const adminWorkspaces = useCurrentUserAdminWorkspaces();
+  const adminRolesQuery = useRolesQuery(undefined, { enabled: isAdmin });
+  const workspaceRolesQuery = useRolesInWorkspacesQuery(isAdmin ? new Set<string>() : adminWorkspaces);
+  const rolesData = isAdmin ? adminRolesQuery.data : workspaceRolesQuery.data;
+  const isLoading = isAdmin ? adminRolesQuery.isLoading : workspaceRolesQuery.isLoading;
+  const error = isAdmin ? adminRolesQuery.error : workspaceRolesQuery.error;
+  const queryEnabled = isAdmin || adminWorkspaces.size > 0;
   const roles = useMemo(() => rolesData?.roles ?? [], [rolesData]);
 
   // Pin "default" workspace's roles first; sort the rest alphabetically
@@ -89,9 +96,7 @@ export const RoleAssignmentForm = ({ value, onChange, disabled }: RoleAssignment
       <div>
         <FieldLabel>Roles</FieldLabel>
         {!queryEnabled ? (
-          <Typography.Text color="secondary">
-            Select a workspace from the workspace selector to choose roles.
-          </Typography.Text>
+          <Typography.Text color="secondary">No roles available.</Typography.Text>
         ) : isLoading ? (
           <div css={{ padding: theme.spacing.sm }}>
             <Spinner size="small" />

--- a/mlflow/server/js/src/admin/components/UserRolesCell.test.tsx
+++ b/mlflow/server/js/src/admin/components/UserRolesCell.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect } from '@jest/globals';
+import React from 'react';
+import { renderWithDesignSystem, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
+
+import { UserRolesCell } from './UserRolesCell';
+import type { Role } from '../types';
+
+const role = (overrides: Partial<Role>): Role => ({
+  id: 1,
+  name: 'reader',
+  workspace: 'default',
+  description: null,
+  permissions: [],
+  ...overrides,
+});
+
+describe('UserRolesCell', () => {
+  it('renders an em-dash placeholder when the user has no roles', () => {
+    renderWithDesignSystem(<UserRolesCell roles={[]} scopeWorkspace={null} />);
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+
+  it('renders one line per role formatted as <workspace> → <name>', () => {
+    renderWithDesignSystem(
+      <UserRolesCell
+        roles={[role({ id: 1, name: 'editor', workspace: 'foo' }), role({ id: 2, name: 'viewer', workspace: 'bar' })]}
+        scopeWorkspace={null}
+      />,
+    );
+    expect(screen.getByText('foo')).toBeInTheDocument();
+    expect(screen.getByText(/editor/)).toBeInTheDocument();
+    expect(screen.getByText('bar')).toBeInTheDocument();
+    expect(screen.getByText(/viewer/)).toBeInTheDocument();
+  });
+
+  it('filters to roles in scopeWorkspace when set, hiding roles in other workspaces', () => {
+    // Per-workspace admin pages pass the active workspace; the cell must
+    // omit roles from any other workspace even if the backend returned them
+    // (e.g. when the requester is a self-viewer who got their global roles).
+    renderWithDesignSystem(
+      <UserRolesCell
+        roles={[role({ id: 1, name: 'editor', workspace: 'foo' }), role({ id: 2, name: 'viewer', workspace: 'bar' })]}
+        scopeWorkspace="foo"
+      />,
+    );
+    expect(screen.getByText('foo')).toBeInTheDocument();
+    expect(screen.getByText(/editor/)).toBeInTheDocument();
+    expect(screen.queryByText('bar')).not.toBeInTheDocument();
+    expect(screen.queryByText(/viewer/)).not.toBeInTheDocument();
+  });
+
+  it('falls back to em-dash when scopeWorkspace excludes every role', () => {
+    renderWithDesignSystem(<UserRolesCell roles={[role({ workspace: 'foo' })]} scopeWorkspace="bar" />);
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+
+  it('shows every role when scopeWorkspace is null (platform-admin path)', () => {
+    // Platform admins see roles unscoped — both ``foo`` and ``bar`` rows must
+    // render side by side rather than getting filtered.
+    renderWithDesignSystem(
+      <UserRolesCell
+        roles={[role({ id: 1, name: 'editor', workspace: 'foo' }), role({ id: 2, name: 'viewer', workspace: 'bar' })]}
+        scopeWorkspace={null}
+      />,
+    );
+    expect(screen.getByText('foo')).toBeInTheDocument();
+    expect(screen.getByText('bar')).toBeInTheDocument();
+  });
+});

--- a/mlflow/server/js/src/admin/components/UserRolesCell.tsx
+++ b/mlflow/server/js/src/admin/components/UserRolesCell.tsx
@@ -1,0 +1,32 @@
+import { Typography, useDesignSystemTheme } from '@databricks/design-system';
+import type { Role } from '../types';
+
+export interface UserRolesCellProps {
+  roles: readonly Role[];
+  scopeWorkspace: string | null;
+}
+
+/**
+ * Per-row Roles cell on the admin Users tab. Reads roles from the user
+ * object eager-loaded by ``useUsersQuery`` — no per-row request. The
+ * backend already scopes the list per requester (admin sees all; workspace
+ * managers see only roles in workspaces they administer).
+ * ``scopeWorkspace`` further narrows to the active workspace for the
+ * per-workspace admin page, so the cell matches the page scope.
+ */
+export const UserRolesCell = ({ roles: allRoles, scopeWorkspace }: UserRolesCellProps) => {
+  const { theme } = useDesignSystemTheme();
+  const roles = scopeWorkspace ? allRoles.filter((r) => r.workspace === scopeWorkspace) : allRoles;
+  if (roles.length === 0) {
+    return <Typography.Text color="secondary">—</Typography.Text>;
+  }
+  return (
+    <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs / 2 }}>
+      {roles.map((role) => (
+        <Typography.Text key={role.id} size="sm">
+          <code>{role.workspace}</code> → {role.name}
+        </Typography.Text>
+      ))}
+    </div>
+  );
+};

--- a/mlflow/server/js/src/admin/hooks.ts
+++ b/mlflow/server/js/src/admin/hooks.ts
@@ -196,16 +196,18 @@ export const useRemovePermission = (roleId: number) => {
 };
 
 // Role assignment mutations
+//
+// Invalidate both the per-user ``userRoles`` query (UserDetailPage, Account
+// page) and the bulk ``users`` query (Admin Users tab eager-loads roles per
+// user) so the new assignment is reflected everywhere on the next render.
 export const useAssignRole = (roleId: number) => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (username: string) => AdminApi.assignRole(username, roleId),
     onSuccess: (_data, username) => {
       queryClient.invalidateQueries({ queryKey: AdminQueryKeys.roleUsers(roleId) });
-      // The Admin Users tab renders a per-user roles cell from
-      // ``useUserRolesQuery(username)``; refetch it so the new role shows up
-      // immediately after the modal closes.
       queryClient.invalidateQueries({ queryKey: AccountQueryKeys.userRoles(username) });
+      queryClient.invalidateQueries({ queryKey: AdminQueryKeys.users });
     },
   });
 };
@@ -217,6 +219,7 @@ export const useUnassignRole = (roleId: number) => {
     onSuccess: (_data, username) => {
       queryClient.invalidateQueries({ queryKey: AdminQueryKeys.roleUsers(roleId) });
       queryClient.invalidateQueries({ queryKey: AccountQueryKeys.userRoles(username) });
+      queryClient.invalidateQueries({ queryKey: AdminQueryKeys.users });
     },
   });
 };

--- a/mlflow/server/js/src/admin/hooks.ts
+++ b/mlflow/server/js/src/admin/hooks.ts
@@ -17,6 +17,7 @@ import type {
 // ``./hooks``. The canonical home is account/hooks.
 export {
   useCurrentUserIsAdmin,
+  useCurrentUserIsWorkspaceAdmin,
   useCurrentUserQuery,
   useIsAuthAvailable,
   useIsBasicAuth,
@@ -108,12 +109,17 @@ export const useUpdateAdmin = () => {
 };
 
 // Role queries and mutations
-export const useRolesQuery = (workspace?: string) => {
+export const useRolesQuery = (workspace?: string, options: { enabled?: boolean } = {}) => {
   return useQuery({
     queryKey: [...AdminQueryKeys.roles, workspace],
     queryFn: () => AdminApi.listRoles(workspace),
     retry: false,
     refetchOnWindowFocus: false,
+    // Default-on. Callers pass ``enabled: false`` to skip the request when
+    // they know it would 403 (e.g. a workspace admin without an active
+    // workspace selected — ``validate_can_list_roles`` rejects unscoped
+    // requests for non-platform-admins).
+    enabled: options.enabled !== false,
   });
 };
 

--- a/mlflow/server/js/src/admin/hooks.ts
+++ b/mlflow/server/js/src/admin/hooks.ts
@@ -16,6 +16,7 @@ import type {
 // Re-export account-side hooks so admin pages can keep importing them via
 // ``./hooks``. The canonical home is account/hooks.
 export {
+  useCurrentUserAdminWorkspaces,
   useCurrentUserIsAdmin,
   useCurrentUserIsWorkspaceAdmin,
   useCurrentUserQuery,

--- a/mlflow/server/js/src/admin/hooks.ts
+++ b/mlflow/server/js/src/admin/hooks.ts
@@ -116,10 +116,7 @@ export const useRolesQuery = (workspace?: string, options: { enabled?: boolean }
     queryFn: () => AdminApi.listRoles(workspace),
     retry: false,
     refetchOnWindowFocus: false,
-    // Default-on. Callers pass ``enabled: false`` to skip the request when
-    // they know it would 403 (e.g. a workspace admin without an active
-    // workspace selected — ``validate_can_list_roles`` rejects unscoped
-    // requests for non-platform-admins).
+    // Callers pass ``enabled: false`` to skip a fetch they know will 403.
     enabled: options.enabled !== false,
   });
 };

--- a/mlflow/server/js/src/admin/hooks.ts
+++ b/mlflow/server/js/src/admin/hooks.ts
@@ -1,5 +1,5 @@
-import { useCallback } from 'react';
-import { useMutation, useQuery, useQueryClient } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { useCallback, useMemo } from 'react';
+import { useMutation, useQueries, useQuery, useQueryClient } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
 import { useSearchParams } from '../common/utils/RoutingUtils';
 import { SETTINGS_RETURN_TO_PARAM } from '../settings/settingsSectionConstants';
 import { AccountQueryKeys } from '../account/hooks';
@@ -119,6 +119,34 @@ export const useRolesQuery = (workspace?: string, options: { enabled?: boolean }
     // Callers pass ``enabled: false`` to skip a fetch they know will 403.
     enabled: options.enabled !== false,
   });
+};
+
+/**
+ * Roles across multiple workspaces. Workspace managers don't have an
+ * unscoped ``list_roles`` endpoint (``validate_can_list_roles`` rejects
+ * non-admin requests without a workspace), so we fan out one query per
+ * workspace they manage and merge the results client-side. ``useQueries``
+ * shares cache entries with ``useRolesQuery``'s queryKey shape, so a
+ * subsequent ``useRolesQuery(ws)`` call elsewhere reads from the same
+ * cache. The N+1 here is bounded by the number of workspaces the user
+ * manages, which is small in practice.
+ */
+export const useRolesInWorkspacesQuery = (workspaces: ReadonlySet<string>) => {
+  const sortedWorkspaces = useMemo(() => Array.from(workspaces).sort(), [workspaces]);
+  const results = useQueries({
+    queries: sortedWorkspaces.map((workspace) => ({
+      queryKey: [...AdminQueryKeys.roles, workspace],
+      queryFn: () => AdminApi.listRoles(workspace),
+      retry: false,
+      refetchOnWindowFocus: false,
+    })),
+  });
+  return useMemo(() => {
+    const isLoading = results.some((r) => r.isLoading);
+    const error = results.find((r) => r.error)?.error ?? null;
+    const roles = results.flatMap((r) => r.data?.roles ?? []);
+    return { isLoading, error, data: { roles } };
+  }, [results]);
 };
 
 export const useRoleDetailQuery = (roleId: number) => {

--- a/mlflow/server/js/src/admin/hooks.ts
+++ b/mlflow/server/js/src/admin/hooks.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from 'react';
-import { useMutation, useQueries, useQuery, useQueryClient } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { useMutation, useQuery, useQueryClient } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
 import { useSearchParams } from '../common/utils/RoutingUtils';
 import { SETTINGS_RETURN_TO_PARAM } from '../settings/settingsSectionConstants';
 import { AccountQueryKeys } from '../account/hooks';
@@ -110,43 +110,25 @@ export const useUpdateAdmin = () => {
 };
 
 // Role queries and mutations
-export const useRolesQuery = (workspace?: string, options: { enabled?: boolean } = {}) => {
+//
+// ``workspaces`` accepts a single workspace, a list of workspaces, or
+// ``undefined`` (admin-only unscoped listing). The cache key normalizes a list
+// to a sorted form so callers passing the same set in different order share
+// the same entry.
+export const useRolesQuery = (workspaces?: string | readonly string[], options: { enabled?: boolean } = {}) => {
+  const normalized = useMemo<string | readonly string[] | undefined>(() => {
+    if (workspaces === undefined) return undefined;
+    if (typeof workspaces === 'string') return workspaces;
+    return [...workspaces].sort();
+  }, [workspaces]);
   return useQuery({
-    queryKey: [...AdminQueryKeys.roles, workspace],
-    queryFn: () => AdminApi.listRoles(workspace),
+    queryKey: [...AdminQueryKeys.roles, normalized],
+    queryFn: () => AdminApi.listRoles(normalized),
     retry: false,
     refetchOnWindowFocus: false,
     // Callers pass ``enabled: false`` to skip a fetch they know will 403.
     enabled: options.enabled !== false,
   });
-};
-
-/**
- * Roles across multiple workspaces. Workspace managers don't have an
- * unscoped ``list_roles`` endpoint (``validate_can_list_roles`` rejects
- * non-admin requests without a workspace), so we fan out one query per
- * workspace they manage and merge the results client-side. ``useQueries``
- * shares cache entries with ``useRolesQuery``'s queryKey shape, so a
- * subsequent ``useRolesQuery(ws)`` call elsewhere reads from the same
- * cache. The N+1 here is bounded by the number of workspaces the user
- * manages, which is small in practice.
- */
-export const useRolesInWorkspacesQuery = (workspaces: ReadonlySet<string>) => {
-  const sortedWorkspaces = useMemo(() => Array.from(workspaces).sort(), [workspaces]);
-  const results = useQueries({
-    queries: sortedWorkspaces.map((workspace) => ({
-      queryKey: [...AdminQueryKeys.roles, workspace],
-      queryFn: () => AdminApi.listRoles(workspace),
-      retry: false,
-      refetchOnWindowFocus: false,
-    })),
-  });
-  return useMemo(() => {
-    const isLoading = results.some((r) => r.isLoading);
-    const error = results.find((r) => r.error)?.error ?? null;
-    const roles = results.flatMap((r) => r.data?.roles ?? []);
-    return { isLoading, error, data: { roles } };
-  }, [results]);
 };
 
 export const useRoleDetailQuery = (roleId: number) => {

--- a/mlflow/server/js/src/admin/pages/AdminPage.tsx
+++ b/mlflow/server/js/src/admin/pages/AdminPage.tsx
@@ -19,6 +19,7 @@ import { FormattedMessage } from 'react-intl';
 import { ScrollablePageWrapper } from '@mlflow/mlflow/src/common/components/ScrollablePageWrapper';
 import { useQueryClient } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
 import { Link, useSearchParams } from '../../common/utils/RoutingUtils';
+import { useActiveWorkspace } from '../../workspaces/utils/WorkspaceUtils';
 import { performLogout } from '../auth-utils';
 import { ConfirmationModal } from '../ConfirmationModal';
 import AdminRoutes from '../routes';
@@ -298,17 +299,17 @@ const UsersTab = () => {
 
 const RolesTab = () => {
   const { theme } = useDesignSystemTheme();
-  // Platform admins fetch unscoped (every workspace); workspace managers
-  // pass the list of workspaces they administer. Every visible row is
-  // therefore in a workspace the user can manage, so bulk-delete is safe.
+  // Per-workspace scope: platform admins fetch unscoped; workspace managers
+  // pass the active workspace (only one viewable at a time on this page).
+  // ``canManageRoles`` checks the *active* workspace specifically — managing
+  // workspace A while currently in B means we can't create/delete here.
   const isAdmin = useCurrentUserIsAdmin();
   const adminWorkspaces = useCurrentUserAdminWorkspaces();
-  const canManageRoles = isAdmin || adminWorkspaces.size > 0;
-  const queryWorkspaces = useMemo(
-    () => (isAdmin ? undefined : Array.from(adminWorkspaces)),
-    [isAdmin, adminWorkspaces],
-  );
-  const { data: rolesData, isLoading, error: queryError } = useRolesQuery(queryWorkspaces);
+  const activeWorkspace = useActiveWorkspace();
+  const canManageRoles = isAdmin || (activeWorkspace !== null && adminWorkspaces.has(activeWorkspace));
+  const queryWorkspace = isAdmin ? undefined : (activeWorkspace ?? undefined);
+  const queryEnabled = isAdmin || Boolean(activeWorkspace);
+  const { data: rolesData, isLoading, error: queryError } = useRolesQuery(queryWorkspace, { enabled: queryEnabled });
   const deleteRole = useDeleteRole();
   const withReturnTo = useWithSettingsReturnTo();
 
@@ -336,6 +337,26 @@ const RolesTab = () => {
     clearSelection();
     setBulkDeleteOpen(false);
   };
+
+  // No active workspace + non-admin: skip the guaranteed 403, prompt instead.
+  if (!queryEnabled) {
+    return (
+      <Empty
+        title={
+          <FormattedMessage
+            defaultMessage="Select a workspace"
+            description="Roles tab empty state shown to workspace admins without an active workspace"
+          />
+        }
+        description={
+          <FormattedMessage
+            defaultMessage="Pick a workspace from the workspace selector to see its roles."
+            description="Roles tab empty state body when no workspace is selected"
+          />
+        }
+      />
+    );
+  }
 
   if (isLoading) {
     return (
@@ -513,8 +534,7 @@ const AdminPage = () => {
   const activeTab = tabFromUrl === 'roles' ? 'roles' : 'users';
 
   const isAdmin = useCurrentUserIsAdmin();
-  const adminWorkspaces = useCurrentUserAdminWorkspaces();
-  const sortedAdminWorkspaces = useMemo(() => Array.from(adminWorkspaces).sort(), [adminWorkspaces]);
+  const activeWorkspace = useActiveWorkspace();
 
   // The route definition's static ``getPageTitle`` is set by ``MlflowRootRoute``
   // *after* this component's effects (parent effects run after children's), so
@@ -553,28 +573,13 @@ const AdminPage = () => {
               )}
             </Typography.Title>
           </div>
-          {!isAdmin && sortedAdminWorkspaces.length > 0 && (
+          {!isAdmin && activeWorkspace && (
             <Typography.Text color="secondary">
-              {sortedAdminWorkspaces.length === 1 ? (
-                <FormattedMessage
-                  defaultMessage="Workspace: {workspaces}"
-                  description="Subtitle on the admin page identifying the single workspace a workspace manager administers"
-                  values={{ workspaces: <code>{sortedAdminWorkspaces[0]}</code> }}
-                />
-              ) : (
-                <FormattedMessage
-                  defaultMessage="Workspaces: {workspaces}"
-                  description="Subtitle on the admin page listing all workspaces a workspace manager administers"
-                  values={{
-                    workspaces: sortedAdminWorkspaces.map((ws, i) => (
-                      <span key={ws}>
-                        {i > 0 ? ', ' : ''}
-                        <code>{ws}</code>
-                      </span>
-                    )),
-                  }}
-                />
-              )}
+              <FormattedMessage
+                defaultMessage="Workspace: {workspace}"
+                description="Subtitle on the admin page identifying the active workspace for workspace managers"
+                values={{ workspace: <code>{activeWorkspace}</code> }}
+              />
             </Typography.Text>
           )}
         </div>

--- a/mlflow/server/js/src/admin/pages/AdminPage.tsx
+++ b/mlflow/server/js/src/admin/pages/AdminPage.tsx
@@ -48,8 +48,20 @@ import { CreateRoleModal } from '../components/CreateRoleModal';
 // parent ask for a red signal on real fetch failures (platform admins
 // reviewing user state) while workspace managers silently fall back to
 // ``—`` when ``validate_can_view_user_roles`` 403s for users outside
-// their workspaces.
-const UserRolesCell = ({ username, showErrorOnFailure }: { username: string; showErrorOnFailure: boolean }) => {
+// their workspaces. ``scopeWorkspace`` (when set) filters the result to
+// roles in that workspace only — keeps the per-user cell aligned with
+// the page's per-workspace scope (the backend self-check returns global
+// roles, and a wp-admin viewing another user gets every workspace they
+// administer, which is broader than the active page's scope).
+const UserRolesCell = ({
+  username,
+  showErrorOnFailure,
+  scopeWorkspace,
+}: {
+  username: string;
+  showErrorOnFailure: boolean;
+  scopeWorkspace: string | null;
+}) => {
   const { theme } = useDesignSystemTheme();
   const { data, isLoading, error } = useUserRolesQuery(username);
   if (isLoading) {
@@ -62,7 +74,8 @@ const UserRolesCell = ({ username, showErrorOnFailure }: { username: string; sho
       </Typography.Text>
     );
   }
-  const roles = error ? [] : (data?.roles ?? []);
+  const allRoles = error ? [] : (data?.roles ?? []);
+  const roles = scopeWorkspace ? allRoles.filter((r) => r.workspace === scopeWorkspace) : allRoles;
   if (roles.length === 0) {
     return <Typography.Text color="secondary">—</Typography.Text>;
   }
@@ -86,10 +99,15 @@ const UsersTab = () => {
   const deleteUser = useDeleteUser();
   const withReturnTo = useWithSettingsReturnTo();
   // Bulk-delete + row checkboxes are platform-admin-only; Create User is
-  // open to workspace admins.
+  // open to workspace admins. ``rolesScopeWorkspace`` keeps the per-row
+  // Roles cell aligned with the page's per-workspace scope: workspace
+  // managers should only see roles in the active workspace, including for
+  // their own row (the backend self-check returns global roles).
   const isAdmin = useCurrentUserIsAdmin();
   const isWorkspaceAdmin = useCurrentUserIsWorkspaceAdmin();
   const canCreateUser = isAdmin || isWorkspaceAdmin;
+  const activeWorkspace = useActiveWorkspace();
+  const rolesScopeWorkspace = isAdmin ? null : activeWorkspace;
 
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
@@ -264,7 +282,11 @@ const UsersTab = () => {
               </Link>
             </TableCell>
             <TableCell css={{ flex: 2 }}>
-              <UserRolesCell username={user.username} showErrorOnFailure={isAdmin} />
+              <UserRolesCell
+                username={user.username}
+                showErrorOnFailure={isAdmin}
+                scopeWorkspace={rolesScopeWorkspace}
+              />
             </TableCell>
             <TableCell css={{ flex: 1 }}>
               {user.is_admin ? (

--- a/mlflow/server/js/src/admin/pages/AdminPage.tsx
+++ b/mlflow/server/js/src/admin/pages/AdminPage.tsx
@@ -36,37 +36,9 @@ import {
   useWithSettingsReturnTo,
 } from '../hooks';
 import { isWorkspaceAdminRole } from '../types';
-import type { Role } from '../types';
 import { CreateUserModal } from '../components/CreateUserModal';
 import { CreateRoleModal } from '../components/CreateRoleModal';
-
-// Reads roles from the user object eager-loaded by ``useUsersQuery`` —
-// no per-row request. The backend already scopes the list per requester
-// (admin sees all; workspace managers see only roles in workspaces they
-// administer). ``scopeWorkspace`` further narrows to the active workspace
-// for the per-workspace admin page, so the cell matches the page scope.
-const UserRolesCell = ({
-  roles: allRoles,
-  scopeWorkspace,
-}: {
-  roles: readonly Role[];
-  scopeWorkspace: string | null;
-}) => {
-  const { theme } = useDesignSystemTheme();
-  const roles = scopeWorkspace ? allRoles.filter((r) => r.workspace === scopeWorkspace) : allRoles;
-  if (roles.length === 0) {
-    return <Typography.Text color="secondary">—</Typography.Text>;
-  }
-  return (
-    <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs / 2 }}>
-      {roles.map((role) => (
-        <Typography.Text key={role.id} size="sm">
-          <code>{role.workspace}</code> → {role.name}
-        </Typography.Text>
-      ))}
-    </div>
-  );
-};
+import { UserRolesCell } from '../components/UserRolesCell';
 
 const UsersTab = () => {
   const { theme } = useDesignSystemTheme();

--- a/mlflow/server/js/src/admin/pages/AdminPage.tsx
+++ b/mlflow/server/js/src/admin/pages/AdminPage.tsx
@@ -501,19 +501,25 @@ const AdminPage = () => {
   const tabFromUrl = searchParams.get('tab');
   const activeTab = tabFromUrl === 'roles' ? 'roles' : 'users';
 
-  const isAdmin = useCurrentUserIsAdmin();
   const activeWorkspace = useActiveWorkspace();
+  // Header / browser-tab title are URL-driven: ``/admin`` (no workspace
+  // param) is the cross-workspace platform-admin view; ``/admin?workspace=…``
+  // is the per-workspace management view. Keying off the URL rather than
+  // the viewer's ``is_admin`` flag means a deep link reads the same way for
+  // anyone authorized to follow it. (A separate route for the per-workspace
+  // view is the natural follow-up; deferred for now.)
+  const isWorkspaceScoped = activeWorkspace !== null;
 
   // The route definition's static ``getPageTitle`` is set by ``MlflowRootRoute``
   // *after* this component's effects (parent effects run after children's), so
-  // we override on a microtask to land last and reflect the workspace-manager
+  // we override on a microtask to land last and reflect the per-workspace
   // header in the browser tab.
   useEffect(() => {
-    const desired = isAdmin ? 'Platform Admin - MLflow' : 'Workspace Manager - MLflow';
+    const desired = isWorkspaceScoped ? 'Workspace Manager - MLflow' : 'Platform Admin - MLflow';
     queueMicrotask(() => {
       document.title = desired;
     });
-  }, [isAdmin]);
+  }, [isWorkspaceScoped]);
 
   return (
     <ScrollablePageWrapper>
@@ -531,21 +537,24 @@ const AdminPage = () => {
               <UserIcon />
             </div>
             <Typography.Title withoutMargins level={2}>
-              {isAdmin ? (
-                <FormattedMessage defaultMessage="Platform Admin" description="Admin page title for platform admins" />
-              ) : (
+              {isWorkspaceScoped ? (
                 <FormattedMessage
                   defaultMessage="Workspace Manager"
-                  description="Admin page title for non-platform-admins (workspace admins)"
+                  description="Admin page title shown when the URL is scoped to a single workspace via ?workspace=…"
+                />
+              ) : (
+                <FormattedMessage
+                  defaultMessage="Platform Admin"
+                  description="Admin page title shown when the URL has no ?workspace=… (cross-workspace platform-admin view)"
                 />
               )}
             </Typography.Title>
           </div>
-          {!isAdmin && activeWorkspace && (
+          {isWorkspaceScoped && (
             <Typography.Text color="secondary">
               <FormattedMessage
                 defaultMessage="Workspace: {workspace}"
-                description="Subtitle on the admin page identifying the active workspace for workspace managers"
+                description="Subtitle on the admin page identifying the active workspace when the URL is per-workspace scoped"
                 values={{ workspace: <code>{activeWorkspace}</code> }}
               />
             </Typography.Text>

--- a/mlflow/server/js/src/admin/pages/AdminPage.tsx
+++ b/mlflow/server/js/src/admin/pages/AdminPage.tsx
@@ -521,6 +521,13 @@ const AdminPage = () => {
   const tabFromUrl = searchParams.get('tab');
   const activeTab = tabFromUrl === 'roles' ? 'roles' : 'users';
 
+  // Title and subtitle differ for platform admins vs. workspace managers.
+  // For workspace managers we show the active workspace by name so the
+  // page makes the scope explicit; the body of the page is already scoped
+  // server-side via ``validate_can_list_roles`` and friends.
+  const isAdmin = useCurrentUserIsAdmin();
+  const activeWorkspace = useActiveWorkspace();
+
   return (
     <ScrollablePageWrapper>
       <div css={{ padding: theme.spacing.md, display: 'flex', flexDirection: 'column', gap: theme.spacing.lg }}>
@@ -537,9 +544,25 @@ const AdminPage = () => {
               <UserIcon />
             </div>
             <Typography.Title withoutMargins level={2}>
-              <FormattedMessage defaultMessage="Platform Admin" description="Admin page title" />
+              {isAdmin ? (
+                <FormattedMessage defaultMessage="Platform Admin" description="Admin page title for platform admins" />
+              ) : (
+                <FormattedMessage
+                  defaultMessage="Workspace Manager"
+                  description="Admin page title for non-platform-admins (workspace admins)"
+                />
+              )}
             </Typography.Title>
           </div>
+          {!isAdmin && activeWorkspace && (
+            <Typography.Text color="secondary">
+              <FormattedMessage
+                defaultMessage="Workspace: {workspace}"
+                description="Subtitle on the admin page identifying the active workspace for workspace managers"
+                values={{ workspace: <code>{activeWorkspace}</code> }}
+              />
+            </Typography.Text>
+          )}
         </div>
         <Tabs.Root
           componentId="admin.tabs"

--- a/mlflow/server/js/src/admin/pages/AdminPage.tsx
+++ b/mlflow/server/js/src/admin/pages/AdminPage.tsx
@@ -26,6 +26,7 @@ import AdminRoutes from '../routes';
 import { useTableSelection } from '../useTableSelection';
 import {
   useCurrentUserIsAdmin,
+  useCurrentUserIsWorkspaceAdmin,
   useCurrentUserQuery,
   useUsersQuery,
   useDeleteUser,
@@ -77,11 +78,14 @@ const UsersTab = () => {
   const currentUsername = currentUserData?.user?.username;
   const deleteUser = useDeleteUser();
   const withReturnTo = useWithSettingsReturnTo();
-  // Create / bulk-delete are platform-admin-only operations. Workspace
-  // admins still see the table (so they can pick users to assign to roles
-  // they manage) but the platform-only controls and the row-selection
-  // affordance fold away.
+  // Workspace admins can create users (so they can seed an account before
+  // assigning it a role in a workspace they manage), but deletion stays
+  // super-admin-only — so the row-selection checkbox column and the bulk
+  // delete button only render for platform admins. The Create User button
+  // renders for both groups.
   const isAdmin = useCurrentUserIsAdmin();
+  const isWorkspaceAdmin = useCurrentUserIsWorkspaceAdmin();
+  const canCreateUser = isAdmin || isWorkspaceAdmin;
 
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
@@ -166,7 +170,7 @@ const UsersTab = () => {
       {error && (
         <Alert componentId="admin.users.error" type="error" message={error} closable onClose={() => setError(null)} />
       )}
-      {isAdmin && (
+      {canCreateUser && (
         <div
           css={{
             display: 'flex',
@@ -175,25 +179,27 @@ const UsersTab = () => {
             gap: theme.spacing.sm,
           }}
         >
-          <Button
-            componentId="admin.users.bulk_delete_button"
-            danger
-            disabled={visibleSelectedUsernames.size === 0}
-            onClick={() => setBulkDeleteOpen(true)}
-          >
-            {visibleSelectedUsernames.size === 0 ? (
-              <FormattedMessage
-                defaultMessage="Delete"
-                description="Bulk-delete button on the users table (no rows selected)"
-              />
-            ) : (
-              <FormattedMessage
-                defaultMessage="Delete ({count})"
-                description="Bulk-delete button on the users table"
-                values={{ count: visibleSelectedUsernames.size }}
-              />
-            )}
-          </Button>
+          {isAdmin && (
+            <Button
+              componentId="admin.users.bulk_delete_button"
+              danger
+              disabled={visibleSelectedUsernames.size === 0}
+              onClick={() => setBulkDeleteOpen(true)}
+            >
+              {visibleSelectedUsernames.size === 0 ? (
+                <FormattedMessage
+                  defaultMessage="Delete"
+                  description="Bulk-delete button on the users table (no rows selected)"
+                />
+              ) : (
+                <FormattedMessage
+                  defaultMessage="Delete ({count})"
+                  description="Bulk-delete button on the users table"
+                  values={{ count: visibleSelectedUsernames.size }}
+                />
+              )}
+            </Button>
+          )}
           <Button componentId="admin.users.create_button" type="primary" onClick={() => setShowCreateModal(true)}>
             <FormattedMessage defaultMessage="Create User" description="Button to create a new user" />
           </Button>
@@ -294,7 +300,13 @@ const RolesTab = () => {
   // workspace param for non-platform-admins). When a workspace admin lands
   // on /admin without an active workspace selected we suppress the query
   // and surface an info state, since the request would 403.
+  //
+  // Bulk-delete renders for either group — for workspace admins the listing
+  // is already scoped server-side to workspaces they manage, so every row
+  // they see is one ``validate_can_manage_roles`` will accept a delete for.
   const isAdmin = useCurrentUserIsAdmin();
+  const isWorkspaceAdmin = useCurrentUserIsWorkspaceAdmin();
+  const canDeleteRoles = isAdmin || isWorkspaceAdmin;
   const activeWorkspace = useActiveWorkspace();
   const queryWorkspace = isAdmin ? undefined : (activeWorkspace ?? undefined);
   const queryEnabled = isAdmin || Boolean(activeWorkspace);
@@ -402,7 +414,7 @@ const RolesTab = () => {
           gap: theme.spacing.sm,
         }}
       >
-        {isAdmin && (
+        {canDeleteRoles && (
           <Button
             componentId="admin.roles.bulk_delete_button"
             danger
@@ -438,7 +450,7 @@ const RolesTab = () => {
         }}
       >
         <TableRow isHeader>
-          {isAdmin && (
+          {canDeleteRoles && (
             <TableHeader componentId="admin.roles.select_header" css={{ flex: 0, minWidth: 40, maxWidth: 40 }}>
               <Checkbox
                 componentId="admin.roles.select_all"
@@ -466,7 +478,7 @@ const RolesTab = () => {
         </TableRow>
         {roles.map((role) => (
           <TableRow key={role.id}>
-            {isAdmin && (
+            {canDeleteRoles && (
               <TableCell css={{ flex: 0, minWidth: 40, maxWidth: 40 }}>
                 <Checkbox
                   componentId="admin.roles.select_row"

--- a/mlflow/server/js/src/admin/pages/AdminPage.tsx
+++ b/mlflow/server/js/src/admin/pages/AdminPage.tsx
@@ -44,18 +44,32 @@ import { CreateRoleModal } from '../components/CreateRoleModal';
 // elsewhere in the admin UI (e.g. the Account page's permission lines like
 // `experiment:* → READ`). Each row issues its own request — React Query
 // caches per-username so subsequent re-renders don't re-fetch.
-const UserRolesCell = ({ username }: { username: string }) => {
+// ``enabled`` lets the parent suppress the per-row request for workspace
+// managers, where ``validate_can_view_user_roles`` would 403 for any user
+// outside a workspace they manage — an N+1 burst of mostly-403 requests
+// per page load. Workspace managers see ``—`` for everyone in this column
+// and drill into a user's detail page for scoped role info instead.
+const UserRolesCell = ({ username, enabled }: { username: string; enabled: boolean }) => {
   const { theme } = useDesignSystemTheme();
-  const { data, isLoading, error } = useUserRolesQuery(username);
+  const { data, isLoading, error } = useUserRolesQuery(username, { enabled });
+  if (!enabled) {
+    return <Typography.Text color="secondary">—</Typography.Text>;
+  }
   if (isLoading) {
     return <Spinner size="small" />;
   }
-  // Render the same muted ``—`` for "no roles assigned", "you can't see this
-  // user's roles" (403 — a workspace admin viewing an outside-workspace
-  // target), and other fetch failures. Surfacing a per-row red error reads as
-  // breakage in workspace-manager mode where 403s are expected and harmless
-  // (the visible role data lives elsewhere in the page).
-  const roles = error ? [] : (data?.roles ?? []);
+  if (error) {
+    // Distinguish "no roles assigned" from "we couldn't load roles" — only
+    // platform admins reach this branch (workspace managers short-circuit
+    // above), so a red signal is appropriate; an admin reviewing user state
+    // should know when a fetch genuinely failed.
+    return (
+      <Typography.Text color="error" size="sm">
+        Failed to load
+      </Typography.Text>
+    );
+  }
+  const roles = data?.roles ?? [];
   if (roles.length === 0) {
     return <Typography.Text color="secondary">—</Typography.Text>;
   }
@@ -260,7 +274,7 @@ const UsersTab = () => {
               </Link>
             </TableCell>
             <TableCell css={{ flex: 2 }}>
-              <UserRolesCell username={user.username} />
+              <UserRolesCell username={user.username} enabled={isAdmin} />
             </TableCell>
             <TableCell css={{ flex: 1 }}>
               {user.is_admin ? (

--- a/mlflow/server/js/src/admin/pages/AdminPage.tsx
+++ b/mlflow/server/js/src/admin/pages/AdminPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   Alert,
   Button,
@@ -307,7 +307,7 @@ const RolesTab = () => {
   // will accept a delete for.
   const isAdmin = useCurrentUserIsAdmin();
   const isWorkspaceAdmin = useCurrentUserIsWorkspaceAdmin();
-  const canDeleteRoles = isAdmin || isWorkspaceAdmin;
+  const canManageRoles = isAdmin || isWorkspaceAdmin;
   const activeWorkspace = useActiveWorkspace();
   const queryWorkspace = isAdmin ? undefined : (activeWorkspace ?? undefined);
   const queryEnabled = isAdmin || Boolean(activeWorkspace);
@@ -414,7 +414,7 @@ const RolesTab = () => {
           gap: theme.spacing.sm,
         }}
       >
-        {canDeleteRoles && (
+        {canManageRoles && (
           <Button
             componentId="admin.roles.bulk_delete_button"
             danger
@@ -435,9 +435,11 @@ const RolesTab = () => {
             )}
           </Button>
         )}
-        <Button componentId="admin.roles.create_button" type="primary" onClick={() => setShowCreateModal(true)}>
-          <FormattedMessage defaultMessage="Create Role" description="Button to create a new role" />
-        </Button>
+        {canManageRoles && (
+          <Button componentId="admin.roles.create_button" type="primary" onClick={() => setShowCreateModal(true)}>
+            <FormattedMessage defaultMessage="Create Role" description="Button to create a new role" />
+          </Button>
+        )}
       </div>
       <Table
         scrollable
@@ -450,7 +452,7 @@ const RolesTab = () => {
         }}
       >
         <TableRow isHeader>
-          {canDeleteRoles && (
+          {canManageRoles && (
             <TableHeader componentId="admin.roles.select_header" css={{ flex: 0, minWidth: 40, maxWidth: 40 }}>
               <Checkbox
                 componentId="admin.roles.select_all"
@@ -478,7 +480,7 @@ const RolesTab = () => {
         </TableRow>
         {roles.map((role) => (
           <TableRow key={role.id}>
-            {canDeleteRoles && (
+            {canManageRoles && (
               <TableCell css={{ flex: 0, minWidth: 40, maxWidth: 40 }}>
                 <Checkbox
                   componentId="admin.roles.select_row"
@@ -535,6 +537,17 @@ const AdminPage = () => {
 
   const isAdmin = useCurrentUserIsAdmin();
   const activeWorkspace = useActiveWorkspace();
+
+  // The route definition's static ``getPageTitle`` is set by ``MlflowRootRoute``
+  // *after* this component's effects (parent effects run after children's), so
+  // we override on a microtask to land last and reflect the workspace-manager
+  // header in the browser tab.
+  useEffect(() => {
+    const desired = isAdmin ? 'Platform Admin - MLflow' : 'Workspace Manager - MLflow';
+    queueMicrotask(() => {
+      document.title = desired;
+    });
+  }, [isAdmin]);
 
   return (
     <ScrollablePageWrapper>

--- a/mlflow/server/js/src/admin/pages/AdminPage.tsx
+++ b/mlflow/server/js/src/admin/pages/AdminPage.tsx
@@ -19,7 +19,6 @@ import { FormattedMessage } from 'react-intl';
 import { ScrollablePageWrapper } from '@mlflow/mlflow/src/common/components/ScrollablePageWrapper';
 import { useQueryClient } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
 import { Link, useSearchParams } from '../../common/utils/RoutingUtils';
-import { useActiveWorkspace } from '../../workspaces/utils/WorkspaceUtils';
 import { performLogout } from '../auth-utils';
 import { ConfirmationModal } from '../ConfirmationModal';
 import AdminRoutes from '../routes';
@@ -32,6 +31,7 @@ import {
   useUsersQuery,
   useDeleteUser,
   useRolesQuery,
+  useRolesInWorkspacesQuery,
   useDeleteRole,
   useUserRolesQuery,
   useWithSettingsReturnTo,
@@ -299,18 +299,17 @@ const UsersTab = () => {
 
 const RolesTab = () => {
   const { theme } = useDesignSystemTheme();
-  // Mutations are authorized per-target-workspace by ``validate_can_manage_roles``,
-  // so ``canManageRoles`` checks the *active* workspace, not just whether the
-  // user admins something somewhere. A wp-admin of A who is currently in B
-  // (member only) would otherwise see Create / bulk-delete CTAs that 403 on
-  // submit.
+  // Platform admins fetch roles unscoped; workspace managers fan out one
+  // query per workspace they administer and merge. Every visible row is
+  // therefore in a workspace the user can manage, so bulk-delete is safe.
   const isAdmin = useCurrentUserIsAdmin();
   const adminWorkspaces = useCurrentUserAdminWorkspaces();
-  const activeWorkspace = useActiveWorkspace();
-  const canManageRoles = isAdmin || (activeWorkspace !== null && adminWorkspaces.has(activeWorkspace));
-  const queryWorkspace = isAdmin ? undefined : (activeWorkspace ?? undefined);
-  const queryEnabled = isAdmin || Boolean(activeWorkspace);
-  const { data: rolesData, isLoading, error: queryError } = useRolesQuery(queryWorkspace, { enabled: queryEnabled });
+  const canManageRoles = isAdmin || adminWorkspaces.size > 0;
+  const adminRolesQuery = useRolesQuery(undefined, { enabled: isAdmin });
+  const workspaceRolesQuery = useRolesInWorkspacesQuery(isAdmin ? new Set<string>() : adminWorkspaces);
+  const rolesData = isAdmin ? adminRolesQuery.data : workspaceRolesQuery.data;
+  const isLoading = isAdmin ? adminRolesQuery.isLoading : workspaceRolesQuery.isLoading;
+  const queryError = isAdmin ? adminRolesQuery.error : workspaceRolesQuery.error;
   const deleteRole = useDeleteRole();
   const withReturnTo = useWithSettingsReturnTo();
 
@@ -338,26 +337,6 @@ const RolesTab = () => {
     clearSelection();
     setBulkDeleteOpen(false);
   };
-
-  // No active workspace + non-admin: skip the guaranteed 403, prompt instead.
-  if (!queryEnabled) {
-    return (
-      <Empty
-        title={
-          <FormattedMessage
-            defaultMessage="Select a workspace"
-            description="Roles tab empty state shown to workspace admins without an active workspace"
-          />
-        }
-        description={
-          <FormattedMessage
-            defaultMessage="Pick a workspace from the workspace selector to see roles you can manage."
-            description="Roles tab empty state body when no workspace is selected"
-          />
-        }
-      />
-    );
-  }
 
   if (isLoading) {
     return (
@@ -535,7 +514,8 @@ const AdminPage = () => {
   const activeTab = tabFromUrl === 'roles' ? 'roles' : 'users';
 
   const isAdmin = useCurrentUserIsAdmin();
-  const activeWorkspace = useActiveWorkspace();
+  const adminWorkspaces = useCurrentUserAdminWorkspaces();
+  const sortedAdminWorkspaces = useMemo(() => Array.from(adminWorkspaces).sort(), [adminWorkspaces]);
 
   // The route definition's static ``getPageTitle`` is set by ``MlflowRootRoute``
   // *after* this component's effects (parent effects run after children's), so
@@ -574,13 +554,28 @@ const AdminPage = () => {
               )}
             </Typography.Title>
           </div>
-          {!isAdmin && activeWorkspace && (
+          {!isAdmin && sortedAdminWorkspaces.length > 0 && (
             <Typography.Text color="secondary">
-              <FormattedMessage
-                defaultMessage="Workspace: {workspace}"
-                description="Subtitle on the admin page identifying the active workspace for workspace managers"
-                values={{ workspace: <code>{activeWorkspace}</code> }}
-              />
+              {sortedAdminWorkspaces.length === 1 ? (
+                <FormattedMessage
+                  defaultMessage="Workspace: {workspaces}"
+                  description="Subtitle on the admin page identifying the single workspace a workspace manager administers"
+                  values={{ workspaces: <code>{sortedAdminWorkspaces[0]}</code> }}
+                />
+              ) : (
+                <FormattedMessage
+                  defaultMessage="Workspaces: {workspaces}"
+                  description="Subtitle on the admin page listing all workspaces a workspace manager administers"
+                  values={{
+                    workspaces: sortedAdminWorkspaces.map((ws, i) => (
+                      <span key={ws}>
+                        {i > 0 ? ', ' : ''}
+                        <code>{ws}</code>
+                      </span>
+                    )),
+                  }}
+                />
+              )}
             </Typography.Text>
           )}
         </div>

--- a/mlflow/server/js/src/admin/pages/AdminPage.tsx
+++ b/mlflow/server/js/src/admin/pages/AdminPage.tsx
@@ -18,11 +18,11 @@ import {
 import { FormattedMessage } from 'react-intl';
 import { ScrollablePageWrapper } from '@mlflow/mlflow/src/common/components/ScrollablePageWrapper';
 import { useQueryClient } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
-import { Link, useSearchParams } from '../../common/utils/RoutingUtils';
+import { Link, useLocation, useSearchParams } from '../../common/utils/RoutingUtils';
 import { useActiveWorkspace } from '../../workspaces/utils/WorkspaceUtils';
 import { performLogout } from '../auth-utils';
 import { ConfirmationModal } from '../ConfirmationModal';
-import AdminRoutes from '../routes';
+import AdminRoutes, { AdminRoutePaths } from '../routes';
 import { useTableSelection } from '../useTableSelection';
 import {
   useCurrentUserAdminWorkspaces,
@@ -502,13 +502,14 @@ const AdminPage = () => {
   const activeTab = tabFromUrl === 'roles' ? 'roles' : 'users';
 
   const activeWorkspace = useActiveWorkspace();
-  // Header / browser-tab title are URL-driven: ``/admin`` (no workspace
-  // param) is the cross-workspace platform-admin view; ``/admin?workspace=…``
-  // is the per-workspace management view. Keying off the URL rather than
-  // the viewer's ``is_admin`` flag means a deep link reads the same way for
-  // anyone authorized to follow it. (A separate route for the per-workspace
-  // view is the natural follow-up; deferred for now.)
-  const isWorkspaceScoped = activeWorkspace !== null;
+  // Mode is path-driven, not role-driven: ``/admin`` is the cross-workspace
+  // platform-admin view; ``/admin/ws`` (with the workspace name in the
+  // ``?workspace=`` query param) is the per-workspace management view. A
+  // deep link reads the same way for anyone authorized to follow it, and
+  // the ``?workspace=`` value is still picked up by ``WorkspaceRouterSync``
+  // to keep the global ``activeWorkspace`` in sync.
+  const { pathname } = useLocation();
+  const isWorkspaceScoped = pathname === AdminRoutePaths.workspaceManagementPage;
 
   // The route definition's static ``getPageTitle`` is set by ``MlflowRootRoute``
   // *after* this component's effects (parent effects run after children's), so

--- a/mlflow/server/js/src/admin/pages/AdminPage.tsx
+++ b/mlflow/server/js/src/admin/pages/AdminPage.tsx
@@ -25,6 +25,7 @@ import { ConfirmationModal } from '../ConfirmationModal';
 import AdminRoutes from '../routes';
 import { useTableSelection } from '../useTableSelection';
 import {
+  useCurrentUserAdminWorkspaces,
   useCurrentUserIsAdmin,
   useCurrentUserIsWorkspaceAdmin,
   useCurrentUserQuery,
@@ -300,15 +301,15 @@ const UsersTab = () => {
 
 const RolesTab = () => {
   const { theme } = useDesignSystemTheme();
-  // Workspace admins must scope to a workspace they manage
-  // (``validate_can_list_roles`` rejects unscoped non-admin requests).
-  // Bulk-delete is open to both groups — the listing is already
-  // server-scoped, so every visible row is one ``validate_can_manage_roles``
-  // will accept a delete for.
+  // Mutations are authorized per-target-workspace by ``validate_can_manage_roles``,
+  // so ``canManageRoles`` checks the *active* workspace, not just whether the
+  // user admins something somewhere. A wp-admin of A who is currently in B
+  // (member only) would otherwise see Create / bulk-delete CTAs that 403 on
+  // submit.
   const isAdmin = useCurrentUserIsAdmin();
-  const isWorkspaceAdmin = useCurrentUserIsWorkspaceAdmin();
-  const canManageRoles = isAdmin || isWorkspaceAdmin;
+  const adminWorkspaces = useCurrentUserAdminWorkspaces();
   const activeWorkspace = useActiveWorkspace();
+  const canManageRoles = isAdmin || (activeWorkspace !== null && adminWorkspaces.has(activeWorkspace));
   const queryWorkspace = isAdmin ? undefined : (activeWorkspace ?? undefined);
   const queryEnabled = isAdmin || Boolean(activeWorkspace);
   const { data: rolesData, isLoading, error: queryError } = useRolesQuery(queryWorkspace, { enabled: queryEnabled });

--- a/mlflow/server/js/src/admin/pages/AdminPage.tsx
+++ b/mlflow/server/js/src/admin/pages/AdminPage.tsx
@@ -19,11 +19,13 @@ import { FormattedMessage } from 'react-intl';
 import { ScrollablePageWrapper } from '@mlflow/mlflow/src/common/components/ScrollablePageWrapper';
 import { useQueryClient } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
 import { Link, useSearchParams } from '../../common/utils/RoutingUtils';
+import { useActiveWorkspace } from '../../workspaces/utils/WorkspaceUtils';
 import { performLogout } from '../auth-utils';
 import { ConfirmationModal } from '../ConfirmationModal';
 import AdminRoutes from '../routes';
 import { useTableSelection } from '../useTableSelection';
 import {
+  useCurrentUserIsAdmin,
   useCurrentUserQuery,
   useUsersQuery,
   useDeleteUser,
@@ -47,16 +49,12 @@ const UserRolesCell = ({ username }: { username: string }) => {
   if (isLoading) {
     return <Spinner size="small" />;
   }
-  if (error) {
-    // Distinguish "no roles assigned" from "we couldn't load roles" — failing
-    // silently to "—" hides 403/500s from admins reviewing user state.
-    return (
-      <Typography.Text color="error" size="sm">
-        Failed to load
-      </Typography.Text>
-    );
-  }
-  const roles = data?.roles ?? [];
+  // Render the same muted ``—`` for "no roles assigned", "you can't see this
+  // user's roles" (403 — a workspace admin viewing an outside-workspace
+  // target), and other fetch failures. Surfacing a per-row red error reads as
+  // breakage in workspace-manager mode where 403s are expected and harmless
+  // (the visible role data lives elsewhere in the page).
+  const roles = error ? [] : (data?.roles ?? []);
   if (roles.length === 0) {
     return <Typography.Text color="secondary">—</Typography.Text>;
   }
@@ -79,6 +77,11 @@ const UsersTab = () => {
   const currentUsername = currentUserData?.user?.username;
   const deleteUser = useDeleteUser();
   const withReturnTo = useWithSettingsReturnTo();
+  // Create / bulk-delete are platform-admin-only operations. Workspace
+  // admins still see the table (so they can pick users to assign to roles
+  // they manage) but the platform-only controls and the row-selection
+  // affordance fold away.
+  const isAdmin = useCurrentUserIsAdmin();
 
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
@@ -163,37 +166,39 @@ const UsersTab = () => {
       {error && (
         <Alert componentId="admin.users.error" type="error" message={error} closable onClose={() => setError(null)} />
       )}
-      <div
-        css={{
-          display: 'flex',
-          justifyContent: 'flex-end',
-          alignItems: 'center',
-          gap: theme.spacing.sm,
-        }}
-      >
-        <Button
-          componentId="admin.users.bulk_delete_button"
-          danger
-          disabled={visibleSelectedUsernames.size === 0}
-          onClick={() => setBulkDeleteOpen(true)}
+      {isAdmin && (
+        <div
+          css={{
+            display: 'flex',
+            justifyContent: 'flex-end',
+            alignItems: 'center',
+            gap: theme.spacing.sm,
+          }}
         >
-          {visibleSelectedUsernames.size === 0 ? (
-            <FormattedMessage
-              defaultMessage="Delete"
-              description="Bulk-delete button on the users table (no rows selected)"
-            />
-          ) : (
-            <FormattedMessage
-              defaultMessage="Delete ({count})"
-              description="Bulk-delete button on the users table"
-              values={{ count: visibleSelectedUsernames.size }}
-            />
-          )}
-        </Button>
-        <Button componentId="admin.users.create_button" type="primary" onClick={() => setShowCreateModal(true)}>
-          <FormattedMessage defaultMessage="Create User" description="Button to create a new user" />
-        </Button>
-      </div>
+          <Button
+            componentId="admin.users.bulk_delete_button"
+            danger
+            disabled={visibleSelectedUsernames.size === 0}
+            onClick={() => setBulkDeleteOpen(true)}
+          >
+            {visibleSelectedUsernames.size === 0 ? (
+              <FormattedMessage
+                defaultMessage="Delete"
+                description="Bulk-delete button on the users table (no rows selected)"
+              />
+            ) : (
+              <FormattedMessage
+                defaultMessage="Delete ({count})"
+                description="Bulk-delete button on the users table"
+                values={{ count: visibleSelectedUsernames.size }}
+              />
+            )}
+          </Button>
+          <Button componentId="admin.users.create_button" type="primary" onClick={() => setShowCreateModal(true)}>
+            <FormattedMessage defaultMessage="Create User" description="Button to create a new user" />
+          </Button>
+        </div>
+      )}
       <Table
         scrollable
         noMinHeight
@@ -205,14 +210,16 @@ const UsersTab = () => {
         }}
       >
         <TableRow isHeader>
-          <TableHeader componentId="admin.users.select_header" css={{ flex: 0, minWidth: 40, maxWidth: 40 }}>
-            <Checkbox
-              componentId="admin.users.select_all"
-              isChecked={allSelected}
-              onChange={toggleSelectAll}
-              aria-label="Select all users"
-            />
-          </TableHeader>
+          {isAdmin && (
+            <TableHeader componentId="admin.users.select_header" css={{ flex: 0, minWidth: 40, maxWidth: 40 }}>
+              <Checkbox
+                componentId="admin.users.select_all"
+                isChecked={allSelected}
+                onChange={toggleSelectAll}
+                aria-label="Select all users"
+              />
+            </TableHeader>
+          )}
           <TableHeader componentId="admin.users.username_header" css={{ flex: 2 }}>
             <FormattedMessage defaultMessage="Username" description="Users table username header" />
           </TableHeader>
@@ -228,14 +235,16 @@ const UsersTab = () => {
         </TableRow>
         {users.map((user) => (
           <TableRow key={user.username}>
-            <TableCell css={{ flex: 0, minWidth: 40, maxWidth: 40 }}>
-              <Checkbox
-                componentId="admin.users.select_row"
-                isChecked={visibleSelectedUsernames.has(user.username)}
-                onChange={() => toggleUserSelection(user.username)}
-                aria-label={`Select user ${user.username}`}
-              />
-            </TableCell>
+            {isAdmin && (
+              <TableCell css={{ flex: 0, minWidth: 40, maxWidth: 40 }}>
+                <Checkbox
+                  componentId="admin.users.select_row"
+                  isChecked={visibleSelectedUsernames.has(user.username)}
+                  onChange={() => toggleUserSelection(user.username)}
+                  aria-label={`Select user ${user.username}`}
+                />
+              </TableCell>
+            )}
             <TableCell css={{ flex: 2 }}>
               <Link
                 componentId="admin.users.username_link"
@@ -280,7 +289,16 @@ const UsersTab = () => {
 
 const RolesTab = () => {
   const { theme } = useDesignSystemTheme();
-  const { data: rolesData, isLoading, error: queryError } = useRolesQuery();
+  // Platform admins can list every role; workspace admins must scope to a
+  // workspace they manage (``validate_can_list_roles`` requires a non-empty
+  // workspace param for non-platform-admins). When a workspace admin lands
+  // on /admin without an active workspace selected we suppress the query
+  // and surface an info state, since the request would 403.
+  const isAdmin = useCurrentUserIsAdmin();
+  const activeWorkspace = useActiveWorkspace();
+  const queryWorkspace = isAdmin ? undefined : (activeWorkspace ?? undefined);
+  const queryEnabled = isAdmin || Boolean(activeWorkspace);
+  const { data: rolesData, isLoading, error: queryError } = useRolesQuery(queryWorkspace, { enabled: queryEnabled });
   const deleteRole = useDeleteRole();
   const withReturnTo = useWithSettingsReturnTo();
 
@@ -308,6 +326,27 @@ const RolesTab = () => {
     clearSelection();
     setBulkDeleteOpen(false);
   };
+
+  // Workspace admin landed on /admin without an active workspace selected:
+  // skip the (guaranteed-403) request and tell them how to proceed instead.
+  if (!queryEnabled) {
+    return (
+      <Empty
+        title={
+          <FormattedMessage
+            defaultMessage="Select a workspace"
+            description="Roles tab empty state shown to workspace admins without an active workspace"
+          />
+        }
+        description={
+          <FormattedMessage
+            defaultMessage="Pick a workspace from the workspace selector to see roles you can manage."
+            description="Roles tab empty state body when no workspace is selected"
+          />
+        }
+      />
+    );
+  }
 
   if (isLoading) {
     return (
@@ -363,25 +402,27 @@ const RolesTab = () => {
           gap: theme.spacing.sm,
         }}
       >
-        <Button
-          componentId="admin.roles.bulk_delete_button"
-          danger
-          disabled={visibleSelectedRoleIds.size === 0}
-          onClick={() => setBulkDeleteOpen(true)}
-        >
-          {visibleSelectedRoleIds.size === 0 ? (
-            <FormattedMessage
-              defaultMessage="Delete"
-              description="Bulk-delete button on the roles table (no rows selected)"
-            />
-          ) : (
-            <FormattedMessage
-              defaultMessage="Delete ({count})"
-              description="Bulk-delete button on the roles table"
-              values={{ count: visibleSelectedRoleIds.size }}
-            />
-          )}
-        </Button>
+        {isAdmin && (
+          <Button
+            componentId="admin.roles.bulk_delete_button"
+            danger
+            disabled={visibleSelectedRoleIds.size === 0}
+            onClick={() => setBulkDeleteOpen(true)}
+          >
+            {visibleSelectedRoleIds.size === 0 ? (
+              <FormattedMessage
+                defaultMessage="Delete"
+                description="Bulk-delete button on the roles table (no rows selected)"
+              />
+            ) : (
+              <FormattedMessage
+                defaultMessage="Delete ({count})"
+                description="Bulk-delete button on the roles table"
+                values={{ count: visibleSelectedRoleIds.size }}
+              />
+            )}
+          </Button>
+        )}
         <Button componentId="admin.roles.create_button" type="primary" onClick={() => setShowCreateModal(true)}>
           <FormattedMessage defaultMessage="Create Role" description="Button to create a new role" />
         </Button>
@@ -397,14 +438,16 @@ const RolesTab = () => {
         }}
       >
         <TableRow isHeader>
-          <TableHeader componentId="admin.roles.select_header" css={{ flex: 0, minWidth: 40, maxWidth: 40 }}>
-            <Checkbox
-              componentId="admin.roles.select_all"
-              isChecked={allSelected}
-              onChange={toggleSelectAll}
-              aria-label="Select all roles"
-            />
-          </TableHeader>
+          {isAdmin && (
+            <TableHeader componentId="admin.roles.select_header" css={{ flex: 0, minWidth: 40, maxWidth: 40 }}>
+              <Checkbox
+                componentId="admin.roles.select_all"
+                isChecked={allSelected}
+                onChange={toggleSelectAll}
+                aria-label="Select all roles"
+              />
+            </TableHeader>
+          )}
           <TableHeader componentId="admin.roles.name_header" css={{ flex: 2 }}>
             <FormattedMessage defaultMessage="Name" description="Roles table name header" />
           </TableHeader>
@@ -423,14 +466,16 @@ const RolesTab = () => {
         </TableRow>
         {roles.map((role) => (
           <TableRow key={role.id}>
-            <TableCell css={{ flex: 0, minWidth: 40, maxWidth: 40 }}>
-              <Checkbox
-                componentId="admin.roles.select_row"
-                isChecked={visibleSelectedRoleIds.has(role.id)}
-                onChange={() => toggleRoleSelection(role.id)}
-                aria-label={`Select role ${role.name}`}
-              />
-            </TableCell>
+            {isAdmin && (
+              <TableCell css={{ flex: 0, minWidth: 40, maxWidth: 40 }}>
+                <Checkbox
+                  componentId="admin.roles.select_row"
+                  isChecked={visibleSelectedRoleIds.has(role.id)}
+                  onChange={() => toggleRoleSelection(role.id)}
+                  aria-label={`Select role ${role.name}`}
+                />
+              </TableCell>
+            )}
             <TableCell css={{ flex: 2 }}>
               <Link componentId="admin.roles.name_link" to={withReturnTo(AdminRoutes.getRoleDetailRoute(role.id))}>
                 {role.name}

--- a/mlflow/server/js/src/admin/pages/AdminPage.tsx
+++ b/mlflow/server/js/src/admin/pages/AdminPage.tsx
@@ -33,48 +33,26 @@ import {
   useDeleteUser,
   useRolesQuery,
   useDeleteRole,
-  useUserRolesQuery,
   useWithSettingsReturnTo,
 } from '../hooks';
 import { isWorkspaceAdminRole } from '../types';
+import type { Role } from '../types';
 import { CreateUserModal } from '../components/CreateUserModal';
 import { CreateRoleModal } from '../components/CreateRoleModal';
 
-// One ``useUserRolesQuery`` per row. Produces an N+1 burst on the Users
-// tab — accepted as a v1 trade-off since the per-row signal is genuinely
-// useful for both platform admins and workspace managers; a backend
-// "list users with my visible roles" endpoint would fold this into one
-// request and is the natural follow-up. ``showErrorOnFailure`` lets the
-// parent ask for a red signal on real fetch failures (platform admins
-// reviewing user state) while workspace managers silently fall back to
-// ``—`` when ``validate_can_view_user_roles`` 403s for users outside
-// their workspaces. ``scopeWorkspace`` (when set) filters the result to
-// roles in that workspace only — keeps the per-user cell aligned with
-// the page's per-workspace scope (the backend self-check returns global
-// roles, and a wp-admin viewing another user gets every workspace they
-// administer, which is broader than the active page's scope).
+// Reads roles from the user object eager-loaded by ``useUsersQuery`` —
+// no per-row request. The backend already scopes the list per requester
+// (admin sees all; workspace managers see only roles in workspaces they
+// administer). ``scopeWorkspace`` further narrows to the active workspace
+// for the per-workspace admin page, so the cell matches the page scope.
 const UserRolesCell = ({
-  username,
-  showErrorOnFailure,
+  roles: allRoles,
   scopeWorkspace,
 }: {
-  username: string;
-  showErrorOnFailure: boolean;
+  roles: readonly Role[];
   scopeWorkspace: string | null;
 }) => {
   const { theme } = useDesignSystemTheme();
-  const { data, isLoading, error } = useUserRolesQuery(username);
-  if (isLoading) {
-    return <Spinner size="small" />;
-  }
-  if (error && showErrorOnFailure) {
-    return (
-      <Typography.Text color="error" size="sm">
-        Failed to load
-      </Typography.Text>
-    );
-  }
-  const allRoles = error ? [] : (data?.roles ?? []);
   const roles = scopeWorkspace ? allRoles.filter((r) => r.workspace === scopeWorkspace) : allRoles;
   if (roles.length === 0) {
     return <Typography.Text color="secondary">—</Typography.Text>;
@@ -282,11 +260,7 @@ const UsersTab = () => {
               </Link>
             </TableCell>
             <TableCell css={{ flex: 2 }}>
-              <UserRolesCell
-                username={user.username}
-                showErrorOnFailure={isAdmin}
-                scopeWorkspace={rolesScopeWorkspace}
-              />
+              <UserRolesCell roles={user.roles ?? []} scopeWorkspace={rolesScopeWorkspace} />
             </TableCell>
             <TableCell css={{ flex: 1 }}>
               {user.is_admin ? (

--- a/mlflow/server/js/src/admin/pages/AdminPage.tsx
+++ b/mlflow/server/js/src/admin/pages/AdminPage.tsx
@@ -40,31 +40,29 @@ import { isWorkspaceAdminRole } from '../types';
 import { CreateUserModal } from '../components/CreateUserModal';
 import { CreateRoleModal } from '../components/CreateRoleModal';
 
-// Renders one line per role assigned to a user, formatted as
-// `<workspace> → <role_name>`. Mirrors the `<scope> → <value>` shape used
-// elsewhere in the admin UI (e.g. the Account page's permission lines like
-// `experiment:* → READ`). Each row issues its own request — React Query
-// caches per-username so subsequent re-renders don't re-fetch.
-// ``enabled`` is false for workspace managers to avoid an N+1 burst of
-// mostly-403 requests (one fetch per visible user row).
-const UserRolesCell = ({ username, enabled }: { username: string; enabled: boolean }) => {
+// One ``useUserRolesQuery`` per row. Produces an N+1 burst on the Users
+// tab — accepted as a v1 trade-off since the per-row signal is genuinely
+// useful for both platform admins and workspace managers; a backend
+// "list users with my visible roles" endpoint would fold this into one
+// request and is the natural follow-up. ``showErrorOnFailure`` lets the
+// parent ask for a red signal on real fetch failures (platform admins
+// reviewing user state) while workspace managers silently fall back to
+// ``—`` when ``validate_can_view_user_roles`` 403s for users outside
+// their workspaces.
+const UserRolesCell = ({ username, showErrorOnFailure }: { username: string; showErrorOnFailure: boolean }) => {
   const { theme } = useDesignSystemTheme();
-  const { data, isLoading, error } = useUserRolesQuery(username, { enabled });
-  if (!enabled) {
-    return <Typography.Text color="secondary">—</Typography.Text>;
-  }
+  const { data, isLoading, error } = useUserRolesQuery(username);
   if (isLoading) {
     return <Spinner size="small" />;
   }
-  if (error) {
-    // Only platform admins reach this branch; surface real fetch failures.
+  if (error && showErrorOnFailure) {
     return (
       <Typography.Text color="error" size="sm">
         Failed to load
       </Typography.Text>
     );
   }
-  const roles = data?.roles ?? [];
+  const roles = error ? [] : (data?.roles ?? []);
   if (roles.length === 0) {
     return <Typography.Text color="secondary">—</Typography.Text>;
   }
@@ -266,7 +264,7 @@ const UsersTab = () => {
               </Link>
             </TableCell>
             <TableCell css={{ flex: 2 }}>
-              <UserRolesCell username={user.username} enabled={isAdmin} />
+              <UserRolesCell username={user.username} showErrorOnFailure={isAdmin} />
             </TableCell>
             <TableCell css={{ flex: 1 }}>
               {user.is_admin ? (

--- a/mlflow/server/js/src/admin/pages/AdminPage.tsx
+++ b/mlflow/server/js/src/admin/pages/AdminPage.tsx
@@ -44,11 +44,8 @@ import { CreateRoleModal } from '../components/CreateRoleModal';
 // elsewhere in the admin UI (e.g. the Account page's permission lines like
 // `experiment:* → READ`). Each row issues its own request — React Query
 // caches per-username so subsequent re-renders don't re-fetch.
-// ``enabled`` lets the parent suppress the per-row request for workspace
-// managers, where ``validate_can_view_user_roles`` would 403 for any user
-// outside a workspace they manage — an N+1 burst of mostly-403 requests
-// per page load. Workspace managers see ``—`` for everyone in this column
-// and drill into a user's detail page for scoped role info instead.
+// ``enabled`` is false for workspace managers to avoid an N+1 burst of
+// mostly-403 requests (one fetch per visible user row).
 const UserRolesCell = ({ username, enabled }: { username: string; enabled: boolean }) => {
   const { theme } = useDesignSystemTheme();
   const { data, isLoading, error } = useUserRolesQuery(username, { enabled });
@@ -59,10 +56,7 @@ const UserRolesCell = ({ username, enabled }: { username: string; enabled: boole
     return <Spinner size="small" />;
   }
   if (error) {
-    // Distinguish "no roles assigned" from "we couldn't load roles" — only
-    // platform admins reach this branch (workspace managers short-circuit
-    // above), so a red signal is appropriate; an admin reviewing user state
-    // should know when a fetch genuinely failed.
+    // Only platform admins reach this branch; surface real fetch failures.
     return (
       <Typography.Text color="error" size="sm">
         Failed to load
@@ -92,11 +86,8 @@ const UsersTab = () => {
   const currentUsername = currentUserData?.user?.username;
   const deleteUser = useDeleteUser();
   const withReturnTo = useWithSettingsReturnTo();
-  // Workspace admins can create users (so they can seed an account before
-  // assigning it a role in a workspace they manage), but deletion stays
-  // super-admin-only — so the row-selection checkbox column and the bulk
-  // delete button only render for platform admins. The Create User button
-  // renders for both groups.
+  // Bulk-delete + row checkboxes are platform-admin-only; Create User is
+  // open to workspace admins.
   const isAdmin = useCurrentUserIsAdmin();
   const isWorkspaceAdmin = useCurrentUserIsWorkspaceAdmin();
   const canCreateUser = isAdmin || isWorkspaceAdmin;
@@ -309,15 +300,11 @@ const UsersTab = () => {
 
 const RolesTab = () => {
   const { theme } = useDesignSystemTheme();
-  // Platform admins can list every role; workspace admins must scope to a
-  // workspace they manage (``validate_can_list_roles`` requires a non-empty
-  // workspace param for non-platform-admins). When a workspace admin lands
-  // on /admin without an active workspace selected we suppress the query
-  // and surface an info state, since the request would 403.
-  //
-  // Bulk-delete renders for either group — for workspace admins the listing
-  // is already scoped server-side to workspaces they manage, so every row
-  // they see is one ``validate_can_manage_roles`` will accept a delete for.
+  // Workspace admins must scope to a workspace they manage
+  // (``validate_can_list_roles`` rejects unscoped non-admin requests).
+  // Bulk-delete is open to both groups — the listing is already
+  // server-scoped, so every visible row is one ``validate_can_manage_roles``
+  // will accept a delete for.
   const isAdmin = useCurrentUserIsAdmin();
   const isWorkspaceAdmin = useCurrentUserIsWorkspaceAdmin();
   const canDeleteRoles = isAdmin || isWorkspaceAdmin;
@@ -353,8 +340,7 @@ const RolesTab = () => {
     setBulkDeleteOpen(false);
   };
 
-  // Workspace admin landed on /admin without an active workspace selected:
-  // skip the (guaranteed-403) request and tell them how to proceed instead.
+  // No active workspace + non-admin: skip the guaranteed 403, prompt instead.
   if (!queryEnabled) {
     return (
       <Empty
@@ -547,10 +533,6 @@ const AdminPage = () => {
   const tabFromUrl = searchParams.get('tab');
   const activeTab = tabFromUrl === 'roles' ? 'roles' : 'users';
 
-  // Title and subtitle differ for platform admins vs. workspace managers.
-  // For workspace managers we show the active workspace by name so the
-  // page makes the scope explicit; the body of the page is already scoped
-  // server-side via ``validate_can_list_roles`` and friends.
   const isAdmin = useCurrentUserIsAdmin();
   const activeWorkspace = useActiveWorkspace();
 

--- a/mlflow/server/js/src/admin/pages/AdminPage.tsx
+++ b/mlflow/server/js/src/admin/pages/AdminPage.tsx
@@ -31,7 +31,6 @@ import {
   useUsersQuery,
   useDeleteUser,
   useRolesQuery,
-  useRolesInWorkspacesQuery,
   useDeleteRole,
   useUserRolesQuery,
   useWithSettingsReturnTo,
@@ -299,17 +298,17 @@ const UsersTab = () => {
 
 const RolesTab = () => {
   const { theme } = useDesignSystemTheme();
-  // Platform admins fetch roles unscoped; workspace managers fan out one
-  // query per workspace they administer and merge. Every visible row is
+  // Platform admins fetch unscoped (every workspace); workspace managers
+  // pass the list of workspaces they administer. Every visible row is
   // therefore in a workspace the user can manage, so bulk-delete is safe.
   const isAdmin = useCurrentUserIsAdmin();
   const adminWorkspaces = useCurrentUserAdminWorkspaces();
   const canManageRoles = isAdmin || adminWorkspaces.size > 0;
-  const adminRolesQuery = useRolesQuery(undefined, { enabled: isAdmin });
-  const workspaceRolesQuery = useRolesInWorkspacesQuery(isAdmin ? new Set<string>() : adminWorkspaces);
-  const rolesData = isAdmin ? adminRolesQuery.data : workspaceRolesQuery.data;
-  const isLoading = isAdmin ? adminRolesQuery.isLoading : workspaceRolesQuery.isLoading;
-  const queryError = isAdmin ? adminRolesQuery.error : workspaceRolesQuery.error;
+  const queryWorkspaces = useMemo(
+    () => (isAdmin ? undefined : Array.from(adminWorkspaces)),
+    [isAdmin, adminWorkspaces],
+  );
+  const { data: rolesData, isLoading, error: queryError } = useRolesQuery(queryWorkspaces);
   const deleteRole = useDeleteRole();
   const withReturnTo = useWithSettingsReturnTo();
 

--- a/mlflow/server/js/src/admin/pages/UserDetailPage.tsx
+++ b/mlflow/server/js/src/admin/pages/UserDetailPage.tsx
@@ -16,7 +16,13 @@ import {
 } from '@databricks/design-system';
 import { ScrollablePageWrapper } from '@mlflow/mlflow/src/common/components/ScrollablePageWrapper';
 import { Link, useParams, useSearchParams } from '../../common/utils/RoutingUtils';
-import { useUserPermissionsQuery, useUserRolesQuery, useUsersQuery, useWithSettingsReturnTo } from '../hooks';
+import {
+  useCurrentUserIsAdmin,
+  useUserPermissionsQuery,
+  useUserRolesQuery,
+  useUsersQuery,
+  useWithSettingsReturnTo,
+} from '../hooks';
 import { useWorkspacesEnabled } from '../../experiment-tracking/hooks/useServerInfo';
 import AdminRoutes from '../routes';
 import { EditAccessModal } from '../components/EditAccessModal';
@@ -34,7 +40,7 @@ const UserDetailPage = () => {
   const tabFromUrl = searchParams.get('tab');
   const activeTab = tabFromUrl === 'permissions' ? 'permissions' : 'roles';
 
-  const { data: rolesData, isLoading: rolesLoading, error: rolesError } = useUserRolesQuery(username);
+  const { data: rolesData, isLoading: rolesLoading, error: rolesErrorRaw } = useUserRolesQuery(username);
   const { data: directPermsData, isLoading: directPermsLoading } = useUserPermissionsQuery(username);
   // ``useUsersQuery`` is admin-only; we use it just to surface the
   // ``is_admin`` flag for this user. Failing this should not block the
@@ -42,6 +48,13 @@ const UserDetailPage = () => {
   const { data: usersData } = useUsersQuery();
   const { workspacesEnabled } = useWorkspacesEnabled();
   const withReturnTo = useWithSettingsReturnTo();
+  // For workspace managers viewing a user outside their workspaces,
+  // ``validate_can_view_user_roles`` 403s — that's expected, not a failure.
+  // Hide the red error banner for non-admins so the page degrades to an
+  // empty "no visible roles" state instead of looking broken; platform
+  // admins still see real fetch failures.
+  const isAdmin = useCurrentUserIsAdmin();
+  const rolesError = isAdmin ? rolesErrorRaw : null;
 
   const [editAccessOpen, setEditAccessOpen] = useState(false);
 
@@ -50,7 +63,14 @@ const UserDetailPage = () => {
   const directPermissions = directPermsData?.permissions ?? [];
 
   const rolesEmptyState =
-    roles.length === 0 ? <Empty title="No roles" description="This user has not been assigned to any roles." /> : null;
+    roles.length === 0 ? (
+      <Empty
+        title="No roles"
+        description={
+          isAdmin ? 'This user has not been assigned to any roles.' : 'No roles visible in workspaces you manage.'
+        }
+      />
+    ) : null;
 
   if (!username) {
     return (

--- a/mlflow/server/js/src/admin/pages/UserDetailPage.tsx
+++ b/mlflow/server/js/src/admin/pages/UserDetailPage.tsx
@@ -16,6 +16,7 @@ import {
 } from '@databricks/design-system';
 import { ScrollablePageWrapper } from '@mlflow/mlflow/src/common/components/ScrollablePageWrapper';
 import { Link, useParams, useSearchParams } from '../../common/utils/RoutingUtils';
+import { useActiveWorkspace } from '../../workspaces/utils/WorkspaceUtils';
 import {
   useCurrentUserIsAdmin,
   useUserPermissionsQuery,
@@ -55,19 +56,36 @@ const UserDetailPage = () => {
   // admins still see real fetch failures.
   const isAdmin = useCurrentUserIsAdmin();
   const rolesError = isAdmin ? rolesErrorRaw : null;
+  // The /admin entry is per-workspace, so non-admin viewers should only
+  // see roles in the active workspace — including for self, where the
+  // backend's self-check returns global roles.
+  const activeWorkspace = useActiveWorkspace();
 
   const [editAccessOpen, setEditAccessOpen] = useState(false);
 
   const user = useMemo(() => usersData?.users?.find((u) => u.username === username), [usersData, username]);
-  const roles = rolesData?.roles ?? [];
-  const directPermissions = directPermsData?.permissions ?? [];
+  const allRoles = rolesData?.roles ?? [];
+  const roles = isAdmin || !activeWorkspace ? allRoles : allRoles.filter((r) => r.workspace === activeWorkspace);
+  const allDirectPermissions = directPermsData?.permissions ?? [];
+  // Direct permissions also carry ``workspace``; same scope rule.
+  // ``workspace: null`` means the underlying resource was deleted — keep
+  // those visible to platform admins, drop for workspace managers (the
+  // grant isn't actionable in any specific workspace anyway).
+  const directPermissions =
+    isAdmin || !activeWorkspace
+      ? allDirectPermissions
+      : allDirectPermissions.filter((p) => p.workspace === activeWorkspace);
 
   const rolesEmptyState =
     roles.length === 0 ? (
       <Empty
         title="No roles"
         description={
-          isAdmin ? 'This user has not been assigned to any roles.' : 'No roles visible in workspaces you manage.'
+          isAdmin
+            ? 'This user has not been assigned to any roles.'
+            : activeWorkspace
+              ? `No roles for this user in workspace "${activeWorkspace}".`
+              : 'No roles visible in workspaces you manage.'
         }
       />
     ) : null;

--- a/mlflow/server/js/src/admin/route-defs.ts
+++ b/mlflow/server/js/src/admin/route-defs.ts
@@ -11,6 +11,15 @@ export const getAdminRouteDefs = () => {
       handle: { getPageTitle: () => 'Platform Admin' } satisfies DocumentTitleHandle,
     },
     {
+      // Per-workspace management view; same ``AdminPage`` element, the
+      // pathname is the mode discriminator. Workspace value lives in
+      // ``?workspace=`` (read by ``WorkspaceRouterSync``).
+      path: AdminRoutePaths.workspaceManagementPage,
+      element: createLazyRouteElement(() => import('./pages/AdminPage')),
+      pageId: AdminPageId.workspaceManagementPage,
+      handle: { getPageTitle: () => 'Workspace Manager' } satisfies DocumentTitleHandle,
+    },
+    {
       path: AdminRoutePaths.roleDetailPage,
       element: createLazyRouteElement(() => import('./pages/RoleDetailPage')),
       pageId: AdminPageId.roleDetailPage,

--- a/mlflow/server/js/src/admin/routes.ts
+++ b/mlflow/server/js/src/admin/routes.ts
@@ -2,6 +2,7 @@ import { createMLflowRoutePath, generatePath } from '../common/utils/RoutingUtil
 
 export enum AdminPageId {
   adminPage = 'mlflow.admin',
+  workspaceManagementPage = 'mlflow.admin.workspace',
   roleDetailPage = 'mlflow.admin.role-detail',
   userDetailPage = 'mlflow.admin.user-detail',
 }
@@ -10,6 +11,14 @@ export enum AdminPageId {
 export class AdminRoutePaths {
   static get adminPage() {
     return createMLflowRoutePath('/admin');
+  }
+
+  // Per-workspace management view. Same component as ``adminPage``; the
+  // pathname is the discriminator and the workspace value still travels in
+  // the ``?workspace=`` query param so ``WorkspaceRouterSync`` keeps the
+  // global ``activeWorkspace`` in sync.
+  static get workspaceManagementPage() {
+    return createMLflowRoutePath('/admin/ws');
   }
 
   static get roleDetailPage() {
@@ -25,6 +34,12 @@ export class AdminRoutePaths {
 class AdminRoutes {
   static get adminPageRoute() {
     return AdminRoutePaths.adminPage;
+  }
+
+  static getWorkspaceManagementRoute(workspaceName: string) {
+    // Workspace name validation runs upstream; URL-encode anyway so a name
+    // containing ``&`` or ``=`` doesn't corrupt the query string.
+    return `${AdminRoutePaths.workspaceManagementPage}?workspace=${encodeURIComponent(workspaceName)}`;
   }
 
   static getRoleDetailRoute(roleId: number) {

--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -30,8 +30,8 @@ import GatewayRoutes from '../../gateway/routes';
 import AccountRoutes from '../../account/routes';
 import AdminRoutes from '../../admin/routes';
 import {
+  useCurrentUserAdminWorkspaces,
   useCurrentUserIsAdmin,
-  useCurrentUserIsWorkspaceAdmin,
   useCurrentUserQuery,
   useIsBasicAuth,
 } from '../../account/hooks';
@@ -147,12 +147,13 @@ export function MlflowSidebar({
   const showNestedExperimentItems = Boolean(activeExperimentId) && shouldEnableWorkflowBasedNavigation();
   const showNestedSettingsItems = isSettingsActive(location);
 
-  // Manage is globally accessible to platform admins and to anyone holding
-  // a workspace-admin role anywhere — /admin lists roles across all
-  // workspaces the user manages, not just the active one.
+  // Manage is per-workspace: visible to platform admins always, and to
+  // workspace admins only when the active workspace is one they manage.
+  // /admin scopes its content to the active workspace.
   const isAdmin = useCurrentUserIsAdmin();
-  const isWorkspaceAdmin = useCurrentUserIsWorkspaceAdmin();
-  const canManage = isAdmin || isWorkspaceAdmin;
+  const adminWorkspaces = useCurrentUserAdminWorkspaces();
+  const activeWorkspace = useActiveWorkspace();
+  const canManage = isAdmin || (activeWorkspace !== null && adminWorkspaces.has(activeWorkspace));
 
   const { openPanel, closePanel, isPanelOpen, isLocalServer } = useAssistant();
   const [isAssistantHovered, setIsAssistantHovered] = useState(false);
@@ -281,8 +282,8 @@ export function MlflowSidebar({
   const workspaceFromUrl = extractWorkspaceFromSearchParams(searchParams);
   // Global routes (e.g. /account) don't carry ``?workspace=`` in the URL but
   // preserve the in-memory active workspace so the sidebar's workspace-scoped
-  // links resume in the same workspace. Fall back to the active workspace.
-  const activeWorkspace = useActiveWorkspace();
+  // links resume in the same workspace. Fall back to the active workspace
+  // (already pulled in above for the Manage gate).
   const effectiveWorkspace = workspaceFromUrl ?? activeWorkspace;
   // Only show workspace-specific menu items when: workspaces are disabled OR a workspace is selected
   const showWorkspaceMenuItems = !workspacesEnabled || effectiveWorkspace !== null;

--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -29,12 +29,7 @@ import { ModelRegistryRoutes } from '../../model-registry/routes';
 import GatewayRoutes from '../../gateway/routes';
 import AccountRoutes from '../../account/routes';
 import AdminRoutes from '../../admin/routes';
-import {
-  useCurrentUserAdminWorkspaces,
-  useCurrentUserIsAdmin,
-  useCurrentUserQuery,
-  useIsBasicAuth,
-} from '../../account/hooks';
+import { useCurrentUserIsAdmin, useCurrentUserQuery, useIsBasicAuth } from '../../account/hooks';
 import { performLogout } from '../../account/auth-utils';
 import { GatewayLabel, GatewayNewTag } from './GatewayNewTag';
 import { FormattedMessage } from 'react-intl';
@@ -147,13 +142,12 @@ export function MlflowSidebar({
   const showNestedExperimentItems = Boolean(activeExperimentId) && shouldEnableWorkflowBasedNavigation();
   const showNestedSettingsItems = isSettingsActive(location);
 
-  // Manage is per-workspace: visible to platform admins always, and to
-  // workspace admins only when the active workspace is one they manage.
-  // /admin scopes its content to the active workspace.
+  // Manage in the avatar dropdown is platform-admin-only — a fast-path
+  // they can hit from anywhere. Workspace managers reach /admin via the
+  // gear icon in the workspaces table on the home page instead, which
+  // ties the entry point to a specific workspace they administer.
   const isAdmin = useCurrentUserIsAdmin();
-  const adminWorkspaces = useCurrentUserAdminWorkspaces();
-  const activeWorkspace = useActiveWorkspace();
-  const canManage = isAdmin || (activeWorkspace !== null && adminWorkspaces.has(activeWorkspace));
+  const canManage = isAdmin;
 
   const { openPanel, closePanel, isPanelOpen, isLocalServer } = useAssistant();
   const [isAssistantHovered, setIsAssistantHovered] = useState(false);
@@ -282,8 +276,8 @@ export function MlflowSidebar({
   const workspaceFromUrl = extractWorkspaceFromSearchParams(searchParams);
   // Global routes (e.g. /account) don't carry ``?workspace=`` in the URL but
   // preserve the in-memory active workspace so the sidebar's workspace-scoped
-  // links resume in the same workspace. Fall back to the active workspace
-  // (already pulled in above for the Manage gate).
+  // links resume in the same workspace. Fall back to the active workspace.
+  const activeWorkspace = useActiveWorkspace();
   const effectiveWorkspace = workspaceFromUrl ?? activeWorkspace;
   // Only show workspace-specific menu items when: workspaces are disabled OR a workspace is selected
   const showWorkspaceMenuItems = !workspacesEnabled || effectiveWorkspace !== null;

--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -29,7 +29,12 @@ import { ModelRegistryRoutes } from '../../model-registry/routes';
 import GatewayRoutes from '../../gateway/routes';
 import AccountRoutes from '../../account/routes';
 import AdminRoutes from '../../admin/routes';
-import { useCurrentUserIsAdmin, useCurrentUserQuery, useIsBasicAuth } from '../../account/hooks';
+import {
+  useCurrentUserIsAdmin,
+  useCurrentUserIsWorkspaceAdmin,
+  useCurrentUserQuery,
+  useIsBasicAuth,
+} from '../../account/hooks';
 import { performLogout } from '../../account/auth-utils';
 import { GatewayLabel, GatewayNewTag } from './GatewayNewTag';
 import { FormattedMessage } from 'react-intl';
@@ -142,7 +147,13 @@ export function MlflowSidebar({
   const showNestedExperimentItems = Boolean(activeExperimentId) && shouldEnableWorkflowBasedNavigation();
   const showNestedSettingsItems = isSettingsActive(location);
 
+  // Show the Manage entry to platform admins AND to workspace admins
+  // (users holding ``(workspace, *, MANAGE)`` in any workspace). Both
+  // groups can use the /admin page; backend validators handle the
+  // scoped behavior beyond that.
   const isAdmin = useCurrentUserIsAdmin();
+  const isWorkspaceAdmin = useCurrentUserIsWorkspaceAdmin();
+  const canManage = isAdmin || isWorkspaceAdmin;
 
   const { openPanel, closePanel, isPanelOpen, isLocalServer } = useAssistant();
   const [isAssistantHovered, setIsAssistantHovered] = useState(false);
@@ -532,7 +543,7 @@ export function MlflowSidebar({
                   >
                     <FormattedMessage defaultMessage="Account" description="Sidebar account menu item" />
                   </DropdownMenu.Item>
-                  {isAdmin && (
+                  {canManage && (
                     <DropdownMenu.Item
                       componentId="mlflow.sidebar.manage"
                       onPointerDown={() => {

--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -147,13 +147,8 @@ export function MlflowSidebar({
   const showNestedExperimentItems = Boolean(activeExperimentId) && shouldEnableWorkflowBasedNavigation();
   const showNestedSettingsItems = isSettingsActive(location);
 
-  // Show the Manage entry to platform admins always, and to workspace
-  // admins only when their currently-active workspace is one they manage
-  // — otherwise /admin's Roles tab can't fetch anything they're allowed
-  // to see (``validate_can_list_roles`` rejects unscoped non-admin
-  // requests). Falling out of the dropdown when context shifts is less
-  // confusing than offering a destination that immediately lands on a
-  // "select a workspace" empty state.
+  // Hide Manage for workspace admins when the active workspace isn't one
+  // they manage — otherwise /admin's Roles tab would 403 and dead-end them.
   const isAdmin = useCurrentUserIsAdmin();
   const adminWorkspaces = useCurrentUserAdminWorkspaces();
   const activeWorkspace = useActiveWorkspace();
@@ -286,8 +281,7 @@ export function MlflowSidebar({
   const workspaceFromUrl = extractWorkspaceFromSearchParams(searchParams);
   // Global routes (e.g. /account) don't carry ``?workspace=`` in the URL but
   // preserve the in-memory active workspace so the sidebar's workspace-scoped
-  // links resume in the same workspace. Fall back to the active workspace
-  // (``activeWorkspace`` is already pulled in above for the Manage gate).
+  // links resume in the same workspace. Fall back to the active workspace.
   const effectiveWorkspace = workspaceFromUrl ?? activeWorkspace;
   // Only show workspace-specific menu items when: workspaces are disabled OR a workspace is selected
   const showWorkspaceMenuItems = !workspacesEnabled || effectiveWorkspace !== null;

--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -30,8 +30,8 @@ import GatewayRoutes from '../../gateway/routes';
 import AccountRoutes from '../../account/routes';
 import AdminRoutes from '../../admin/routes';
 import {
+  useCurrentUserAdminWorkspaces,
   useCurrentUserIsAdmin,
-  useCurrentUserIsWorkspaceAdmin,
   useCurrentUserQuery,
   useIsBasicAuth,
 } from '../../account/hooks';
@@ -147,13 +147,17 @@ export function MlflowSidebar({
   const showNestedExperimentItems = Boolean(activeExperimentId) && shouldEnableWorkflowBasedNavigation();
   const showNestedSettingsItems = isSettingsActive(location);
 
-  // Show the Manage entry to platform admins AND to workspace admins
-  // (users holding ``(workspace, *, MANAGE)`` in any workspace). Both
-  // groups can use the /admin page; backend validators handle the
-  // scoped behavior beyond that.
+  // Show the Manage entry to platform admins always, and to workspace
+  // admins only when their currently-active workspace is one they manage
+  // — otherwise /admin's Roles tab can't fetch anything they're allowed
+  // to see (``validate_can_list_roles`` rejects unscoped non-admin
+  // requests). Falling out of the dropdown when context shifts is less
+  // confusing than offering a destination that immediately lands on a
+  // "select a workspace" empty state.
   const isAdmin = useCurrentUserIsAdmin();
-  const isWorkspaceAdmin = useCurrentUserIsWorkspaceAdmin();
-  const canManage = isAdmin || isWorkspaceAdmin;
+  const adminWorkspaces = useCurrentUserAdminWorkspaces();
+  const activeWorkspace = useActiveWorkspace();
+  const canManage = isAdmin || (activeWorkspace !== null && adminWorkspaces.has(activeWorkspace));
 
   const { openPanel, closePanel, isPanelOpen, isLocalServer } = useAssistant();
   const [isAssistantHovered, setIsAssistantHovered] = useState(false);
@@ -282,8 +286,8 @@ export function MlflowSidebar({
   const workspaceFromUrl = extractWorkspaceFromSearchParams(searchParams);
   // Global routes (e.g. /account) don't carry ``?workspace=`` in the URL but
   // preserve the in-memory active workspace so the sidebar's workspace-scoped
-  // links resume in the same workspace. Fall back to the active workspace.
-  const activeWorkspace = useActiveWorkspace();
+  // links resume in the same workspace. Fall back to the active workspace
+  // (``activeWorkspace`` is already pulled in above for the Manage gate).
   const effectiveWorkspace = workspaceFromUrl ?? activeWorkspace;
   // Only show workspace-specific menu items when: workspaces are disabled OR a workspace is selected
   const showWorkspaceMenuItems = !workspacesEnabled || effectiveWorkspace !== null;

--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -30,8 +30,8 @@ import GatewayRoutes from '../../gateway/routes';
 import AccountRoutes from '../../account/routes';
 import AdminRoutes from '../../admin/routes';
 import {
-  useCurrentUserAdminWorkspaces,
   useCurrentUserIsAdmin,
+  useCurrentUserIsWorkspaceAdmin,
   useCurrentUserQuery,
   useIsBasicAuth,
 } from '../../account/hooks';
@@ -147,12 +147,12 @@ export function MlflowSidebar({
   const showNestedExperimentItems = Boolean(activeExperimentId) && shouldEnableWorkflowBasedNavigation();
   const showNestedSettingsItems = isSettingsActive(location);
 
-  // Hide Manage for workspace admins when the active workspace isn't one
-  // they manage — otherwise /admin's Roles tab would 403 and dead-end them.
+  // Manage is globally accessible to platform admins and to anyone holding
+  // a workspace-admin role anywhere — /admin lists roles across all
+  // workspaces the user manages, not just the active one.
   const isAdmin = useCurrentUserIsAdmin();
-  const adminWorkspaces = useCurrentUserAdminWorkspaces();
-  const activeWorkspace = useActiveWorkspace();
-  const canManage = isAdmin || (activeWorkspace !== null && adminWorkspaces.has(activeWorkspace));
+  const isWorkspaceAdmin = useCurrentUserIsWorkspaceAdmin();
+  const canManage = isAdmin || isWorkspaceAdmin;
 
   const { openPanel, closePanel, isPanelOpen, isLocalServer } = useAssistant();
   const [isAssistantHovered, setIsAssistantHovered] = useState(false);
@@ -282,6 +282,7 @@ export function MlflowSidebar({
   // Global routes (e.g. /account) don't carry ``?workspace=`` in the URL but
   // preserve the in-memory active workspace so the sidebar's workspace-scoped
   // links resume in the same workspace. Fall back to the active workspace.
+  const activeWorkspace = useActiveWorkspace();
   const effectiveWorkspace = workspaceFromUrl ?? activeWorkspace;
   // Only show workspace-specific menu items when: workspaces are disabled OR a workspace is selected
   const showWorkspaceMenuItems = !workspacesEnabled || effectiveWorkspace !== null;

--- a/mlflow/server/js/src/home/components/WorkspacesHomeView.test.tsx
+++ b/mlflow/server/js/src/home/components/WorkspacesHomeView.test.tsx
@@ -5,12 +5,18 @@ import userEvent from '@testing-library/user-event';
 import { WorkspacesHomeView } from './WorkspacesHomeView';
 import { useWorkspaces } from '../../workspaces/hooks/useWorkspaces';
 import { getLastUsedWorkspace } from '../../workspaces/utils/WorkspaceUtils';
-import { renderWithIntl, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
+import { useCurrentUserAdminWorkspaces } from '../../account/hooks';
+import { renderWithDesignSystem, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
 import { MemoryRouter } from '../../common/utils/RoutingUtils';
 import { QueryClient, QueryClientProvider } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
 
 jest.mock('../../workspaces/hooks/useWorkspaces');
 jest.mock('../../workspaces/utils/WorkspaceUtils');
+jest.mock('../../account/hooks', () => ({
+  useCurrentUserAdminWorkspaces: jest.fn<() => Set<string>>(() => new Set()),
+}));
+
+const mockedAdminWorkspaces = jest.mocked(useCurrentUserAdminWorkspaces);
 
 const reloadMock = jest.fn();
 
@@ -27,6 +33,9 @@ describe('WorkspacesHomeView', () => {
     jest.clearAllMocks();
     // Mock last used workspace for "Last used" badge
     jest.mocked(getLastUsedWorkspace).mockReturnValue('ml-research');
+    // Default: no admin reach. Individual cases override for the
+    // workspace-manager column-visibility tests.
+    mockedAdminWorkspaces.mockReturnValue(new Set());
 
     Object.defineProperty(window, 'location', {
       value: { ...window.location, reload: reloadMock },
@@ -45,7 +54,7 @@ describe('WorkspacesHomeView', () => {
         mutations: { retry: false },
       },
     });
-    return renderWithIntl(
+    return renderWithDesignSystem(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
           <WorkspacesHomeView onCreateWorkspace={mockOnCreateWorkspace} />
@@ -194,5 +203,44 @@ describe('WorkspacesHomeView', () => {
     const retryButton = screen.getByText('Retry');
     await userEvent.click(retryButton);
     expect(mockRefetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('hides Manage column when the user has no admin workspaces', () => {
+    // Covers both platform admins (``useCurrentUserAdminWorkspaces`` short-
+    // circuits to an empty set for them) and regular users. Platform admins
+    // navigate via the sidebar Manage entry, not this gear column.
+    mockedAdminWorkspaces.mockReturnValue(new Set());
+    jest.mocked(useWorkspaces).mockReturnValue({
+      workspaces: [
+        { name: 'ml-research', description: 'Research experiments' },
+        { name: 'production-models', description: 'Production-ready models' },
+      ],
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn() as any,
+    });
+
+    renderComponent();
+    expect(screen.queryByText('Manage')).not.toBeInTheDocument();
+    expect(screen.queryAllByLabelText(/Manage workspace/)).toHaveLength(0);
+  });
+
+  test('shows Manage column with gear icon only on workspaces the user administers', () => {
+    mockedAdminWorkspaces.mockReturnValue(new Set(['ml-research']));
+    jest.mocked(useWorkspaces).mockReturnValue({
+      workspaces: [
+        { name: 'ml-research', description: 'Research experiments' },
+        { name: 'production-models', description: 'Production-ready models' },
+      ],
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn() as any,
+    });
+
+    renderComponent();
+    expect(screen.getByText('Manage')).toBeInTheDocument();
+    const gears = screen.getAllByLabelText(/Manage workspace/);
+    expect(gears).toHaveLength(1);
+    expect(gears[0]).toHaveAttribute('aria-label', 'Manage workspace ml-research');
   });
 });

--- a/mlflow/server/js/src/home/components/WorkspacesHomeView.test.tsx
+++ b/mlflow/server/js/src/home/components/WorkspacesHomeView.test.tsx
@@ -268,4 +268,22 @@ describe('WorkspacesHomeView', () => {
     expect(gears).toHaveLength(1);
     expect(gears[0]).toHaveAttribute('aria-label', 'Manage workspace ml-research');
   });
+
+  test('Manage gear navigates to the per-workspace admin route', async () => {
+    mockedAdminWorkspaces.mockReturnValue(new Set(['ml-research']));
+    jest.mocked(useWorkspaces).mockReturnValue({
+      workspaces: [{ name: 'ml-research', description: 'Research experiments' }],
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn() as any,
+    });
+
+    renderComponent();
+    const gear = screen.getByLabelText('Manage workspace ml-research');
+    await userEvent.click(gear);
+
+    // Hard reload onto ``/admin/ws?workspace=…`` — the per-workspace mode.
+    expect(window.location.hash).toBe('#/admin/ws?workspace=ml-research');
+    expect(window.location.reload).toHaveBeenCalled();
+  });
 });

--- a/mlflow/server/js/src/home/components/WorkspacesHomeView.test.tsx
+++ b/mlflow/server/js/src/home/components/WorkspacesHomeView.test.tsx
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { WorkspacesHomeView } from './WorkspacesHomeView';
 import { useWorkspaces } from '../../workspaces/hooks/useWorkspaces';
 import { getLastUsedWorkspace } from '../../workspaces/utils/WorkspaceUtils';
-import { useCurrentUserAdminWorkspaces } from '../../account/hooks';
+import { useCurrentUserAdminWorkspaces, useCurrentUserIsAdmin } from '../../account/hooks';
 import { renderWithDesignSystem, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
 import { MemoryRouter } from '../../common/utils/RoutingUtils';
 import { QueryClient, QueryClientProvider } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
@@ -14,9 +14,11 @@ jest.mock('../../workspaces/hooks/useWorkspaces');
 jest.mock('../../workspaces/utils/WorkspaceUtils');
 jest.mock('../../account/hooks', () => ({
   useCurrentUserAdminWorkspaces: jest.fn<() => Set<string>>(() => new Set()),
+  useCurrentUserIsAdmin: jest.fn<() => boolean>(() => false),
 }));
 
 const mockedAdminWorkspaces = jest.mocked(useCurrentUserAdminWorkspaces);
+const mockedIsAdmin = jest.mocked(useCurrentUserIsAdmin);
 
 const reloadMock = jest.fn();
 
@@ -33,9 +35,10 @@ describe('WorkspacesHomeView', () => {
     jest.clearAllMocks();
     // Mock last used workspace for "Last used" badge
     jest.mocked(getLastUsedWorkspace).mockReturnValue('ml-research');
-    // Default: no admin reach. Individual cases override for the
-    // workspace-manager column-visibility tests.
+    // Default: regular user with no admin reach. Individual cases override
+    // for the workspace-manager / platform-admin column-visibility tests.
     mockedAdminWorkspaces.mockReturnValue(new Set());
+    mockedIsAdmin.mockReturnValue(false);
 
     Object.defineProperty(window, 'location', {
       value: { ...window.location, reload: reloadMock },
@@ -206,10 +209,32 @@ describe('WorkspacesHomeView', () => {
   });
 
   test('hides Manage column when the user has no admin workspaces', () => {
-    // Covers both platform admins (``useCurrentUserAdminWorkspaces`` short-
-    // circuits to an empty set for them) and regular users. Platform admins
-    // navigate via the sidebar Manage entry, not this gear column.
+    // Regular user with no admin reach — the typical case.
     mockedAdminWorkspaces.mockReturnValue(new Set());
+    mockedIsAdmin.mockReturnValue(false);
+    jest.mocked(useWorkspaces).mockReturnValue({
+      workspaces: [
+        { name: 'ml-research', description: 'Research experiments' },
+        { name: 'production-models', description: 'Production-ready models' },
+      ],
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn() as any,
+    });
+
+    renderComponent();
+    expect(screen.queryByText('Manage')).not.toBeInTheDocument();
+    expect(screen.queryAllByLabelText(/Manage workspace/)).toHaveLength(0);
+  });
+
+  test('hides Manage column for platform admins even if their admin workspaces set is non-empty', () => {
+    // Defense-in-depth: ``useCurrentUserAdminWorkspaces`` already short-
+    // circuits to an empty set for admins, but the visibility predicate
+    // additionally gates on ``!isAdmin`` so the gear stays hidden if that
+    // short-circuit ever changes. Simulate a future hook returning the
+    // admin's MANAGE roles and assert the column is still hidden.
+    mockedIsAdmin.mockReturnValue(true);
+    mockedAdminWorkspaces.mockReturnValue(new Set(['ml-research']));
     jest.mocked(useWorkspaces).mockReturnValue({
       workspaces: [
         { name: 'ml-research', description: 'Research experiments' },

--- a/mlflow/server/js/src/home/components/WorkspacesHomeView.tsx
+++ b/mlflow/server/js/src/home/components/WorkspacesHomeView.tsx
@@ -19,7 +19,7 @@ import {
 } from '@databricks/design-system';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { Link } from '../../common/utils/RoutingUtils';
-import { useCurrentUserAdminWorkspaces, useCurrentUserIsAdmin } from '../../account/hooks';
+import { useCurrentUserAdminWorkspaces } from '../../account/hooks';
 import { useWorkspaces, type Workspace } from '../../workspaces/hooks/useWorkspaces';
 import {
   getLastUsedWorkspace,
@@ -375,12 +375,12 @@ export const WorkspacesHomeView = ({ onCreateWorkspace }: WorkspacesHomeViewProp
   // Get last used workspace from localStorage for the "Last used" badge
   const lastUsedWorkspace = getLastUsedWorkspace();
   const [currentPage, setCurrentPage] = useState(1);
-  // Manage column: shown only to users with admin reach somewhere (platform
-  // admin sees it on every row; workspace managers see it only on rows for
-  // workspaces they administer).
-  const isAdmin = useCurrentUserIsAdmin();
+  // Manage column: shown only to workspace managers — gear icon scopes
+  // ``/admin?workspace=<name>`` for them. Platform admins navigate via the
+  // sidebar ``Manage`` entry instead, since the admin page ignores the
+  // workspace param for them anyway.
   const adminWorkspaces = useCurrentUserAdminWorkspaces();
-  const showManageColumn = isAdmin || adminWorkspaces.size > 0;
+  const showManageColumn = adminWorkspaces.size > 0;
 
   const shouldShowEmptyState = !isLoading && !isError && workspaces.length === 0;
 
@@ -503,7 +503,7 @@ export const WorkspacesHomeView = ({ onCreateWorkspace }: WorkspacesHomeViewProp
                   key={workspace.name}
                   workspace={workspace}
                   isLastUsed={workspace.name === lastUsedWorkspace}
-                  canManage={isAdmin || adminWorkspaces.has(workspace.name)}
+                  canManage={adminWorkspaces.has(workspace.name)}
                   showManageColumn={showManageColumn}
                 />
               ))

--- a/mlflow/server/js/src/home/components/WorkspacesHomeView.tsx
+++ b/mlflow/server/js/src/home/components/WorkspacesHomeView.tsx
@@ -19,7 +19,7 @@ import {
 } from '@databricks/design-system';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { Link } from '../../common/utils/RoutingUtils';
-import { useCurrentUserAdminWorkspaces } from '../../account/hooks';
+import { useCurrentUserAdminWorkspaces, useCurrentUserIsAdmin } from '../../account/hooks';
 import { useWorkspaces, type Workspace } from '../../workspaces/hooks/useWorkspaces';
 import {
   getLastUsedWorkspace,
@@ -379,8 +379,15 @@ export const WorkspacesHomeView = ({ onCreateWorkspace }: WorkspacesHomeViewProp
   // ``/admin?workspace=<name>`` for them. Platform admins navigate via the
   // sidebar ``Manage`` entry instead, since the admin page ignores the
   // workspace param for them anyway.
+  //
+  // ``useCurrentUserAdminWorkspaces`` already short-circuits to an empty set
+  // for admins (it skips the role fetch when ``is_admin`` is true), so the
+  // ``adminWorkspaces.size`` check alone would suffice — but explicitly
+  // gating on ``!isAdmin`` is defense-in-depth so the gear stays hidden for
+  // admins even if that short-circuit ever changes.
+  const isAdmin = useCurrentUserIsAdmin();
   const adminWorkspaces = useCurrentUserAdminWorkspaces();
-  const showManageColumn = adminWorkspaces.size > 0;
+  const showManageColumn = !isAdmin && adminWorkspaces.size > 0;
 
   const shouldShowEmptyState = !isLoading && !isError && workspaces.length === 0;
 
@@ -503,7 +510,7 @@ export const WorkspacesHomeView = ({ onCreateWorkspace }: WorkspacesHomeViewProp
                   key={workspace.name}
                   workspace={workspace}
                   isLastUsed={workspace.name === lastUsedWorkspace}
-                  canManage={adminWorkspaces.has(workspace.name)}
+                  canManage={!isAdmin && adminWorkspaces.has(workspace.name)}
                   showManageColumn={showManageColumn}
                 />
               ))

--- a/mlflow/server/js/src/home/components/WorkspacesHomeView.tsx
+++ b/mlflow/server/js/src/home/components/WorkspacesHomeView.tsx
@@ -92,9 +92,12 @@ const WorkspaceRow = ({
 
   const handleManageClick = () => {
     // Same hard-reload pattern as handleNameClick — flushes any stale auth /
-    // workspace context before landing on /admin scoped to this workspace.
+    // workspace context before landing on the per-workspace management view.
+    // ``/admin/ws`` is the workspace-mode pathname; the workspace value still
+    // travels in ``?workspace=`` so ``WorkspaceRouterSync`` keeps the global
+    // ``activeWorkspace`` in sync.
     setLastUsedWorkspace(workspace.name);
-    window.location.hash = `#/admin?${WORKSPACE_QUERY_PARAM}=${encodeURIComponent(workspace.name)}`;
+    window.location.hash = `#/admin/ws?${WORKSPACE_QUERY_PARAM}=${encodeURIComponent(workspace.name)}`;
     window.location.reload();
   };
 
@@ -278,13 +281,13 @@ const WorkspaceRow = ({
                 componentId="mlflow.home.workspaces.manage_tooltip"
                 content={intl.formatMessage({
                   defaultMessage: 'Manage workspace',
-                  description: 'Tooltip on the gear icon that links to /admin scoped to this workspace',
+                  description: 'Tooltip on the gear icon that links to /admin/ws scoped to this workspace',
                 })}
               >
                 <Link
                   componentId="mlflow.home.workspaces.manage_link"
                   disableWorkspacePrefix
-                  to={`/admin?${WORKSPACE_QUERY_PARAM}=${encodeURIComponent(workspace.name)}`}
+                  to={`/admin/ws?${WORKSPACE_QUERY_PARAM}=${encodeURIComponent(workspace.name)}`}
                   onClick={(e) => {
                     e.preventDefault();
                     handleManageClick();
@@ -375,10 +378,10 @@ export const WorkspacesHomeView = ({ onCreateWorkspace }: WorkspacesHomeViewProp
   // Get last used workspace from localStorage for the "Last used" badge
   const lastUsedWorkspace = getLastUsedWorkspace();
   const [currentPage, setCurrentPage] = useState(1);
-  // Manage column: shown only to workspace managers — gear icon scopes
-  // ``/admin?workspace=<name>`` for them. Platform admins navigate via the
-  // sidebar ``Manage`` entry instead, since the admin page ignores the
-  // workspace param for them anyway.
+  // Manage column: shown only to workspace managers — gear icon links to
+  // ``/admin/ws?workspace=<name>`` (the per-workspace management view).
+  // Platform admins navigate via the sidebar ``Manage`` entry instead,
+  // which lands on ``/admin`` (the cross-workspace platform-admin view).
   //
   // ``useCurrentUserAdminWorkspaces`` already short-circuits to an empty set
   // for admins (it skips the role fetch when ``is_admin`` is true), so the

--- a/mlflow/server/js/src/home/components/WorkspacesHomeView.tsx
+++ b/mlflow/server/js/src/home/components/WorkspacesHomeView.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import {
   Alert,
   Button,
+  GearIcon,
   Input,
   Modal,
   Pagination,
@@ -11,12 +12,14 @@ import {
   TableCell,
   TableHeader,
   TableRow,
+  Tooltip,
   Typography,
   useDesignSystemTheme,
   Tag,
 } from '@databricks/design-system';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { Link } from '../../common/utils/RoutingUtils';
+import { useCurrentUserAdminWorkspaces, useCurrentUserIsAdmin } from '../../account/hooks';
 import { useWorkspaces, type Workspace } from '../../workspaces/hooks/useWorkspaces';
 import {
   getLastUsedWorkspace,
@@ -62,7 +65,17 @@ const WorkspacesEmptyState = ({ onCreateWorkspace }: { onCreateWorkspace: () => 
   );
 };
 
-const WorkspaceRow = ({ workspace, isLastUsed }: { workspace: Workspace; isLastUsed: boolean }) => {
+const WorkspaceRow = ({
+  workspace,
+  isLastUsed,
+  canManage,
+  showManageColumn,
+}: {
+  workspace: Workspace;
+  isLastUsed: boolean;
+  canManage: boolean;
+  showManageColumn: boolean;
+}) => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
   const { mutate: updateWorkspace, isLoading: isPending } = useUpdateWorkspace();
@@ -74,6 +87,14 @@ const WorkspaceRow = ({ workspace, isLastUsed }: { workspace: Workspace; isLastU
     // Persist to localStorage for UI hints then hard reload to cleanly switch workspace
     setLastUsedWorkspace(workspace.name);
     window.location.hash = `#/?${WORKSPACE_QUERY_PARAM}=${encodeURIComponent(workspace.name)}`;
+    window.location.reload();
+  };
+
+  const handleManageClick = () => {
+    // Same hard-reload pattern as handleNameClick — flushes any stale auth /
+    // workspace context before landing on /admin scoped to this workspace.
+    setLastUsedWorkspace(workspace.name);
+    window.location.hash = `#/admin?${WORKSPACE_QUERY_PARAM}=${encodeURIComponent(workspace.name)}`;
     window.location.reload();
   };
 
@@ -242,6 +263,51 @@ const WorkspaceRow = ({ workspace, isLastUsed }: { workspace: Workspace; isLastU
             </Button>
           </div>
         </TableCell>
+        {showManageColumn && (
+          <TableCell
+            css={{
+              flex: 0,
+              minWidth: 100,
+              maxWidth: 100,
+              justifyContent: 'center',
+              paddingRight: theme.spacing.md,
+            }}
+          >
+            {canManage ? (
+              <Tooltip
+                componentId="mlflow.home.workspaces.manage_tooltip"
+                content={intl.formatMessage({
+                  defaultMessage: 'Manage workspace',
+                  description: 'Tooltip on the gear icon that links to /admin scoped to this workspace',
+                })}
+              >
+                <Link
+                  componentId="mlflow.home.workspaces.manage_link"
+                  disableWorkspacePrefix
+                  to={`/admin?${WORKSPACE_QUERY_PARAM}=${encodeURIComponent(workspace.name)}`}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    handleManageClick();
+                  }}
+                  aria-label={intl.formatMessage(
+                    {
+                      defaultMessage: 'Manage workspace {name}',
+                      description: 'Aria label on the gear icon for managing a workspace',
+                    },
+                    { name: workspace.name },
+                  )}
+                  css={{
+                    color: theme.colors.textSecondary,
+                    display: 'inline-flex',
+                    '&:hover': { color: theme.colors.actionLinkHover },
+                  }}
+                >
+                  <GearIcon />
+                </Link>
+              </Tooltip>
+            ) : null}
+          </TableCell>
+        )}
       </TableRow>
 
       <Modal
@@ -309,6 +375,12 @@ export const WorkspacesHomeView = ({ onCreateWorkspace }: WorkspacesHomeViewProp
   // Get last used workspace from localStorage for the "Last used" badge
   const lastUsedWorkspace = getLastUsedWorkspace();
   const [currentPage, setCurrentPage] = useState(1);
+  // Manage column: shown only to users with admin reach somewhere (platform
+  // admin sees it on every row; workspace managers see it only on rows for
+  // workspaces they administer).
+  const isAdmin = useCurrentUserIsAdmin();
+  const adminWorkspaces = useCurrentUserAdminWorkspaces();
+  const showManageColumn = isAdmin || adminWorkspaces.size > 0;
 
   const shouldShowEmptyState = !isLoading && !isError && workspaces.length === 0;
 
@@ -399,6 +471,23 @@ export const WorkspacesHomeView = ({ onCreateWorkspace }: WorkspacesHomeViewProp
                   description="Workspaces table artifact root column header"
                 />
               </TableHeader>
+              {showManageColumn && (
+                <TableHeader
+                  componentId="mlflow.home.workspaces_table.header.manage"
+                  css={{
+                    flex: 0,
+                    minWidth: 100,
+                    maxWidth: 100,
+                    justifyContent: 'center',
+                    paddingRight: theme.spacing.md,
+                  }}
+                >
+                  <FormattedMessage
+                    defaultMessage="Manage"
+                    description="Workspaces table column header for the per-row admin entry point"
+                  />
+                </TableHeader>
+              )}
             </TableRow>
             {isLoading ? (
               <TableRow>
@@ -414,6 +503,8 @@ export const WorkspacesHomeView = ({ onCreateWorkspace }: WorkspacesHomeViewProp
                   key={workspace.name}
                   workspace={workspace}
                   isLastUsed={workspace.name === lastUsedWorkspace}
+                  canManage={isAdmin || adminWorkspaces.has(workspace.name)}
+                  showManageColumn={showManageColumn}
                 />
               ))
             )}

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -6307,6 +6307,10 @@
     "defaultMessage": "Tool Call Efficiency",
     "description": "LLM template option"
   },
+  "aTO9J7": {
+    "defaultMessage": "Manage workspace",
+    "description": "Tooltip on the gear icon that links to /admin/ws scoped to this workspace"
+  },
   "aTnlkS": {
     "defaultMessage": "Search for a provider...",
     "description": "Placeholder for provider search input"
@@ -8938,10 +8942,6 @@
   "pEpexK": {
     "defaultMessage": "Clear filters",
     "description": "Label for a button that clears all filters, visible on a experiment runs page next to a empty state when all runs have been filtered out"
-  },
-  "pJ4Oqm": {
-    "defaultMessage": "Manage workspace",
-    "description": "Tooltip on the gear icon that links to /admin scoped to this workspace"
   },
   "pMb1cg": {
     "defaultMessage": "Download {contentType} ({size})",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -539,6 +539,10 @@
     "defaultMessage": "Using controls above, select at least one artifact containing table.",
     "description": "Experiment page > artifact compare view > empty state for no tables selected > subtitle with the hint"
   },
+  "19v9XQ": {
+    "defaultMessage": "Workspace Manager",
+    "description": "Admin page title for non-platform-admins (workspace admins)"
+  },
   "1BIc9x": {
     "defaultMessage": "Launch Demo",
     "description": "Demo banner launch button"
@@ -562,6 +566,10 @@
   "1NeHsz": {
     "defaultMessage": "{count, plural, one {1 trace selected} other {# traces selected}}",
     "description": "Label for the number of traces selected"
+  },
+  "1Q2i/2": {
+    "defaultMessage": "Platform Admin",
+    "description": "Admin page title for platform admins"
   },
   "1RAM3C": {
     "defaultMessage": "Failed to delete some API keys. Please try again.",
@@ -786,6 +794,10 @@
   "2gmOVq": {
     "defaultMessage": "Process {evaluableRowCount} rows without evaluation output",
     "description": "Experiment page > artifact compare view > run column header > \"Evaluate all\" button tooltip"
+  },
+  "2gvIco": {
+    "defaultMessage": "Workspace: {workspace}",
+    "description": "Subtitle on the admin page identifying the active workspace for workspace managers"
   },
   "2gxV/O": {
     "defaultMessage": "Evaluation not available when grouping is enabled",
@@ -3022,10 +3034,6 @@
   "GKVTw4": {
     "defaultMessage": "JSON",
     "description": "JSON select menu option for assessment data type"
-  },
-  "GKXuD6": {
-    "defaultMessage": "Platform Admin",
-    "description": "Admin page title"
   },
   "GKiPV1": {
     "defaultMessage": "Start Time:",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -795,6 +795,10 @@
     "defaultMessage": "Process {evaluableRowCount} rows without evaluation output",
     "description": "Experiment page > artifact compare view > run column header > \"Evaluate all\" button tooltip"
   },
+  "2gvIco": {
+    "defaultMessage": "Workspace: {workspace}",
+    "description": "Subtitle on the admin page identifying the active workspace for workspace managers"
+  },
   "2gxV/O": {
     "defaultMessage": "Evaluation not available when grouping is enabled",
     "description": "Experiment page > artifact compare view > disabled due to run grouping > title"
@@ -5315,6 +5319,10 @@
     "defaultMessage": "Ground truth values annotated to the trace",
     "description": "Tooltip description for the Expectation column group in the traces table"
   },
+  "UsvDLH": {
+    "defaultMessage": "Select a workspace",
+    "description": "Roles tab empty state shown to workspace admins without an active workspace"
+  },
   "UtUq/x": {
     "defaultMessage": "Registered models",
     "description": "Header title for the registered models column in the logged model list table"
@@ -5767,6 +5775,10 @@
     "defaultMessage": "Session ID",
     "description": "Label for the session id section"
   },
+  "XJP2Uv": {
+    "defaultMessage": "Pick a workspace from the workspace selector to see its roles.",
+    "description": "Roles tab empty state body when no workspace is selected"
+  },
   "XK+0na": {
     "defaultMessage": "Reset period",
     "description": "Budget reset period column header"
@@ -6122,10 +6134,6 @@
   "Zb6BqS": {
     "defaultMessage": "Relative Time",
     "description": "Label for the relative axis on the runs compare chart"
-  },
-  "ZbEDiu": {
-    "defaultMessage": "Workspace: {workspaces}",
-    "description": "Subtitle on the admin page identifying the single workspace a workspace manager administers"
   },
   "Zbff/R": {
     "defaultMessage": "Unified interface for accessing multiple LLM providers.",
@@ -7366,10 +7374,6 @@
   "gUhc5g": {
     "defaultMessage": "You need to evaluate the resulting output first",
     "description": "Experiment page > new run modal > invalid state - result not evaluated"
-  },
-  "gUnBuA": {
-    "defaultMessage": "Workspaces: {workspaces}",
-    "description": "Subtitle on the admin page listing all workspaces a workspace manager administers"
   },
   "gVxisd": {
     "defaultMessage": "Tag \"{value}\" already exists.",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -795,10 +795,6 @@
     "defaultMessage": "Process {evaluableRowCount} rows without evaluation output",
     "description": "Experiment page > artifact compare view > run column header > \"Evaluate all\" button tooltip"
   },
-  "2gvIco": {
-    "defaultMessage": "Workspace: {workspace}",
-    "description": "Subtitle on the admin page identifying the active workspace for workspace managers"
-  },
   "2gxV/O": {
     "defaultMessage": "Evaluation not available when grouping is enabled",
     "description": "Experiment page > artifact compare view > disabled due to run grouping > title"
@@ -5319,10 +5315,6 @@
     "defaultMessage": "Ground truth values annotated to the trace",
     "description": "Tooltip description for the Expectation column group in the traces table"
   },
-  "UsvDLH": {
-    "defaultMessage": "Select a workspace",
-    "description": "Roles tab empty state shown to workspace admins without an active workspace"
-  },
   "UtUq/x": {
     "defaultMessage": "Registered models",
     "description": "Header title for the registered models column in the logged model list table"
@@ -5991,10 +5983,6 @@
     "defaultMessage": "Relevance",
     "description": "Evaluation results > known type of evaluation result assessment > relevance assessment. Used to indicate if the result is relevant to query in context of LLMs evaluation. Label displayed if user provided custom value, e.g. \"Relevance: moderate\""
   },
-  "YjUyVr": {
-    "defaultMessage": "Pick a workspace from the workspace selector to see roles you can manage.",
-    "description": "Roles tab empty state body when no workspace is selected"
-  },
   "YkcoeV": {
     "defaultMessage": "Displaying Runs from {numExperiments} Experiments",
     "description": "Breadcrumb nav item to link to compare-experiments page on compare runs page"
@@ -6134,6 +6122,10 @@
   "Zb6BqS": {
     "defaultMessage": "Relative Time",
     "description": "Label for the relative axis on the runs compare chart"
+  },
+  "ZbEDiu": {
+    "defaultMessage": "Workspace: {workspaces}",
+    "description": "Subtitle on the admin page identifying the single workspace a workspace manager administers"
   },
   "Zbff/R": {
     "defaultMessage": "Unified interface for accessing multiple LLM providers.",
@@ -7374,6 +7366,10 @@
   "gUhc5g": {
     "defaultMessage": "You need to evaluate the resulting output first",
     "description": "Experiment page > new run modal > invalid state - result not evaluated"
+  },
+  "gUnBuA": {
+    "defaultMessage": "Workspaces: {workspaces}",
+    "description": "Subtitle on the admin page listing all workspaces a workspace manager administers"
   },
   "gVxisd": {
     "defaultMessage": "Tag \"{value}\" already exists.",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -539,10 +539,6 @@
     "defaultMessage": "Using controls above, select at least one artifact containing table.",
     "description": "Experiment page > artifact compare view > empty state for no tables selected > subtitle with the hint"
   },
-  "19v9XQ": {
-    "defaultMessage": "Workspace Manager",
-    "description": "Admin page title for non-platform-admins (workspace admins)"
-  },
   "1BIc9x": {
     "defaultMessage": "Launch Demo",
     "description": "Demo banner launch button"
@@ -566,10 +562,6 @@
   "1NeHsz": {
     "defaultMessage": "{count, plural, one {1 trace selected} other {# traces selected}}",
     "description": "Label for the number of traces selected"
-  },
-  "1Q2i/2": {
-    "defaultMessage": "Platform Admin",
-    "description": "Admin page title for platform admins"
   },
   "1RAM3C": {
     "defaultMessage": "Failed to delete some API keys. Please try again.",
@@ -794,10 +786,6 @@
   "2gmOVq": {
     "defaultMessage": "Process {evaluableRowCount} rows without evaluation output",
     "description": "Experiment page > artifact compare view > run column header > \"Evaluate all\" button tooltip"
-  },
-  "2gvIco": {
-    "defaultMessage": "Workspace: {workspace}",
-    "description": "Subtitle on the admin page identifying the active workspace for workspace managers"
   },
   "2gxV/O": {
     "defaultMessage": "Evaluation not available when grouping is enabled",
@@ -4402,6 +4390,10 @@
   "P/Uvf4": {
     "defaultMessage": "Classification",
     "description": "Label for experiments focused on classification modeling"
+  },
+  "P0Y/ks": {
+    "defaultMessage": "Workspace Manager",
+    "description": "Admin page title shown when the URL is scoped to a single workspace via ?workspace=…"
   },
   "P31kXd": {
     "defaultMessage": "Cost breakdown",
@@ -9979,6 +9971,10 @@
     "defaultMessage": "At least one form field has incorrect value. Please correct and try again.",
     "description": "Generic error message for an invalid form input"
   },
+  "vaeS94": {
+    "defaultMessage": "Platform Admin",
+    "description": "Admin page title shown when the URL has no ?workspace=… (cross-workspace platform-admin view)"
+  },
   "vedifc": {
     "defaultMessage": "Enter API key or select saved key",
     "description": "Placeholder for API key combobox input"
@@ -10598,6 +10594,10 @@
   "zEXwQL": {
     "defaultMessage": "Error",
     "description": "Label for an assessment with an error"
+  },
+  "zIXqYZ": {
+    "defaultMessage": "Workspace: {workspace}",
+    "description": "Subtitle on the admin page identifying the active workspace when the URL is per-workspace scoped"
   },
   "zLTdCZ": {
     "defaultMessage": "Reviewed",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -1899,6 +1899,10 @@
     "defaultMessage": "An error occurred while rendering this component.",
     "description": "Description for default error message in experiment datasets UI"
   },
+  "9JbHw8": {
+    "defaultMessage": "Manage",
+    "description": "Workspaces table column header for the per-row admin entry point"
+  },
   "9KLNi5": {
     "defaultMessage": "Delete",
     "description": "Experiments page list, delete bulk experiments modal primary button"
@@ -3290,6 +3294,10 @@
   "I9bJ/T": {
     "defaultMessage": "Select All",
     "description": "Option to select all items in the item selector"
+  },
+  "IARcQx": {
+    "defaultMessage": "Manage workspace {name}",
+    "description": "Aria label on the gear icon for managing a workspace"
   },
   "IAyAgH": {
     "defaultMessage": "Move up",
@@ -5867,10 +5875,6 @@
     "defaultMessage": "Scanning <tracesLink>{totalTraces} traces</tracesLink>, <issuesLink>{identifiedIssues} issues</issuesLink> identified so far",
     "description": "Issue detection progress > Progress summary while running"
   },
-  "Y/1i4Y": {
-    "defaultMessage": "{label}: {behavior}",
-    "description": "Helper text under the log-level slider explaining how the currently selected level filters the trace view."
-  },
   "Y+dLul": {
     "defaultMessage": "Choose your integration. Install the {code} package for automatic tracing, or use {trace} for custom functions.",
     "description": "Step 2 description for TypeScript traces onboarding"
@@ -5878,6 +5882,10 @@
   "Y+nCpQ": {
     "defaultMessage": "Pending",
     "description": "Label indicating this onboarding step is not yet completed"
+  },
+  "Y/1i4Y": {
+    "defaultMessage": "{label}: {behavior}",
+    "description": "Helper text under the log-level slider explaining how the currently selected level filters the trace view."
   },
   "Y1eg9D": {
     "defaultMessage": "In progress",
@@ -8938,6 +8946,10 @@
   "pEpexK": {
     "defaultMessage": "Clear filters",
     "description": "Label for a button that clears all filters, visible on a experiment runs page next to a empty state when all runs have been filtered out"
+  },
+  "pJ4Oqm": {
+    "defaultMessage": "Manage workspace",
+    "description": "Tooltip on the gear icon that links to /admin scoped to this workspace"
   },
   "pMb1cg": {
     "defaultMessage": "Download {contentType} ({size})",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -5311,6 +5311,10 @@
     "defaultMessage": "Ground truth values annotated to the trace",
     "description": "Tooltip description for the Expectation column group in the traces table"
   },
+  "UsvDLH": {
+    "defaultMessage": "Select a workspace",
+    "description": "Roles tab empty state shown to workspace admins without an active workspace"
+  },
   "UtUq/x": {
     "defaultMessage": "Registered models",
     "description": "Header title for the registered models column in the logged model list table"
@@ -5978,6 +5982,10 @@
   "Yhydp3": {
     "defaultMessage": "Relevance",
     "description": "Evaluation results > known type of evaluation result assessment > relevance assessment. Used to indicate if the result is relevant to query in context of LLMs evaluation. Label displayed if user provided custom value, e.g. \"Relevance: moderate\""
+  },
+  "YjUyVr": {
+    "defaultMessage": "Pick a workspace from the workspace selector to see roles you can manage.",
+    "description": "Roles tab empty state body when no workspace is selected"
   },
   "YkcoeV": {
     "defaultMessage": "Displaying Runs from {numExperiments} Experiments",

--- a/tests/server/auth/test_auth_workspace.py
+++ b/tests/server/auth/test_auth_workspace.py
@@ -2153,6 +2153,35 @@ def test_validate_can_list_users(role_auth_setup, actor, expected):
         assert auth_module.validate_can_list_users() is expected
 
 
+@pytest.mark.parametrize(
+    ("actor", "expected"),
+    [
+        # Same matrix as ``list_users``: workspace admins may need to seed a
+        # user before assigning a role to them in a workspace they manage.
+        # Deletion stays super-admin-only (see ``validate_can_delete_user``).
+        ("super_admin", True),
+        ("ws_admin_foo", True),
+        ("ws_admin_bar", True),
+        ("ws_member_foo", False),
+        ("outsider", False),
+    ],
+)
+def test_validate_can_create_user(role_auth_setup, actor, expected):
+    role_auth_setup["login_as"](actor)
+    with auth_module.app.test_request_context("/api/2.0/mlflow/users/create", method="POST"):
+        assert auth_module.validate_can_create_user() is expected
+
+
+def test_validate_can_delete_user_stays_super_admin_only(role_auth_setup):
+    # Workspace admins explicitly do NOT get delete; the only path to True is
+    # the ``_before_request`` super-admin bypass. Smoke-check by exercising a
+    # workspace admin and a non-member; both must return False.
+    for actor in ("ws_admin_foo", "outsider"):
+        role_auth_setup["login_as"](actor)
+        with auth_module.app.test_request_context("/api/2.0/mlflow/users/delete", method="DELETE"):
+            assert auth_module.validate_can_delete_user() is False
+
+
 def test_validate_can_view_user_roles_self_always_allowed(role_auth_setup):
     # A user can always read their own role list, even one with no roles.
     # Using ``outsider`` (zero roles) exercises the self-short-circuit without

--- a/tests/server/auth/test_auth_workspace.py
+++ b/tests/server/auth/test_auth_workspace.py
@@ -2131,6 +2131,28 @@ def test_validate_can_list_roles_blank_workspace_denied_for_non_admin(role_auth_
         assert auth_module.validate_can_list_roles() is False
 
 
+@pytest.mark.parametrize(
+    ("actor", "expected"),
+    [
+        # Super admin always passes — also bypasses _before_request in production,
+        # but we exercise the validator's defensive `is_admin` short-circuit here.
+        ("super_admin", True),
+        # Workspace admins (in any workspace) need to see all usernames so they
+        # can grant roles to outsiders into the workspaces they manage.
+        ("ws_admin_foo", True),
+        ("ws_admin_bar", True),
+        # A bare member of a workspace is not a workspace admin.
+        ("ws_member_foo", False),
+        # A user with no presence anywhere stays denied.
+        ("outsider", False),
+    ],
+)
+def test_validate_can_list_users(role_auth_setup, actor, expected):
+    role_auth_setup["login_as"](actor)
+    with auth_module.app.test_request_context("/api/2.0/mlflow/users/list", method="GET"):
+        assert auth_module.validate_can_list_users() is expected
+
+
 def test_validate_can_view_user_roles_self_always_allowed(role_auth_setup):
     # A user can always read their own role list, even one with no roles.
     # Using ``outsider`` (zero roles) exercises the self-short-circuit without

--- a/tests/server/auth/test_auth_workspace.py
+++ b/tests/server/auth/test_auth_workspace.py
@@ -2132,9 +2132,38 @@ def test_validate_can_list_roles_blank_workspace_denied_for_non_admin(role_auth_
 
 
 @pytest.mark.parametrize(
+    ("actor", "workspaces", "expected"),
+    [
+        # Super admin lists across any combination unconditionally.
+        ("super_admin", ["foo", "bar"], True),
+        # Workspace admin must hold a role in *every* requested workspace.
+        ("ws_admin_foo", ["foo"], True),
+        ("ws_admin_foo", ["foo", "bar"], False),  # not present in bar
+        ("ws_admin_foo", ["foo", "foo"], True),  # duplicate is fine
+        # Member of foo can list foo, but not foo + bar.
+        ("ws_member_foo", ["foo"], True),
+        ("ws_member_foo", ["foo", "bar"], False),
+        # Outsider can list nothing.
+        ("outsider", ["foo"], False),
+        ("outsider", ["foo", "bar"], False),
+    ],
+)
+def test_validate_can_list_roles_multi_workspace(role_auth_setup, actor, workspaces, expected):
+    role_auth_setup["login_as"](actor)
+    with auth_module.app.test_request_context(
+        "/api/3.0/mlflow/roles/list",
+        method="GET",
+        query_string=[("workspace", w) for w in workspaces],
+    ):
+        assert auth_module.validate_can_list_roles() is expected
+
+
+# Super admin is omitted from these parametrizations: ``_before_request``
+# short-circuits via ``sender_is_admin`` before the validator is reached, so
+# the validator is unreachable for them in production.
+@pytest.mark.parametrize(
     ("actor", "expected"),
     [
-        ("super_admin", True),
         ("ws_admin_foo", True),
         ("ws_admin_bar", True),
         ("ws_member_foo", False),
@@ -2150,7 +2179,6 @@ def test_validate_can_list_users(role_auth_setup, actor, expected):
 @pytest.mark.parametrize(
     ("actor", "expected"),
     [
-        ("super_admin", True),
         ("ws_admin_foo", True),
         ("ws_admin_bar", True),
         ("ws_member_foo", False),

--- a/tests/server/auth/test_auth_workspace.py
+++ b/tests/server/auth/test_auth_workspace.py
@@ -2176,6 +2176,44 @@ def test_validate_can_list_users(role_auth_setup, actor, expected):
         assert auth_module.validate_can_list_users() is expected
 
 
+def test_list_users_handler_eager_loads_scoped_roles(role_auth_setup):
+    # Workspace admin: bulk response includes per-user roles, scoped to
+    # workspaces the requester administers (plus self, unscoped).
+    role_auth_setup["login_as"]("ws_admin_foo")
+    with auth_module.app.test_request_context("/api/2.0/mlflow/users/list", method="GET"):
+        response = auth_module.list_users()
+    by_username = {u["username"]: u for u in response.get_json()["users"]}
+
+    # Self: own admin role visible.
+    assert {(r["workspace"], r["name"]) for r in by_username["ws_admin_foo"]["roles"]} == {
+        ("foo", "admin-foo")
+    }
+    # Cross-user in foo: filtered to foo only (member-foo lives in foo).
+    assert {(r["workspace"], r["name"]) for r in by_username["ws_member_foo"]["roles"]} == {
+        ("foo", "member-foo")
+    }
+    # Cross-user outside requester's admin set: roles hidden.
+    assert by_username["ws_admin_bar"]["roles"] == []
+    assert by_username["outsider"]["roles"] == []
+
+
+def test_list_users_handler_super_admin_sees_every_role(role_auth_setup):
+    role_auth_setup["login_as"]("super_admin")
+    with auth_module.app.test_request_context("/api/2.0/mlflow/users/list", method="GET"):
+        response = auth_module.list_users()
+    by_username = {u["username"]: u for u in response.get_json()["users"]}
+
+    assert {(r["workspace"], r["name"]) for r in by_username["ws_admin_foo"]["roles"]} == {
+        ("foo", "admin-foo")
+    }
+    assert {(r["workspace"], r["name"]) for r in by_username["ws_admin_bar"]["roles"]} == {
+        ("bar", "admin-bar")
+    }
+    assert {(r["workspace"], r["name"]) for r in by_username["ws_member_foo"]["roles"]} == {
+        ("foo", "member-foo")
+    }
+
+
 @pytest.mark.parametrize(
     ("actor", "expected"),
     [

--- a/tests/server/auth/test_auth_workspace.py
+++ b/tests/server/auth/test_auth_workspace.py
@@ -2134,16 +2134,10 @@ def test_validate_can_list_roles_blank_workspace_denied_for_non_admin(role_auth_
 @pytest.mark.parametrize(
     ("actor", "expected"),
     [
-        # Super admin always passes — also bypasses _before_request in production,
-        # but we exercise the validator's defensive `is_admin` short-circuit here.
         ("super_admin", True),
-        # Workspace admins (in any workspace) need to see all usernames so they
-        # can grant roles to outsiders into the workspaces they manage.
         ("ws_admin_foo", True),
         ("ws_admin_bar", True),
-        # A bare member of a workspace is not a workspace admin.
         ("ws_member_foo", False),
-        # A user with no presence anywhere stays denied.
         ("outsider", False),
     ],
 )
@@ -2156,9 +2150,6 @@ def test_validate_can_list_users(role_auth_setup, actor, expected):
 @pytest.mark.parametrize(
     ("actor", "expected"),
     [
-        # Same matrix as ``list_users``: workspace admins may need to seed a
-        # user before assigning a role to them in a workspace they manage.
-        # Deletion stays super-admin-only (see ``validate_can_delete_user``).
         ("super_admin", True),
         ("ws_admin_foo", True),
         ("ws_admin_bar", True),
@@ -2173,9 +2164,7 @@ def test_validate_can_create_user(role_auth_setup, actor, expected):
 
 
 def test_validate_can_delete_user_stays_super_admin_only(role_auth_setup):
-    # Workspace admins explicitly do NOT get delete; the only path to True is
-    # the ``_before_request`` super-admin bypass. Smoke-check by exercising a
-    # workspace admin and a non-member; both must return False.
+    # Regression: the create-user widening must not have leaked into delete.
     for actor in ("ws_admin_foo", "outsider"):
         role_auth_setup["login_as"](actor)
         with auth_module.app.test_request_context("/api/2.0/mlflow/users/delete", method="DELETE"):

--- a/tests/server/auth/test_sqlalchemy_store_rbac.py
+++ b/tests/server/auth/test_sqlalchemy_store_rbac.py
@@ -101,6 +101,28 @@ def test_list_all_roles(store):
     assert len(all_roles) == 2
 
 
+def test_list_roles_in_workspaces(store):
+    store.create_role(name="viewer", workspace="ws1")
+    store.create_role(name="editor", workspace="ws1")
+    store.create_role(name="viewer", workspace="ws2")
+    store.create_role(name="other", workspace="ws3")
+
+    # Subset across two workspaces.
+    roles = store.list_roles_in_workspaces(["ws1", "ws2"])
+    assert {(r.workspace, r.name) for r in roles} == {
+        ("ws1", "viewer"),
+        ("ws1", "editor"),
+        ("ws2", "viewer"),
+    }
+
+    # Single-element list matches ``list_roles`` behavior.
+    assert {r.name for r in store.list_roles_in_workspaces(["ws3"])} == {"other"}
+
+    # Empty input returns nothing — callers must use ``list_all_roles`` for
+    # the unscoped admin path.
+    assert store.list_roles_in_workspaces([]) == []
+
+
 def test_update_role(store):
     role = store.create_role(name="old-name", workspace="ws1", description="old desc")
     updated = store.update_role(role.id, name="new-name", description="new desc")

--- a/tests/server/auth/test_sqlalchemy_store_rbac.py
+++ b/tests/server/auth/test_sqlalchemy_store_rbac.py
@@ -112,6 +112,43 @@ def test_list_roles(store):
     }
 
 
+def test_list_users_with_roles_eager_loads_in_one_batch(store, user, user2):
+    # Two roles for the first user, one for the second; one extra unassigned
+    # role just to confirm we only return roles tied to a user.
+    r1 = store.create_role(name="viewer", workspace="ws1")
+    r2 = store.create_role(name="editor", workspace="ws2")
+    r3 = store.create_role(name="other", workspace="ws3")
+    store.create_role(name="unassigned", workspace="ws1")
+
+    store.assign_role_to_user(user.id, r1.id)
+    store.assign_role_to_user(user.id, r2.id)
+    store.assign_role_to_user(user2.id, r3.id)
+
+    users_with_roles = store.list_users_with_roles()
+    by_username = {u.username: roles for u, roles in users_with_roles}
+
+    assert {(r.workspace, r.name) for r in by_username[user.username]} == {
+        ("ws1", "viewer"),
+        ("ws2", "editor"),
+    }
+    assert {(r.workspace, r.name) for r in by_username[user2.username]} == {("ws3", "other")}
+
+
+def test_list_user_present_workspaces(store, user):
+    # No assignments → empty set.
+    assert store.list_user_present_workspaces(user.id) == set()
+
+    r1 = store.create_role(name="viewer", workspace="ws1")
+    r2 = store.create_role(name="editor", workspace="ws2")
+    r3 = store.create_role(name="other", workspace="ws2")
+
+    store.assign_role_to_user(user.id, r1.id)
+    store.assign_role_to_user(user.id, r2.id)
+    store.assign_role_to_user(user.id, r3.id)
+
+    assert store.list_user_present_workspaces(user.id) == {"ws1", "ws2"}
+
+
 def test_update_role(store):
     role = store.create_role(name="old-name", workspace="ws1", description="old desc")
     updated = store.update_role(role.id, name="new-name", description="new desc")

--- a/tests/server/auth/test_sqlalchemy_store_rbac.py
+++ b/tests/server/auth/test_sqlalchemy_store_rbac.py
@@ -85,42 +85,31 @@ def test_list_roles(store):
     store.create_role(name="viewer", workspace="ws1")
     store.create_role(name="editor", workspace="ws1")
     store.create_role(name="viewer", workspace="ws2")
-
-    ws1_roles = store.list_roles("ws1")
-    assert len(ws1_roles) == 2
-    assert {r.name for r in ws1_roles} == {"viewer", "editor"}
-
-    ws2_roles = store.list_roles("ws2")
-    assert len(ws2_roles) == 1
-
-
-def test_list_all_roles(store):
-    store.create_role(name="viewer", workspace="ws1")
-    store.create_role(name="editor", workspace="ws2")
-    all_roles = store.list_all_roles()
-    assert len(all_roles) == 2
-
-
-def test_list_roles_in_workspaces(store):
-    store.create_role(name="viewer", workspace="ws1")
-    store.create_role(name="editor", workspace="ws1")
-    store.create_role(name="viewer", workspace="ws2")
     store.create_role(name="other", workspace="ws3")
 
+    # Single workspace.
+    ws1_roles = store.list_roles(["ws1"])
+    assert {r.name for r in ws1_roles} == {"viewer", "editor"}
+
     # Subset across two workspaces.
-    roles = store.list_roles_in_workspaces(["ws1", "ws2"])
+    roles = store.list_roles(["ws1", "ws2"])
     assert {(r.workspace, r.name) for r in roles} == {
         ("ws1", "viewer"),
         ("ws1", "editor"),
         ("ws2", "viewer"),
     }
 
-    # Single-element list matches ``list_roles`` behavior.
-    assert {r.name for r in store.list_roles_in_workspaces(["ws3"])} == {"other"}
+    # Empty iterable is interpreted literally — no roles.
+    assert store.list_roles([]) == []
 
-    # Empty input returns nothing — callers must use ``list_all_roles`` for
-    # the unscoped admin path.
-    assert store.list_roles_in_workspaces([]) == []
+    # ``None`` (default) lists across the whole system — the admin path.
+    all_roles = store.list_roles()
+    assert {(r.workspace, r.name) for r in all_roles} == {
+        ("ws1", "viewer"),
+        ("ws1", "editor"),
+        ("ws2", "viewer"),
+        ("ws3", "other"),
+    }
 
 
 def test_update_role(store):
@@ -165,8 +154,8 @@ def test_delete_roles_for_workspace(store):
     store.create_role(name="r3", workspace="ws2")
 
     store.delete_roles_for_workspace("ws1")
-    assert store.list_roles("ws1") == []
-    assert len(store.list_roles("ws2")) == 1
+    assert store.list_roles(["ws1"]) == []
+    assert len(store.list_roles(["ws2"])) == 1
 
 
 def test_delete_roles_for_workspace_cascades(store, user):
@@ -176,7 +165,7 @@ def test_delete_roles_for_workspace_cascades(store, user):
 
     store.delete_roles_for_workspace("ws1")
 
-    assert store.list_roles("ws1") == []
+    assert store.list_roles(["ws1"]) == []
     assert store.list_user_roles(user.id) == []
 
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/23086/files) to review incremental changes.
- [**stack/fe/rbac/03-workspace-manager**](https://github.com/mlflow/mlflow/pull/23086) [[Files changed](https://github.com/mlflow/mlflow/pull/23086/files)]

---------
### Related Issues/PRs

Relates to #22929 (Platform Admin pages — landed)

### What changes are proposed in this pull request?

Today the bottom-left sidebar `Manage` entry and the `/admin` page itself are gated on platform-admin only (`is_admin === true`). This PR opens `/admin` to **workspace managers** — users holding `(workspace, *, MANAGE)` in one or more workspaces — with a scoped UX.

Workspace managers can:
- List **all users** (so they can assign outsiders to roles in workspaces they manage). Per-user role/permission cells render `—` for users in workspaces the manager doesn't oversee — they don't leak grants outside the manager's purview.
- See and manage **roles** scoped to the active workspace — list, create, and bulk-delete (every visible row is server-checked via `validate_can_manage_roles`).
- **Create users** (creating a user grants no access on its own; they have no roles or permissions until explicitly assigned).

Workspace managers cannot:
- Toggle `is_admin` (`Admin status` section in modals stays platform-admin-only).
- Bulk-delete users (super-admin-only; row-checkbox column folds away).

#### Backend (`mlflow/server/auth/__init__.py`)

- `validate_can_list_users` extended to allow workspace admins. The `users` payload (`id`, `username`, `is_admin`) carries no per-workspace data, so exposing the list is safe.
- `validate_can_create_user` extended to allow workspace admins. Deletion stays super-admin-only.
- Other admin-area validators were already wired correctly via the existing "admin / self / WP-admin-of-target" pattern (`validate_can_view_user_roles`, `validate_can_manage_roles`, `validate_can_list_roles`).

#### Frontend (`mlflow/server/js/src/...`)

- New `useCurrentUserAdminWorkspaces` hook (`account/hooks.ts`) — returns the `Set<string>` of workspaces in which the current user is a workspace admin. Mirrors the backend `store.list_workspace_admin_workspaces`. Holds the last computed Set in a ref so the gate stays stable through `queryClient.invalidateQueries()` storms after a workspace switch.
- `useCurrentUserIsWorkspaceAdmin` is now a thin wrapper over `useCurrentUserAdminWorkspaces`.
- `MlflowSidebar`: `Manage` entry shown when `isAdmin || (activeWorkspace ∈ adminWorkspaces)`. So workspace managers only see the entry when their currently-active workspace is one they manage — no clicks-to-dead-ends.
- `AdminPage`:
  - Header reads `Workspace Manager` for non-platform-admins, with the active workspace name as a subtitle. `Platform Admin` for platform admins.
  - Users tab: bulk-delete + row-selection checkbox column hidden for non-platform-admins. `Create User` button visible to both groups.
  - Roles tab: query scoped to active workspace for non-admins (`useRolesQuery` now supports `enabled`). When a workspace admin lands without an active workspace selected, an empty state instructs them to pick one. Bulk-delete + checkboxes visible to workspace managers (the visible rows are already server-scoped to workspaces they manage).
  - `UserRolesCell` collapses 403 / empty / fetch-failure into the same muted `—`, so workspace managers don't see red errors for users in workspaces they can't see.
- `RoleAssignmentForm`: scopes the role list to the active workspace for non-admins, so the picker actually populates inside `CreateUserModal` / `EditAccessModal`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

**Backend tests** (`tests/server/auth/test_auth_workspace.py`):
- New parametrized `test_validate_can_list_users` covering `super_admin`, two ws-admins, a member, and an outsider.
- New parametrized `test_validate_can_create_user` covering the same matrix.
- New `test_validate_can_delete_user_stays_super_admin_only` regression — workspace admins explicitly do **not** inherit delete.

**Frontend tests** (`mlflow/server/js/src/account/hooks.test.tsx`):
- New `useCurrentUserAdminWorkspaces` cases — the multi-workspace happy path, member-only no-admin case, and loading state.
- Existing `useCurrentUserIsWorkspaceAdmin` cases retained.

**Manual smoke** with two seeded users:
- `wp_admin` is a workspace admin in `wsA`. Logged in: sidebar `Manage` shows when active workspace is `wsA`, hides when active workspace is something else. `/admin` opens with the `Workspace Manager — wsA` header. Users tab lists everyone; a user with no roles in `wsA` shows `—` in the roles column. Roles tab shows roles in `wsA`. Bulk-delete works. Create User opens, the role picker populates with `wsA` roles, and submit succeeds without a 403.
- `super_admin`: full UX unchanged.

https://github.com/user-attachments/assets/c56f6e91-d037-4fa9-bc80-972541ddfcc1




### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Workspace admins now have a `Manage` entry in the sidebar and can use `/admin` to manage users and roles scoped to workspaces they administer.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release


