### PR TITLE
Migrate `update_ml_package_versions.py` to `dev/pypi`

### DIFF
--- a/dev/tests/test_update_ml_package_versions.py
+++ b/dev/tests/test_update_ml_package_versions.py
@@ -51,9 +51,10 @@ def run_test(src, src_expected, mock_packages):
 
     with (
         mock.patch("dev.update_ml_package_versions.get_packages", new=fake_get_packages),
-        mock.patch("dev.update_ml_package_versions.check_pypi_accessibility"),
+        mock.patch("dev.update_ml_package_versions.check_pypi_accessibility") as mock_check,
     ):
         update_ml_package_versions.update()
+        mock_check.assert_called_once()
 
     assert versions_yaml.read_text() == src_expected
 

--- a/dev/tests/test_update_ml_package_versions.py
+++ b/dev/tests/test_update_ml_package_versions.py
@@ -1,55 +1,35 @@
-import json
-import re
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest import mock
 
 import pytest
+from pypi import Package
 
 from dev import update_ml_package_versions
 from dev.update_ml_package_versions import VersionInfo
 
 
-class MockResponse:
-    def __init__(self, body):
-        self.body = json.dumps(body).encode("utf-8")
+def _iso8601(dt: datetime) -> str:
+    return (dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)).isoformat()
 
-    def read(self):
-        return self.body
 
-    def __enter__(self):
-        return self
+def package_from_version_infos(version_infos: list[VersionInfo]) -> Package:
+    return Package.from_json({
+        "releases": {
+            v.version: [
+                {
+                    "filename": v.version + ".whl",
+                    "upload_time_iso_8601": _iso8601(v.upload_time),
+                }
+            ]
+            for v in version_infos
+        },
+    })
 
-    def __exit__(self, exc_type, exc_value, traceback):
-        pass
 
-    @classmethod
-    def from_versions(cls, versions):
-        return cls({
-            "releases": {
-                v: [
-                    {
-                        "filename": v + ".whl",
-                        "upload_time": "2023-10-04T16:38:57",
-                    }
-                ]
-                for v in versions
-            }
-        })
-
-    @classmethod
-    def from_version_infos(cls, version_infos: list[VersionInfo]) -> "MockResponse":
-        return cls({
-            "releases": {
-                v.version: [
-                    {
-                        "filename": v.version + ".whl",
-                        "upload_time": v.upload_time.isoformat(),
-                    }
-                ]
-                for v in version_infos
-            }
-        })
+def package_from_versions(versions: list[str]) -> Package:
+    fixed = datetime(2023, 10, 4, 16, 38, 57, tzinfo=timezone.utc)
+    return package_from_version_infos([VersionInfo(v, fixed) for v in versions])
 
 
 @pytest.fixture(autouse=True)
