### PR TITLE
Add admin UI test coverage

### DIFF
--- a/mlflow/server/js/src/admin/api.test.ts
+++ b/mlflow/server/js/src/admin/api.test.ts
@@ -1,0 +1,63 @@
+import { describe, jest, it, expect, beforeEach } from '@jest/globals';
+
+import { AdminApi } from './api';
+import { fetchEndpoint } from '../common/utils/FetchUtils';
+
+jest.mock('../common/utils/FetchUtils', () => ({
+  fetchEndpoint: jest.fn(() => Promise.resolve({ roles: [] })),
+}));
+
+const mockedFetch = jest.mocked(fetchEndpoint);
+
+const lastUrl = (): string => {
+  const calls = mockedFetch.mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  return (calls[calls.length - 1][0] as { relativeUrl: string }).relativeUrl;
+};
+
+beforeEach(() => {
+  mockedFetch.mockClear();
+});
+
+describe('AdminApi.listRoles URL shape', () => {
+  it('omits the workspace param entirely when called with no argument', () => {
+    AdminApi.listRoles();
+    // Bare path — no trailing ``?`` even when there are zero params, since the
+    // earlier ``join('?')`` form polluted logs and broke some signature checks.
+    expect(lastUrl()).toBe('ajax-api/3.0/mlflow/roles/list');
+  });
+
+  it('appends a single workspace when called with a string', () => {
+    AdminApi.listRoles('ml-research');
+    expect(lastUrl()).toBe('ajax-api/3.0/mlflow/roles/list?workspace=ml-research');
+  });
+
+  it('appends one workspace param per element when called with an array', () => {
+    AdminApi.listRoles(['foo', 'bar']);
+    // Repeated ``workspace=`` query params (one per element) is the wire shape
+    // the server reads via ``request.args.getlist("workspace")``.
+    expect(lastUrl()).toBe('ajax-api/3.0/mlflow/roles/list?workspace=foo&workspace=bar');
+  });
+
+  it('returns the bare URL (no trailing ``?``) when called with an empty array', () => {
+    AdminApi.listRoles([]);
+    // The validator denies empty unscoped lists for non-admins; the handler
+    // treats no params as the unscoped admin path. Either way the URL is bare.
+    expect(lastUrl()).toBe('ajax-api/3.0/mlflow/roles/list');
+  });
+
+  it('skips falsy entries within an array (defensive)', () => {
+    AdminApi.listRoles(['foo', '']);
+    expect(lastUrl()).toBe('ajax-api/3.0/mlflow/roles/list?workspace=foo');
+  });
+
+  it('URL-encodes workspace names containing reserved characters', () => {
+    AdminApi.listRoles(['ws&with=reserved']);
+    expect(lastUrl()).toBe('ajax-api/3.0/mlflow/roles/list?workspace=ws%26with%3Dreserved');
+  });
+
+  it('preserves caller-provided order in the URL (the cache key normalizes; the wire does not need to)', () => {
+    AdminApi.listRoles(['b', 'a']);
+    expect(lastUrl()).toBe('ajax-api/3.0/mlflow/roles/list?workspace=b&workspace=a');
+  });
+});

