### PR TITLE
Skip `mistral` in `test_autolog_genai_import` while `mistralai` is disabled

### DIFF
--- a/tests/tracking/fluent/test_fluent_autolog.py
+++ b/tests/tracking/fluent/test_fluent_autolog.py
@@ -514,6 +514,8 @@ def test_autolog_genai_import(disable, flavor_and_module):
         "agno",
         "strands",
         "haystack",
+        # mistral is disabled - see https://github.com/mistralai/client-python/issues/523
+        "mistral",
     }:
         return
 


### PR DESCRIPTION
### Related Issues/PRs

Follow-up to #23227.

### What changes are proposed in this pull request?

`test_autolog_genai_import` parametrizes over `FLAVOR_TO_MODULE_NAME` (defined in `mlflow/ml_package_versions.py`) and does `__import__(module)` for each flavor. That dict still contains `"mistral": "mistralai"`, but #23227 removed `mistralai` from the test environment due to the [supply chain compromise](https://github.com/mistralai/client-python/issues/523), so the test now fails on master with:

```
ModuleNotFoundError: No module named 'mistralai'
tests/tracking/fluent/test_fluent_autolog.py::test_autolog_genai_import[False-flavor_and_module27]
tests/tracking/fluent/test_fluent_autolog.py::test_autolog_genai_import[True-flavor_and_module27]
```

(See [job 75498081340](https://github.com/mlflow/mlflow/actions/runs/25713342386/job/75498081340).)

Add `"mistral"` to the per-flavor skip set so the test matches the post-#23227 reality. This is symmetric with how #23227 already handled the other call sites in the same file. Skip can be removed when `mistralai` is re-enabled.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)