### PR TITLE
Disable uv and npm caches in setup composite actions

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -5,12 +5,13 @@ inputs:
     description: "Node version to use."
     default: 24
     required: false
+  # NOTE: `cache` / `cache-dependency-path` are currently ignored; caching is hardcoded off below.
   cache:
-    description: "Currently ignored: node caching is hardcoded off in this composite to avoid cache-poisoning exposure. Retained for easy rewire if caching is re-enabled in the future."
+    description: "Package manager to cache (e.g., npm, yarn)."
     default: ""
     required: false
   cache-dependency-path:
-    description: "Currently ignored: node caching is hardcoded off in this composite. See `cache` input."
+    description: "Path to dependency file(s) for cache key generation."
     default: ""
     required: false
 

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -20,8 +20,9 @@ runs:
     - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: ${{ inputs.node-version }}
-        cache: ${{ inputs.cache }}
-        cache-dependency-path: ${{ inputs.cache-dependency-path }}
+        # Hardcoded to empty to avoid cache-poisoning exposure. To re-enable, wire back to ${{ inputs.cache }} / ${{ inputs.cache-dependency-path }}.
+        cache: ""
+        cache-dependency-path: ""
     - run: |
         # min-release-age requires npm >= 11.10.0 (https://github.com/npm/cli/releases/tag/v11.10.0)
         npm install -g npm@"^11.10.0"

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -6,11 +6,11 @@ inputs:
     default: 24
     required: false
   cache:
-    description: "Package manager to cache (e.g., npm, yarn)."
+    description: "Currently ignored: node caching is hardcoded off in this composite to avoid cache-poisoning exposure. Retained for easy rewire if caching is re-enabled in the future."
     default: ""
     required: false
   cache-dependency-path:
-    description: "Path to dependency file(s) for cache key generation."
+    description: "Currently ignored: node caching is hardcoded off in this composite. See `cache` input."
     default: ""
     required: false
 

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -9,7 +9,7 @@ inputs:
     required: false
     default: "true"
   enable-uv-cache:
-    description: "Enable uv's built-in cache. Set to false for short jobs where cache restore/save overhead isn't worth it."
+    description: "Currently ignored: uv caching is hardcoded off in this composite to avoid cache-poisoning exposure. Retained for easy rewire if caching is re-enabled in the future."
     required: false
     default: "true"
 outputs:

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -59,7 +59,8 @@ runs:
     - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
       with:
         version: "0.11.7"
-        enable-cache: ${{ inputs.enable-uv-cache }}
+        # Hardcoded to false to avoid cache-poisoning exposure. To re-enable, wire back to ${{ inputs.enable-uv-cache }}.
+        enable-cache: false
     - run: |
         # The default `first-index` strategy is too strict. Use `unsafe-first-match` instead.
         # https://docs.astral.sh/uv/configuration/environment/#uv_index_strategy

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -8,8 +8,9 @@ inputs:
     description: "Whether to pin to a specific micro version for Anaconda compatibility. Set to false for workflows that don't need conda/pyenv to hit the runner's pre-installed Python cache and avoid a ~9s download."
     required: false
     default: "true"
+  # NOTE: `enable-uv-cache` is currently ignored; caching is hardcoded off below.
   enable-uv-cache:
-    description: "Currently ignored: uv caching is hardcoded off in this composite to avoid cache-poisoning exposure. Retained for easy rewire if caching is re-enabled in the future."
+    description: "Enable uv's built-in cache. Set to false for short jobs where cache restore/save overhead isn't worth it."
     required: false
     default: "true"
 outputs:


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

Hardcode `enable-cache: false` on `astral-sh/setup-uv` in `.github/actions/setup-python/action.yml` and `cache: ""` on `actions/setup-node` in `.github/actions/setup-node/action.yml`.

This reduces cache-poisoning exposure across every CI workflow that consumes these composites: a PR run can no longer plant wheels or npm packages that a later privileged workflow would restore and execute at install time. The input knobs (`enable-uv-cache`, `cache`, `cache-dependency-path`) are kept in place so re-enabling caching is a one-line rewire if the speedup ever outweighs the risk for a specific workflow.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)