### PR TITLE
Add troubleshooting note for port conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ From zero to full-stack LLMOps in minutes. No complex setup or major code change
 ```bash
 uvx mlflow server
 ```
+**Windows PowerShell users:** If you're using a Python virtual environment, activate it before running MLflow commands:
+
+```powershell
+.venv\Scripts\activate
+```
 
 **2. Enable Logging**
 

--- a/docs/src/content/setup_server.mdx
+++ b/docs/src/content/setup_server.mdx
@@ -14,6 +14,13 @@ Start a MLflow server locally.
 ```shell
 uvx mlflow server
 ```
+:::tip
+If port `5000` is already in use, start MLflow on another port:
+
+```shell
+uvx mlflow server --port 5001
+```
+:::
 
 :::info
 See [Secure Installs](/self-hosting/security/secure-installs) to learn how to pin dependencies to known good versions using hash checking and upload-time filtering.


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

Added a troubleshooting note explaining how to start the MLflow server on a different port when port `5000` is already in use.

### How is this PR tested?

* [ ] Existing unit/integration tests
* [ ] New unit/integration tests
* [x] Manual tests

### Does this PR require documentation update?

* [ ] No.
* [x] Yes. I've updated:

  * [ ] Examples
  * [ ] API references
  * [x] Instructions

### Does this PR require updating the MLflow Skills repository?

* [x] No.
* [ ] Yes.

### Release Notes

#### Is this a user-facing change?

* [ ] No.
* [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added a troubleshooting note for resolving port conflicts when starting the MLflow server locally.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

* [x] `area/docs`: MLflow documentation pages

#### How should the PR be classified in the release notes? Choose one:

* [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

* [ ] This PR is critical and needs to be in the next patch release
* [x] This PR can wait for the next minor release
