### PR TITLE
feat: Add job store lifecycle APIs for executor framework

### DIFF
--- a/mlflow/store/jobs/abstract_store.py
+++ b/mlflow/store/jobs/abstract_store.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from enum import Enum
 from typing import Any, Iterator
 
 from mlflow.entities._job import Job, JobProgress
@@ -16,6 +17,13 @@ class JobTerminalStateUpdateException(MlflowException):
             f"The Job {job_id} is already finalized with status: {status}, it can't be updated.",
             error_code=INVALID_PARAMETER_VALUE,
         )
+
+
+class JobUpdateStatus(str, Enum):
+    """Outcome of a conditional job state transition."""
+
+    APPLIED = "APPLIED"
+    WRONG_STATE = "WRONG_STATE"
 
 
 @developer_stable
@@ -41,6 +49,114 @@ class AbstractJobStore(ABC):
 
         Returns:
             Job entity instance
+        """
+
+    @abstractmethod
+    def claim_job(self, job_id: str, lease_duration: float | None = None) -> JobUpdateStatus:
+        """
+        Conditionally claim a pending job for execution.
+
+        Args:
+            job_id: The ID of the job to claim
+            lease_duration: Optional lease duration in seconds. When provided,
+                the store should persist the corresponding lease expiry while
+                transitioning the row to ``RUNNING``.
+
+        Returns:
+            ``APPLIED`` if the job transitioned from ``PENDING`` to
+            ``RUNNING``, ``WRONG_STATE`` if the row exists but was no longer
+            claimable
+        """
+
+    @abstractmethod
+    def renew_job_lease(self, job_id: str, lease_duration: float) -> JobUpdateStatus:
+        """
+        Renew the short-lived lease for a running job.
+
+        Args:
+            job_id: The ID of the job whose lease should be renewed
+            lease_duration: New lease duration in seconds, measured from the
+                time the renewal is persisted.
+
+        Returns:
+            ``APPLIED`` if the lease was renewed, ``WRONG_STATE`` if the row
+            exists but is no longer in a renewable state
+        """
+
+    @abstractmethod
+    def retry_job(self, job_id: str) -> int:
+        """
+        Transition a running job back to ``PENDING`` for another attempt.
+
+        Args:
+            job_id: The ID of the job to retry
+
+        Returns:
+            The incremented retry count
+        """
+
+    @abstractmethod
+    def mark_job_needs_recovery(self, job_id: str) -> JobUpdateStatus:
+        """
+        Transition a stale running job to ``NEEDS_RECOVERY``.
+
+        Args:
+            job_id: The ID of the job to mark for recovery
+
+        Returns:
+            ``APPLIED`` if the transition succeeded, ``WRONG_STATE`` if the
+            row exists but is no longer in a recoverable running state
+        """
+
+    @abstractmethod
+    def reattach_job(self, job_id: str, lease_duration: float | None = None) -> JobUpdateStatus:
+        """
+        Transition a recovery-owned job back to ``RUNNING``.
+
+        Args:
+            job_id: The ID of the job to reattach to active monitoring
+            lease_duration: Optional new lease duration in seconds to apply
+                when the job returns to ``RUNNING``.
+
+        Returns:
+            ``APPLIED`` if the transition succeeded, ``WRONG_STATE`` if the
+            row exists but is no longer in ``NEEDS_RECOVERY``
+        """
+
+    @abstractmethod
+    def requeue_job(self, job_id: str) -> JobUpdateStatus:
+        """
+        Transition a recovery-owned job back to ``PENDING`` without incrementing retries.
+
+        Args:
+            job_id: The ID of the job to requeue
+
+        Returns:
+            ``APPLIED`` if the transition succeeded, ``WRONG_STATE`` if the
+            row exists but is no longer in ``NEEDS_RECOVERY``
+        """
+
+    @abstractmethod
+    def report_job_result(
+        self,
+        job_id: str,
+        status: JobStatus,
+        result: str | None = None,
+        error_message: str | None = None,
+        is_transient_error: bool = False,
+    ) -> None:
+        """
+        Persist a terminal job outcome for framework-owned execution.
+
+        Args:
+            job_id: The ID of the job to terminalize
+            status: Terminal status to persist
+            result: Serialized successful result payload, when applicable
+            error_message: Human-readable terminal error payload, when
+                applicable.
+            is_transient_error: Executor-side retry classification. Stores do
+                not persist this flag today, but callers may use this signature
+                to match the job-result contract.
         """
 
     @abstractmethod

--- a/mlflow/store/jobs/sqlalchemy_store.py
+++ b/mlflow/store/jobs/sqlalchemy_store.py
@@ -1,7 +1,9 @@
 import json
+import logging
+import math
 import threading
 import uuid
-from typing import Any, Iterator
+from typing import Any, Iterator, NoReturn
 
 import sqlalchemy
 
@@ -14,7 +16,11 @@ from mlflow.store.db.utils import (
     _safe_initialize_tables,
     create_sqlalchemy_engine_with_retry,
 )
-from mlflow.store.jobs.abstract_store import AbstractJobStore, JobTerminalStateUpdateException
+from mlflow.store.jobs.abstract_store import (
+    AbstractJobStore,
+    JobTerminalStateUpdateException,
+    JobUpdateStatus,
+)
 from mlflow.store.tracking.dbmodels.models import SqlJob
 from mlflow.utils.time import get_current_time_millis
 from mlflow.utils.uri import extract_db_type_from_uri
@@ -23,6 +29,7 @@ from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
 sqlalchemy.orm.configure_mappers()
 
 _LIST_JOB_PAGE_SIZE = 100
+_logger = logging.getLogger(__name__)
 
 
 class SqlAlchemyJobStore(AbstractJobStore):
@@ -87,21 +94,110 @@ class SqlAlchemyJobStore(AbstractJobStore):
         return instance
 
     @staticmethod
-    def _clear_job_transient_fields(job: SqlJob) -> None:
-        # TODO: Move job lifecycle transition policy out of the store once the
-        # framework owns a shared state-machine/transition layer. The store
-        # should still apply the resulting field updates atomically.
-        job.lease_expires_at = None
-        job.status_message = None
-        job.progress = None
-        job.progress_updated_at = None
-        job.token_hash = None
-        job.scoped_permissions = None
+    def _lease_expiration_time(lease_duration: float | None) -> int | None:
+        if lease_duration is None:
+            return None
+        if not math.isfinite(lease_duration) or lease_duration <= 0:
+            raise MlflowException.invalid_parameter_value(
+                "`lease_duration` must be a finite positive number."
+            )
+        return get_current_time_millis() + int(lease_duration * 1000)
+
+    @staticmethod
+    def _transient_field_update_values() -> dict[Any, Any]:
+        # Runtime-only fields (lease, progress, auth tokens) cleared when a job
+        # reaches a terminal or re-queued state to avoid retaining stale
+        # metadata and reduce stored row size.
+        return {
+            SqlJob.lease_expires_at: None,
+            SqlJob.status_message: None,
+            SqlJob.progress: None,
+            SqlJob.progress_updated_at: None,
+            SqlJob.token_hash: None,
+            SqlJob.scoped_permissions: None,
+        }
 
     @classmethod
-    def _reset_job_for_pending(cls, job: SqlJob) -> None:
-        job.result = None
-        cls._clear_job_transient_fields(job)
+    def _terminal_update_values(
+        cls, status: JobStatus, payload: str | None, update_time: int
+    ) -> dict[Any, Any]:
+        return {
+            SqlJob.status: status.to_int(),
+            SqlJob.result: payload,
+            SqlJob.last_update_time: update_time,
+            **cls._transient_field_update_values(),
+        }
+
+    @classmethod
+    def _pending_update_values(
+        cls, update_time: int, *, increment_retry: bool = False
+    ) -> dict[Any, Any]:
+        values: dict[Any, Any] = {
+            SqlJob.status: JobStatus.PENDING.to_int(),
+            SqlJob.result: None,
+            SqlJob.last_update_time: update_time,
+            **cls._transient_field_update_values(),
+        }
+        if increment_retry:
+            values[SqlJob.retry_count] = SqlJob.retry_count + 1
+        return values
+
+    def _conditional_status_update(
+        self,
+        session,
+        job_id: str,
+        current_statuses: tuple[JobStatus, ...],
+        values: dict[Any, Any],
+        additional_filters: tuple[Any, ...] = (),
+    ) -> JobUpdateStatus:
+        rows_updated = (
+            self
+            ._get_query(session, SqlJob)
+            .filter(
+                SqlJob.id == job_id,
+                SqlJob.status.in_([status.to_int() for status in current_statuses]),
+                *additional_filters,
+            )
+            .update(values, synchronize_session=False)
+        )
+        if rows_updated > 0:
+            return JobUpdateStatus.APPLIED
+
+        # Distinguish "job not found" from "job exists but not in the
+        # required status". Raises MlflowException if the job does not exist.
+        exists = (
+            self
+            ._get_query(session, SqlJob)
+            .filter(SqlJob.id == job_id)
+            .with_entities(SqlJob.id)
+            .first()
+        )
+        if exists is None:
+            raise MlflowException(
+                f"Job with ID {job_id} not found", error_code=RESOURCE_DOES_NOT_EXIST
+            )
+        return JobUpdateStatus.WRONG_STATE
+
+    def _raise_invalid_transition(
+        self,
+        session,
+        job_id: str,
+        action: str,
+        current_statuses: tuple[JobStatus, ...],
+    ) -> NoReturn:
+        job = self._get_sql_job(session, job_id, populate_existing=True)
+        current_status = JobStatus.from_int(job.status)
+        if JobStatus.is_finalized(current_status):
+            raise MlflowException.invalid_parameter_value(
+                "The Job "
+                f"{job_id} is already finalized with status: {current_status}, "
+                "it can't be updated."
+            )
+        expected_statuses = ", ".join(status.name for status in current_statuses)
+        raise MlflowException.invalid_parameter_value(
+            f"Job {job_id} is in {current_status} state, cannot {action} "
+            f"(must be {expected_statuses})"
+        )
 
     def create_job(self, job_name: str, params: str, timeout: float | None = None) -> Job:
         """
