### PR TITLE
Deny deprecated `app-id` input on `create-github-app-token`

### DIFF
--- a/.github/policy.rego
+++ b/.github/policy.rego
@@ -56,6 +56,17 @@ deny_create_app_token_without_permissions contains msg if {
 	)
 }
 
+deny_create_app_token_with_app_id contains msg if {
+	some job_id, job in input.jobs
+	some step in job.steps
+	startswith(step.uses, "actions/create-github-app-token@")
+	step["with"]["app-id"]
+	msg := sprintf(
+		"actions/create-github-app-token in job '%s' uses deprecated 'app-id'. Use 'client-id' instead.",
+		[job_id],
+	)
+}
+
 step_has_app_token_permissions(step) if {
 	some key, _ in step["with"]
 	startswith(key, "permission-")


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23157

### What changes are proposed in this pull request?

Adds a `policy.rego` rule that flags any `actions/create-github-app-token@*` step using the deprecated `app-id` input, so new workflows can't reintroduce it after the repo-wide migration to `client-id`.

### How is this PR tested?

- [x] Manual tests

Flipped `client-id` → `app-id` in `resolve.yml` locally and ran `bin/conftest test --namespace mlflow --policy .github/policy.rego .github/workflows/resolve.yml` — the new rule fired with the expected message. Reverted the workflow change.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)