### PR TITLE
Fix ended `LiveSpan` state mutation

### DIFF
--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -755,6 +755,7 @@ class LiveSpan(Span):
         from mlflow.environment_variables import MLFLOW_TRACE_MAX_ATTACHMENT_SIZE
 
         if not self._is_recording():
+            _logger.debug("Skipping attachment storage because the span is no longer recording.")
             return attachment.ref(self.trace_id)
 
         max_size = MLFLOW_TRACE_MAX_ATTACHMENT_SIZE.get()
@@ -1003,6 +1004,7 @@ class LiveSpan(Span):
                 :py:class:`Link <mlflow.entities.Link>` object.
         """
         if not self._is_recording():
+            _logger.debug("Skipping link addition because the span is no longer recording.")
             return
 
         if not isinstance(link, Link):

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -689,6 +689,9 @@ class LiveSpan(Span):
         normalized = SpanLogLevel.from_value(level)
         self.set_attribute(SpanAttributeKey.LOG_LEVEL, int(normalized))
 
+    def _is_recording(self) -> bool:
+        return self._span.is_recording()
+
     def set_inputs(self, inputs: Any):
         """Set the input values to the span."""
         extract_base64 = self._should_extract_base64()
@@ -750,6 +753,9 @@ class LiveSpan(Span):
 
     def _store_attachment(self, attachment: Attachment) -> str:
         from mlflow.environment_variables import MLFLOW_TRACE_MAX_ATTACHMENT_SIZE
+
+        if not self._is_recording():
+            return attachment.ref(self.trace_id)
 
         max_size = MLFLOW_TRACE_MAX_ATTACHMENT_SIZE.get()
         if max_size is not None and max_size > 0 and len(attachment.content_bytes) > max_size:
@@ -996,6 +1002,9 @@ class LiveSpan(Span):
             link: The link to add to the span. This should be a
                 :py:class:`Link <mlflow.entities.Link>` object.
         """
+        if not self._is_recording():
+            return
+
         if not isinstance(link, Link):
             raise MlflowException(
                 f"The `link` parameter must be a Link instance, but got {type(link)}.",

--- a/tests/entities/test_span.py
+++ b/tests/entities/test_span.py
@@ -879,6 +879,27 @@ def test_live_span_add_link():
         assert otel_span.links[0].context.span_id == 0xAABBCCDDEEFF0011
 
 
+def test_add_link_after_end_does_not_store_link():
+    from mlflow.entities.link import Link
+
+    trace_id = "tr-12345"
+    tracer = _get_tracer("test")
+    otel_span = tracer.start_span("test_span")
+    span = create_mlflow_span(otel_span, trace_id=trace_id)
+    span.end()
+
+    span.add_link(
+        Link(
+            trace_id="tr-abc123",
+            span_id="aabbccddeeff0011",
+            attributes={"relationship": "triggered_by"},
+        )
+    )
+
+    assert len(span.links) == 0
+    assert len(otel_span.links) == 0
+
+
 def test_add_link_rejects_invalid_ids():
     from mlflow.entities.link import Link
 

--- a/tests/entities/test_span.py
+++ b/tests/entities/test_span.py
@@ -1,5 +1,6 @@
 import json
 from datetime import datetime
+from unittest import mock
 
 import opentelemetry.trace as trace_api
 import pytest
@@ -888,16 +889,20 @@ def test_add_link_after_end_does_not_store_link():
     span = create_mlflow_span(otel_span, trace_id=trace_id)
     span.end()
 
-    span.add_link(
-        Link(
-            trace_id="tr-abc123",
-            span_id="aabbccddeeff0011",
-            attributes={"relationship": "triggered_by"},
+    with mock.patch("mlflow.entities.span._logger.debug") as mock_debug:
+        span.add_link(
+            Link(
+                trace_id="tr-abc123",
+                span_id="aabbccddeeff0011",
+                attributes={"relationship": "triggered_by"},
+            )
         )
-    )
 
     assert len(span.links) == 0
     assert len(otel_span.links) == 0
+    mock_debug.assert_called_once_with(
+        "Skipping link addition because the span is no longer recording."
+    )
 
 
 def test_add_link_rejects_invalid_ids():

--- a/tests/entities/test_span_attachments.py
+++ b/tests/entities/test_span_attachments.py
@@ -115,3 +115,25 @@ def test_to_immutable_span_propagates_attachments():
     assert isinstance(immutable, Span)
     assert att.id in immutable._attachments
     assert immutable._attachments[att.id] is att
+
+
+def test_set_inputs_after_end_does_not_store_attachment():
+    span = _make_live_span()
+    span.end()
+
+    att = Attachment(content_type="image/png", content_bytes=b"img")
+    span.set_inputs({"image": att})
+
+    assert att.id not in span._attachments
+    assert span.inputs is None
+
+
+def test_set_outputs_after_end_does_not_store_attachment():
+    span = _make_live_span()
+    span.end()
+
+    att = Attachment(content_type="audio/wav", content_bytes=b"audio")
+    span.set_outputs({"sound": att})
+
+    assert att.id not in span._attachments
+    assert span.outputs is None

--- a/tests/entities/test_span_attachments.py
+++ b/tests/entities/test_span_attachments.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from mlflow.entities.span import LiveSpan, Span
 from mlflow.tracing.attachments import Attachment
 
@@ -122,10 +124,14 @@ def test_set_inputs_after_end_does_not_store_attachment():
     span.end()
 
     att = Attachment(content_type="image/png", content_bytes=b"img")
-    span.set_inputs({"image": att})
+    with mock.patch("mlflow.entities.span._logger.debug") as mock_debug:
+        span.set_inputs({"image": att})
 
     assert att.id not in span._attachments
     assert span.inputs is None
+    mock_debug.assert_called_once_with(
+        "Skipping attachment storage because the span is no longer recording."
+    )
 
 
 def test_set_outputs_after_end_does_not_store_attachment():


### PR DESCRIPTION
### Related Issues/PRs

Closes #23004

### What changes are proposed in this pull request?

This PR prevents `LiveSpan` from mutating MLflow-managed state after the underlying OpenTelemetry span has ended.

Specifically:
- `LiveSpan._store_attachment()` returns without adding to `_attachments` when the span is no longer recording.
- `LiveSpan.add_link()` returns without adding to `_links` or forwarding to OpenTelemetry when the span is no longer recording.

This keeps attachment and link behavior consistent with OpenTelemetry's ended-span no-op behavior for native span mutations.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Ran:

```sh
python3 -m pytest tests/entities/test_span.py tests/entities/test_span_attachments.py
python3 -m ruff check --isolated mlflow/entities/span.py tests/entities/test_span.py tests/entities/test_span_attachments.py
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Ended `LiveSpan` objects now avoid storing links or attachments that would not be persisted after the underlying OpenTelemetry span has ended.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release