@@ -61,18 +41,18 @@ def change_working_directory(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
 
-def run_test(src, src_expected, mock_responses):
-    def patch_urlopen(url, **kwargs):
-        match = re.search(r"/pypi/(.+)/json", url)
-        if not match:
-            return MockResponse({"status": "ok"})
-        return mock_responses[match.group(1)]
+def run_test(src, src_expected, mock_packages):
+    async def fake_get_packages(names):
+        return [mock_packages[n] for n in names]
 
     versions_yaml = Path("mlflow/ml-package-versions.yml")
     versions_yaml.parent.mkdir()
     versions_yaml.write_text(src)
 
-    with mock.patch("urllib.request.urlopen", new=patch_urlopen):
+    with (
+        mock.patch("dev.update_ml_package_versions.get_packages", new=fake_get_packages),
+        mock.patch("dev.update_ml_package_versions.check_pypi_accessibility"),
+    ):
         update_ml_package_versions.update()
 
     assert versions_yaml.read_text() == src_expected
@@ -91,9 +71,9 @@ xgboost:
   autologging:
     maximum: "0.1.1"
 """
-    mock_responses = {
-        "sklearn": MockResponse.from_versions(["0.0.2"]),
-        "xgboost": MockResponse.from_versions(["0.1.2"]),
+    mock_packages = {
+        "sklearn": package_from_versions(["0.0.2"]),
+        "xgboost": package_from_versions(["0.1.2"]),
     }
     src_expected = """
 sklearn:
@@ -107,7 +87,7 @@ xgboost:
   autologging:
     maximum: "0.1.2"
 """
-    run_test(src, src_expected, mock_responses)
+    run_test(src, src_expected, mock_packages)
 
 
 def test_both_models_and_autologging_are_updated():
@@ -120,8 +100,8 @@ sklearn:
   autologging:
     maximum: "0.0.1"
 """
-    mock_responses = {
-        "sklearn": MockResponse.from_versions(["0.0.2"]),
+    mock_packages = {
+        "sklearn": package_from_versions(["0.0.2"]),
     }
     src_expected = """
 sklearn:
@@ -132,7 +112,7 @@ sklearn:
   autologging:
     maximum: "0.0.2"
 """
-    run_test(src, src_expected, mock_responses)
+    run_test(src, src_expected, mock_packages)
 
 
 def test_pre_and_dev_versions_are_ignored():
@@ -143,8 +123,8 @@ sklearn:
   autologging:
     maximum: "0.0.1"
 """
-    mock_responses = {
-        "sklearn": MockResponse.from_versions([
+    mock_packages = {
+        "sklearn": package_from_versions([
             # pre-release and dev-release should be filtered out
             "0.0.3.rc1",  # pre-release
             "0.0.3.dev1",  # dev-release
@@ -157,9 +137,9 @@ sklearn:
   package_info:
     pip_release: sklearn
   autologging:
-    maximum: "0.0.2.post"
+    maximum: "0.0.2.post0"
 """
-    run_test(src, src_expected, mock_responses)
+    run_test(src, src_expected, mock_packages)
 
 
 def test_unsupported_versions_are_ignored():
@@ -171,7 +151,7 @@ sklearn:
     unsupported: ["0.0.3"]
     maximum: "0.0.1"
 """
-    mock_responses = {"sklearn": MockResponse.from_versions(["0.0.2", "0.0.3"])}
+    mock_packages = {"sklearn": package_from_versions(["0.0.2", "0.0.3"])}
     src_expected = """
 sklearn:
   package_info:
@@ -180,7 +160,7 @@ sklearn:
     unsupported: ["0.0.3"]
     maximum: "0.0.2"
 """
-    run_test(src, src_expected, mock_responses)
+    run_test(src, src_expected, mock_packages)
 
 
 def test_freeze_field_prevents_updating_maximum_version():
@@ -192,7 +172,7 @@ sklearn:
     pin_maximum: True
     maximum: "0.0.1"
 """
-    mock_responses = {"sklearn": MockResponse.from_versions(["0.0.2"])}
+    mock_packages = {"sklearn": package_from_versions(["0.0.2"])}
     src_expected = """
 sklearn:
   package_info:
@@ -201,7 +181,7 @@ sklearn:
     pin_maximum: True
     maximum: "0.0.1"
 """
-    run_test(src, src_expected, mock_responses)
+    run_test(src, src_expected, mock_packages)
 
 
 def test_update_min_supported_version():
@@ -213,8 +193,8 @@ sklearn:
     minimum: "0.0.1"
     maximum: "0.0.8"
 """
-    mock_responses = {
-        "sklearn": MockResponse.from_version_infos([
+    mock_packages = {
+        "sklearn": package_from_version_infos([
             VersionInfo("0.0.2", datetime.now() - timedelta(days=1000)),
             VersionInfo("0.0.3", datetime.now() - timedelta(days=365)),
             VersionInfo("0.0.8", datetime.now() - timedelta(days=180)),
@@ -228,7 +208,7 @@ sklearn:
     minimum: "0.0.3"
     maximum: "0.0.8"
 """
-    run_test(src, src_expected, mock_responses)
+    run_test(src, src_expected, mock_packages)
 
 
 def test_update_min_supported_version_for_dead_package():
@@ -240,8 +220,8 @@ sklearn:
     minimum: "0.0.7"
     maximum: "0.0.8"
 """
-    mock_responses = {
-        "sklearn": MockResponse.from_version_infos([
+    mock_packages = {
+        "sklearn": package_from_version_infos([
             VersionInfo("0.0.7", datetime.now() - timedelta(days=1000)),
             VersionInfo("0.0.8", datetime.now() - timedelta(days=800)),
         ])
@@ -254,4 +234,4 @@ sklearn:
     minimum: "0.0.8"
     maximum: "0.0.8"
 """
-    run_test(src, src_expected, mock_responses)
+    run_test(src, src_expected, mock_packages)

--- a/dev/update_ml_package_versions.py
+++ b/dev/update_ml_package_versions.py
@@ -9,11 +9,10 @@ $ python dev/update_ml_package_versions.py
 """
 
 import argparse
+import asyncio
 import json
 import os
 import re
-import sys
-import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
@@ -22,6 +21,7 @@ from pathlib import Path
 
 import yaml
 from packaging.version import Version
+from pypi import Package, get_packages
 
 
 def read_file(path):
@@ -55,43 +55,15 @@ class VersionInfo:
     upload_time: datetime
 
 
-def get_package_version_infos(package_name: str) -> list[VersionInfo]:
-    url = f"{PYPI_URL}/pypi/{package_name}/json"
-    for _ in range(5):  # Retry up to 5 times
-        try:
-            with urllib.request.urlopen(url) as res:
-                data = json.load(res)
-        except ConnectionResetError as e:
-            sys.stderr.write(f"Retrying {url} due to {e}\n")
-            time.sleep(1)
-        else:
-            break
-    else:
-        raise Exception(f"Failed to fetch {url}")
-
-    def is_dev_or_pre_release(version_str):
-        v = Version(version_str)
-        return v.is_devrelease or v.is_prerelease
-
+def get_package_version_infos(package: Package) -> list[VersionInfo]:
     cutoff = datetime.now(timezone.utc) - timedelta(days=RELEASE_CUTOFF_DAYS)
-
-    def uploaded_within_cutoff(dist) -> bool:
-        if ut := dist.get("upload_time_iso_8601"):
-            return datetime.fromisoformat(ut.replace("Z", "+00:00")) >= cutoff
-        return False
-
     return [
-        VersionInfo(
-            version=version,
-            upload_time=datetime.fromisoformat(dist_files[0]["upload_time"]),
-        )
-        for version, dist_files in data["releases"].items()
-        if (
-            len(dist_files) > 0
-            and not is_dev_or_pre_release(version)
-            and not any(uploaded_within_cutoff(dist) for dist in dist_files)
-            and not any(dist.get("yanked", False) for dist in dist_files)
-        )
+        VersionInfo(version=str(r.version), upload_time=r.upload_time)
+        for r in package.releases
+        if not r.yanked
+        and not r.version.is_devrelease
+        and not r.version.is_prerelease
+        and r.upload_time < cutoff
     ]
 
 
@@ -265,8 +237,7 @@ def get_min_supported_version(versions_infos: list[VersionInfo], genai: bool = F
     Get the minimum version that is released within the past two years
     """
     years = 1 if genai else 2
-    min_support_date = datetime.now() - timedelta(days=years * 365)
-    min_support_date = min_support_date.replace(tzinfo=None)
+    min_support_date = datetime.now(timezone.utc) - timedelta(days=years * 365)
 
     # Extract versions that were released in the past two years
     recent_versions = [v for v in versions_infos if v.upload_time > min_support_date]
@@ -287,13 +258,14 @@ def update(skip_yml=False):
         old_src = read_file(yml_path)
         new_src = old_src
         config_dict = yaml.load(old_src, Loader=yaml.SafeLoader)
-        for flavor_key, config in config_dict.items():
-            # We currently don't have bandwidth to support newer versions of these flavors.
-            if flavor_key in ["litellm"]:
-                continue
+        # We currently don't have bandwidth to support newer versions of these flavors.
+        flavors = [(k, c) for k, c in config_dict.items() if k not in ["litellm"]]
+        package_names = sorted({c["package_info"]["pip_release"] for _, c in flavors})
+        packages = dict(zip(package_names, asyncio.run(get_packages(package_names))))
+        for flavor_key, config in flavors:
             package_name = config["package_info"]["pip_release"]
             genai = config["package_info"].get("genai", False)
-            versions_and_upload_times = get_package_version_infos(package_name)
+            versions_and_upload_times = get_package_version_infos(packages[package_name])
             min_supported_version = get_min_supported_version(
                 versions_and_upload_times, genai=genai
             )

--- a/dev/update_ml_package_versions.py
+++ b/dev/update_ml_package_versions.py
@@ -234,7 +234,7 @@ def parse_args():
 
 def get_min_supported_version(versions_infos: list[VersionInfo], genai: bool = False) -> str | None:
     """
-    Get the minimum version that is released within the past two years
+    Get the minimum version that is released within the past 1 year (genai) or 2 years (non-genai).
     """
     years = 1 if genai else 2
     min_support_date = datetime.now(timezone.utc) - timedelta(days=years * 365)


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23143, #23140

### What changes are proposed in this pull request?

Migrate `dev/update_ml_package_versions.py` to use the shared `dev/pypi` async client (introduced in #23140 and #23143) for fetching package metadata.

- Replaced the per-package `urllib.request.urlopen` retry loop with a single batched `asyncio.run(get_packages(...))` call before the flavor loop, so all 40 packages are fetched concurrently.
- Reshaped `get_package_version_infos` to take a `Package` and lean on the typed `Release` model (yanked / pre-release / dev-release / cutoff filtering).
- Fixed a latent bug in `get_min_supported_version`: it now uses tz-aware UTC consistently instead of comparing naive local time against naive UTC upload times.
- Updated tests to mock `dev.update_ml_package_versions.get_packages` (returning `Package` instances built via `Package.from_json`) and stub `check_pypi_accessibility`.

**Performance** (real PyPI, 40 packages, full run with `mlflow/ml-package-versions.yml` write):

- Before (serial `urlopen`): ~10.85 s
- After (concurrent `aiohttp`): ~1.25 s
- ~8.7× faster

**Behavior changes** (intentional, mirroring the `set_matrix.py` migration):

- The 14-day freshness cutoff now compares against the earliest dist upload of a release rather than excluding any release with any recent dist.
- Versions are returned in their PEP 440 normalized form (e.g., `0.0.2.post` -> `0.0.2.post0`).

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Manual: ran the migrated script end-to-end against real PyPI; verified the resulting `mlflow/ml-package-versions.yml` / `mlflow/ml_package_versions.py` differ from the original only at expected boundary versions caused by the UTC fix and the new cutoff semantics.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release