### PR TITLE
Support GenAI operation details event translation

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.utils.tsx
@@ -16,6 +16,7 @@ import {
   getEvaluationResultAssessmentValue,
   KnownEvaluationResultAssessmentStringValue,
   stringifyValue,
+  tryExtractMessageContent,
 } from './components/GenAiEvaluationTracesReview.utils';
 import { RESPONSE_COLUMN_ID } from './hooks/useTableColumns';
 import type {
@@ -103,14 +104,8 @@ export const formatResponseTitle = (outputs: string) => {
 
   try {
     const parsedOutputs = JSON.parse(outputs);
-
-    // Try to parse OpenAI messages
-    const choices = parsedOutputs['response']['choices'];
-    if (Array.isArray(choices) && !isNil(choices[0]?.message?.content)) {
-      outputsTitle = choices[0]?.message?.content;
-    } else {
-      outputsTitle = stringifyValue(outputs);
-    }
+    const response = parsedOutputs?.response ?? parsedOutputs;
+    outputsTitle = tryExtractMessageContent(response, 'assistant') ?? stringifyValue(outputs);
   } catch {
     outputsTitle = stringifyValue(outputs);
   }

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/GenAiEvaluationTracesReview.utils.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/GenAiEvaluationTracesReview.utils.test.ts
@@ -262,6 +262,15 @@ describe('EvaluationsReview utils', () => {
       expect(tryExtractUserMessageContent(openaiInput)).toEqual('Hello there');
     });
 
+    it('should extract user message from GenAI semantic convention parts', () => {
+      const genAIInput = [
+        { role: 'system', parts: [{ type: 'text', content: 'You are helpful' }] },
+        { role: 'user', parts: [{ type: 'text', content: 'What is MLflow?' }] },
+      ];
+
+      expect(tryExtractUserMessageContent(genAIInput)).toEqual('What is MLflow?');
+    });
+
     it('should return undefined for non-chat-like objects', () => {
       expect(tryExtractUserMessageContent({ foo: 'bar' })).toBeUndefined();
       expect(tryExtractUserMessageContent({ data: [1, 2, 3] })).toBeUndefined();

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/GenAiEvaluationTracesReview.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/GenAiEvaluationTracesReview.utils.tsx
@@ -23,30 +23,41 @@ export const INPUT_REQUEST_KEY = 'request';
 const COMMON_MESSAGE_FORMATS = ['openai', 'langchain', 'anthropic'] as const;
 
 /**
- * Attempts to extract the last user message content from various chat formats.
+ * Attempts to extract the last message content for the given role from various chat formats.
  * Returns undefined if the input cannot be parsed as a chat format.
  */
-export const tryExtractUserMessageContent = (input: unknown): string | undefined => {
-  // This prevents raw/truncated strings from being incorrectly treated as user messages
+export const tryExtractMessageContent = (input: unknown, role: string): string | undefined => {
+  // This prevents raw/truncated strings from being incorrectly treated as messages.
   if (isNil(input) || typeof input !== 'object') {
     return undefined;
   }
 
   try {
+    const extractContent = (messages: ReturnType<typeof normalizeConversation>) => {
+      const message = messages?.findLast((msg) => msg.role === role);
+      return message?.content || undefined;
+    };
+
     for (const format of COMMON_MESSAGE_FORMATS) {
-      const messages = normalizeConversation(input, format);
-      if (messages && messages.length > 0) {
-        const lastUserMessage = [...messages].reverse().find((msg) => msg.role === 'user');
-        if (lastUserMessage?.content) {
-          return lastUserMessage.content;
-        }
+      const content = extractContent(normalizeConversation(input, format));
+      if (content) {
+        return content;
       }
+    }
+
+    const content = extractContent(normalizeConversation(input));
+    if (content) {
+      return content;
     }
   } catch {
     // JSON may be truncated or malformed, silently fail
   }
 
   return undefined;
+};
+
+export const tryExtractUserMessageContent = (input: unknown): string | undefined => {
+  return tryExtractMessageContent(input, 'user');
 };
 
 const INPUT_MESSAGES_KEY = 'messages';

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/TraceUtils.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/TraceUtils.test.ts
@@ -746,6 +746,30 @@ describe('convertTraceInfoV3ToRunEvalEntry', () => {
     expect(result.inputsTitle).toEqual('Hello there');
   });
 
+  it('should extract user message from GenAI semantic convention input using request_preview', () => {
+    const genAIRequest = JSON.stringify([
+      { role: 'system', parts: [{ type: 'text', content: 'You are helpful' }] },
+      { role: 'user', parts: [{ type: 'text', content: 'What is MLflow?' }] },
+    ]);
+
+    const traceInfo: ModelTraceInfoV3 = {
+      trace_id: 'trace_genai',
+      trace_location: { type: 'MLFLOW_EXPERIMENT', mlflow_experiment: { experiment_id: 'exp_genai' } },
+      request_time: '2023-10-01T00:00:00Z',
+      state: 'OK',
+      client_request_id: 'client_genai',
+      request_preview: genAIRequest,
+      response_preview: '{}',
+      tags: {},
+      trace_metadata: {},
+      assessments: [],
+    };
+
+    const result = convertTraceInfoV3ToRunEvalEntry(traceInfo);
+
+    expect(result.inputsTitle).toEqual('What is MLflow?');
+  });
+
   it('should fallback to deprecated request field when request_preview is not available', () => {
     const openaiRequest = JSON.stringify({
       messages: [{ role: 'user', content: 'Using deprecated request field' }],

--- a/mlflow/tracing/otel/translation/__init__.py
+++ b/mlflow/tracing/otel/translation/__init__.py
@@ -49,6 +49,7 @@ _TRANSLATORS: list[OtelSchemaTranslator] = [
 
 # Event-based translators (for frameworks that use events for input/output)
 _EVENT_TRANSLATORS = [
+    GenAiTranslator(),
     SpringAiTranslator(),
     LiveKitTranslator(),
 ]

--- a/mlflow/tracing/otel/translation/genai_semconv.py
+++ b/mlflow/tracing/otel/translation/genai_semconv.py
@@ -55,20 +55,37 @@ class GenAiTranslator(OtelSchemaTranslator):
     LLM_PROVIDER_KEY = "gen_ai.provider.name"
     TOOL_DEFINITION_KEYS = ["gen_ai.tool.definitions"]
 
+    INFERENCE_OPERATION_DETAILS_EVENT_NAME = "gen_ai.client.inference.operation.details"
+
     def _decode_json_value(self, value: Any) -> Any:
         """Decode JSON-serialized string values."""
-        if isinstance(value, str):
+        while isinstance(value, str):
             try:
-                return json.loads(value)
+                decoded = json.loads(value)
             except (json.JSONDecodeError, TypeError):
-                pass
+                break
+            if decoded == value:
+                break
+            value = decoded
         return value
+
+    def _get_operation_details_event_value(self, events: list[dict[str, Any]], key: str) -> Any:
+        for event in events:
+            if event.get("name") != self.INFERENCE_OPERATION_DETAILS_EVENT_NAME:
+                continue
+            event_attrs = event.get("attributes", {})
+            if value := event_attrs.get(key):
+                return json.dumps(self._decode_json_value(value))
+        return None
 
     def get_input_value_from_events(self, events: list[dict[str, Any]]) -> Any:
         """
         Get input value from GenAI semantic convention events.
 
-        GenAI semantic convention events for LLM messages:
+        Latest GenAI semantic convention event:
+        - gen_ai.client.inference.operation.details with gen_ai.input.messages attribute
+
+        Legacy GenAI semantic convention events for LLM messages:
         - gen_ai.system.message
         - gen_ai.user.message
         - gen_ai.assistant.message
@@ -79,6 +96,9 @@ class GenAiTranslator(OtelSchemaTranslator):
         Returns:
             JSON-serialized list of input messages or None if not found
         """
+        if value := self._get_operation_details_event_value(events, "gen_ai.input.messages"):
+            return value
+
         messages = []
 
         for event in events:
@@ -106,7 +126,10 @@ class GenAiTranslator(OtelSchemaTranslator):
         """
         Get output value from GenAI semantic convention events.
 
-        GenAI semantic convention events for LLM responses:
+        Latest GenAI semantic convention event:
+        - gen_ai.client.inference.operation.details with gen_ai.output.messages attribute
+
+        Legacy GenAI semantic convention event for LLM responses:
         - gen_ai.choice
 
         Args:
@@ -115,6 +138,9 @@ class GenAiTranslator(OtelSchemaTranslator):
         Returns:
             JSON-serialized list of output messages or None if not found
         """
+        if value := self._get_operation_details_event_value(events, "gen_ai.output.messages"):
+            return value
+
         messages = []
 
         for event in events:

--- a/mlflow/tracing/utils/truncation.py
+++ b/mlflow/tracing/utils/truncation.py
@@ -25,7 +25,7 @@ def set_request_response_preview(trace_info: TraceInfo, trace_data: TraceData) -
 
 
 def _get_truncated_preview(
-    request_or_response: str | dict[str, Any] | None, role: str
+    request_or_response: str | dict[str, Any] | list[Any] | None, role: str
 ) -> str | None:
     if request_or_response is None:
         return None
@@ -34,7 +34,7 @@ def _get_truncated_preview(
 
     content = None
     obj = None
-    if isinstance(request_or_response, dict):
+    if isinstance(request_or_response, (dict, list)):
         obj = request_or_response
         request_or_response = json.dumps(request_or_response)
     elif isinstance(request_or_response, str):
@@ -66,7 +66,10 @@ def _get_max_length() -> int:
     )
 
 
-def _try_extract_messages(obj: dict[str, Any]) -> list[dict[str, Any]] | None:
+def _try_extract_messages(obj: dict[str, Any] | list[Any]) -> list[dict[str, Any]] | None:
+    if isinstance(obj, list):
+        return [item for item in obj if _is_message(item)]
+
     if not isinstance(obj, dict):
         return None
 
@@ -101,7 +104,7 @@ def _try_extract_messages(obj: dict[str, Any]) -> list[dict[str, Any]] | None:
 
 
 def _is_message(item: Any) -> bool:
-    return isinstance(item, dict) and "role" in item and "content" in item
+    return isinstance(item, dict) and "role" in item and ("content" in item or "parts" in item)
 
 
 def _get_last_message(messages: list[dict[str, Any]], role: str) -> dict[str, Any]:
@@ -126,4 +129,10 @@ def _get_text_content_from_message(message: dict[str, Any]) -> str:
                 return part.get("text")
     elif isinstance(content, str):
         return content
+
+    parts = message.get("parts")
+    if isinstance(parts, list):
+        for part in parts:
+            if isinstance(part, dict) and part.get("type") == "text":
+                return part.get("content") or part.get("text") or ""
     return ""

--- a/tests/tracing/otel/test_span_translation.py
+++ b/tests/tracing/otel/test_span_translation.py
@@ -513,6 +513,56 @@ def test_translate_outputs_for_spans_traceloop(output_key: str, output_value: An
 
 
 @pytest.mark.parametrize(
+    "encode_event_value",
+    [
+        lambda value: value,
+        json.dumps,
+        lambda value: json.dumps(json.dumps(value)),
+    ],
+)
+def test_translate_inputs_outputs_from_genai_events_matches_attributes(encode_event_value):
+    input_messages = [{"role": "user", "parts": [{"type": "text", "content": "hello"}]}]
+    output_messages = [
+        {
+            "role": "assistant",
+            "parts": [{"type": "text", "content": "hi"}],
+            "finish_reason": "stop",
+        }
+    ]
+
+    attribute_span = mock.Mock(spec=Span)
+    attribute_span.to_dict.return_value = {
+        "attributes": {
+            "gen_ai.input.messages": json.dumps(input_messages),
+            "gen_ai.output.messages": json.dumps(output_messages),
+        },
+    }
+    event_span = mock.Mock(spec=Span)
+    event_span.to_dict.return_value = {
+        "attributes": {},
+        "events": [
+            {
+                "name": "gen_ai.client.inference.operation.details",
+                "attributes": {
+                    "gen_ai.input.messages": encode_event_value(input_messages),
+                    "gen_ai.output.messages": encode_event_value(output_messages),
+                },
+            }
+        ],
+    }
+
+    attribute_result = translate_span_when_storing(attribute_span)
+    event_result = translate_span_when_storing(event_span)
+
+    assert event_result["attributes"][SpanAttributeKey.INPUTS] == attribute_result["attributes"][
+        SpanAttributeKey.INPUTS
+    ]
+    assert event_result["attributes"][SpanAttributeKey.OUTPUTS] == attribute_result["attributes"][
+        SpanAttributeKey.OUTPUTS
+    ]
+
+
+@pytest.mark.parametrize(
     (
         "parent_id",
         "attributes",

--- a/tests/tracing/utils/test_truncation.py
+++ b/tests/tracing/utils/test_truncation.py
@@ -149,6 +149,20 @@ def test_truncate_responses_api_output():
     assert _get_truncated_preview(input_str, role="assistant") == "a" * 47 + "..."
 
 
+def test_truncate_genai_semconv_message_parts():
+    messages = [
+        {"role": "system", "parts": [{"type": "text", "content": "You are helpful"}]},
+        {"role": "user", "parts": [{"type": "text", "content": "What is MLflow?"}]},
+        {"role": "assistant", "parts": [{"type": "text", "content": "MLflow tracks ML experiments."}]},
+    ]
+
+    assert _get_truncated_preview(json.dumps(messages), role="user") == "What is MLflow?"
+    assert (
+        _get_truncated_preview(json.dumps(messages), role="assistant")
+        == "MLflow tracks ML experiments."
+    )
+
+
 @pytest.mark.parametrize(
     "input_data",
     [


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

Closes #23063

### What changes are proposed in this pull request?

* Use OTel GenAI event input/output message to display on GenAI Trace.
* Original attribute input/output message still keeping.

#### Example for before/apply this PR

**Trace Event**
<img width="612" height="395" alt="image" src="https://github.com/user-attachments/assets/b14ba889-7af3-45f1-9d1d-8b9ff667a9ed" />

**Before Apply**
 
<img width="915" height="556" alt="image" src="https://github.com/user-attachments/assets/576d8010-df1e-4b4f-9bb4-83958cc1dce2" />

**After Apply**

<img width="926" height="483" alt="image" src="https://github.com/user-attachments/assets/6f0b7d1a-9ab8-4301-a6ed-ce5de52aee4f" />



### How is this PR tested?

- [X] New unit/integration tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [X] No.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

Support GenAI operation details event translation

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [X] This PR can wait for the next minor release

