### PR TITLE
Quote MLproject extra parameter keys

### DIFF
--- a/mlflow/projects/_project_spec.py
+++ b/mlflow/projects/_project_spec.py
@@ -302,7 +302,11 @@ class EntryPoint:
         params, extra_params = self.compute_parameters(user_parameters, storage_dir)
         command_with_params = self.command.format(**params)
         command_arr = [command_with_params]
-        command_arr.extend([f"--{key} {value}" for key, value in extra_params.items()])
+        # Quote `key` because the assembled command is passed to `bash -c`; an
+        # extra-param key containing shell metacharacters would otherwise be
+        # interpreted by the shell. `value` is already quoted by
+        # `_sanitize_param_dict`.
+        command_arr.extend([f"--{quote(str(key))} {value}" for key, value in extra_params.items()])
         return " ".join(command_arr)
 
     @staticmethod

--- a/tests/projects/test_entry_point.py
+++ b/tests/projects/test_entry_point.py
@@ -1,4 +1,5 @@
 import os
+import shlex
 from shlex import quote
 from unittest import mock
 
@@ -55,6 +56,35 @@ def test_entry_point_compute_command():
         name_value = "friend; echo 'hi'"
         command = entry_point.compute_command({"name": name_value}, storage_dir)
         assert command == "python greeter.py {} {}".format(quote("hi"), quote(name_value))
+
+
+@pytest.mark.parametrize(
+    "malicious_key",
+    [
+        "x; id > /tmp/pwned; echo ",
+        "a&&b",
+        "$(whoami)",
+        "a|b",
+        "a`b`",
+        "a>b",
+    ],
+)
+def test_compute_command_quotes_extra_param_keys(malicious_key):
+    project = load_project()
+    entry_point = project.get_entry_point("greeter")
+    with TempDir() as tmp:
+        storage_dir = tmp.path()
+        command = entry_point.compute_command({"name": "friend", malicious_key: "1"}, storage_dir)
+        # The injected key must be shell-quoted in the assembled command so
+        # `bash -c` parses it as a single flag token rather than additional
+        # shell tokens.
+        assert f"--{quote(malicious_key)} " in command
+        tokens = shlex.split(command)
+        assert f"--{malicious_key}" in tokens
+        # Metacharacters from the key must not produce extra shell tokens
+        # like `;`, `&&`, or `$(whoami)` invocations.
+        for forbidden in [";", "&&", "|", "`", "$(", ">", "id", "whoami"]:
+            assert forbidden not in tokens
 
 
 def test_path_parameter():


### PR DESCRIPTION
### Related Issues/PRs

Relates to GitHub Security Advisory `GHSA-p2gf-345f-mhmm` (private).

### What changes are proposed in this pull request?

`EntryPoint.compute_command` in `mlflow/projects/_project_spec.py` assembled undeclared ("extra") MLproject parameters as `--{key} {value}` and joined them into a shell string that the local backend hands to `bash -c`. Values were already shell-quoted by `_sanitize_param_dict`, but keys were not, so a user invoking `mlflow run` with a parameter whose name contains shell metacharacters would have those metacharacters expanded by the shell. The fix applies `mlflow.utils.string_utils.quote` (cross-platform helper that handles `cmd /c` on Windows) to extra-param keys inline at the `compute_command` use site, leaving the declared-parameter path through `self.command.format(**params)` untouched so template placeholders continue to match.

This is a local-CLI self-injection scenario (the user controls the `parameters` dict on their own machine), not a remote vulnerability, so it lands as defense-in-depth / code quality.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/projects`: MLproject format, project running backends

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

Reported by @theluckystrike via GitHub Security Advisory GHSA-p2gf-345f-mhmm.