### PR TITLE
RBAC Phase 2: drop pre-RBAC permission tables (graduation of #22855)

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -55,7 +55,6 @@ from mlflow.protos.databricks_pb2 import (
     BAD_REQUEST,
     INTERNAL_ERROR,
     INVALID_PARAMETER_VALUE,
-    RESOURCE_ALREADY_EXISTS,
     RESOURCE_DOES_NOT_EXIST,
     ErrorCode,
 )
@@ -2284,7 +2283,7 @@ def set_can_manage_experiment_permission(resp: Response):
     parse_dict(resp.json, response_message)
     experiment_id = response_message.experiment_id
     username = authenticate_request().username
-    store.create_experiment_permission(experiment_id, username, MANAGE.name)
+    store.grant_user_permission(username, "experiment", experiment_id, MANAGE.name)
 
 
 def set_can_manage_registered_model_permission(resp: Response):
@@ -2292,21 +2291,17 @@ def set_can_manage_registered_model_permission(resp: Response):
     parse_dict(resp.json, response_message)
     name = response_message.registered_model.name
     username = authenticate_request().username
-    store.create_registered_model_permission(name, username, MANAGE.name)
+    store.grant_user_permission(username, "registered_model", name, MANAGE.name)
 
 
 def delete_can_manage_registered_model_permission(resp: Response):
     """
-    Delete registered model permissions when the model is deleted.
-
-    We need to do this because the primary key of the registered model is the name,
-    unlike the experiment where the primary key is experiment_id (UUID). Therefore,
-    we have to delete existing permission records when the model is deleted; otherwise, they would
-    implicitly apply if a new model is later created with the same name.
+    Sweep registered-model grants when the model is deleted. The model's primary
+    key is its name (unlike experiments which use a UUID), so a future model
+    with the same name would otherwise inherit stale grants.
     """
-    # Get model name from request context because it's not available in the response
     name = request.get_json(force=True, silent=True)["name"]
-    store.delete_registered_model_permissions(name)
+    store.delete_grants_for_resource("registered_model", name, workspace_scoped=True)
 
 
 # ---- Role management handlers (RBAC) ----
@@ -2782,9 +2777,13 @@ def rename_registered_model_permission(resp: Response):
 
     Changing the model registry name must be propagated to all users.
     """
-    # get registry model name before update
     data = request.get_json(force=True, silent=True)
-    store.rename_registered_model_permissions(data.get("name"), data.get("new_name"))
+    store.rename_grants_for_resource(
+        "registered_model",
+        data.get("name"),
+        data.get("new_name"),
+        workspace_scoped=True,
+    )
 
 
 def set_can_manage_scorer_permission(resp: Response):
@@ -2793,13 +2792,10 @@ def set_can_manage_scorer_permission(resp: Response):
     experiment_id = response_message.experiment_id
     name = response_message.name
     username = authenticate_request().username
-    try:
-        store.create_scorer_permission(experiment_id, name, username, MANAGE.name)
-    except MlflowException as e:
-        if e.error_code == ErrorCode.Name(RESOURCE_ALREADY_EXISTS):
-            pass  # Permission already exists from a previous registration
-        else:
-            raise
+    # ``grant_user_permission`` is upsert, so re-registration is a no-op
+    # rather than an error — no try/except needed.
+    pattern = store._scorer_pattern(experiment_id, name)
+    store.grant_user_permission(username, "scorer", pattern, MANAGE.name)
 
 
 def delete_scorer_permissions_cascade(resp: Response):
@@ -2807,7 +2803,8 @@ def delete_scorer_permissions_cascade(resp: Response):
     experiment_id = data.get("experiment_id")
     name = data.get("name")
     if experiment_id and name:
-        store.delete_scorer_permissions_for_scorer(experiment_id, name)
+        pattern = store._scorer_pattern(experiment_id, name)
+        store.delete_grants_for_resource("scorer", pattern)
 
 
 def set_can_manage_gateway_secret_permission(resp: Response):
@@ -2815,13 +2812,13 @@ def set_can_manage_gateway_secret_permission(resp: Response):
     parse_dict(resp.json, response_message)
     secret_id = response_message.secret.secret_id
     username = authenticate_request().username
-    store.create_gateway_secret_permission(secret_id, username, MANAGE.name)
+    store.grant_user_permission(username, "gateway_secret", secret_id, MANAGE.name)
 
 
 def delete_gateway_secret_permissions_cascade(resp: Response):
     data = request.get_json(force=True, silent=True)
     if secret_id := data.get("secret_id"):
-        store.delete_gateway_secret_permissions_for_secret(secret_id)
+        store.delete_grants_for_resource("gateway_secret", secret_id)
 
 
 def set_can_manage_gateway_endpoint_permission(resp: Response):
@@ -2829,13 +2826,13 @@ def set_can_manage_gateway_endpoint_permission(resp: Response):
     parse_dict(resp.json, response_message)
     endpoint_id = response_message.endpoint.endpoint_id
     username = authenticate_request().username
-    store.create_gateway_endpoint_permission(endpoint_id, username, MANAGE.name)
+    store.grant_user_permission(username, "gateway_endpoint", endpoint_id, MANAGE.name)
 
 
 def delete_gateway_endpoint_permissions_cascade(resp: Response):
     data = request.get_json(force=True, silent=True)
     if endpoint_id := data.get("endpoint_id"):
-        store.delete_gateway_endpoint_permissions_for_endpoint(endpoint_id)
+        store.delete_grants_for_resource("gateway_endpoint", endpoint_id)
 
 
 def set_can_manage_gateway_model_definition_permission(resp: Response):
@@ -2843,13 +2840,15 @@ def set_can_manage_gateway_model_definition_permission(resp: Response):
     parse_dict(resp.json, response_message)
     model_definition_id = response_message.model_definition.model_definition_id
     username = authenticate_request().username
-    store.create_gateway_model_definition_permission(model_definition_id, username, MANAGE.name)
+    store.grant_user_permission(
+        username, "gateway_model_definition", model_definition_id, MANAGE.name
+    )
 
 
 def delete_gateway_model_definition_permissions_cascade(resp: Response):
     data = request.get_json(force=True, silent=True)
     if model_definition_id := data.get("model_definition_id"):
-        store.delete_gateway_model_definition_permissions_for_model_definition(model_definition_id)
+        store.delete_grants_for_resource("gateway_model_definition", model_definition_id)
 
 
 AFTER_REQUEST_PATH_HANDLERS = {

--- a/mlflow/server/auth/db/migrations/versions/f6a7b8c9d0e1_drop_legacy_permission_tables.py
+++ b/mlflow/server/auth/db/migrations/versions/f6a7b8c9d0e1_drop_legacy_permission_tables.py
@@ -1,0 +1,133 @@
+"""Drop pre-RBAC permission tables
+
+Revision ID: f6a7b8c9d0e1
+Revises: e5f6a7b8c9d0
+Create Date: 2026-05-06 17:00:00.000000
+
+The graduation migration for the RBAC simplification stack. ``e5f6a7b8c9d0``
+backfilled every legacy per-resource permission row into ``role_permissions``
+and stopped the auth server from reading or writing the legacy tables, but
+**retained** the seven pre-RBAC tables on disk so operators could roll back
+without restoring from backup. This migration removes them now that the
+simplified model has bedded in.
+
+The seven tables dropped here, with their introducing migration:
+
+- ``experiment_permissions``           — ``8606fa83a998_initial_migration``
+- ``registered_model_permissions``     — ``8606fa83a998_initial_migration``
+- ``scorer_permissions``               — ``0965eb92f5f0_add_scorer_permissions``
+- ``gateway_secret_permissions``       — ``a1b2c3d4e5f6_add_gateway_permissions``
+- ``gateway_endpoint_permissions``     — ``a1b2c3d4e5f6_add_gateway_permissions``
+- ``gateway_model_definition_permissions`` — ``a1b2c3d4e5f6_add_gateway_permissions``
+- ``workspace_permissions``            — ``2ed73881770d_workspace_permissions``
+
+After this migration:
+
+- ``SqlAlchemyStore.delete_user`` no longer needs to scrub legacy rows; the
+  cascade through ``SqlUser.user_role_assignments`` is sufficient.
+- The ``_RETAINED_LEGACY_PERMISSION_TABLES`` constant in ``sqlalchemy_store.py``
+  can become ``()`` (or be removed); the corresponding test
+  ``test_delete_user_clears_retained_legacy_permission_rows`` is no longer
+  reachable and should be dropped.
+
+Downgrade rebuilds the table schemas (so subsequent ``alembic downgrade`` calls
+that rebuild prior revisions can stamp the schema correctly), but does **not**
+restore the row data — that's the point-of-no-return contract this migration
+ships under. Operators rolling back to a state that needs the legacy data must
+restore from backup.
+
+Tracking: https://github.com/mlflow/mlflow/issues/23087
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f6a7b8c9d0e1"
+down_revision = "e5f6a7b8c9d0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Order matters under non-cascading FKs: child tables before any parent.
+    # All seven tables FK only to ``users.id`` (which we leave alone), so the
+    # internal order between them is purely cosmetic — keep it alphabetic.
+    op.drop_table("experiment_permissions")
+    op.drop_table("gateway_endpoint_permissions")
+    op.drop_table("gateway_model_definition_permissions")
+    op.drop_table("gateway_secret_permissions")
+    op.drop_table("registered_model_permissions")
+    op.drop_table("scorer_permissions")
+    op.drop_table("workspace_permissions")
+
+
+def downgrade() -> None:
+    # Rebuild the table schemas so older migrations referencing them remain
+    # introspectable. The shapes match each table's introducing migration
+    # exactly. Row data is *not* restored — see module docstring.
+    op.create_table(
+        "experiment_permissions",
+        sa.Column("id", sa.Integer(), nullable=False, primary_key=True),
+        sa.Column("experiment_id", sa.String(length=255), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("permission", sa.String(length=255), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], name="fk_user_id"),
+        sa.UniqueConstraint("experiment_id", "user_id", name="unique_experiment_user"),
+    )
+    op.create_table(
+        "registered_model_permissions",
+        sa.Column("id", sa.Integer(), nullable=False, primary_key=True),
+        sa.Column("workspace", sa.String(length=255), nullable=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("permission", sa.String(length=255), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], name="fk_user_id"),
+        sa.UniqueConstraint("workspace", "name", "user_id", name="unique_name_user"),
+    )
+    op.create_table(
+        "scorer_permissions",
+        sa.Column("id", sa.Integer(), nullable=False, primary_key=True),
+        sa.Column("experiment_id", sa.String(length=255), nullable=False),
+        sa.Column("scorer_name", sa.String(length=255), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("permission", sa.String(length=255), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], name="fk_user_id"),
+        sa.UniqueConstraint("experiment_id", "scorer_name", "user_id", name="unique_scorer_user"),
+    )
+    op.create_table(
+        "gateway_secret_permissions",
+        sa.Column("id", sa.Integer(), nullable=False, primary_key=True),
+        sa.Column("secret_id", sa.String(length=255), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("permission", sa.String(length=255), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], name="fk_user_id"),
+        sa.UniqueConstraint("secret_id", "user_id", name="unique_secret_user"),
+    )
+    op.create_table(
+        "gateway_endpoint_permissions",
+        sa.Column("id", sa.Integer(), nullable=False, primary_key=True),
+        sa.Column("endpoint_id", sa.String(length=255), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("permission", sa.String(length=255), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], name="fk_user_id"),
+        sa.UniqueConstraint("endpoint_id", "user_id", name="unique_endpoint_user"),
+    )
+    op.create_table(
+        "gateway_model_definition_permissions",
+        sa.Column("id", sa.Integer(), nullable=False, primary_key=True),
+        sa.Column("model_definition_id", sa.String(length=255), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("permission", sa.String(length=255), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], name="fk_user_id"),
+        sa.UniqueConstraint("model_definition_id", "user_id", name="unique_model_definition_user"),
+    )
+    op.create_table(
+        "workspace_permissions",
+        sa.Column("id", sa.Integer(), nullable=False, primary_key=True),
+        sa.Column("workspace", sa.String(length=255), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("permission", sa.String(length=255), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], name="fk_user_id"),
+        sa.UniqueConstraint("workspace", "user_id", name="unique_workspace_user"),
+    )

--- a/mlflow/server/auth/sqlalchemy_store.py
+++ b/mlflow/server/auth/sqlalchemy_store.py
@@ -335,6 +335,111 @@ class SqlAlchemyStore:
             query = query.filter(SqlRole.workspace == workspace)
         return [rid for (rid, name) in query.all() if self._is_synthetic_role_name(name)]
 
+    # ---- Per-user grant helpers ----
+    #
+    # Generic API for per-user permission grants on the user's synthetic
+    # ``__user_<id>__`` role in the active workspace. Cascade handlers
+    # (``set_can_manage_*_permission``, ``delete_*_permissions_cascade``,
+    # ``rename_registered_model_permission``) call these directly. Per-resource
+    # CRUD methods below remain only as tombstones backing the deprecated REST
+    # surface; remove them when the deprecated handlers are dropped.
+
+    def grant_user_permission(
+        self,
+        username: str,
+        resource_type: str,
+        resource_pattern: str,
+        permission: str,
+    ) -> None:
+        """
+        Upsert a ``permission`` grant on ``(resource_type, resource_pattern)`` for
+        ``username`` via their synthetic role in the active workspace.
+        """
+        _validate_permission_for_resource_type(permission, resource_type)
+        with self.ManagedSessionMaker() as session:
+            user = self._get_user(session, username=username)
+            workspace_name = self._get_active_workspace_name()
+            role = self._get_or_create_synthetic_user_role(session, user.id, workspace_name)
+            existing = (
+                session
+                .query(SqlRolePermission)
+                .filter(
+                    SqlRolePermission.role_id == role.id,
+                    SqlRolePermission.resource_type == resource_type,
+                    SqlRolePermission.resource_pattern == resource_pattern,
+                )
+                .first()
+            )
+            if existing is None:
+                session.add(
+                    SqlRolePermission(
+                        role_id=role.id,
+                        resource_type=resource_type,
+                        resource_pattern=resource_pattern,
+                        permission=permission,
+                    )
+                )
+            else:
+                existing.permission = permission
+
+    def delete_grants_for_resource(
+        self,
+        resource_type: str,
+        resource_pattern: str,
+        *,
+        workspace_scoped: bool = False,
+    ) -> None:
+        """
+        Delete every synthetic-role grant matching ``(resource_type,
+        resource_pattern)``. ``workspace_scoped=True`` restricts to the active
+        workspace — for resources whose pattern can collide across workspaces
+        (e.g. registered-model names). Admin-created roles are never touched.
+        """
+        with self.ManagedSessionMaker() as session:
+            workspace = self._get_active_workspace_name() if workspace_scoped else None
+            role_ids = self._synthetic_role_ids(session, workspace=workspace)
+            if not role_ids:
+                return
+            session.query(SqlRolePermission).filter(
+                SqlRolePermission.role_id.in_(role_ids),
+                SqlRolePermission.resource_type == resource_type,
+                SqlRolePermission.resource_pattern == resource_pattern,
+            ).delete(synchronize_session=False)
+
+    def rename_grants_for_resource(
+        self,
+        resource_type: str,
+        old_pattern: str,
+        new_pattern: str,
+        *,
+        workspace_scoped: bool = False,
+    ) -> None:
+        """
+        Rewrite every synthetic-role grant on ``(resource_type, old_pattern)`` to
+        ``(resource_type, new_pattern)``. Used for resources whose pattern is the
+        primary key and can change (e.g. registered-model rename).
+        """
+        with self.ManagedSessionMaker() as session:
+            workspace = self._get_active_workspace_name() if workspace_scoped else None
+            role_ids = self._synthetic_role_ids(session, workspace=workspace)
+            if not role_ids:
+                return
+            session.query(SqlRolePermission).filter(
+                SqlRolePermission.role_id.in_(role_ids),
+                SqlRolePermission.resource_type == resource_type,
+                SqlRolePermission.resource_pattern == old_pattern,
+            ).update(
+                {SqlRolePermission.resource_pattern: new_pattern},
+                synchronize_session=False,
+            )
+
+    # ---- Legacy per-resource CRUD (tombstones) ----
+    #
+    # The methods below back the deprecated REST handlers in ``__init__.py``.
+    # Internal callers should use ``grant_user_permission`` /
+    # ``delete_grants_for_resource`` / ``rename_grants_for_resource`` instead.
+    # Remove these when the deprecated REST surface is dropped.
+
     def create_experiment_permission(
         self, experiment_id: str, username: str, permission: str
     ) -> ExperimentPermission:
@@ -633,41 +738,6 @@ class SqlAlchemyStore:
         with self.ManagedSessionMaker() as session:
             _, _, rp = self._get_registered_model_permission_row(session, name, username)
             session.delete(rp)
-
-    def delete_registered_model_permissions(self, name: str) -> None:
-        """
-        Delete *all* registered model permission rows for the given model name in the active
-        workspace.
-
-        This is primarily used as cleanup when a registered model is deleted to ensure that
-        previously granted permissions do not implicitly carry over if a new model is later created
-        with the same name. Synthetic-role-only — admin-created roles with an overlapping
-        registered_model grant are untouched.
-        """
-        with self.ManagedSessionMaker() as session:
-            workspace_name = self._get_active_workspace_name()
-            role_ids = self._synthetic_role_ids(session, workspace=workspace_name)
-            if not role_ids:
-                return
-            session.query(SqlRolePermission).filter(
-                SqlRolePermission.role_id.in_(role_ids),
-                SqlRolePermission.resource_type == RESOURCE_TYPE_REGISTERED_MODEL,
-                SqlRolePermission.resource_pattern == name,
-            ).delete(synchronize_session=False)
-
-    def rename_registered_model_permissions(self, old_name: str, new_name: str):
-        # Synthetic-role-only rename; admin-created roles with a grant on ``old_name``
-        # are untouched so we don't accidentally mutate their grants.
-        with self.ManagedSessionMaker() as session:
-            workspace_name = self._get_active_workspace_name()
-            role_ids = self._synthetic_role_ids(session, workspace=workspace_name)
-            if not role_ids:
-                return
-            session.query(SqlRolePermission).filter(
-                SqlRolePermission.role_id.in_(role_ids),
-                SqlRolePermission.resource_type == RESOURCE_TYPE_REGISTERED_MODEL,
-                SqlRolePermission.resource_pattern == old_name,
-            ).update({SqlRolePermission.resource_pattern: new_name}, synchronize_session=False)
 
     def _list_workspace_perm_rows(
         self,
@@ -1078,19 +1148,6 @@ class SqlAlchemyStore:
             _, rp = self._get_scorer_permission_row(session, experiment_id, scorer_name, username)
             session.delete(rp)
 
-    def delete_scorer_permissions_for_scorer(self, experiment_id: str, scorer_name: str):
-        """Synthetic-role-only cleanup for when a scorer is deleted."""
-        pattern = self._scorer_pattern(experiment_id, scorer_name)
-        with self.ManagedSessionMaker() as session:
-            role_ids = self._synthetic_role_ids(session)
-            if not role_ids:
-                return
-            session.query(SqlRolePermission).filter(
-                SqlRolePermission.role_id.in_(role_ids),
-                SqlRolePermission.resource_type == RESOURCE_TYPE_SCORER,
-                SqlRolePermission.resource_pattern == pattern,
-            ).delete(synchronize_session=False)
-
     # ---- Gateway permission helpers ----
     #
     # The three gateway resource types (secret / endpoint / model_definition) share a
@@ -1238,20 +1295,6 @@ class SqlAlchemyStore:
             # access.
             return user_id, rows
 
-    def _delete_per_resource_permissions_for_resource(
-        self, resource_type: str, resource_pattern: str
-    ) -> None:
-        """Synthetic-role-only cleanup when a resource itself is deleted."""
-        with self.ManagedSessionMaker() as session:
-            role_ids = self._synthetic_role_ids(session)
-            if not role_ids:
-                return
-            session.query(SqlRolePermission).filter(
-                SqlRolePermission.role_id.in_(role_ids),
-                SqlRolePermission.resource_type == resource_type,
-                SqlRolePermission.resource_pattern == resource_pattern,
-            ).delete(synchronize_session=False)
-
     # ---- gateway_secret ----
 
     def create_gateway_secret_permission(
@@ -1323,9 +1366,6 @@ class SqlAlchemyStore:
                 f"username={username} not found"
             ),
         )
-
-    def delete_gateway_secret_permissions_for_secret(self, secret_id: str) -> None:
-        self._delete_per_resource_permissions_for_resource(RESOURCE_TYPE_GATEWAY_SECRET, secret_id)
 
     # ---- gateway_endpoint ----
 
@@ -1399,11 +1439,6 @@ class SqlAlchemyStore:
                 f"Gateway endpoint permission with endpoint_id={endpoint_id} and "
                 f"username={username} not found"
             ),
