### PR TITLE
Migrate `update_requirements.py` to `dev/pypi`

### DIFF
--- a/dev/update_requirements.py
+++ b/dev/update_requirements.py
@@ -3,13 +3,15 @@ This script updates the `max_major_version` attribute of each package in a YAML 
 specification (e.g. requirements/core-requirements.yaml) to the maximum available version on PyPI.
 """
 
+import asyncio
 import os
 import re
+import urllib.error
+import urllib.request
 from datetime import datetime, timedelta, timezone
 
-import requests
 import yaml
-from packaging.version import InvalidVersion, Version
+from pypi import Package, get_packages
 
 PACKAGE_NAMES = ["tracing", "skinny", "core", "gateway"]
 RELEASE_CUTOFF_DAYS = 14
@@ -18,46 +20,25 @@ PYPI_URL = os.environ.get("PYPI_URL", "https://pypi.org").rstrip("/")
 
 def check_pypi_accessibility() -> None:
     try:
-        response = requests.head(PYPI_URL, timeout=5)
-        response.raise_for_status()
-    except requests.exceptions.RequestException:
+        with urllib.request.urlopen(PYPI_URL, timeout=5):
+            pass
+    except (urllib.error.URLError, OSError):
         raise SystemExit(
             f"Error: Cannot connect to {PYPI_URL}. "
             "If it's not accessible, set the PYPI_URL environment variable to a PyPI proxy URL."
         )
 
 
-def get_latest_major_version(package_name: str) -> int | None:
-    url = f"{PYPI_URL}/pypi/{package_name}/json"
-    response = requests.get(url)
-    response.raise_for_status()
-    data = response.json()
+def get_latest_major_version(package: Package) -> int | None:
     cutoff = datetime.now(tz=timezone.utc) - timedelta(days=RELEASE_CUTOFF_DAYS)
-    versions = []
-    for version, distributions in data["releases"].items():
-        if len(distributions) == 0 or any(d.get("yanked", False) for d in distributions):
-            continue
-
-        upload_times = [
-            datetime.fromisoformat(ut.replace("Z", "+00:00"))
-            for dist in distributions
-            if (ut := dist.get("upload_time_iso_8601"))
-        ]
-        release_date = min(upload_times) if upload_times else None
-        if not release_date or release_date >= cutoff:
-            continue
-
-        try:
-            version = Version(version)
-        except InvalidVersion:
-            # Ignore invalid versions such as https://pypi.org/project/pytz/2004d
-            continue
-
-        if version.is_devrelease or version.is_prerelease:
-            continue
-
-        versions.append(version)
-
+    versions = [
+        r.version
+        for r in package.releases
+        if not r.yanked
+        and not r.version.is_devrelease
+        and not r.version.is_prerelease
+        and r.upload_time < cutoff
+    ]
     return max(versions).major if versions else None
 
 
@@ -81,21 +62,33 @@ def update_max_major_version(raw: str, key: str, old_value: int, new_value: int)
 
 def main() -> None:
     check_pypi_accessibility()
+
+    file_to_requirements = {}
+    file_to_src = {}
+    pip_releases: set[str] = set()
     for package_name in PACKAGE_NAMES:
         req_file_path = os.path.join("requirements", package_name + "-requirements.yaml")
         with open(req_file_path) as f:
             requirements_src = f.read()
-
         requirements = yaml.safe_load(requirements_src)
-        updated_src = requirements_src
-        changes_made = False
+        file_to_requirements[req_file_path] = requirements
+        file_to_src[req_file_path] = requirements_src
+        for req_info in requirements.values():
+            if not req_info.get("freeze", False):
+                pip_releases.add(req_info["pip_release"])
 
+    sorted_releases = sorted(pip_releases)
+    packages = dict(zip(sorted_releases, asyncio.run(get_packages(sorted_releases))))
+
+    for req_file_path, requirements in file_to_requirements.items():
+        updated_src = file_to_src[req_file_path]
+        changes_made = False
         for key, req_info in requirements.items():
             pip_release = req_info["pip_release"]
             max_major_version = req_info["max_major_version"]
             if req_info.get("freeze", False):
                 continue
-            latest_major_version = get_latest_major_version(pip_release)
+            latest_major_version = get_latest_major_version(packages[pip_release])
             if latest_major_version is None:
                 print(f"Skipping {key}: no releases older than {RELEASE_CUTOFF_DAYS}d found")
                 continue


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23148

### What changes are proposed in this pull request?

Migrate `dev/update_requirements.py` to use the `dev/pypi` package instead of calling `requests` directly, following the precedent set by #23148, #23143, and #23140.

- Drops the `requests` dependency in favor of `urllib.request` for the connectivity check (matching `dev/update_ml_package_versions.py`).
- Replaces per-package sequential `requests.get(...)` calls with a single `asyncio.run(get_packages(...))` batched fetch over all unique `pip_release` names across the four requirement YAMLs.
- Reuses `pypi.Package` model parsing (handles invalid versions, missing distributions, and upload-time normalization), so the per-version filtering logic in `get_latest_major_version` collapses to a list comprehension over `package.releases`.

End-to-end timing on master, three iterations each via `uv run --frozen python dev/update_requirements.py`:

| version | run 1 | run 2 | run 3 | mean |
|---|---|---|---|---|
| before (sequential `requests`)  | 6.38s | 6.26s | 6.50s | 6.38s |
| after  (concurrent `pypi`)      | 1.27s | 1.22s | 1.40s | 1.30s |

Both versions produced the same set of bumps on the current YAMLs (`starlette` -> 1, `pandas` -> 3, `cryptography` -> 47, `pyarrow` -> 24, `huey` -> 3), confirming behavioral equivalence.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Ran the migrated script locally against `pypi.org` and confirmed identical output to the pre-migration version on the same checkout.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release