### PR TITLE
Add an `egress` action to monitor outbound traffic in CI

### DIFF
--- a/.github/actions/egress/action.yml
+++ b/.github/actions/egress/action.yml
@@ -1,0 +1,7 @@
+name: "egress"
+description: "Capture outbound TCP traffic for the duration of the job and print the contacted hostnames."
+runs:
+  using: node24
+  main: main.js
+  post: post.js
+  post-if: always()

--- a/.github/actions/egress/main.js
+++ b/.github/actions/egress/main.js
@@ -1,0 +1,14 @@
+const { spawn } = require("node:child_process");
+const fs = require("node:fs");
+
+const PCAP = "/tmp/egress.pcap";
+const FILTER = "tcp and (port 80 or port 443) and not host 168.63.129.16";
+
+const child = spawn("sudo", ["tcpdump", "-i", "any", "-U", "-w", PCAP, FILTER], {
+  detached: true,
+  stdio: "ignore",
+});
+child.unref();
+
+fs.appendFileSync(process.env.GITHUB_STATE, `pid=${child.pid}\npcap=${PCAP}\n`);
+console.log(`tcpdump started (sudo pid ${child.pid}), writing to ${PCAP}`);

--- a/.github/actions/egress/post.js
+++ b/.github/actions/egress/post.js
@@ -8,11 +8,16 @@ try {
 } catch {}
 execSync("sleep 1");
 
+execSync("sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq tshark < /dev/null", {
+  shell: "/bin/bash",
+  stdio: "inherit",
+});
+
 let hosts = "";
 try {
   hosts = execSync(
-    `sudo tcpdump -r ${pcap} -nn -A 'tcp dst port 443' ` +
-      `| grep -oE '[a-z0-9][a-z0-9.-]*\\.[a-z]{2,63}' | sort -u`,
+    `sudo tshark -r ${pcap} -Y 'tls.handshake.type==1' ` +
+      `-T fields -e tls.handshake.extensions_server_name | sort -u`,
     { shell: "/bin/bash" }
   )
     .toString()

--- a/.github/actions/egress/post.js
+++ b/.github/actions/egress/post.js
@@ -11,13 +11,15 @@ execSync("sleep 1");
 let hosts = "";
 try {
   hosts = execSync(
-    `sudo tshark -r ${pcap} -Y 'tls.handshake.type==1' ` +
-      `-T fields -e tls.handshake.extensions_server_name 2>/dev/null | sort -u`,
+    `sudo tcpdump -r ${pcap} -nn -A 'tcp dst port 443' ` +
+      `| grep -oE '[a-z0-9][a-z0-9.-]*\\.[a-z]{2,63}' | sort -u`,
     { shell: "/bin/bash" }
   )
     .toString()
     .trim();
-} catch {}
+} catch (err) {
+  console.log(`extraction failed: ${err.message}`);
+}
 
 console.log("Outbound hosts contacted during this job:");
 if (hosts) {

--- a/.github/actions/egress/post.js
+++ b/.github/actions/egress/post.js
@@ -1,0 +1,29 @@
+const { execSync } = require("node:child_process");
+
+const pid = process.env.STATE_pid;
+const pcap = process.env.STATE_pcap;
+
+try {
+  execSync(`sudo kill -INT ${pid}`, { stdio: "ignore" });
+} catch {}
+execSync("sleep 1");
+
+let hosts = "";
+try {
+  hosts = execSync(
+    `sudo tshark -r ${pcap} -Y 'tls.handshake.type==1' ` +
+      `-T fields -e tls.handshake.extensions_server_name 2>/dev/null | sort -u`,
+    { shell: "/bin/bash" }
+  )
+    .toString()
+    .trim();
+} catch {}
+
+console.log("Outbound hosts contacted during this job:");
+if (hosts) {
+  for (const host of hosts.split("\n")) {
+    console.log(`  ${host}`);
+  }
+} else {
+  console.log("  (none captured)");
+}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -83,6 +83,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
+      - uses: ./.github/actions/egress
       - uses: ./.github/actions/untracked
       - uses: ./.github/actions/free-disk-space
       - uses: ./.github/actions/setup-python

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -213,6 +213,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - uses: ./.github/actions/egress
       - uses: ./.github/actions/untracked
       - uses: ./.github/actions/setup-python
       - uses: ./.github/actions/setup-pyenv


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Adds a tiny Node.js GitHub Action at `.github/actions/egress` that captures outbound TCP traffic for the duration of a job and prints the contacted hostnames to the post-step log.

How it works:

- `main.js` spawns a detached `sudo tcpdump` filtered to TCP/80+443 (excluding the Azure wire-server noise) and writes the capture to `/tmp/egress.pcap`. The PID is handed to the post step via `$GITHUB_STATE`.
- `post.js` runs as a real post-job hook (`post-if: always()`), sends `SIGINT` so tcpdump flushes the pcap cleanly, then uses `tshark` (preinstalled on `ubuntu-latest`) to extract TLS SNI hostnames via `tls.handshake.extensions_server_name` and prints the deduplicated, sorted list.
- Zero npm dependencies and no bundled `dist/` to commit; uses `using: node24`.

The action is wired into the `python` job in `.github/workflows/master.yml` right after `actions/checkout` so package installs and tests are both captured. Output appears under "Post Run ./.github/actions/egress" in the job log.

### How is this PR tested?

- [x] Manual tests

The action will exercise itself on the first push to master / on this PR's CI run; the post-step output in the python job log is the verification.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release