### PR TITLE
Filter `xtest_viz` output to entries whose latest run failed

### DIFF
--- a/dev/xtest_viz.py
+++ b/dev/xtest_viz.py
@@ -324,10 +324,20 @@ class XTestViz:
 
         return "\n".join(lines)
 
+    def filter_latest_not_success(self, data_rows: list[JobResult]) -> list[JobResult]:
+        """Keep only jobs whose latest run for each name was not a success."""
+        latest_per_name: dict[str, JobResult] = {}
+        for r in data_rows:
+            cur = latest_per_name.get(r.name)
+            if cur is None or r.started_at > cur.started_at:
+                latest_per_name[r.name] = r
+        keep = {name for name, r in latest_per_name.items() if r.conclusion != "success"}
+        return [r for r in data_rows if r.name in keep]
+
     def render_results_table(self, data_rows: list[JobResult]) -> str:
         """Render job data as a markdown table."""
         if not data_rows:
-            return "No test jobs found."
+            return "All latest cross-version tests succeeded."
 
         pivot_data, sorted_dates, sorted_names = self._pivot_job_results(data_rows)
         return self._build_markdown_table(pivot_data, sorted_dates, sorted_names)
@@ -363,6 +373,7 @@ async def main() -> None:
 
     visualizer = XTestViz(github_token=token, repo=args.repo)
     data_rows = await visualizer.fetch_all_jobs(args.days)
+    data_rows = visualizer.filter_latest_not_success(data_rows)
     if args.json_output:
         Path(args.json_output).write_text(visualizer.render_json(data_rows))
     if not data_rows:

--- a/dev/xtest_viz.py
+++ b/dev/xtest_viz.py
@@ -337,7 +337,7 @@ class XTestViz:
     def render_results_table(self, data_rows: list[JobResult]) -> str:
         """Render job data as a markdown table."""
         if not data_rows:
-            return "All latest cross-version tests succeeded."
+            return "No test jobs found."
 
         pivot_data, sorted_dates, sorted_names = self._pivot_job_results(data_rows)
         return self._build_markdown_table(pivot_data, sorted_dates, sorted_names)
@@ -372,12 +372,15 @@ async def main() -> None:
         print("Set GH_TOKEN environment variable or use --token option.", file=sys.stderr)
 
     visualizer = XTestViz(github_token=token, repo=args.repo)
-    data_rows = await visualizer.fetch_all_jobs(args.days)
-    data_rows = visualizer.filter_latest_not_success(data_rows)
+    raw_rows = await visualizer.fetch_all_jobs(args.days)
+    data_rows = visualizer.filter_latest_not_success(raw_rows)
     if args.json_output:
         Path(args.json_output).write_text(visualizer.render_json(data_rows))
     if not data_rows:
-        print("No workflow runs found in the specified time period.")
+        if raw_rows:
+            print("All latest cross-version tests succeeded.")
+        else:
+            print("No workflow runs found in the specified time period.")
     else:
         print(visualizer.render_results_table(data_rows))
 


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

`dev/xtest_viz.py` previously rendered every test entry, including those that have been passing consistently. With ~360 jobs per run, the resulting markdown table (and uploaded JSON artifact) was dominated by entries that aren't actionable.

This PR filters the data so both the markdown summary and the JSON artifact only include test names whose **latest** run was not successful. Tests that have recovered (e.g. failed three days ago, passed today) are dropped.

#### Sample output

Tested locally with `--days 5` against `mlflow/dev`. The filter reduced the table from ~360 jobs/run to 8 names whose most recent run failed:

| Name                                | 05/07                                                                       | 05/06                                                                       | 05/05                                                                       | 05/04                                                                       |
| ----------------------------------- | --------------------------------------------------------------------------- | --------------------------------------------------------------------------- | --------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| dspy / autologging / 3.2.0          | [❌](https://github.com/mlflow/dev/actions/runs/25499435107/job/74893008096) | [❌](https://github.com/mlflow/dev/actions/runs/25438955938/job/74688179419) | —                                                                           | —                                                                           |
| dspy / models / 3.2.0               | [❌](https://github.com/mlflow/dev/actions/runs/25499435107/job/74893008100) | [❌](https://github.com/mlflow/dev/actions/runs/25438955938/job/74688179359) | —                                                                           | —                                                                           |
| llama_index / autologging / 0.14.20 | —                                                                           | —                                                                           | —                                                                           | [❌](https://github.com/mlflow/dev/actions/runs/25322437438/job/74291969937) |
| llama_index / autologging / 0.14.21 | [❌](https://github.com/mlflow/dev/actions/runs/25499435107/job/74893008099) | [❌](https://github.com/mlflow/dev/actions/runs/25438955938/job/74688179363) | [❌](https://github.com/mlflow/dev/actions/runs/25379984544/job/74489373589) | —                                                                           |
| llama_index / models / 0.14.20      | —                                                                           | —                                                                           | —                                                                           | [❌](https://github.com/mlflow/dev/actions/runs/25322437438/job/74291969910) |
| llama_index / models / 0.14.21      | [❌](https://github.com/mlflow/dev/actions/runs/25499435107/job/74893008097) | [❌](https://github.com/mlflow/dev/actions/runs/25438955938/job/74688179417) | [❌](https://github.com/mlflow/dev/actions/runs/25379984544/job/74489373504) | —                                                                           |
| transformers / autologging / 4.43.4 | —                                                                           | [❌](https://github.com/mlflow/dev/actions/runs/25438955938/job/74688179660) | [❌](https://github.com/mlflow/dev/actions/runs/25379984544/job/74489377201) | [❌](https://github.com/mlflow/dev/actions/runs/25322437438/job/74291968620) |
| transformers / autologging / 4.44.2 | [❌](https://github.com/mlflow/dev/actions/runs/25499435107/job/74893008190) | —                                                                           | —                                                                           | —                                                                           |

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release