### PR TITLE
feat: Add MLFLOW_WORKSPACE_DISABLE_ARTIFACT_PREFIX env var

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -142,6 +142,15 @@ MLFLOW_WORKSPACE_ARTIFACT_ROOT_CACHE_TTL_SECONDS = _EnvironmentVariable(
     "MLFLOW_WORKSPACE_ARTIFACT_ROOT_CACHE_TTL_SECONDS", int, 60
 )
 
+#: When true, disables the automatic ``/workspaces/<workspace_name>`` prefix that is
+#: appended to artifact roots when workspace support is enabled. Use this to keep workspaces
+#: functional while retaining compatibility with artifact paths created before workspace support
+#: was introduced.
+#: (default: ``False``)
+MLFLOW_WORKSPACE_DISABLE_ARTIFACT_PREFIX = _BooleanEnvironmentVariable(
+    "MLFLOW_WORKSPACE_DISABLE_ARTIFACT_PREFIX", False
+)
+
 #: Specifies the ``dfs_tmpdir`` parameter to use for ``mlflow.spark.save_model``,
 #: ``mlflow.spark.log_model`` and ``mlflow.spark.load_model``. See
 #: https://www.mlflow.org/docs/latest/python_api/mlflow.spark.html#mlflow.spark.save_model

--- a/mlflow/store/tracking/sqlalchemy_workspace_store.py
+++ b/mlflow/store/tracking/sqlalchemy_workspace_store.py
@@ -49,6 +49,7 @@ from mlflow.utils.uri import (
     append_to_uri_path,
 )
 from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME, WORKSPACES_DIR_NAME
+from mlflow.environment_variables import MLFLOW_WORKSPACE_DISABLE_ARTIFACT_PREFIX
 
 _logger = logging.getLogger(__name__)
 
@@ -496,7 +497,7 @@ class WorkspaceAwareSqlAlchemyStore(WorkspaceAwareMixin, SqlAlchemyStore):
                 error_code=INVALID_PARAMETER_VALUE,
             )
 
-        if should_append:
+        if should_append and not MLFLOW_WORKSPACE_DISABLE_ARTIFACT_PREFIX.get():
             resolved_root = append_to_uri_path(resolved_root, WORKSPACES_DIR_NAME, workspace)
 
         return append_to_uri_path(resolved_root, str(experiment_id))

--- a/tests/store/tracking/test_sqlalchemy_store_workspace.py
+++ b/tests/store/tracking/test_sqlalchemy_store_workspace.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from mlflow.environment_variables import MLFLOW_WORKSPACE_DISABLE_ARTIFACT_PREFIX
+from mlflow.store.tracking.sqlalchemy_workspace_store import WorkspaceAwareSqlAlchemyStore
+from mlflow.utils.workspace_utils import WORKSPACES_DIR_NAME
+
+
+ARTIFACT_ROOT = "s3://my-bucket/mlflow"
+WORKSPACE = "my-workspace"
+
+
+@pytest.fixture
+def store(tmp_path):
+    db_uri = f"sqlite:///{tmp_path / 'mlflow.db'}"
+    with mock.patch.object(
+        WorkspaceAwareSqlAlchemyStore,
+        "_initialize_store_state",
+    ):
+        s = WorkspaceAwareSqlAlchemyStore(db_uri, ARTIFACT_ROOT)
+    return s
+
+
+def _mock_provider(root, should_append):
+    provider = mock.MagicMock()
+    provider.resolve_artifact_root.return_value = (root, should_append)
+    return provider
+
+
+def test_artifact_location_appends_workspace_prefix_by_default(store):
+    store._workspace_provider = _mock_provider(ARTIFACT_ROOT, True)
+    location = store._get_artifact_location(42, WORKSPACE)
+    assert f"/{WORKSPACES_DIR_NAME}/{WORKSPACE}/" in location
+    assert location.endswith("/42")
+
+
+def test_artifact_location_no_prefix_when_provider_returns_false(store):
+    store._workspace_provider = _mock_provider(ARTIFACT_ROOT, False)
+    location = store._get_artifact_location(42, WORKSPACE)
+    assert WORKSPACES_DIR_NAME not in location
+    assert location.endswith("/42")
+
+
+@pytest.mark.parametrize("experiment_id", [0, 42])
+def test_artifact_location_disable_prefix_env_var(store, experiment_id):
+    store._workspace_provider = _mock_provider(ARTIFACT_ROOT, True)
+    with mock.patch.object(
+        MLFLOW_WORKSPACE_DISABLE_ARTIFACT_PREFIX, "get", return_value=True
+    ):
+        location = store._get_artifact_location(experiment_id, WORKSPACE)
+    assert WORKSPACES_DIR_NAME not in location
+    assert location.endswith(f"/{experiment_id}")


### PR DESCRIPTION
Introduce a new boolean environment variable that suppresses the automatic `/workspaces/<name>` prefix appended to artifact roots when workspace support is enabled. Setting this flag allows workspaces to remain active while preserving compatibility with artifact paths that were created before workspace support was introduced.

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

When workspaces are enabled, MLflow automatically appends `/workspaces/<workspace_name>` to the artifact root URI for every new experiment. This breaks access to existing artifacts that were stored under the old flat path layout.

This PR adds `MLFLOW_WORKSPACE_DISABLE_ARTIFACT_PREFIX=true` to opt out of this behaviour. When set, the workspace middleware remains fully active (experiment/run isolation per workspace, RBAC, etc.) but the artifact root is left as-is — matching the layout used before workspaces were introduced.

### How is this PR tested?

- [x] New unit/integration tests

Three new tests in `tests/store/tracking/test_sqlalchemy_store_workspace.py`:
- prefix is appended by default when the provider signals `should_append=True`
- prefix is suppressed when the provider signals `should_append=False`
- prefix is suppressed when `MLFLOW_WORKSPACE_DISABLE_ARTIFACT_PREFIX=true` regardless of the provider signal

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

The new env var is documented inline in `environment_variables.py` following the existing pattern.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Users running MLflow with workspaces enabled (`MLFLOW_ENABLE_WORKSPACES=true`) who have pre-existing artifacts stored under a flat path layout can now set `MLFLOW_WORKSPACE_DISABLE_ARTIFACT_PREFIX=true` to keep workspaces active without breaking access to those older resources.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release