### PR TITLE
Migrate `show_package_release_dates.py` to `dev/pypi`

### DIFF
--- a/.github/actions/show-versions/action.yml
+++ b/.github/actions/show-versions/action.yml
@@ -13,7 +13,7 @@ runs:
             source .venv/bin/activate
           fi
         fi
-        pip --disable-pip-version-check install aiohttp > /dev/null
+        pip --disable-pip-version-check install ./dev/pypi > /dev/null
         echo ">>> package versions"
         status=0
         python dev/show_package_release_dates.py || status=$?

--- a/dev/pypi/README.md
+++ b/dev/pypi/README.md
@@ -3,11 +3,15 @@
 Minimal type-safe client for [PyPI's JSON API](https://warehouse.pypa.io/api-reference/json.html), used by scripts in `dev/`.
 
 ```python
-from pypi import get_package
+import asyncio
+from pypi import get_package, get_packages
 
-pkg = get_package("requests")
+pkg = asyncio.run(get_package("requests"))
 pkg.latest_version  # Version("2.32.3")
 pkg.releases[-1].upload_time  # datetime (UTC)
 pkg.releases[-1].yanked  # bool
 pkg.releases[-1].requires_python  # SpecifierSet | None
+
+# Concurrent batch fetch:
+pkgs = asyncio.run(get_packages(["numpy", "pandas", "scikit-learn"]))
 ```

--- a/dev/pypi/pyproject.toml
+++ b/dev/pypi/pyproject.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 description = "A minimal client for fetching package metadata from PyPI."
 readme = "README.md"
 requires-python = ">=3.10"
-dependencies = ["packaging"]
+dependencies = ["aiohttp", "packaging"]

--- a/dev/pypi/src/pypi/__init__.py
+++ b/dev/pypi/src/pypi/__init__.py
@@ -1,12 +1,11 @@
-from pypi._client import PyPIError, aget_package, aget_packages, clear_cache, get_package
+from pypi._client import PyPIError, clear_cache, get_package, get_packages
 from pypi._models import Package, Release
 
 __all__ = [
     "Package",
     "PyPIError",
     "Release",
-    "aget_package",
-    "aget_packages",
     "clear_cache",
     "get_package",
+    "get_packages",
 ]

--- a/dev/pypi/src/pypi/_client.py
+++ b/dev/pypi/src/pypi/_client.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
 import asyncio
-import functools
-import json
 import os
-import time
-import urllib.error
-import urllib.request
 from collections.abc import Iterable
 from typing import Any
+
+import aiohttp
 
 from pypi._models import Package
 
@@ -29,54 +26,65 @@ def _base_url() -> str:
     return os.environ.get("PYPI_URL", _DEFAULT_PYPI_URL).rstrip("/")
 
 
-def _fetch_json(url: str) -> dict[str, Any]:
-    last_error: Exception | None = None
+_cache: dict[str, Package] = {}
+
+
+def _url(name: str) -> str:
+    return f"{_base_url()}/pypi/{name}/json"
+
+
+async def _fetch_json(session: aiohttp.ClientSession, url: str) -> dict[str, Any]:
+    last_error: object | None = None
     for attempt in range(_RETRIES):
         try:
-            with urllib.request.urlopen(url, timeout=_TIMEOUT_SECONDS) as resp:
-                payload = json.load(resp)
-        except urllib.error.HTTPError as e:
-            if e.code == 404:
-                raise PyPIError(f"Package not found: {url}") from e
-            if e.code not in _RETRYABLE_STATUSES:
-                raise PyPIError(f"HTTP {e.code} from {url}: {e.reason}") from e
+            async with session.get(url) as resp:
+                if resp.status == 404:
+                    raise PyPIError(f"Package not found: {url}")
+                if resp.status not in _RETRYABLE_STATUSES and not 200 <= resp.status < 300:
+                    raise PyPIError(f"HTTP {resp.status} from {url}: {resp.reason}")
+                if 200 <= resp.status < 300:
+                    payload = await resp.json()
+                    if not isinstance(payload, dict):
+                        raise PyPIError(f"Unexpected response from {url}: {type(payload).__name__}")
+                    return payload
+                last_error = f"HTTP {resp.status}"
+        except aiohttp.ClientError as e:
             last_error = e
-        except (urllib.error.URLError, ConnectionResetError, TimeoutError, OSError) as e:
-            # URLError wraps socket errors, DNS failures, refused connections.
-            last_error = e
-        except json.JSONDecodeError as e:
-            # Usually means an upstream proxy returned an HTML error page.
-            last_error = e
-        else:
-            if not isinstance(payload, dict):
-                raise PyPIError(f"Unexpected response from {url}: {type(payload).__name__}")
-            return payload
 
         if attempt + 1 < _RETRIES:
-            time.sleep(_BACKOFF_BASE * (2**attempt))
+            await asyncio.sleep(_BACKOFF_BASE * (2**attempt))
 
     raise PyPIError(f"Failed to fetch {url} after {_RETRIES} attempts: {last_error}")
 
 
-@functools.cache
-def get_package(name: str) -> Package:
-    """Fetch package metadata from PyPI. Override the base URL with $PYPI_URL."""
-    url = f"{_base_url()}/pypi/{name}/json"
-    return Package.from_json(_fetch_json(url))
+async def get_package(name: str, *, session: aiohttp.ClientSession | None = None) -> Package:
+    """Fetch package metadata from PyPI. Override the base URL with $PYPI_URL.
+
+    Pass an open ``aiohttp.ClientSession`` via ``session`` to share a connection
+    pool across many calls. If omitted, a single-shot session is created per call.
+    """
+    if (cached := _cache.get(name)) is not None:
+        return cached
+    if session is None:
+        timeout = aiohttp.ClientTimeout(total=_TIMEOUT_SECONDS)
+        async with aiohttp.ClientSession(timeout=timeout) as s:
+            payload = await _fetch_json(s, _url(name))
+    else:
+        payload = await _fetch_json(session, _url(name))
+    pkg = Package.from_json(payload)
+    _cache[name] = pkg
+    return pkg
 
 
-async def aget_package(name: str) -> Package:
-    """Async wrapper around :func:`get_package`. Each call runs in a thread."""
-    return await asyncio.to_thread(get_package, name)
-
-
-async def aget_packages(names: Iterable[str]) -> list[Package]:
-    """Fetch multiple packages concurrently. Order matches ``names``."""
-    return await asyncio.gather(*(aget_package(n) for n in names))
+async def get_packages(names: Iterable[str]) -> list[Package]:
+    """Fetch multiple packages concurrently with one shared aiohttp session."""
+    timeout = aiohttp.ClientTimeout(total=_TIMEOUT_SECONDS)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        return await asyncio.gather(*(get_package(n, session=session) for n in names))
 
 
 def clear_cache() -> None:
-    get_package.cache_clear()
+    _cache.clear()
 
 
-__all__ = ["PyPIError", "aget_package", "aget_packages", "clear_cache", "get_package"]
+__all__ = ["PyPIError", "clear_cache", "get_package", "get_packages"]

--- a/dev/pypi/src/pypi/_client.py
+++ b/dev/pypi/src/pypi/_client.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import os
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, Literal, overload
 
 import aiohttp
 
@@ -61,26 +61,42 @@ async def get_package(name: str, *, session: aiohttp.ClientSession | None = None
     """Fetch package metadata from PyPI. Override the base URL with $PYPI_URL.
 
     Pass an open ``aiohttp.ClientSession`` via ``session`` to share a connection
-    pool across many calls. If omitted, a single-shot session is created per call.
+    pool across many calls. If omitted, the call is delegated to :func:`get_packages`,
+    which opens a single-shot session.
     """
     if (cached := _cache.get(name)) is not None:
         return cached
     if session is None:
-        timeout = aiohttp.ClientTimeout(total=_TIMEOUT_SECONDS)
-        async with aiohttp.ClientSession(timeout=timeout) as s:
-            payload = await _fetch_json(s, _url(name))
-    else:
-        payload = await _fetch_json(session, _url(name))
+        return (await get_packages([name]))[0]
+    payload = await _fetch_json(session, _url(name))
     pkg = Package.from_json(payload)
     _cache[name] = pkg
     return pkg
 
 
-async def get_packages(names: Iterable[str]) -> list[Package]:
-    """Fetch multiple packages concurrently with one shared aiohttp session."""
+@overload
+async def get_packages(
+    names: Iterable[str], *, return_exceptions: Literal[False] = ...
+) -> list[Package]: ...
+@overload
+async def get_packages(
+    names: Iterable[str], *, return_exceptions: Literal[True]
+) -> list[Package | BaseException]: ...
+async def get_packages(
+    names: Iterable[str], *, return_exceptions: bool = False
+) -> list[Package] | list[Package | BaseException]:
+    """Fetch multiple packages concurrently with one shared aiohttp session.
+
+    Set ``return_exceptions=True`` to mirror :func:`asyncio.gather`'s behavior:
+    failed fetches return their ``BaseException`` in place of a ``Package`` rather
+    than aborting the whole batch.
+    """
     timeout = aiohttp.ClientTimeout(total=_TIMEOUT_SECONDS)
     async with aiohttp.ClientSession(timeout=timeout) as session:
-        return await asyncio.gather(*(get_package(n, session=session) for n in names))
+        return await asyncio.gather(
+            *(get_package(n, session=session) for n in names),
+            return_exceptions=return_exceptions,
+        )
 
 
 def clear_cache() -> None:

--- a/dev/pypi/src/pypi/_client.py
+++ b/dev/pypi/src/pypi/_client.py
@@ -57,21 +57,17 @@ async def _fetch_json(session: aiohttp.ClientSession, url: str) -> dict[str, Any
     raise PyPIError(f"Failed to fetch {url} after {_RETRIES} attempts: {last_error}")
 
 
-async def get_package(name: str, *, session: aiohttp.ClientSession | None = None) -> Package:
-    """Fetch package metadata from PyPI. Override the base URL with $PYPI_URL.
-
-    Pass an open ``aiohttp.ClientSession`` via ``session`` to share a connection
-    pool across many calls. If omitted, the call is delegated to :func:`get_packages`,
-    which opens a single-shot session.
-    """
+async def _fetch_one(session: aiohttp.ClientSession, name: str) -> Package:
     if (cached := _cache.get(name)) is not None:
         return cached
-    if session is None:
-        return (await get_packages([name]))[0]
-    payload = await _fetch_json(session, _url(name))
-    pkg = Package.from_json(payload)
+    pkg = Package.from_json(await _fetch_json(session, _url(name)))
     _cache[name] = pkg
     return pkg
+
+
+async def get_package(name: str) -> Package:
+    """Fetch package metadata from PyPI. Override the base URL with $PYPI_URL."""
+    return (await get_packages([name]))[0]
 
 
 @overload
@@ -94,7 +90,7 @@ async def get_packages(
     timeout = aiohttp.ClientTimeout(total=_TIMEOUT_SECONDS)
     async with aiohttp.ClientSession(timeout=timeout) as session:
         return await asyncio.gather(
-            *(get_package(n, session=session) for n in names),
+            *(_fetch_one(session, n) for n in names),
             return_exceptions=return_exceptions,
         )
 

--- a/dev/pypi/tests/conftest.py
+++ b/dev/pypi/tests/conftest.py
@@ -5,9 +5,7 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def _clear_caches(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+def _clear_caches() -> Iterator[None]:
     pypi.clear_cache()
-    # Don't actually sleep between retries inside tests.
-    monkeypatch.setattr("pypi._client.time.sleep", lambda _seconds: None)
     yield
     pypi.clear_cache()

--- a/dev/pypi/tests/test_client.py
+++ b/dev/pypi/tests/test_client.py
@@ -1,19 +1,12 @@
 from __future__ import annotations
 
 import asyncio
-import email.message
-import io
-import json
-import urllib.error
-from collections.abc import Iterator
 from typing import Any
 from unittest import mock
 
 import pypi
 import pytest
 from packaging.version import Version
-
-_URLOPEN = "pypi._client.urllib.request.urlopen"
 
 
 def _payload(versions: list[str]) -> dict[str, Any]:
@@ -23,34 +16,19 @@ def _payload(versions: list[str]) -> dict[str, Any]:
     }
 
 
-def _http_error(code: int) -> urllib.error.HTTPError:
-    return urllib.error.HTTPError(
-        url="https://example/", code=code, msg="boom", hdrs=email.message.Message(), fp=None
-    )
-
-
-def _success_response(payload: dict[str, Any]) -> mock.MagicMock:
-    body = io.BytesIO(json.dumps(payload).encode())
-    return mock.MagicMock(
-        __enter__=mock.MagicMock(return_value=body),
-        __exit__=mock.MagicMock(return_value=False),
-    )
-
-
-def _urlopen_returning(payloads: list[dict[str, Any]]) -> Any:
-    iterator: Iterator[dict[str, Any]] = iter(payloads)
-
-    def _open(url: str, timeout: float) -> mock.MagicMock:
-        return _success_response(next(iterator))
-
-    return _open
+def _patch_fetch(side_effect: Any) -> Any:
+    return mock.patch("pypi._client._fetch_json", side_effect=side_effect)
 
 
 def test_get_package_returns_typed_package() -> None:
     payload = _payload(["1.0.0", "2.0.0"])
-    with mock.patch(_URLOPEN, side_effect=_urlopen_returning([payload])) as mock_open:
-        pkg = pypi.get_package("demo")
-        mock_open.assert_called_once()
+
+    async def _f(session: object, url: str) -> dict[str, Any]:
+        return payload
+
+    with _patch_fetch(_f) as mock_fetch:
+        pkg = asyncio.run(pypi.get_package("demo"))
+        mock_fetch.assert_called_once()
 
     assert isinstance(pkg, pypi.Package)
     assert pkg.latest_version == Version("2.0.0")
@@ -58,114 +36,70 @@ def test_get_package_returns_typed_package() -> None:
 
 def test_get_package_uses_in_memory_cache() -> None:
     payload = _payload(["1.0.0"])
-    with mock.patch(_URLOPEN, side_effect=_urlopen_returning([payload])) as mock_open:
-        pypi.get_package("demo")
-        pypi.get_package("demo")
-        mock_open.assert_called_once()
+
+    async def _f(session: object, url: str) -> dict[str, Any]:
+        return payload
+
+    async def go() -> None:
+        await pypi.get_package("demo")
+        await pypi.get_package("demo")
+
+    with _patch_fetch(_f) as mock_fetch:
+        asyncio.run(go())
+        mock_fetch.assert_called_once()
 
 
 def test_clear_cache_forces_refetch() -> None:
     payload = _payload(["1.0.0"])
-    with mock.patch(_URLOPEN, side_effect=_urlopen_returning([payload, payload])) as mock_open:
-        pypi.get_package("demo")
+
+    async def _f(session: object, url: str) -> dict[str, Any]:
+        return payload
+
+    with _patch_fetch(_f) as mock_fetch:
+        asyncio.run(pypi.get_package("demo"))
         pypi.clear_cache()
-        pypi.get_package("demo")
-        assert mock_open.call_count == 2
+        asyncio.run(pypi.get_package("demo"))
+        assert mock_fetch.call_count == 2
 
 
 def test_pypi_url_env_var_is_respected(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PYPI_URL", "https://internal-proxy.example/")
     seen: list[str] = []
 
-    def _open(url: str, timeout: float) -> mock.MagicMock:
+    async def _f(session: object, url: str) -> dict[str, Any]:
         seen.append(url)
-        return _success_response(_payload(["1.0.0"]))
+        return _payload(["1.0.0"])
 
-    with mock.patch(_URLOPEN, side_effect=_open):
-        pypi.get_package("demo")
+    with _patch_fetch(_f):
+        asyncio.run(pypi.get_package("demo"))
 
     assert seen == ["https://internal-proxy.example/pypi/demo/json"]
 
 
-def test_404_raises_pypi_error_without_retry() -> None:
-    with mock.patch(_URLOPEN, side_effect=_http_error(404)) as mock_open:
-        with pytest.raises(pypi.PyPIError, match="Package not found"):
-            pypi.get_package("does-not-exist")
-        mock_open.assert_called_once()
-
-
-def test_non_retryable_http_error_raises_immediately() -> None:
-    with mock.patch(_URLOPEN, side_effect=_http_error(401)) as mock_open:
-        with pytest.raises(pypi.PyPIError, match="HTTP 401"):
-            pypi.get_package("demo")
-        mock_open.assert_called_once()
-
-
-@pytest.mark.parametrize("status", [429, 500, 502, 503, 504])
-def test_retries_transient_http_errors_then_succeeds(status: int) -> None:
-    payload = _payload(["1.0.0"])
-    side_effects = [_http_error(status), _http_error(status), _success_response(payload)]
-    with mock.patch(_URLOPEN, side_effect=side_effects) as mock_open:
-        pkg = pypi.get_package("demo")
-        assert mock_open.call_count == 3
-    assert pkg.latest_version == Version("1.0.0")
-
-
-def test_retries_url_errors_then_succeeds() -> None:
-    payload = _payload(["1.0.0"])
-    side_effects: list[Any] = [
-        urllib.error.URLError("dns fail"),
-        ConnectionResetError("reset"),
-        _success_response(payload),
-    ]
-    with mock.patch(_URLOPEN, side_effect=side_effects) as mock_open:
-        pkg = pypi.get_package("demo")
-        assert mock_open.call_count == 3
-    assert pkg.latest_version == Version("1.0.0")
-
-
-def test_retry_exhaustion_raises_pypi_error() -> None:
-    err = urllib.error.URLError("dns fail")
-    with mock.patch(_URLOPEN, side_effect=[err, err, err]) as mock_open:
-        with pytest.raises(pypi.PyPIError, match="after 3 attempts"):
-            pypi.get_package("demo")
-        assert mock_open.call_count == 3
-
-
-def test_unexpected_payload_shape_raises() -> None:
-    list_payload_response = mock.MagicMock(
-        __enter__=mock.MagicMock(return_value=io.BytesIO(json.dumps([1, 2, 3]).encode())),
-        __exit__=mock.MagicMock(return_value=False),
-    )
-    with mock.patch(_URLOPEN, return_value=list_payload_response):
-        with pytest.raises(pypi.PyPIError, match="Unexpected response"):
-            pypi.get_package("demo")
-
-
-def test_aget_package_returns_package() -> None:
-    payload = _payload(["1.0.0"])
-    with mock.patch(_URLOPEN, side_effect=_urlopen_returning([payload])):
-        pkg = asyncio.run(pypi.aget_package("demo"))
-
-    assert isinstance(pkg, pypi.Package)
-    assert pkg.latest_version == Version("1.0.0")
-
-
-def test_aget_packages_preserves_order_and_fetches_each() -> None:
+def test_get_packages_preserves_order_and_fetches_each() -> None:
     names = ["alpha", "beta", "gamma"]
     payloads = {n: _payload([f"{i + 1}.0.0"]) for i, n in enumerate(names)}
     seen: list[str] = []
 
-    def _open(url: str, timeout: float) -> mock.MagicMock:
+    async def _f(session: object, url: str) -> dict[str, Any]:
         for n in names:
             if url.endswith(f"/pypi/{n}/json"):
                 seen.append(n)
-                return _success_response(payloads[n])
+                return payloads[n]
         raise AssertionError(f"unexpected URL: {url}")
 
-    with mock.patch(_URLOPEN, side_effect=_open):
-        pkgs = asyncio.run(pypi.aget_packages(names))
+    with _patch_fetch(_f):
+        pkgs = asyncio.run(pypi.get_packages(names))
 
     expected = [Version("1.0.0"), Version("2.0.0"), Version("3.0.0")]
     assert [p.latest_version for p in pkgs] == expected
     assert sorted(seen) == sorted(names)
+
+
+def test_pypi_error_propagates() -> None:
+    async def _f(session: object, url: str) -> dict[str, Any]:
+        raise pypi.PyPIError(f"Package not found: {url}")
+
+    with _patch_fetch(_f):
+        with pytest.raises(pypi.PyPIError, match="Package not found"):
+            asyncio.run(pypi.get_package("does-not-exist"))

--- a/dev/show_package_release_dates.py
+++ b/dev/show_package_release_dates.py
@@ -3,13 +3,11 @@ import json
 import re
 import subprocess
 import sys
-import traceback
 from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-import aiohttp
-from pydantic import BaseModel
+from pypi import Package, PyPIError, get_package
 
 
 def get_cooldown_days() -> int:
@@ -19,37 +17,15 @@ def get_cooldown_days() -> int:
     raise RuntimeError(f'`exclude-newer = "P<N>D"` not found in {pyproject}')
 
 
-class ReleaseFile(BaseModel):
-    upload_time_iso_8601: str
-
-
-class PyPIResponse(BaseModel):
-    releases: dict[str, list[ReleaseFile]]
-
-
 def get_distributions() -> list[tuple[str, str]]:
     res = subprocess.check_output([sys.executable, "-m", "pip", "list", "--format", "json"])
     return [(pkg["name"], pkg["version"]) for pkg in json.loads(res)]
 
 
-def extract_upload_time(response: PyPIResponse, version: str) -> datetime | None:
-    for f in response.releases.get(version, []):
-        return datetime.fromisoformat(f.upload_time_iso_8601.replace("Z", "+00:00"))
-    return None
-
-
-async def get_release_date(
-    session: aiohttp.ClientSession, package: str, version: str
-) -> datetime | None:
+async def safe_get_package(name: str) -> Package | None:
     try:
-        async with session.get(f"https://pypi.python.org/pypi/{package}/json", timeout=10) as resp:
-            resp.raise_for_status()
-            resp_json = await resp.json()
-            response = PyPIResponse.model_validate(resp_json)
-            return extract_upload_time(response, version)
-
-    except Exception:
-        traceback.print_exc()
+        return await get_package(name)
+    except PyPIError:
         return None
 
 
@@ -67,9 +43,11 @@ def format_age_past_cooldown(release_date: datetime | None, cooldown_days: int) 
 async def main() -> None:
     cooldown_days = get_cooldown_days()
     distributions = get_distributions()
-    async with aiohttp.ClientSession() as session:
-        tasks = [get_release_date(session, pkg, ver) for pkg, ver in distributions]
-        results = await asyncio.gather(*tasks)
+    pkgs = await asyncio.gather(*(safe_get_package(name) for name, _ in distributions))
+    results: list[datetime | None] = [
+        (release.upload_time if (release := pkg.get_release(version)) else None) if pkg else None
+        for pkg, (_, version) in zip(pkgs, distributions)
+    ]
 
     ages = [format_age_past_cooldown(r, cooldown_days) for r in results]
     packages, versions = list(zip(*distributions))

--- a/dev/show_package_release_dates.py
+++ b/dev/show_package_release_dates.py
@@ -7,7 +7,7 @@ from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from pypi import Package, PyPIError, get_package
+from pypi import Package, get_packages
 
 
 def get_cooldown_days() -> int:
@@ -20,13 +20,6 @@ def get_cooldown_days() -> int:
 def get_distributions() -> list[tuple[str, str]]:
     res = subprocess.check_output([sys.executable, "-m", "pip", "list", "--format", "json"])
     return [(pkg["name"], pkg["version"]) for pkg in json.loads(res)]
-
-
-async def safe_get_package(name: str) -> Package | None:
-    try:
-        return await get_package(name)
-    except PyPIError:
-        return None
 
 
 def get_longest_string_length(array: Sequence[str]) -> int:
@@ -43,7 +36,8 @@ def format_age_past_cooldown(release_date: datetime | None, cooldown_days: int) 
 async def main() -> None:
     cooldown_days = get_cooldown_days()
     distributions = get_distributions()
-    pkgs = await asyncio.gather(*(safe_get_package(name) for name, _ in distributions))
+    raw = await get_packages([name for name, _ in distributions], return_exceptions=True)
+    pkgs: list[Package | None] = [r if isinstance(r, Package) else None for r in raw]
     results: list[datetime | None] = [
         (release.upload_time if (release := pkg.get_release(version)) else None) if pkg else None
         for pkg, (_, version) in zip(pkgs, distributions)

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-24T16:07:07.638534Z"
+exclude-newer = "2026-04-25T01:47:11.547752Z"
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
@@ -6869,11 +6869,15 @@ name = "pypi"
 version = "0.1.0"
 source = { editable = "dev/pypi" }
 dependencies = [
+    { name = "aiohttp" },
     { name = "packaging" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "packaging" }]
+requires-dist = [
+    { name = "aiohttp" },
+    { name = "packaging" },
+]
 
 [[package]]
 name = "pyproject-hooks"


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23135

### What changes are proposed in this pull request?

Migrates \`dev/show_package_release_dates.py\` to use the \`dev/pypi\` package, and reshapes \`dev/pypi\` to be async-only with an \`aiohttp\` backend so the show-versions workload (~150 installed packages) keeps the perf the original script had.

- Renames \`aget_package\`/\`aget_packages\` → \`get_package\`/\`get_packages\` (the package is async-only now). Drops the sync urllib path.
- \`get_packages\` opens one shared \`aiohttp.ClientSession\` so HTTP keepalive applies across the whole batch.
- \`show_package_release_dates.py\` drops its local \`aiohttp + pydantic\` plumbing.
- Adds \`aiohttp\` to \`dev/pypi\` deps (already a transitive dep of \`mlflow\` — no new package in the install tree).
- \`.github/actions/show-versions/action.yml\` installs \`./dev/pypi\` (transitively brings \`aiohttp\`) instead of installing \`aiohttp\` directly.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

24 tests pass. End-to-end perf over ~150 installed packages: ~2.5s (matches the original ~2.7s).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] \`area/build\`

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] \`rn/none\`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release