@@ -136,32 +232,172 @@ class SqlAlchemyJobStore(AbstractJobStore):
             session.flush()
             return job.to_mlflow_entity()
 
-    def _update_job(
+    def _try_claim_job(
+        self, session, job_id: str, lease_duration: float | None = None
+    ) -> JobUpdateStatus:
+        update_time = get_current_time_millis()
+        return self._conditional_status_update(
+            session,
+            job_id,
+            (JobStatus.PENDING,),
+            {
+                SqlJob.status: JobStatus.RUNNING.to_int(),
+                SqlJob.lease_expires_at: self._lease_expiration_time(lease_duration),
+                SqlJob.last_update_time: update_time,
+            },
+        )
+
+    def claim_job(self, job_id: str, lease_duration: float | None = None) -> JobUpdateStatus:
+        with self.ManagedSessionMaker(read_only=False) as session:
+            return self._try_claim_job(session, job_id, lease_duration)
+
+    def renew_job_lease(self, job_id: str, lease_duration: float) -> JobUpdateStatus:
+        if lease_duration is None:
+            raise MlflowException.invalid_parameter_value(
+                "`lease_duration` must be provided when renewing a job lease."
+            )
+        with self.ManagedSessionMaker(read_only=False) as session:
+            update_time = get_current_time_millis()
+            return self._conditional_status_update(
+                session,
+                job_id,
+                (JobStatus.RUNNING,),
+                {
+                    SqlJob.lease_expires_at: self._lease_expiration_time(lease_duration),
+                    SqlJob.last_update_time: update_time,
+                },
+            )
+
+    def retry_job(self, job_id: str) -> int:
+        with self.ManagedSessionMaker(read_only=False) as session:
+            update_time = get_current_time_millis()
+            if (
+                self._conditional_status_update(
+                    session,
+                    job_id,
+                    (JobStatus.RUNNING,),
+                    self._pending_update_values(update_time, increment_retry=True),
+                )
+                != JobUpdateStatus.APPLIED
+            ):
+                self._raise_invalid_transition(session, job_id, "retry", (JobStatus.RUNNING,))
+
+            updated_job = self._get_sql_job(session, job_id, populate_existing=True)
+            return updated_job.retry_count
+
+    def mark_job_needs_recovery(self, job_id: str) -> JobUpdateStatus:
+        with self.ManagedSessionMaker(read_only=False) as session:
+            update_time = get_current_time_millis()
+            return self._conditional_status_update(
+                session,
+                job_id,
+                (JobStatus.RUNNING,),
+                {
+                    SqlJob.status: JobStatus.NEEDS_RECOVERY.to_int(),
+                    SqlJob.lease_expires_at: None,
+                    SqlJob.last_update_time: update_time,
+                },
+            )
+
+    def reattach_job(self, job_id: str, lease_duration: float | None = None) -> JobUpdateStatus:
+        with self.ManagedSessionMaker(read_only=False) as session:
+            update_time = get_current_time_millis()
+            return self._conditional_status_update(
+                session,
+                job_id,
+                (JobStatus.NEEDS_RECOVERY,),
+                {
+                    SqlJob.status: JobStatus.RUNNING.to_int(),
+                    SqlJob.lease_expires_at: self._lease_expiration_time(lease_duration),
+                    SqlJob.last_update_time: update_time,
+                },
+            )
+
+    def requeue_job(self, job_id: str) -> JobUpdateStatus:
+        with self.ManagedSessionMaker(read_only=False) as session:
+            update_time = get_current_time_millis()
+            return self._conditional_status_update(
+                session,
+                job_id,
+                (JobStatus.NEEDS_RECOVERY,),
+                self._pending_update_values(update_time),
+            )
+
+    def _try_report_job_result(
+        self,
+        session,
+        job_id: str,
+        status: JobStatus,
+        payload: str | None,
+    ) -> JobUpdateStatus:
+        update_time = get_current_time_millis()
+        return self._conditional_status_update(
+            session,
+            job_id,
+            (JobStatus.RUNNING, JobStatus.NEEDS_RECOVERY),
+            self._terminal_update_values(status, payload, update_time),
+        )
+
+    def report_job_result(
         self,
         job_id: str,
-        new_status: JobStatus,
+        status: JobStatus,
         result: str | None = None,
-    ) -> Job:
-        with self.ManagedSessionMaker(read_only=False) as session:
-            job = self._get_sql_job(session, job_id)
+        error_message: str | None = None,
+        is_transient_error: bool = False,
+    ) -> None:
+        # Keep this parameter to match the job-result/API contract. Remote
+        # executors send transient-error classification through the API layer,
+        # but the SQL store does not persist it; higher layers use it to decide
+        # whether the job should be retried.
+        del is_transient_error
 
