### PR TITLE
Profile CPU and memory during JS tests

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -85,6 +85,14 @@ jobs:
         run: |
           "$GITHUB_WORKSPACE/dev/profile.sh" \
             yarn test --silent $MATRIX_OPTION src/experiment-tracking/components
+      - name: Upload profile metrics
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: profile-metrics-${{ strategy.job-index }}
+          path: /tmp/profile-metrics.csv
+          retention-days: 3
+          if-no-files-found: ignore
       - name: Run build
         env:
           # Prevent warnings (emitted from react-pdf) from being treated as errors

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -82,16 +82,16 @@ jobs:
       - name: Run tests
         env:
           MATRIX_OPTION: ${{ matrix.option }}
+          JOB_INDEX: ${{ strategy.job-index }}
         run: |
-          SUFFIX="${MATRIX_OPTION#--}"
           yarn test --silent $MATRIX_OPTION src/experiment-tracking/components \
-            --json --outputFile=/tmp/jest-results-${SUFFIX}.json
+            --json --outputFile=/tmp/jest-results-${JOB_INDEX}.json
       - name: Upload Jest results
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: jest-results-${{ matrix.option }}
-          path: /tmp/jest-results-*.json
+          name: jest-results-${{ strategy.job-index }}
+          path: /tmp/jest-results-${{ strategy.job-index }}.json
           retention-days: 7
           if-no-files-found: ignore
       - name: Run build

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -83,7 +83,29 @@ jobs:
         env:
           MATRIX_OPTION: ${{ matrix.option }}
         run: |
-          yarn test --silent $MATRIX_OPTION src/experiment-tracking/components
+          SUFFIX="${MATRIX_OPTION#--}"
+          yarn test --silent $MATRIX_OPTION src/experiment-tracking/components \
+            --json --outputFile=jest-results-${SUFFIX}.json
+      - name: Filter Jest results
+        if: failure()
+        env:
+          MATRIX_OPTION: ${{ matrix.option }}
+        run: |
+          SUFFIX="${MATRIX_OPTION#--}"
+          if [ -f jest-results-${SUFFIX}.json ]; then
+            jq '[.testResults[] | .assertionResults[]
+                  | select(.status != "passed" or .duration > 1000)
+                  | {name: .fullName, status, duration, failureMessages}]' \
+              jest-results-${SUFFIX}.json > jest-failures-${SUFFIX}.json
+          fi
+      - name: Upload Jest results
+        if: failure()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: jest-failures-${{ matrix.option }}
+          path: mlflow/server/js/jest-failures-*.json
+          retention-days: 7
+          if-no-files-found: ignore
       - name: Run build
         env:
           # Prevent warnings (emitted from react-pdf) from being treated as errors

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -86,24 +86,12 @@ jobs:
           SUFFIX="${MATRIX_OPTION#--}"
           yarn test --silent $MATRIX_OPTION src/experiment-tracking/components \
             --json --outputFile=jest-results-${SUFFIX}.json
-      - name: Filter Jest results
-        if: failure()
-        env:
-          MATRIX_OPTION: ${{ matrix.option }}
-        run: |
-          SUFFIX="${MATRIX_OPTION#--}"
-          if [ -f jest-results-${SUFFIX}.json ]; then
-            jq '[.testResults[] | .assertionResults[]
-                  | select(.status != "passed" or .duration > 1000)
-                  | {name: .fullName, status, duration, failureMessages}]' \
-              jest-results-${SUFFIX}.json > jest-failures-${SUFFIX}.json
-          fi
       - name: Upload Jest results
         if: failure()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: jest-failures-${{ matrix.option }}
-          path: mlflow/server/js/jest-failures-*.json
+          name: jest-results-${{ matrix.option }}
+          path: mlflow/server/js/jest-results-*.json
           retention-days: 7
           if-no-files-found: ignore
       - name: Run build

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -79,11 +79,62 @@ jobs:
       - name: Run type-check
         run: |
           yarn type-check