-        )
-
-    def delete_gateway_endpoint_permissions_for_endpoint(self, endpoint_id: str) -> None:
-        self._delete_per_resource_permissions_for_resource(
-            RESOURCE_TYPE_GATEWAY_ENDPOINT, endpoint_id
         )
 
     # ---- gateway_model_definition ----
@@ -1492,13 +1527,6 @@ class SqlAlchemyStore:
                 f"Gateway model definition permission with "
                 f"model_definition_id={model_definition_id} and username={username} not found"
             ),
-        )
-
-    def delete_gateway_model_definition_permissions_for_model_definition(
-        self, model_definition_id: str
-    ) -> None:
-        self._delete_per_resource_permissions_for_resource(
-            RESOURCE_TYPE_GATEWAY_MODEL_DEFINITION, model_definition_id
         )
 
     # ---- Role CRUD ----

--- a/mlflow/server/auth/sqlalchemy_store.py
+++ b/mlflow/server/auth/sqlalchemy_store.py
@@ -55,36 +55,13 @@ from mlflow.utils.uri import extract_db_type_from_uri
 from mlflow.utils.validation import _validate_password, _validate_username
 from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
 
-# Pre-RBAC permission tables retained on disk by
-# ``e5f6a7b8c9d0_migrate_permissions_to_roles``. The runtime no longer reads or
-# writes these tables — they exist solely so operators can roll back the
-# simplification migration without restoring from backup. Their FKs to
-# ``users.id`` are non-cascading from earlier migrations
-# (``8606fa83a998_initial_migration``), so ``delete_user`` must scrub the user's
-# rows here before deleting the user row itself.
-#
-# GRADUATION LEVER. When the drop migration
-# (``f6a7b8c9d0e1_drop_legacy_permission_tables``, scheduled for MLflow 3.X+2 —
-# tracking: https://github.com/mlflow/mlflow/issues/23087) lands and removes
-# these tables from the schema, this tuple becomes ``()`` and the loop in
-# ``delete_user`` below becomes a no-op. The graduation PR should:
-#   1. Add ``f6a7b8c9d0e1_drop_legacy_permission_tables`` that ``op.drop_table``s
-#      every entry in this tuple.
-#   2. Set this tuple to ``()`` (or remove the constant + loop entirely).
-#   3. Update ``test_auth_and_tracking_store_coexist`` and
-#      ``test_upgrade_from_legacy_database`` to assert the tables are absent
-#      post-upgrade.
-#   4. Drop ``test_delete_user_clears_retained_legacy_permission_rows`` —
-#      cleanup-by-cascade is sufficient once the legacy FKs are gone.
-_RETAINED_LEGACY_PERMISSION_TABLES: tuple[str, ...] = (
-    "experiment_permissions",
-    "registered_model_permissions",
-    "scorer_permissions",
-    "gateway_secret_permissions",
-    "gateway_endpoint_permissions",
-    "gateway_model_definition_permissions",
-    "workspace_permissions",
-)
+# Pre-RBAC permission tables were retained on disk by ``e5f6a7b8c9d0`` for
+# rollback safety and dropped by ``f6a7b8c9d0e1_drop_legacy_permission_tables``
+# once the simplified RBAC model had bedded in. Tuple kept as an empty constant
+# so ``delete_user``'s loop remains explicit (and remains a no-op for any future
+# legacy-table additions that need transient cleanup); it can be removed
+# entirely whenever the surrounding code is next touched.
+_RETAINED_LEGACY_PERMISSION_TABLES: tuple[str, ...] = ()
 
 
 class SqlAlchemyStore:
