### PR TITLE
Fix `/review` workflow sandbox initialization on Ubuntu 24.04 runners

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -92,11 +92,16 @@ jobs:
       - name: Install Claude CLI
         run: |
           .claude/scripts/install-claude.sh
-      - name: Install bubblewrap
+      - name: Install subprocess isolation dependencies
+        # Mirrors anthropics/claude-code-action: install bubblewrap + socat and
+        # relax the Ubuntu 24.04 AppArmor restriction on unprivileged user
+        # namespaces, otherwise bwrap fails with "Sandbox failed to initialize".
+        # https://github.com/anthropics/claude-code-action/blob/dde2242db6af13460b916652159b6ba19a598f30/action.yml#L198-L221
         run: |
-          if ! command -v bwrap >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y bubblewrap
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends bubblewrap socat
+          if [ -f /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
           fi
       - name: Verify Claude CLI
         run: |
@@ -142,7 +147,6 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           PROMPT: ${{ steps.prompt.outputs.prompt }}
           MODEL: ${{ steps.prompt.outputs.model || 'opus' }}
@@ -152,7 +156,8 @@ jobs:
 
           # Safe construction using arrays - PROMPT is passed as separate argument to prevent shell injection
           if [ "$EVENT_NAME" = "pull_request" ]; then
-            ARGS=("Hi")
+            # Smoke test: exercise the Bash tool so sandbox regressions surface here.
+            ARGS=("Run ls")
           else
             ARGS=("/pr-review")
             [ -n "$PROMPT" ] && ARGS+=("$PROMPT")


### PR DESCRIPTION
### Related Issues/PRs

Follow-up to #23224

### What changes are proposed in this pull request?

The `review` job installs `bubblewrap` so the Claude CLI can sandbox its Bash tool. On Ubuntu 24.04 — the current `ubuntu-latest` image — the kernel ships with `kernel.apparmor_restrict_unprivileged_userns=1`, which blocks unprivileged user namespaces. `bwrap` can't initialize, and every Bash call returns just `"Sandbox failed to initialize."` (see the artifact of [run 25713344241](https://github.com/mlflow/mlflow/actions/runs/25713344241)).

Mirror the upstream [`anthropics/claude-code-action` setup](https://github.com/anthropics/claude-code-action/blob/dde2242db6af13460b916652159b6ba19a598f30/action.yml#L198-L221):

- Also install `socat` alongside `bubblewrap`.
- Relax the AppArmor sysctl before launching Claude:

  ```
  sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
  ```
- Drop `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1` — only the `=0` opt-out value is honored, so setting it to `1` is a no-op.

### How is this PR tested?

- [x] Manual tests

Verified by inspecting the Claude stream artifact from the failing run: every Bash invocation (with and without `dangerouslyDisableSandbox: true`) returned the bare `"Sandbox failed to initialize."` string. The sysctl + `socat` installation matches the upstream action that does work on Ubuntu 24.04. Next `/review` invocation will be the real validation.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)