+      - name: Start resource sampler
+        run: |
+          nohup bash -c '
+            PREV_TOTAL=0; PREV_IDLE=0
+            while true; do
+              read _ U N S I IO IRQ SI ST _ < /proc/stat
+              T=$((U+N+S+I+IO+IRQ+SI+ST))
+              if [ "$PREV_TOTAL" -ne 0 ]; then
+                DT=$((T-PREV_TOTAL))
+                DI=$(( (I+IO)-PREV_IDLE ))
+                CPU=$(( DT>0 ? 100*(DT-DI)/DT : 0 ))
+              else
+                CPU=0
+              fi
+              PREV_TOTAL=$T
+              PREV_IDLE=$((I+IO))
+              MEM=$(awk "/MemTotal/{t=\$2}/MemAvailable/{a=\$2}END{print int((t-a)/1024)}" /proc/meminfo)
+              printf "%s,%s,%s\n" "$(date +%s)" "$CPU" "$MEM"
+              sleep 2
+            done' > /tmp/metrics.csv 2>&1 &
+          echo $! > /tmp/sampler.pid
       - name: Run tests
         env:
           MATRIX_OPTION: ${{ matrix.option }}
         run: |
           yarn test --silent --verbose $MATRIX_OPTION src/experiment-tracking/components
