### PR TITLE
Document that `pipefail` is already on under `shell: bash`

### DIFF
--- a/.claude/rules/github-actions.md
+++ b/.claude/rules/github-actions.md
@@ -39,3 +39,7 @@ use `gh` CLI instead of `actions/github-script`. It avoids the need for
   run: |
     gh pr comment ...
 ```
+
+## `pipefail` Is Already On
+
+Every workflow in this repo sets top-level `defaults.run.shell: bash` (enforced by [`.github/policy.rego`](../../.github/policy.rego)). GitHub Actions runs `shell: bash` as `bash --noprofile --norc -eo pipefail {0}`, so `pipefail` is already enabled. Don't ask for `set -o pipefail` in workflow `run:` steps. ([docs](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#defaultsrunshell))

--- a/.github/instructions/github-actions.instructions.md
+++ b/.github/instructions/github-actions.instructions.md
@@ -1,0 +1,7 @@
+---
+applyTo: ".github/workflows/**/*.yml"
+---
+
+# GitHub Actions Code Review Instructions
+
+For workflow style conventions, see [.claude/rules/github-actions.md](../../.claude/rules/github-actions.md).


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23154

### What changes are proposed in this pull request?

The mlflow-app reviewer (and Copilot) repeatedly flag `uv lock 2>&1 | tee ...` style pipes as missing `pipefail` and recommend `set -o pipefail`. This is a false positive: when a workflow sets `defaults.run.shell: bash` (or a step uses `shell: bash`), GitHub Actions invokes the script as `bash --noprofile --norc -eo pipefail {0}`, so `pipefail` is already on.

This was flagged twice on #23154 alone:

1. https://github.com/mlflow/mlflow/pull/23154#discussion_r3214666099 (Copilot, CRITICAL)
2. https://github.com/mlflow/mlflow/pull/23154#discussion_r3214672018 (mlflow-app, CRITICAL, claimed shell was `bash -eux`, hallucinated)

Both threads were resolved as false positives.

Changes:

- Add a short note to `.claude/rules/github-actions.md` documenting the `pipefail` default and instructing reviewers not to recommend `set -o pipefail`.
- Add `.github/instructions/github-actions.instructions.md` (mirroring the existing `python.instructions.md`) so Copilot reviews of `.github/workflows/**/*.yml` pull from the same `.claude/rules/github-actions.md` file. This avoids duplicating rule text across the two systems.

### How is this PR tested?

- [x] Manual tests

Docs-only change. The `applyTo` glob mirrors `python.instructions.md`'s pattern.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release