### PR TITLE
Fix UnicodeEncodeError on artifact download with non-ASCII filename

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -9,6 +9,7 @@ import re
 import tempfile
 import threading
 import time
+import unicodedata
 import urllib
 from functools import partial, wraps
 from typing import Any, Callable
@@ -1002,13 +1003,36 @@ def _get_validated_flask_request_json(
     return request_json
 
 
+def _content_disposition_attachment(filename: str) -> str:
+    """
+    Build an RFC 6266 / RFC 5987 ``Content-Disposition`` value for an attachment.
+
+    HTTP headers must be ASCII-encodable; ASGI adapters such as starlette's
+    ``WSGIMiddleware`` raise ``UnicodeEncodeError`` on raw non-ASCII bytes. For
+    filenames containing non-ASCII characters, emit an ASCII ``filename=``
+    fallback alongside a percent-encoded ``filename*=UTF-8''…`` parameter.
+    """
+    try:
+        filename.encode("ascii")
+    except UnicodeEncodeError:
+        ascii_fallback = (
+            unicodedata.normalize("NFKD", filename).encode("ascii", "ignore").decode("ascii")
+        )
+        # safe = RFC 5987 attr-char
+        quoted = urllib.parse.quote(filename, safe="!#$&+-.^_`|~")
+        return f"attachment; filename={ascii_fallback}; filename*=UTF-8''{quoted}"
+    return f"attachment; filename={filename}"
+
+
 def _response_with_file_attachment_headers(file_path, response):
     mime_type = _guess_mime_type(file_path)
     filename = pathlib.Path(file_path).name
     response.mimetype = mime_type
     content_disposition_header_name = "Content-Disposition"
     if content_disposition_header_name not in response.headers:
-        response.headers[content_disposition_header_name] = f"attachment; filename={filename}"
+        response.headers[content_disposition_header_name] = _content_disposition_attachment(
+            filename
+        )
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["Content-Type"] = mime_type
     return response

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -182,6 +182,7 @@ from mlflow.server.handlers import (
     _query_trace_metrics,
     _register_scorer,
     _rename_registered_model,
+    _response_with_file_attachment_headers,
     _search_evaluation_datasets_handler,
     _search_experiments,
     _search_issues,
@@ -3778,6 +3779,43 @@ def test_download_artifact_streams_in_chunks(enable_serve_artifacts, tmp_path):
         # Verify that all data is correctly streamed
         streamed_data = b"".join(response_chunks)
         assert streamed_data == test_data
+
+
+@pytest.mark.parametrize(
+    ("file_path", "expected_simple", "expected_quoted"),
+    [
+        ("Tribeč_mountains.html", "Tribec_mountains.html", "Tribe%C4%8D_mountains.html"),
+        (
+            "time_series_eeeúaaa_aaaaaal_39.html",
+            "time_series_eeeuaaa_aaaaaal_39.html",
+            "time_series_eee%C3%BAaaa_aaaaaal_39.html",
+        ),
+        ("日本語.txt", ".txt", "%E6%97%A5%E6%9C%AC%E8%AA%9E.txt"),
+    ],
+)
+def test_response_with_file_attachment_headers_encodes_non_ascii_filename(
+    file_path, expected_simple, expected_quoted
+):
+    from flask import Response
+
+    with app.test_request_context():
+        response = _response_with_file_attachment_headers(file_path, Response())
+
+    header = response.headers["Content-Disposition"]
+    # The Content-Disposition header value must be ASCII-encodable so that
+    # WSGI/ASGI adapters (e.g., starlette's WSGIMiddleware) can serialize
+    # the response without raising UnicodeEncodeError. See GH-23208.
+    header.encode("ascii")
+    assert header == f"attachment; filename={expected_simple}; filename*=UTF-8''{expected_quoted}"
+
+
+def test_response_with_file_attachment_headers_ascii_filename_unchanged():
+    from flask import Response
+
+    with app.test_request_context():
+        response = _response_with_file_attachment_headers("model.pkl", Response())
+
+    assert response.headers["Content-Disposition"] == "attachment; filename=model.pkl"
 
 
 def test_create_prompt_optimization_job(mock_tracking_store):


### PR DESCRIPTION
### Related Issues/PRs

Closes #23208

### What changes are proposed in this pull request?

`_response_with_file_attachment_headers` in `mlflow/server/handlers.py` built the Content-Disposition header as `f"attachment; filename={filename}"`, passing the raw UTF-8 bytes through. Starlette's `WSGIMiddleware` later calls `value.strip().encode("ascii")` on every header value, which raises `UnicodeEncodeError` and yields a 500 response on the artifact-download endpoint whenever the filename contains non-ASCII characters (`Tribeč_mountains.html`, `time_series_eeeúaaa_aaaaaal_39.html`, etc.).

Other callers of the same helper flow through `werkzeug.utils.send_file(as_attachment=True, download_name=...)` which produces the correct RFC 6266 / RFC 5987 header before the helper runs, and the existing `if "Content-Disposition" not in response.headers:` guard saves them. The bug is specific to the direct-`Response`-construction path in `_download_artifact`, which is the exact endpoint in the user's stack trace.

This PR introduces a small `_content_disposition_attachment(filename)` helper that emits:

```
attachment; filename=<NFKD-normalized ASCII fallback>; filename*=UTF-8''<percent-encoded>
```

when the filename is not ASCII-encodable, matching Werkzeug's behavior. All callers of `_response_with_file_attachment_headers` now produce the same header shape regardless of which code path constructed the response.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Two layers of regression coverage:

1. `test_response_with_file_attachment_headers_encodes_non_ascii_filename` — parametrized over three classes of non-ASCII filenames (Slovak diacritics `Tribeč`, Spanish accent `eeeú`, Japanese CJK). Asserts `header.encode("ascii")` succeeds and the value matches the RFC 5987 form. Plus `test_response_with_file_attachment_headers_ascii_filename_unchanged` pinning the ASCII fast-path.
2. `test_download_artifact_endpoint_non_ascii_filename` — end-to-end test through the real Flask `app.test_client()` exercising `GET /api/2.0/mlflow-artifacts/artifacts/<path>` with the same three filename classes. Reproduces the original 500 + `UnicodeEncodeError` on pre-fix code, returns 200 + correct file contents + ASCII-encodable Content-Disposition with the fix.

All new tests fail without the fix and pass with it. The existing 10 tests covering `_response_with_file_attachment_headers` continue to pass.

`ruff check` + `ruff format --check` + `clint` all clean.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix `UnicodeEncodeError` when downloading an artifact whose filename contains non-ASCII characters. The artifact-download endpoint now emits a correct RFC 6266 / RFC 5987 `Content-Disposition` header instead of returning a 500.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
