### PR TITLE
Strip `ANTHROPIC_API_KEY` from Claude subprocess env in `review.yml` and `resolve.yml`

### DIFF
--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -178,6 +178,7 @@ jobs:
         id: claude-fix
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PROMPT: ${{ needs.precheck.outputs.prompt }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -135,6 +135,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           PROMPT: ${{ steps.prompt.outputs.prompt }}
           MODEL: ${{ steps.prompt.outputs.model || 'opus' }}


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Sets `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1` in the `Review` step of `review.yml` and the `Run Claude resolve command` step of `resolve.yml`.

Per the [Claude Code env vars docs](https://code.claude.com/docs/en/env-vars):

> Set to `1` to strip Anthropic and cloud provider credentials from subprocess environments (Bash tool, hooks, MCP stdio servers). The parent Claude process keeps these credentials for API calls, but child processes cannot read them.

The Claude parent process still has the key for API calls; only spawned subprocesses (Bash tool, hooks, MCP stdio servers) lose it. This reduces the chance that an accidental `printenv` or env-printing tool could leak `ANTHROPIC_API_KEY` into the stream-json transcript that `review.yml` now uploads as a workflow artifact.

`GH_TOKEN` is intentionally not affected; the `gh` CLI subprocesses need it.

### How is this PR tested?

- [x] Manual tests

Will verify after merge by running `/review` and checking the uploaded transcript artifact contains no occurrences of the API key value.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release