### PR TITLE
Add artifact_path support for logged model artifacts

### DIFF
--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -913,11 +913,24 @@ class TrackingServiceClient:
     def delete_logged_model_tag(self, model_id: str, key: str) -> None:
         return self.store.delete_logged_model_tag(model_id, key)
 
-    def log_model_artifact(self, model_id: str, local_path: str) -> None:
-        self._get_artifact_repo(model_id, resource="logged_model").log_artifact(local_path)
+    def log_model_artifact(
+        self,
+        model_id: str,
+        local_path: str,
+        artifact_path: str | None = None,
+    ) -> None:
+        self._get_artifact_repo(
+            model_id,
+            resource="logged_model",
+        ).log_artifact(local_path, artifact_path)
 
-    def log_model_artifacts(self, model_id: str, local_dir: str) -> None:
-        self._get_artifact_repo(model_id, resource="logged_model").log_artifacts(local_dir)
+    def log_model_artifacts(
+        self,
+        model_id: str,
+        local_dir: str,
+        artifact_path: str | None = None,
+    ) -> None:
+        self._get_artifact_repo(model_id, resource="logged_model").log_artifacts(local_dir, artifact_path)
 
     def search_logged_models(
         self,

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -5907,31 +5907,51 @@ class MlflowClient:
         _validate_model_id_specified(model_id)
         return self._tracking_client.delete_logged_model_tag(model_id, key)
 
-    def log_model_artifact(self, model_id: str, local_path: str) -> None:
+    def log_model_artifact(
+        self,
+        model_id: str,
+        local_path: str,
+        artifact_path: str | None = None,
+    ) -> None:
         """
         Upload an artifact to the specified logged model.
 
         Args:
             model_id: ID of the model.
             local_path: Local path to the artifact to upload.
+            artifact_path: Optional artifact path within the model's artifacts.
 
         Returns:
             None
         """
-        return self._tracking_client.log_model_artifact(model_id, local_path)
+        return self._tracking_client.log_model_artifact(
+            model_id,
+            local_path,
+            artifact_path,
+        )
 
-    def log_model_artifacts(self, model_id: str, local_dir: str) -> None:
+    def log_model_artifacts(
+        self,
+        model_id: str,
+        local_dir: str,
+        artifact_path: str | None = None,
+    ) -> None:
         """
         Upload a set of artifacts to the specified logged model.
 
         Args:
             model_id: ID of the model.
             local_dir: Local directory containing the artifacts to upload.
+            artifact_path: Optional artifact path within the model's artifacts.
 
         Returns:
             None
         """
-        return self._tracking_client.log_model_artifacts(model_id, local_dir)
+        return self._tracking_client.log_model_artifacts(
+            model_id,
+            local_dir,
+            artifact_path,
+        )
 
     def search_logged_models(
         self,

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -2759,45 +2759,97 @@ def test_log_model_artifact(tmp_path: Path, tracking_uri: str) -> None:
     client = MlflowClient(tracking_uri=tracking_uri)
     experiment_id = client.create_experiment("test")
     model = client.create_logged_model(experiment_id=experiment_id)
+
     tmp_path = tmp_path.joinpath("artifacts")
     tmp_path.mkdir()
+
     tmp_file = tmp_path.joinpath("file")
     tmp_file.write_text("a")
-    client.log_model_artifact(model_id=model.model_id, local_path=str(tmp_file))
+
+    client.log_model_artifact(
+        model_id=model.model_id,
+        local_path=str(tmp_file),
+        artifact_path="subdir",
+    )
+
     artifacts = client.list_logged_model_artifacts(model_id=model.model_id)
-    assert artifacts == [FileInfo(path="file", is_dir=False, file_size=1)]
+    assert artifacts == [FileInfo(path="subdir", is_dir=True, file_size=None)]
+
+    artifacts = client.list_logged_model_artifacts(
+        model_id=model.model_id,
+        path="subdir",
+    )
+    assert artifacts == [
+        FileInfo(path="subdir/file", is_dir=False, file_size=1)
+    ]
+
     another_tmp_file = tmp_path.joinpath("another_file")
     another_tmp_file.write_text("aa")
-    client.log_model_artifact(model_id=model.model_id, local_path=str(another_tmp_file))
+
+    client.log_model_artifact(
+        model_id=model.model_id,
+        local_path=str(another_tmp_file),
+    )
+
     artifacts = client.list_logged_model_artifacts(model_id=model.model_id)
     artifacts = sorted(artifacts, key=lambda x: x.path)
+
     assert artifacts == [
         FileInfo(path="another_file", is_dir=False, file_size=2),
-        FileInfo(path="file", is_dir=False, file_size=1),
+        FileInfo(path="subdir", is_dir=True, file_size=None),
     ]
 
 
 def test_log_model_artifacts(tmp_path: Path, tracking_uri: str) -> None:
     client = MlflowClient(tracking_uri=tracking_uri)
+
     experiment_id = client.create_experiment("test")
     model = client.create_logged_model(experiment_id=experiment_id)
+
     tmp_path = tmp_path.joinpath("artifacts")
     tmp_path.mkdir()
+
     tmp_file = tmp_path.joinpath("file")
     tmp_file.write_text("a")
+
     tmp_dir = tmp_path.joinpath("dir")
     tmp_dir.mkdir()
+
     another_file = tmp_dir.joinpath("another_file")
     another_file.write_text("aa")
-    client.log_model_artifacts(model_id=model.model_id, local_dir=str(tmp_path))
+
+    client.log_model_artifacts(
+        model_id=model.model_id,
+        local_dir=str(tmp_path),
+        artifact_path="subdir",
+    )
+
     artifacts = client.list_logged_model_artifacts(model_id=model.model_id)
-    artifacts = sorted(artifacts, key=lambda x: x.path)
+
     assert artifacts == [
-        FileInfo(path="dir", is_dir=True, file_size=None),
-        FileInfo(path="file", is_dir=False, file_size=1),
+        FileInfo(path="subdir", is_dir=True, file_size=None),
     ]
-    artifacts = client.list_logged_model_artifacts(model_id=model.model_id, path="dir")
-    assert artifacts == [FileInfo(path="dir/another_file", is_dir=False, file_size=2)]
+
+    artifacts = client.list_logged_model_artifacts(
+        model_id=model.model_id,
+        path="subdir",
+    )
+
+    artifacts = sorted(artifacts, key=lambda x: x.path)
+
+    assert artifacts == [
+        FileInfo(path="subdir/dir", is_dir=True, file_size=None),
+        FileInfo(path="subdir/file", is_dir=False, file_size=1),
+    ]
+
+    artifacts = client.list_logged_model_artifacts(
+        model_id=model.model_id,
+        path="subdir/dir",
+    )
+
+    assert artifacts == [
+        FileInfo(path="subdir/dir/another_file", is_dir=False, file_size=2)
+    ]
 
 
 def test_logged_model_model_id_required(tracking_uri):


### PR DESCRIPTION
## Related Issues/PRs

Fixes #23081

## What changes are proposed in this pull request?

Adds optional `artifact_path` support to:

* `log_model_artifact`
* `log_model_artifacts`

This makes the logged model artifact APIs consistent with the existing run artifact logging APIs.

Changes made:

* Added optional `artifact_path` parameter to public tracking client APIs
* Passed `artifact_path` through tracking service client
* Added tests covering artifact uploads into subdirectories

## How is this patch tested?

Ran targeted tracking client tests:

```bash
pytest tests/tracking/test_client.py -k "log_model_artifact or log_model_artifacts" -q
```

Result:

```text
2 passed, 2 skipped
```

## Does this PR require documentation updates?

No.

## Have you signed off your commit electronically?

Yes.
