### PR TITLE
Auto-merge bot-authored `uv.lock` PRs

### DIFF
--- a/.github/workflows/approval.js
+++ b/.github/workflows/approval.js
@@ -63,6 +63,12 @@ function hasAnyApproval(reviews) {
 }
 
 module.exports = async ({ github, context, core }) => {
+  const { pull_request: pr } = context.payload;
+  const authorLogin = pr?.user?.login;
+  if (authorLogin === "mlflow-app[bot]") {
+    return;
+  }
+
   const maintainers = await getMaintainers({ github, context });
   const reviews = await github.paginate(github.rest.pulls.listReviews, {
     owner: context.repo.owner,
@@ -75,9 +81,6 @@ module.exports = async ({ github, context, core }) => {
       (maintainers.includes(user.login) ||
         (user.type.toLowerCase() === "bot" && user.login === "mlflow-app[bot]"))
   );
-
-  const { pull_request: pr } = context.payload;
-  const authorLogin = pr?.user?.login;
 
   const files = await github.paginate(github.rest.pulls.listFiles, {
     owner: context.repo.owner,

--- a/.github/workflows/uv.js
+++ b/.github/workflows/uv.js
@@ -129,4 +129,14 @@ module.exports = async ({ github, context }) => {
     labels: ["team-review"],
   });
   console.log("Added team-review label to the PR");
+
+  await github.graphql(
+    `mutation($pullRequestId: ID!) {
+      enablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId, mergeMethod: SQUASH }) {
+        pullRequest { autoMergeRequest { enabledAt } }
+      }
+    }`,
+    { pullRequestId: pr.node_id }
+  );
+  console.log("Enabled auto-merge");
 };

--- a/.github/workflows/uv.js
+++ b/.github/workflows/uv.js
@@ -132,7 +132,7 @@ module.exports = async ({ github, context }) => {
 
   await github.graphql(
     `mutation($pullRequestId: ID!) {
-      enablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId, mergeMethod: SQUASH }) {
+      enablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId }) {
         pullRequest { autoMergeRequest { enabledAt } }
       }
     }`,

--- a/.github/workflows/uv.yml
+++ b/.github/workflows/uv.yml
@@ -22,8 +22,10 @@ defaults:
 
 jobs:
   uv:
-    # Skip scheduled runs on forks
-    if: github.event_name != 'schedule' || github.repository == 'mlflow/mlflow'
+    # Skip scheduled runs on forks, and PR runs from fork branches (no access to secrets)
+    if: |
+      (github.event_name != 'schedule' || github.repository == 'mlflow/mlflow') &&
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23098

### What changes are proposed in this pull request?

Automate merging of the daily `Update uv.lock` PRs opened by `mlflow-app[bot]`.

- `.github/workflows/approval.js`: short-circuit the `Approval` check when the PR author is `mlflow-app[bot]`. The check reports green so the `Protect` watchdog (which polls every other workflow) no longer fails on a missing maintainer approval.
- `.github/workflows/uv.js`: after creating a new lockfile-bump PR, enable squash auto-merge via the `enablePullRequestAutoMerge` GraphQL mutation. The PR self-merges once `lint` and `protect` pass.

`protect` continues to gate on real check failures and flakes; only the `Approval` link in its watchdog is bypassed for the bot.

### How is this PR tested?

- [x] Manual tests

Verified by tracing through the chain: `approval.js` returns early for the bot, `protect.js` no longer sees `Approval` as a failure, and `enablePullRequestAutoMerge` is the only programmatic path to enable auto-merge (REST has no equivalent).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release