### PR TITLE
Ignore S3 directory markers in artifact listing

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -246,6 +246,13 @@ MLFLOW_S3_UPLOAD_EXTRA_ARGS = _EnvironmentVariable("MLFLOW_S3_UPLOAD_EXTRA_ARGS"
 #: (default: ``None``)
 MLFLOW_S3_EXPECTED_BUCKET_OWNER = _EnvironmentVariable("MLFLOW_S3_EXPECTED_BUCKET_OWNER", str, None)
 
+#: Specifies whether or not to ignore directory markers when listing artifacts in S3.
+#: Directory markers are zero-byte objects with keys that end with "/" which some S3-compatible
+#: storage providers create to represent directories. These objects can cause issues when listing
+#: and subsequently downloading artifacts.
+#: (default: ``True``)
+MLFLOW_S3_IGNORE_DIRECTORY_MARKERS= _BooleanEnvironmentVariable("MLFLOW_S3_IGNORE_DIRECTORY_MARKERS", True)
+
 #: Specifies the location of a Kerberos ticket cache to use for HDFS artifact operations.
 #: (default: ``None``)
 MLFLOW_KERBEROS_TICKET_CACHE = _EnvironmentVariable("MLFLOW_KERBEROS_TICKET_CACHE", str, None)

--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -17,6 +17,7 @@ from mlflow.environment_variables import (
     MLFLOW_BOTO_CLIENT_ADDRESSING_STYLE,
     MLFLOW_S3_ENDPOINT_URL,
     MLFLOW_S3_EXPECTED_BUCKET_OWNER,
+    MLFLOW_S3_IGNORE_DIRECTORY_MARKERS,
     MLFLOW_S3_IGNORE_TLS,
     MLFLOW_S3_UPLOAD_EXTRA_ARGS,
 )
@@ -433,7 +434,10 @@ class S3ArtifactRepository(
                 )
                 file_rel_path = posixpath.relpath(path=file_path, start=artifact_path)
                 file_size = int(obj.get("Size"))
-                infos.append(FileInfo(file_rel_path, False, file_size))
+                file_info = FileInfo(file_rel_path, False, file_size)
+                if MLFLOW_S3_IGNORE_DIRECTORY_MARKERS and self._file_is_directory_marker(file_info):
+                    continue
+                infos.append(file_info)
         return sorted(infos, key=lambda f: f.path)
 
     @staticmethod
@@ -444,6 +448,10 @@ class S3ArtifactRepository(
                 f" artifact path. Artifact path: {artifact_path}. Object path:"
                 f" {listed_object_path}."
             )
+
+    @staticmethod
+    def _file_is_directory_marker(file_info):
+        return file_info.file_size == 0 and file_info.path.endswith("/")
 
     def _download_file(self, remote_file_path, local_path):
         """


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

I did not create an issue for this as the fix was as straightforward as writing the issue

### What changes are proposed in this pull request?

This PR fixes artifact listing for S3-compatible object stores that persist directory marker objects alongside real artifact files.

In S3, directories are not real filesystem entries; they are usually represented implicitly by object key prefixes. Some S3-compatible backends also create explicit zero-byte objects whose keys end with / to make those prefixes show up as directories in tools such as aws s3 ls. In the example below, entries like artifacts/, artifacts/llm_adapter/, and artifacts/llm_adapter/peft/ are not real artifact files, but directory marker objects:

```
2025-09-10 22:32:23          0 41/d1333c6ba70c49148a95881677f74cfe/artifacts/
2025-09-10 22:32:23          0 41/d1333c6ba70c49148a95881677f74cfe/artifacts/llm_adapter/
2025-09-10 22:33:45          0 41/d1333c6ba70c49148a95881677f74cfe/artifacts/llm_adapter/peft/
```

MLflow currently sees these entries in S3 listings as regular objects, which means they can be surfaced as downloadable artifacts even though they only exist to represent folder structure. That creates incorrect artifact listings and can lead to confusing behavior when browsing or failures when downloading artifacts.

This PR adds a new environment variable, `MLFLOW_S3_IGNORE_DIRECTORY_MARKERS, defaulting to True, and updates the S3 artifact repository to filter out zero-byte objects whose relative path ends with / during artifact listing. Real files remain unchanged, while directory marker objects are excluded from the returned artifact list.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions
  - [x] *None yet*: It would require updating the documentation about S3 configuration, but I'd first love some feedback. Perhaps it shouldn't even be configurable and just be the new default behaviour.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