-            if JobStatus.is_finalized(JobStatus.from_int(job.status)):
+        if not JobStatus.is_finalized(status):
+            raise MlflowException.invalid_parameter_value(
+                "`report_job_result()` requires a terminal JobStatus."
+            )
+
+        if status == JobStatus.SUCCEEDED:
+            if error_message is not None:
                 raise MlflowException.invalid_parameter_value(
-                    "The Job "
-                    f"{job_id} is already finalized with status: {JobStatus.from_int(job.status)}, "
-                    "it can't be updated."
+                    "Succeeded job results must leave `error_message` unset."
                 )
+            payload = result
+        elif status == JobStatus.FAILED:
+            if error_message is None or result is not None:
+                raise MlflowException.invalid_parameter_value(
+                    "Failed job results must set `error_message` and leave `result` unset."
+                )
+            payload = error_message
+        elif status == JobStatus.TIMEOUT:
+            if result is not None:
+                raise MlflowException.invalid_parameter_value(
+                    "Timed-out job results must leave `result` unset; `error_message` is optional."
+                )
+            payload = error_message
+        elif status == JobStatus.CANCELED:
+            if result is not None or error_message is not None:
+                _logger.warning(
+                    "Ignoring payload for canceled job result update for job_id=%s.",
+                    job_id,
+                )
+            payload = None
+        else:
+            raise MlflowException.invalid_parameter_value(
+                f"Unsupported terminal JobStatus for result reporting: {status}"
+            )
 
-            job.status = new_status.to_int()
-            if new_status == JobStatus.PENDING:
-                self._reset_job_for_pending(job)
-            else:
-                if result is not None:
-                    job.result = result
-                if JobStatus.is_finalized(new_status):
-                    self._clear_job_transient_fields(job)
-            job.last_update_time = get_current_time_millis()
-            return job.to_mlflow_entity()
+        with self.ManagedSessionMaker(read_only=False) as session:
+            if (
+                self._try_report_job_result(session, job_id, status, payload)
+                != JobUpdateStatus.APPLIED
+            ):
+                self._raise_invalid_transition(
+                    session,
+                    job_id,
+                    "report result",
+                    (JobStatus.RUNNING, JobStatus.NEEDS_RECOVERY),
+                )
 
     def start_job(self, job_id: str) -> None:
         """
@@ -175,27 +411,9 @@ class SqlAlchemyJobStore(AbstractJobStore):
             MlflowException: If job is not in PENDING state or doesn't exist
         """
         with self.ManagedSessionMaker(read_only=False) as session:
