### PR TITLE
Add workspace isolation on scorers when creating a guardrail

### DIFF
--- a/mlflow/store/tracking/gateway/sqlalchemy_mixin.py
+++ b/mlflow/store/tracking/gateway/sqlalchemy_mixin.py
@@ -1381,6 +1381,9 @@ class SqlAlchemyGatewayStoreMixin:
         created_by: str | None = None,
     ) -> GatewayGuardrail:
         with self.ManagedSessionMaker() as session:
+            # Ensure the scorer is valid and in the current workspace
+            self._get_scorer_version(session, scorer_id, scorer_version)
+
             guardrail_id = f"gr-{uuid.uuid4().hex}"
             current_time = get_current_time_millis()
 

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -2621,34 +2621,61 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                     RESOURCE_DOES_NOT_EXIST,
                 )
 
-            # Build query for scorer versions
-            query = session.query(SqlScorerVersion).filter(
-                SqlScorerVersion.scorer_id == scorer.scorer_id
-            )
-
-            if version is not None:
-                # Get specific version
-                sql_scorer_version = query.filter(
-                    SqlScorerVersion.scorer_version == version
-                ).first()
-                if sql_scorer_version is None:
+            try:
+                sql_scorer_version = self._get_scorer_version(
+                    session=session,
+                    scorer_id=scorer.scorer_id,
+                    version=version,
+                )
+            except MlflowException as e:
+                if e.error_code != ErrorCode.Name(RESOURCE_DOES_NOT_EXIST):
+                    raise
+                if version is not None:
                     raise MlflowException(
                         f"Scorer with name '{name}' and version {version} not found for "
                         f"experiment {experiment_id}.",
                         RESOURCE_DOES_NOT_EXIST,
-                    )
-            else:
-                # Get maximum version
-                sql_scorer_version = query.order_by(SqlScorerVersion.scorer_version.desc()).first()
-                if sql_scorer_version is None:
-                    raise MlflowException(
-                        f"Scorer with name '{name}' not found for experiment {experiment_id}.",
-                        RESOURCE_DOES_NOT_EXIST,
-                    )
+                    ) from e
+                raise MlflowException(
+                    f"Scorer with name '{name}' not found for experiment {experiment_id}.",
+                    RESOURCE_DOES_NOT_EXIST,
+                ) from e
 
             entity = sql_scorer_version.to_mlflow_entity()
             # Resolve gateway endpoint ID to name before returning
             return self.resolve_endpoint_in_scorer(entity)
