### PR TITLE
Drop dead `post-review` step in `review.yml`

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -22,8 +22,6 @@ jobs:
     permissions:
       pull-requests: write
     timeout-minutes: 30
-    outputs:
-      bot-approved: ${{ steps.check-approval.outputs.approved }}
     # Security: Only run for authorized users.
     # - pull_request: Only run for non-fork PRs
     # - issue_comment: BOTH PR author and commenter must be authorized (can't trust external PRs)
@@ -222,70 +220,3 @@ jobs:
               comment_id: comment.id,
               body: updatedBody
             });
-
-      - name: Check bot approval
-        id: check-approval
-        if: github.event_name == 'issue_comment'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_NUMBER: ${{ github.event.issue.number }}
-          REPO: ${{ github.repository }}
-          COMMENT_CREATED_AT: ${{ github.event.comment.created_at }}
-        run: |
-          count=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
-            --jq '[.[]
-                   | select(.user.login == "mlflow-app[bot]"
-                            and .state == "APPROVED"
-                            and .submitted_at >= env.COMMENT_CREATED_AT)
-                  ] | length')
-          approved=$([ "$count" -gt 0 ] && echo true || echo false)
-          echo "approved=$approved" >> "$GITHUB_OUTPUT"
-
-  post-review:
-    needs: review
-    if: github.event_name == 'issue_comment' && needs.review.outputs.bot-approved == 'true'
-    runs-on: ubuntu-slim
-    timeout-minutes: 5
-    permissions:
-      actions: write
-      pull-requests: read
-    steps:
-      - name: Approve queued rerun workflows
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.issue.number }}
-          REPO: ${{ github.repository }}
-          COMMENT_CREATED_AT: ${{ github.event.comment.created_at }}
-        run: |
-          head_sha=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid --jq '.headRefOid')
-
-          # Poll for up to ~30s: the `rerun` workflow may not be queued yet
-          # when this step starts, since mlflow-app[bot]'s approval review
-          # fires it asynchronously.
-          run_ids=""
-          for i in $(seq 1 6); do
-            run_ids=$(
-              gh api --paginate "repos/${REPO}/actions/runs?head_sha=${head_sha}" \
-                --jq '.workflow_runs[]
-                      | select(.name == "rerun"
-                               and .conclusion == "action_required"
-                               and .actor.login == "mlflow-app[bot]"
-                               and .created_at >= env.COMMENT_CREATED_AT)
-                      | .id'
-            )
-            [ -n "$run_ids" ] && break
-            echo "No action_required rerun yet (attempt $i); sleeping 5s..."
-            sleep 5
-          done
-
-          if [ -z "$run_ids" ]; then
-            echo "Timed out waiting for action_required rerun workflows"
-            exit 0
-          fi
-
-          # Use /rerun since /approve fails with "not a fork pull request" on runs from `pull_request_review` events.
-          while IFS= read -r run_id; do
-            gh api --method POST "repos/${REPO}/actions/runs/${run_id}/rerun" >/dev/null \
-              && echo "Approved run $run_id" \
-              || echo "Failed to approve run $run_id"
-          done <<< "$run_ids"


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

Removes the `post-review` job (and its `Check bot approval` step and `bot-approved` output) from `review.yml`.

**Why:** the job's only step polled for `rerun` workflow runs in `action_required` state and called `/rerun` on them. Sometime between 2026-05-01 and 2026-05-04, the behavior changed: `mlflow-app[bot]`-triggered `rerun` runs on fork PRs no longer enter `action_required` — they start running immediately. The cause isn't confirmed (no MLflow workflow commits in that window, no relevant org/repo audit log events), but the empirical effect is clear: the post-review poll has been finding nothing on every call and hitting the 30s timeout cleanly since then.

Confirmed live in #23185:
- bot approved → rerun workflow [run 25650568536](https://github.com/mlflow/mlflow/actions/runs/25650568536) started in the same second (`created_at == run_started_at`), `conclusion: success`, no approval needed.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Verified the pattern across 87 bot-triggered rerun runs (47 pre-boundary, all with non-zero gap; 40 post-boundary, all with 0s gap) and the live test on #23185.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)