### PR TITLE
fenil-fix: experiment name error

### DIFF
--- a/mlflow/server/js/src/common/forms/validations.test.ts
+++ b/mlflow/server/js/src/common/forms/validations.test.ts
@@ -2,6 +2,8 @@ import { test, jest, expect, describe } from '@jest/globals';
 import { getExperimentNameValidator, modelNameValidator } from './validations';
 import { MlflowService } from '../../experiment-tracking/sdk/MlflowService';
 import { Services as ModelRegistryService } from '../../model-registry/services';
+import { ErrorCodes } from '../constants';
+import { ErrorWrapper } from '../utils/ErrorWrapper';
 
 test('ExperimentNameValidator works properly', () => {
   const experimentNames = ['Default', 'Test Experiment'];
@@ -47,12 +49,25 @@ describe('ExperimentNameValidator server-side fallback', () => {
   });
 
   test('shows no error when experiment is not found via API', async () => {
-    MlflowService.getExperimentByName = jest.fn(() => Promise.reject()) as any;
+    MlflowService.getExperimentByName = jest.fn(() =>
+      Promise.reject(new ErrorWrapper({ error_code: ErrorCodes.RESOURCE_DOES_NOT_EXIST, message: 'not found' }, 404)),
+    ) as any;
     const experimentNameValidator = getExperimentNameValidator(() => []);
     const mockCallback = jest.fn((err) => err);
     experimentNameValidator(undefined, 'nonexistent-experiment', mockCallback);
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(mockCallback).toHaveBeenCalledWith(undefined);
+  });
+
+  test('shows validation error when API lookup fails for reasons other than not found', async () => {
+    MlflowService.getExperimentByName = jest.fn(() =>
+      Promise.reject(new ErrorWrapper({ error_code: ErrorCodes.INTERNAL_ERROR, message: 'server error' }, 500)),
+    ) as any;
+    const experimentNameValidator = getExperimentNameValidator(() => []);
+    const mockCallback = jest.fn((err) => err);
+    experimentNameValidator(undefined, 'maybe-existing-experiment', mockCallback);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mockCallback).toHaveBeenCalledWith('Could not validate experiment name. Please try again.');
   });
 });
 

--- a/mlflow/server/js/src/common/forms/validations.ts
+++ b/mlflow/server/js/src/common/forms/validations.ts
@@ -1,5 +1,13 @@
 import { MlflowService } from '../../experiment-tracking/sdk/MlflowService';
 import { Services as ModelRegistryService } from '../../model-registry/services';
+import { ErrorCodes } from '../constants';
+
+const isResourceDoesNotExistError = (error: unknown) =>
+  typeof error === 'object' &&
+  error !== null &&
+  'getErrorCode' in error &&
+  typeof error.getErrorCode === 'function' &&
+  error.getErrorCode() === ErrorCodes.RESOURCE_DOES_NOT_EXIST;
 
 export const getExperimentNameValidator = (getExistingExperimentNames: () => string[]) => {
   return (rule: unknown, value: string | undefined, callback: (arg?: string) => void) => {
@@ -23,7 +31,13 @@ export const getExperimentNameValidator = (getExistingExperimentNames: () => str
             callback(`Experiment "${value}" already exists.`);
           }
         })
-        .catch((e) => callback(undefined)); // no experiment returned
+        .catch((e) => {
+          if (isResourceDoesNotExistError(e)) {
+            callback(undefined);
+          } else {
+            callback('Could not validate experiment name. Please try again.');
+          }
+        });
     }
   };
 };

--- a/mlflow/server/js/src/experiment-tracking/components/modals/RenameExperimentModal.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/RenameExperimentModal.test.tsx
@@ -7,6 +7,8 @@ import userEvent from '@testing-library/user-event';
 import { MlflowService } from '../../sdk/MlflowService';
 import { getExperimentApi, updateExperimentApi } from '../../actions';
 import Utils from '../../../common/utils/Utils';
+import { ErrorCodes } from '../../../common/constants';
+import { ErrorWrapper } from '../../../common/utils/ErrorWrapper';
 
 jest.mock('../../actions', () => ({
   getExperimentApi: jest.fn(() => ({ type: 'action', meta: {}, payload: Promise.resolve({}) })),
@@ -22,7 +24,11 @@ describe('RenameExperimentModal', () => {
   beforeEach(() => {
     jest.mocked(updateExperimentApi).mockClear();
     jest.mocked(getExperimentApi).mockClear();
-    jest.spyOn(MlflowService, 'getExperimentByName').mockImplementation(() => Promise.reject({} as any));
+    jest
+      .spyOn(MlflowService, 'getExperimentByName')
+      .mockImplementation(() =>
+        Promise.reject(new ErrorWrapper({ error_code: ErrorCodes.RESOURCE_DOES_NOT_EXIST, message: 'not found' }, 404)),
+      );
     jest.spyOn(Utils, 'logErrorAndNotifyUser');
     jest.clearAllMocks();
   });


### PR DESCRIPTION
### Related Issues/PRs

Closes https://github.com/mlflow/mlflow/issues/23095

### What changes are proposed in this pull request?

This PR updates `getExperimentNameValidator` so failed experiment-name lookups no longer silently clear validation errors for every rejected request.

The validator now only treats `RESOURCE_DOES_NOT_EXIST` as an available experiment name. Other lookup failures, such as network errors or server errors, surface a neutral validation message so users know the name could not be validated.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

```sh
node yarn/releases/yarn-4.12.0.cjs test src/common/forms/validations.test.ts --runInBand
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Improves Create Experiment form validation by showing an error when experiment-name validation cannot be completed due to network or server failures.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

<img width="1422" height="904" alt="ss_Image" src="https://github.com/user-attachments/assets/28ac6de8-3dee-4b1b-af19-5db4f77617a0" />

