### PR TITLE
Pin `sentence-transformers<5.4` for `transformers<4.46` cross-version tests

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -522,6 +522,9 @@ transformers:
       "< 4.41": ["huggingface_hub<0.24.0", "datasets<=2.4.0", "evaluate<0.4.3", "pyarrow<21.0.0"]
       # sentence-transformers 5.1.2 introduces breaking changes with AcceleratorConfig
       "< 4.42": ["sentence-transformers<5.1.2"]
+      # sentence-transformers 5.4 passes `processing_class` to transformers Trainer,
+      # which was added in transformers 4.46.0
+      "< 4.46": ["sentence-transformers<5.4"]
       "< 4.52.0.dev0": ["accelerate<1"]
       # transformers 5.x requires accelerate>=1.1.0 for Trainer
       ">= 5.0": ["accelerate>=1.1.0"]


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

`sentence-transformers >= 5.4` calls `transformers.Trainer.__init__(..., processing_class=...)`, but `processing_class` was only added to `transformers.Trainer` in 4.46.0. As a result, the cross-version test combination of `transformers 4.43.4` + `sentence-transformers 5.4.1` fails with:

```
TypeError: Trainer.__init__() got an unexpected keyword argument 'processing_class'
```

at `sentence_transformers/sentence_transformer/trainer.py:138` during `setfit_trainer` fixture setup. This affects four tests in `tests/transformers/test_transformers_autolog.py` (the SetFit-related tests).

This PR adds a pin: when `transformers < 4.46`, install `sentence-transformers < 5.4`.

Failed cross-version run example: https://github.com/mlflow/dev/actions/runs/25438955938/job/74688179660 (transformers 4.43.4, sentence-transformers 5.4.1).

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release