### PR TITLE
Upload Claude stream transcript as workflow artifact in `review.yml`

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -161,6 +161,15 @@ jobs:
             exit $EXIT_CODE
           fi
 
+      - name: Upload Claude stream transcript
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: claude-stream-${{ github.run_id }}-${{ github.run_attempt }}
+          path: /tmp/output.json
+          retention-days: 1
+          if-no-files-found: ignore
+
       - name: Report review results
         if: github.event_name == 'issue_comment'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -140,7 +140,7 @@ jobs:
           MODEL: ${{ steps.prompt.outputs.model || 'opus' }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
-          OUTPUT_FILE="/tmp/output.json"
+          OUTPUT_FILE="/tmp/output.jsonl"
 
           # Safe construction using arrays - PROMPT is passed as separate argument to prevent shell injection
           if [ "$EVENT_NAME" = "pull_request" ]; then
@@ -166,7 +166,7 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: claude-stream-${{ github.run_id }}-${{ github.run_attempt }}
-          path: /tmp/output.json
+          path: /tmp/output.jsonl
           retention-days: 1
           if-no-files-found: ignore
 
@@ -182,7 +182,7 @@ jobs:
             const { comment } = context.payload;
 
             // Read Claude output from file instead of environment variable
-            const outputPath = '/tmp/output.json';
+            const outputPath = '/tmp/output.jsonl';
             let claudeOutput = '';
             try {
               if (fs.existsSync(outputPath)) {

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -163,6 +163,7 @@ jobs:
 
       - name: Upload Claude stream transcript
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: claude-stream-${{ github.run_id }}-${{ github.run_attempt }}


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Adds an `actions/upload-artifact` step to `review.yml` that uploads `/tmp/output.jsonl` (the raw `stream-json` produced by the Claude CLI, one JSON object per line) as a workflow artifact named `claude-stream-<run_id>-<attempt>`.

- `if: always()` — capture the transcript even when the `Review` step fails or times out.
- `retention-days: 1` — short retention, since these are only needed for short-term forensics.
- `if-no-files-found: ignore` — don't fail the workflow if the file is missing.

Also renames `/tmp/output.json` → `/tmp/output.jsonl` throughout `review.yml`. The file has always been JSON Lines (one stream-json event per line), so `.jsonl` is the accurate extension.

Motivation: the human-readable workflow log only summarizes tool_use inputs, tool_result content, and thinking blocks by character count (e.g., `📥 tool_result (98 chars)`). When debugging review-bot misbehavior, the raw content is what we actually need. Uploading the full transcript gives us that without dumping it inline into public Actions logs.

### How is this PR tested?

- [x] Manual tests

The artifact will be produced on the first `/review` invocation against this PR. Will verify that the artifact is downloadable via `gh run download` and that the file is valid NDJSON (`jq -c '.' output.jsonl`).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release