### PR TITLE
Adding metric filter component for Experiment Usage tab

### DIFF
--- a/.github/actions/check-component-ids/componentId-registry.js
+++ b/.github/actions/check-component-ids/componentId-registry.js
@@ -2027,6 +2027,16 @@ module.exports = {
   "mlflow.traces-table.refresh-button": "",
   "mlflow.traces-table.refresh-button.tooltip": "",
 
+  // -- mlflow.usage --
+  "mlflow.usage.metrics_filter": "",
+  "mlflow.usage.metrics_filter.add_row": "",
+  "mlflow.usage.metrics_filter.apply": "",
+  "mlflow.usage.metrics_filter.button": "",
+  "mlflow.usage.metrics_filter.column": "",
+  "mlflow.usage.metrics_filter.delete_row": "",
+  "mlflow.usage.metrics_filter.operator": "",
+  "mlflow.usage.metrics_filter.value": "",
+
   // -- shared.media-rendering-utils --
   "shared.media-rendering-utils.fetch-download": "",
 

--- a/mlflow/server/js/src/common/components/MetricsFilter.test.tsx
+++ b/mlflow/server/js/src/common/components/MetricsFilter.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, jest } from '@jest/globals';
+import { useState } from 'react';
 import userEvent from '@testing-library/user-event';
 import { renderWithDesignSystem, screen, waitFor } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
 import { MetricsFilter } from './MetricsFilter';
@@ -126,6 +127,28 @@ describe('MetricsFilter', () => {
       await screen.findByText('Field');
 
       expect(screen.getByDisplayValue('alice')).toBeInTheDocument();
+    });
+
+    it('clears the form when filters are cleared externally while the popover is open', async () => {
+      const ControlledHarness = () => {
+        const [filters, setFilters] = useState<MetricFilter[]>([{ column: 'user', value: 'alice' }]);
+        return <MetricsFilter filters={filters} setFilters={setFilters} columnOptions={TEST_COLUMN_OPTIONS} />;
+      };
+      const { container } = renderWithDesignSystem(<ControlledHarness />);
+
+      await userEvent.click(screen.getByRole('button', { name: /filters/i }));
+      await screen.findByText('Field');
+      expect(screen.getByDisplayValue('alice')).toBeInTheDocument();
+
+      // Click the clear-all icon in the trigger; popover stays open due to stopPropagation.
+      const clearIcon = container.querySelector('[tabindex="-1"]');
+      await userEvent.click(clearIcon!);
+
+      // The form should now reflect the cleared state instead of showing stale rows.
+      await waitFor(() => {
+        expect(screen.queryByDisplayValue('alice')).not.toBeInTheDocument();
+      });
+      expect(screen.getByPlaceholderText('Enter value')).toHaveValue('');
     });
   });
 });