@@ -204,10 +181,11 @@ class SqlAlchemyStore:
             synthetic_name = self._synthetic_user_role_name(user.id)
             for role in session.query(SqlRole).filter(SqlRole.name == synthetic_name).all():
                 session.delete(role)
-            # Scrub the user's rows from the retained legacy permission tables.
-            # See ``_RETAINED_LEGACY_PERMISSION_TABLES`` (top of module) for why
-            # this loop exists and the steps to retire it once the drop migration
-            # ships. When that constant is empty, this is a no-op.
+            # ``_RETAINED_LEGACY_PERMISSION_TABLES`` is empty post-graduation
+            # (``f6a7b8c9d0e1_drop_legacy_permission_tables`` retired the legacy
+            # tables that this loop used to scrub). Loop kept as a no-op so the
+            # call site stays explicit; can be removed wholesale next time this
+            # function is touched.
             for table in _RETAINED_LEGACY_PERMISSION_TABLES:
                 session.execute(
                     text(f"DELETE FROM {table} WHERE user_id = :uid"),

--- a/tests/server/auth/db/test_cli.py
+++ b/tests/server/auth/db/test_cli.py
@@ -20,22 +20,16 @@ def test_upgrade(tmp_path: Path) -> None:
         cursor.execute("SELECT name FROM sqlite_master WHERE type='table';")
         tables = cursor.fetchall()
 
-    # The legacy per-resource permission tables are created by earlier migrations
-    # and intentionally retained by ``e5f6a7b8c9d0`` so operators can still roll
-    # back without restoring from backup. A future migration will drop them.
+    # The legacy per-resource permission tables were retained by ``e5f6a7b8c9d0``
+    # for rollback safety and dropped by ``f6a7b8c9d0e1_drop_legacy_permission_tables``.
+    # Post-graduation, only the role_permissions / role / user-assignment tables
+    # remain alongside the alembic version + users tables.
     assert sorted(tables) == sorted([
         ("alembic_version_auth",),
         ("users",),
         ("roles",),
         ("role_permissions",),
         ("user_role_assignments",),
-        ("experiment_permissions",),
-        ("registered_model_permissions",),
-        ("scorer_permissions",),
-        ("gateway_secret_permissions",),
-        ("gateway_endpoint_permissions",),
-        ("gateway_model_definition_permissions",),
-        ("workspace_permissions",),
     ])
 
 
@@ -65,16 +59,16 @@ def test_auth_and_tracking_store_coexist(tmp_path: Path) -> None:
     assert "user_role_assignments" in tables
     assert "experiments" in tables
     assert "runs" in tables
-    # Legacy per-resource permission tables are intentionally retained by the
-    # ``e5f6a7b8c9d0`` migration so operators can still roll back without
-    # restoring from backup.
-    assert "experiment_permissions" in tables
-    assert "registered_model_permissions" in tables
-    assert "scorer_permissions" in tables
-    assert "gateway_secret_permissions" in tables
-    assert "gateway_endpoint_permissions" in tables
-    assert "gateway_model_definition_permissions" in tables
-    assert "workspace_permissions" in tables
+    # Legacy per-resource permission tables are dropped by
+    # ``f6a7b8c9d0e1_drop_legacy_permission_tables`` after the simplified RBAC
+    # model has bedded in.
+    assert "experiment_permissions" not in tables
+    assert "registered_model_permissions" not in tables
+    assert "scorer_permissions" not in tables
+    assert "gateway_secret_permissions" not in tables
+    assert "gateway_endpoint_permissions" not in tables
+    assert "gateway_model_definition_permissions" not in tables
+    assert "workspace_permissions" not in tables
 
 
 def test_upgrade_from_legacy_database(tmp_path: Path) -> None:
@@ -138,14 +132,12 @@ def test_upgrade_from_legacy_database(tmp_path: Path) -> None:
     assert "roles" in tables
     assert "role_permissions" in tables
     assert "user_role_assignments" in tables
-    # Legacy tables are intentionally retained by ``e5f6a7b8c9d0`` so operators
-    # can still roll back without restoring from backup. A future migration
-    # will drop them once the simplified RBAC model has bedded in.
-    assert "experiment_permissions" in tables
-    assert "scorer_permissions" in tables
-    assert "registered_model_permissions" in tables
-    assert "workspace_permissions" in tables
-    assert version[0] == "e5f6a7b8c9d0"
+    # Legacy tables are dropped by ``f6a7b8c9d0e1_drop_legacy_permission_tables``.
+    assert "experiment_permissions" not in tables
+    assert "scorer_permissions" not in tables
+    assert "registered_model_permissions" not in tables
+    assert "workspace_permissions" not in tables
+    assert version[0] == "f6a7b8c9d0e1"
     assert user == ("testuser", 1)
 
 
@@ -438,11 +430,19 @@ def test_upgrade_then_downgrade_then_upgrade_is_idempotent(tmp_path: Path) -> No
         )
         conn.commit()
 
