### PR TITLE
Disable uv cache and Python micro-version pinning in privileged workflows

### DIFF
--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -118,6 +118,9 @@ jobs:
           git fetch base $BASE_REF
           git merge base/$BASE_REF
       - uses: ./.github/actions/setup-python
+        with:
+          enable-uv-cache: false
+          pin-micro-version: false
       # ************************************************************************
       # pre-commit
       # ************************************************************************

--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -161,6 +161,9 @@ jobs:
           git config user.email "${AUTHOR_ID}+${AUTHOR_LOGIN}@users.noreply.github.com"
 
       - uses: ./.github/actions/setup-python
+        with:
+          enable-uv-cache: false
+          pin-micro-version: false
 
       - name: Set up pre-commit
         run: |

--- a/.github/workflows/ui-preview.yml
+++ b/.github/workflows/ui-preview.yml
@@ -89,6 +89,9 @@ jobs:
           ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}
 
       - uses: ./.github/actions/setup-python
+        with:
+          enable-uv-cache: false
+          pin-micro-version: false
       - uses: ./.github/actions/setup-node
 
       - name: Install build tools

--- a/.github/workflows/update-model-catalog.yml
+++ b/.github/workflows/update-model-catalog.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: ./.github/actions/setup-python
         with:
           pin-micro-version: false
+          enable-uv-cache: false
 
       - uses: ./.github/actions/setup-node
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #N/A

### What changes are proposed in this pull request?

Pass `enable-uv-cache: false` and `pin-micro-version: false` to `./.github/actions/setup-python` in workflows that either ship build artifacts externally or run with elevated credentials, to reduce cache-poisoning supply-chain risk:

- `ui-preview.yml` — deploys to Databricks Apps
- `resolve.yml` — runs with `ANTHROPIC_API_KEY` + APP credentials
- `autoformat.yml` — commits formatted code back to PRs via APP token
- `update-model-catalog.yml` — opens PRs via APP token

A poisoned cache entry could otherwise inject a malicious package into a build artifact or a privileged execution context. Ordinary CI workflows (test matrices, lint) keep the cache since they don't have secrets beyond `GITHUB_TOKEN`.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)