### PR TITLE
Fix `sentence_transformers` pyfunc predict for v5.4+

### DIFF
--- a/mlflow/sentence_transformers/__init__.py
+++ b/mlflow/sentence_transformers/__init__.py
@@ -541,7 +541,7 @@ class _SentenceTransformerModelWrapper:
             # `model.encode` rejects `pd.Series`/`DataFrame` since sentence-transformers v5.4
             # (https://github.com/huggingface/sentence-transformers/pull/3554)
             sentences = sentences.iloc[:, 0].tolist()
-            if type(sentences[0]) == list:
+            if sentences and type(sentences[0]) == list:
                 sentences = sentences[0]
         elif type(sentences) == pd.Series:
             sentences = sentences.tolist()

--- a/mlflow/sentence_transformers/__init__.py
+++ b/mlflow/sentence_transformers/__init__.py
@@ -538,6 +538,8 @@ class _SentenceTransformerModelWrapper:
             # Wrap the output to OpenAI format only when the input is dict `{"input": ... }`
             if self.task and list(sentences.columns)[0] == _LLM_V1_EMBEDDING_INPUT_KEY:
                 convert_output_to_llm_v1_format = True
+            # `model.encode` rejects `pd.Series`/`DataFrame` since sentence-transformers v5.4
+            # (https://github.com/huggingface/sentence-transformers/pull/3554)
             sentences = sentences.iloc[:, 0].tolist()
             if type(sentences[0]) == list:
                 sentences = sentences[0]

--- a/mlflow/sentence_transformers/__init__.py
+++ b/mlflow/sentence_transformers/__init__.py
@@ -538,9 +538,11 @@ class _SentenceTransformerModelWrapper:
             # Wrap the output to OpenAI format only when the input is dict `{"input": ... }`
             if self.task and list(sentences.columns)[0] == _LLM_V1_EMBEDDING_INPUT_KEY:
                 convert_output_to_llm_v1_format = True
-            sentences = sentences.iloc[:, 0]
+            sentences = sentences.iloc[:, 0].tolist()
             if type(sentences[0]) == list:
                 sentences = sentences[0]
+        elif type(sentences) == pd.Series:
+            sentences = sentences.tolist()
 
         # The encode API has additional parameters that we can add as kwargs.
         # See https://www.sbert.net/docs/package_reference/SentenceTransformer.html#sentence_transformers.SentenceTransformer.encode


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

`sentence-transformers` v5.4.0 ([huggingface/sentence-transformers#3554](https://github.com/UKPLab/sentence-transformers/pull/3554), squash-merged as `2b232af7f8`) introduced a new `infer_modality()` whose `case _:` branch raises `ValueError: Unsupported input type: Series. Expected one of: str, dict, PIL.Image.Image, np.ndarray, torch.Tensor` for any input that isn't `str`, `dict`, `PIL.Image.Image`, `np.ndarray`, or `torch.Tensor`.

`_SentenceTransformerModelWrapper.predict` extracts the first column of the input DataFrame as a `pandas.Series` and passes it directly to `model.encode()`, which now fails on v5.4+. The same path is hit during serving-input validation in `log_model`, producing the warning visible in `examples/sentence_transformers/simple.py` before the fatal error from `loaded_model.predict([...])`.

This PR converts the extracted column to a `list[str]` (and likewise for bare `pd.Series` inputs) before calling `model.encode()`, restoring compatibility on v5.4+ without changing behavior on earlier supported versions (>=3.0.0).

Bisect (verified locally with `--with 'sentence-transformers @ git+...'`):

| Ref | Result |
| --- | --- |
| `v5.3.0` | accepts `pd.Series` |
| parent of #3554 (`03bfbdfcde`) | accepts `pd.Series` |
| #3554 squash (`2b232af7f8`) | rejects `pd.Series` |
| `v5.4.0` / `v5.4.1` | rejects `pd.Series` |

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Manual:

- `examples/sentence_transformers/simple.py` runs end-to-end against `sentence-transformers==3.0.0`, `==5.3.0`, and `==5.4.1` (no warning, no traceback, embeddings printed).
- `pytest tests/sentence_transformers/test_sentence_transformers_model_export.py::test_model_pyfunc_save_load tests/sentence_transformers/test_sentence_transformers_model_export.py::test_model_pyfunc_predict_with_params` passes on the same matrix.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Restore compatibility of the `sentence_transformers` pyfunc flavor with `sentence-transformers>=5.4.0` by converting `pandas.Series`/`DataFrame` inputs to lists before delegating to `model.encode()`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
