### PR TITLE
Show age past cooldown in `show-versions` action

### DIFF
--- a/dev/show_package_release_dates.py
+++ b/dev/show_package_release_dates.py
@@ -20,7 +20,7 @@ def get_cooldown_days() -> int:
 
 
 class ReleaseFile(BaseModel):
-    upload_time: str
+    upload_time_iso_8601: str
 
 
 class PyPIResponse(BaseModel):
@@ -34,7 +34,7 @@ def get_distributions() -> list[tuple[str, str]]:
 
 def extract_upload_time(response: PyPIResponse, version: str) -> datetime | None:
     for f in response.releases.get(version, []):
-        return datetime.fromisoformat(f.upload_time).replace(tzinfo=timezone.utc)
+        return datetime.fromisoformat(f.upload_time_iso_8601.replace("Z", "+00:00"))
     return None
 
 

--- a/dev/show_package_release_dates.py
+++ b/dev/show_package_release_dates.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 import traceback
 from collections.abc import Sequence
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import aiohttp
@@ -60,8 +60,8 @@ def get_longest_string_length(array: Sequence[str]) -> int:
 def format_age_past_cooldown(release_date: datetime | None, cooldown_days: int) -> str:
     if release_date is None:
         return ""
-    days = (datetime.now(timezone.utc) - release_date).days - cooldown_days
-    return f"{days}d"
+    delta = datetime.now(timezone.utc) - release_date - timedelta(days=cooldown_days)
+    return f"{delta.total_seconds() / 86400:.1f}d"
 
 
 async def main() -> None:

--- a/dev/show_package_release_dates.py
+++ b/dev/show_package_release_dates.py
@@ -1,12 +1,22 @@
 import asyncio
 import json
+import re
 import subprocess
 import sys
 import traceback
 from collections.abc import Sequence
+from datetime import datetime, timezone
+from pathlib import Path
 
 import aiohttp
 from pydantic import BaseModel
+
+
+def get_cooldown_days() -> int:
+    pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+    if m := re.search(r'^exclude-newer\s*=\s*"P(\d+)D"\s*$', pyproject.read_text(), re.MULTILINE):
+        return int(m.group(1))
+    raise RuntimeError(f'`exclude-newer = "P<N>D"` not found in {pyproject}')
 
 
 class ReleaseFile(BaseModel):
@@ -22,15 +32,15 @@ def get_distributions() -> list[tuple[str, str]]:
     return [(pkg["name"], pkg["version"]) for pkg in json.loads(res)]
 
 
-def extract_upload_time(response: PyPIResponse, version: str) -> str | None:
+def extract_upload_time(response: PyPIResponse, version: str) -> datetime | None:
     for f in response.releases.get(version, []):
-        return f.upload_time.replace("T", " ")
+        return datetime.fromisoformat(f.upload_time).replace(tzinfo=timezone.utc)
     return None
 
 
 async def get_release_date(
     session: aiohttp.ClientSession, package: str, version: str
-) -> str | None:
+) -> datetime | None:
     try:
         async with session.get(f"https://pypi.python.org/pypi/{package}/json", timeout=10) as resp:
             resp.raise_for_status()
@@ -47,33 +57,41 @@ def get_longest_string_length(array: Sequence[str]) -> int:
     return len(max(array, key=len))
 
 
+def format_age_past_cooldown(release_date: datetime | None, cooldown_days: int) -> str:
+    if release_date is None:
+        return ""
+    days = (datetime.now(timezone.utc) - release_date).days - cooldown_days
+    return f"{days}d"
+
+
 async def main() -> None:
+    cooldown_days = get_cooldown_days()
     distributions = get_distributions()
     async with aiohttp.ClientSession() as session:
         tasks = [get_release_date(session, pkg, ver) for pkg, ver in distributions]
         results = await asyncio.gather(*tasks)
 
-    release_dates = [r or "" for r in results]
+    ages = [format_age_past_cooldown(r, cooldown_days) for r in results]
     packages, versions = list(zip(*distributions))
+    age_header = f"Age past {cooldown_days}d cooldown"
     package_length = get_longest_string_length(packages)
     version_length = get_longest_string_length(versions)
-    release_timestamp_length = get_longest_string_length(release_dates)
+    age_length = max(get_longest_string_length(ages), len(age_header))
     print(
         "Package".ljust(package_length),
         "Version".ljust(version_length),
-        "Release Timestamp".ljust(release_timestamp_length),
+        age_header.ljust(age_length),
     )
-    print("-" * (package_length + version_length + release_timestamp_length + 2))
-    for package, version, release_date in sorted(
-        zip(packages, versions, release_dates),
-        # Sort by release date in descending order
-        key=lambda x: x[2],
-        reverse=True,
+    print("-" * (package_length + version_length + age_length + 2))
+    for package, version, age, _ in sorted(
+        zip(packages, versions, ages, results),
+        # Newest first; entries without a release date sort to the end.
+        key=lambda x: (x[3] is None, -x[3].timestamp() if x[3] else 0),
     ):
         print(
             package.ljust(package_length),
             version.ljust(version_length),
-            release_date.ljust(release_timestamp_length),
+            age.ljust(age_length),
         )
 
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

Update `dev/show_package_release_dates.py` (used by the `.github/actions/show-versions` composite action) so the third column reports each package's age past the uv cooldown window instead of the raw release timestamp.

- Drop the `Release Timestamp` column.
- Add an `Age past Nd cooldown` column, where `N` is parsed from `tool.uv.exclude-newer` (currently `P14D`) in `pyproject.toml` via a small regex; the script raises if the key is missing or not in `P<N>D` form.
- Sort newest first (entries without a release date sort to the end).

Sample output:

```
Package                                  Version         Age past 14d cooldown
------------------------------------------------------------------------------
databricks-sdk                           0.105.0         0d
uvicorn                                  0.46.0          0d
...
Mako                                     1.3.11          9d
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Ran `dev/show_package_release_dates.py` locally and verified the new column displays the expected `Nd` values relative to a 14-day cooldown.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release