### PR TITLE
Gate PickleEvaluationArtifact load on MLFLOW_ALLOW_PICKLE_DESERIALIZATION

### DIFF
--- a/mlflow/models/evaluation/artifacts.py
+++ b/mlflow/models/evaluation/artifacts.py
@@ -8,6 +8,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
+from mlflow.environment_variables import MLFLOW_ALLOW_PICKLE_DESERIALIZATION
 from mlflow.exceptions import MlflowException
 from mlflow.models.evaluation.base import EvaluationArtifact
 from mlflow.utils.annotations import developer_stable
@@ -88,6 +89,15 @@ class PickleEvaluationArtifact(EvaluationArtifact):
             pickle.dump(self._content, f)
 
     def _load_content_from_file(self, local_artifact_path):
+        if not MLFLOW_ALLOW_PICKLE_DESERIALIZATION.get():
+            raise MlflowException(
+                "Deserializing evaluation artifact using pickle is disallowed. The "
+                f"artifact at '{local_artifact_path}' is stored in pickle format, which "
+                "can execute arbitrary code during deserialization. To allow loading "
+                "this artifact, set the environment variable "
+                "'MLFLOW_ALLOW_PICKLE_DESERIALIZATION' to 'true', and only do so if the "
+                "artifact source is trusted."
+            )
         with open(local_artifact_path, "rb") as f:
             self._content = pickle.load(f)
         return self._content

--- a/tests/models/test_artifacts.py
+++ b/tests/models/test_artifacts.py
@@ -1,5 +1,6 @@
 import json
 import pathlib
+import pickle
 
 import numpy as np
 import pandas as pd
@@ -114,3 +115,31 @@ def test_infer_artifact_type_and_ext_raise_exception_for_unsupported_ext(tmp_pat
         match=f"with path '{path}' does not match any of the supported file extensions",
     ):
         _infer_artifact_type_and_ext("invalid_ext_artifact", path, cm_fn_tuple)
+
+
+@pytest.mark.parametrize("allow_pickle", ["true", None])
+def test_pickle_evaluation_artifact_load_allowed(tmp_path, monkeypatch, allow_pickle):
+    if allow_pickle is None:
+        monkeypatch.delenv("MLFLOW_ALLOW_PICKLE_DESERIALIZATION", raising=False)
+    else:
+        monkeypatch.setenv("MLFLOW_ALLOW_PICKLE_DESERIALIZATION", allow_pickle)
+
+    payload = {"a": 1, "b": [1, 2, 3]}
+    pickle_path = tmp_path / "artifact.pickle"
+    with open(pickle_path, "wb") as f:
+        pickle.dump(payload, f)
+
+    artifact = PickleEvaluationArtifact(uri=str(pickle_path))
+    assert artifact._load_content_from_file(str(pickle_path)) == payload
+
+
+def test_pickle_evaluation_artifact_load_disallowed(tmp_path, monkeypatch):
+    monkeypatch.setenv("MLFLOW_ALLOW_PICKLE_DESERIALIZATION", "false")
+
+    pickle_path = tmp_path / "artifact.pickle"
+    with open(pickle_path, "wb") as f:
+        pickle.dump({"a": 1}, f)
+
+    artifact = PickleEvaluationArtifact(uri=str(pickle_path))
+    with pytest.raises(MlflowException, match="MLFLOW_ALLOW_PICKLE_DESERIALIZATION"):
+        artifact._load_content_from_file(str(pickle_path))


### PR DESCRIPTION
### Related Issues/PRs

Relates to advisory GHSA-qqff-98jq-gphc (private).

### What changes are proposed in this pull request?

`PickleEvaluationArtifact._load_content_from_file` was the only pickle loader in MLflow that did not check `MLFLOW_ALLOW_PICKLE_DESERIALIZATION` before calling `pickle.load`. The sklearn, pmdarima, tensorflow, pyfunc, and dspy loaders all honor this opt-out. This PR adds the same check for consistency, raising `MlflowException` with guidance on enabling the env var if pickle loading is intended.

Note: the threat model here is defense-in-depth. An attacker with write access to the artifact store already has RCE-on-load via `python_model.py` or `MLmodel` edits, so this is not a CVE-class fix. The change ensures operators who explicitly set `MLFLOW_ALLOW_PICKLE_DESERIALIZATION=false` see uniform refusal across every pickle deserialization path in MLflow.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Operators who set `MLFLOW_ALLOW_PICKLE_DESERIALIZATION=false` will now see an explicit `MlflowException` when an evaluation artifact pickle load is attempted. Default behavior (env var unset, which defaults to `true`) is unchanged.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

Reported by @Saadet-T via GitHub Security Advisory GHSA-qqff-98jq-gphc.