-    # Snapshot legacy state pre-upgrade so we can verify it survives.
+    # Snapshot legacy state pre-upgrade so we can verify it survives the
+    # backfill (before the drop migration retires the tables).
     legacy_snapshot = _snapshot_legacy_tables(db)
 
-    # First upgrade.
-    res = runner.invoke(cli.upgrade, ["--url", db_url], catch_exceptions=False)
+    # First upgrade — pin to the backfill revision (NOT ``head``) so the
+    # legacy tables still exist for the rollback-contract assertions below.
+    # ``f6a7b8c9d0e1_drop_legacy_permission_tables`` drops them at head; that
+    # path is exercised by ``test_drop_migration_removes_legacy_tables``.
+    res = runner.invoke(
+        cli.upgrade,
+        ["--url", db_url, "--revision", "e5f6a7b8c9d0"],
+        catch_exceptions=False,
+    )
     assert res.exit_code == 0, res.output
     rp_after_first_upgrade = _snapshot_role_permissions(db)
     assert rp_after_first_upgrade, "first upgrade produced no role_permissions rows"
@@ -471,8 +471,13 @@ def test_upgrade_then_downgrade_then_upgrade_is_idempotent(tmp_path: Path) -> No
     # Legacy contents survive the downgrade — that's the rollback contract.
     assert _snapshot_legacy_tables(db) == legacy_snapshot
 
