### PR TITLE
Remove redundant trace re-fetch in `mlflow.genai.evaluate()` to fix OOM

### DIFF
--- a/mlflow/genai/evaluation/harness.py
+++ b/mlflow/genai/evaluation/harness.py
@@ -698,10 +698,6 @@ def run(
     # Link traces to the run if the backend support it
     batch_link_traces_to_run(run_id=run_id, eval_results=eval_results)
 
-    # Refresh traces on eval_results to include all logged assessments.
-    # This is done once after all assessments (single-turn and multi-turn) are logged to the traces.
-    _refresh_eval_result_traces(eval_results)
-
     # Aggregate scorer stats from single-turn results
     for result in eval_results:
         if result is not None:
@@ -967,36 +963,6 @@ def _log_assessments(
             _logger.debug(f"No root span found for trace {trace.info.trace_id}")
 
         mlflow.log_assessment(trace_id=assessment.trace_id, assessment=assessment)
-
-
-def _refresh_eval_result_traces(eval_results: list[EvalResult]) -> None:
-    """
-    Refresh traces on eval_results to include logged assessments.
-
-    This function fetches the updated traces from the backend after all assessments
-    (both single-turn and multi-turn) have been logged.
-    """
-
-    def _fetch_trace(eval_result: EvalResult):
-        if eval_result.eval_item.trace is None:
-            return None
-        trace_id = eval_result.eval_item.trace.info.trace_id
-        try:
-            return eval_result, mlflow.get_trace(trace_id)
-        except Exception as e:
-            _logger.warning(f"Failed to refresh trace {trace_id}: {e}")
-            return None
-
-    with ThreadPoolExecutor(
-        max_workers=MLFLOW_GENAI_EVAL_MAX_WORKERS.get(),
-        thread_name_prefix="GenAIEvaluationTraceRefresh",
-    ) as executor:
-        futures = [executor.submit(_fetch_trace, er) for er in eval_results]
-        for future in as_completed(futures):
-            result = future.result()
-            if result is not None:
-                eval_result, refreshed_trace = result
-                eval_result.eval_item.trace = refreshed_trace
 
 
 def _should_clone_trace(


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

After all assessments are logged, `_refresh_eval_result_traces` was re-fetching every full trace from the server — one `mlflow.get_trace()` call per eval item, executed in parallel. For sessions with ~100 traces at 30–50 MB each, this caused a **3–5 GB memory spike** even when the caller had already stripped traces down to root-span-only before passing them to `evaluate()`.

The re-fetch was redundant. `construct_eval_result_df` already:
1. Calls `search_traces(include_spans=False)` to get a fresh `TraceInfo` for every trace (which carries all logged assessments), and
2. Uses that fresh `TraceInfo` to override the `eval_item`'s info when building the result DataFrame.

The span data used in the DataFrame (`eval_item.trace.data`) comes from whatever the caller provided in memory — so passing stripped traces works correctly after this change, and the assessment columns are unaffected.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. `mlflow.genai.evaluate()` no longer re-fetches full traces from the server after scoring. Callers who pre-strip traces to reduce memory (e.g. root-span-only) will no longer see those optimizations reversed by the evaluation harness, and the post-scoring OOM spike for large sessions is eliminated.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release