### PR TITLE
Allow `/review` to override the review model

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -105,6 +105,7 @@ jobs:
         run: |
           cat > /tmp/parse_args.py <<'EOF'
           import argparse
+          import secrets
           import sys
 
           ALIASES = {
@@ -123,7 +124,9 @@ jobs:
 
           model = ALIASES.get(args.model, args.model)
           prompt = " ".join(leftover) + sep + tail
-          sys.stdout.write(f"prompt<<PROMPT_EOF\n{prompt}\nPROMPT_EOF\nmodel={model}\n")
+          # Random delimiter so user input can't terminate the heredoc.
+          delim = f"PROMPT_EOF_{secrets.token_hex(8)}"
+          sys.stdout.write(f"prompt<<{delim}\n{prompt}\n{delim}\nmodel={model}\n")
           EOF
 
           echo "$COMMENT_BODY" | python /tmp/parse_args.py >> "$GITHUB_OUTPUT"

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -108,12 +108,14 @@ jobs:
           import secrets
           import sys
 
-          ALIASES = {
-              "opus": "claude-opus-4-6",
-              "sonnet": "claude-sonnet-4-6",
-              "haiku": "claude-haiku-4-5",
-          }
-          CHOICES = list(ALIASES) + list(ALIASES.values())
+          CHOICES = [
+              "opus",
+              "sonnet",
+              "haiku",
+              "claude-opus-4-6",
+              "claude-sonnet-4-6",
+              "claude-haiku-4-5",
+          ]
 
           body = sys.stdin.read().removeprefix("/review")
           head, sep, tail = body.partition("\n")
@@ -122,11 +124,10 @@ jobs:
           parser.add_argument("-m", "--model", choices=CHOICES, default="opus")
           args, leftover = parser.parse_known_args(head.split())
 
-          model = ALIASES.get(args.model, args.model)
           prompt = " ".join(leftover) + sep + tail
           # Random delimiter so user input can't terminate the heredoc.
           delim = f"PROMPT_EOF_{secrets.token_hex(8)}"
-          sys.stdout.write(f"prompt<<{delim}\n{prompt}\n{delim}\nmodel={model}\n")
+          sys.stdout.write(f"prompt<<{delim}\n{prompt}\n{delim}\nmodel={args.model}\n")
           EOF
 
           echo "$COMMENT_BODY" | python /tmp/parse_args.py >> "$GITHUB_OUTPUT"
@@ -138,7 +139,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           PROMPT: ${{ steps.prompt.outputs.prompt }}
-          MODEL: ${{ steps.prompt.outputs.model || 'claude-opus-4-6' }}
+          MODEL: ${{ steps.prompt.outputs.model || 'opus' }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
           OUTPUT_FILE="/tmp/output.json"

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -97,18 +97,36 @@ jobs:
         run: |
           claude --version
 
-      - name: Extract optional prompt from comment
+      - name: Extract optional prompt and model from comment
         if: github.event_name == 'issue_comment'
         id: prompt
         env:
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
-          PROMPT=$(echo "$COMMENT_BODY" | sed 's|^/review||')
-          {
-            echo 'prompt<<PROMPT_EOF'
-            echo "$PROMPT"
-            echo 'PROMPT_EOF'
-          } >> "$GITHUB_OUTPUT"
+          cat > /tmp/parse_args.py <<'EOF'
+          import argparse
+          import sys
+
+          ALIASES = {
+              "opus": "claude-opus-4-6",
+              "sonnet": "claude-sonnet-4-6",
+              "haiku": "claude-haiku-4-5",
+          }
+          CHOICES = list(ALIASES) + list(ALIASES.values())
+
+          body = sys.stdin.read().removeprefix("/review")
+          head, sep, tail = body.partition("\n")
+
+          parser = argparse.ArgumentParser(add_help=False)
+          parser.add_argument("-m", "--model", choices=CHOICES, default="opus")
+          args, leftover = parser.parse_known_args(head.split())
+
+          model = ALIASES.get(args.model, args.model)
+          prompt = " ".join(leftover) + sep + tail
+          sys.stdout.write(f"prompt<<PROMPT_EOF\n{prompt}\nPROMPT_EOF\nmodel={model}\n")
+          EOF
+
+          echo "$COMMENT_BODY" | python /tmp/parse_args.py >> "$GITHUB_OUTPUT"
 
       - name: Review
         id: review
@@ -117,6 +135,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           PROMPT: ${{ steps.prompt.outputs.prompt }}
+          MODEL: ${{ steps.prompt.outputs.model || 'claude-opus-4-6' }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
           OUTPUT_FILE="/tmp/output.json"
@@ -131,7 +150,7 @@ jobs:
 
           EXIT_CODE=0
           # Note: ARGS[*] is intentional - claude CLI expects a single prompt string
-          timeout 20m claude --model claude-opus-4-6 --print --verbose --output-format stream-json "${ARGS[*]}" | .claude/scripts/stream.sh "$OUTPUT_FILE" || EXIT_CODE=$?
+          timeout 20m claude --model "$MODEL" --print --verbose --output-format stream-json "${ARGS[*]}" | .claude/scripts/stream.sh "$OUTPUT_FILE" || EXIT_CODE=$?
           if [ "${EXIT_CODE:-0}" -eq 124 ]; then
             echo "Warning: Claude command timed out after 20 minutes"
           elif [ "${EXIT_CODE:-0}" -ne 0 ]; then


### PR DESCRIPTION
### Related Issues/PRs

Relates to #N/A

### What changes are proposed in this pull request?

The `review` workflow's `/review` comment trigger now accepts an optional `-m`/`--model` flag so reviewers can pick a model per invocation:

- `/review` → `claude-opus-4-6` (default)
- `/review -m haiku focus on tests` → `claude-haiku-4-5`
- `/review --model sonnet` → `claude-sonnet-4-6`

Implementation: a single workflow step writes a small Python helper to `/tmp/parse_args.py`, then pipes `$COMMENT_BODY` through it. The script uses `argparse` (with `choices=`) for validation, maps friendly aliases (`opus`/`sonnet`/`haiku`) to canonical model IDs, and emits `prompt`/`model` step outputs. The `Review` step substitutes the parsed model into the `claude --model` invocation, falling back to `claude-opus-4-6` for the `pull_request` trigger (where the prompt step is skipped).

Splitting on plain whitespace (`head.split()`) instead of `shlex.split()` so natural-language prompts containing apostrophes or unmatched quotes (e.g., `/review what's changed?`) don't crash the workflow.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Locally exercised the parsing helper across the bare `/review`, prompt-only, model-only, model + prompt, multi-line prompt, apostrophes, unmatched quotes, and invalid-model cases. Valid combinations emit the expected `prompt`/`model` outputs; invalid models exit `2` with argparse's standard error.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release