### PR TITLE
Bump default Node version in CI to 24

### DIFF
--- a/.github/actions/check-component-ids/action.yml
+++ b/.github/actions/check-component-ids/action.yml
@@ -3,8 +3,6 @@ description: "Verify that all componentIds in the MLflow UI are registered in th
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-      with:
-        node-version: 20
+    - uses: ./.github/actions/setup-node
     - run: node ${GITHUB_ACTION_PATH}/index.js
       shell: bash

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -3,7 +3,7 @@ description: "Set up Node"
 inputs:
   node-version:
     description: "Node version to use."
-    default: 20
+    default: 24
     required: false
   cache:
     description: "Package manager to cache (e.g., npm, yarn)."

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,7 @@ on:
       - mlflow/**
       - docs/**
       - .github/workflows/docs.yml
+      - .github/actions/setup-node/**
     branches:
       - master
   pull_request:
@@ -21,6 +22,7 @@ on:
       - mlflow/**
       - docs/**
       - .github/workflows/docs.yml
+      - .github/actions/setup-node/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         # 22.22.2 has a regression where `npm install -g` fails
         # See: https://github.com/nodejs/node/issues/62425
-        node-version: [20, 22.22.1, 24]
+        node-version: [22.22.1, 24]
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

Node.js 20 reached end-of-life last week, so bump the CI default to Node 24:

- `.github/actions/setup-node/action.yml`: change the default `node-version` from `20` to `24`. This matches `mlflow/server/js/package.json` (`engines.node: ^24.14.0`) and flips every workflow that uses the composite action without an explicit version.
- `.github/workflows/typescript.yml`: drop `20` from the matrix; the workflow now exercises `[22.22.1, 24]`.
- `.github/actions/check-component-ids/action.yml`: switch from a direct `actions/setup-node` invocation to the local `./.github/actions/setup-node` composite (and drop the hard-coded `node-version: 20` so it inherits the new default).

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release