-            # Atomic update: only transition from PENDING to RUNNING
-            rows_updated = (
-                self
-                ._get_query(session, SqlJob)
-                .filter(SqlJob.id == job_id, SqlJob.status == JobStatus.PENDING.to_int())
-                .update({
-                    SqlJob.status: JobStatus.RUNNING.to_int(),
-                    SqlJob.last_update_time: get_current_time_millis(),
-                })
-            )
-
-            if rows_updated == 0:
-                job = self._get_query(session, SqlJob).filter(SqlJob.id == job_id).one_or_none()
-                if job is None:
-                    raise MlflowException(
-                        f"Job with ID {job_id} not found", error_code=RESOURCE_DOES_NOT_EXIST
-                    )
-                raise MlflowException(
-                    f"Job {job_id} is in {JobStatus.from_int(job.status)} state, "
-                    "cannot start (must be PENDING)"
-                )
+            if self._try_claim_job(session, job_id) == JobUpdateStatus.APPLIED:
+                return
+            self._raise_invalid_transition(session, job_id, "start", (JobStatus.PENDING,))
 
     def reset_job(self, job_id: str) -> None:
         """
@@ -204,7 +422,23 @@ class SqlAlchemyJobStore(AbstractJobStore):
         Args:
             job_id: The ID of the job to re-enqueue.
         """
-        self._update_job(job_id, JobStatus.PENDING)
+        with self.ManagedSessionMaker(read_only=False) as session:
+            update_time = get_current_time_millis()
+            if (
+                self._conditional_status_update(
+                    session,
+                    job_id,
+                    (JobStatus.PENDING, JobStatus.RUNNING, JobStatus.NEEDS_RECOVERY),
+                    self._pending_update_values(update_time),
+                )
+                != JobUpdateStatus.APPLIED
+            ):
+                self._raise_invalid_transition(
+                    session,
+                    job_id,
+                    "reset",
+                    (JobStatus.PENDING, JobStatus.RUNNING, JobStatus.NEEDS_RECOVERY),
+                )
 
     def finish_job(self, job_id: str, result: str) -> None:
         """
@@ -214,7 +448,23 @@ class SqlAlchemyJobStore(AbstractJobStore):
             job_id: The ID of the job to finish
             result: The job result as a string
         """
-        self._update_job(job_id, JobStatus.SUCCEEDED, result)
+        with self.ManagedSessionMaker(read_only=False) as session:
+            update_time = get_current_time_millis()
+            if (
+                self._conditional_status_update(
+                    session,
+                    job_id,
+                    (JobStatus.PENDING, JobStatus.RUNNING, JobStatus.NEEDS_RECOVERY),
+                    self._terminal_update_values(JobStatus.SUCCEEDED, result, update_time),
+                )
+                != JobUpdateStatus.APPLIED
+            ):
+                self._raise_invalid_transition(
+                    session,
+                    job_id,
+                    "finish",
+                    (JobStatus.PENDING, JobStatus.RUNNING, JobStatus.NEEDS_RECOVERY),
+                )
 
     def fail_job(self, job_id: str, error: str) -> None:
         """
@@ -224,7 +474,23 @@ class SqlAlchemyJobStore(AbstractJobStore):
             job_id: The ID of the job to fail
             error: The error message as a string
         """
-        self._update_job(job_id, JobStatus.FAILED, error)
+        with self.ManagedSessionMaker(read_only=False) as session:
+            update_time = get_current_time_millis()
+            if (
+                self._conditional_status_update(
+                    session,
+                    job_id,
+                    (JobStatus.PENDING, JobStatus.RUNNING, JobStatus.NEEDS_RECOVERY),
+                    self._terminal_update_values(JobStatus.FAILED, error, update_time),
+                )
+                != JobUpdateStatus.APPLIED
+            ):
+                self._raise_invalid_transition(
+                    session,
+                    job_id,
+                    "fail",
+                    (JobStatus.PENDING, JobStatus.RUNNING, JobStatus.NEEDS_RECOVERY),
+                )
 
     def mark_job_timed_out(self, job_id: str) -> None:
         """
@@ -233,13 +499,32 @@ class SqlAlchemyJobStore(AbstractJobStore):
         Args:
             job_id: The ID of the job
         """
-        self._update_job(job_id, JobStatus.TIMEOUT)
+        with self.ManagedSessionMaker(read_only=False) as session:
+            update_time = get_current_time_millis()
+            if (
+                self._conditional_status_update(
+                    session,
+                    job_id,
+                    (JobStatus.PENDING, JobStatus.RUNNING, JobStatus.NEEDS_RECOVERY),
+                    self._terminal_update_values(JobStatus.TIMEOUT, None, update_time),
+                )
+                != JobUpdateStatus.APPLIED
+            ):
+                self._raise_invalid_transition(
+                    session,
+                    job_id,
+                    "time out",
+                    (JobStatus.PENDING, JobStatus.RUNNING, JobStatus.NEEDS_RECOVERY),
+                )
 
     def retry_or_fail_job(self, job_id: str, error: str) -> int | None:
         """
-        If the job retry_count is less than maximum allowed retry count,
-        increment the retry_count and reset the job to PENDING status,
-        otherwise set the job to FAILED status and fill the job's error field.
+        Retry or fail a running job based on the configured retry budget.
+
+        If the running job retry_count is less than the maximum allowed retry
+        count, increment the retry_count and reset the job to PENDING status.
+        Otherwise set the running job to FAILED status and fill the job's error
+        field.
 
         Args:
             job_id: The ID of the job to fail
@@ -248,32 +533,44 @@ class SqlAlchemyJobStore(AbstractJobStore):
         Returns:
             If the job is allowed to retry, returns the retry count,
             otherwise returns None.
+
+        Raises:
+            MlflowException: If the job is not in RUNNING state, is already
+                finalized, or does not exist.
         """
         from mlflow.environment_variables import MLFLOW_SERVER_JOB_TRANSIENT_ERROR_MAX_RETRIES
 
         max_retries = MLFLOW_SERVER_JOB_TRANSIENT_ERROR_MAX_RETRIES.get()
 
         with self.ManagedSessionMaker(read_only=False) as session:
