### PR TITLE
Drop sandboxing from `/review` workflow

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -174,11 +174,12 @@ jobs:
         run: |
           python <<'PY'
           import os
+          import sys
           from pathlib import Path
 
           path = Path("/tmp/output.jsonl")
           if not path.exists():
-              raise SystemExit(0)
+              sys.exit(0)
           data = path.read_text()
           for name in ("ANTHROPIC_API_KEY", "GH_TOKEN"):
               if val := os.environ.get(name):

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -92,20 +92,6 @@ jobs:
       - name: Install Claude CLI
         run: |
           .claude/scripts/install-claude.sh
-      - name: Install subprocess isolation dependencies
-        # Mirrors anthropics/claude-code-action: install bubblewrap + socat and
-        # relax the Ubuntu 24.04 AppArmor restriction on unprivileged user
-        # namespaces, otherwise bwrap fails with "Sandbox failed to initialize".
-        # https://github.com/anthropics/claude-code-action/blob/dde2242db6af13460b916652159b6ba19a598f30/action.yml#L198-L221
-        run: |
-          if ! command -v bwrap >/dev/null 2>&1 || ! command -v socat >/dev/null 2>&1; then
-            sudo apt-get update -qq
-            sudo apt-get install -y --no-install-recommends bubblewrap socat
-          fi
-          sysctl_file=/proc/sys/kernel/apparmor_restrict_unprivileged_userns
-          if [ -f "$sysctl_file" ] && [ "$(cat "$sysctl_file")" = "1" ]; then
-            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-          fi
       - name: Verify Claude CLI
         run: |
           claude --version
@@ -150,7 +136,6 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           PROMPT: ${{ steps.prompt.outputs.prompt }}
           MODEL: ${{ steps.prompt.outputs.model || 'opus' }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -166,6 +166,26 @@ jobs:
             exit $EXIT_CODE
           fi
 
+      - name: Redact secrets from transcript
+        if: always()
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          python <<'PY'
+          import os
+          from pathlib import Path
+
+          path = Path("/tmp/output.jsonl")
+          if not path.exists():
+              raise SystemExit(0)
+          data = path.read_text()
+          for name in ("ANTHROPIC_API_KEY", "GH_TOKEN"):
+              if val := os.environ.get(name):
+                  data = data.replace(val, "***")
+          path.write_text(data)
+          PY
+
       - name: Upload Claude stream transcript
         if: always()
         continue-on-error: true


### PR DESCRIPTION
### Related Issues/PRs

Reverts the sandboxing chain introduced by #23207, #23224, and #23230.

### What changes are proposed in this pull request?

`CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1` (added in #23207 to strip `ANTHROPIC_API_KEY` from subprocess env) opted the Claude CLI into per-Bash-call sandboxing via `bwrap`. The CI runners don't ship `bwrap`, and Ubuntu 24.04's `kernel.apparmor_restrict_unprivileged_userns=1` blocks unprivileged user namespaces, so the sandbox couldn't initialize. #23224 installed `bubblewrap` and #23230 added `socat` + the AppArmor sysctl tweak to make the sandbox work.

The sandbox also breaks the `pr-review` skill's `fetch-diff` invocation: `uv run --package skills` triggers a setuptools editable install that writes `src/skills.egg-info/` back into the source tree, which `bwrap` makes read-only:

```
× Failed to build `skills @ file:///home/runner/work/mlflow/mlflow/.claude/skills`
╰─▶ Call to `setuptools.build_meta:__legacy__.build_editable` failed
    error: could not create 'src/skills.egg-info': Read-only file system
```

(See [run 25715473344](https://github.com/mlflow/mlflow/actions/runs/25715473344).)

Drop the env var (the trigger) and the install step (now unnecessary). The pre-#23207 behavior runs Bash without sandbox/env-scrub, which was working fine and removes both the sandbox-init failure mode and the editable-install conflict.

### How is this PR tested?

- [x] Manual tests

The `pull_request` smoke test on this PR runs `gh pr view $PR_NUMBER` through the (now-unsandboxed) Bash tool — that is the validation.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)