### PR TITLE
Lint composite-action steps for direct `${{ }}` interpolation

### DIFF
--- a/.github/actions/setup-java/action.yml
+++ b/.github/actions/setup-java/action.yml
@@ -21,5 +21,7 @@ runs:
 
     - name: Set MLFLOW_DOCKER_OPENJDK_VERSION
       shell: bash
+      env:
+        JAVA_VERSION: ${{ inputs.java-version }}
       run: |
-        echo "MLFLOW_DOCKER_OPENJDK_VERSION=${{ inputs.java-version }}" >> $GITHUB_ENV
+        echo "MLFLOW_DOCKER_OPENJDK_VERSION=$JAVA_VERSION" >> $GITHUB_ENV

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -26,20 +26,23 @@ runs:
       # in 3.x on Anaconda, but it turned out `conda search` is very slow (takes 40 ~ 50 seconds).
       # This overhead sums up to a significant amount of delay in the cross version tests
       # where we trigger more than 100 GitHub Actions runs.
+      env:
+        PYTHON_VERSION_INPUT: ${{ inputs.python-version }}
+        PIN_MICRO_VERSION: ${{ inputs.pin-micro-version }}
       run: |
-        python_version="${{ inputs.python-version }}"
+        python_version="$PYTHON_VERSION_INPUT"
         if [ -z "$python_version" ]; then
           python_version=$(cat .python-version)
         fi
-        if [[ "${{ inputs.pin-micro-version }}" == "true" ]]; then
+        if [[ "$PIN_MICRO_VERSION" == "true" ]]; then
           if [[ "$python_version" == "3.10" ]]; then
-            if [ ${{ runner.os }} == "Linux" ]; then
+            if [ "$RUNNER_OS" == "Linux" ]; then
               python_version="3.10.19"
             else
               python_version="3.10.11"
             fi
           elif [[ "$python_version" == "3.11" ]]; then
-            if [ ${{ runner.os }} == "Windows" ]; then
+            if [ "$RUNNER_OS" == "Windows" ]; then
               python_version="3.11.9"
             else
               python_version="3.11.14"

--- a/.github/actions/show-versions/action.yml
+++ b/.github/actions/show-versions/action.yml
@@ -7,7 +7,7 @@ runs:
       run: |
         # Activate the virtual environment if .venv exists
         if [ -d .venv ]; then
-          if [ ${{ runner.os }} == "Windows" ]; then
+          if [ "$RUNNER_OS" == "Windows" ]; then
             source .venv/Scripts/activate
           else
             source .venv/bin/activate

--- a/.github/policy.rego
+++ b/.github/policy.rego
@@ -199,12 +199,15 @@ deny_interpolation_in_run contains msg if {
 
 deny_interpolation_in_run contains msg if {
 	not input.jobs
-	some step in input.runs.steps
+	some i, step in input.runs.steps
 	regex.match(`\$\{\{`, step.run)
-	msg := concat("", [
-		"Direct ${{ }} interpolation in run block of composite action step. ",
-		"Use env: to pass the value and reference it as $VAR in the script.",
-	])
+	msg := sprintf(
+		concat("", [
+			"Direct ${{ }} interpolation in run block of composite action step #%d. ",
+			"Use env: to pass the value and reference it as $VAR in the script.",
+		]),
+		[i + 1],
+	)
 }
 
 deny_interpolation_in_github_script contains msg if {
@@ -223,13 +226,16 @@ deny_interpolation_in_github_script contains msg if {
 
 deny_interpolation_in_github_script contains msg if {
 	not input.jobs
-	some step in input.runs.steps
+	some i, step in input.runs.steps
 	startswith(step.uses, "actions/github-script@")
 	regex.match(`\$\{\{`, step["with"].script)
-	msg := concat("", [
-		"Direct ${{ }} interpolation in github-script of composite action step. ",
-		"Use env: to pass the value and reference it as process.env.VAR in the script.",
-	])
+	msg := sprintf(
+		concat("", [
+			"Direct ${{ }} interpolation in github-script of composite action step #%d. ",
+			"Use env: to pass the value and reference it as process.env.VAR in the script.",
+		]),
+		[i + 1],
+	)
 }
 
 deny_interpolation_in_job_if contains msg if {

--- a/.github/policy.rego
+++ b/.github/policy.rego
@@ -197,6 +197,16 @@ deny_interpolation_in_run contains msg if {
 	)
 }
 
+deny_interpolation_in_run contains msg if {
+	not input.jobs
+	some step in input.runs.steps
+	regex.match(`\$\{\{`, step.run)
+	msg := concat("", [
+		"Direct ${{ }} interpolation in run block of composite action step. ",
+		"Use env: to pass the value and reference it as $VAR in the script.",
+	])
+}
+
 deny_interpolation_in_github_script contains msg if {
 	some job_id, job in input.jobs
 	some step in job.steps
@@ -209,6 +219,17 @@ deny_interpolation_in_github_script contains msg if {
 		]),
 		[job_id],
 	)
+}
+
+deny_interpolation_in_github_script contains msg if {
+	not input.jobs
+	some step in input.runs.steps
+	startswith(step.uses, "actions/github-script@")
+	regex.match(`\$\{\{`, step["with"].script)
+	msg := concat("", [
+		"Direct ${{ }} interpolation in github-script of composite action step. ",
+		"Use env: to pass the value and reference it as process.env.VAR in the script.",
+	])
 }
 
 deny_interpolation_in_job_if contains msg if {

--- a/.github/policy.rego
+++ b/.github/policy.rego
@@ -199,6 +199,7 @@ deny_interpolation_in_run contains msg if {
 
 deny_interpolation_in_run contains msg if {
 	not input.jobs
+	input.runs.steps
 	some i, step in input.runs.steps
 	regex.match(`\$\{\{`, step.run)
 	msg := sprintf(
@@ -226,6 +227,7 @@ deny_interpolation_in_github_script contains msg if {
 
 deny_interpolation_in_github_script contains msg if {
 	not input.jobs
+	input.runs.steps
 	some i, step in input.runs.steps
 	startswith(step.uses, "actions/github-script@")
 	regex.match(`\$\{\{`, step["with"].script)


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

Extend the `deny_interpolation_in_run` and `deny_interpolation_in_github_script` rules in `.github/policy.rego` to also traverse composite actions (`input.runs.steps`), mirroring the existing composite-action branch on `unpinned_actions`. Previously these rules only iterated `input.jobs[*].steps`, so composite actions silently bypassed the lint and could inline `${{ ... }}` directly inside `run:` script bodies.

Fix the three composite actions that newly fail the rule:

- `.github/actions/setup-java/action.yml`: pass `inputs.java-version` via step `env:` instead of inlining it in the `run` block.
- `.github/actions/setup-python/action.yml`: pass `inputs.python-version` and `inputs.pin-micro-version` via step `env:`, and replace `${{ runner.os }}` with the built-in `$RUNNER_OS`.
- `.github/actions/show-versions/action.yml`: replace `${{ runner.os }}` with `$RUNNER_OS`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Ran `bin/conftest test --namespace mlflow --policy .github/policy.rego .github/actions/*/action.yml .github/workflows/*.yml` locally:
- Before the fixes: 3 failures (one per offending composite action).
- After the fixes: 2304 tests, 2304 passed, 0 failures.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release