-    # Re-run upgrade. Output must match the first run row-for-row.
-    res = runner.invoke(cli.upgrade, ["--url", db_url], catch_exceptions=False)
+    # Re-run upgrade (still pinned to the backfill revision). Output must match
+    # the first run row-for-row.
+    res = runner.invoke(
+        cli.upgrade,
+        ["--url", db_url, "--revision", "e5f6a7b8c9d0"],
+        catch_exceptions=False,
+    )
     assert res.exit_code == 0, res.output
     assert _snapshot_role_permissions(db) == rp_after_first_upgrade
 
@@ -517,3 +522,58 @@ def _snapshot_legacy_tables(db: Path) -> dict[str, list[tuple[object, ...]]]:
             cursor.execute(query)
             snapshot[table] = cursor.fetchall()
     return snapshot
+
+
+def test_drop_migration_removes_legacy_tables(tmp_path: Path) -> None:
+    """``f6a7b8c9d0e1_drop_legacy_permission_tables`` is the graduation step
+    for the simplification migration: once the simplified RBAC model has bedded
+    in (target: MLflow 3.X+2 — see #23087), the seven retained pre-RBAC tables
+    are dropped. Pin the upgrade-then-downgrade contract:
+
+    - Upgrading to ``f6a7b8c9d0e1`` removes every legacy table from the schema.
+    - Downgrading rebuilds the schemas (so older revisions remain
+      introspectable) but does **not** restore the row data — the contract is
+      "no rollback after this point without restoring from backup."
+    """
+    runner = CliRunner()
+    db = tmp_path / "test.db"
+    db_url = f"sqlite:///{db}"
+
+    res = runner.invoke(cli.upgrade, ["--url", db_url], catch_exceptions=False)
+    assert res.exit_code == 0, res.output
+
+    with sqlite3.connect(db) as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table';")
+        tables_after_upgrade = {t[0] for t in cursor.fetchall()}
+        cursor.execute("SELECT version_num FROM alembic_version_auth;")
+        version_after_upgrade = cursor.fetchone()[0]
+
+    legacy_tables = {
+        "experiment_permissions",
+        "registered_model_permissions",
+        "scorer_permissions",
+        "gateway_secret_permissions",
+        "gateway_endpoint_permissions",
+        "gateway_model_definition_permissions",
+        "workspace_permissions",
+    }
+    assert tables_after_upgrade.isdisjoint(legacy_tables)
+    assert version_after_upgrade == "f6a7b8c9d0e1"
+
+    # Downgrade to the previous revision rebuilds the table schemas but with
+    # no row data — operators rolling back here must restore from backup if
+    # they need the original grants.
+    _alembic_downgrade(db_url, "e5f6a7b8c9d0")
+
+    with sqlite3.connect(db) as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table';")
+        tables_after_downgrade = {t[0] for t in cursor.fetchall()}
+        legacy_row_counts = {
+            table: cursor.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+            for table in legacy_tables
+        }
+
+    assert legacy_tables.issubset(tables_after_downgrade)
+    assert all(count == 0 for count in legacy_row_counts.values())

