### PR TITLE
Fix stale workflow `paths` filters

### DIFF
--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/resolve.yml
-      - .claude/commands/resolve.md
+      - .claude/skills/resolve/**
       - .claude/skills/fetch-unresolved-comments/**
 
 concurrency:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/review.yml"
-      - ".claude/commands/pr-review.md"
+      - ".claude/skills/pr-review/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}


### PR DESCRIPTION
### Related Issues/PRs

Relates to N/A

### What changes are proposed in this pull request?

`/pr-review` and `/resolve` slash commands were moved from `.claude/commands/*.md` to `.claude/skills/<name>/SKILL.md`, but the `paths:` triggers in `review.yml` and `resolve.yml` still reference the old command files. Those filters now match no file, so the self-edit `pull_request` trigger never fires when the skill itself is modified.

This PR repoints the filters to the new skill directories:

- `.github/workflows/review.yml`: `.claude/commands/pr-review.md` → `.claude/skills/pr-review/**`
- `.github/workflows/resolve.yml`: `.claude/commands/resolve.md` → `.claude/skills/resolve/**`

### How is this PR tested?

- [x] Manual tests

Verified locally by running a small script that walks each workflow's `paths:`/`paths-ignore:` entries and checks each pattern against `git ls-files` with gitignore-style matching; both broken patterns were flagged before this fix, and all patterns resolve after it.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release