### PR TITLE
Drop `setup-python` from `remove-experimental-decorators` workflow

### DIFF
--- a/.github/workflows/remove-experimental-decorators.yml
+++ b/.github/workflows/remove-experimental-decorators.yml
@@ -35,8 +35,6 @@ jobs:
           persist-credentials: true
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: ./.github/actions/setup-python
-
       - name: Run remove_experimental_decorators script
         id: remove
         run: |

--- a/.github/workflows/remove-experimental-decorators.yml
+++ b/.github/workflows/remove-experimental-decorators.yml
@@ -5,6 +5,10 @@ on:
     # Run on the 1st day of every month at 00:00 UTC
     - cron: "0 0 1 * *"
   workflow_dispatch: # Allow manual triggering
+  pull_request:
+    paths:
+      - .github/workflows/remove-experimental-decorators.yml
+      - dev/remove_experimental_decorators.py
 
 defaults:
   run:
@@ -23,6 +27,7 @@ jobs:
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        if: github.event_name != 'pull_request'
         id: app-token
         with:
           app-id: ${{ secrets.APP_ID }}
@@ -33,7 +38,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: true
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.app-token.outputs.token || github.token }}
 
       - name: Run remove_experimental_decorators script
         id: remove
@@ -44,7 +49,7 @@ jobs:
           echo "has_changes=$has_changes" >> $GITHUB_OUTPUT
 
       - name: Create branch, commit and push changes
-        if: steps.remove.outputs.has_changes == 'true'
+        if: steps.remove.outputs.has_changes == 'true' && github.event_name != 'pull_request'
         id: branch
         run: |
           git config user.name 'mlflow-app[bot]'
@@ -62,7 +67,7 @@ jobs:
           git push origin $BRANCH_NAME
 
       - name: Create Pull Request
-        if: steps.remove.outputs.has_changes == 'true'
+        if: steps.remove.outputs.has_changes == 'true' && github.event_name != 'pull_request'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           BRANCH_NAME: ${{ steps.branch.outputs.branch_name }}


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

The `remove-experimental-decorators` workflow was timing out: the [2026-05-01 scheduled run](https://github.com/mlflow/mlflow/actions/runs/25196665260) was cancelled at 5m51s, with `./.github/actions/setup-python` alone consuming **3m21s** of the 5-minute job budget and the script step getting cancelled mid-run.

`dev/remove_experimental_decorators.py` only uses stdlib (`argparse`, `ast`, `json`, `subprocess`, `dataclasses`, `datetime`, `pathlib`, `urllib.request`), so the heavy composite (`actions/setup-python` + `astral-sh/setup-uv` + 414 MB uv-cache restore) is unnecessary. The `ubuntu-slim` runner already ships Python 3.12 with `/usr/bin/python` symlinked to `python3.12` (verified empirically by probing the runner), which satisfies the PEP 604 `str | None` syntax used in the script.

Changes:

- Drop the `./.github/actions/setup-python` step and run `python dev/remove_experimental_decorators.py` directly against the runner's preinstalled interpreter.
- Add a `pull_request` trigger (scoped to the workflow file and the script) so future changes are exercised before the next scheduled run. The bot-token / branch-push / PR-creation steps are skipped on `pull_request` events since they require write access that isn't available on PR runs.

The previous successful run (2026-04-01) spent ~30s on `setup-python`, so this should make the workflow ~30s faster on a normal day and avoid the timeout class of failures entirely.

### How is this PR tested?

- [x] Manual tests

The change is exercised by the new `pull_request` trigger on this PR, plus the next scheduled run on the 1st of the month or via `workflow_dispatch`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release