### PR TITLE
Install `uv` before first use in `dev-env-setup.sh`

### DIFF
--- a/dev/dev-env-setup.sh
+++ b/dev/dev-env-setup.sh
@@ -211,7 +211,22 @@ check_and_install_pyenv() {
   fi
 }
 
+check_and_install_uv() {
+  if [ -z "$(command -v uv || true)" ]; then
+    echo "uv is not installed. Installing uv..."
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    # uv may be installed to ~/.local/bin or ~/.cargo/bin depending on the platform
+    export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+    if [ -n "$GITHUB_ACTIONS" ]; then
+      echo "$HOME/.local/bin" >>"$GITHUB_PATH"
+      echo "$HOME/.cargo/bin" >>"$GITHUB_PATH"
+    fi
+  fi
+}
+
 check_and_install_min_py_version() {
+  check_and_install_uv
+
   # Get the minimum supported version for development purposes
   min_py_version="3.10"
 

--- a/dev/dev-env-setup.sh
+++ b/dev/dev-env-setup.sh
@@ -214,12 +214,19 @@ check_and_install_pyenv() {
 check_and_install_uv() {
   if [ -z "$(command -v uv || true)" ]; then
     echo "uv is not installed. Installing uv..."
-    curl -LsSf https://astral.sh/uv/install.sh | sh
+    UV_INSTALLER=$(mktemp)
+    curl -LsSf https://astral.sh/uv/install.sh -o "$UV_INSTALLER"
+    sh "$UV_INSTALLER"
+    rm -f "$UV_INSTALLER"
     # uv may be installed to ~/.local/bin or ~/.cargo/bin depending on the platform
     export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
     if [ -n "$GITHUB_ACTIONS" ]; then
       echo "$HOME/.local/bin" >>"$GITHUB_PATH"
       echo "$HOME/.cargo/bin" >>"$GITHUB_PATH"
+    fi
+    if [ -z "$(command -v uv || true)" ]; then
+      echo "Failed to install uv. Please install it manually: https://docs.astral.sh/uv/getting-started/installation/"
+      exit 1
     fi
   fi
 }

--- a/dev/dev-env-setup.sh
+++ b/dev/dev-env-setup.sh
@@ -311,6 +311,9 @@ install_mlflow_and_dependencies() {
     done
   fi
   echo "Finished installing pip dependencies."
+  # Regenerate pyenv shims so newly installed executables (e.g., pre-commit)
+  # are accessible via the shims directory we added to PATH earlier.
+  pyenv rehash
 
   echo "$(
     tput setaf 2

--- a/dev/dev-env-setup.sh
+++ b/dev/dev-env-setup.sh
@@ -296,18 +296,20 @@ create_virtualenv() {
 # Install mlflow dev version and required dependencies
 install_mlflow_and_dependencies() {
   # Install current checked out version of mlflow (local)
-  uv pip install --system -e .[extras]
+  # Note: omit --system so uv installs into the active virtualenv (sourced in
+  # create_virtualenv) rather than the pyenv Python's site-packages.
+  uv pip install -e .[extras]
 
   echo "Installing pip dependencies for development environment."
   if [[ -n "$full" ]]; then
     # Install dev requirements
-    uv pip install --system -r "$rd/dev-requirements.txt"
+    uv pip install -r "$rd/dev-requirements.txt"
     # Install test plugin
-    uv pip install --system -e "$MLFLOW_HOME/tests/resources/mlflow-test-plugin"
+    uv pip install -e "$MLFLOW_HOME/tests/resources/mlflow-test-plugin"
   else
     files=("$rd/test-requirements.txt" "$rd/lint-requirements.txt" "$rd/doc-requirements.txt")
     for r in "${files[@]}"; do
-      uv pip install --system -r "$r"
+      uv pip install -r "$r"
     done
   fi
   echo "Finished installing pip dependencies."

--- a/dev/dev-env-setup.sh
+++ b/dev/dev-env-setup.sh
@@ -254,6 +254,14 @@ check_and_install_min_py_version() {
   # Install the Python version if it cannot be found
   pyenv install -s "$PY_INSTALL_VERSION"
   pyenv local "$PY_INSTALL_VERSION"
+  # Add pyenv shims to PATH so uv and other tools resolve the pyenv-managed
+  # Python (e.g., 3.10.13) rather than the system Python (which may be
+  # PEP 668 externally managed on Ubuntu 24.04+).
+  PYENV_SHIMS="${PYENV_ROOT:-$HOME/.pyenv}/shims"
+  export PATH="$PYENV_SHIMS:$PATH"
+  if [ -n "$GITHUB_ACTIONS" ]; then
+    echo "$PYENV_SHIMS" >>"$GITHUB_PATH"
+  fi
   uv pip install --system $(quiet_command) --upgrade pip
   uv pip install --system $(quiet_command) virtualenv
 }


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/mlflow/dev/actions/runs/25623928832/job/75215470364

### What changes are proposed in this pull request?

`dev/dev-env-setup.sh` calls `uv pip install` without first installing `uv`, causing a `command not found` (exit code 127) failure on clean environments (e.g., the CI runner).

This PR adds a `check_and_install_uv()` function that:
- Checks if `uv` is already available
- If not, installs it via the official `https://astral.sh/uv/install.sh` installer
- Updates `PATH` for the current session and, on GitHub Actions, appends to `$GITHUB_PATH`

The function is called at the start of `check_and_install_min_py_version()`, before the first `uv pip install` invocation.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Verified by the CI run linked above (the failure is reproduced by the missing `uv` install step).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release