### PR TITLE
Migrate GitHub App auth from `app-id` to `client-id`

### DIFF
--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -216,7 +216,7 @@ jobs:
       - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         id: app-token
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           # See https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/managing-private-keys-for-github-apps
           # for how to rotate the private key
           private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -213,7 +213,7 @@ jobs:
     outputs:
       head_sha: ${{ steps.push.outputs.head_sha }}
     steps:
-      - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
           client-id: ${{ secrets.APP_CLIENT_ID }}

--- a/.github/workflows/remove-experimental-decorators.yml
+++ b/.github/workflows/remove-experimental-decorators.yml
@@ -30,7 +30,7 @@ jobs:
         if: github.event_name != 'pull_request'
         id: app-token
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write

--- a/.github/workflows/remove-experimental-decorators.yml
+++ b/.github/workflows/remove-experimental-decorators.yml
@@ -26,7 +26,7 @@ jobs:
     env:
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
-      - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         if: github.event_name != 'pull_request'
         id: app-token
         with:

--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -137,7 +137,7 @@ jobs:
       - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         id: app-token
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: read

--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -134,7 +134,7 @@ jobs:
       pull-requests: read
     timeout-minutes: 30
     steps:
-      - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
           client-id: ${{ secrets.APP_CLIENT_ID }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         id: app-token
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           permission-contents: read
           permission-pull-requests: write

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -42,7 +42,7 @@ jobs:
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
        startsWith(github.event.comment.body, '/review'))
     steps:
-      - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
           client-id: ${{ secrets.APP_CLIENT_ID }}

--- a/.github/workflows/update-model-catalog.yml
+++ b/.github/workflows/update-model-catalog.yml
@@ -19,7 +19,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
           client-id: ${{ secrets.APP_CLIENT_ID }}

--- a/.github/workflows/update-model-catalog.yml
+++ b/.github/workflows/update-model-catalog.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         id: app-token
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write

--- a/.github/workflows/uv.yml
+++ b/.github/workflows/uv.yml
@@ -33,7 +33,7 @@ jobs:
         if: github.event_name != 'pull_request'
         id: app-token
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write

--- a/.github/workflows/uv.yml
+++ b/.github/workflows/uv.yml
@@ -29,7 +29,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         if: github.event_name != 'pull_request'
         id: app-token
         with:


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

`actions/create-github-app-token` deprecated `app-id` in favor of `client-id` ([#353](https://github.com/actions/create-github-app-token/pull/353)) — GitHub recommends Client ID as the canonical GitHub App identifier going forward.

- Bump the action pin to v3.1.1 (first release with `client-id`).
- Replace `app-id: ${{ secrets.APP_ID }}` → `client-id: ${{ secrets.APP_CLIENT_ID }}` in 6 workflows.
- The old `APP_ID` secret can be deleted after merge.

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release