### PR TITLE
Use comma-separated form for multi-package `uv run --with` examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ uv run pytest tests/
 uv run pytest tests/test_version.py
 
 # Run tests with specific package versions
-uv run --with abc==1.2.3 --with xyz==4.5.6 pytest tests/test_version.py
+uv run --with 'abc==1.2.3,xyz==4.5.6' pytest tests/test_version.py
 
 # Run tests with optional dependencies/extras
 uv run --with transformers pytest tests/transformers

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -652,7 +652,7 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
             "To run tests with additional packages, use:\n"
             "  uv run --with <package> pytest ...\n\n"
             "For multiple packages:\n"
-            "  uv run --with <package1> --with <package2> pytest ...\n\n",
+            "  uv run --with '<package1>,<package2>' pytest ...\n\n",
             yellow=True,
         )
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #N/A

### What changes are proposed in this pull request?

Consolidate the multi-package `uv run --with` examples to use the single-flag, comma-separated form (`--with 'a,b'`) instead of repeating the flag (`--with a --with b`):

- `CLAUDE.md` — testing example
- `tests/conftest.py` — pytest hint emitted on `ModuleNotFoundError`/`ImportError` when running under `uv run`

Both forms work; the single-flag form is shorter and is what the rest of the docs already lean toward.

### How is this PR tested?

- [x] Manual tests

Verified locally that `uv run --with 'cowsay==6.1,six==1.16.0' python -c '...'` resolves and installs both packages into the ephemeral overlay env.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release