### PR TITLE
Ignore `rerun.yml` runs in the `protect` merge gate

### DIFF
--- a/.github/workflows/protect.js
+++ b/.github/workflows/protect.js
@@ -19,6 +19,8 @@ module.exports = async ({ github, context }) => {
     failure: "failure",
   };
 
+  const IGNORED_WORKFLOWS = new Set([".github/workflows/rerun.yml"]);
+
   async function sleep(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
@@ -96,7 +98,8 @@ module.exports = async ({ github, context }) => {
         // Exclude this workflow to avoid self-checking
         path !== ".github/workflows/protect.yml" &&
         // Exclude dynamic workflows (GitHub-managed, e.g., Copilot code review)
-        event !== "dynamic"
+        event !== "dynamic" &&
+        !IGNORED_WORKFLOWS.has(path)
     );
 
     // Deduplicate workflow runs by path and event, keeping the latest attempt


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

Adds an `IGNORED_WORKFLOWS` allowlist to `protect.js` and excludes `rerun.yml` from it.

**What happened on #23141:** the `protect` job failed because a `rerun.yml` run was stuck in `action_required`. Two `rerun.yml` runs were queued — the first by `mlflow-app[bot]`'s approving review (auto-approved by `post-review` and ran successfully), the second by Copilot's `COMMENTED` review (no auto-approval path exists for non-`/review` events, so it sat in `action_required`).

**Why this is needed:** in `protect.js`, anything that isn't `success`/`skipped`/`cancelled-as-failure` is mapped to `failure`, so `action_required` flips the merge gate red. `rerun.yml` is a utility workflow that re-triggers other jobs — it's not load-bearing for merge correctness, so it shouldn't block the gate when it's waiting on approval.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

The same scenario — Copilot reviewing a PR after `mlflow-app` approves — will reproduce the original failure on `master`. With this change, `protect` ignores the queued `rerun.yml` run and continues.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name=\"release-note-category\"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the \"Small Bugfixes and Documentation Updates\" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release