### PR TITLE
Quote host argument for R rfunc serve

### DIFF
--- a/mlflow/rfunc/backend.py
+++ b/mlflow/rfunc/backend.py
@@ -104,7 +104,7 @@ class RFuncBackend(FlavorBackend):
 
         model_path = _download_artifact_from_uri(model_uri)
         command = "mlflow::mlflow_rfunc_serve('{}', port = {}, host = '{}')".format(
-            quote(model_path), port, host
+            quote(model_path), port, _r_quote(host)
         )
         _execute(command)
 
@@ -146,3 +146,7 @@ def _execute(command, extra_envs=None):
 
 def _str_optional(s):
     return "NULL" if s is None else f"'{quote(str(s))}'"
+
+
+def _r_quote(s):
+    return s.replace("\\", "\\\\").replace("'", "\\'")

--- a/tests/rfunc/test_backend.py
+++ b/tests/rfunc/test_backend.py
@@ -1,0 +1,16 @@
+import pytest
+
+from mlflow.rfunc.backend import _r_quote
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("simple", "simple"),
+        ("with'quote", "with\\'quote"),
+        ("with\\back", "with\\\\back"),
+        ("'); system('id'); c('", "\\'); system(\\'id\\'); c(\\'"),
+    ],
+)
+def test_r_quote_escapes_r_string_literal(value, expected):
+    assert _r_quote(value) == expected


### PR DESCRIPTION
### Related Issues/PRs

Relates to GitHub Security Advisory `GHSA-jrjh-p742-jvf9`.

### What changes are proposed in this pull request?

`RFuncBackend.serve` interpolated the `host` argument directly into an R command string that is later executed via `subprocess.Popen(["Rscript", "-e", command])`. Because `Rscript -e` parses the argument as R code (not as a shell command), `shlex.quote` is the wrong tool here, so this PR adds a small `_r_quote` helper that escapes backslashes and single quotes inside R single-quoted string literals and applies it to `host` in `serve()`.

This is a local-CLI self-injection - the user supplies `--host` (or `MLFLOW_HOST`) on their own machine and already controls the host process, so there is no privilege boundary to cross and no CVE is being assigned. Landing as defense-in-depth / code quality.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added `tests/rfunc/test_backend.py` with a parametrized unit test that exercises `_r_quote` directly across benign, single-quote, backslash, and the advisory's PoC payload inputs.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

Reported by @theluckystrike via GitHub Security Advisory GHSA-jrjh-p742-jvf9.