### PR TITLE
Enforce explicit permissions on `actions/create-github-app-token`

### DIFF
--- a/.github/policy.rego
+++ b/.github/policy.rego
@@ -40,6 +40,27 @@ safe_pull_request_target_workflow if {
 	input.name == "UI Preview"
 }
 
+deny_create_app_token_without_permissions contains msg if {
+	some job_id, job in input.jobs
+	some step in job.steps
+	startswith(step.uses, "actions/create-github-app-token@")
+	not step_has_app_token_permissions(step)
+	msg := sprintf(
+		concat("", [
+			"actions/create-github-app-token in job '%s' must explicitly request permissions ",
+			"via 'permission-<name>: <level>' inputs (e.g., permission-contents: write) for ",
+			"least-privilege access. See ",
+			"https://github.com/actions/create-github-app-token#create-a-token-with-specific-permissions",
+		]),
+		[job_id],
+	)
+}
+
+step_has_app_token_permissions(step) if {
+	some key, _ in step["with"]
+	startswith(key, "permission-")
+}
+
 deny_unnecessary_github_token contains msg if {
 	some job in input.jobs
 	some step in job.steps

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -220,6 +220,7 @@ jobs:
           # See https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/managing-private-keys-for-github-apps
           # for how to rotate the private key
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: true

--- a/.github/workflows/remove-experimental-decorators.yml
+++ b/.github/workflows/remove-experimental-decorators.yml
@@ -27,6 +27,8 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -139,6 +139,8 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: read
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -47,6 +47,8 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: read
+          permission-pull-requests: write
       - name: React to comment
         if: github.event_name == 'issue_comment'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0

--- a/.github/workflows/update-model-catalog.yml
+++ b/.github/workflows/update-model-catalog.yml
@@ -24,6 +24,8 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/uv.yml
+++ b/.github/workflows/uv.yml
@@ -37,6 +37,8 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: true


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

Adds a `policy.rego` rule that flags `actions/create-github-app-token` steps without explicit `permission-*` inputs, and sets least-privilege permissions on each existing usage. This enforces that every app-token issuance scopes itself down from the installation defaults, per the action's [recommendation](https://github.com/actions/create-github-app-token#create-a-token-with-specific-permissions).

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Verified locally with `bin/conftest test --namespace mlflow --policy .github/policy.rego .github/workflows/*.yml` (1980/1980 pass).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release