--- a/tests/server/auth/test_sqlalchemy_store.py
+++ b/tests/server/auth/test_sqlalchemy_store.py
@@ -269,71 +269,25 @@ def test_per_user_grants_isolated_across_workspaces(store, monkeypatch):
     )
 
 
-def test_delete_user_clears_retained_legacy_permission_rows(store):
-    """``e5f6a7b8c9d0`` retains the legacy permission tables on disk (they hold
-    pre-migration data for rollback). Their FKs to ``users.id`` are non-cascading
-    in earlier migrations, so a user with surviving legacy rows can't be deleted
-    on strict FK backends (e.g. PostgreSQL) unless ``delete_user`` first clears
-    them. Simulate that state by inserting raw rows into every legacy table and
-    confirm ``delete_user`` cleans them up rather than orphaning or erroring.
-    """
-    from sqlalchemy import text
+def test_per_user_grants_use_one_synthetic_role_per_workspace(store, monkeypatch):
+    from mlflow.environment_variables import MLFLOW_ENABLE_WORKSPACES
+    from mlflow.server.auth.db.models import SqlRole
+    from mlflow.server.auth.permissions import USE
+    from mlflow.utils.workspace_context import WorkspaceContext
 
-    username = random_str()
-    user = _user_maker(store, username, random_str())
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+    user = _user_maker(store, random_str(), random_str())
 
