### PR TITLE
Update Claude Code installer to new download URL

### DIFF
--- a/.claude/scripts/install-claude.sh
+++ b/.claude/scripts/install-claude.sh
@@ -10,7 +10,7 @@ if [ "${CI:-}" != "true" ]; then
   exit 1
 fi
 
-GCS_BUCKET="https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases"
+GCS_BUCKET="https://downloads.claude.ai/claude-code-releases"
 PLATFORM="linux-x64"
 
 VERSION="$(curl -fsSL --retry 3 --retry-delay 2 "$GCS_BUCKET/stable")"

--- a/.claude/scripts/install-claude.sh
+++ b/.claude/scripts/install-claude.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Downloads the Claude Code binary directly from GCS and verifies it against the
+# Downloads the Claude Code binary from the official distribution URL and verifies it against the
 # checksum published in the per-version manifest, avoiding `curl | bash` which
 # pipes an unverified script with access to CI secrets.
 # Ref: https://github.com/dagster-io/erk/blob/61ecee08754717959bb2f9cb6e7079df81ba80ea/.github/actions/setup-claude-code/action.yml
@@ -10,17 +10,17 @@ if [ "${CI:-}" != "true" ]; then
   exit 1
 fi
 
-GCS_BUCKET="https://downloads.claude.ai/claude-code-releases"
+DOWNLOAD_URL="https://downloads.claude.ai/claude-code-releases"
 PLATFORM="linux-x64"
 
-VERSION="$(curl -fsSL --retry 3 --retry-delay 2 "$GCS_BUCKET/stable")"
-CHECKSUM="$(curl -fsSL --retry 3 --retry-delay 2 "$GCS_BUCKET/$VERSION/manifest.json" \
+VERSION="$(curl -fsSL --retry 3 --retry-delay 2 "$DOWNLOAD_URL/stable")"
+CHECKSUM="$(curl -fsSL --retry 3 --retry-delay 2 "$DOWNLOAD_URL/$VERSION/manifest.json" \
   | jq -r ".platforms[\"$PLATFORM\"].checksum")"
 
 tmp_claude="$(mktemp)"
 trap 'rm -f "$tmp_claude"' EXIT
 
-curl -fsSL --retry 3 --retry-delay 2 "$GCS_BUCKET/$VERSION/$PLATFORM/claude" -o "$tmp_claude"
+curl -fsSL --retry 3 --retry-delay 2 "$DOWNLOAD_URL/$VERSION/$PLATFORM/claude" -o "$tmp_claude"
 echo "${CHECKSUM}  $tmp_claude" | sha256sum -c -
 mkdir -p ~/.local/bin
 chmod +x "$tmp_claude"


### PR DESCRIPTION
### Related Issues/PRs

Relates to N/A

### What changes are proposed in this pull request?

Update the Claude Code CI installer script to use the new official download URL. As of Claude Code 2.1.116, the binary distribution moved from `https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases` to `https://downloads.claude.ai/claude-code-releases`. This updates `.claude/scripts/install-claude.sh` accordingly.

### How is this PR tested?

- [x] Manual tests

The new URL was confirmed to serve the same `stable`, `<version>/manifest.json`, and `<version>/<platform>/claude` paths used by the script.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release