### PR TITLE
Catch `PermissionError` in `terminate_session_process` on Windows

### DIFF
--- a/mlflow/server/assistant/session.py
+++ b/mlflow/server/assistant/session.py
@@ -231,6 +231,6 @@ def terminate_session_process(session_id: str) -> bool:
             os.kill(pid, signal.SIGTERM)
             clear_process_pid(session_id)
             return True
-        except ProcessLookupError:
+        except (ProcessLookupError, PermissionError):
             clear_process_pid(session_id)
     return False

--- a/tests/server/assistant/test_api.py
+++ b/tests/server/assistant/test_api.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -356,7 +357,7 @@ def test_patch_session_cancel_with_process(client):
     session_id = r.json()["session_id"]
 
     # Start a real subprocess and register it with the session
-    with subprocess.Popen(["sleep", "10"]) as proc:
+    with subprocess.Popen([sys.executable, "-c", "import time; time.sleep(10)"]) as proc:
         save_process_pid(session_id, proc.pid)
 
         assert _is_process_running(proc.pid)


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

On Windows, `os.kill(pid, signal.SIGTERM)` calls `OpenProcess` + `TerminateProcess` under the hood. If the target PID is already dead (e.g., the subprocess crashed or exited before cancellation reached the server), Windows returns `ERROR_ACCESS_DENIED` (`WinError 5`) rather than the equivalent of "no such process". Python maps this to `PermissionError`, not `ProcessLookupError`.

`terminate_session_process` only caught `ProcessLookupError`, so the dead-PID case on Windows surfaced as an uncaught `PermissionError` and made `test_patch_session_cancel_with_process` flaky on Windows CI.

This PR widens the except clause to also catch `PermissionError`, so cleanup runs in both cases.

#### Failed CI run

`MLflow tests / windows (2)` (attempt 1) — https://github.com/mlflow/mlflow/actions/runs/25505870831/job/74851420398 (passed on rerun in attempt 2).

```
E               PermissionError: [WinError 5] Access is denied

pid        = 10200
session_id = '08dcacc1-5a0e-4728-8f6d-368165c389f0'

mlflow\server\assistant\session.py:231: PermissionError
...
FAILED tests/server/assistant/test_api.py::test_patch_session_cancel_with_process - PermissionError: [WinError 5] Access is denied
```

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release