### PR TITLE
Fix Vertex AI gateway to use Anthropic API format for Claude models

### DIFF
--- a/mlflow/gateway/providers/anthropic.py
+++ b/mlflow/gateway/providers/anthropic.py
@@ -531,6 +531,15 @@ class AnthropicProvider(BaseProvider, AnthropicAdapter):
         else:
             raise ValueError(f"Invalid route type {route_type}")
 
+    def _get_chat_path(self) -> str:
+        return "messages"
+
+    def _get_chat_stream_path(self) -> str:
+        return "messages"
+
+    def _prepare_payload(self, payload: dict) -> dict:
+        return payload
+
     async def _chat_stream(
         self, payload: chat.RequestPayload
     ) -> AsyncIterable[chat.StreamResponsePayload]:
@@ -539,13 +548,14 @@ class AnthropicProvider(BaseProvider, AnthropicAdapter):
         payload = jsonable_encoder(payload, exclude_none=True)
         self.check_for_model_field(payload)
         payload = AnthropicAdapter.chat_streaming_to_model(payload, self.config)
+        payload = self._prepare_payload(payload)
 
         headers = self._get_headers(payload)
 
         stream = send_stream_request(
             headers=headers,
             base_url=self.base_url,
-            path="messages",
+            path=self._get_chat_stream_path(),
             payload=payload,
         )
 
@@ -611,13 +621,14 @@ class AnthropicProvider(BaseProvider, AnthropicAdapter):
         payload = jsonable_encoder(payload, exclude_none=True)
         self.check_for_model_field(payload)
         payload = AnthropicAdapter.chat_to_model(payload, self.config)
+        payload = self._prepare_payload(payload)
 
         headers = self._get_headers(payload)
 
         resp = await send_request(
             headers=headers,
             base_url=self.base_url,
-            path="messages",
+            path=self._get_chat_path(),
             payload=payload,
         )
         return AnthropicAdapter.model_to_chat(resp, self.config)

--- a/mlflow/gateway/providers/anthropic.py
+++ b/mlflow/gateway/providers/anthropic.py
@@ -537,7 +537,7 @@ class AnthropicProvider(BaseProvider, AnthropicAdapter):
     def _get_chat_stream_path(self) -> str:
         return "messages"
 