-    legacy_inserts = {
-        "experiment_permissions": (
-            "INSERT INTO experiment_permissions (experiment_id, user_id, permission)"
-            " VALUES (:eid, :uid, 'READ')"
-        ),
-        "registered_model_permissions": (
-            "INSERT INTO registered_model_permissions (workspace, name, user_id, permission)"
-            " VALUES ('ws-default', :rid, :uid, 'READ')"
-        ),
-        "scorer_permissions": (
-            "INSERT INTO scorer_permissions"
-            " (experiment_id, scorer_name, user_id, permission)"
-            " VALUES (:eid, :sname, :uid, 'READ')"
-        ),
-        "gateway_secret_permissions": (
-            "INSERT INTO gateway_secret_permissions (secret_id, user_id, permission)"
-            " VALUES (:gid, :uid, 'READ')"
-        ),
-        "gateway_endpoint_permissions": (
-            "INSERT INTO gateway_endpoint_permissions (endpoint_id, user_id, permission)"
-            " VALUES (:eid, :uid, 'READ')"
-        ),
-        "gateway_model_definition_permissions": (
-            "INSERT INTO gateway_model_definition_permissions"
-            " (model_definition_id, user_id, permission)"
-            " VALUES (:mid, :uid, 'READ')"
-        ),
-        "workspace_permissions": (
-            "INSERT INTO workspace_permissions (workspace, user_id, permission)"
-            " VALUES ('ws-default', :uid, 'USE')"
-        ),
-    }
+    workspaces = [f"ws-{random_str()}" for _ in range(2)]
+    for ws in workspaces:
+        with WorkspaceContext(ws):
+            store.grant_user_permission(user.username, "workspace", "*", USE.name)
+
+    # Distinct synthetic roles: one per workspace.
+    name = store._synthetic_user_role_name(user.id)
     with store.ManagedSessionMaker() as session:
