### PR TITLE
Cap JS test memory with `--maxWorkers=2`

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -82,9 +82,7 @@ jobs:
       - name: Run tests
         env:
           MATRIX_OPTION: ${{ matrix.option }}
-        # --maxWorkers=2: Jest's default (3 on this 4-vCPU runner) pushed peak
-        # RSS to ~15 GB out of the 16 GB ubuntu-latest cap due to per-worker
-        # module-cache leaks across test files. Two workers keeps peak ~13 GB.
+        # --maxWorkers=2: Jest's default (3) saturates the 16 GB runner.
         run: |
           "$GITHUB_WORKSPACE/dev/profile.sh" \
             yarn test --silent --maxWorkers=2 $MATRIX_OPTION src/experiment-tracking/components

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -82,7 +82,6 @@ jobs:
       - name: Run tests
         env:
           MATRIX_OPTION: ${{ matrix.option }}
-          NODE_OPTIONS: --max-old-space-size=4096
         run: |
           "$GITHUB_WORKSPACE/dev/profile.sh" \
             yarn test --silent --maxWorkers=2 --logHeapUsage $MATRIX_OPTION src/experiment-tracking/components

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -82,9 +82,10 @@ jobs:
       - name: Run tests
         env:
           MATRIX_OPTION: ${{ matrix.option }}
+          NODE_OPTIONS: --max-old-space-size=4096
         run: |
           "$GITHUB_WORKSPACE/dev/profile.sh" \
-            yarn test --silent --maxWorkers=1 --logHeapUsage $MATRIX_OPTION src/experiment-tracking/components
+            yarn test --silent --maxWorkers=2 --logHeapUsage $MATRIX_OPTION src/experiment-tracking/components
       - name: Upload profile metrics
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -84,7 +84,7 @@ jobs:
           MATRIX_OPTION: ${{ matrix.option }}
         run: |
           "$GITHUB_WORKSPACE/dev/profile.sh" \
-            yarn test --silent --maxWorkers=2 --logHeapUsage $MATRIX_OPTION src/experiment-tracking/components
+            yarn test --silent --maxWorkers=1 --logHeapUsage $MATRIX_OPTION src/experiment-tracking/components
       - name: Upload profile metrics
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -84,7 +84,7 @@ jobs:
           MATRIX_OPTION: ${{ matrix.option }}
         run: |
           "$GITHUB_WORKSPACE/dev/profile.sh" \
-            yarn test --silent --maxWorkers=2 --logHeapUsage $MATRIX_OPTION src/experiment-tracking/components
+            yarn test --silent --maxWorkers=2 $MATRIX_OPTION src/experiment-tracking/components
       - name: Upload profile metrics
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -82,6 +82,9 @@ jobs:
       - name: Run tests
         env:
           MATRIX_OPTION: ${{ matrix.option }}
+        # --maxWorkers=2: Jest's default (3 on this 4-vCPU runner) pushed peak
+        # RSS to ~15 GB out of the 16 GB ubuntu-latest cap due to per-worker
+        # module-cache leaks across test files. Two workers keeps peak ~13 GB.
         run: |
           "$GITHUB_WORKSPACE/dev/profile.sh" \
             yarn test --silent --maxWorkers=2 $MATRIX_OPTION src/experiment-tracking/components

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -84,7 +84,7 @@ jobs:
           MATRIX_OPTION: ${{ matrix.option }}
         run: |
           "$GITHUB_WORKSPACE/dev/profile.sh" \
-            yarn test --silent $MATRIX_OPTION src/experiment-tracking/components
+            yarn test --silent --workerIdleMemoryLimit=2GB $MATRIX_OPTION src/experiment-tracking/components
       - name: Upload profile metrics
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -82,7 +82,8 @@ jobs:
       - name: Run tests
         env:
           MATRIX_OPTION: ${{ matrix.option }}
-        # --maxWorkers=2: Jest's default (3) saturates the 16 GB runner.
+        # --maxWorkers=2: Jest's default (3) leaks module cache across test
+        # files and peaks ~15 GB RSS on the 16 GB runner; 2 keeps peak ~13 GB.
         run: |
           "$GITHUB_WORKSPACE/dev/profile.sh" \
             yarn test --silent --maxWorkers=2 $MATRIX_OPTION src/experiment-tracking/components

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -84,7 +84,7 @@ jobs:
           MATRIX_OPTION: ${{ matrix.option }}
         run: |
           "$GITHUB_WORKSPACE/dev/profile.sh" \
-            yarn test --silent --workerIdleMemoryLimit=2GB $MATRIX_OPTION src/experiment-tracking/components
+            yarn test --silent --maxWorkers=2 --logHeapUsage $MATRIX_OPTION src/experiment-tracking/components
       - name: Upload profile metrics
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0


### PR DESCRIPTION
### Related Issues/PRs

Follow-up to #23129. Relates to flaky `js.yml` test failures.

### What changes are proposed in this pull request?

Pass `--maxWorkers=2` to the `yarn test` invocation in `js.yml`. Jest's default on the 4-vCPU `ubuntu-latest` runner is 3 workers; their per-worker module caches leak across test files and pushed peak RSS to ~15 GB out of the 16 GB cap (per #23129's profile metrics). Two workers keeps peak ~13 GB at no measurable wall-time cost.

Other approaches were tried on this branch and rejected: `--workerIdleMemoryLimit` is silently ignored by the Jest 27 bundled with `react-scripts@5`; bumping Jest to 30 works but needs transformer overrides plus ~30 jsdom test rewrites (out of scope); `NODE_OPTIONS=--max-old-space-size` does not propagate to Jest workers; `--maxWorkers=1` cuts memory further but adds 65–75% wall time.

### How is this PR tested?

- [x] Manual tests

`dev/profile.sh` artifacts confirm peak RSS drops from ~15 GB to ~13 GB on both shards versus master.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] \`area/build\`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] \`rn/none\` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release