+
+    def _get_scorer_version(
+        self,
+        session: Session,
+        scorer_id: str,
+        version: int | None = None,
+    ) -> SqlScorerVersion:
+        scorer = (
+            self._get_query(session, SqlScorer).filter(SqlScorer.scorer_id == scorer_id).first()
+        )
+        if scorer is None:
+            raise MlflowException(
+                f"Scorer with ID '{scorer_id}' not found.",
+                RESOURCE_DOES_NOT_EXIST,
+            )
+
+        query = session.query(SqlScorerVersion).filter(SqlScorerVersion.scorer_id == scorer_id)
+        if version is not None:
+            sql_scorer_version = query.filter(SqlScorerVersion.scorer_version == version).first()
+            if sql_scorer_version is None:
+                raise MlflowException(
+                    f"Scorer with ID '{scorer_id}' and version {version} not found.",
+                    RESOURCE_DOES_NOT_EXIST,
+                )
+        else:
+            sql_scorer_version = query.order_by(SqlScorerVersion.scorer_version.desc()).first()
+            if sql_scorer_version is None:
+                raise MlflowException(
+                    f"Scorer with ID '{scorer_id}' not found.",
+                    RESOURCE_DOES_NOT_EXIST,
+                )
+        return sql_scorer_version
 
     def delete_scorer(self, experiment_id, name, version=None) -> None:
         """

--- a/mlflow/store/tracking/sqlalchemy_workspace_store.py
+++ b/mlflow/store/tracking/sqlalchemy_workspace_store.py
@@ -34,6 +34,7 @@ from mlflow.store.tracking.dbmodels.models import (
     SqlLoggedModel,
     SqlOnlineScoringConfig,
     SqlRun,
+    SqlScorer,
     SqlTraceInfo,
 )
 from mlflow.store.tracking.sqlalchemy_store import (
@@ -98,6 +99,11 @@ class WorkspaceAwareSqlAlchemyStore(WorkspaceAwareMixin, SqlAlchemyStore):
         if model is SqlOnlineScoringConfig:
             return query.join(
                 SqlExperiment, SqlOnlineScoringConfig.experiment_id == SqlExperiment.experiment_id
+            ).filter(SqlExperiment.workspace == workspace)
+
+        if model is SqlScorer:
+            return query.join(
+                SqlExperiment, SqlScorer.experiment_id == SqlExperiment.experiment_id
             ).filter(SqlExperiment.workspace == workspace)
 
         if model is SqlEvaluationDataset:

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_workspace_store.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_workspace_store.py
@@ -2310,3 +2310,38 @@ def test_guardrails_are_workspace_scoped(gateway_workspace_store):
         guardrails = gateway_workspace_store.list_gateway_guardrails()
         assert len(guardrails) == 1
         assert guardrails[0].guardrail_id == guardrail_a.guardrail_id
+
+
+def test_guardrails_reject_cross_workspace_scorers(gateway_workspace_store):
+    with WorkspaceContext("team-guard-create-a"):
+        scorer_a, _ = _create_scorer_in_workspace(gateway_workspace_store, "team-guard-create-a")
+
+    with WorkspaceContext("team-guard-create-b"):
+        with pytest.raises(
+            MlflowException,
+            match=rf"Scorer with ID '{scorer_a.scorer_id}' not found",
+        ):
+            gateway_workspace_store.create_gateway_guardrail(
+                name="guardrail-cross-workspace",
+                scorer_id=scorer_a.scorer_id,
+                scorer_version=scorer_a.scorer_version,
+                stage=GuardrailStage.BEFORE,
+                action=GuardrailAction.VALIDATION,
+            )
+
+
+def test_guardrails_reject_missing_scorer_version_in_same_workspace(gateway_workspace_store):
+    with WorkspaceContext("team-guard-version-a"):
+        scorer_a, _ = _create_scorer_in_workspace(gateway_workspace_store, "team-guard-version-a")
+
+        with pytest.raises(
+            MlflowException,
+            match=rf"Scorer with ID '{scorer_a.scorer_id}' and version 999 not found",
+        ):
+            gateway_workspace_store.create_gateway_guardrail(
+                name="guardrail-missing-version",
+                scorer_id=scorer_a.scorer_id,
+                scorer_version=999,
+                stage=GuardrailStage.BEFORE,
+                action=GuardrailAction.VALIDATION,
+            )

--- a/tests/store/tracking/test_gateway_sql_store.py
+++ b/tests/store/tracking/test_gateway_sql_store.py
@@ -2476,6 +2476,31 @@ def _create_scorer(store: SqlAlchemyStore, endpoint_name: str | None = None):
     return store.register_scorer(experiment_id, f"safety-judge-{name_suffix}", serialized_scorer)
 
 
+def _create_scorer_versions(store: SqlAlchemyStore):
+    """Helper to create multiple versions of a scorer for guardrail tests."""
+    name_suffix = uuid.uuid4().hex[:8]
+    endpoint = _create_gateway_endpoint(store, f"guardrail-ep-{name_suffix}")
+    experiment_id = store.create_experiment(f"guardrail-scorer-exp-{name_suffix}")
+    scorer_name = f"safety-judge-{name_suffix}"
+
+    serialized_scorer_v1 = json.dumps({
+        "instructions_judge_pydantic_data": {
+            "model": f"gateway:/{endpoint.name}",
+            "instructions": "Is this input safe?",
+        }
+    })
+    serialized_scorer_v2 = json.dumps({
+        "instructions_judge_pydantic_data": {
+            "model": f"gateway:/{endpoint.name}",
+            "instructions": "Is this input still safe?",
+        }
+    })
+
+    scorer_v1 = store.register_scorer(experiment_id, scorer_name, serialized_scorer_v1)
+    scorer_v2 = store.register_scorer(experiment_id, scorer_name, serialized_scorer_v2)
+    return scorer_v1, scorer_v2
+
+
 def test_create_gateway_guardrail(store: SqlAlchemyStore):
     scorer = _create_scorer(store)
 
@@ -2514,6 +2539,33 @@ def test_create_gateway_guardrail_after_sanitization(store: SqlAlchemyStore):
 
     assert guardrail.stage == GuardrailStage.AFTER
     assert guardrail.action == GuardrailAction.SANITIZATION
+
+
+def test_create_gateway_guardrail_rejects_unknown_scorer(store: SqlAlchemyStore):
+    with pytest.raises(MlflowException, match="Scorer with ID 'missing-scorer' not found"):
+        store.create_gateway_guardrail(
+            name="test-guardrail",
+            scorer_id="missing-scorer",
+            scorer_version=1,
+            stage=GuardrailStage.BEFORE,
+            action=GuardrailAction.VALIDATION,
+        )
+
+
+def test_create_gateway_guardrail_rejects_unknown_scorer_version(store: SqlAlchemyStore):
+    scorer = _create_scorer(store)
+
+    with pytest.raises(
+        MlflowException,
+        match=rf"Scorer with ID '{scorer.scorer_id}' and version 999 not found",
+    ):
+        store.create_gateway_guardrail(
+            name="test-guardrail",
+            scorer_id=scorer.scorer_id,
+            scorer_version=999,
+            stage=GuardrailStage.BEFORE,
+            action=GuardrailAction.VALIDATION,
+        )
 
 
 def test_get_gateway_guardrail(store: SqlAlchemyStore):


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Previous to this commit, the scorer_id was not validated when creating a guardrail so it could cross workspace boundaries.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Enforce that scorers are in the same workspace when creating a guardrail.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