--- a/mlflow/server/js/src/admin/components/EditAccessModal.test.ts
+++ b/mlflow/server/js/src/admin/components/EditAccessModal.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from '@jest/globals';
+
+import { computeAccessDiff } from './EditAccessModal';
+import type { StagedDirectPermission } from './DirectPermissionsSection';
+
+const direct = (overrides: Partial<StagedDirectPermission> = {}): StagedDirectPermission => ({
+  resourceType: 'experiment',
+  resourceId: '42',
+  permission: 'EDIT',
+  ...overrides,
+});
+
+describe('computeAccessDiff', () => {
+  it('returns an empty diff when current and desired are identical', () => {
+    const snap = {
+      roleIds: [1, 2, 3],
+      directPermissions: [direct({ resourceId: '42' }), direct({ resourceId: '7' })],
+      isAdmin: false,
+    };
+    const diff = computeAccessDiff(snap, snap, true);
+    expect(diff).toEqual({
+      rolesToAssign: [],
+      rolesToUnassign: [],
+      directToGrant: [],
+      directToRevoke: [],
+      adminChange: false,
+    });
+  });
+
+  it('detects roles to assign without disturbing existing roles', () => {
+    const diff = computeAccessDiff(
+      { roleIds: [1, 2], directPermissions: [], isAdmin: false },
+      { roleIds: [1, 2, 3, 4], directPermissions: [], isAdmin: false },
+      false,
+    );
+    expect(diff.rolesToAssign).toEqual([3, 4]);
+    expect(diff.rolesToUnassign).toEqual([]);
+  });
+
+  it('detects roles to unassign without disturbing remaining roles', () => {
+    const diff = computeAccessDiff(
+      { roleIds: [1, 2, 3], directPermissions: [], isAdmin: false },
+      { roleIds: [1], directPermissions: [], isAdmin: false },
+      false,
+    );
+    expect(diff.rolesToAssign).toEqual([]);
+    expect(diff.rolesToUnassign).toEqual([2, 3]);
+  });
+
+  it('handles a swap of role assignments (assign and unassign in the same diff)', () => {
+    const diff = computeAccessDiff(
+      { roleIds: [1, 2], directPermissions: [], isAdmin: false },
+      { roleIds: [2, 3], directPermissions: [], isAdmin: false },
+      false,
+    );
+    expect(diff.rolesToAssign).toEqual([3]);
+    expect(diff.rolesToUnassign).toEqual([1]);
+  });
+
+  it('detects direct permissions to grant and to revoke', () => {
+    const a = direct({ resourceId: '42', permission: 'READ' });
+    const b = direct({ resourceId: '99', permission: 'EDIT' });
+    const c = direct({ resourceId: '7', permission: 'READ' });
+    const diff = computeAccessDiff(
+      { roleIds: [], directPermissions: [a, b], isAdmin: false },
+      { roleIds: [], directPermissions: [b, c], isAdmin: false },
+      false,
+    );
+    expect(diff.directToGrant).toEqual([c]);
+    expect(diff.directToRevoke).toEqual([a]);
+  });
+
+  it('treats permission-level changes on the same resource as revoke + grant', () => {
+    // Same (resource_type, resource_id), different permission level — the key
+    // includes the permission, so the old grant must be revoked and the new
+    // one granted. Operators see both rows in the Review step.
+    const oldGrant = direct({ resourceId: '42', permission: 'READ' });
+    const newGrant = direct({ resourceId: '42', permission: 'EDIT' });
+    const diff = computeAccessDiff(
+      { roleIds: [], directPermissions: [oldGrant], isAdmin: false },
+      { roleIds: [], directPermissions: [newGrant], isAdmin: false },
+      false,
+    );
+    expect(diff.directToGrant).toEqual([newGrant]);
+    expect(diff.directToRevoke).toEqual([oldGrant]);
+  });
+
+  it('reports adminChange=true when the platform admin promotes a non-admin', () => {
+    const diff = computeAccessDiff(
+      { roleIds: [], directPermissions: [], isAdmin: false },
+      { roleIds: [], directPermissions: [], isAdmin: true },
+      true,
+    );
+    expect(diff.adminChange).toBe(true);
+  });
+
+  it('reports adminChange=true when the platform admin demotes an admin', () => {
+    const diff = computeAccessDiff(
+      { roleIds: [], directPermissions: [], isAdmin: true },
+      { roleIds: [], directPermissions: [], isAdmin: false },
+      true,
+    );
+    expect(diff.adminChange).toBe(true);
+  });
+
+  it('reports adminChange=false when the desired admin status matches the current', () => {
+    const diff = computeAccessDiff(
+      { roleIds: [], directPermissions: [], isAdmin: true },
+      { roleIds: [], directPermissions: [], isAdmin: true },
+      true,
+    );
+    expect(diff.adminChange).toBe(false);
+  });
+
+  it('suppresses adminChange for non-platform-admin viewers regardless of desired flag', () => {
+    // A workspace manager opens the modal — the admin-status section is not
+    // rendered for them, but defensively the diff still reports no change so
+    // the apply step never tries to call ``updateAdmin``.
+    const diff = computeAccessDiff(
+      { roleIds: [], directPermissions: [], isAdmin: false },
+      { roleIds: [], directPermissions: [], isAdmin: true },
+      false,
+    );
+    expect(diff.adminChange).toBe(false);
+  });
+
+  it('combines role, direct-permission, and admin-status changes into one diff', () => {
+    const oldGrant = direct({ resourceId: '42', permission: 'READ' });
+    const newGrant = direct({ resourceId: '99', permission: 'EDIT' });
+    const diff = computeAccessDiff(
+      { roleIds: [1, 2], directPermissions: [oldGrant], isAdmin: false },
+      { roleIds: [2, 3], directPermissions: [newGrant], isAdmin: true },
+      true,
+    );
+    expect(diff).toEqual({
+      rolesToAssign: [3],
+      rolesToUnassign: [1],
+      directToGrant: [newGrant],
+      directToRevoke: [oldGrant],
+      adminChange: true,
+    });
+  });
+});