-    def _prepare_payload(self, payload: dict) -> dict:
+    def _prepare_payload(self, payload: dict[str, Any]) -> dict[str, Any]:
         return payload
 
     async def _chat_stream(

--- a/mlflow/gateway/providers/vertex_ai.py
+++ b/mlflow/gateway/providers/vertex_ai.py
@@ -21,6 +21,7 @@ Three model types are supported:
 import json
 from enum import Enum
 from pathlib import Path
+from typing import Any
 
 from mlflow.gateway.config import EndpointConfig, VertexAIConfig
 from mlflow.gateway.exceptions import AIGatewayException
@@ -91,7 +92,7 @@ class _VertexAIClaudeProvider(AnthropicProvider):
     def _get_chat_stream_path(self) -> str:
         return f"{self.config.model.name}:streamRawPredict"
 
-    def _prepare_payload(self, payload: dict) -> dict:
+    def _prepare_payload(self, payload: dict[str, Any]) -> dict[str, Any]:
         payload.pop("model", None)
         payload["anthropic_version"] = _VERTEX_ANTHROPIC_VERSION
         return payload

--- a/mlflow/gateway/providers/vertex_ai.py
+++ b/mlflow/gateway/providers/vertex_ai.py
@@ -4,8 +4,11 @@ Vertex AI provider for MLflow AI Gateway.
 Extends the Gemini provider to use Vertex AI endpoints with Google Cloud
 authentication (Application Default Credentials or service account JSON).
 
-Vertex AI uses the same Gemini API format but with different URL patterns
-and auth mechanism.
+For Google-published models (e.g. gemini-2.0-flash), this uses the Gemini API
+format with :generateContent/:streamGenerateContent endpoints.
+
+For Anthropic Claude models, this uses AnthropicProvider's logic with Vertex AI
+auth (Bearer token) and :rawPredict/:streamRawPredict endpoints.
 """
 
 import json
@@ -13,18 +16,65 @@ from enum import Enum
 from pathlib import Path
 
 from mlflow.gateway.config import EndpointConfig, VertexAIConfig
+from mlflow.gateway.providers.anthropic import AnthropicProvider
+from mlflow.gateway.providers.base import BaseProvider
 from mlflow.gateway.providers.gemini import GeminiProvider
 
 _DEFAULT_SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
 
+# Version string required by Vertex AI for Anthropic models
+_VERTEX_ANTHROPIC_VERSION = "vertex-2023-10-16"
+
+
+class _VertexAIClaudeProvider(AnthropicProvider):
+    """AnthropicProvider adapted for Claude models hosted on Vertex AI.
+
+    Uses Vertex AI Bearer-token auth and :rawPredict/:streamRawPredict endpoints
+    instead of the standard Anthropic API key and /messages endpoint.
+    """
+
+    DISPLAY_NAME = "Vertex AI"
+    CONFIG_TYPE = VertexAIConfig
+
+    def __init__(self, config: EndpointConfig, vertex_config: VertexAIConfig, get_credentials_fn):
+        # Call BaseProvider.__init__ directly — AnthropicProvider.__init__ would reject
+        # VertexAIConfig since it expects AnthropicConfig.
+        BaseProvider.__init__(self, config)
+        self.vertex_config = vertex_config
+        self._get_creds = get_credentials_fn
+
+    @property
+    def headers(self) -> dict[str, str]:
+        creds = self._get_creds()
+        return {"Authorization": f"Bearer {creds.token}"}
+
+    @property
+    def base_url(self) -> str:
+        project = self.vertex_config.vertex_project
+        location = self.vertex_config.vertex_location or "global"
+        prefix = "" if location == "global" else f"{location}-"
+        host = f"https://{prefix}aiplatform.googleapis.com"
+        path = f"/v1/projects/{project}/locations/{location}/publishers/anthropic/models"
+        return f"{host}{path}"
+
+    def _get_chat_path(self) -> str:
+        return f"{self.config.model.name}:rawPredict"
+
+    def _get_chat_stream_path(self) -> str:
+        return f"{self.config.model.name}:streamRawPredict"
+
+    def _prepare_payload(self, payload: dict) -> dict:
+        payload.pop("model", None)
+        payload["anthropic_version"] = _VERTEX_ANTHROPIC_VERSION
+        return payload
+
 
 class VertexAIProvider(GeminiProvider):
-    """Vertex AI provider for Google's Gemini models.
+    """Vertex AI provider supporting both Google (Gemini) and Anthropic (Claude) models.
 
-    Currently supports Google-published models only (e.g., gemini-2.0-flash).
-    Partner models hosted on Vertex AI (Anthropic, Mistral, Llama, etc.) use
-    different publisher paths and API formats (e.g., :rawPredict with
-    Anthropic Messages API) and are not yet supported by this provider.
+    Google-published models use the Gemini API format (:generateContent).
+    Anthropic Claude models are handled by _VertexAIClaudeProvider, which reuses
+    AnthropicProvider's request/response logic with Vertex AI auth and endpoints.
     """
 
     DISPLAY_NAME = "Vertex AI"
@@ -42,6 +92,14 @@ class VertexAIProvider(GeminiProvider):
         self._provider_name = provider.value if isinstance(provider, Enum) else str(provider)
         self.vertex_config: VertexAIConfig = config.model.config
         self._cached_credentials = None
+        self._claude_provider: _VertexAIClaudeProvider | None = (
+            _VertexAIClaudeProvider(config, self.vertex_config, self._get_credentials)
+            if self._is_claude_model()
+            else None
+        )
+
+    def _is_claude_model(self) -> bool:
+        return self.config.model.name.lower().startswith("claude")
 
     def _get_credentials(self):
         """Get Google Cloud credentials, caching them for reuse."""
@@ -87,6 +145,9 @@ class VertexAIProvider(GeminiProvider):
         credentials = self._get_credentials()
         return {"Authorization": f"Bearer {credentials.token}"}
 
+    def _get_publisher(self) -> str:
+        return "anthropic" if self._is_claude_model() else "google"
+
     @property
     def base_url(self) -> str:
         project = self.vertex_config.vertex_project
@@ -95,5 +156,36 @@ class VertexAIProvider(GeminiProvider):
         # https://docs.cloud.google.com/vertex-ai/docs/general/googleapi-access-methods#regional-global-endpoints
         prefix = "" if location == "global" else f"{location}-"
         host = f"https://{prefix}aiplatform.googleapis.com"
-        path = f"/v1/projects/{project}/locations/{location}/publishers/google/models"
+        publisher = self._get_publisher()
+        path = f"/v1/projects/{project}/locations/{location}/publishers/{publisher}/models"
         return f"{host}{path}"
+
+    async def _chat(self, payload):
+        if self._claude_provider:
+            return await self._claude_provider._chat(payload)
+        return await super()._chat(payload)
+
+    async def _chat_stream(self, payload):
+        if self._claude_provider:
+            async for chunk in self._claude_provider._chat_stream(payload):
+                yield chunk
+            return
+        async for chunk in super()._chat_stream(payload):
+            yield chunk
+
+    async def _completions(self, payload):
+        if self._claude_provider:
+            raise NotImplementedError(
+                "The completions endpoint is not supported for Anthropic Claude models on "
+                "Vertex AI. Use the chat endpoint instead."
+            )
+        return await super()._completions(payload)
+
+    async def _completions_stream(self, payload):
+        if self._claude_provider:
+            raise NotImplementedError(
+                "The completions endpoint is not supported for Anthropic Claude models on "
+                "Vertex AI. Use the chat endpoint instead."
+            )
+        async for chunk in super()._completions_stream(payload):
+            yield chunk

--- a/mlflow/gateway/providers/vertex_ai.py
+++ b/mlflow/gateway/providers/vertex_ai.py
@@ -22,7 +22,7 @@ import json
 from enum import Enum
 from pathlib import Path
 
-from mlflow.gateway.config import EndpointConfig, EndpointType, VertexAIConfig
+from mlflow.gateway.config import EndpointConfig, VertexAIConfig
 from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.providers.anthropic import AnthropicProvider
 from mlflow.gateway.providers.base import BaseProvider
@@ -44,7 +44,7 @@ def _classify_model(model_name: str) -> str:
     name = model_name.lower()
     if name.startswith("claude"):
         return "claude"
-    if "/" in name or name.startswith(_MAAS_PREFIXES):
+    if "/" in name or name.startswith(_MAAS_PREFIXES) or name.endswith("-maas"):
         return "maas"
     return "gemini"
 
@@ -81,7 +81,7 @@ class _VertexAIClaudeProvider(AnthropicProvider):
         return f"{host}{path}"
 
     def get_endpoint_url(self, route_type: str) -> str:
-        if route_type in ("llm/v1/chat", EndpointType.LLM_V1_CHAT):
+        if route_type == "llm/v1/chat":
             return f"{self.base_url}/{self.config.model.name}:rawPredict"
         raise ValueError(f"Unsupported route type for Vertex AI Claude: {route_type}")
 
@@ -207,6 +207,8 @@ class VertexAIProvider(GeminiProvider):
 
     @property
     def base_url(self) -> str:
+        if self._model_type == "maas":
+            return self._delegate._api_base
         project = self.vertex_config.vertex_project
         location = self.vertex_config.vertex_location or "global"
         # Regional endpoints use a "{location}-" prefix; the global endpoint has no prefix.

--- a/mlflow/gateway/providers/vertex_ai.py
+++ b/mlflow/gateway/providers/vertex_ai.py
@@ -4,16 +4,16 @@ Vertex AI provider for MLflow AI Gateway.
 Extends the Gemini provider to use Vertex AI endpoints with Google Cloud
 authentication (Application Default Credentials or service account JSON).
 
-Three tiers of models are supported:
+Three model types are supported:
 
-- **Tier 1 — Google models** (gemini-*, medlm-*, text-embedding-*, etc.):
+- **Google models** (gemini-*, medlm-*, text-embedding-*, etc.):
   Gemini API format with :generateContent/:streamGenerateContent endpoints.
 
-- **Tier 2 — Anthropic Claude models** (claude-*):
+- **Anthropic Claude models** (claude-*):
   Anthropic Messages API format with :rawPredict/:streamRawPredict endpoints,
   routed through publishers/anthropic.
 
-- **Tier 3 — OpenAI-compatible MaaS models** (Meta/Llama, Mistral, DeepSeek,
+- **OpenAI-compatible MaaS models** (Meta/Llama, Mistral, DeepSeek,
   AI21 Jamba, xAI Grok, Qwen, etc.):
   OpenAI Chat Completions format via the shared /endpoints/openapi endpoint.
 """
@@ -22,7 +22,8 @@ import json
 from enum import Enum
 from pathlib import Path
 
-from mlflow.gateway.config import EndpointConfig, VertexAIConfig
+from mlflow.gateway.config import EndpointConfig, EndpointType, VertexAIConfig
+from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.providers.anthropic import AnthropicProvider
 from mlflow.gateway.providers.base import BaseProvider
 from mlflow.gateway.providers.gemini import GeminiProvider
@@ -33,17 +34,17 @@ _DEFAULT_SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
 # Version string required by Vertex AI for Anthropic models
 _VERTEX_ANTHROPIC_VERSION = "vertex-2023-10-16"
 
-# No-slash model name prefixes that belong to Tier 3 (OpenAI-compatible MaaS)
-# rather than Tier 1 (Gemini API).
-_TIER3_PREFIXES = ("mistral", "codestral", "jamba")
+# No-slash model name prefixes that belong to the MaaS (OpenAI-compatible) type
+# rather than the Google (Gemini API) type.
+_MAAS_PREFIXES = ("mistral", "codestral", "jamba")
 
 
 def _classify_model(model_name: str) -> str:
-    """Return the tier for a Vertex AI model name: 'gemini', 'claude', or 'maas'."""
+    """Return the model type for a Vertex AI model name: 'gemini', 'claude', or 'maas'."""
     name = model_name.lower()
     if name.startswith("claude"):
         return "claude"
-    if "/" in name or name.startswith(_TIER3_PREFIXES):
+    if "/" in name or name.startswith(_MAAS_PREFIXES):
         return "maas"
     return "gemini"
 
@@ -78,6 +79,11 @@ class _VertexAIClaudeProvider(AnthropicProvider):
         host = f"https://{prefix}aiplatform.googleapis.com"
         path = f"/v1/projects/{project}/locations/{location}/publishers/anthropic/models"
         return f"{host}{path}"
+
+    def get_endpoint_url(self, route_type: str) -> str:
+        if route_type in ("llm/v1/chat", EndpointType.LLM_V1_CHAT):
+            return f"{self.base_url}/{self.config.model.name}:rawPredict"
+        raise ValueError(f"Unsupported route type for Vertex AI Claude: {route_type}")
 
     def _get_chat_path(self) -> str:
         return f"{self.config.model.name}:rawPredict"
@@ -126,10 +132,9 @@ class _VertexAIMaaSProvider(OpenAICompatibleProvider):
 class VertexAIProvider(GeminiProvider):
     """Vertex AI provider supporting Google, Anthropic, and OpenAI-compatible MaaS models.
 
-    - Gemini/Google models → Tier 1: Gemini API (:generateContent)
-    - Claude models        → Tier 2: Anthropic API (:rawPredict) via _VertexAIClaudeProvider
-    - MaaS models          → Tier 3: OpenAI Chat Completions (/endpoints/openapi/chat/completions)
-                             via _VertexAIMaaSProvider
+    - Google models  → Gemini API (:generateContent)
+    - Claude models  → Anthropic API (:rawPredict) via _VertexAIClaudeProvider
+    - MaaS models    → OpenAI Chat Completions (/endpoints/openapi) via _VertexAIMaaSProvider
     """
 
     DISPLAY_NAME = "Vertex AI"
@@ -148,12 +153,12 @@ class VertexAIProvider(GeminiProvider):
         self.vertex_config: VertexAIConfig = config.model.config
         self._cached_credentials = None
 
-        self._tier = _classify_model(config.model.name)
-        if self._tier == "claude":
+        self._model_type = _classify_model(config.model.name)
+        if self._model_type == "claude":
             self._delegate = _VertexAIClaudeProvider(
                 config, self.vertex_config, self._get_credentials
             )
-        elif self._tier == "maas":
+        elif self._model_type == "maas":
             self._delegate = _VertexAIMaaSProvider(
                 config, self.vertex_config, self._get_credentials
             )
@@ -208,9 +213,14 @@ class VertexAIProvider(GeminiProvider):
         # https://docs.cloud.google.com/vertex-ai/docs/general/googleapi-access-methods#regional-global-endpoints
         prefix = "" if location == "global" else f"{location}-"
         host = f"https://{prefix}aiplatform.googleapis.com"
-        publisher = "anthropic" if self._tier == "claude" else "google"
+        publisher = "anthropic" if self._model_type == "claude" else "google"
         path = f"/v1/projects/{project}/locations/{location}/publishers/{publisher}/models"
         return f"{host}{path}"
+
+    def get_endpoint_url(self, route_type: str) -> str:
+        if self._delegate:
+            return self._delegate.get_endpoint_url(route_type)
+        return super().get_endpoint_url(route_type)
 
     async def _chat(self, payload):
         if self._delegate:
@@ -226,18 +236,24 @@ class VertexAIProvider(GeminiProvider):
             yield chunk
 
     async def _completions(self, payload):
-        if self._tier in ("claude", "maas"):
-            raise NotImplementedError(
-                f"The completions endpoint is not supported for {self.config.model.name} on "
-                "Vertex AI. Use the chat endpoint instead."
+        if self._model_type in ("claude", "maas"):
+            raise AIGatewayException(
+                status_code=501,
+                detail=(
+                    f"The completions endpoint is not supported for {self.config.model.name} on "
+                    "Vertex AI. Use the chat endpoint instead."
+                ),
             )
         return await super()._completions(payload)
 
     async def _completions_stream(self, payload):
-        if self._tier in ("claude", "maas"):
-            raise NotImplementedError(
-                f"The completions endpoint is not supported for {self.config.model.name} on "
-                "Vertex AI. Use the chat endpoint instead."
+        if self._model_type in ("claude", "maas"):
+            raise AIGatewayException(
+                status_code=501,
+                detail=(
+                    f"The completions endpoint is not supported for {self.config.model.name} on "
+                    "Vertex AI. Use the chat endpoint instead."
+                ),
             )
         async for chunk in super()._completions_stream(payload):
             yield chunk

--- a/mlflow/gateway/providers/vertex_ai.py
+++ b/mlflow/gateway/providers/vertex_ai.py
@@ -4,11 +4,18 @@ Vertex AI provider for MLflow AI Gateway.
 Extends the Gemini provider to use Vertex AI endpoints with Google Cloud
 authentication (Application Default Credentials or service account JSON).
 
-For Google-published models (e.g. gemini-2.0-flash), this uses the Gemini API
-format with :generateContent/:streamGenerateContent endpoints.
+Three tiers of models are supported:
 
-For Anthropic Claude models, this uses AnthropicProvider's logic with Vertex AI
-auth (Bearer token) and :rawPredict/:streamRawPredict endpoints.
+- **Tier 1 — Google models** (gemini-*, medlm-*, text-embedding-*, etc.):
+  Gemini API format with :generateContent/:streamGenerateContent endpoints.
+
+- **Tier 2 — Anthropic Claude models** (claude-*):
+  Anthropic Messages API format with :rawPredict/:streamRawPredict endpoints,
+  routed through publishers/anthropic.
+
+- **Tier 3 — OpenAI-compatible MaaS models** (Meta/Llama, Mistral, DeepSeek,
+  AI21 Jamba, xAI Grok, Qwen, etc.):
+  OpenAI Chat Completions format via the shared /endpoints/openapi endpoint.
 """
 
 import json
@@ -19,11 +26,26 @@ from mlflow.gateway.config import EndpointConfig, VertexAIConfig
 from mlflow.gateway.providers.anthropic import AnthropicProvider
 from mlflow.gateway.providers.base import BaseProvider
 from mlflow.gateway.providers.gemini import GeminiProvider
+from mlflow.gateway.providers.openai_compatible import OpenAICompatibleProvider
 
 _DEFAULT_SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
 
 # Version string required by Vertex AI for Anthropic models
 _VERTEX_ANTHROPIC_VERSION = "vertex-2023-10-16"
+
+# No-slash model name prefixes that belong to Tier 3 (OpenAI-compatible MaaS)
+# rather than Tier 1 (Gemini API).
+_TIER3_PREFIXES = ("mistral", "codestral", "jamba")
+
+
+def _classify_model(model_name: str) -> str:
+    """Return the tier for a Vertex AI model name: 'gemini', 'claude', or 'maas'."""
+    name = model_name.lower()
+    if name.startswith("claude"):
+        return "claude"
+    if "/" in name or name.startswith(_TIER3_PREFIXES):
+        return "maas"
+    return "gemini"
 
 
 class _VertexAIClaudeProvider(AnthropicProvider):
@@ -69,12 +91,45 @@ class _VertexAIClaudeProvider(AnthropicProvider):
         return payload
 
 
-class VertexAIProvider(GeminiProvider):
-    """Vertex AI provider supporting both Google (Gemini) and Anthropic (Claude) models.
+class _VertexAIMaaSProvider(OpenAICompatibleProvider):
+    """OpenAICompatibleProvider adapted for MaaS models hosted on Vertex AI.
 
-    Google-published models use the Gemini API format (:generateContent).
-    Anthropic Claude models are handled by _VertexAIClaudeProvider, which reuses
-    AnthropicProvider's request/response logic with Vertex AI auth and endpoints.
+    All partner MaaS models (Meta/Llama, Mistral, DeepSeek, AI21, xAI, Qwen, etc.)
+    share a single OpenAI-compatible endpoint at /endpoints/openapi, authenticated
+    with a GCP Bearer token.
+    """
+
+    DISPLAY_NAME = "Vertex AI"
+    CONFIG_TYPE = VertexAIConfig
+
+    def __init__(self, config: EndpointConfig, vertex_config: VertexAIConfig, get_credentials_fn):
+        # Call BaseProvider.__init__ directly — OpenAICompatibleProvider.__init__ would
+        # reject VertexAIConfig since it expects an _OpenAICompatibleConfig.
+        BaseProvider.__init__(self, config)
+        self.vertex_config = vertex_config
+        self._get_creds = get_credentials_fn
+
+    @property
+    def headers(self) -> dict[str, str]:
+        creds = self._get_creds()
+        return {"Authorization": f"Bearer {creds.token}"}
+
+    @property
+    def _api_base(self) -> str:
+        project = self.vertex_config.vertex_project
+        location = self.vertex_config.vertex_location or "us-central1"
+        prefix = "" if location == "global" else f"{location}-"
+        host = f"https://{prefix}aiplatform.googleapis.com"
+        return f"{host}/v1/projects/{project}/locations/{location}/endpoints/openapi"
+
+
+class VertexAIProvider(GeminiProvider):
+    """Vertex AI provider supporting Google, Anthropic, and OpenAI-compatible MaaS models.
+
+    - Gemini/Google models → Tier 1: Gemini API (:generateContent)
+    - Claude models        → Tier 2: Anthropic API (:rawPredict) via _VertexAIClaudeProvider
+    - MaaS models          → Tier 3: OpenAI Chat Completions (/endpoints/openapi/chat/completions)
+                             via _VertexAIMaaSProvider
     """
 
     DISPLAY_NAME = "Vertex AI"
@@ -92,14 +147,18 @@ class VertexAIProvider(GeminiProvider):
         self._provider_name = provider.value if isinstance(provider, Enum) else str(provider)
         self.vertex_config: VertexAIConfig = config.model.config
         self._cached_credentials = None
-        self._claude_provider: _VertexAIClaudeProvider | None = (
-            _VertexAIClaudeProvider(config, self.vertex_config, self._get_credentials)
-            if self._is_claude_model()
-            else None
-        )
 
-    def _is_claude_model(self) -> bool:
-        return self.config.model.name.lower().startswith("claude")
+        self._tier = _classify_model(config.model.name)
+        if self._tier == "claude":
+            self._delegate = _VertexAIClaudeProvider(
+                config, self.vertex_config, self._get_credentials
+            )
+        elif self._tier == "maas":
+            self._delegate = _VertexAIMaaSProvider(
+                config, self.vertex_config, self._get_credentials
+            )
+        else:
+            self._delegate = None
 
     def _get_credentials(self):
         """Get Google Cloud credentials, caching them for reuse."""
@@ -117,11 +176,9 @@ class VertexAIProvider(GeminiProvider):
             return self._cached_credentials
 
         if creds_data := self.vertex_config.vertex_credentials:
-            # Try parsing as JSON string
             try:
                 info = json.loads(creds_data)
             except (json.JSONDecodeError, TypeError):
-                # Try as file path
                 try:
                     info = json.loads(Path(creds_data).read_text())
                 except Exception as e:
@@ -132,10 +189,8 @@ class VertexAIProvider(GeminiProvider):
                 info, scopes=_DEFAULT_SCOPES
             )
         else:
-            # Use Application Default Credentials
             credentials, _ = google.auth.default(scopes=_DEFAULT_SCOPES)
 
-        # Refresh to get a valid access token
         credentials.refresh(google.auth.transport.requests.Request())
         self._cached_credentials = credentials
         return credentials
@@ -145,9 +200,6 @@ class VertexAIProvider(GeminiProvider):
         credentials = self._get_credentials()
         return {"Authorization": f"Bearer {credentials.token}"}
 
-    def _get_publisher(self) -> str:
-        return "anthropic" if self._is_claude_model() else "google"
-
     @property
     def base_url(self) -> str:
         project = self.vertex_config.vertex_project
@@ -156,35 +208,35 @@ class VertexAIProvider(GeminiProvider):
         # https://docs.cloud.google.com/vertex-ai/docs/general/googleapi-access-methods#regional-global-endpoints
         prefix = "" if location == "global" else f"{location}-"
         host = f"https://{prefix}aiplatform.googleapis.com"
-        publisher = self._get_publisher()
+        publisher = "anthropic" if self._tier == "claude" else "google"
         path = f"/v1/projects/{project}/locations/{location}/publishers/{publisher}/models"
         return f"{host}{path}"
 
     async def _chat(self, payload):
-        if self._claude_provider:
-            return await self._claude_provider._chat(payload)
+        if self._delegate:
+            return await self._delegate._chat(payload)
         return await super()._chat(payload)
 
     async def _chat_stream(self, payload):
-        if self._claude_provider:
-            async for chunk in self._claude_provider._chat_stream(payload):
+        if self._delegate:
+            async for chunk in self._delegate._chat_stream(payload):
                 yield chunk
             return
         async for chunk in super()._chat_stream(payload):
             yield chunk
 
     async def _completions(self, payload):
-        if self._claude_provider:
+        if self._tier in ("claude", "maas"):
             raise NotImplementedError(
-                "The completions endpoint is not supported for Anthropic Claude models on "
+                f"The completions endpoint is not supported for {self.config.model.name} on "
                 "Vertex AI. Use the chat endpoint instead."
             )
         return await super()._completions(payload)
 
     async def _completions_stream(self, payload):
-        if self._claude_provider:
+        if self._tier in ("claude", "maas"):
             raise NotImplementedError(
-                "The completions endpoint is not supported for Anthropic Claude models on "
+                f"The completions endpoint is not supported for {self.config.model.name} on "
                 "Vertex AI. Use the chat endpoint instead."
             )
         async for chunk in super()._completions_stream(payload):

--- a/tests/gateway/providers/test_vertex_ai.py
+++ b/tests/gateway/providers/test_vertex_ai.py
@@ -321,7 +321,7 @@ def _make_maas_provider(model_name: str, location: str = "us-central1") -> Verte
 )
 def test_maas_model_uses_openapi_endpoint(model_name):
     provider = _make_maas_provider(model_name)
-    assert provider._tier == "maas"
+    assert provider._model_type == "maas"
     assert provider._delegate is not None
     assert provider._delegate._api_base == (
         "https://us-central1-aiplatform.googleapis.com"
@@ -368,6 +368,35 @@ async def test_maas_chat_uses_openai_format():
         },
         timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
     )
+
+
+def test_claude_get_endpoint_url():
+    provider = _make_claude_provider()
+    assert provider.get_endpoint_url("llm/v1/chat") == (
+        "https://us-east5-aiplatform.googleapis.com"
+        "/v1/projects/my-gcp-project/locations/us-east5/publishers/anthropic/models"
+        "/claude-sonnet-4-5@20251101:rawPredict"
+    )
+
+
+def test_maas_get_endpoint_url():
+    provider = _make_maas_provider("meta/llama-3.1-405b-instruct-maas")
+    assert provider.get_endpoint_url("llm/v1/chat") == (
+        "https://us-central1-aiplatform.googleapis.com"
+        "/v1/projects/my-gcp-project/locations/us-central1/endpoints/openapi/chat/completions"
+    )
+
+
+@pytest.mark.asyncio
+async def test_claude_completions_raises_gateway_exception():
+    from mlflow.gateway.exceptions import AIGatewayException
+    from mlflow.gateway.schemas import completions
+
+    provider = _make_claude_provider()
+    with pytest.raises(AIGatewayException, match="completions endpoint is not supported"):
+        await provider.completions(
+            completions.RequestPayload(prompt="hello", max_tokens=10)
+        )
 
 
 def test_with_credentials():

--- a/tests/gateway/providers/test_vertex_ai.py
+++ b/tests/gateway/providers/test_vertex_ai.py
@@ -11,8 +11,9 @@ from mlflow.gateway.constants import (
     MLFLOW_AI_GATEWAY_ANTHROPIC_DEFAULT_MAX_TOKENS,
     MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS,
 )
+from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.providers.vertex_ai import VertexAIProvider
-from mlflow.gateway.schemas import chat
+from mlflow.gateway.schemas import chat, completions
 
 from tests.gateway.tools import MockAsyncResponse, MockAsyncStreamingResponse, mock_http_client
 
@@ -389,9 +390,6 @@ def test_maas_get_endpoint_url():
 
 @pytest.mark.asyncio
 async def test_claude_completions_raises_gateway_exception():
-    from mlflow.gateway.exceptions import AIGatewayException
-    from mlflow.gateway.schemas import completions
-
     provider = _make_claude_provider()
     with pytest.raises(AIGatewayException, match="completions endpoint is not supported"):
         await provider.completions(

--- a/tests/gateway/providers/test_vertex_ai.py
+++ b/tests/gateway/providers/test_vertex_ai.py
@@ -289,6 +289,87 @@ async def test_claude_chat_stream_uses_stream_raw_predict_endpoint():
     assert "model" not in call_kwargs[1]["json"]
 
 
+def _make_maas_provider(model_name: str, location: str = "us-central1") -> VertexAIProvider:
+    endpoint_config = EndpointConfig(
+        name="vertex-maas-endpoint",
+        endpoint_type="llm/v1/chat",
+        model={
+            "provider": "vertex_ai",
+            "name": model_name,
+            "config": {
+                "vertex_project": "my-gcp-project",
+                "vertex_location": location,
+            },
+        },
+    )
+    provider = VertexAIProvider(endpoint_config)
+    provider._cached_credentials = _mock_credentials()
+    return provider
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "meta/llama-3.1-405b-instruct-maas",
+        "mistral-large-2411",
+        "codestral-2501",
+        "jamba-1.5",
+        "deepseek-ai/deepseek-r1-0528-maas",
+        "xai/grok-4.1-fast-reasoning",
+        "qwen/qwen3-235b-a22b-instruct-2507-maas",
+    ],
+)
+def test_maas_model_uses_openapi_endpoint(model_name):
+    provider = _make_maas_provider(model_name)
+    assert provider._tier == "maas"
+    assert provider._delegate is not None
+    assert provider._delegate._api_base == (
+        "https://us-central1-aiplatform.googleapis.com"
+        "/v1/projects/my-gcp-project/locations/us-central1/endpoints/openapi"
+    )
+
+
+@pytest.mark.asyncio
+async def test_maas_chat_uses_openai_format():
+    provider = _make_maas_provider("meta/llama-3.1-405b-instruct-maas")
+    openai_resp = {
+        "id": "chatcmpl-123",
+        "object": "chat.completion",
+        "created": 1677858242,
+        "model": "meta/llama-3.1-405b-instruct-maas",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "Hello from Llama on Vertex AI!"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 8, "total_tokens": 18},
+    }
+
+    with (
+        mock.patch("aiohttp.ClientSession.post", return_value=MockAsyncResponse(openai_resp))
+        as mock_post,
+    ):
+        payload = chat.RequestPayload(messages=[{"role": "user", "content": "Hello"}])
+        response = await provider.chat(payload)
+
+    result = jsonable_encoder(response)
+    assert result["choices"][0]["message"]["content"] == "Hello from Llama on Vertex AI!"
+    assert result["usage"]["prompt_tokens"] == 10
+
+    mock_post.assert_called_once_with(
+        "https://us-central1-aiplatform.googleapis.com"
+        "/v1/projects/my-gcp-project/locations/us-central1/endpoints/openapi/chat/completions",
+        json={
+            "model": "meta/llama-3.1-405b-instruct-maas",
+            "n": 1,
+            "messages": [{"role": "user", "content": "Hello"}],
+        },
+        timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
+    )
+
+
 def test_with_credentials():
     creds_json = json.dumps({"type": "service_account", "project_id": "test"})
     config = VertexAIConfig(vertex_project="my-project", vertex_credentials=creds_json)

--- a/tests/gateway/providers/test_vertex_ai.py
+++ b/tests/gateway/providers/test_vertex_ai.py
@@ -2,14 +2,19 @@ import json
 from unittest import mock
 
 import pytest
+from aiohttp import ClientTimeout
 from fastapi.encoders import jsonable_encoder
 from pydantic import ValidationError
 
 from mlflow.gateway.config import EndpointConfig, VertexAIConfig
+from mlflow.gateway.constants import (
+    MLFLOW_AI_GATEWAY_ANTHROPIC_DEFAULT_MAX_TOKENS,
+    MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS,
+)
 from mlflow.gateway.providers.vertex_ai import VertexAIProvider
 from mlflow.gateway.schemas import chat
 
-from tests.gateway.tools import MockAsyncResponse, mock_http_client
+from tests.gateway.tools import MockAsyncResponse, MockAsyncStreamingResponse, mock_http_client
 
 
 def _mock_credentials():
@@ -143,6 +148,145 @@ def test_global_location_uses_global_endpoint():
         "https://aiplatform.googleapis.com"
         "/v1/projects/my-gcp-project/locations/global/publishers/google/models"
     )
+
+
+def test_anthropic_model_uses_anthropic_publisher():
+    endpoint_config = EndpointConfig(
+        name="vertex-endpoint",
+        endpoint_type="llm/v1/chat",
+        model={
+            "provider": "vertex_ai",
+            "name": "claude-sonnet-4-5@20251101",
+            "config": {
+                "vertex_project": "my-gcp-project",
+                "vertex_location": "us-east5",
+            },
+        },
+    )
+    provider = VertexAIProvider(endpoint_config)
+    provider._cached_credentials = _mock_credentials()
+    assert provider.base_url == (
+        "https://us-east5-aiplatform.googleapis.com"
+        "/v1/projects/my-gcp-project/locations/us-east5/publishers/anthropic/models"
+    )
+
+
+def test_anthropic_model_global_location():
+    endpoint_config = EndpointConfig(
+        name="vertex-endpoint",
+        endpoint_type="llm/v1/chat",
+        model={
+            "provider": "vertex_ai",
+            "name": "claude-opus-4-5@20251101",
+            "config": {
+                "vertex_project": "my-project",
+                "vertex_location": "global",
+            },
+        },
+    )
+    provider = VertexAIProvider(endpoint_config)
+    provider._cached_credentials = _mock_credentials()
+    assert provider.base_url == (
+        "https://aiplatform.googleapis.com"
+        "/v1/projects/my-project/locations/global/publishers/anthropic/models"
+    )
+
+
+def _make_claude_provider() -> VertexAIProvider:
+    endpoint_config = EndpointConfig(
+        name="vertex-claude-endpoint",
+        endpoint_type="llm/v1/chat",
+        model={
+            "provider": "vertex_ai",
+            "name": "claude-sonnet-4-5@20251101",
+            "config": {
+                "vertex_project": "my-gcp-project",
+                "vertex_location": "us-east5",
+            },
+        },
+    )
+    provider = VertexAIProvider(endpoint_config)
+    provider._cached_credentials = _mock_credentials()
+    return provider
+
+
+def _claude_chat_response():
+    return {
+        "content": [{"text": "Hello from Claude on Vertex AI!", "type": "text"}],
+        "id": "msg-vertex-test",
+        "model": "claude-sonnet-4-5@20251101",
+        "role": "assistant",
+        "stop_reason": "end_turn",
+        "stop_sequence": None,
+        "type": "message",
+        "usage": {"input_tokens": 10, "output_tokens": 15},
+    }
+
+
+@pytest.mark.asyncio
+async def test_claude_chat_uses_raw_predict_endpoint():
+    provider = _make_claude_provider()
+    resp = _claude_chat_response()
+
+    with (
+        mock.patch("time.time", return_value=1677858242),
+        mock.patch("aiohttp.ClientSession.post", return_value=MockAsyncResponse(resp)) as mock_post,
+    ):
+        payload = chat.RequestPayload(messages=[{"role": "user", "content": "Hello"}])
+        response = await provider.chat(payload)
+
+    result = jsonable_encoder(response)
+    assert result["choices"][0]["message"]["content"] == "Hello from Claude on Vertex AI!"
+    assert result["choices"][0]["message"]["role"] == "assistant"
+    assert result["usage"]["prompt_tokens"] == 10
+    assert result["usage"]["completion_tokens"] == 15
+
+    mock_post.assert_called_once_with(
+        "https://us-east5-aiplatform.googleapis.com/v1/projects/my-gcp-project"
+        "/locations/us-east5/publishers/anthropic/models"
+        "/claude-sonnet-4-5@20251101:rawPredict",
+        json={
+            "messages": [{"role": "user", "content": "Hello"}],
+            "max_tokens": MLFLOW_AI_GATEWAY_ANTHROPIC_DEFAULT_MAX_TOKENS,
+            "anthropic_version": "vertex-2023-10-16",
+        },
+        timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
+    )
+
+
+@pytest.mark.asyncio
+async def test_claude_chat_stream_uses_stream_raw_predict_endpoint():
+    provider = _make_claude_provider()
+    stream_data = [
+        b"event: message_start\n",
+        b'data: {"type": "message_start", "message": {"id": "msg-1", "type": "message", '
+        b'"role": "assistant", "content": [], "model": "claude-sonnet-4-5@20251101", '
+        b'"stop_reason": null, "stop_sequence": null, "usage": {"input_tokens": 5, "output_tokens": 1}}}\n',
+        b"\n",
+        b"event: content_block_delta\n",
+        b'data: {"type": "content_block_delta", "index": 0, '
+        b'"delta": {"type": "text_delta", "text": "Hello"}}\n',
+        b"\n",
+        b"event: message_delta\n",
+        b'data: {"type": "message_delta", "delta": {"stop_reason": "end_turn"}, '
+        b'"usage": {"output_tokens": 1}}\n',
+        b"\n",
+    ]
+    mock_response = MockAsyncStreamingResponse(stream_data)
+    mock_client = mock_http_client(mock_response)
+
+    with mock.patch("aiohttp.ClientSession", return_value=mock_client):
+        payload = chat.RequestPayload(
+            messages=[{"role": "user", "content": "Hello"}], stream=True
+        )
+        chunks = [chunk async for chunk in provider.chat_stream(payload)]
+
+    assert len(chunks) > 0
+    mock_client.post.assert_called_once()
+    call_kwargs = mock_client.post.call_args
+    assert ":streamRawPredict" in call_kwargs[0][0]
+    assert call_kwargs[1]["json"]["anthropic_version"] == "vertex-2023-10-16"
+    assert "model" not in call_kwargs[1]["json"]
 
 
 def test_with_credentials():

--- a/tests/gateway/providers/test_vertex_ai.py
+++ b/tests/gateway/providers/test_vertex_ai.py
@@ -262,7 +262,8 @@ async def test_claude_chat_stream_uses_stream_raw_predict_endpoint():
         b"event: message_start\n",
         b'data: {"type": "message_start", "message": {"id": "msg-1", "type": "message", '
         b'"role": "assistant", "content": [], "model": "claude-sonnet-4-5@20251101", '
-        b'"stop_reason": null, "stop_sequence": null, "usage": {"input_tokens": 5, "output_tokens": 1}}}\n',
+        b'"stop_reason": null, "stop_sequence": null, '
+        b'"usage": {"input_tokens": 5, "output_tokens": 1}}}\n',
         b"\n",
         b"event: content_block_delta\n",
         b'data: {"type": "content_block_delta", "index": 0, '

--- a/tests/gateway/providers/test_vertex_ai.py
+++ b/tests/gateway/providers/test_vertex_ai.py
@@ -277,9 +277,7 @@ async def test_claude_chat_stream_uses_stream_raw_predict_endpoint():
     mock_client = mock_http_client(mock_response)
 
     with mock.patch("aiohttp.ClientSession", return_value=mock_client):
-        payload = chat.RequestPayload(
-            messages=[{"role": "user", "content": "Hello"}], stream=True
-        )
+        payload = chat.RequestPayload(messages=[{"role": "user", "content": "Hello"}], stream=True)
         chunks = [chunk async for chunk in provider.chat_stream(payload)]
 
     assert len(chunks) > 0
@@ -349,8 +347,9 @@ async def test_maas_chat_uses_openai_format():
     }
 
     with (
-        mock.patch("aiohttp.ClientSession.post", return_value=MockAsyncResponse(openai_resp))
-        as mock_post,
+        mock.patch(
+            "aiohttp.ClientSession.post", return_value=MockAsyncResponse(openai_resp)
+        ) as mock_post,
     ):
         payload = chat.RequestPayload(messages=[{"role": "user", "content": "Hello"}])
         response = await provider.chat(payload)
@@ -392,9 +391,7 @@ def test_maas_get_endpoint_url():
 async def test_claude_completions_raises_gateway_exception():
     provider = _make_claude_provider()
     with pytest.raises(AIGatewayException, match="completions endpoint is not supported"):
-        await provider.completions(
-            completions.RequestPayload(prompt="hello", max_tokens=10)
-        )
+        await provider.completions(completions.RequestPayload(prompt="hello", max_tokens=10))
 
 
 def test_with_credentials():


### PR DESCRIPTION
### Related Issues/PRs

Closes #23092

### What changes are proposed in this pull request?

Vertex AI hosts models in three distinct tiers, each requiring a different API format. Previously only Tier 1 (Gemini) worked; this PR adds Tier 2 and Tier 3.

**Tier 1 — Google models** (`gemini-*`, `medlm-*`, `text-embedding-*`, etc.): already worked via the Gemini API format.

**Tier 2 — Anthropic Claude models** (`claude-*`): require `publishers/anthropic` in the URL, `:rawPredict`/`:streamRawPredict` endpoints, Anthropic Messages API request/response format, and `anthropic_version: "vertex-2023-10-16"` in the body. Previously caused a 404 because `publishers/google` and the Gemini format were used.

**Tier 3 — OpenAI-compatible MaaS models** (Meta/Llama, Mistral, Codestral, AI21 Jamba, DeepSeek, xAI Grok, Qwen, etc.): use a shared OpenAI-compatible endpoint at `/endpoints/openapi/chat/completions` with standard OpenAI Chat Completions format.

**Implementation:**

- `_classify_model(name)` returns `"gemini"`, `"claude"`, or `"maas"` based on the model name.
- `_VertexAIClaudeProvider(AnthropicProvider)`: overrides `headers`/`base_url` for Vertex AI auth, and three hook methods added to `AnthropicProvider` (`_get_chat_path`, `_get_chat_stream_path`, `_prepare_payload`) to route to `:rawPredict`/`:streamRawPredict`. Reuses all of `AnthropicProvider`'s SSE streaming, usage tracking, and tool call logic.
- `_VertexAIMaaSProvider(OpenAICompatibleProvider)`: overrides `headers` and `_api_base` for the shared `/endpoints/openapi` URL with Vertex AI Bearer auth. Reuses all of `OpenAICompatibleProvider`'s logic.
- `VertexAIProvider.__init__` creates the appropriate sub-provider at init time and delegates `_chat`/`_chat_stream` to it.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

New tests in `tests/gateway/providers/test_vertex_ai.py`:
- `test_anthropic_model_uses_anthropic_publisher` / `test_anthropic_model_global_location` — correct `base_url` for Claude
- `test_claude_chat_uses_raw_predict_endpoint` — full request hits `:rawPredict` with Anthropic format and `anthropic_version`
- `test_claude_chat_stream_uses_stream_raw_predict_endpoint` — streaming hits `:streamRawPredict`
- `test_maas_model_uses_openapi_endpoint` (parametrized over 7 model names) — MaaS models resolve to `/endpoints/openapi`
- `test_maas_chat_uses_openai_format` — full MaaS request hits `/endpoints/openapi/chat/completions` with OpenAI payload

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed the Vertex AI gateway provider to correctly route requests based on the model type: Anthropic Claude models now use `publishers/anthropic` with the Anthropic Messages API (`:rawPredict`), and partner MaaS models (Meta/Llama, Mistral, Codestral, DeepSeek, AI21 Jamba, xAI Grok, Qwen, etc.) now use the OpenAI-compatible `/endpoints/openapi/chat/completions` endpoint. Previously all models incorrectly used the Gemini API format, causing 404 errors.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release