### PR TITLE
Fix dspy cross-version test failures for dspy 3.2.0

### DIFF
--- a/mlflow/dspy/load.py
+++ b/mlflow/dspy/load.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 import logging
 import os
@@ -75,9 +76,11 @@ def _load_model(model_uri, dst_path=None):
     else:
         model = dspy.load(os.path.join(local_model_path, model_path), allow_pickle=True)
 
-        dspy_settings = dspy.load_settings(
-            os.path.join(local_model_path, _MODEL_DATA_PATH, _DSPY_SETTINGS_FILE_NAME)
-        )
+        settings_path = os.path.join(local_model_path, _MODEL_DATA_PATH, _DSPY_SETTINGS_FILE_NAME)
+        if "allow_pickle" in inspect.signature(dspy.load_settings).parameters:
+            dspy_settings = dspy.load_settings(settings_path, allow_pickle=True)
+        else:
+            dspy_settings = dspy.load_settings(settings_path)
 
         model_config_file = os.path.join(
             local_model_path, _MODEL_DATA_PATH, _MODEL_CONFIG_FILE_NAME

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -599,14 +599,14 @@ dspy:
       uv pip install --system git+https://github.com/stanfordnlp/dspy.git
   models:
     minimum: "2.6.23"
-    maximum: "3.1.3"
+    maximum: "3.2.0"
     requirements:
       ">= 0.0.0": ["openai"]
     run: |
       pytest tests/dspy --ignore tests/dspy/test_dspy_autolog.py
   autologging:
     minimum: "2.6.23"
-    maximum: "3.1.3"
+    maximum: "3.2.0"
     requirements:
       ">= 0.0.0": ["openai"]
     run: |

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -30,11 +30,11 @@ _ML_PACKAGE_VERSIONS = {
         },
         "models": {
             "minimum": "2.6.23",
-            "maximum": "3.1.3"
+            "maximum": "3.2.0"
         },
         "autologging": {
             "minimum": "2.6.23",
-            "maximum": "3.1.3"
+            "maximum": "3.2.0"
         }
     },
     "langchain": {

--- a/tests/dspy/test_dspy_autolog.py
+++ b/tests/dspy/test_dspy_autolog.py
@@ -32,6 +32,8 @@ _DSPY_UNDER_2_6 = _DSPY_VERSION < Version("2.6.0rc1")
 
 _DSPY_3_0_4_OR_NEWER = _DSPY_VERSION >= Version("3.0.4")
 
+_DSPY_3_2_0_OR_NEWER = _DSPY_VERSION >= Version("3.2.0")
+
 
 # Test module
 class CoT(dspy.Module):
@@ -171,7 +173,13 @@ def test_autolog_cot():
 
 
 def test_mlflow_callback_exception():
-    from litellm import ContextWindowExceededError
+    # dspy 3.2.0+ replaced litellm's ContextWindowExceededError with its own.
+    # ChatAdapter only skips the JSONAdapter fallback for dspy.ContextWindowExceededError,
+    # so we must raise the appropriate type to keep the expected span count.
+    if _DSPY_3_2_0_OR_NEWER:
+        ContextWindowExceededError = dspy.ContextWindowExceededError
+    else:
+        from litellm import ContextWindowExceededError
 
     mlflow.dspy.autolog()
 
@@ -179,8 +187,11 @@ def test_mlflow_callback_exception():
         @with_callbacks
         def __call__(self, prompt=None, messages=None, **kwargs):
             time.sleep(0.1)
-            # pdpy.ChatAdapter falls back to JSONAdapter unless it's not ContextWindowExceededError
-            raise ContextWindowExceededError("Error", "invalid model", "provider")
+            if _DSPY_3_2_0_OR_NEWER:
+                raise dspy.ContextWindowExceededError(message="Error")
+            else:
+                from litellm import ContextWindowExceededError as _CWE
+                raise _CWE("Error", "invalid model", "provider")
 
     cot = dspy.ChainOfThought("question -> answer", n=3)
 

--- a/tests/dspy/test_dspy_autolog.py
+++ b/tests/dspy/test_dspy_autolog.py
@@ -191,6 +191,7 @@ def test_mlflow_callback_exception():
                 raise dspy.ContextWindowExceededError(message="Error")
             else:
                 from litellm import ContextWindowExceededError as _CWE
+
                 raise _CWE("Error", "invalid model", "provider")
 
     cot = dspy.ChainOfThought("question -> answer", n=3)


### PR DESCRIPTION
### Related Issues/PRs

Relates to cross-version CI failures for `dspy`.

### What changes are proposed in this pull request?

Two breaking changes introduced in dspy 3.2.0 are addressed:

1. **`dspy.ContextWindowExceededError` rename**: dspy 3.2.0 replaced `litellm.ContextWindowExceededError` with its own `dspy.ContextWindowExceededError`. `ChatAdapter` only skips the JSONAdapter fallback when `dspy.ContextWindowExceededError` is raised; raising the litellm version causes an extra JSONAdapter fallback attempt that adds unexpected spans. Fix `test_mlflow_callback_exception` to raise `dspy.ContextWindowExceededError` on dspy >= 3.2.0.

2. **`dspy.load_settings()` `allow_pickle` parameter**: dspy 3.2.0 added `allow_pickle=False` as a default parameter to `dspy.load_settings()`. Calling it without `allow_pickle=True` raises `ValueError` when loading settings that contain pickled objects. Use `inspect.signature` to detect the new parameter and pass `allow_pickle=True` only when supported, preserving backward compatibility with dspy < 3.2.0.

Bump `maximum` to `3.2.0` for both models and autologging.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release