### PR TITLE
Add `name` field to `pr-review` and `resolve` skills

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,8 +1,9 @@
 ---
+name: pr-review
+description: Review a GitHub pull request, add review comments for issues found, and approve if no significant issues exist
 disable-model-invocation: true
 allowed-tools: Read, Skill, Bash, Grep, Glob
-argument-hint: [extra_context]
-description: Review a GitHub pull request, add review comments for issues found, and approve if no significant issues exist
+argument-hint: "[extra_context]"
 ---
 
 # Review Pull Request

--- a/.claude/skills/resolve/SKILL.md
+++ b/.claude/skills/resolve/SKILL.md
@@ -1,8 +1,9 @@
 ---
+name: resolve
+description: Resolve PR review comments by fetching unresolved feedback and making necessary code changes
 disable-model-invocation: true
 allowed-tools: Skill, Read, Edit, Write, Glob, Grep, Bash
-argument-hint: [extra_context]
-description: Resolve PR review comments by fetching unresolved feedback and making necessary code changes
+argument-hint: "[extra_context]"
 ---
 
 # Resolve PR Review Comments


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

The Anthropic Agent Skills spec requires both `name` and `description` in
the SKILL.md YAML frontmatter, but `pr-review` and `resolve` were
missing the `name` field. This PR:

- Adds the `name` field to `.claude/skills/pr-review/SKILL.md` and
  `.claude/skills/resolve/SKILL.md`.
- Quotes the `argument-hint` value (`"[extra_context]"`) so YAML parses
  it as a string rather than a flow sequence (the unquoted form
  `[extra_context]` is rejected by strict YAML parsers).

No behavioral changes for Claude Code; the existing
`disable-model-invocation`, `allowed-tools`, and `argument-hint`
extensions are preserved.

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
