### PR TITLE
fix: correct trace UI typo

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/GenAiDeleteTraceModal.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/GenAiDeleteTraceModal.tsx
@@ -30,7 +30,7 @@ export const GenAiDeleteTraceModal = ({
     } catch (e: any) {
       setErrorMessage(
         intl.formatMessage({
-          defaultMessage: 'An error occured while attempting to delete traces. Please refresh the page and try again.',
+          defaultMessage: 'An error occurred while attempting to delete traces. Please refresh the page and try again.',
           description: 'Experiment page > traces view controls > Delete traces modal > Error message',
         }),
       );

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/oss-notebook-renderer/ModelTraceExplorerOSSNotebookRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/oss-notebook-renderer/ModelTraceExplorerOSSNotebookRenderer.tsx
@@ -76,7 +76,7 @@ export const ModelTraceExplorerOSSNotebookRenderer = () => {
     );
   }
 
-  // some error occured
+  // some error occurred
   if (!traceData) {
     return (
       <div css={{ paddingTop: theme.spacing.md, width: 'calc(100% - 2px)' }}>
@@ -87,7 +87,7 @@ export const ModelTraceExplorerOSSNotebookRenderer = () => {
               <Typography.Paragraph>
                 <FormattedMessage
                   defaultMessage="An error occurred while attempting to fetch trace data (ID: {traceId}). Please ensure that the MLflow tracking server is running, and that the trace data exists. Error details:"
-                  description="An error message explaining that an error occured while fetching trace data"
+                  description="An error message explaining that an error occurred while fetching trace data"
                   values={{ traceId: traceIds[activeTraceIndex] }}
                 />
               </Typography.Paragraph>


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes a small spelling typo in GenAI trace UI text and nearby translation/comment metadata:

- `occured` -> `occurred` in the delete traces error message
- `occured` -> `occurred` in the trace fetch error description/comment

## How is this patch tested?

- `git diff --check`
- `grep -RIn "occured" <touched files>` confirms the typo no longer appears in the changed files

Full frontend tests were not run because this is a spelling-only copy change in two TSX files.