### PR TITLE
Properly escape host parameter in rfunc serve command

### DIFF
--- a/mlflow/rfunc/backend.py
+++ b/mlflow/rfunc/backend.py
@@ -103,8 +103,8 @@ class RFuncBackend(FlavorBackend):
             raise Exception("RBackend does not support redirect stdout/stderr.")
 
         model_path = _download_artifact_from_uri(model_uri)
-        command = "mlflow::mlflow_rfunc_serve('{}', port = {}, host = '{}')".format(
-            quote(model_path), port, host
+        command = "mlflow::mlflow_rfunc_serve({}, port = {}, host = {})".format(
+            _r_quote(model_path), port, _r_quote(host)
         )
         _execute(command)
 
@@ -146,3 +146,11 @@ def _execute(command, extra_envs=None):
 
 def _str_optional(s):
     return "NULL" if s is None else f"'{quote(str(s))}'"
+
+
+def _r_quote(s: str) -> str:
+    # The `command` is passed directly as an argv element to `Rscript -e`, so
+    # the string is parsed by R, not the shell. Escape backslashes and single
+    # quotes so the result is a safe R single-quoted string literal.
+    escaped = s.replace("\\", "\\\\").replace("'", "\\'")
+    return f"'{escaped}'"

--- a/mlflow/rfunc/backend.py
+++ b/mlflow/rfunc/backend.py
@@ -7,7 +7,6 @@ import sys
 from mlflow.exceptions import MlflowException
 from mlflow.models import FlavorBackend
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
-from mlflow.utils.string_utils import quote
 
 _logger = logging.getLogger(__name__)
 
@@ -61,11 +60,11 @@ class RFuncBackend(FlavorBackend):
             raise MlflowException("pip_requirements_override is not supported in the R backend.")
         model_path = _download_artifact_from_uri(model_uri)
         str_cmd = (
-            "mlflow:::mlflow_rfunc_predict(model_path = '{0}', input_path = {1}, "
+            "mlflow:::mlflow_rfunc_predict(model_path = {0}, input_path = {1}, "
             "output_path = {2}, content_type = {3})"
         )
         command = str_cmd.format(
-            quote(model_path),
+            _r_quote(model_path),
             _str_optional(input_path),
             _str_optional(output_path),
             _str_optional(content_type),
@@ -145,7 +144,7 @@ def _execute(command, extra_envs=None):
 
 
 def _str_optional(s):
-    return "NULL" if s is None else f"'{quote(str(s))}'"
+    return "NULL" if s is None else _r_quote(str(s))
 
 
 def _r_quote(s: str) -> str:

--- a/tests/rfunc/test_backend.py
+++ b/tests/rfunc/test_backend.py
@@ -1,0 +1,80 @@
+from unittest import mock
+
+import pytest
+
+from mlflow.rfunc.backend import RFuncBackend, _r_quote
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("localhost", "'localhost'"),
+        ("0.0.0.0", "'0.0.0.0'"),
+        ("foo bar", "'foo bar'"),
+        ("it's", "'it\\'s'"),
+        ("back\\slash", "'back\\\\slash'"),
+        (
+            "localhost'); file.create('/tmp/pwned'); cat('",
+            "'localhost\\'); file.create(\\'/tmp/pwned\\'); cat(\\''",
+        ),
+    ],
+)
+def test_r_quote_escapes_single_quotes_and_backslashes(value, expected):
+    assert _r_quote(value) == expected
+
+
+def test_serve_escapes_malicious_host():
+    backend = RFuncBackend(config={})
+    malicious_host = "localhost'); file.create('/tmp/pwned'); cat('"
+
+    with (
+        mock.patch(
+            "mlflow.rfunc.backend._download_artifact_from_uri",
+            return_value="/tmp/model",
+        ) as mock_download,
+        mock.patch("mlflow.rfunc.backend._execute") as mock_execute,
+    ):
+        backend.serve(
+            model_uri="models:/foo/1",
+            port=5000,
+            host=malicious_host,
+            timeout=None,
+            enable_mlserver=False,
+        )
+
+    mock_download.assert_called_once_with("models:/foo/1")
+    mock_execute.assert_called_once()
+    (command,) = mock_execute.call_args.args
+
+    # The injected payload must not appear as a separate top-level R statement;
+    # the single quotes that would close the host argument must be escaped.
+    assert "file.create('/tmp/pwned')" not in command
+    assert "\\'); file.create(\\'/tmp/pwned\\'); cat(\\'" in command
+    # The full host value is contained as a single R single-quoted string literal.
+    assert "host = 'localhost\\'); file.create(\\'/tmp/pwned\\'); cat(\\''" in command
+    # The model path is also passed as an R string literal (no surrounding `'{}'`
+    # template anymore - `_r_quote` adds its own quotes).
+    assert "mlflow::mlflow_rfunc_serve('/tmp/model', port = 5000, host = " in command
+
+
+def test_serve_benign_host():
+    backend = RFuncBackend(config={})
+
+    with (
+        mock.patch(
+            "mlflow.rfunc.backend._download_artifact_from_uri",
+            return_value="/tmp/model",
+        ),
+        mock.patch("mlflow.rfunc.backend._execute") as mock_execute,
+    ):
+        backend.serve(
+            model_uri="models:/foo/1",
+            port=5000,
+            host="127.0.0.1",
+            timeout=None,
+            enable_mlserver=False,
+        )
+
+    mock_execute.assert_called_once_with(
+        "mlflow::mlflow_rfunc_serve('/tmp/model', port = 5000, host = '127.0.0.1')"
+    )


### PR DESCRIPTION
### Related Issues/PRs

Relates to GitHub Security Advisory `GHSA-pv9m-v5wv-j2xw`.

### What changes are proposed in this pull request?

`RFuncBackend.serve` constructs an R expression executed via `Rscript -e` by interpolating the `host` parameter into a single-quoted R string literal without any escaping:

```python
command = "mlflow::mlflow_rfunc_serve('{}', port = {}, host = '{}')".format(
    quote(model_path), port, host
)
```

A `host` value containing `'); ...` would close the R string literal and allow a second R top-level statement to be injected. The `command` is passed as an argv element directly to `Rscript -e` (no shell), so the previously-used `shlex.quote` would not produce a correct R string literal either.

This PR introduces a small `_r_quote` helper that escapes backslashes and single quotes and wraps the value in R single quotes, and applies it to both `model_path` and `host` in `serve`. After the fix:

```python
command = "mlflow::mlflow_rfunc_serve({}, port = {}, host = {})".format(
    _r_quote(model_path), port, _r_quote(host)
)
```

Note: this is not a security vulnerability in practice — `host` comes from the local `mlflow models serve --host` CLI flag set by the user, and the injected expression would only run after the blocking serve call returns. It is, however, a real code-quality bug worth fixing.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added `tests/rfunc/test_backend.py` covering:
- `_r_quote` behavior across benign, whitespace, single-quote and backslash inputs.
- An end-to-end check that `RFuncBackend.serve` with a malicious host like `localhost'); file.create('/tmp/pwned'); cat('` produces a command string in which the payload cannot escape its R string literal.
- A regression check that benign hosts produce the expected command.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

Reported by @sreelim via GitHub Security Advisory GHSA-pv9m-v5wv-j2xw.