--- a/mlflow/server/js/src/admin/components/EditAccessModal.tsx
+++ b/mlflow/server/js/src/admin/components/EditAccessModal.tsx
@@ -47,13 +47,46 @@ const isDirectGrantResourceType = (rt: string): rt is DirectGrantResourceType =>
   rt === 'gateway_endpoint' ||
   rt === 'gateway_model_definition';
 
-interface AccessDiff {
+export interface AccessDiff {
   rolesToAssign: number[];
   rolesToUnassign: number[];
   directToGrant: StagedDirectPermission[];
   directToRevoke: StagedDirectPermission[];
   adminChange: boolean;
 }
+
+interface AccessSnapshot {
+  roleIds: number[];
+  directPermissions: StagedDirectPermission[];
+  isAdmin: boolean;
+}
+
+/**
+ * Pure diff between the user's current backend access and the desired
+ * staged state. Exported for unit testing; called by the modal via
+ * ``useMemo`` on every form change. ``isCurrentUserAdmin`` gates the
+ * admin-status diff so workspace managers (who can't toggle ``is_admin``)
+ * never see an admin change in the review step.
+ */
+export const computeAccessDiff = (
+  current: AccessSnapshot,
+  desired: AccessSnapshot,
+  isCurrentUserAdmin: boolean,
+): AccessDiff => {
+  const currentRoleIdSet = new Set(current.roleIds);
+  const desiredRoleIdSet = new Set(desired.roleIds);
+  const rolesToAssign = desired.roleIds.filter((id) => !currentRoleIdSet.has(id));
+  const rolesToUnassign = current.roleIds.filter((id) => !desiredRoleIdSet.has(id));
+
+  const currentDirectKeys = new Set(current.directPermissions.map(directPermKey));
+  const desiredDirectKeys = new Set(desired.directPermissions.map(directPermKey));
+  const directToGrant = desired.directPermissions.filter((p) => !currentDirectKeys.has(directPermKey(p)));
+  const directToRevoke = current.directPermissions.filter((p) => !desiredDirectKeys.has(directPermKey(p)));
+
+  const adminChange = isCurrentUserAdmin && desired.isAdmin !== current.isAdmin;
+
+  return { rolesToAssign, rolesToUnassign, directToGrant, directToRevoke, adminChange };
+};
 
 /**
  * Edit-style modal for managing one user's access. Pre-fills role
@@ -122,30 +155,24 @@ export const EditAccessModal = ({ open, onClose, username, onCreateRoleForAllOfT
     setError(null);
   }, [open, currentRoleIds, currentDirectPerms, currentIsAdmin]);
 
-  // --- Diff computation ---
-  const diff = useMemo<AccessDiff>(() => {
-    const currentRoleIdSet = new Set(currentRoleIds);
-    const desiredRoleIdSet = new Set(roleValue.roleIds);
-    const rolesToAssign = roleValue.roleIds.filter((id) => !currentRoleIdSet.has(id));
-    const rolesToUnassign = currentRoleIds.filter((id) => !desiredRoleIdSet.has(id));
-
-    const currentDirectKeys = new Set(currentDirectPerms.map(directPermKey));
-    const desiredDirectKeys = new Set(directPermissions.map(directPermKey));
-    const directToGrant = directPermissions.filter((p) => !currentDirectKeys.has(directPermKey(p)));
-    const directToRevoke = currentDirectPerms.filter((p) => !desiredDirectKeys.has(directPermKey(p)));
-
-    const adminChange = isCurrentUserAdmin && isAdmin !== currentIsAdmin;
-
-    return { rolesToAssign, rolesToUnassign, directToGrant, directToRevoke, adminChange };
-  }, [
-    currentRoleIds,
-    currentDirectPerms,
-    currentIsAdmin,
-    roleValue.roleIds,
-    directPermissions,
-    isAdmin,
-    isCurrentUserAdmin,
-  ]);
+  // --- Diff computation (delegates to the pure ``computeAccessDiff``) ---
+  const diff = useMemo<AccessDiff>(
+    () =>
+      computeAccessDiff(
+        { roleIds: currentRoleIds, directPermissions: currentDirectPerms, isAdmin: currentIsAdmin },
+        { roleIds: roleValue.roleIds, directPermissions, isAdmin },
+        isCurrentUserAdmin,
+      ),
+    [
+      currentRoleIds,
+      currentDirectPerms,
+      currentIsAdmin,
+      roleValue.roleIds,
+      directPermissions,
+      isAdmin,
+      isCurrentUserAdmin,
+    ],
+  );
 
   const hasAnyChange =
     diff.rolesToAssign.length > 0 ||

--- a/mlflow/server/js/src/admin/components/EditRoleModal.test.ts
+++ b/mlflow/server/js/src/admin/components/EditRoleModal.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from '@jest/globals';
+
+import { computeRoleDiff } from './EditRoleModal';
+import type { StagedRolePermission } from './RolePermissionsSection';
+
+const perm = (overrides: Partial<StagedRolePermission> = {}): StagedRolePermission => ({
+  resourceType: 'experiment',
+  resourcePattern: '42',
+  permission: 'EDIT',
+  ...overrides,
+});
+
+describe('computeRoleDiff', () => {
+  it('returns an empty diff when current and desired are identical', () => {
+    const snap = {
+      name: 'editor',
+      description: 'edits stuff',
+      permissions: [perm({ id: 1 }), perm({ id: 2, resourcePattern: '7' })],
+      usernames: ['alice', 'bob'],
+    };
+    const diff = computeRoleDiff(snap, snap);
+    expect(diff).toEqual({
+      nameChange: null,
+      descriptionChange: null,
+      permissionsToAdd: [],
+      permissionIdsToRemove: [],
+      usersToAssign: [],
+      usersToUnassign: [],
+    });
+  });
+
+  describe('name change', () => {
+    it('reports the trimmed new name when it differs from the current', () => {
+      const diff = computeRoleDiff(
+        { name: 'old', description: '', permissions: [], usernames: [] },
+        { name: '  new  ', description: '', permissions: [], usernames: [] },
+      );
+      expect(diff.nameChange).toBe('new');
+    });
+
+    it('reports null when the trimmed name matches (whitespace-only edit is a no-op)', () => {
+      const diff = computeRoleDiff(
+        { name: 'editor', description: '', permissions: [], usernames: [] },
+        { name: '  editor  ', description: '', permissions: [], usernames: [] },
+      );
+      expect(diff.nameChange).toBeNull();
+    });
+
+    it('reports null when the desired name is empty (the modal blocks empty-name submit)', () => {
+      const diff = computeRoleDiff(
+        { name: 'editor', description: '', permissions: [], usernames: [] },
+        { name: '   ', description: '', permissions: [], usernames: [] },
+      );
+      expect(diff.nameChange).toBeNull();
+    });
+  });
+
+  describe('description change', () => {
+    it('reports the new description when it differs', () => {
+      const diff = computeRoleDiff(
+        { name: 'r', description: 'old desc', permissions: [], usernames: [] },
+        { name: 'r', description: 'new desc', permissions: [], usernames: [] },
+      );
+      expect(diff.descriptionChange).toBe('new desc');
+    });
+
+    it('reports the empty string when the user clears a previously-set description', () => {
+      // Empty string is meaningful ("clear the description"); only null means
+      // "no change". This distinction matters at the apply step.
+      const diff = computeRoleDiff(
+        { name: 'r', description: 'old desc', permissions: [], usernames: [] },
+        { name: 'r', description: '', permissions: [], usernames: [] },
+      );
+      expect(diff.descriptionChange).toBe('');
+    });
+
+    it('reports null when the description is unchanged', () => {
+      const diff = computeRoleDiff(
+        { name: 'r', description: 'same', permissions: [], usernames: [] },
+        { name: 'r', description: 'same', permissions: [], usernames: [] },
+      );
+      expect(diff.descriptionChange).toBeNull();
+    });
+  });
+
+  describe('permissions', () => {
+    it('treats staged rows without an id as additions', () => {
+      const newRow = perm({ id: undefined, resourcePattern: '99' });
+      const diff = computeRoleDiff(
+        { name: 'r', description: '', permissions: [perm({ id: 1 })], usernames: [] },
+        { name: 'r', description: '', permissions: [perm({ id: 1 }), newRow], usernames: [] },
+      );
+      expect(diff.permissionsToAdd).toEqual([newRow]);
+      expect(diff.permissionIdsToRemove).toEqual([]);
+    });
+
+    it('treats current rows whose triple is no longer staged as removals', () => {
+      const diff = computeRoleDiff(
+        {
+          name: 'r',
+          description: '',
+          permissions: [perm({ id: 1 }), perm({ id: 2, resourcePattern: '7' })],
+          usernames: [],
+        },
+        { name: 'r', description: '', permissions: [perm({ id: 1 })], usernames: [] },
+      );
+      expect(diff.permissionsToAdd).toEqual([]);
+      expect(diff.permissionIdsToRemove).toEqual([2]);
+    });
+
+    it('treats a permission-level change as a removal of the old id plus an add for the new triple', () => {
+      // Same (resourceType, resourcePattern), different permission level: the
+      // dedup key includes ``permission``, so the old persisted row is
+      // removed and the new staged row (id=undefined) is added.
+      const oldRow = perm({ id: 1, permission: 'READ' });
+      const newRow = perm({ id: undefined, permission: 'EDIT' });
+      const diff = computeRoleDiff(
+        { name: 'r', description: '', permissions: [oldRow], usernames: [] },
+        { name: 'r', description: '', permissions: [newRow], usernames: [] },
+      );
+      expect(diff.permissionsToAdd).toEqual([newRow]);
+      expect(diff.permissionIdsToRemove).toEqual([1]);
+    });
+  });
+
+  describe('users', () => {
+    it('detects users to assign and to unassign in the same diff', () => {
+      const diff = computeRoleDiff(
+        { name: 'r', description: '', permissions: [], usernames: ['alice', 'bob'] },
+        { name: 'r', description: '', permissions: [], usernames: ['bob', 'carol'] },
+      );
+      expect(diff.usersToAssign).toEqual(['carol']);
+      expect(diff.usersToUnassign).toEqual(['alice']);
+    });
+
+    it('returns empty user changes when the assignment set is unchanged', () => {
+      const diff = computeRoleDiff(
+        { name: 'r', description: '', permissions: [], usernames: ['alice', 'bob'] },
+        { name: 'r', description: '', permissions: [], usernames: ['alice', 'bob'] },
+      );
+      expect(diff.usersToAssign).toEqual([]);
+      expect(diff.usersToUnassign).toEqual([]);
+    });
+  });
+
+  it('combines name, description, permissions, and user changes into one diff', () => {
+    const diff = computeRoleDiff(
+      {
+        name: 'old-name',
+        description: 'old desc',
+        permissions: [perm({ id: 1, resourcePattern: '42' })],
+        usernames: ['alice'],
+      },
+      {
+        name: 'new-name',
+        description: '',
+        permissions: [perm({ id: undefined, resourcePattern: '99' })],
+        usernames: ['bob'],
+      },
+    );
+    expect(diff).toEqual({
+      nameChange: 'new-name',
+      descriptionChange: '',
+      permissionsToAdd: [perm({ id: undefined, resourcePattern: '99' })],
+      permissionIdsToRemove: [1],
+      usersToAssign: ['bob'],
+      usersToUnassign: ['alice'],
+    });
+  });
+});

--- a/mlflow/server/js/src/admin/components/EditRoleModal.tsx
+++ b/mlflow/server/js/src/admin/components/EditRoleModal.tsx
@@ -35,7 +35,7 @@ export interface EditRoleModalProps {
 const permTripleKey = (p: { resourceType: string; resourcePattern: string; permission: string }) =>
   `${p.resourceType}::${p.resourcePattern}::${p.permission}`;
 
-interface RoleDiff {
+export interface RoleDiff {
   nameChange: string | null;
   descriptionChange: string | null;
   permissionsToAdd: StagedRolePermission[];
@@ -43,6 +43,46 @@ interface RoleDiff {
   usersToAssign: string[];
   usersToUnassign: string[];
 }
+
+interface RoleSnapshot {
+  name: string;
+  description: string;
+  permissions: StagedRolePermission[];
+  /** Sorted list of usernames assigned to the role. */
+  usernames: string[];
+}
+
+/**
+ * Pure diff between the role's current backend state and the staged
+ * desired state. Exported for unit testing; called by the modal via
+ * ``useMemo`` on every form change.
+ *
+ * - ``nameChange`` is non-null only when the trimmed name differs from
+ *   the current and is non-empty (the modal blocks empty-name submit).
+ * - ``descriptionChange`` is non-null whenever it differs — empty string
+ *   is meaningful (clears the description).
+ * - ``permissionsToAdd`` is the staged permissions whose ``id`` is null
+ *   (newly added in the form). ``permissionIdsToRemove`` is the current
+ *   permission ids that no longer match any staged triple.
+ */
+export const computeRoleDiff = (current: RoleSnapshot, desired: RoleSnapshot): RoleDiff => {
+  const trimmedName = desired.name.trim();
+  const nameChange = trimmedName !== current.name.trim() && trimmedName.length > 0 ? trimmedName : null;
+  const descriptionChange = desired.description !== current.description ? desired.description : null;
+
+  const desiredKeys = new Set(desired.permissions.map(permTripleKey));
+  const permissionsToAdd = desired.permissions.filter((p) => p.id == null);
+  const permissionIdsToRemove = current.permissions
+    .filter((p) => p.id != null && !desiredKeys.has(permTripleKey(p)))
+    .map((p) => p.id as number);
+
+  const desiredUsernameSet = new Set(desired.usernames);
+  const currentUsernameSet = new Set(current.usernames);
+  const usersToAssign = desired.usernames.filter((u) => !currentUsernameSet.has(u));
+  const usersToUnassign = current.usernames.filter((u) => !desiredUsernameSet.has(u));
+
+  return { nameChange, descriptionChange, permissionsToAdd, permissionIdsToRemove, usersToAssign, usersToUnassign };
+};
 
 /**
  * Edit-style modal for managing one role end-to-end. Pre-fills name,
@@ -121,35 +161,20 @@ export const EditRoleModal = ({ open, onClose, roleId }: EditRoleModalProps) => 
     setError(null);
   }, [open, currentName, currentDescription, currentPermissions, currentUsernames]);
 
-  // --- Diff ---
-  const diff = useMemo<RoleDiff>(() => {
-    const trimmedName = name.trim();
-    const nameChange = trimmedName !== currentName.trim() && trimmedName.length > 0 ? trimmedName : null;
-    // Empty description is meaningful (clears it); only ``null`` means "no change".
-    const descriptionChange = description !== currentDescription ? description : null;
-
-    const desiredKeys = new Set(permissions.map(permTripleKey));
-    const permissionsToAdd = permissions.filter((p) => p.id == null);
-    const permissionIdsToRemove = currentPermissions
-      .filter((p) => p.id != null && !desiredKeys.has(permTripleKey(p)))
-      .map((p) => p.id as number);
-
-    const desiredUsernameSet = new Set(usernames);
-    const currentUsernameSet = new Set(currentUsernames);
-    const usersToAssign = usernames.filter((u) => !currentUsernameSet.has(u));
-    const usersToUnassign = currentUsernames.filter((u) => !desiredUsernameSet.has(u));
-
-    return { nameChange, descriptionChange, permissionsToAdd, permissionIdsToRemove, usersToAssign, usersToUnassign };
-  }, [
-    name,
-    description,
-    permissions,
-    usernames,
-    currentName,
-    currentDescription,
-    currentPermissions,
-    currentUsernames,
-  ]);
+  // --- Diff (delegates to the pure ``computeRoleDiff``) ---
+  const diff = useMemo<RoleDiff>(
+    () =>
+      computeRoleDiff(
+        {
+          name: currentName,
+          description: currentDescription,
+          permissions: currentPermissions,
+          usernames: currentUsernames,
+        },
+        { name, description, permissions, usernames },
+      ),
+    [name, description, permissions, usernames, currentName, currentDescription, currentPermissions, currentUsernames],
+  );
 
   const hasAnyChange =
     diff.nameChange !== null ||

--- a/mlflow/server/js/src/admin/hooks.test.tsx
+++ b/mlflow/server/js/src/admin/hooks.test.tsx
@@ -1,0 +1,172 @@
+import { describe, jest, it, expect, beforeEach } from '@jest/globals';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@databricks/web-shared/query-client';
+
+import { AdminApi } from './api';
+import {
+  AdminQueryKeys,
+  useAssignRole,
+  useGrantUserPermission,
+  useRevokeUserPermission,
+  useRolesQuery,
+  useUnassignRole,
+} from './hooks';
+import { AccountQueryKeys } from '../account/hooks';
+
+jest.mock('./api', () => ({
+  AdminApi: {
+    listRoles: jest.fn(),
+    assignRole: jest.fn(),
+    unassignRole: jest.fn(),
+    grantUserPermission: jest.fn(),
+    revokeUserPermission: jest.fn(),
+  },
+}));
+
+const mockedApi = AdminApi as jest.Mocked<typeof AdminApi>;
+
+const makeWrapper = (client: QueryClient) => {
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+};
+
+const freshClient = () => new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('useRolesQuery cache-key normalization', () => {
+  // The cache key is ``[...AdminQueryKeys.roles, normalized]`` — for a list,
+  // ``normalized`` is the input sorted ascending, so callers passing the same
+  // set in different order share one cache entry.
+
+  const findRolesKeys = (client: QueryClient): unknown[][] => {
+    return client
+      .getQueryCache()
+      .getAll()
+      .map((q) => q.queryKey as unknown[])
+      .filter((k) => Array.isArray(k) && k[0] === AdminQueryKeys.roles[0]);
+  };
+
+  it('uses ``undefined`` as the trailing segment when called with no argument', async () => {
+    mockedApi.listRoles.mockResolvedValueOnce({ roles: [] });
+    const client = freshClient();
+    const { result } = renderHook(() => useRolesQuery(), { wrapper: makeWrapper(client) });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(findRolesKeys(client)).toEqual([['admin_roles', undefined]]);
+  });
+
+  it('preserves a string workspace literal in the key', async () => {
+    mockedApi.listRoles.mockResolvedValueOnce({ roles: [] });
+    const client = freshClient();
+    const { result } = renderHook(() => useRolesQuery('foo'), { wrapper: makeWrapper(client) });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(findRolesKeys(client)).toEqual([['admin_roles', 'foo']]);
+  });
+
+  it('canonicalizes a list to sorted form so input order does not affect the cache key', async () => {
+    mockedApi.listRoles.mockResolvedValue({ roles: [] });
+    const client = freshClient();
+
+    // Mount two readers with the same set in different order — they should
+    // share one cache entry under the sorted key.
+    const { result: r1 } = renderHook(() => useRolesQuery(['b', 'a']), {
+      wrapper: makeWrapper(client),
+    });
+    await waitFor(() => expect(r1.current.isSuccess).toBe(true));
+
+    const { result: r2 } = renderHook(() => useRolesQuery(['a', 'b']), {
+      wrapper: makeWrapper(client),
+    });
+    await waitFor(() => expect(r2.current.isSuccess).toBe(true));
+
+    // Single cache entry, normalized to sorted form. (Refetch behavior is
+    // governed by staleTime, which is unrelated to the cache-key contract.)
+    expect(findRolesKeys(client)).toEqual([['admin_roles', ['a', 'b']]]);
+  });
+
+  it('skips the fetch when explicitly disabled via options', () => {
+    const client = freshClient();
+    renderHook(() => useRolesQuery('foo', { enabled: false }), { wrapper: makeWrapper(client) });
+    expect(mockedApi.listRoles).not.toHaveBeenCalled();
+  });
+});
+
+describe('mutation invalidation contract', () => {
+  // These hooks fan invalidations to multiple query keys so the admin Users
+  // tab (eager-loaded ``users[].roles``), the per-user roles query, and
+  // role-detail views all refresh after a single mutation. Pinning the
+  // contract here guards the eager-load N+1 fix from regressing.
+
+  const setupSpy = (client: QueryClient) => jest.spyOn(client, 'invalidateQueries');
+
+  it('useAssignRole invalidates roleUsers, per-user userRoles, and the bulk users query', async () => {
+    mockedApi.assignRole.mockResolvedValueOnce({} as any);
+    const client = freshClient();
+    const spy = setupSpy(client);
+    const { result } = renderHook(() => useAssignRole(42), { wrapper: makeWrapper(client) });
+
+    await result.current.mutateAsync('alice');
+
+    const keys = spy.mock.calls.map((c) => c[0] as { queryKey?: unknown } | undefined).map((arg) => arg?.queryKey);
+    expect(keys).toEqual(
+      expect.arrayContaining([AdminQueryKeys.roleUsers(42), AccountQueryKeys.userRoles('alice'), AdminQueryKeys.users]),
+    );
+  });
+
+  it('useUnassignRole invalidates the same three query sets', async () => {
+    mockedApi.unassignRole.mockResolvedValueOnce(undefined);
+    const client = freshClient();
+    const spy = setupSpy(client);
+    const { result } = renderHook(() => useUnassignRole(42), { wrapper: makeWrapper(client) });
+
+    await result.current.mutateAsync('alice');
+
+    const keys = spy.mock.calls.map((c) => c[0] as { queryKey?: unknown } | undefined).map((arg) => arg?.queryKey);
+    expect(keys).toEqual(
+      expect.arrayContaining([AdminQueryKeys.roleUsers(42), AccountQueryKeys.userRoles('alice'), AdminQueryKeys.users]),
+    );
+  });
+
+  it('useGrantUserPermission invalidates per-user userRoles and userPermissions', async () => {
+    mockedApi.grantUserPermission.mockResolvedValueOnce(undefined);
+    const client = freshClient();
+    const spy = setupSpy(client);
+    const { result } = renderHook(() => useGrantUserPermission(), { wrapper: makeWrapper(client) });
+
+    await result.current.mutateAsync({
+      resource_type: 'experiment',
+      resource_id: '42',
+      username: 'alice',
+      permission: 'EDIT',
+    });
+
+    const keys = spy.mock.calls.map((c) => c[0] as { queryKey?: unknown } | undefined).map((arg) => arg?.queryKey);
+    expect(keys).toEqual(
+      expect.arrayContaining([AccountQueryKeys.userRoles('alice'), AdminQueryKeys.userPermissions('alice')]),
+    );
+  });
+
+  it('useRevokeUserPermission invalidates per-user userRoles and userPermissions', async () => {
+    mockedApi.revokeUserPermission.mockResolvedValueOnce(undefined);
+    const client = freshClient();
+    const spy = setupSpy(client);
+    const { result } = renderHook(() => useRevokeUserPermission(), { wrapper: makeWrapper(client) });
+
+    await result.current.mutateAsync({
+      resource_type: 'experiment',
+      resource_id: '42',
+      username: 'alice',
+    });
+
+    const keys = spy.mock.calls.map((c) => c[0] as { queryKey?: unknown } | undefined).map((arg) => arg?.queryKey);
+    expect(keys).toEqual(
+      expect.arrayContaining([AccountQueryKeys.userRoles('alice'), AdminQueryKeys.userPermissions('alice')]),
+    );
+  });
+});


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23086, #22929 (admin UI surface this covers).

### What changes are proposed in this pull request?

Closes the admin/ FE coverage gap on the operator-impact paths. We had 1 test file across 17 admin source files; this brings it to 5 files, 44 tests, covering the load-bearing diff logic, the hook invalidation contract, and the `listRoles` URL shape.

| File | # | What it covers |
|---|---|---|
| `api.test.ts` | 7 | `listRoles` URL shape across no-arg / string / empty array / multi-workspace inputs, including encoding of workspace names that contain reserved query characters |
| `hooks.test.tsx` | 8 | `useRolesQuery` cache-key normalization (sorted-list canonicalization so `['b','a']` and `['a','b']` share one cache entry); `useAssignRole` / `useUnassignRole` / `useGrantUserPermission` / `useRevokeUserPermission` invalidation sets — the bulk-users invalidation guards the eager-load N+1 fix from silently regressing |
| `EditAccessModal.test.ts` | 11 | Pure `computeAccessDiff` (extracted as a sibling export). Role add / remove / swap, direct-grant add / remove / permission-level swap, admin promote / demote, defensive suppression of `adminChange` for workspace-manager viewers |
| `EditRoleModal.test.ts` | 13 | Pure `computeRoleDiff` (extracted the same way). Name (trim, no-op, blocked-empty), description (incl. clearing to empty), permission add / remove / level change, user assign / unassign, combined diff |

Two small source extractions in `EditAccessModal.tsx` and `EditRoleModal.tsx` make the diff functions testable as pure helpers — no behavior change.

**Why these tests.** Each round of admin-UI review on #23086 surfaced real bugs (per-row N+1, gear visibility, header semantics, scope filtering) that targeted unit tests would have caught earlier. Backend RBAC has ~382 tests across 10 files; the FE admin surface had 5. The diff-logic and invalidation contract are the two most regression-prone pieces, so this round focuses there.

**Out of scope (named follow-ups).** Page-level integration tests for `AdminPage` / `RoleDetailPage` / `UserDetailPage` (high mock surface, low marginal value), backend unit test for the new `_role_based_read_predicate` helper landing in #22859, parametrized backfill mapping test for the Alembic migration `e5f6a7b8c9d0` (useful before #23089 graduates).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

```bash
yarn test --testPathPattern='admin/'   # 44/44 pass
yarn type-check                         # clean
yarn lint src/admin                     # clean
yarn prettier:check src/admin           # clean
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release