### PR TITLE
[Security] Add `MLFLOW_ALLOW_PICKLE_DESERIALIZATION` guard to `PickleEvaluationArtifact`

### DIFF
--- a/mlflow/models/evaluation/artifacts.py
+++ b/mlflow/models/evaluation/artifacts.py
@@ -8,6 +8,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
+from mlflow.environment_variables import MLFLOW_ALLOW_PICKLE_DESERIALIZATION
 from mlflow.exceptions import MlflowException
 from mlflow.models.evaluation.base import EvaluationArtifact
 from mlflow.utils.annotations import developer_stable
@@ -88,6 +89,12 @@ class PickleEvaluationArtifact(EvaluationArtifact):
             pickle.dump(self._content, f)
 
     def _load_content_from_file(self, local_artifact_path):
+        if not MLFLOW_ALLOW_PICKLE_DESERIALIZATION.get():
+            raise MlflowException(
+                "Deserializing evaluation artifacts using pickle is disallowed. "
+                "Set environment variable 'MLFLOW_ALLOW_PICKLE_DESERIALIZATION' to 'true' "
+                "to allow deserializing evaluation artifacts using pickle."
+            )
         with open(local_artifact_path, "rb") as f:
             self._content = pickle.load(f)
         return self._content

--- a/tests/models/test_artifacts.py
+++ b/tests/models/test_artifacts.py
@@ -1,5 +1,6 @@
 import json
 import pathlib
+import pickle
 
 import numpy as np
 import pandas as pd
@@ -117,8 +118,6 @@ def test_infer_artifact_type_and_ext_raise_exception_for_unsupported_ext(tmp_pat
 
 
 def test_pickle_evaluation_artifact_load_raises_without_env_var(tmp_path, monkeypatch):
-    import pickle
-
     monkeypatch.setenv("MLFLOW_ALLOW_PICKLE_DESERIALIZATION", "false")
 
     artifact_path = tmp_path / "artifact.pickle"

--- a/tests/models/test_artifacts.py
+++ b/tests/models/test_artifacts.py
@@ -117,7 +117,9 @@ def test_infer_artifact_type_and_ext_raise_exception_for_unsupported_ext(tmp_pat
         _infer_artifact_type_and_ext("invalid_ext_artifact", path, cm_fn_tuple)
 
 
-def test_pickle_evaluation_artifact_load_raises_when_pickle_deserialization_disabled(tmp_path, monkeypatch):
+def test_pickle_evaluation_artifact_load_raises_when_pickle_deserialization_disabled(
+    tmp_path, monkeypatch
+):
     monkeypatch.setenv("MLFLOW_ALLOW_PICKLE_DESERIALIZATION", "false")
 
     artifact_path = tmp_path / "artifact.pickle"

--- a/tests/models/test_artifacts.py
+++ b/tests/models/test_artifacts.py
@@ -117,7 +117,7 @@ def test_infer_artifact_type_and_ext_raise_exception_for_unsupported_ext(tmp_pat
         _infer_artifact_type_and_ext("invalid_ext_artifact", path, cm_fn_tuple)
 
 
-def test_pickle_evaluation_artifact_load_raises_without_env_var(tmp_path, monkeypatch):
+def test_pickle_evaluation_artifact_load_raises_when_pickle_deserialization_disabled(tmp_path, monkeypatch):
     monkeypatch.setenv("MLFLOW_ALLOW_PICKLE_DESERIALIZATION", "false")
 
     artifact_path = tmp_path / "artifact.pickle"

--- a/tests/models/test_artifacts.py
+++ b/tests/models/test_artifacts.py
@@ -114,3 +114,17 @@ def test_infer_artifact_type_and_ext_raise_exception_for_unsupported_ext(tmp_pat
         match=f"with path '{path}' does not match any of the supported file extensions",
     ):
         _infer_artifact_type_and_ext("invalid_ext_artifact", path, cm_fn_tuple)
+
+
+def test_pickle_evaluation_artifact_load_raises_without_env_var(tmp_path, monkeypatch):
+    import pickle
+
+    monkeypatch.setenv("MLFLOW_ALLOW_PICKLE_DESERIALIZATION", "false")
+
+    artifact_path = tmp_path / "artifact.pickle"
+    with open(artifact_path, "wb") as f:
+        pickle.dump({"key": "value"}, f)
+
+    artifact = PickleEvaluationArtifact(uri="test_uri")
+    with pytest.raises(MlflowException, match="MLFLOW_ALLOW_PICKLE_DESERIALIZATION"):
+        artifact._load_content_from_file(artifact_path)


### PR DESCRIPTION
### Related Issues/PRs

Relates to #security

### What changes are proposed in this pull request?

`PickleEvaluationArtifact._load_content_from_file` was calling `pickle.load()` unconditionally, without checking the `MLFLOW_ALLOW_PICKLE_DESERIALIZATION` environment variable guard that every other pickle deserialization path in MLflow enforces (see `mlflow/pyfunc/model.py`, `mlflow/langchain/model.py`, `mlflow/dspy/load.py`).

This PR adds the missing guard:
- Added `from mlflow.environment_variables import MLFLOW_ALLOW_PICKLE_DESERIALIZATION` import to `mlflow/models/evaluation/artifacts.py`
- Raises `MlflowException` in `PickleEvaluationArtifact._load_content_from_file` before calling `pickle.load()` when `MLFLOW_ALLOW_PICKLE_DESERIALIZATION` is not set to `true`
- Note: unlike `pyfunc` and other model flavors, the Databricks runtime bypasses are intentionally omitted here since evaluation artifacts are user-generated custom metric outputs, not trusted model artifacts

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added `test_pickle_evaluation_artifact_load_raises_without_env_var` in `tests/models/test_artifacts.py` which:
- Sets `MLFLOW_ALLOW_PICKLE_DESERIALIZATION=false` via `monkeypatch.setenv`
- Asserts `MlflowException` is raised with a message matching `"MLFLOW_ALLOW_PICKLE_DESERIALIZATION"`

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`PickleEvaluationArtifact._load_content_from_file` now raises `MlflowException` when `MLFLOW_ALLOW_PICKLE_DESERIALIZATION` environment variable is not set to `true`, consistent with all other pickle deserialization paths in MLflow.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release

This pull request was AI-assisted by Isaac.