### PR TITLE
fix(gateway): use .get() for finish_reason in openai_compatible streaming

### DIFF
--- a/mlflow/gateway/providers/openai_compatible.py
+++ b/mlflow/gateway/providers/openai_compatible.py
@@ -113,7 +113,7 @@ class OpenAICompatibleAdapter(ProviderAdapter):
             choices=[
                 chat.StreamChoice(
                     index=c["index"],
-                    finish_reason=c["finish_reason"],
+                    finish_reason=c.get("finish_reason"),
                     delta=chat.StreamDelta(
                         role=c["delta"].get("role"),
                         content=c["delta"].get("content"),

--- a/tests/gateway/providers/test_openai_compatible.py
+++ b/tests/gateway/providers/test_openai_compatible.py
@@ -206,6 +206,31 @@ async def test_chat_stream():
 
 
 @pytest.mark.asyncio
+async def test_chat_stream_missing_finish_reason():
+    # Anthropic-compatible upstreams omit "finish_reason" on intermediate chunks;
+    # model_to_chat_streaming must not raise KeyError in that case.
+    provider = _make_provider()
+    chunk_data = (
+        b'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,'
+        b'"model":"test-model","choices":[{"index":0,"delta":{"role":"assistant",'
+        b'"content":"Hi"}}]}\n\n'
+    )
+    chunks = [chunk_data, b"data: [DONE]\n\n"]
+    mock_client = mock_http_client(MockAsyncStreamingResponse(chunks))
+
+    with mock.patch("aiohttp.ClientSession", return_value=mock_client):
+        payload = chat.RequestPayload(
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+        responses = [chunk async for chunk in provider.chat_stream(payload)]
+
+    assert len(responses) == 1
+    result = jsonable_encoder(responses[0])
+    assert result["choices"][0]["delta"]["content"] == "Hi"
+    assert result["choices"][0]["finish_reason"] is None
+
+
+@pytest.mark.asyncio
 async def test_embeddings():
     provider = _make_provider()
     mock_client = mock_http_client(MockAsyncResponse(_embeddings_response()))


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23139

### What changes are proposed in this pull request?

Anthropic-compatible upstreams (Claude, Bedrock, etc.) omit `finish_reason` on intermediate streaming chunks — only the final chunk carries it. OpenAI always sends `"finish_reason": null` on every chunk, so `model_to_chat_streaming` in `openai_compatible.py` was using bracket access (`c["finish_reason"]`), which raises `KeyError` when the key is absent.

The non-streaming `model_to_chat` path at line 81 already handles this correctly with `c.get("finish_reason")`. This PR aligns the streaming path at line 116 to use `.get()` as well, matching the established pattern.

Also adds `test_chat_stream_missing_finish_reason` to cover the case where a streaming chunk carries no `finish_reason` key at all (previously not tested).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New test: `tests/gateway/providers/test_openai_compatible.py::test_chat_stream_missing_finish_reason` — sends a streaming chunk with no `finish_reason` key and verifies the response is parsed without error and `finish_reason` is `None`.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Streaming requests through the MLflow AI Gateway to Anthropic-compatible endpoints (Claude, Bedrock) no longer crash with `KeyError: 'finish_reason'` on intermediate chunks.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

## Summary

One-character fix (`c["finish_reason"]` → `c.get("finish_reason")`) in `model_to_chat_streaming` of the OpenAI-compatible gateway adapter, plus a new unit test reproducing the crash.

## Local verification

```
$ cd /tmp/mlflow
$ python3 -m ruff check mlflow/gateway/providers/openai_compatible.py tests/gateway/providers/test_openai_compatible.py
All checks passed!
$ python3 -m ruff format --check mlflow/gateway/providers/openai_compatible.py tests/gateway/providers/test_openai_compatible.py
2 files already formatted
$ python -m pytest tests/gateway/providers/test_openai_compatible.py -v 2>&1 | tail -20
tests/gateway/providers/test_openai_compatible.py::test_default_api_base PASSED
tests/gateway/providers/test_openai_compatible.py::test_custom_api_base PASSED
tests/gateway/providers/test_openai_compatible.py::test_headers PASSED
tests/gateway/providers/test_openai_compatible.py::test_get_headers_merges_client_headers PASSED
tests/gateway/providers/test_openai_compatible.py::test_get_headers_strips_client_authorization PASSED
tests/gateway/providers/test_openai_compatible.py::test_get_headers_preserves_client_key_for_credential_agents[claude-cli/2.0.37 (external, cli)] PASSED
tests/gateway/providers/test_openai_compatible.py::test_get_headers_preserves_client_key_for_credential_agents[Codex-Desktop/26.422.2437.0] PASSED
tests/gateway/providers/test_openai_compatible.py::test_get_headers_preserves_client_key_for_credential_agents[GeminiCLI/0.39.0/gemini-2.0-pro (darwin; x64)] PASSED
tests/gateway/providers/test_openai_compatible.py::test_chat PASSED
tests/gateway/providers/test_openai_compatible.py::test_chat_stream PASSED
tests/gateway/providers/test_openai_compatible.py::test_chat_stream_missing_finish_reason PASSED
tests/gateway/providers/test_openai_compatible.py::test_embeddings PASSED
tests/gateway/providers/test_openai_compatible.py::test_passthrough_non_streaming PASSED
tests/gateway/providers/test_openai_compatible.py::test_passthrough_streaming PASSED
tests/gateway/providers/test_openai_compatible.py::test_chat_to_model_adds_model_name PASSED
tests/gateway/providers/test_openai_compatible.py::test_model_to_chat PASSED
tests/gateway/providers/test_openai_compatible.py::test_model_to_embeddings PASSED
tests/gateway/providers/test_openai_compatible.py::test_model_to_chat_with_tool_calls PASSED
tests/gateway/providers/test_openai_compatible.py::test_basic_config PASSED
tests/gateway/providers/test_openai_compatible.py::test_config_with_api_base PASSED
20 passed, 1 warning in 7.65s
=== LOCAL_TEST_PASSED ===
```

## Risk

Only the streaming path for the gateway's OpenAI-compatible adapter is touched. The change from `c["finish_reason"]` to `c.get("finish_reason")` is identical to what the non-streaming path already does, so the behavior for standard OpenAI upstreams (which always send the key) is unchanged. Anthropic/Claude-compatible upstreams that omit the key on intermediate chunks will now get `None` instead of a crash, which is correct.