-            job = self._get_sql_job(session, job_id)
-
-            if JobStatus.is_finalized(JobStatus.from_int(job.status)):
-                raise MlflowException.invalid_parameter_value(
-                    "The Job "
-                    f"{job_id} is already finalized with status: {JobStatus.from_int(job.status)}, "
-                    "it can't be updated."
+            update_time = get_current_time_millis()
+            if (
+                self._conditional_status_update(
+                    session,
+                    job_id,
+                    (JobStatus.RUNNING,),
+                    self._pending_update_values(update_time, increment_retry=True),
+                    additional_filters=(SqlJob.retry_count < max_retries,),
                 )
+                == JobUpdateStatus.APPLIED
+            ):
+                updated_job = self._get_sql_job(session, job_id, populate_existing=True)
+                return updated_job.retry_count
 
-            if job.retry_count >= max_retries:
-                job.status = JobStatus.FAILED.to_int()
-                job.result = error
-                self._clear_job_transient_fields(job)
-                job.last_update_time = get_current_time_millis()
+            update_time = get_current_time_millis()
+            if (
+                self._conditional_status_update(
+                    session,
+                    job_id,
+                    (JobStatus.RUNNING,),
+                    self._terminal_update_values(JobStatus.FAILED, error, update_time),
+                    additional_filters=(SqlJob.retry_count >= max_retries,),
+                )
+                == JobUpdateStatus.APPLIED
+            ):
                 return None
-            job.retry_count += 1
-            job.status = JobStatus.PENDING.to_int()
-            self._reset_job_for_pending(job)
-            job.last_update_time = get_current_time_millis()
-            return job.retry_count
+
+            self._raise_invalid_transition(session, job_id, "fail", (JobStatus.RUNNING,))
 
     def list_jobs(
         self,
@@ -311,7 +608,7 @@ class SqlAlchemyJobStore(AbstractJobStore):
             return True
 
         while True:
-            with self.ManagedSessionMaker(read_only=False) as session:
+            with self.ManagedSessionMaker() as session:
                 # Select all columns needed for Job entity
                 query = self._get_query(session, SqlJob)
 
@@ -359,8 +656,11 @@ class SqlAlchemyJobStore(AbstractJobStore):
                 # Move to next page
                 offset += _LIST_JOB_PAGE_SIZE
 
-    def _get_sql_job(self, session, job_id) -> SqlJob:
-        job = self._get_query(session, SqlJob).filter(SqlJob.id == job_id).one_or_none()
+    def _get_sql_job(self, session, job_id, *, populate_existing: bool = False) -> SqlJob:
+        query = self._get_query(session, SqlJob).filter(SqlJob.id == job_id)
+        if populate_existing:
+            query = query.populate_existing()
+        job = query.one_or_none()
         if job is None:
             raise MlflowException(
                 f"Job with ID {job_id} not found", error_code=RESOURCE_DOES_NOT_EXIST
@@ -380,7 +680,7 @@ class SqlAlchemyJobStore(AbstractJobStore):
         Raises:
             MlflowException: If job with the given ID is not found
         """
-        with self.ManagedSessionMaker(read_only=False) as session:
+        with self.ManagedSessionMaker() as session:
             job = self._get_sql_job(session, job_id)
             return job.to_mlflow_entity()
 
@@ -448,7 +748,24 @@ class SqlAlchemyJobStore(AbstractJobStore):
         Raises:
             MlflowException: If job with the given ID is not found
         """
-        return self._update_job(job_id, JobStatus.CANCELED)
+        with self.ManagedSessionMaker(read_only=False) as session:
+            update_time = get_current_time_millis()
+            if (
+                self._conditional_status_update(
+                    session,
+                    job_id,
+                    (JobStatus.PENDING, JobStatus.RUNNING, JobStatus.NEEDS_RECOVERY),
+                    self._terminal_update_values(JobStatus.CANCELED, None, update_time),
+                )
+                != JobUpdateStatus.APPLIED
+            ):
+                self._raise_invalid_transition(
+                    session,
+                    job_id,
+                    "cancel",
+                    (JobStatus.PENDING, JobStatus.RUNNING, JobStatus.NEEDS_RECOVERY),
+                )
+            return self._get_sql_job(session, job_id).to_mlflow_entity()
 
     def update_status_details(self, job_id: str, status_details: dict[str, Any]) -> None:
         """
@@ -492,7 +809,7 @@ class SqlAlchemyJobStore(AbstractJobStore):
         if message is None and progress is None:
             return
 
-        with self.ManagedSessionMaker() as session:
+        with self.ManagedSessionMaker(read_only=False) as session:
             job = self._get_sql_job(session, job_id)
 
             if JobStatus.is_finalized(JobStatus.from_int(job.status)):

--- a/tests/server/jobs/test_jobs.py
+++ b/tests/server/jobs/test_jobs.py
@@ -32,7 +32,7 @@ from mlflow.server.jobs.utils import (
     _enqueue_unfinished_jobs,
     _exec_job,
 )
-from mlflow.store.jobs.abstract_store import JobTerminalStateUpdateException
+from mlflow.store.jobs.abstract_store import JobTerminalStateUpdateException, JobUpdateStatus
 from mlflow.store.jobs.sqlalchemy_store import SqlAlchemyJobStore
 from mlflow.store.jobs.sqlalchemy_workspace_store import WorkspaceAwareSqlAlchemyJobStore
 from mlflow.store.tracking.dbmodels.models import SqlJob, SqlJobLock
@@ -436,6 +436,267 @@ def test_retry_or_fail_job_clears_transient_fields_on_exhaustion(monkeypatch, tm
         assert sql_job.lease_expires_at is None
         assert sql_job.token_hash is None
         assert sql_job.scoped_permissions is None
+
+
+def test_retry_or_fail_job_rejects_needs_recovery_jobs(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("MLFLOW_SERVER_JOB_TRANSIENT_ERROR_MAX_RETRIES", "0")
+    backend_store_uri = f"sqlite:///{tmp_path / 'test.db'}"
+    store = SqlAlchemyJobStore(backend_store_uri)
+
+    job = store.create_job("test_job", "{}")
+    store.claim_job(job.job_id, lease_duration=30.0)
+    assert store.reattach_job(job.job_id, lease_duration=30.0) == JobUpdateStatus.WRONG_STATE
+    assert store.requeue_job(job.job_id) == JobUpdateStatus.WRONG_STATE
+    assert store.mark_job_needs_recovery(job.job_id) == JobUpdateStatus.APPLIED
+
+    with pytest.raises(MlflowException, match="cannot fail \\(must be RUNNING\\)"):
+        store.retry_or_fail_job(job.job_id, "retry exhausted")
+
+
+def test_retry_or_fail_job_rejects_pending_jobs(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("MLFLOW_SERVER_JOB_TRANSIENT_ERROR_MAX_RETRIES", "0")
+    backend_store_uri = f"sqlite:///{tmp_path / 'test.db'}"
+    store = SqlAlchemyJobStore(backend_store_uri)
+
+    job = store.create_job("test_job", "{}")
+
+    with pytest.raises(MlflowException, match="cannot fail \\(must be RUNNING\\)"):
+        store.retry_or_fail_job(job.job_id, "retry exhausted")
+
+
+def test_retry_or_fail_job_returns_incremented_retry_count(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("MLFLOW_SERVER_JOB_TRANSIENT_ERROR_MAX_RETRIES", "2")
+    backend_store_uri = f"sqlite:///{tmp_path / 'test.db'}"
+    store = SqlAlchemyJobStore(backend_store_uri)
+
+    job = store.create_job("test_job", "{}")
+    store.claim_job(job.job_id, lease_duration=30.0)
+
+    retry_count = store.retry_or_fail_job(job.job_id, "retry me")
+
+    assert retry_count == 1
+    assert store.get_job(job.job_id).retry_count == 1
+
+
+def test_claim_job_and_renew_lease(tmp_path: Path):
+    backend_store_uri = f"sqlite:///{tmp_path / 'test.db'}"
+    store = SqlAlchemyJobStore(backend_store_uri)
+
+    job = store.create_job("test_job", "{}")
+
+    with pytest.raises(MlflowException, match="must be provided when renewing a job lease"):
+        store.renew_job_lease(job.job_id, None)
+
+    assert store.renew_job_lease(job.job_id, 30.0) == JobUpdateStatus.WRONG_STATE
+    assert store.claim_job(job.job_id, lease_duration=5.0) == JobUpdateStatus.APPLIED
+    assert store.claim_job(job.job_id, lease_duration=5.0) == JobUpdateStatus.WRONG_STATE
+
+    claimed_job = store.get_job(job.job_id)
+    assert claimed_job.status == JobStatus.RUNNING
+    assert claimed_job.lease_expires_at is not None
+    assert claimed_job.lease_expires_at > int(time.time() * 1000)
+
+    first_lease_expiration = claimed_job.lease_expires_at
+    assert store.renew_job_lease(job.job_id, 30.0) == JobUpdateStatus.APPLIED
+
+    renewed_job = store.get_job(job.job_id)
+    assert renewed_job.lease_expires_at is not None
+    assert renewed_job.lease_expires_at > first_lease_expiration
+
+
+def test_claim_job_respects_workspace_isolation(tmp_path: Path, workspaces_enabled):
+    backend_store_uri = f"sqlite:///{tmp_path / 'test.db'}"
+    store_cls = WorkspaceAwareSqlAlchemyJobStore if workspaces_enabled else SqlAlchemyJobStore
+    store = store_cls(backend_store_uri)
+
+    if workspaces_enabled:
+        with WorkspaceContext("workspace-b"):
+            job = store.create_job("test_job", "{}")
+
+        with pytest.raises(MlflowException, match=f"Job with ID {job.job_id} not found"):
+            store.claim_job(job.job_id, lease_duration=5.0)
+
+        with WorkspaceContext("workspace-b"):
+            assert store.claim_job(job.job_id, lease_duration=5.0) == JobUpdateStatus.APPLIED
+    else:
+        job = store.create_job("test_job", "{}")
+        assert store.claim_job(job.job_id, lease_duration=5.0) == JobUpdateStatus.APPLIED
+
+
+def test_claim_job_is_atomic(tmp_path: Path, workspaces_enabled):
+    backend_store_uri = f"sqlite:///{tmp_path / 'test.db'}"
+    store_cls = WorkspaceAwareSqlAlchemyJobStore if workspaces_enabled else SqlAlchemyJobStore
+    store = store_cls(backend_store_uri)
+
+    job = store.create_job("test.function", '{"param": "value"}')
+    assert job.status == JobStatus.PENDING
+
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=5, thread_name_prefix="test-concurrent-claims"
+    ) as executor:
+        futures = [executor.submit(store.claim_job, job.job_id, 5.0) for _ in range(5)]
+        results = [f.result() for f in concurrent.futures.as_completed(futures)]
+
+    assert results.count(JobUpdateStatus.APPLIED) == 1
+    assert results.count(JobUpdateStatus.WRONG_STATE) == 4
+    assert store.get_job(job.job_id).status == JobStatus.RUNNING
+
+
+def test_lifecycle_transitions_raise_for_missing_job(tmp_path: Path):
+    backend_store_uri = f"sqlite:///{tmp_path / 'test.db'}"
+    store = SqlAlchemyJobStore(backend_store_uri)
+    missing_job_id = "missing-job-id"
+
+    with pytest.raises(MlflowException, match=f"Job with ID {missing_job_id} not found"):
+        store.claim_job(missing_job_id, lease_duration=5.0)
+
+    with pytest.raises(MlflowException, match=f"Job with ID {missing_job_id} not found"):
+        store.renew_job_lease(missing_job_id, 5.0)
+
+    with pytest.raises(MlflowException, match=f"Job with ID {missing_job_id} not found"):
+        store.mark_job_needs_recovery(missing_job_id)
+
+    with pytest.raises(MlflowException, match=f"Job with ID {missing_job_id} not found"):
+        store.reattach_job(missing_job_id, lease_duration=5.0)
+
+    with pytest.raises(MlflowException, match=f"Job with ID {missing_job_id} not found"):
+        store.requeue_job(missing_job_id)
+
+
+def test_retry_job_clears_transient_fields(tmp_path: Path):
+    backend_store_uri = f"sqlite:///{tmp_path / 'test.db'}"
+    store = SqlAlchemyJobStore(backend_store_uri)
+
+    job = store.create_job("test_job", "{}")
+    store.claim_job(job.job_id, lease_duration=30.0)
+
+    with store.ManagedSessionMaker() as session:
+        session.query(SqlJob).filter(SqlJob.id == job.job_id).update({
+            SqlJob.status_message: "running",
+            SqlJob.progress: {"completed": 1, "total": 2},
+            SqlJob.progress_updated_at: int(time.time() * 1000),
+            SqlJob.token_hash: "abc123",
+            SqlJob.scoped_permissions: [
+                {
+                    "resource_type": "experiment",
+                    "resource_identifier": "1",
+                    "workspace": None,
+                    "permission": "EDIT",
+                }
+            ],
+        })
+
+    retry_count = store.retry_job(job.job_id)
+    assert retry_count == 1
+
+    updated_job = store.get_job(job.job_id)
+    assert updated_job.status == JobStatus.PENDING
+    assert updated_job.retry_count == 1
+    assert updated_job.result is None
+    assert updated_job.status_message is None
+    assert updated_job.progress is None
+    assert updated_job.progress_updated_at is None
+    assert updated_job.token_hash is None
+    assert updated_job.scoped_permissions is None
+    assert updated_job.lease_expires_at is None
+
+
+def test_report_job_result_clears_transient_fields(tmp_path: Path):
+    backend_store_uri = f"sqlite:///{tmp_path / 'test.db'}"
+    store = SqlAlchemyJobStore(backend_store_uri)
+
+    job = store.create_job("test_job", "{}")
+    store.claim_job(job.job_id, lease_duration=30.0)
+
+    with store.ManagedSessionMaker() as session:
+        session.query(SqlJob).filter(SqlJob.id == job.job_id).update({
+            SqlJob.status_message: "running",
+            SqlJob.progress: {"completed": 1, "total": 2},
+            SqlJob.progress_updated_at: int(time.time() * 1000),
+            SqlJob.token_hash: "abc123",
+            SqlJob.scoped_permissions: [
+                {
+                    "resource_type": "experiment",
+                    "resource_identifier": "1",
+                    "workspace": None,
+                    "permission": "EDIT",
+                }
+            ],
+        })
+
+    assert store.report_job_result(job.job_id, JobStatus.SUCCEEDED, result='{"ok": true}') is None
+
+    with pytest.raises(MlflowException, match="already finalized"):
+        store.report_job_result(job.job_id, JobStatus.SUCCEEDED, result='{"ok": true}')
+
+    updated_job = store.get_job(job.job_id)
+    assert updated_job.status == JobStatus.SUCCEEDED
+    assert updated_job.parsed_result == {"ok": True}
+    assert updated_job.status_message is None
+    assert updated_job.progress is None
+    assert updated_job.progress_updated_at is None
+    assert updated_job.token_hash is None
+    assert updated_job.scoped_permissions is None
+    assert updated_job.lease_expires_at is None
+
+
+def test_recovery_transitions_preserve_and_clear_expected_fields(tmp_path: Path):
+    backend_store_uri = f"sqlite:///{tmp_path / 'test.db'}"
+    store = SqlAlchemyJobStore(backend_store_uri)
+
+    job = store.create_job("test_job", "{}")
+    store.claim_job(job.job_id, lease_duration=30.0)
+
+    with store.ManagedSessionMaker() as session:
+        session.query(SqlJob).filter(SqlJob.id == job.job_id).update({
+            SqlJob.status_message: "running",
+            SqlJob.progress: {"phase": "scoring", "completed": 1, "total": 2, "unit": "trace"},
+            SqlJob.progress_updated_at: int(time.time() * 1000),
+            SqlJob.token_hash: "abc123",
+            SqlJob.scoped_permissions: [
+                {
+                    "resource_type": "experiment",
+                    "resource_identifier": "1",
+                    "workspace": None,
+                    "permission": "EDIT",
+                }
+            ],
+        })
+
+    assert store.mark_job_needs_recovery(job.job_id) == JobUpdateStatus.APPLIED
+
+    recovery_job = store.get_job(job.job_id)
+    assert recovery_job.status == JobStatus.NEEDS_RECOVERY
+    assert recovery_job.lease_expires_at is None
+    assert recovery_job.status_message == "running"
+    assert recovery_job.progress == JobProgress(phase="scoring", completed=1, total=2, unit="trace")
+    assert recovery_job.token_hash == "abc123"
+    assert recovery_job.scoped_permissions == [
+        JobScopedPermission(
+            resource_type="experiment",
+            resource_identifier="1",
+            workspace=None,
+            permission="EDIT",
+        )
+    ]
+
+    assert store.reattach_job(job.job_id, lease_duration=30.0) == JobUpdateStatus.APPLIED
+    running_job = store.get_job(job.job_id)
+    assert running_job.status == JobStatus.RUNNING
+    assert running_job.lease_expires_at is not None
+
+    assert store.mark_job_needs_recovery(job.job_id) == JobUpdateStatus.APPLIED
+    assert store.requeue_job(job.job_id) == JobUpdateStatus.APPLIED
+
+    pending_job = store.get_job(job.job_id)
+    assert pending_job.status == JobStatus.PENDING
+    assert pending_job.result is None
+    assert pending_job.status_message is None
+    assert pending_job.progress is None
+    assert pending_job.progress_updated_at is None
+    assert pending_job.token_hash is None
+    assert pending_job.scoped_permissions is None
+    assert pending_job.lease_expires_at is None
 
 
 def test_job_progress_hydrates_to_dataclass(tmp_path: Path):

--- a/tests/server/jobs/test_jobs.py
+++ b/tests/server/jobs/test_jobs.py
@@ -403,7 +403,7 @@ def test_retry_or_fail_job_clears_transient_fields_on_exhaustion(monkeypatch, tm
     job = store.create_job("test_job", "{}")
     store.start_job(job.job_id)
 
-    with store.ManagedSessionMaker() as session:
+    with store.ManagedSessionMaker(read_only=False) as session:
         session.query(SqlJob).filter(SqlJob.id == job.job_id).update({
             SqlJob.lease_expires_at: int(time.time() * 1000),
             SqlJob.status_message: "running",
@@ -570,7 +570,7 @@ def test_retry_job_clears_transient_fields(tmp_path: Path):
     job = store.create_job("test_job", "{}")
     store.claim_job(job.job_id, lease_duration=30.0)
 
-    with store.ManagedSessionMaker() as session:
+    with store.ManagedSessionMaker(read_only=False) as session:
         session.query(SqlJob).filter(SqlJob.id == job.job_id).update({
             SqlJob.status_message: "running",
             SqlJob.progress: {"completed": 1, "total": 2},
@@ -608,7 +608,7 @@ def test_report_job_result_clears_transient_fields(tmp_path: Path):
     job = store.create_job("test_job", "{}")
     store.claim_job(job.job_id, lease_duration=30.0)
 
-    with store.ManagedSessionMaker() as session:
+    with store.ManagedSessionMaker(read_only=False) as session:
         session.query(SqlJob).filter(SqlJob.id == job.job_id).update({
             SqlJob.status_message: "running",
             SqlJob.progress: {"completed": 1, "total": 2},
@@ -647,7 +647,7 @@ def test_recovery_transitions_preserve_and_clear_expected_fields(tmp_path: Path)
     job = store.create_job("test_job", "{}")
     store.claim_job(job.job_id, lease_duration=30.0)
 
-    with store.ManagedSessionMaker() as session:
+    with store.ManagedSessionMaker(read_only=False) as session:
         session.query(SqlJob).filter(SqlJob.id == job.job_id).update({
             SqlJob.status_message: "running",
             SqlJob.progress: {"phase": "scoring", "completed": 1, "total": 2, "unit": "trace"},
@@ -704,7 +704,7 @@ def test_job_progress_hydrates_to_dataclass(tmp_path: Path):
     store = SqlAlchemyJobStore(backend_store_uri)
 
     job = store.create_job("test_job", "{}")
-    with store.ManagedSessionMaker() as session:
+    with store.ManagedSessionMaker(read_only=False) as session:
         session.query(SqlJob).filter(SqlJob.id == job.job_id).update({
             SqlJob.progress: {
                 "phase": "scoring",
@@ -783,7 +783,7 @@ def test_job_scoped_permissions_payload_hydrates_to_dataclass(tmp_path: Path):
     store = SqlAlchemyJobStore(backend_store_uri)
 
     job = store.create_job("test_job", "{}")
-    with store.ManagedSessionMaker() as session:
+    with store.ManagedSessionMaker(read_only=False) as session:
         session.query(SqlJob).filter(SqlJob.id == job.job_id).update({
             SqlJob.scoped_permissions: [
                 {
@@ -823,7 +823,7 @@ def test_job_scoped_permissions_payload_defaults_permission_to_read(tmp_path: Pa
     store = SqlAlchemyJobStore(backend_store_uri)
 
     job = store.create_job("test_job", "{}")
-    with store.ManagedSessionMaker() as session:
+    with store.ManagedSessionMaker(read_only=False) as session:
         session.query(SqlJob).filter(SqlJob.id == job.job_id).update({
             SqlJob.scoped_permissions: [
                 {
@@ -1214,7 +1214,7 @@ def test_delete_jobs_only_deletes_finalized(tmp_path: Path):
 
     needs_recovery_job = store.create_job("needs_recovery_job", "{}")
     store.start_job(needs_recovery_job.job_id)
-    with store.ManagedSessionMaker() as session:
+    with store.ManagedSessionMaker(read_only=False) as session:
         session.query(SqlJob).filter(SqlJob.id == needs_recovery_job.job_id).update({
             SqlJob.status: JobStatus.NEEDS_RECOVERY.to_int(),
             SqlJob.last_update_time: int(time.time() * 1000),
@@ -1650,7 +1650,7 @@ def test_delete_jobs_cascades_job_locks(tmp_path: Path):
     store.start_job(job.job_id)
     store.finish_job(job.job_id, "result")
 
-    with store.ManagedSessionMaker() as session:
+    with store.ManagedSessionMaker(read_only=False) as session:
         session.add(
             SqlJobLock(
                 lock_key="finished_job:1234",


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Relates to https://github.com/mlflow/rfcs/pull/2

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

This PR adds the job store lifecycle APIs and state transitions needed for the executor framework.

It adds `claim_job`, `renew_job_lease`, `retry_job`, `mark_job_needs_recovery`, `reattach_job`, `requeue_job`, `report_job_progress` and `report_job_result` in the abstract job store and SQLAlchemy job store. It also updates the existing store methods to preserve current behavior.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
