### PR TITLE
Support attempt URLs in `/analyze-ci` skill

### DIFF
--- a/.claude/skills/src/skills/commands/analyze_ci.py
+++ b/.claude/skills/src/skills/commands/analyze_ci.py
@@ -187,8 +187,14 @@ def truncate_logs(logs: str, max_tokens: int = MAX_LOG_TOKENS) -> str:
 
 
 PR_URL_PATTERN = re.compile(r"github\.com/([^/]+/[^/]+)/pull/(\d+)")
-JOB_URL_PATTERN = re.compile(r"github\.com/([^/]+/[^/]+)/actions/runs/(\d+)/job/(\d+)")
-RUN_URL_PATTERN = re.compile(r"github\.com/([^/]+/[^/]+)/actions/runs/(\d+)")
+# Job URLs may optionally embed an attempt segment (`/attempts/{n}`) before `/job/{id}`.
+# The job ID is unique across attempts so the attempt number isn't needed for lookup.
+JOB_URL_PATTERN = re.compile(
+    r"github\.com/([^/]+/[^/]+)/actions/runs/(\d+)(?:/attempts/\d+)?/job/(\d+)"
+)
+# Run URLs may optionally specify an attempt (`/attempts/{n}`); when omitted, GitHub's
+# default behavior is to return jobs from the latest attempt only.
+RUN_URL_PATTERN = re.compile(r"github\.com/([^/]+/[^/]+)/actions/runs/(\d+)(?:/attempts/(\d+))?")
 
 
 async def get_failed_jobs_from_pr(
@@ -228,8 +234,11 @@ async def resolve_urls(client: GitHubClient, urls: list[str]) -> list[Job]:
             repo_full = match.group(1)
             owner, repo = repo_full.split("/")
             run_id = int(match.group(2))
+            attempt = int(match.group(3)) if match.group(3) else None
             run_jobs = [
-                j async for j in client.get_jobs(owner, repo, run_id) if j.conclusion == "failure"
+                j
+                async for j in client.get_jobs(owner, repo, run_id, attempt)
+                if j.conclusion == "failure"
             ]
             jobs.extend(run_jobs)
         elif match := PR_URL_PATTERN.search(url):

--- a/.claude/skills/src/skills/github/client.py
+++ b/.claude/skills/src/skills/github/client.py
@@ -110,14 +110,22 @@ class GitHubClient:
                 break
             page += 1
 
-    async def get_jobs(self, owner: str, repo: str, run_id: int) -> AsyncIterator[Job]:
-        """Get jobs for a workflow run."""
+    async def get_jobs(
+        self, owner: str, repo: str, run_id: int, attempt: int | None = None
+    ) -> AsyncIterator[Job]:
+        """Get jobs for a workflow run.
+
+        If `attempt` is None, returns jobs from the latest attempt only (GitHub's default).
+        If `attempt` is given, returns jobs from that specific attempt.
+        """
+        endpoint = (
+            f"/repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt}/jobs"
+            if attempt is not None
+            else f"/repos/{owner}/{repo}/actions/runs/{run_id}/jobs"
+        )
         page = 1
         while True:
-            data = await self._get_json(
-                f"/repos/{owner}/{repo}/actions/runs/{run_id}/jobs",
-                {"per_page": 100, "page": page},
-            )
+            data = await self._get_json(endpoint, {"per_page": 100, "page": page})
             jobs = data.get("jobs", [])
             if not jobs:
                 break


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

The `/analyze-ci` skill called the `/repos/.../actions/runs/{id}/jobs` endpoint without a `filter` parameter, which returns only the latest attempt's jobs. As a result, failures on prior attempts (which is the common situation right after a `gh run rerun --failed`) were silently invisible to the skill.

This PR teaches the skill to recognize the `/attempts/{n}` segment in run/job URLs:

- `…/actions/runs/{id}` — unchanged behavior; returns the latest attempt's jobs.
- `…/actions/runs/{id}/attempts/{n}` — new; routes through `/runs/{id}/attempts/{n}/jobs` so jobs from that specific attempt are returned.
- `…/actions/runs/{id}/attempts/{n}/job/{job_id}` — new; tolerated by the job-URL pattern (job IDs are unique across attempts, so the existing `/actions/jobs/{job_id}` lookup still works).

The PR-URL flow is unchanged (still latest-attempt-only) per the smallest-change principle; users who need older attempts can now point the skill directly at the attempt URL.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Verified locally with the skill against:

- A non-attempt run URL — unchanged result.
- An attempt-1 URL of a multi-attempt run — correctly surfaces the failure that was on the prior attempt (which the latest-only default would have missed).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
