### PR TITLE
Hide redundant metric names in chart cards (superseded)

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewMetricCharts.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewMetricCharts.test.tsx
@@ -191,6 +191,12 @@ describe('RunViewMetricCharts', () => {
         timestamp: 0,
         value: 1000,
       },
+      'custom-prefix/test-line-metric': {
+        key: 'custom-prefix/test-line-metric',
+        step: 5,
+        timestamp: 0,
+        value: 1000,
+      },
     };
 
     renderComponent({
@@ -203,9 +209,12 @@ describe('RunViewMetricCharts', () => {
     });
     expect(screen.getByText('Bar plot for metric_4')).toBeInTheDocument();
     expect(screen.getByText('Bar plot for custom-prefix/test-metric')).toBeInTheDocument();
+    expect(screen.getByText('Line plot for custom-prefix/test-line-metric')).toBeInTheDocument();
 
     // Assert new section
     expect(screen.getByText('custom-prefix')).toBeInTheDocument();
+    expect(screen.getByText('test-metric')).toBeInTheDocument();
+    expect(screen.getByText('test-line-metric')).toBeInTheDocument();
   });
 
   it('adds should not call for image artifacts when `mlflow.loggedImages` tag is not set', async () => {

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/cards/RunsChartsLineChartCard.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/cards/RunsChartsLineChartCard.tsx
@@ -49,7 +49,11 @@ const getV2ChartTitle = (cardConfig: RunsChartsLineCardConfig): string => {
     return expressions?.join(' vs ') || '';
   }
   if (!cardConfig.selectedMetricKeys || cardConfig.selectedMetricKeys.length === 0) {
-    return cardConfig.metricKey;
+    return cardConfig.displayName ?? cardConfig.metricKey;
+  }
+
+  if (cardConfig.selectedMetricKeys.length === 1) {
+    return cardConfig.displayName ?? cardConfig.selectedMetricKeys[0];
   }
 
   return cardConfig.selectedMetricKeys.join(' vs ');

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/runs-charts.types.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/runs-charts.types.test.ts
@@ -196,4 +196,35 @@ describe('RunsChartsCardConfig.getBaseChartAndSectionConfigs', () => {
       expect(gpuSectionExists).toBe(false);
     });
   });
+
+  test('uses section-relative display names for generated nested metric charts', () => {
+    const runsData = [
+      createMockRunData({
+        'train/losses/grouped_by_x/after_y/mae': {
+          key: 'train/losses/grouped_by_x/after_y/mae',
+          value: 0.1,
+          step: 0,
+        },
+        'system/gpu_1': {
+          key: 'system/gpu_1',
+          value: 10,
+          step: 2,
+        },
+      }),
+    ];
+
+    const { resultChartSet, resultSectionSet } = RunsChartsCardConfig.getBaseChartAndSectionConfigs({
+      runsData,
+    });
+
+    const nestedMetricChart = resultChartSet.find(
+      (chart) => 'metricKey' in chart && chart.metricKey === 'train/losses/grouped_by_x/after_y/mae',
+    );
+    const systemMetricChart = resultChartSet.find((chart) => 'metricKey' in chart && chart.metricKey === 'system/gpu_1');
+
+    expect(nestedMetricChart?.displayName).toBe('mae');
+    expect(systemMetricChart?.displayName).toBe('gpu_1');
+    expect(resultSectionSet.some((section) => section.name === 'train/losses/grouped_by_x/after_y')).toBe(true);
+    expect(resultSectionSet.some((section) => section.name === 'System metrics')).toBe(true);
+  });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/runs-charts.types.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/runs-charts.types.ts
@@ -132,6 +132,7 @@ export abstract class RunsChartsCardConfig {
       resultChartSet.push({
         ...RunsChartsCardConfig.getEmptyChartCardByType(chartType, true, getUUID()),
         metricKey: metricsKey,
+        displayName: RunsChartsCardConfig.extractChartDisplayName(metricsKey),
       } as RunsChartsBarCardConfig);
     });
 
@@ -155,6 +156,12 @@ export abstract class RunsChartsCardConfig {
       return MLFLOW_SYSTEM_METRIC_NAME;
     }
     return section;
+  };
+
+  static extractChartDisplayName = (metricKey: string, delimiter = '/') => {
+    const displayMetricName = customMetricBehaviorDefs[metricKey]?.displayName ?? metricKey;
+    const parts = displayMetricName.split(delimiter);
+    return parts[parts.length - 1] || displayMetricName;
   };
 
   static getBaseChartAndSectionConfigs({
@@ -274,6 +281,7 @@ export abstract class RunsChartsCardConfig {
         resultChartSet.push({
           ...RunsChartsCardConfig.getEmptyChartCardByType(chartType, true, getUUID(), sectionId),
           metricKey: metricsKey,
+          displayName: RunsChartsCardConfig.extractChartDisplayName(metricsKey),
           ...(metricsKey.startsWith(MLFLOW_SYSTEM_METRIC_PREFIX) ? { xAxisKey: 'time', useGlobalXaxisKey: false } : {}),
         } as RunsChartsBarCardConfig);
       });
@@ -517,6 +525,7 @@ export abstract class RunsChartsCardConfig {
         const newChartConfig = {
           ...RunsChartsCardConfig.getEmptyChartCardByType(chartType, true, getUUID(), sectionId),
           metricKey: metricKey,
+          displayName: RunsChartsCardConfig.extractChartDisplayName(metricKey),
           ...(metricKey.startsWith(MLFLOW_SYSTEM_METRIC_PREFIX) ? { xAxisKey: 'time', useGlobalXaxisKey: false } : {}),
         } as RunsChartsBarCardConfig;
 
@@ -547,6 +556,7 @@ export abstract class RunsChartsCardConfig {
             prevChart.metricSectionId,
           ),
           metricKey: metricKey,
+          displayName: RunsChartsCardConfig.extractChartDisplayName(metricKey),
           deleted: prevChart.deleted,
           ...(metricKey.startsWith(MLFLOW_SYSTEM_METRIC_PREFIX) ? { xAxisKey: 'time', useGlobalXaxisKey: false } : {}),
         } as RunsChartsLineCardConfig;


### PR DESCRIPTION
## Summary

This PR shortens generated chart titles in the run page metrics tabs when metrics are already grouped by prefix.

Instead of repeating the full metric path inside each card title, generated single-metric cards now display only the section-relative suffix (for example `mae` instead of `train/losses/grouped_by_x/after_y/mae`).

Fixes #22966.

## What changed

- added a helper to derive section-relative chart display names for generated metric cards
- applied that display name when generating and updating run page chart configs
- updated single-metric line chart titles to prefer the shortened display name
- added tests for generated config display names and run page rendering

## User impact

Grouped metric sections become easier to scan because chart titles no longer repeat the already-visible prefix.

## Validation

- `node yarn/releases/yarn-4.12.0.cjs eslint src/experiment-tracking/components/run-page/RunViewMetricCharts.test.tsx src/experiment-tracking/components/runs-charts/components/cards/RunsChartsLineChartCard.tsx src/experiment-tracking/components/runs-charts/runs-charts.types.test.ts src/experiment-tracking/components/runs-charts/runs-charts.types.ts`
- attempted targeted Jest runs for the two updated test files, but the local CRACO/Jest test command hung without producing a result in this environment