+      - name: Stop sampler and post resource chart
+        if: always()
+        run: |
+          kill "$(cat /tmp/sampler.pid)" 2>/dev/null || true
+          if [ ! -s /tmp/metrics.csv ]; then
+            exit 0
+          fi
+          N=$(wc -l < /tmp/metrics.csv)
+          STEP=$(( N / 30 + 1 ))
+          awk -v step="$STEP" 'NR % step == 0' /tmp/metrics.csv > /tmp/s.csv
+          LABELS=$(awk -F, 'BEGIN{p="["} {p=p"\"T" NR "\","} END{sub(/,$/,"",p); print p"]"}' /tmp/s.csv)
+          CPU=$(awk -F, '{printf "%s,",$2}' /tmp/s.csv | sed 's/,$//')
+          MEM=$(awk -F, '{printf "%s,",$3}' /tmp/s.csv | sed 's/,$//')
+          {
+            echo '## CPU usage (%)'
+            echo '```mermaid'
+            echo 'xychart-beta'
+            echo "  x-axis $LABELS"
+            echo '  y-axis "CPU %" 0 --> 100'
+            echo "  line [$CPU]"
+            echo '```'
+            echo
+            echo '## Memory used (MB)'
+            echo '```mermaid'
+            echo 'xychart-beta'
+            echo "  x-axis $LABELS"
+            echo '  y-axis "Memory MB"'
+            echo "  line [$MEM]"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
       - name: Run build
         env:
           # Prevent warnings (emitted from react-pdf) from being treated as errors

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -82,7 +82,6 @@ jobs:
       - name: Run tests
         env:
           MATRIX_OPTION: ${{ matrix.option }}
-          PROFILE_DATA_FILE: /tmp/profile-metrics-${{ strategy.job-index }}.csv
         run: |
           "$GITHUB_WORKSPACE/dev/profile.sh" \
             yarn test --silent $MATRIX_OPTION src/experiment-tracking/components
@@ -90,8 +89,11 @@ jobs:
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          path: /tmp/profile-metrics-${{ strategy.job-index }}.csv
-          archive: false
+          name: profile-metrics-${{ strategy.job-index }}
+          path: /tmp/profile-metrics.csv
+          # TODO: Uncomment once `gh run download` supports non-zipped artifacts.
+          # https://github.com/cli/cli/issues/13012
+          # archive: false
           retention-days: 3
           if-no-files-found: ignore
       - name: Run build

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -85,13 +85,13 @@ jobs:
         run: |
           SUFFIX="${MATRIX_OPTION#--}"
           yarn test --silent $MATRIX_OPTION src/experiment-tracking/components \
-            --json --outputFile=jest-results-${SUFFIX}.json
+            --json --outputFile=/tmp/jest-results-${SUFFIX}.json
       - name: Upload Jest results
         if: failure()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: jest-results-${{ matrix.option }}
-          path: mlflow/server/js/jest-results-*.json
+          path: /tmp/jest-results-*.json
           retention-days: 7
           if-no-files-found: ignore
       - name: Run build

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -82,18 +82,8 @@ jobs:
       - name: Run tests
         env:
           MATRIX_OPTION: ${{ matrix.option }}
-          JOB_INDEX: ${{ strategy.job-index }}
         run: |
-          yarn test --silent $MATRIX_OPTION src/experiment-tracking/components \
-            --json --outputFile=/tmp/jest-results-${JOB_INDEX}.json
-      - name: Upload Jest results
-        if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: jest-results-${{ strategy.job-index }}
-          path: /tmp/jest-results-${{ strategy.job-index }}.json
-          retention-days: 7
-          if-no-files-found: ignore
+          yarn test --silent --verbose $MATRIX_OPTION src/experiment-tracking/components
       - name: Run build
         env:
           # Prevent warnings (emitted from react-pdf) from being treated as errors

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -82,6 +82,7 @@ jobs:
       - name: Run tests
         env:
           MATRIX_OPTION: ${{ matrix.option }}
+          PROFILE_DATA_FILE: /tmp/profile-metrics-${{ strategy.job-index }}.csv
         run: |
           "$GITHUB_WORKSPACE/dev/profile.sh" \
             yarn test --silent $MATRIX_OPTION src/experiment-tracking/components
@@ -89,8 +90,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: profile-metrics-${{ strategy.job-index }}
-          path: /tmp/profile-metrics.csv
+          path: /tmp/profile-metrics-${{ strategy.job-index }}.csv
+          archive: false
           retention-days: 3
           if-no-files-found: ignore
       - name: Run build

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -79,62 +79,12 @@ jobs:
       - name: Run type-check
         run: |
           yarn type-check
-      - name: Start resource sampler
-        run: |
-          nohup bash -c '
-            PREV_TOTAL=0; PREV_IDLE=0
-            while true; do
-              read _ U N S I IO IRQ SI ST _ < /proc/stat
-              T=$((U+N+S+I+IO+IRQ+SI+ST))
-              if [ "$PREV_TOTAL" -ne 0 ]; then
-                DT=$((T-PREV_TOTAL))
-                DI=$(( (I+IO)-PREV_IDLE ))
-                CPU=$(( DT>0 ? 100*(DT-DI)/DT : 0 ))
-              else
-                CPU=0
-              fi
-              PREV_TOTAL=$T
-              PREV_IDLE=$((I+IO))
-              MEM=$(awk "/MemTotal/{t=\$2}/MemAvailable/{a=\$2}END{print int((t-a)/1024)}" /proc/meminfo)
-              printf "%s,%s,%s\n" "$(date +%s)" "$CPU" "$MEM"
-              sleep 2
-            done' > /tmp/metrics.csv 2>&1 &
-          echo $! > /tmp/sampler.pid
       - name: Run tests
         env:
           MATRIX_OPTION: ${{ matrix.option }}
         run: |
-          yarn test --silent --verbose $MATRIX_OPTION src/experiment-tracking/components
-      - name: Stop sampler and post resource chart
-        if: always()
-        run: |
-          kill "$(cat /tmp/sampler.pid)" 2>/dev/null || true
-          if [ ! -s /tmp/metrics.csv ]; then
-            exit 0
-          fi
-          N=$(wc -l < /tmp/metrics.csv)
-          STEP=$(( N / 30 + 1 ))
-          awk -v step="$STEP" 'NR % step == 0' /tmp/metrics.csv > /tmp/s.csv
-          LABELS=$(awk -F, 'BEGIN{p="["} {p=p"\"T" NR "\","} END{sub(/,$/,"",p); print p"]"}' /tmp/s.csv)
-          CPU=$(awk -F, '{printf "%s,",$2}' /tmp/s.csv | sed 's/,$//')
-          MEM=$(awk -F, '{printf "%s,",$3}' /tmp/s.csv | sed 's/,$//')
-          {
-            echo '## CPU usage (%)'
-            echo '```mermaid'
-            echo 'xychart-beta'
-            echo "  x-axis $LABELS"
-            echo '  y-axis "CPU %" 0 --> 100'
-            echo "  line [$CPU]"
-            echo '```'
-            echo
-            echo '## Memory used (MB)'
-            echo '```mermaid'
-            echo 'xychart-beta'
-            echo "  x-axis $LABELS"
-            echo '  y-axis "Memory MB"'
-            echo "  line [$MEM]"
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
+          "$GITHUB_WORKSPACE/dev/profile.sh" \
+            yarn test --silent $MATRIX_OPTION src/experiment-tracking/components
       - name: Run build
         env:
           # Prevent warnings (emitted from react-pdf) from being treated as errors

--- a/dev/profile.sh
+++ b/dev/profile.sh
@@ -37,7 +37,7 @@ fi
     fi
     prev_total=$t
     prev_idle=$((i + io))
-    mem=$(awk '/MemTotal/{T=$2} /MemAvailable/{A=$2} END{print int((T-A)/1024)}' /proc/meminfo)
+    mem=$(awk '/MemTotal/{T=$2} /MemAvailable/{A=$2} END{printf "%.2f", (T-A)/1024/1024}' /proc/meminfo)
     printf '%s,%s,%s\n' "$(date +%s)" "$cpu" "$mem"
     sleep "$SAMPLE_INTERVAL"
   done
@@ -70,11 +70,11 @@ cleanup() {
     echo "  line [$cpu_list]"
     echo '```'
     echo
-    echo '## Memory used (MB)'
+    echo '## Memory used (GB)'
     echo '```mermaid'
     echo 'xychart-beta'
     echo "  x-axis \"Elapsed (s)\" 0 --> $total"
-    echo '  y-axis "Memory MB"'
+    echo '  y-axis "Memory GB"'
     echo "  line [$mem_list]"
     echo '```'
   } >>"$SUMMARY_FILE"

--- a/dev/profile.sh
+++ b/dev/profile.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Sample CPU and memory usage while running a command, then post mermaid
+# xychart-beta line charts to GITHUB_STEP_SUMMARY (or stdout if running
+# locally outside GitHub Actions).
+#
+# Usage: dev/profile.sh <command> [args...]
+#
+# Environment overrides:
+#   PROFILE_INTERVAL   sampling interval in seconds (default: 2)
+#   PROFILE_DATA_FILE  path to write raw CSV samples (default: /tmp/profile-metrics.csv)
+#
+# Linux-only: reads /proc/stat and /proc/meminfo.
+
+set -uo pipefail
+
+SAMPLE_FILE=${PROFILE_DATA_FILE:-/tmp/profile-metrics.csv}
+SAMPLE_INTERVAL=${PROFILE_INTERVAL:-2}
+SUMMARY_FILE=${GITHUB_STEP_SUMMARY:-/dev/stdout}
+
+if [ ! -r /proc/stat ] || [ ! -r /proc/meminfo ]; then
+  echo "profile.sh: /proc/stat or /proc/meminfo unavailable; running command without sampling" >&2
+  exec "$@"
+fi
+
+(
+  prev_total=0
+  prev_idle=0
+  while true; do
+    read _ u n s i io irq si st _ < /proc/stat
+    t=$((u + n + s + i + io + irq + si + st))
+    if [ "$prev_total" -ne 0 ]; then
+      dt=$((t - prev_total))
+      di=$(((i + io) - prev_idle))
+      cpu=$((dt > 0 ? 100 * (dt - di) / dt : 0))
+    else
+      cpu=0
+    fi
+    prev_total=$t
+    prev_idle=$((i + io))
+    mem=$(awk '/MemTotal/{T=$2} /MemAvailable/{A=$2} END{print int((T-A)/1024)}' /proc/meminfo)
+    printf '%s,%s,%s\n' "$(date +%s)" "$cpu" "$mem"
+    sleep "$SAMPLE_INTERVAL"
+  done
+) >"$SAMPLE_FILE" 2>&1 &
+sampler_pid=$!
+
+cleanup() {
+  kill "$sampler_pid" 2>/dev/null || true
+  wait "$sampler_pid" 2>/dev/null || true
+
+  if [ ! -s "$SAMPLE_FILE" ]; then
+    return 0
+  fi
+
+  local sampled=/tmp/profile-sampled.csv
+  local n step labels cpu_list mem_list
+  n=$(wc -l <"$SAMPLE_FILE")
+  step=$((n / 30 + 1))
+  awk -v step="$step" 'NR % step == 0' "$SAMPLE_FILE" >"$sampled"
+  labels=$(awk -F, 'BEGIN{p="["} {p=p"\"T" NR "\","} END{sub(/,$/,"",p); print p"]"}' "$sampled")
+  cpu_list=$(awk -F, '{printf "%s,",$2}' "$sampled" | sed 's/,$//')
+  mem_list=$(awk -F, '{printf "%s,",$3}' "$sampled" | sed 's/,$//')
+
+  {
+    echo '## CPU usage (%)'
+    echo '```mermaid'
+    echo 'xychart-beta'
+    echo "  x-axis $labels"
+    echo '  y-axis "CPU %" 0 --> 100'
+    echo "  line [$cpu_list]"
+    echo '```'
+    echo
+    echo '## Memory used (MB)'
+    echo '```mermaid'
+    echo 'xychart-beta'
+    echo "  x-axis $labels"
+    echo '  y-axis "Memory MB"'
+    echo "  line [$mem_list]"
+    echo '```'
+  } >>"$SUMMARY_FILE"
+}
+trap cleanup EXIT
+
+"$@"

--- a/dev/profile.sh
+++ b/dev/profile.sh
@@ -53,11 +53,11 @@ cleanup() {
   fi
 
   local sampled=/tmp/profile-sampled.csv
-  local n step labels cpu_list mem_list
+  local n step total cpu_list mem_list
   n=$(wc -l <"$SAMPLE_FILE")
   step=$((n / 30 + 1))
   awk -v step="$step" 'NR % step == 0' "$SAMPLE_FILE" >"$sampled"
-  labels=$(awk -F, 'BEGIN{p="["} {p=p"\"T" NR "\","} END{sub(/,$/,"",p); print p"]"}' "$sampled")
+  total=$(awk -F, 'NR==1{first=$1} END{print $1-first}' "$SAMPLE_FILE")
   cpu_list=$(awk -F, '{printf "%s,",$2}' "$sampled" | sed 's/,$//')
   mem_list=$(awk -F, '{printf "%s,",$3}' "$sampled" | sed 's/,$//')
 
@@ -65,7 +65,7 @@ cleanup() {
     echo '## CPU usage (%)'
     echo '```mermaid'
     echo 'xychart-beta'
-    echo "  x-axis $labels"
+    echo "  x-axis \"Elapsed (s)\" 0 --> $total"
     echo '  y-axis "CPU %" 0 --> 100'
     echo "  line [$cpu_list]"
     echo '```'
@@ -73,7 +73,7 @@ cleanup() {
     echo '## Memory used (MB)'
     echo '```mermaid'
     echo 'xychart-beta'
-    echo "  x-axis $labels"
+    echo "  x-axis \"Elapsed (s)\" 0 --> $total"
     echo '  y-axis "Memory MB"'
     echo "  line [$mem_list]"
     echo '```'

--- a/dev/profile.sh
+++ b/dev/profile.sh
@@ -6,15 +6,15 @@
 # Usage: dev/profile.sh <command> [args...]
 #
 # Environment overrides:
-#   PROFILE_INTERVAL   sampling interval in seconds (default: 2)
-#   PROFILE_DATA_FILE  path to write raw CSV samples (default: /tmp/profile-metrics.csv)
+#   PROFILE_INTERVAL_SECONDS  sampling interval in seconds (default: 2)
+#   PROFILE_DATA_FILE         path to write raw CSV samples (default: /tmp/profile-metrics.csv)
 #
 # Linux-only: reads /proc/stat and /proc/meminfo.
 
 set -uo pipefail
 
 SAMPLE_FILE=${PROFILE_DATA_FILE:-/tmp/profile-metrics.csv}
-SAMPLE_INTERVAL=${PROFILE_INTERVAL:-2}
+SAMPLE_INTERVAL_SECONDS=${PROFILE_INTERVAL_SECONDS:-2}
 SUMMARY_FILE=${GITHUB_STEP_SUMMARY:-/dev/stdout}
 
 if [ ! -r /proc/stat ] || [ ! -r /proc/meminfo ]; then
@@ -39,7 +39,7 @@ fi
     prev_idle=$((i + io))
     mem=$(awk '/MemTotal/{T=$2} /MemAvailable/{A=$2} END{printf "%.2f", (T-A)/1024/1024}' /proc/meminfo)
     printf '%s,%s,%s\n' "$(date +%s)" "$cpu" "$mem"
-    sleep "$SAMPLE_INTERVAL"
+    sleep "$SAMPLE_INTERVAL_SECONDS"
   done
 ) >"$SAMPLE_FILE" 2>&1 &
 sampler_pid=$!

--- a/dev/profile.sh
+++ b/dev/profile.sh
@@ -23,6 +23,7 @@ if [ ! -r /proc/stat ] || [ ! -r /proc/meminfo ]; then
 fi
 
 (
+  printf 'timestamp,cpu_pct,mem_gb\n'
   prev_total=0
   prev_idle=0
   while true; do
@@ -52,12 +53,14 @@ cleanup() {
     return 0
   fi
 
+  local data_csv=/tmp/profile-data.csv
   local sampled=/tmp/profile-sampled.csv
   local n step total cpu_list mem_list
-  n=$(wc -l <"$SAMPLE_FILE")
+  tail -n +2 "$SAMPLE_FILE" >"$data_csv"
+  n=$(wc -l <"$data_csv")
   step=$((n / 30 + 1))
-  awk -v step="$step" 'NR % step == 0' "$SAMPLE_FILE" >"$sampled"
-  total=$(awk -F, 'NR==1{first=$1} END{print $1-first}' "$SAMPLE_FILE")
+  awk -v step="$step" 'NR % step == 0' "$data_csv" >"$sampled"
+  total=$(awk -F, 'NR==1{first=$1} END{print $1-first}' "$data_csv")
   cpu_list=$(awk -F, '{printf "%s,",$2}' "$sampled" | sed 's/,$//')
   mem_list=$(awk -F, '{printf "%s,",$3}' "$sampled" | sed 's/,$//')
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to flaky `js.yml` test failures.

### What changes are proposed in this pull request?

Adds a small reusable shell wrapper that samples runner CPU and memory while a command runs, then writes mermaid `xychart-beta` line charts to `GITHUB_STEP_SUMMARY`. Wires it around the `yarn test` invocation in `js.yml` so each js matrix job posts its own CPU and memory chart in the job summary, helping diagnose whether sporadic test timeouts correlate with resource pressure on the runner.

Highlights:

- `dev/profile.sh` — samples `/proc/stat` and `/proc/meminfo` every 2 s into a CSV with a `timestamp,cpu_pct,mem_gb` header, downsamples to ~30 points, and emits two mermaid line charts. Linux-only; falls back to `exec "$@"` on platforms without `/proc`. Writes the markdown to stdout when `GITHUB_STEP_SUMMARY` is unset, so the script works locally too.
- `js.yml` — wraps the existing `yarn test` invocation with `dev/profile.sh` (test command unchanged) and adds an `actions/upload-artifact` step (3-day retention) so the raw `profile-metrics.csv` is fetchable for offline trend analysis.

The x-axis on the charts is a numeric `Elapsed (s) 0 --> total` range so the time scale matches actual wall clock.

### How is this PR tested?

- [x] Manual tests

Verified end-to-end on the branch: the profile script runs in CI, the job summary renders both charts, and the uploaded CSV downloads cleanly via `gh run download` with the expected `timestamp,cpu_pct,mem_gb` header. Locally the script writes the same markdown to stdout.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release