--- a/mlflow/server/js/src/common/components/MetricsFilter.test.tsx
+++ b/mlflow/server/js/src/common/components/MetricsFilter.test.tsx
@@ -35,13 +35,27 @@ describe('MetricsFilter', () => {
   it('calls setFilters with an empty array when the clear button is clicked', async () => {
     const setFilters = jest.fn();
     const activeFilters: MetricFilter[] = [{ column: 'user', value: 'alice' }];
-    const { container } = renderFilter(activeFilters, setFilters);
+    renderFilter(activeFilters, setFilters);
 
-    // XCircleFillIcon renders as an aria-hidden anticon span with tabindex="-1"
-    const clearIcon = container.querySelector('[tabindex="-1"]');
-    expect(clearIcon).toBeInTheDocument();
-    await userEvent.click(clearIcon!);
+    await userEvent.click(screen.getByRole('button', { name: /clear filters/i }));
     expect(setFilters).toHaveBeenCalledWith([]);
+  });
+
+  it('clears filters via keyboard activation (Enter and Space)', async () => {
+    const setFilters = jest.fn();
+    const activeFilters: MetricFilter[] = [{ column: 'user', value: 'alice' }];
+    renderFilter(activeFilters, setFilters);
+
+    const clearButton = screen.getByRole('button', { name: /clear filters/i });
+    clearButton.focus();
+    expect(clearButton).toHaveFocus();
+
+    await userEvent.keyboard('{Enter}');
+    expect(setFilters).toHaveBeenLastCalledWith([]);
+
+    setFilters.mockClear();
+    await userEvent.keyboard(' ');
+    expect(setFilters).toHaveBeenLastCalledWith([]);
   });
 
   describe('filter form (popover)', () => {
@@ -123,7 +137,7 @@ describe('MetricsFilter', () => {
     it('initialises the form with existing active filters', async () => {
       const activeFilters: MetricFilter[] = [{ column: 'user', value: 'alice' }];
       renderFilter(activeFilters);
-      await userEvent.click(screen.getByRole('button', { name: /filters/i }));
+      await userEvent.click(screen.getByRole('button', { name: /^filters/i }));
       await screen.findByText('Field');
 
       expect(screen.getByDisplayValue('alice')).toBeInTheDocument();
@@ -134,15 +148,14 @@ describe('MetricsFilter', () => {
         const [filters, setFilters] = useState<MetricFilter[]>([{ column: 'user', value: 'alice' }]);
         return <MetricsFilter filters={filters} setFilters={setFilters} columnOptions={TEST_COLUMN_OPTIONS} />;
       };
-      const { container } = renderWithDesignSystem(<ControlledHarness />);
+      renderWithDesignSystem(<ControlledHarness />);
 
-      await userEvent.click(screen.getByRole('button', { name: /filters/i }));
+      await userEvent.click(screen.getByRole('button', { name: /^filters/i }));
       await screen.findByText('Field');
       expect(screen.getByDisplayValue('alice')).toBeInTheDocument();
 
-      // Click the clear-all icon in the trigger; popover stays open due to stopPropagation.
-      const clearIcon = container.querySelector('[tabindex="-1"]');
-      await userEvent.click(clearIcon!);
+      // Click the clear-all control in the trigger; popover stays open due to stopPropagation.
+      await userEvent.click(screen.getByRole('button', { name: /clear filters/i }));
 
       // The form should now reflect the cleared state instead of showing stale rows.
       await waitFor(() => {

--- a/mlflow/server/js/src/common/components/MetricsFilter.test.tsx
+++ b/mlflow/server/js/src/common/components/MetricsFilter.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import userEvent from '@testing-library/user-event';
+import { renderWithDesignSystem, screen, waitFor } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
+import { MetricsFilter } from './MetricsFilter';
+import type { MetricFilter, MetricFilterColumn, MetricFilterColumnOption } from './MetricsFilter.utils';
+
+const TEST_COLUMN_OPTIONS: MetricFilterColumnOption[] = [{ value: 'user' as MetricFilterColumn, label: 'User' }];
+
+const renderFilter = (filters: MetricFilter[] = [], setFilters = jest.fn()) =>
+  renderWithDesignSystem(
+    <MetricsFilter filters={filters} setFilters={setFilters} columnOptions={TEST_COLUMN_OPTIONS} />,
+  );
+
+describe('MetricsFilter', () => {
+  it('renders the filter button', () => {
+    renderFilter();
+    expect(screen.getByRole('button', { name: /filters/i })).toBeInTheDocument();
+  });
+
+  it('shows the active filter count in the button label', () => {
+    const activeFilters: MetricFilter[] = [
+      { column: 'user', value: 'alice' },
+      { column: 'user', value: 'bob' },
+    ];
+    renderFilter(activeFilters);
+    expect(screen.getByRole('button', { name: /filters \(2\)/i })).toBeInTheDocument();
+  });
+
+  it('does not show a count when there are no active filters', () => {
+    renderFilter([]);
+    expect(screen.getByRole('button', { name: /^filters$/i })).toBeInTheDocument();
+  });
+
+  it('calls setFilters with an empty array when the clear button is clicked', async () => {
+    const setFilters = jest.fn();
+    const activeFilters: MetricFilter[] = [{ column: 'user', value: 'alice' }];
+    const { container } = renderFilter(activeFilters, setFilters);
+
+    // XCircleFillIcon renders as an aria-hidden anticon span with tabindex="-1"
+    const clearIcon = container.querySelector('[tabindex="-1"]');
+    expect(clearIcon).toBeInTheDocument();
+    await userEvent.click(clearIcon!);
+    expect(setFilters).toHaveBeenCalledWith([]);
+  });
+
+  describe('filter form (popover)', () => {
+    it('opens the filter form when the button is clicked', async () => {
+      renderFilter();
+      await userEvent.click(screen.getByRole('button', { name: /filters/i }));
+      expect(await screen.findByText('Field')).toBeInTheDocument();
+      expect(screen.getByText('Operator')).toBeInTheDocument();
+      expect(screen.getByText('Value')).toBeInTheDocument();
+    });
+
+    it('shows the column options in the field dropdown', async () => {
+      renderFilter();
+      await userEvent.click(screen.getByRole('button', { name: /filters/i }));
+      await screen.findByText('Field');
+      expect(screen.getByText('User')).toBeInTheDocument();
+    });
+
+    it('adds a new filter row when "Add filter" is clicked', async () => {
+      renderFilter();
+      await userEvent.click(screen.getByRole('button', { name: /filters/i }));
+      await screen.findByText('Field');
+
+      const valueInputsBefore = screen.getAllByPlaceholderText('Enter value');
+      await userEvent.click(screen.getByRole('button', { name: /add filter/i }));
+
+      const valueInputsAfter = screen.getAllByPlaceholderText('Enter value');
+      expect(valueInputsAfter).toHaveLength(valueInputsBefore.length + 1);
+    });
+
+    it('removes a filter row when the delete button is clicked', async () => {
+      renderFilter();
+      await userEvent.click(screen.getByRole('button', { name: /filters/i }));
+      await screen.findByText('Field');
+
+      await userEvent.click(screen.getByRole('button', { name: /add filter/i }));
+      expect(screen.getAllByPlaceholderText('Enter value')).toHaveLength(2);
+
+      await userEvent.click(screen.getAllByRole('button', { name: /remove filter/i })[0]);
+      expect(screen.getAllByPlaceholderText('Enter value')).toHaveLength(1);
+    });
+
+    it('resets to one empty row when the last filter row is removed', async () => {
+      renderFilter();
+      await userEvent.click(screen.getByRole('button', { name: /filters/i }));
+      await screen.findByText('Field');
+
+      await userEvent.click(screen.getByRole('button', { name: /remove filter/i }));
+      expect(screen.getAllByPlaceholderText('Enter value')).toHaveLength(1);
+    });
+
+    it('calls setFilters with only complete filters on apply', async () => {
+      const setFilters = jest.fn();
+      renderFilter([], setFilters);
+      await userEvent.click(screen.getByRole('button', { name: /filters/i }));
+      await screen.findByText('Field');
+
+      const valueInput = screen.getByPlaceholderText('Enter value');
+      await userEvent.type(valueInput, 'alice');
+
+      await userEvent.click(screen.getByRole('button', { name: /apply filters/i }));
+
+      await waitFor(() => {
+        expect(setFilters).toHaveBeenCalledWith([{ column: 'user', value: 'alice' }]);
+      });
+    });
+
+    it('calls setFilters with empty array when applying with no values filled in', async () => {
+      const setFilters = jest.fn();
+      renderFilter([], setFilters);
+      await userEvent.click(screen.getByRole('button', { name: /filters/i }));
+      await screen.findByText('Field');
+
+      await userEvent.click(screen.getByRole('button', { name: /apply filters/i }));
+
+      expect(setFilters).toHaveBeenCalledWith([]);
+    });
+
+    it('initialises the form with existing active filters', async () => {
+      const activeFilters: MetricFilter[] = [{ column: 'user', value: 'alice' }];
+      renderFilter(activeFilters);
+      await userEvent.click(screen.getByRole('button', { name: /filters/i }));
+      await screen.findByText('Field');
+
+      expect(screen.getByDisplayValue('alice')).toBeInTheDocument();
+    });
+  });
+});

--- a/mlflow/server/js/src/common/components/MetricsFilter.tsx
+++ b/mlflow/server/js/src/common/components/MetricsFilter.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
 import {
   Button,
   ChevronDownIcon,
@@ -27,6 +28,16 @@ import {
   type MetricFilterColumn,
   type MetricFilterColumnOption,
 } from './MetricsFilter.utils';
+
+// UI-only row state. The `id` is a stable per-row identifier used as the
+// React key so that adding/removing rows does not cause adjacent rows to
+// inherit one another's component state (focus, dropdown open state, etc.).
+// It is stripped before filters are forwarded to the parent via setFilters.
+interface FilterRowState extends MetricFilter {
+  id: string;
+}
+
+const toRowState = (filter: MetricFilter): FilterRowState => ({ ...filter, id: uuidv4() });
 
 interface MetricsFilterProps {
   filters: MetricFilter[];
@@ -89,47 +100,51 @@ const FilterForm = ({ filters, setFilters, columnOptions }: MetricsFilterProps) 
     () => ({ column: columnOptions[0]?.value ?? ('' as MetricFilterColumn), value: '' }),
     [columnOptions],
   );
-  const [localFilters, setLocalFilters] = useState<MetricFilter[]>(
-    filters.length > 0 ? filters : [emptyFilter],
+  const [localFilters, setLocalFilters] = useState<FilterRowState[]>(() =>
+    (filters.length > 0 ? filters : [emptyFilter]).map(toRowState),
   );
 
   // Keep the draft in sync with the applied filters so that external changes
   // (e.g. clicking the clear icon in the trigger while the popover is open)
   // are reflected in the form instead of being clobbered on the next Apply.
   useEffect(() => {
-    setLocalFilters(filters.length > 0 ? filters : [emptyFilter]);
+    setLocalFilters((filters.length > 0 ? filters : [emptyFilter]).map(toRowState));
   }, [filters, emptyFilter]);
 
-  const updateAt = (index: number, next: MetricFilter) => {
-    setLocalFilters((prev) => prev.map((f, i) => (i === index ? next : f)));
+  const updateAt = (id: string, next: MetricFilter) => {
+    setLocalFilters((prev) => prev.map((row) => (row.id === id ? { ...row, ...next } : row)));
   };
 
-  const removeAt = (index: number) => {
+  const removeAt = (id: string) => {
     setLocalFilters((prev) => {
-      const next = prev.filter((_, i) => i !== index);
-      return next.length === 0 ? [emptyFilter] : next;
+      const next = prev.filter((row) => row.id !== id);
+      return next.length === 0 ? [toRowState(emptyFilter)] : next;
     });
   };
 
   const addRow = () => {
-    setLocalFilters((prev) => [...prev, emptyFilter]);
+    setLocalFilters((prev) => [...prev, toRowState(emptyFilter)]);
   };
 
   const apply = () => {
-    setFilters(localFilters.filter(isCompleteFilter));
+    setFilters(
+      localFilters
+        .filter(isCompleteFilter)
+        .map((row): MetricFilter => ({ column: row.column, value: row.value })),
+    );
   };
 
   return (
     <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.lg }}>
       <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
-        {localFilters.map((filter, index) => (
+        {localFilters.map((row) => (
           <FilterRow
-            key={index}
-            index={index}
-            filter={filter}
+            key={row.id}
+            rowId={row.id}
+            filter={row}
             columnOptions={columnOptions}
-            onChange={(next) => updateAt(index, next)}
-            onDelete={() => removeAt(index)}
+            onChange={(next) => updateAt(row.id, next)}
+            onDelete={() => removeAt(row.id)}
           />
         ))}
       </div>
@@ -162,14 +177,14 @@ const FilterForm = ({ filters, setFilters, columnOptions }: MetricsFilterProps) 
 };
 
 interface FilterRowProps {
-  index: number;
+  rowId: string;
   filter: MetricFilter;
   columnOptions: MetricFilterColumnOption[];
   onChange: (next: MetricFilter) => void;
   onDelete: () => void;
 }
 
-const FilterRow = ({ index, filter, columnOptions, onChange, onDelete }: FilterRowProps) => {
+const FilterRow = ({ rowId, filter, columnOptions, onChange, onDelete }: FilterRowProps) => {
   const { theme } = useDesignSystemTheme();
   const selectedOption = columnOptions.find((o) => o.value === filter.column);
 
@@ -177,7 +192,7 @@ const FilterRow = ({ index, filter, columnOptions, onChange, onDelete }: FilterR
     <div css={{ display: 'flex', flexDirection: 'row', gap: theme.spacing.sm, alignItems: 'flex-end' }}>
       {/* Field (Column) */}
       <div css={{ display: 'flex', flexDirection: 'column' }}>
-        <FormUI.Label htmlFor={`usage-metrics-filter-column-${index}`}>
+        <FormUI.Label htmlFor={`usage-metrics-filter-column-${rowId}`}>
           <FormattedMessage
             defaultMessage="Field"
             description="Usage overview > filter row > field column label"
@@ -185,7 +200,7 @@ const FilterRow = ({ index, filter, columnOptions, onChange, onDelete }: FilterR
         </FormUI.Label>
         <DialogCombobox
           componentId="mlflow.usage.metrics_filter.column"
-          id={`usage-metrics-filter-column-${index}`}
+          id={`usage-metrics-filter-column-${rowId}`}
           value={filter.column ? [filter.column] : []}
         >
           <DialogComboboxTrigger
@@ -214,7 +229,7 @@ const FilterRow = ({ index, filter, columnOptions, onChange, onDelete }: FilterR
 
       {/* Operator (locked to "=") */}
       <div css={{ display: 'flex', flexDirection: 'column' }}>
-        <FormUI.Label htmlFor={`usage-metrics-filter-operator-${index}`}>
+        <FormUI.Label htmlFor={`usage-metrics-filter-operator-${rowId}`}>
           <FormattedMessage
             defaultMessage="Operator"
             description="Usage overview > filter row > operator column label"
@@ -223,7 +238,7 @@ const FilterRow = ({ index, filter, columnOptions, onChange, onDelete }: FilterR
         <SimpleSelect
           aria-label="Operator"
           componentId="mlflow.usage.metrics_filter.operator"
-          id={`usage-metrics-filter-operator-${index}`}
+          id={`usage-metrics-filter-operator-${rowId}`}
           value="="
           disabled
           contentProps={{ style: { zIndex: theme.options.zIndexBase + 100 } }}
@@ -235,7 +250,7 @@ const FilterRow = ({ index, filter, columnOptions, onChange, onDelete }: FilterR
 
       {/* Value */}
       <div css={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
-        <FormUI.Label htmlFor={`usage-metrics-filter-value-${index}`}>
+        <FormUI.Label htmlFor={`usage-metrics-filter-value-${rowId}`}>
           <FormattedMessage
             defaultMessage="Value"
             description="Usage overview > filter row > value column label"
@@ -243,7 +258,7 @@ const FilterRow = ({ index, filter, columnOptions, onChange, onDelete }: FilterR
         </FormUI.Label>
         <Input
           componentId="mlflow.usage.metrics_filter.value"
-          id={`usage-metrics-filter-value-${index}`}
+          id={`usage-metrics-filter-value-${rowId}`}
           value={filter.value}
           onChange={(e) => onChange({ ...filter, value: e.target.value })}
           placeholder="Enter value"

--- a/mlflow/server/js/src/common/components/MetricsFilter.tsx
+++ b/mlflow/server/js/src/common/components/MetricsFilter.tsx
@@ -187,6 +187,7 @@ interface FilterRowProps {
 
 const FilterRow = ({ rowId, filter, columnOptions, onChange, onDelete }: FilterRowProps) => {
   const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
   const selectedOption = columnOptions.find((o) => o.value === filter.column);
 
   return (
@@ -203,7 +204,10 @@ const FilterRow = ({ rowId, filter, columnOptions, onChange, onDelete }: FilterR
         >
           <DialogComboboxTrigger
             withInlineLabel={false}
-            placeholder="Select field"
+            placeholder={intl.formatMessage({
+              defaultMessage: 'Select field',
+              description: 'Usage overview > filter row > field column placeholder',
+            })}
             renderDisplayedValue={() => selectedOption?.label ?? ''}
             width={160}
             allowClear={false}
@@ -234,7 +238,10 @@ const FilterRow = ({ rowId, filter, columnOptions, onChange, onDelete }: FilterR
           />
         </FormUI.Label>
         <SimpleSelect
-          aria-label="Operator"
+          aria-label={intl.formatMessage({
+            defaultMessage: 'Operator',
+            description: 'Usage overview > filter row > operator dropdown aria label',
+          })}
           componentId="mlflow.usage.metrics_filter.operator"
           id={`usage-metrics-filter-operator-${rowId}`}
           value="="
@@ -256,7 +263,10 @@ const FilterRow = ({ rowId, filter, columnOptions, onChange, onDelete }: FilterR
           id={`usage-metrics-filter-value-${rowId}`}
           value={filter.value}
           onChange={(e) => onChange({ ...filter, value: e.target.value })}
-          placeholder="Enter value"
+          placeholder={intl.formatMessage({
+            defaultMessage: 'Enter value',
+            description: 'Usage overview > filter row > value input placeholder',
+          })}
         />
       </div>
 
@@ -265,7 +275,10 @@ const FilterRow = ({ rowId, filter, columnOptions, onChange, onDelete }: FilterR
         componentId="mlflow.usage.metrics_filter.delete_row"
         icon={<CloseIcon />}
         onClick={onDelete}
-        aria-label="Remove filter"
+        aria-label={intl.formatMessage({
+          defaultMessage: 'Remove filter',
+          description: 'Usage overview > filter row > remove row button aria label',
+        })}
       />
     </div>
   );

--- a/mlflow/server/js/src/common/components/MetricsFilter.tsx
+++ b/mlflow/server/js/src/common/components/MetricsFilter.tsx
@@ -71,18 +71,41 @@ export const MetricsFilter = ({ filters, setFilters, columnOptions }: MetricsFil
               { numFilters: hasActiveFilters ? ` (${filters.length})` : '' },
             )}
             {hasActiveFilters && (
-              <XCircleFillIcon
+              <span
+                role="button"
+                tabIndex={0}
+                aria-label={intl.formatMessage({
+                  defaultMessage: 'Clear filters',
+                  description: 'Usage overview > clear metrics filters button',
+                })}
                 css={{
                   fontSize: 12,
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
                   cursor: 'pointer',
                   color: theme.colors.grey400,
                   '&:hover': { color: theme.colors.grey600 },
+                  '&:focus-visible': {
+                    outline: `2px solid ${theme.colors.actionDefaultBorderFocus}`,
+                    outlineOffset: 2,
+                    borderRadius: theme.general.borderRadiusBase,
+                  },
                 }}
                 onClick={(e) => {
                   e.stopPropagation();
                   setFilters([]);
                 }}
-              />
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    setFilters([]);
+                  }
+                }}
+              >
+                <XCircleFillIcon css={{ fontSize: 12 }} />
+              </span>
             )}
           </div>
         </Button>

--- a/mlflow/server/js/src/common/components/MetricsFilter.tsx
+++ b/mlflow/server/js/src/common/components/MetricsFilter.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   Button,
   ChevronDownIcon,
@@ -85,10 +85,20 @@ export const MetricsFilter = ({ filters, setFilters, columnOptions }: MetricsFil
 
 const FilterForm = ({ filters, setFilters, columnOptions }: MetricsFilterProps) => {
   const { theme } = useDesignSystemTheme();
-  const emptyFilter: MetricFilter = { column: columnOptions[0]?.value ?? ('' as MetricFilterColumn), value: '' };
+  const emptyFilter = useMemo<MetricFilter>(
+    () => ({ column: columnOptions[0]?.value ?? ('' as MetricFilterColumn), value: '' }),
+    [columnOptions],
+  );
   const [localFilters, setLocalFilters] = useState<MetricFilter[]>(
     filters.length > 0 ? filters : [emptyFilter],
   );
+
+  // Keep the draft in sync with the applied filters so that external changes
+  // (e.g. clicking the clear icon in the trigger while the popover is open)
+  // are reflected in the form instead of being clobbered on the next Apply.
+  useEffect(() => {
+    setLocalFilters(filters.length > 0 ? filters : [emptyFilter]);
+  }, [filters, emptyFilter]);
 
   const updateAt = (index: number, next: MetricFilter) => {
     setLocalFilters((prev) => prev.map((f, i) => (i === index ? next : f)));

--- a/mlflow/server/js/src/common/components/MetricsFilter.tsx
+++ b/mlflow/server/js/src/common/components/MetricsFilter.tsx
@@ -1,0 +1,252 @@
+import { useState } from 'react';
+import {
+  Button,
+  ChevronDownIcon,
+  CloseIcon,
+  DialogCombobox,
+  DialogComboboxContent,
+  DialogComboboxOptionList,
+  DialogComboboxOptionListSelectItem,
+  DialogComboboxTrigger,
+  FilterIcon,
+  FormUI,
+  Input,
+  PlusIcon,
+  Popover,
+  SimpleSelect,
+  SimpleSelectOption,
+  XCircleFillIcon,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
+import { FormattedMessage, useIntl } from 'react-intl';
+import type {
+  MetricFilter
+} from './MetricsFilter.utils';
+import {
+  isCompleteFilter,
+  type MetricFilterColumn,
+  type MetricFilterColumnOption,
+} from './MetricsFilter.utils';
+
+interface MetricsFilterProps {
+  filters: MetricFilter[];
+  setFilters: (filters: MetricFilter[]) => void;
+  columnOptions: MetricFilterColumnOption[];
+}
+
+export const MetricsFilter = ({ filters, setFilters, columnOptions }: MetricsFilterProps) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+  const hasActiveFilters = filters.length > 0;
+
+  return (
+    <Popover.Root componentId="mlflow.usage.metrics_filter">
+      <Popover.Trigger asChild>
+        <Button
+          endIcon={<ChevronDownIcon />}
+          componentId="mlflow.usage.metrics_filter.button"
+          css={{
+            border: hasActiveFilters ? `1px solid ${theme.colors.actionDefaultBorderFocus} !important` : '',
+            backgroundColor: hasActiveFilters ? `${theme.colors.actionDefaultBackgroundHover} !important` : '',
+          }}
+        >
+          <div css={{ display: 'flex', gap: theme.spacing.sm, alignItems: 'center' }}>
+            <FilterIcon />
+            {intl.formatMessage(
+              {
+                defaultMessage: 'Filters{numFilters}',
+                description: 'Usage overview > metrics filter dropdown button',
+              },
+              { numFilters: hasActiveFilters ? ` (${filters.length})` : '' },
+            )}
+            {hasActiveFilters && (
+              <XCircleFillIcon
+                css={{
+                  fontSize: 12,
+                  cursor: 'pointer',
+                  color: theme.colors.grey400,
+                  '&:hover': { color: theme.colors.grey600 },
+                }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setFilters([]);
+                }}
+              />
+            )}
+          </div>
+        </Button>
+      </Popover.Trigger>
+      <Popover.Content align="start" css={{ padding: theme.spacing.md, minWidth: 480 }}>
+        <FilterForm filters={filters} setFilters={setFilters} columnOptions={columnOptions} />
+      </Popover.Content>
+    </Popover.Root>
+  );
+};
+
+const FilterForm = ({ filters, setFilters, columnOptions }: MetricsFilterProps) => {
+  const { theme } = useDesignSystemTheme();
+  const emptyFilter: MetricFilter = { column: columnOptions[0]?.value ?? ('' as MetricFilterColumn), value: '' };
+  const [localFilters, setLocalFilters] = useState<MetricFilter[]>(
+    filters.length > 0 ? filters : [emptyFilter],
+  );
+
+  const updateAt = (index: number, next: MetricFilter) => {
+    setLocalFilters((prev) => prev.map((f, i) => (i === index ? next : f)));
+  };
+
+  const removeAt = (index: number) => {
+    setLocalFilters((prev) => {
+      const next = prev.filter((_, i) => i !== index);
+      return next.length === 0 ? [emptyFilter] : next;
+    });
+  };
+
+  const addRow = () => {
+    setLocalFilters((prev) => [...prev, emptyFilter]);
+  };
+
+  const apply = () => {
+    setFilters(localFilters.filter(isCompleteFilter));
+  };
+
+  return (
+    <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.lg }}>
+      <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
+        {localFilters.map((filter, index) => (
+          <FilterRow
+            key={index}
+            index={index}
+            filter={filter}
+            columnOptions={columnOptions}
+            onChange={(next) => updateAt(index, next)}
+            onDelete={() => removeAt(index)}
+          />
+        ))}
+      </div>
+      <div>
+        <Button
+          componentId="mlflow.usage.metrics_filter.add_row"
+          icon={<PlusIcon />}
+          onClick={addRow}
+        >
+          <FormattedMessage
+            defaultMessage="Add filter"
+            description="Usage overview > add filter row button"
+          />
+        </Button>
+      </div>
+      <div css={{ display: 'flex', justifyContent: 'flex-end' }}>
+        <Button
+          componentId="mlflow.usage.metrics_filter.apply"
+          type="primary"
+          onClick={apply}
+        >
+          <FormattedMessage
+            defaultMessage="Apply filters"
+            description="Usage overview > apply filters button"
+          />
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+interface FilterRowProps {
+  index: number;
+  filter: MetricFilter;
+  columnOptions: MetricFilterColumnOption[];
+  onChange: (next: MetricFilter) => void;
+  onDelete: () => void;
+}
+
+const FilterRow = ({ index, filter, columnOptions, onChange, onDelete }: FilterRowProps) => {
+  const { theme } = useDesignSystemTheme();
+  const selectedOption = columnOptions.find((o) => o.value === filter.column);
+
+  return (
+    <div css={{ display: 'flex', flexDirection: 'row', gap: theme.spacing.sm, alignItems: 'flex-end' }}>
+      {/* Field (Column) */}
+      <div css={{ display: 'flex', flexDirection: 'column' }}>
+        <FormUI.Label htmlFor={`usage-metrics-filter-column-${index}`}>
+          <FormattedMessage
+            defaultMessage="Field"
+            description="Usage overview > filter row > field column label"
+          />
+        </FormUI.Label>
+        <DialogCombobox
+          componentId="mlflow.usage.metrics_filter.column"
+          id={`usage-metrics-filter-column-${index}`}
+          value={filter.column ? [filter.column] : []}
+        >
+          <DialogComboboxTrigger
+            withInlineLabel={false}
+            placeholder="Select field"
+            renderDisplayedValue={() => selectedOption?.label ?? ''}
+            width={160}
+            allowClear={false}
+          />
+          <DialogComboboxContent width={160} style={{ zIndex: theme.options.zIndexBase + 100 }}>
+            <DialogComboboxOptionList>
+              {columnOptions.map((option) => (
+                <DialogComboboxOptionListSelectItem
+                  key={option.value}
+                  value={option.value}
+                  checked={option.value === filter.column}
+                  onChange={(value: string) => onChange({ ...filter, column: value as MetricFilterColumn })}
+                >
+                  {option.label}
+                </DialogComboboxOptionListSelectItem>
+              ))}
+            </DialogComboboxOptionList>
+          </DialogComboboxContent>
+        </DialogCombobox>
+      </div>
+
+      {/* Operator (locked to "=") */}
+      <div css={{ display: 'flex', flexDirection: 'column' }}>
+        <FormUI.Label htmlFor={`usage-metrics-filter-operator-${index}`}>
+          <FormattedMessage
+            defaultMessage="Operator"
+            description="Usage overview > filter row > operator column label"
+          />
+        </FormUI.Label>
+        <SimpleSelect
+          aria-label="Operator"
+          componentId="mlflow.usage.metrics_filter.operator"
+          id={`usage-metrics-filter-operator-${index}`}
+          value="="
+          disabled
+          contentProps={{ style: { zIndex: theme.options.zIndexBase + 100 } }}
+          css={{ width: 80 }}
+        >
+          <SimpleSelectOption value="=">=</SimpleSelectOption>
+        </SimpleSelect>
+      </div>
+
+      {/* Value */}
+      <div css={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
+        <FormUI.Label htmlFor={`usage-metrics-filter-value-${index}`}>
+          <FormattedMessage
+            defaultMessage="Value"
+            description="Usage overview > filter row > value column label"
+          />
+        </FormUI.Label>
+        <Input
+          componentId="mlflow.usage.metrics_filter.value"
+          id={`usage-metrics-filter-value-${index}`}
+          value={filter.value}
+          onChange={(e) => onChange({ ...filter, value: e.target.value })}
+          placeholder="Enter value"
+        />
+      </div>
+
+      {/* Delete row */}
+      <Button
+        componentId="mlflow.usage.metrics_filter.delete_row"
+        icon={<CloseIcon />}
+        onClick={onDelete}
+        aria-label="Remove filter"
+      />
+    </div>
+  );
+};

--- a/mlflow/server/js/src/common/components/MetricsFilter.tsx
+++ b/mlflow/server/js/src/common/components/MetricsFilter.tsx
@@ -20,14 +20,8 @@ import {
   useDesignSystemTheme,
 } from '@databricks/design-system';
 import { FormattedMessage, useIntl } from 'react-intl';
-import type {
-  MetricFilter
-} from './MetricsFilter.utils';
-import {
-  isCompleteFilter,
-  type MetricFilterColumn,
-  type MetricFilterColumnOption,
-} from './MetricsFilter.utils';
+import type { MetricFilter } from './MetricsFilter.utils';
+import { isCompleteFilter, type MetricFilterColumn, type MetricFilterColumnOption } from './MetricsFilter.utils';
 
 // UI-only row state. The `id` is a stable per-row identifier used as the
 // React key so that adding/removing rows does not cause adjacent rows to
@@ -151,9 +145,7 @@ const FilterForm = ({ filters, setFilters, columnOptions }: MetricsFilterProps) 
 
   const apply = () => {
     setFilters(
-      localFilters
-        .filter(isCompleteFilter)
-        .map((row): MetricFilter => ({ column: row.column, value: row.value })),
+      localFilters.filter(isCompleteFilter).map((row): MetricFilter => ({ column: row.column, value: row.value })),
     );
   };
 
@@ -172,27 +164,13 @@ const FilterForm = ({ filters, setFilters, columnOptions }: MetricsFilterProps) 
         ))}
       </div>
       <div>
-        <Button
-          componentId="mlflow.usage.metrics_filter.add_row"
-          icon={<PlusIcon />}
-          onClick={addRow}
-        >
-          <FormattedMessage
-            defaultMessage="Add filter"
-            description="Usage overview > add filter row button"
-          />
+        <Button componentId="mlflow.usage.metrics_filter.add_row" icon={<PlusIcon />} onClick={addRow}>
+          <FormattedMessage defaultMessage="Add filter" description="Usage overview > add filter row button" />
         </Button>
       </div>
       <div css={{ display: 'flex', justifyContent: 'flex-end' }}>
-        <Button
-          componentId="mlflow.usage.metrics_filter.apply"
-          type="primary"
-          onClick={apply}
-        >
-          <FormattedMessage
-            defaultMessage="Apply filters"
-            description="Usage overview > apply filters button"
-          />
+        <Button componentId="mlflow.usage.metrics_filter.apply" type="primary" onClick={apply}>
+          <FormattedMessage defaultMessage="Apply filters" description="Usage overview > apply filters button" />
         </Button>
       </div>
     </div>
@@ -216,10 +194,7 @@ const FilterRow = ({ rowId, filter, columnOptions, onChange, onDelete }: FilterR
       {/* Field (Column) */}
       <div css={{ display: 'flex', flexDirection: 'column' }}>
         <FormUI.Label htmlFor={`usage-metrics-filter-column-${rowId}`}>
-          <FormattedMessage
-            defaultMessage="Field"
-            description="Usage overview > filter row > field column label"
-          />
+          <FormattedMessage defaultMessage="Field" description="Usage overview > filter row > field column label" />
         </FormUI.Label>
         <DialogCombobox
           componentId="mlflow.usage.metrics_filter.column"
@@ -274,10 +249,7 @@ const FilterRow = ({ rowId, filter, columnOptions, onChange, onDelete }: FilterR
       {/* Value */}
       <div css={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
         <FormUI.Label htmlFor={`usage-metrics-filter-value-${rowId}`}>
-          <FormattedMessage
-            defaultMessage="Value"
-            description="Usage overview > filter row > value column label"
-          />
+          <FormattedMessage defaultMessage="Value" description="Usage overview > filter row > value column label" />
         </FormUI.Label>
         <Input
           componentId="mlflow.usage.metrics_filter.value"

--- a/mlflow/server/js/src/common/components/MetricsFilter.tsx
+++ b/mlflow/server/js/src/common/components/MetricsFilter.tsx
@@ -73,7 +73,7 @@ export const MetricsFilter = ({ filters, setFilters, columnOptions }: MetricsFil
                   description: 'Usage overview > clear metrics filters button',
                 })}
                 css={{
-                  fontSize: 12,
+                  fontSize: theme.typography.fontSizeSm,
                   display: 'inline-flex',
                   alignItems: 'center',
                   justifyContent: 'center',
@@ -98,7 +98,7 @@ export const MetricsFilter = ({ filters, setFilters, columnOptions }: MetricsFil
                   }
                 }}
               >
-                <XCircleFillIcon css={{ fontSize: 12 }} />
+                <XCircleFillIcon css={{ fontSize: theme.typography.fontSizeSm }} />
               </span>
             )}
           </div>

--- a/mlflow/server/js/src/common/components/MetricsFilter.utils.test.ts
+++ b/mlflow/server/js/src/common/components/MetricsFilter.utils.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { isCompleteFilter, translateToMetricsFilters, type MetricFilter } from './MetricsFilter.utils';
+
+jest.mock('@databricks/web-shared/model-trace-explorer', () => ({
+  createTraceMetadataFilter: jest.fn((key: string, value: string) => `${key}='${value}'`),
+}));
+
+describe('isCompleteFilter', () => {
+  it('returns true when both column and value are set', () => {
+    const filter: MetricFilter = { column: 'user', value: 'alice' };
+    expect(isCompleteFilter(filter)).toBe(true);
+  });
+
+  it('returns false when value is empty', () => {
+    const filter: MetricFilter = { column: 'user', value: '' };
+    expect(isCompleteFilter(filter)).toBe(false);
+  });
+
+  it('returns false when column is empty', () => {
+    const filter = { column: '' as MetricFilter['column'], value: 'alice' };
+    expect(isCompleteFilter(filter)).toBe(false);
+  });
+});
+
+describe('translateToMetricsFilters', () => {
+  it('returns undefined for an empty filters array', () => {
+    expect(translateToMetricsFilters([])).toBeUndefined();
+  });
+
+  it('returns undefined when all filters are incomplete', () => {
+    const filters: MetricFilter[] = [
+      { column: 'user', value: '' },
+      { column: '' as MetricFilter['column'], value: 'alice' },
+    ];
+    expect(translateToMetricsFilters(filters)).toBeUndefined();
+  });
+
+  it('translates a user filter to a DSL string', () => {
+    const filters: MetricFilter[] = [{ column: 'user', value: 'alice' }];
+    const result = translateToMetricsFilters(filters);
+    expect(result).toEqual(["mlflow.trace.user='alice'"]);
+  });
+
+  it('skips incomplete filters and returns the rest', () => {
+    const filters: MetricFilter[] = [
+      { column: 'user', value: 'alice' },
+      { column: 'user', value: '' },
+    ];
+    const result = translateToMetricsFilters(filters);
+    expect(result).toEqual(["mlflow.trace.user='alice'"]);
+  });
+
+  it('translates multiple complete filters', () => {
+    const filters: MetricFilter[] = [
+      { column: 'user', value: 'alice' },
+      { column: 'user', value: 'bob' },
+    ];
+    const result = translateToMetricsFilters(filters);
+    expect(result).toEqual(["mlflow.trace.user='alice'", "mlflow.trace.user='bob'"]);
+  });
+});

--- a/mlflow/server/js/src/common/components/MetricsFilter.utils.test.ts
+++ b/mlflow/server/js/src/common/components/MetricsFilter.utils.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { describe, it, expect, jest } from '@jest/globals';
 import { isCompleteFilter, translateToMetricsFilters, type MetricFilter } from './MetricsFilter.utils';
 
 jest.mock('@databricks/web-shared/model-trace-explorer', () => ({
+  MLFLOW_TRACE_USER_KEY: 'mlflow.trace.user',
   createTraceMetadataFilter: jest.fn(
     (key: string, value: string) => `trace.metadata.\`${key}\` = "${value}"`,
   ),

--- a/mlflow/server/js/src/common/components/MetricsFilter.utils.test.ts
+++ b/mlflow/server/js/src/common/components/MetricsFilter.utils.test.ts
@@ -3,9 +3,7 @@ import { isCompleteFilter, translateToMetricsFilters, type MetricFilter } from '
 
 jest.mock('@databricks/web-shared/model-trace-explorer', () => ({
   MLFLOW_TRACE_USER_KEY: 'mlflow.trace.user',
-  createTraceMetadataFilter: jest.fn(
-    (key: string, value: string) => `trace.metadata.\`${key}\` = "${value}"`,
-  ),
+  createTraceMetadataFilter: jest.fn((key: string, value: string) => `trace.metadata.\`${key}\` = "${value}"`),
 }));
 
 describe('isCompleteFilter', () => {

--- a/mlflow/server/js/src/common/components/MetricsFilter.utils.test.ts
+++ b/mlflow/server/js/src/common/components/MetricsFilter.utils.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import { isCompleteFilter, translateToMetricsFilters, type MetricFilter } from './MetricsFilter.utils';
 
 jest.mock('@databricks/web-shared/model-trace-explorer', () => ({
-  createTraceMetadataFilter: jest.fn((key: string, value: string) => `${key}='${value}'`),
+  createTraceMetadataFilter: jest.fn(
+    (key: string, value: string) => `trace.metadata.\`${key}\` = "${value}"`,
+  ),
 }));
 
 describe('isCompleteFilter', () => {
@@ -38,7 +40,7 @@ describe('translateToMetricsFilters', () => {
   it('translates a user filter to a DSL string', () => {
     const filters: MetricFilter[] = [{ column: 'user', value: 'alice' }];
     const result = translateToMetricsFilters(filters);
-    expect(result).toEqual(["mlflow.trace.user='alice'"]);
+    expect(result).toEqual(['trace.metadata.`mlflow.trace.user` = "alice"']);
   });
 
   it('skips incomplete filters and returns the rest', () => {
@@ -47,7 +49,7 @@ describe('translateToMetricsFilters', () => {
       { column: 'user', value: '' },
     ];
     const result = translateToMetricsFilters(filters);
-    expect(result).toEqual(["mlflow.trace.user='alice'"]);
+    expect(result).toEqual(['trace.metadata.`mlflow.trace.user` = "alice"']);
   });
 
   it('translates multiple complete filters', () => {
@@ -56,6 +58,9 @@ describe('translateToMetricsFilters', () => {
       { column: 'user', value: 'bob' },
     ];
     const result = translateToMetricsFilters(filters);
-    expect(result).toEqual(["mlflow.trace.user='alice'", "mlflow.trace.user='bob'"]);
+    expect(result).toEqual([
+      'trace.metadata.`mlflow.trace.user` = "alice"',
+      'trace.metadata.`mlflow.trace.user` = "bob"',
+    ]);
   });
 });

--- a/mlflow/server/js/src/common/components/MetricsFilter.utils.ts
+++ b/mlflow/server/js/src/common/components/MetricsFilter.utils.ts
@@ -16,8 +16,7 @@ export interface MetricFilterColumnOption {
   label: string;
 }
 
-export const isCompleteFilter = (filter: MetricFilter): boolean =>
-  Boolean(filter.column) && Boolean(filter.value);
+export const isCompleteFilter = (filter: MetricFilter): boolean => Boolean(filter.column) && Boolean(filter.value);
 
 /**
  * Translates user-driven filter rows from MetricsFilter into metrics-API DSL

--- a/mlflow/server/js/src/common/components/MetricsFilter.utils.ts
+++ b/mlflow/server/js/src/common/components/MetricsFilter.utils.ts
@@ -20,10 +20,10 @@ export const isCompleteFilter = (filter: MetricFilter): boolean =>
   Boolean(filter.column) && Boolean(filter.value);
 
 /**
- * Translates user-driven filter rows from OverviewMetricsFilter into metrics-API DSL
+ * Translates user-driven filter rows from MetricsFilter into metrics-API DSL
  * filter strings consumed by useTraceMetricsQuery via OverviewChartProvider.
  *
- * Add a new case here when adding a new column option in OverviewMetricsFilter.
+ * Add a new case here when adding a new column option in MetricsFilter.
  */
 export const translateToMetricsFilters = (filters: MetricFilter[]): string[] | undefined => {
   const result = filters

--- a/mlflow/server/js/src/common/components/MetricsFilter.utils.ts
+++ b/mlflow/server/js/src/common/components/MetricsFilter.utils.ts
@@ -1,0 +1,41 @@
+import { createTraceMetadataFilter } from '@databricks/web-shared/model-trace-explorer';
+
+/**
+ * Curated list of columns the metrics API can filter on with `=`.
+ * Add a new entry here AND in `translateToMetricsFilters` to expose more dimensions.
+ */
+export type MetricFilterColumn = 'user';
+
+export interface MetricFilter {
+  column: MetricFilterColumn;
+  value: string;
+}
+
+export interface MetricFilterColumnOption {
+  value: MetricFilterColumn;
+  label: string;
+}
+
+export const isCompleteFilter = (filter: MetricFilter): boolean =>
+  Boolean(filter.column) && Boolean(filter.value);
+
+/**
+ * Translates user-driven filter rows from OverviewMetricsFilter into metrics-API DSL
+ * filter strings consumed by useTraceMetricsQuery via OverviewChartProvider.
+ *
+ * Add a new case here when adding a new column option in OverviewMetricsFilter.
+ */
+export const translateToMetricsFilters = (filters: MetricFilter[]): string[] | undefined => {
+  const result = filters
+    .map((f) => {
+      if (!f.column || !f.value) return null;
+      switch (f.column) {
+        case 'user':
+          return createTraceMetadataFilter('mlflow.trace.user', f.value);
+        default:
+          return null;
+      }
+    })
+    .filter((s): s is string => s !== null);
+  return result.length > 0 ? result : undefined;
+};

--- a/mlflow/server/js/src/common/components/MetricsFilter.utils.ts
+++ b/mlflow/server/js/src/common/components/MetricsFilter.utils.ts
@@ -1,4 +1,4 @@
-import { createTraceMetadataFilter } from '@databricks/web-shared/model-trace-explorer';
+import { MLFLOW_TRACE_USER_KEY, createTraceMetadataFilter } from '@databricks/web-shared/model-trace-explorer';
 
 /**
  * Curated list of columns the metrics API can filter on with `=`.
@@ -30,7 +30,7 @@ export const translateToMetricsFilters = (filters: MetricFilter[]): string[] | u
       if (!f.column || !f.value) return null;
       switch (f.column) {
         case 'user':
-          return createTraceMetadataFilter('mlflow.trace.user', f.value);
+          return createTraceMetadataFilter(MLFLOW_TRACE_USER_KEY, f.value);
         default:
           return null;
       }

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.test.tsx
@@ -366,6 +366,65 @@ describe('ExperimentGenAIOverviewPage', () => {
     });
   });
 
+  describe('metrics filter', () => {
+    it('should render the metrics filter button on the Usage tab', async () => {
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /filters/i })).toBeInTheDocument();
+      });
+    });
+
+    it('should not render the metrics filter button on the Quality tab', async () => {
+      const user = userEvent.setup();
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByRole('tab', { name: 'Quality' })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('tab', { name: 'Quality' }));
+
+      await waitFor(() => {
+        expect(screen.queryByRole('button', { name: /filters/i })).not.toBeInTheDocument();
+      });
+    });
+
+    it('should not render the metrics filter button on the Tool calls tab', async () => {
+      const user = userEvent.setup();
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByRole('tab', { name: 'Tool calls' })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('tab', { name: 'Tool calls' }));
+
+      await waitFor(() => {
+        expect(screen.queryByRole('button', { name: /filters/i })).not.toBeInTheDocument();
+      });
+    });
+
+    it('should reshow the metrics filter button when switching back to the Usage tab', async () => {
+      const user = userEvent.setup();
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByRole('tab', { name: 'Quality' })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('tab', { name: 'Quality' }));
+      await waitFor(() => {
+        expect(screen.queryByRole('button', { name: /filters/i })).not.toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('tab', { name: 'Usage' }));
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /filters/i })).toBeInTheDocument();
+      });
+    });
+  });
+
   describe('demo experiment time range', () => {
     it('should set time range from demo experiment tags', async () => {
       // Mock demo experiment with time range tags

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.tsx
@@ -221,7 +221,11 @@ const ExperimentGenAIOverviewPageImpl = () => {
           }}
         >
           {activeTab === OverviewTab.Usage && (
-            <MetricsFilter filters={metricFilters} setFilters={setMetricFilters} columnOptions={metricsFilterColumnOptions} />
+            <MetricsFilter
+              filters={metricFilters}
+              setFilters={setMetricFilters}
+              columnOptions={metricsFilterColumnOptions}
+            />
           )}
 
           {/* Time unit selector for chart grouping */}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.tsx
@@ -37,6 +37,14 @@ import { TIME_UNIT_SECONDS, calculateDefaultTimeUnit, isTimeUnitValid } from './
 import { generateTimeBuckets } from './utils/chartUtils';
 import { OverviewChartProvider } from './OverviewChartContext';
 import { useOverviewTab, OverviewTab } from './hooks/useOverviewTab';
+import { MetricsFilter } from '../../../common/components/MetricsFilter';
+import {
+  translateToMetricsFilters,
+  type MetricFilter,
+  type MetricFilterColumnOption,
+} from '../../../common/components/MetricsFilter.utils';
+
+const METRICS_FILTER_COLUMN_OPTIONS: MetricFilterColumnOption[] = [{ value: 'user', label: 'User' }];
 
 const DEMO_START_TIME_TAG = 'mlflow.demo.start_time_ms';
 const DEMO_END_TIME_TAG = 'mlflow.demo.end_time_ms';
@@ -138,6 +146,11 @@ const ExperimentGenAIOverviewPageImpl = () => {
     [startTimeMs, endTimeMs, timeIntervalSeconds],
   );
 
+  // User-driven filter rows captured by MetricsFilter. Translated into
+  // metrics-API DSL strings via translateToMetricsFilters and passed to the chart provider.
+  const [metricFilters, setMetricFilters] = useState<MetricFilter[]>([]);
+  const chartFilters = useMemo(() => translateToMetricsFilters(metricFilters), [metricFilters]);
+
   return (
     <div
       css={{
@@ -196,6 +209,10 @@ const ExperimentGenAIOverviewPageImpl = () => {
             gap: theme.spacing.sm,
           }}
         >
+          {activeTab === OverviewTab.Usage && (
+            <MetricsFilter filters={metricFilters} setFilters={setMetricFilters} columnOptions={METRICS_FILTER_COLUMN_OPTIONS} />
+          )}
+
           {/* Time unit selector for chart grouping */}
           <TimeUnitSelector
             value={effectiveTimeUnit}
@@ -228,6 +245,7 @@ const ExperimentGenAIOverviewPageImpl = () => {
           endTimeMs={endTimeMs}
           timeIntervalSeconds={timeIntervalSeconds}
           timeBuckets={timeBuckets}
+          filters={chartFilters}
         >
           <Tabs.Content value={OverviewTab.Usage} css={{ flex: 1, overflowY: 'auto' }}>
             <TabContentContainer>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useMemo } from 'react';
 import invariant from 'invariant';
 import { useParams } from '../../../common/utils/RoutingUtils';
 import { Alert, Tabs, Typography, useDesignSystemTheme } from '@databricks/design-system';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import { shouldEnableIssueDetection } from '../../../common/utils/FeatureUtils';
 import { IssueDetectionModal } from '../../components/experiment-page/components/traces-v3/IssueDetectionModal';
 import { DetectIssuesButton } from '../../../shared/web-shared/genai-traces-table/components/DetectIssuesButton';
@@ -44,12 +44,11 @@ import {
   type MetricFilterColumnOption,
 } from '../../../common/components/MetricsFilter.utils';
 
-const METRICS_FILTER_COLUMN_OPTIONS: MetricFilterColumnOption[] = [{ value: 'user', label: 'User' }];
-
 const DEMO_START_TIME_TAG = 'mlflow.demo.start_time_ms';
 const DEMO_END_TIME_TAG = 'mlflow.demo.end_time_ms';
 
 const ExperimentGenAIOverviewPageImpl = () => {
+  const intl = useIntl();
   const { experimentId } = useParams();
   const { theme } = useDesignSystemTheme();
   const [activeTab, setActiveTab] = useOverviewTab();
@@ -150,6 +149,18 @@ const ExperimentGenAIOverviewPageImpl = () => {
   // metrics-API DSL strings via translateToMetricsFilters and passed to the chart provider.
   const [metricFilters, setMetricFilters] = useState<MetricFilter[]>([]);
   const chartFilters = useMemo(() => translateToMetricsFilters(metricFilters), [metricFilters]);
+  const metricsFilterColumnOptions = useMemo<MetricFilterColumnOption[]>(
+    () => [
+      {
+        value: 'user',
+        label: intl.formatMessage({
+          defaultMessage: 'User',
+          description: 'Usage overview > metrics filter > user column option label',
+        }),
+      },
+    ],
+    [intl],
+  );
 
   return (
     <div
@@ -210,7 +221,7 @@ const ExperimentGenAIOverviewPageImpl = () => {
           }}
         >
           {activeTab === OverviewTab.Usage && (
-            <MetricsFilter filters={metricFilters} setFilters={setMetricFilters} columnOptions={METRICS_FILTER_COLUMN_OPTIONS} />
+            <MetricsFilter filters={metricFilters} setFilters={setMetricFilters} columnOptions={metricsFilterColumnOptions} />
           )}
 
           {/* Time unit selector for chart grouping */}

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -1775,6 +1775,10 @@
     "defaultMessage": "Enable Usage Tracking in the Overview tab to view logs",
     "description": "Tooltip shown on disabled Logs tab explaining that usage tracking must be enabled first"
   },
+  "8oh0iW": {
+    "defaultMessage": "Clear filters",
+    "description": "Usage overview > clear metrics filters button"
+  },
   "8qJt7/": {
     "defaultMessage": "Experimental",
     "description": "Experimental badge shown for features which are experimental"
@@ -2126,6 +2130,10 @@
   "Ai/ANo": {
     "defaultMessage": "Usage",
     "description": "Page title"
+  },
+  "AmLGSf": {
+    "defaultMessage": "Apply filters",
+    "description": "Usage overview > apply filters button"
   },
   "AoDwev": {
     "defaultMessage": "Description (optional)",
@@ -3154,6 +3162,10 @@
   "HSMagB": {
     "defaultMessage": "Error evaluating \"{label}\"",
     "description": "Error evaluating label"
+  },
+  "HT6/F3": {
+    "defaultMessage": "Value",
+    "description": "Usage overview > filter row > value column label"
   },
   "HUC492": {
     "defaultMessage": "See detailed trace view",
@@ -6331,6 +6343,10 @@
     "defaultMessage": "Please select metric",
     "description": "Placeholder text where one can select metrics from the list of available metrics to render on the graph"
   },
+  "aZKtr2": {
+    "defaultMessage": "Field",
+    "description": "Usage overview > filter row > field column label"
+  },
   "aZV8M7": {
     "defaultMessage": "Delete",
     "description": "Delete assessment menu item"
@@ -8091,6 +8107,10 @@
     "defaultMessage": "Discard",
     "description": "Experiment page > artifact compare view > prompt lab artifact synchronization > submit button label"
   },
+  "kQ9rmr": {
+    "defaultMessage": "Operator",
+    "description": "Usage overview > filter row > operator column label"
+  },
   "kQw850": {
     "defaultMessage": "Test succeeded (HTTP {status})",
     "description": "Message informing the user that the webhook test succeeded"
@@ -8654,6 +8674,10 @@
   "nWeQCU": {
     "defaultMessage": "Show differences only",
     "description": "Runs charts > components > config > RunsChartsConfigureDifferenceChart > Show differences only toggle"
+  },
+  "nXsSZ1": {
+    "defaultMessage": "Add filter",
+    "description": "Usage overview > add filter row button"
   },
   "nY1YrF": {
     "defaultMessage": "Internal server error",
@@ -10330,6 +10354,10 @@
   "xbfKJS": {
     "defaultMessage": "JSON body for the OpenAI-compatible Chat Completions API. Include \"model\" (endpoint name) and \"messages\".",
     "description": "Request body tooltip for unified Chat Completions API"
+  },
+  "xc+tL4": {
+    "defaultMessage": "Filters{numFilters}",
+    "description": "Usage overview > metrics filter dropdown button"
   },
   "xdFMIN": {
     "defaultMessage": "Dataset name",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -8675,6 +8675,10 @@
     "defaultMessage": "Show differences only",
     "description": "Runs charts > components > config > RunsChartsConfigureDifferenceChart > Show differences only toggle"
   },
+  "nXIn89": {
+    "defaultMessage": "User",
+    "description": "Usage overview > metrics filter > user column option label"
+  },
   "nXsSZ1": {
     "defaultMessage": "Add filter",
     "description": "Usage overview > add filter row button"

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -4411,6 +4411,10 @@
     "defaultMessage": "Cost breakdown",
     "description": "Header for span cost breakdown"
   },
+  "P5OG6u": {
+    "defaultMessage": "Select field",
+    "description": "Usage overview > filter row > field column placeholder"
+  },
   "PAUNgq": {
     "defaultMessage": "Cost Breakdown",
     "description": "Title for the cost breakdown chart"
@@ -4522,6 +4526,10 @@
   "Pgxfhl": {
     "defaultMessage": "Role",
     "description": "Roles table column header for the role name"
+  },
+  "PlP56F": {
+    "defaultMessage": "Enter value",
+    "description": "Usage overview > filter row > value input placeholder"
   },
   "PmPV+3": {
     "defaultMessage": "Models",
@@ -4818,6 +4826,10 @@
   "RhQhT4": {
     "defaultMessage": "Model",
     "description": "Label for model name in span details"
+  },
+  "RiZy19": {
+    "defaultMessage": "Remove filter",
+    "description": "Usage overview > filter row > remove row button aria label"
   },
   "RlBbjb": {
     "defaultMessage": "A tag key is required",
@@ -6090,6 +6102,10 @@
   "ZBZBrn": {
     "defaultMessage": "Input /1M",
     "description": "Table header for input cost"
+  },
+  "ZBaNWk": {
+    "defaultMessage": "Operator",
+    "description": "Usage overview > filter row > operator dropdown aria label"
   },
   "ZGrkWk": {
     "defaultMessage": "Perform inference via model.transform()",


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

- Added a new MetricsFilter component with a popover-based filter UI, allowing users to filter overview Usage charts by configurable field columns (i.e. Currently we're only scoping it to "User" for aggregated usage charts)
- Integrated MetricsFilter into the experiment overview Usage tab, wiring applied filters through to the chart data API
- Added unit tests for MetricsFilter component and utility functions, and extended ExperimentGenAIOverviewPage tests to cover filter rendering behaviour across tabs

Related follow ups to be picked up separately:
- Apply compatible Search API DSL for Usage charts with "View traces in this period" navigation to Experiments Traces Page
- Update AI Gateway Usage tab with this new usage filter component

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

Before Changes:

<img width="1421" height="1061" alt="Before Changes Screenshot" src="https://github.com/user-attachments/assets/e1872d44-f8e5-4a95-97d8-9c0307a8eec4" />

After Changes:

https://github.com/user-attachments/assets/46c3548a-7559-44b0-8790-d3773ae27c87

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

Users can now filter the experiment overview Usage tab charts by specific dimensions (e.g. by User) using a new Filters button in the control bar, making it easier to drill down into trace metrics for a specific subset of traffic.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
