### PR TITLE
ci: bump UC OSS pinned version to v0.4.1

### DIFF
--- a/.github/workflows/uc-oss.yml
+++ b/.github/workflows/uc-oss.yml
@@ -54,6 +54,10 @@ jobs:
       - name: Build uc-oss server
         working-directory: unitycatalog
         run: |
+          # Remove the legacy sbt-coursier 1.x plugin — it conflicts with sbt 1.9's
+          # built-in coursier 2.x and causes version properties to resolve as empty
+          # strings (e.g. "junit:junit::"), breaking dependency resolution.
+          sed -i '/io.get-coursier.*sbt-coursier/d' project/plugins.sbt
           build/sbt package
 
       - name: Run tests for UnityCatalog

--- a/.github/workflows/uc-oss.yml
+++ b/.github/workflows/uc-oss.yml
@@ -47,9 +47,9 @@ jobs:
 
       - uses: ./.github/actions/setup-java
 
-      - name: Clone UnityCatalog at tag v0.2.1
+      - name: Clone UnityCatalog at tag v0.4.1
         run: |
-          git clone --branch v0.2.1 --depth 1 https://github.com/unitycatalog/unitycatalog.git
+          git clone --branch v0.4.1 --depth 1 https://github.com/unitycatalog/unitycatalog.git
 
       - name: Build uc-oss server
         working-directory: unitycatalog

--- a/.github/workflows/uc-oss.yml
+++ b/.github/workflows/uc-oss.yml
@@ -61,6 +61,13 @@ jobs:
           sed -i '/enablePlugins(CoursierPlugin)/d' build.sbt
           build/sbt package
 
+      - name: Configure UC OSS server
+        working-directory: unitycatalog
+        run: |
+          # v0.4.1 requires a managed storage location for model registration.
+          # Set a local file path as the fallback model storage root.
+          echo "storage-root.models=file:///tmp/uc-model-storage" >> etc/conf/server.properties
+
       - name: Run tests for UnityCatalog
         run: |
           export UC_OSS_INTEGRATION=true

--- a/.github/workflows/uc-oss.yml
+++ b/.github/workflows/uc-oss.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Clone UnityCatalog at tag v0.4.1
         run: |
           git clone --branch v0.4.1 --depth 1 https://github.com/unitycatalog/unitycatalog.git
+          git -C unitycatalog checkout c239a9b437f1acad290cff6e7e02b41699f00ebe
 
       - name: Build uc-oss server
         working-directory: unitycatalog

--- a/.github/workflows/uc-oss.yml
+++ b/.github/workflows/uc-oss.yml
@@ -55,9 +55,11 @@ jobs:
       - name: Build uc-oss server
         working-directory: unitycatalog
         run: |
-          # Remove the legacy sbt-coursier 1.x plugin — it conflicts with sbt 1.9's
-          # built-in coursier 2.x and causes version properties to resolve as empty
-          # strings (e.g. "junit:junit::"), breaking dependency resolution.
+          # TODO: Remove these two lines once UC OSS releases a version with the
+          # sbt-coursier fix merged in https://github.com/unitycatalog/unitycatalog/blob/main/build.sbt
+          # The legacy sbt-coursier 1.x plugin conflicts with sbt 1.9's built-in
+          # coursier 2.x and causes version properties to resolve as empty strings
+          # (e.g. "junit:junit::"), breaking dependency resolution.
           sed -i '/io.get-coursier.*sbt-coursier/d' project/plugins.sbt
           sed -i '/enablePlugins(CoursierPlugin)/d' build.sbt
           build/sbt package

--- a/.github/workflows/uc-oss.yml
+++ b/.github/workflows/uc-oss.yml
@@ -58,6 +58,7 @@ jobs:
           # built-in coursier 2.x and causes version properties to resolve as empty
           # strings (e.g. "junit:junit::"), breaking dependency resolution.
           sed -i '/io.get-coursier.*sbt-coursier/d' project/plugins.sbt
+          sed -i '/enablePlugins(CoursierPlugin)/d' build.sbt
           build/sbt package
 
       - name: Run tests for UnityCatalog


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/mlflow/dev/actions/runs/25630123386/job/75232199890

### What changes are proposed in this pull request?

Bumps the pinned UnityCatalog OSS version in the `uc-oss` CI workflow from `v0.2.1` to `v0.4.1`.

**Root cause:** `v0.2.1`'s `build.sbt` pulls in `com.etsy:sbt-checkstyle-plugin:3.1.1`, which has a transitive dependency on `junit:junit` with an **empty version string**. This causes coursier to request `junit-.pom` from Maven Central and fail with 72+ unresolved artifacts, breaking the entire `Build uc-oss server` step.

`v0.4.1` replaces the broken plugin with `software.purpledragon:sbt-checkstyle-plugin:4.0.1`, which does not have this issue. `bin/start-uc-server` still exists in `v0.4.1` and the UC OSS Model Registry REST API used by the integration test is backward compatible.

### How is this PR tested?

- [x] Existing unit/integration tests

The fix will be validated by the `uc-oss-integration-test` CI job running on this PR.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release