-        for stmt in legacy_inserts.values():
-            session.execute(
-                text(stmt),
-                {
-                    "uid": user.id,
-                    "eid": random_str(),
-                    "rid": random_str(),
-                    "sname": random_str(),
-                    "gid": random_str(),
-                    "mid": random_str(),
-                },
-            )
-
-    store.delete_user(username)
-
-    with store.ManagedSessionMaker() as session:
-        for table in legacy_inserts:
-            count = session.execute(
-                text(f"SELECT COUNT(*) FROM {table} WHERE user_id = :uid"),
-                {"uid": user.id},
-            ).scalar()
-            assert count == 0, f"legacy rows in {table} not cleaned up by delete_user"
+        observed_workspaces = sorted(
+            workspace
+            for (workspace,) in session.query(SqlRole.workspace).filter(SqlRole.name == name).all()
+        )
+    assert observed_workspaces == sorted(workspaces)


### PR DESCRIPTION
> ## ⚠️ DO NOT MERGE
>
> This is the **graduation migration** for the RBAC simplification stack. It exists on the stack so reviewers can see the full graduation arc, but **must not land** until the simplified RBAC model has had at least one full release cycle of bake time. Target: **MLflow 3.X+2** (where 3.X is the release that ships #22855).
>
> Tracking: https://github.com/mlflow/mlflow/issues/23087

## 🥞 Stacked PR

- [stack/rbac/phase2-simplified](https://github.com/mlflow/mlflow/pull/22855) — ✅ MERGED
- [stack/rbac/phase2-legacy-endpoints](https://github.com/mlflow/mlflow/pull/22859) — ✅ MERGED
  - [stack/rbac/phase2-store-cleanup](https://github.com/mlflow/mlflow/pull/22861) [[Files changed](https://github.com/mlflow/mlflow/pull/22861/files)]
    - **[stack/rbac/phase2-drop-legacy-tables](https://github.com/mlflow/mlflow/pull/23089)** [[Files changed (incremental)](https://github.com/mlflow/mlflow/pull/23089/files/bc3ce389b..9fe8311af)] ← you are here

**Stacks on #22861.** Land that whole stack first, give the simplified model time to bed in across at least one MLflow release, then land this PR.

## What this PR does

Adds a single new alembic revision, `f6a7b8c9d0e1_drop_legacy_permission_tables`, that retires the seven pre-RBAC permission tables retained on disk by `e5f6a7b8c9d0`:

- `experiment_permissions`
- `registered_model_permissions`
- `scorer_permissions`
- `gateway_secret_permissions`
- `gateway_endpoint_permissions`
- `gateway_model_definition_permissions`
- `workspace_permissions`

Plus the cleanup that's only safe once those tables are gone:

- `_RETAINED_LEGACY_PERMISSION_TABLES` in `sqlalchemy_store.py` is set to `()`. The loop in `delete_user` becomes a no-op.
- `test_delete_user_clears_retained_legacy_permission_rows` is removed (no longer reachable).
- `test_upgrade`, `test_auth_and_tracking_store_coexist`, and `test_upgrade_from_legacy_database` flip their "legacy tables in" assertions to "not in".
- `test_upgrade_then_downgrade_then_upgrade_is_idempotent` pins its upgrade target at `e5f6a7b8c9d0` (not `head`) so it still exercises the retention contract on the prior revision.
- New `test_drop_migration_removes_legacy_tables` pins the upgrade/downgrade behavior of this migration.
- New `test_per_user_grants_use_one_synthetic_role_per_workspace` pins the synthetic-role-per-workspace invariant (added in this rebase since `delete_user_clears_retained_legacy_permission_rows` was the last test exercising the retention contract).

## Why DO NOT MERGE

The retention in `e5f6a7b8c9d0` exists specifically to give operators a window to roll back to the legacy code path without restoring from backup. Merging this PR before that window closes defeats the whole purpose of the two-step graduation. The simplified model needs to ship for at least one release with the legacy tables present so:

1. Operators have a real chance to validate it under their workloads.
2. Any rollbacks can use the legacy code path against still-populated legacy tables.
3. We catch any "we still need that legacy table for X" surprises before they become irreversible.

## Downgrade contract — point of no return

`downgrade()` rebuilds the table schemas (so older revisions referencing them remain introspectable) but **does not** restore the row data. Operators rolling back to a state that needs the legacy data must restore from backup. This is the deliberate cost of graduation; the breadcrumbs in #22855's `_RETAINED_LEGACY_PERMISSION_TABLES` docstring spell out the full checklist.

## How is this PR tested?

- [x] Full auth suite (~492 tests) passes.
- [x] Existing migration tests pass (8 in `tests/server/auth/db/test_cli.py`), including the new `test_drop_migration_removes_legacy_tables` and the rebased upgrade/downgrade-idempotency case.
- [ ] Manual: not yet — would test on a Postgres deployment with seeded legacy data before merging.

## Release Notes

#### Is this a user-facing change?

- [x] Yes. The pre-RBAC permission tables retained for rollback by MLflow 3.X are dropped in 3.X+2. Operators rolling back from 3.X+2 to a pre-3.X state must restore from backup. Operators staying on 3.X+2 or later see no change in behavior — the runtime stopped reading or writing these tables in 3.X.

#### What component(s) does this PR affect?

- [x] `area/server-infra`

#### How should the PR be classified in the release notes?

- [x] `rn/breaking-change`

#### Is this a critical bugfix?

- [x] Can wait for the next minor release.