### PR TITLE
Fix `/review` workflow sandbox initialization on Ubuntu 24.04 runners

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -163,7 +163,7 @@ jobs:
             # Smoke test: exercise the Bash tool (and gh CLI + app token) so
             # sandbox or auth regressions surface here.
             ARGS=("Run \`gh pr view $PR_NUMBER\` and summarize the PR")
-            EXTRA_FLAGS+=(--allowedTools "Bash(gh pr view:*)")
+            EXTRA_FLAGS+=("--allowedTools=Bash(gh pr view:*)")
           else
             ARGS=("/pr-review")
             [ -n "$PROMPT" ] && ARGS+=("$PROMPT")

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -92,11 +92,19 @@ jobs:
       - name: Install Claude CLI
         run: |
           .claude/scripts/install-claude.sh
-      - name: Install bubblewrap
+      - name: Install subprocess isolation dependencies
+        # Mirrors anthropics/claude-code-action: install bubblewrap + socat and
+        # relax the Ubuntu 24.04 AppArmor restriction on unprivileged user
+        # namespaces, otherwise bwrap fails with "Sandbox failed to initialize".
+        # https://github.com/anthropics/claude-code-action/blob/dde2242db6af13460b916652159b6ba19a598f30/action.yml#L198-L221
         run: |
-          if ! command -v bwrap >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y bubblewrap
+          if ! command -v bwrap >/dev/null 2>&1 || ! command -v socat >/dev/null 2>&1; then
+            sudo apt-get update -qq
+            sudo apt-get install -y --no-install-recommends bubblewrap socat
+          fi
+          sysctl_file=/proc/sys/kernel/apparmor_restrict_unprivileged_userns
+          if [ -f "$sysctl_file" ] && [ "$(cat "$sysctl_file")" = "1" ]; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
           fi
       - name: Verify Claude CLI
         run: |
@@ -142,7 +150,6 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           PROMPT: ${{ steps.prompt.outputs.prompt }}
           MODEL: ${{ steps.prompt.outputs.model || 'opus' }}
@@ -152,7 +159,8 @@ jobs:
 
           # Safe construction using arrays - PROMPT is passed as separate argument to prevent shell injection
           if [ "$EVENT_NAME" = "pull_request" ]; then
-            ARGS=("Hi")
+            # Smoke test: exercise the Bash tool so sandbox regressions surface here.
+            ARGS=("Run ls")
           else
             ARGS=("/pr-review")
             [ -n "$PROMPT" ] && ARGS+=("$PROMPT")

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -150,6 +150,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           PROMPT: ${{ steps.prompt.outputs.prompt }}
           MODEL: ${{ steps.prompt.outputs.model || 'opus' }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -159,8 +159,9 @@ jobs:
 
           # Safe construction using arrays - PROMPT is passed as separate argument to prevent shell injection
           if [ "$EVENT_NAME" = "pull_request" ]; then
-            # Smoke test: exercise the Bash tool so sandbox regressions surface here.
-            ARGS=("Run ls")
+            # Smoke test: exercise the Bash tool (and gh CLI + app token) so
+            # sandbox or auth regressions surface here.
+            ARGS=("Run \`gh pr view $PR_NUMBER\` and summarize the PR")
           else
             ARGS=("/pr-review")
             [ -n "$PROMPT" ] && ARGS+=("$PROMPT")

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -158,10 +158,12 @@ jobs:
           OUTPUT_FILE="/tmp/output.jsonl"
 
           # Safe construction using arrays - PROMPT is passed as separate argument to prevent shell injection
+          EXTRA_FLAGS=()
           if [ "$EVENT_NAME" = "pull_request" ]; then
             # Smoke test: exercise the Bash tool (and gh CLI + app token) so
             # sandbox or auth regressions surface here.
             ARGS=("Run \`gh pr view $PR_NUMBER\` and summarize the PR")
+            EXTRA_FLAGS+=(--allowedTools "Bash(gh pr view:*)")
           else
             ARGS=("/pr-review")
             [ -n "$PROMPT" ] && ARGS+=("$PROMPT")
@@ -169,7 +171,7 @@ jobs:
 
           EXIT_CODE=0
           # Note: ARGS[*] is intentional - claude CLI expects a single prompt string
-          timeout 20m claude --model "$MODEL" --print --verbose --output-format stream-json "${ARGS[*]}" | .claude/scripts/stream.sh "$OUTPUT_FILE" || EXIT_CODE=$?
+          timeout 20m claude --model "$MODEL" --print --verbose --output-format stream-json "${EXTRA_FLAGS[@]}" "${ARGS[*]}" | .claude/scripts/stream.sh "$OUTPUT_FILE" || EXIT_CODE=$?
           if [ "${EXIT_CODE:-0}" -eq 124 ]; then
             echo "Warning: Claude command timed out after 20 minutes"
           elif [ "${EXIT_CODE:-0}" -ne 0 ]; then


### PR DESCRIPTION
### Related Issues/PRs

Follow-up to #23224. Re-files closed #23229 from the upstream remote so the workflow's `pull_request` smoke-test path (which gates on `head.repo.full_name == github.repository`) actually runs.

### What changes are proposed in this pull request?

The `review` job installs `bubblewrap` so the Claude CLI can sandbox its Bash tool. On Ubuntu 24.04 — the current `ubuntu-latest` image — the kernel ships with `kernel.apparmor_restrict_unprivileged_userns=1`, which blocks unprivileged user namespaces. `bwrap` can't initialize, and every Bash call returns just `"Sandbox failed to initialize."` (see the artifact of [run 25713344241](https://github.com/mlflow/mlflow/actions/runs/25713344241)).

Mirror the upstream [`anthropics/claude-code-action` setup](https://github.com/anthropics/claude-code-action/blob/dde2242db6af13460b916652159b6ba19a598f30/action.yml#L198-L221):

- Also install `socat` alongside `bubblewrap`.
- Relax the AppArmor sysctl before launching Claude:

  ```
  sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
  ```
- Strengthen the `pull_request` smoke-test prompt from `"Hi"` to ``Run `gh pr view $PR_NUMBER` and summarize the PR``, allowlisting `Bash(gh pr view:*)` only on the smoke-test path. This exercises the Bash tool, the `gh` CLI, and the GitHub App token end-to-end so sandbox or auth regressions surface on PRs that touch this workflow.

### How is this PR tested?

- [x] Manual tests

The `pull_request` trigger on this PR hits the smoke-test path and exercises the Bash tool through the sandbox — that is the validation. See [run 25714674094](https://github.com/mlflow/mlflow/actions/runs/25714674094): `gh pr view` ran cleanly, returned 2,848 chars of PR data, and the model summarized the PR (11s, 2 turns, $0.11).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)