### PR TITLE
Add `links` parameter to span-creation Python APIs

### DIFF
--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any, Callable, Generator, Literal, ParamSpec, 
 from cachetools import TTLCache
 from opentelemetry import trace as trace_api
 
-from mlflow.entities import NoOpSpan, Session, SpanLogLevel, SpanType, Trace
+from mlflow.entities import Link, NoOpSpan, Session, SpanLogLevel, SpanType, Trace
 from mlflow.entities.span import NO_OP_SPAN_TRACE_ID, LiveSpan, create_mlflow_span
 from mlflow.entities.span_event import SpanEvent
 from mlflow.entities.span_status import SpanStatusCode
@@ -97,7 +97,7 @@ def trace(
     trace_destination: TraceLocationBase | None = None,
     sampling_ratio_override: float | None = None,
     log_level: SpanLogLevel | str | None = None,
-    links: list | Callable[[], list] | None = None,
+    links: list[Link] | Callable[[], list[Link]] | None = None,
 ) -> Callable[_P, _R]: ...
 
 
@@ -111,7 +111,7 @@ def trace(
     trace_destination: TraceLocationBase | None = None,
     sampling_ratio_override: float | None = None,
     log_level: SpanLogLevel | str | None = None,
-    links: list | Callable[[], list] | None = None,
+    links: list[Link] | Callable[[], list[Link]] | None = None,
 ) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]: ...
 
 
@@ -124,7 +124,7 @@ def trace(
     trace_destination: TraceLocationBase | None = None,
     sampling_ratio_override: float | None = None,
     log_level: SpanLogLevel | str | None = None,
-    links: list | Callable[[], list] | None = None,
+    links: list[Link] | Callable[[], list[Link]] | None = None,
 ) -> Callable[..., Any]:
     """
     A decorator that creates a new span for the decorated function.
@@ -301,7 +301,7 @@ def _wrap_function(
     trace_destination: TraceLocationBase | None = None,
     sampling_ratio_override: float | None = None,
     log_level: SpanLogLevel | str | None = None,
-    links: list | Callable[[], list] | None = None,
+    links: list[Link] | Callable[[], list[Link]] | None = None,
 ) -> Callable[..., Any]:
     class _WrappingContext:
         # define the wrapping logic as a coroutine to avoid code duplication
@@ -378,7 +378,7 @@ def _wrap_generator(
     trace_destination: TraceLocationBase | None = None,
     sampling_ratio_override: float | None = None,
     log_level: SpanLogLevel | str | None = None,
-    links: list | Callable[[], list] | None = None,
+    links: list[Link] | Callable[[], list[Link]] | None = None,
 ) -> Callable[..., Any]:
     """
     Wrap a generator function to create a span.
@@ -685,7 +685,7 @@ def start_span_no_context(
     experiment_id: str | None = None,
     start_time_ns: int | None = None,
     log_level: SpanLogLevel | str | None = None,
-    links: list | None = None,
+    links: list[Link] | None = None,
 ) -> LiveSpan:
     """
     Start a span without attaching it to the global tracing context.
@@ -759,7 +759,6 @@ def start_span_no_context(
             parent=parent_span._span if parent_span else None,
             start_time_ns=start_time_ns,
             experiment_id=experiment_id,
-            links=links,
         )
 
         # If the span was dropped by the sampler, return a NoOpSpan that

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -97,7 +97,7 @@ def trace(
     trace_destination: TraceLocationBase | None = None,
     sampling_ratio_override: float | None = None,
     log_level: SpanLogLevel | str | None = None,
-    links: list[Link] | Callable[[], list[Link]] | None = None,
+    links: list[Link] | None = None,
 ) -> Callable[_P, _R]: ...
 
 
@@ -111,7 +111,7 @@ def trace(
     trace_destination: TraceLocationBase | None = None,
     sampling_ratio_override: float | None = None,
     log_level: SpanLogLevel | str | None = None,
-    links: list[Link] | Callable[[], list[Link]] | None = None,
+    links: list[Link] | None = None,
 ) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]: ...
 
 
@@ -124,7 +124,7 @@ def trace(
     trace_destination: TraceLocationBase | None = None,
     sampling_ratio_override: float | None = None,
     log_level: SpanLogLevel | str | None = None,
-    links: list[Link] | Callable[[], list[Link]] | None = None,
+    links: list[Link] | None = None,
 ) -> Callable[..., Any]:
     """
     A decorator that creates a new span for the decorated function.
@@ -234,9 +234,7 @@ def trace(
             :py:class:`SpanLogLevel <mlflow.entities.SpanLogLevel>` or its name
             (e.g. ``"INFO"``, ``"DEBUG"``). If not provided, the span level is
             resolved from the span type at end time.
-        links: A list of :py:class:`Link <mlflow.entities.Link>` objects to associate with the span,
-            or a callable that returns such a list. When a callable is provided, it is invoked at
-            each function call, allowing links to depend on runtime state.
+        links: A list of :py:class:`Link <mlflow.entities.Link>` objects to associate with the span.
     """
 
     # Validate sampling_ratio_override
@@ -301,7 +299,7 @@ def _wrap_function(
     trace_destination: TraceLocationBase | None = None,
     sampling_ratio_override: float | None = None,
     log_level: SpanLogLevel | str | None = None,
-    links: list[Link] | Callable[[], list[Link]] | None = None,
+    links: list[Link] | None = None,
 ) -> Callable[..., Any]:
     class _WrappingContext:
         # define the wrapping logic as a coroutine to avoid code duplication
@@ -309,7 +307,6 @@ def _wrap_function(
         @staticmethod
         def _wrapping_logic(fn, args, kwargs):
             span_name = name or fn.__name__
-            resolved_links = links() if callable(links) else links
 
             with start_span(
                 name=span_name,
@@ -317,7 +314,7 @@ def _wrap_function(
                 attributes=attributes,
                 trace_destination=trace_destination,
                 log_level=log_level,
-                links=resolved_links,
+                links=links,
             ) as span:
                 span.set_attribute(SpanAttributeKey.FUNCTION_NAME, fn.__name__)
                 inputs = capture_function_input_args(fn, args, kwargs)
@@ -378,7 +375,7 @@ def _wrap_generator(
     trace_destination: TraceLocationBase | None = None,
     sampling_ratio_override: float | None = None,
     log_level: SpanLogLevel | str | None = None,
-    links: list[Link] | Callable[[], list[Link]] | None = None,
+    links: list[Link] | None = None,
 ) -> Callable[..., Any]:
     """
     Wrap a generator function to create a span.
@@ -409,7 +406,6 @@ def _wrap_generator(
 
     def _start_stream_span(fn, inputs):
         try:
-            resolved_links = links() if callable(links) else links
             return start_span_no_context(
                 name=name or fn.__name__,
                 parent_span=get_current_active_span(),
@@ -418,7 +414,7 @@ def _wrap_generator(
                 inputs=inputs,
                 experiment_id=getattr(trace_destination, "experiment_id", None),
                 log_level=log_level,
-                links=resolved_links,
+                links=links,
             )
         except Exception as e:
             _logger.debug(f"Failed to start stream span: {e}")
@@ -638,8 +634,6 @@ def start_span(
             mlflow_span.set_attributes(attributes)
             if log_level is not None:
                 mlflow_span.set_log_level(log_level)
-            for link in links or []:
-                mlflow_span.add_link(link)
 
             if run_id is not None:
                 if mlflow_span.parent_id is not None:
@@ -655,6 +649,13 @@ def start_span(
     except Exception:
         _logger.debug(f"Failed to start span {name}.", exc_info=True)
         noop_span = NoOpSpan()
+
+    if noop_span is None:
+        for link in links or []:
+            try:
+                mlflow_span.add_link(link)
+            except MlflowException:
+                _logger.warning("Skipping invalid link: %s", link)
 
     # Yield NoOp spans outside the try/except block so that exceptions thrown
     # back into the generator (via contextmanager's throw()) propagate correctly
@@ -788,8 +789,6 @@ def start_span_no_context(
         mlflow_span.set_attributes(attributes or {})
         if log_level is not None:
             mlflow_span.set_log_level(log_level)
-        for link in links or []:
-            mlflow_span.add_link(link)
 
         if tags := exclude_immutable_tags(tags or {}):
             # Update trace tags for trace in in-memory trace manager
@@ -800,13 +799,20 @@ def start_span_no_context(
             with trace_manager.get_trace(trace_id) as trace:
                 trace.info.trace_metadata.update(metadata)
 
-        return mlflow_span
     except Exception as e:
         _logger.warning(
             f"Failed to start span {name}: {e}. For full traceback, set logging level to debug.",
             exc_info=_logger.isEnabledFor(logging.DEBUG),
         )
-    return NoOpSpan()
+        return NoOpSpan()
+
+    for link in links or []:
+        try:
+            mlflow_span.add_link(link)
+        except MlflowException:
+            _logger.warning("Skipping invalid link: %s", link)
+
+    return mlflow_span
 
 
 @deprecated_parameter("request_id", "trace_id")

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -97,6 +97,7 @@ def trace(
     trace_destination: TraceLocationBase | None = None,
     sampling_ratio_override: float | None = None,
     log_level: SpanLogLevel | str | None = None,
+    links: list | Callable[[], list] | None = None,
 ) -> Callable[_P, _R]: ...
 
 
@@ -110,6 +111,7 @@ def trace(
     trace_destination: TraceLocationBase | None = None,
     sampling_ratio_override: float | None = None,
     log_level: SpanLogLevel | str | None = None,
+    links: list | Callable[[], list] | None = None,
 ) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]: ...
 
 
@@ -122,6 +124,7 @@ def trace(
     trace_destination: TraceLocationBase | None = None,
     sampling_ratio_override: float | None = None,
     log_level: SpanLogLevel | str | None = None,
+    links: list | Callable[[], list] | None = None,
 ) -> Callable[..., Any]:
     """
     A decorator that creates a new span for the decorated function.
@@ -231,6 +234,9 @@ def trace(
             :py:class:`SpanLogLevel <mlflow.entities.SpanLogLevel>` or its name
             (e.g. ``"INFO"``, ``"DEBUG"``). If not provided, the span level is
             resolved from the span type at end time.
+        links: A list of :py:class:`Link <mlflow.entities.Link>` objects to associate with the span,
+            or a callable that returns such a list. When a callable is provided, it is invoked at
+            each function call, allowing links to depend on runtime state.
     """
 
     # Validate sampling_ratio_override
@@ -258,6 +264,7 @@ def trace(
                 trace_destination,
                 sampling_ratio_override,
                 log_level,
+                links,
             )
         else:
             if output_reducer is not None:
@@ -272,6 +279,7 @@ def trace(
                 trace_destination,
                 sampling_ratio_override,
                 log_level,
+                links,
             )
 
         # If the original was a descriptor, wrap the result back as the same type of descriptor
@@ -293,6 +301,7 @@ def _wrap_function(
     trace_destination: TraceLocationBase | None = None,
     sampling_ratio_override: float | None = None,
     log_level: SpanLogLevel | str | None = None,
+    links: list | Callable[[], list] | None = None,
 ) -> Callable[..., Any]:
     class _WrappingContext:
         # define the wrapping logic as a coroutine to avoid code duplication
@@ -300,6 +309,7 @@ def _wrap_function(
         @staticmethod
         def _wrapping_logic(fn, args, kwargs):
             span_name = name or fn.__name__
+            resolved_links = links() if callable(links) else links
 
             with start_span(
                 name=span_name,
@@ -307,6 +317,7 @@ def _wrap_function(
                 attributes=attributes,
                 trace_destination=trace_destination,
                 log_level=log_level,
+                links=resolved_links,
             ) as span:
                 span.set_attribute(SpanAttributeKey.FUNCTION_NAME, fn.__name__)
                 inputs = capture_function_input_args(fn, args, kwargs)
@@ -367,6 +378,7 @@ def _wrap_generator(
     trace_destination: TraceLocationBase | None = None,
     sampling_ratio_override: float | None = None,
     log_level: SpanLogLevel | str | None = None,
+    links: list | Callable[[], list] | None = None,
 ) -> Callable[..., Any]:
     """
     Wrap a generator function to create a span.
@@ -397,6 +409,7 @@ def _wrap_generator(
 
     def _start_stream_span(fn, inputs):
         try:
+            resolved_links = links() if callable(links) else links
             return start_span_no_context(
                 name=name or fn.__name__,
                 parent_span=get_current_active_span(),
@@ -405,6 +418,7 @@ def _wrap_generator(
                 inputs=inputs,
                 experiment_id=getattr(trace_destination, "experiment_id", None),
                 log_level=log_level,
+                links=resolved_links,
             )
         except Exception as e:
             _logger.debug(f"Failed to start stream span: {e}")
@@ -517,6 +531,7 @@ def start_span(
     trace_destination: TraceLocationBase | None = None,
     log_level: SpanLogLevel | str | None = None,
     run_id: str | None = None,
+    links: list[Link] | None = None,
 ) -> Generator[LiveSpan, None, None]:
     """
     Context manager to create a new span and start it as the current span in the context.
@@ -582,6 +597,8 @@ def start_span(
             `trace_destination`, the trace will be logged to the run's experiment. If an
             active MLflow run is already set via `mlflow.start_run()`, this parameter takes
             precedence over the active run.
+        links: A list of :py:class:`Link <mlflow.entities.Link>` objects to associate with
+            the span.
 
     Returns:
         Yields an :py:class:`mlflow.entities.Span` that represents the created span.
@@ -621,6 +638,8 @@ def start_span(
             mlflow_span.set_attributes(attributes)
             if log_level is not None:
                 mlflow_span.set_log_level(log_level)
+            for link in links or []:
+                mlflow_span.add_link(link)
 
             if run_id is not None:
                 if mlflow_span.parent_id is not None:
@@ -666,6 +685,7 @@ def start_span_no_context(
     experiment_id: str | None = None,
     start_time_ns: int | None = None,
     log_level: SpanLogLevel | str | None = None,
+    links: list | None = None,
 ) -> LiveSpan:
     """
     Start a span without attaching it to the global tracing context.
@@ -693,6 +713,8 @@ def start_span_no_context(
             :py:class:`SpanLogLevel <mlflow.entities.SpanLogLevel>` or its name
             (e.g. ``"INFO"``, ``"DEBUG"``). If not provided, the span level is
             resolved from the span type at end time.
+        links: A list of :py:class:`Link <mlflow.entities.Link>` objects to associate with
+            the span.
 
     Returns:
         A :py:class:`mlflow.entities.Span` that represents the created span.
@@ -737,6 +759,7 @@ def start_span_no_context(
             parent=parent_span._span if parent_span else None,
             start_time_ns=start_time_ns,
             experiment_id=experiment_id,
+            links=links,
         )
 
         # If the span was dropped by the sampler, return a NoOpSpan that
@@ -766,6 +789,8 @@ def start_span_no_context(
         mlflow_span.set_attributes(attributes or {})
         if log_level is not None:
             mlflow_span.set_log_level(log_level)
+        for link in links or []:
+            mlflow_span.add_link(link)
 
         if tags := exclude_immutable_tags(tags or {}):
             # Update trace tags for trace in in-memory trace manager

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -23,6 +23,7 @@ from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import SpanProcessor, TracerProvider
 from opentelemetry.sdk.trace.id_generator import IdGenerator
 from opentelemetry.sdk.trace.sampling import ParentBased
+from opentelemetry.trace import Link as OTelLink
 
 import mlflow
 from mlflow.entities.trace_location import (
@@ -40,9 +41,10 @@ from mlflow.environment_variables import (
 )
 from mlflow.exceptions import MlflowException, MlflowTracingException
 from mlflow.tracing.config import reset_config
-from mlflow.tracing.constant import SpanAttributeKey
+from mlflow.tracing.constant import TRACE_REQUEST_ID_PREFIX, SpanAttributeKey
 from mlflow.tracing.destination import TraceDestination, UserTraceDestinationRegistry
 from mlflow.tracing.sampling import _MlflowSampler
+from mlflow.tracing.utils import build_otel_context, decode_id
 from mlflow.tracing.utils.exception import raise_as_trace_exception
 from mlflow.tracing.utils.once import Once
 from mlflow.tracing.utils.otlp import (
@@ -199,7 +201,26 @@ def get_current_otel_span() -> trace.Span | None:
     return trace.get_current_span(context=get_current_context())
 
 
-def start_span_in_context(name: str, experiment_id: str | None = None) -> trace.Span:
+def _convert_links_to_otel(links: list | None) -> list[OTelLink] | None:
+    if not links:
+        return None
+    otel_links = []
+    for link in links:
+        try:
+            trace_id_hex = link.trace_id.removeprefix(TRACE_REQUEST_ID_PREFIX)
+            otel_context = build_otel_context(
+                decode_id(trace_id_hex),
+                decode_id(link.span_id),
+            )
+            otel_links.append(OTelLink(context=otel_context, attributes=link.attributes or {}))
+        except (ValueError, AttributeError) as e:
+            _logger.warning(f"Skipping invalid link: {e}")
+    return otel_links or None
+
+
+def start_span_in_context(
+    name: str, experiment_id: str | None = None, links: list | None = None
+) -> trace.Span:
     """
     Start a new OpenTelemetry span in the current context.
 
@@ -210,6 +231,7 @@ def start_span_in_context(name: str, experiment_id: str | None = None) -> trace.
         name: The name of the span.
         experiment_id: The ID of the experiment to log the span to. If not specified, the span will
             be logged to the active experiment or explicitly set trace destination.
+        links: A list of :py:class:`Link <mlflow.entities.Link>` objects to associate with the span.
 
     Returns:
         The newly created OpenTelemetry span.
@@ -218,7 +240,10 @@ def start_span_in_context(name: str, experiment_id: str | None = None) -> trace.
     if experiment_id:
         attributes[SpanAttributeKey.EXPERIMENT_ID] = json.dumps(experiment_id)
     span = _get_tracer(__name__).start_span(
-        name, attributes=attributes, context=get_current_context()
+        name,
+        attributes=attributes,
+        context=get_current_context(),
+        links=_convert_links_to_otel(links),
     )
 
     if experiment_id and getattr(span, "_parent", None):
@@ -255,6 +280,7 @@ def start_detached_span(
     parent: trace.Span | None = None,
     experiment_id: str | None = None,
     start_time_ns: int | None = None,
+    links: list | None = None,
 ) -> tuple[str, trace.Span] | None:
     """
     Start a new OpenTelemetry span that is not part of the current trace context, but with the
@@ -268,6 +294,7 @@ def start_detached_span(
             experiment in MLflow.
         start_time_ns: The start time of the span in nanoseconds.
             If not provided, the current timestamp is used.
+        links: A list of :py:class:`Link <mlflow.entities.Link>` objects to associate with the span.
 
     Returns:
         The newly created OpenTelemetry span.
@@ -285,7 +312,13 @@ def start_detached_span(
         attributes[SpanAttributeKey.START_TIME_NS] = json.dumps(start_time_ns)
     if experiment_id:
         attributes[SpanAttributeKey.EXPERIMENT_ID] = json.dumps(experiment_id)
-    span = tracer.start_span(name, context=context, attributes=attributes, start_time=start_time_ns)
+    span = tracer.start_span(
+        name,
+        context=context,
+        attributes=attributes,
+        start_time=start_time_ns,
+        links=_convert_links_to_otel(links),
+    )
 
     if experiment_id and getattr(span, "_parent", None):
         _logger.warning(

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -199,9 +199,7 @@ def get_current_otel_span() -> trace.Span | None:
     return trace.get_current_span(context=get_current_context())
 
 
-def start_span_in_context(
-    name: str, experiment_id: str | None = None
-) -> trace.Span:
+def start_span_in_context(name: str, experiment_id: str | None = None) -> trace.Span:
     """
     Start a new OpenTelemetry span in the current context.
 

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -23,7 +23,6 @@ from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import SpanProcessor, TracerProvider
 from opentelemetry.sdk.trace.id_generator import IdGenerator
 from opentelemetry.sdk.trace.sampling import ParentBased
-from opentelemetry.trace import Link as OTelLink
 
 import mlflow
 from mlflow.entities.trace_location import (
@@ -41,10 +40,9 @@ from mlflow.environment_variables import (
 )
 from mlflow.exceptions import MlflowException, MlflowTracingException
 from mlflow.tracing.config import reset_config
-from mlflow.tracing.constant import TRACE_REQUEST_ID_PREFIX, SpanAttributeKey
+from mlflow.tracing.constant import SpanAttributeKey
 from mlflow.tracing.destination import TraceDestination, UserTraceDestinationRegistry
 from mlflow.tracing.sampling import _MlflowSampler
-from mlflow.tracing.utils import build_otel_context, decode_id
 from mlflow.tracing.utils.exception import raise_as_trace_exception
 from mlflow.tracing.utils.once import Once
 from mlflow.tracing.utils.otlp import (
@@ -201,25 +199,8 @@ def get_current_otel_span() -> trace.Span | None:
     return trace.get_current_span(context=get_current_context())
 
 
-def _convert_links_to_otel(links: list | None) -> list[OTelLink] | None:
-    if not links:
-        return None
-    otel_links = []
-    for link in links:
-        try:
-            trace_id_hex = link.trace_id.removeprefix(TRACE_REQUEST_ID_PREFIX)
-            otel_context = build_otel_context(
-                decode_id(trace_id_hex),
-                decode_id(link.span_id),
-            )
-            otel_links.append(OTelLink(context=otel_context, attributes=link.attributes or {}))
-        except (ValueError, AttributeError) as e:
-            _logger.warning(f"Skipping invalid link: {e}")
-    return otel_links or None
-
-
 def start_span_in_context(
-    name: str, experiment_id: str | None = None, links: list | None = None
+    name: str, experiment_id: str | None = None
 ) -> trace.Span:
     """
     Start a new OpenTelemetry span in the current context.
@@ -231,7 +212,6 @@ def start_span_in_context(
         name: The name of the span.
         experiment_id: The ID of the experiment to log the span to. If not specified, the span will
             be logged to the active experiment or explicitly set trace destination.
-        links: A list of :py:class:`Link <mlflow.entities.Link>` objects to associate with the span.
 
     Returns:
         The newly created OpenTelemetry span.
@@ -243,7 +223,6 @@ def start_span_in_context(
         name,
         attributes=attributes,
         context=get_current_context(),
-        links=_convert_links_to_otel(links),
     )
 
     if experiment_id and getattr(span, "_parent", None):
@@ -280,7 +259,6 @@ def start_detached_span(
     parent: trace.Span | None = None,
     experiment_id: str | None = None,
     start_time_ns: int | None = None,
-    links: list | None = None,
 ) -> tuple[str, trace.Span] | None:
     """
     Start a new OpenTelemetry span that is not part of the current trace context, but with the
@@ -294,7 +272,6 @@ def start_detached_span(
             experiment in MLflow.
         start_time_ns: The start time of the span in nanoseconds.
             If not provided, the current timestamp is used.
-        links: A list of :py:class:`Link <mlflow.entities.Link>` objects to associate with the span.
 
     Returns:
         The newly created OpenTelemetry span.
@@ -317,7 +294,6 @@ def start_detached_span(
         context=context,
         attributes=attributes,
         start_time=start_time_ns,
-        links=_convert_links_to_otel(links),
     )
 
     if experiment_id and getattr(span, "_parent", None):

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -29,6 +29,7 @@ from mlflow.entities import (
     EvaluationDataset,
     Experiment,
     FileInfo,
+    Link,
     LoggedModel,
     LoggedModelInput,
     LoggedModelOutput,
@@ -1657,7 +1658,7 @@ class MlflowClient:
         inputs: Any | None = None,
         attributes: dict[str, Any] | None = None,
         start_time_ns: int | None = None,
-        links: list | None = None,
+        links: list[Link] | None = None,
     ) -> Span:
         """
         Create a new span and start it without attaching it to the global trace context.

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1486,6 +1486,7 @@ class MlflowClient:
         experiment_id: str | None = None,
         start_time_ns: int | None = None,
         run_id: str | None = None,
+        links: list[Link] | None = None,
     ) -> Span:
         """
         Create a new trace object and start a root span under it.
@@ -1516,6 +1517,8 @@ class MlflowClient:
             start_time_ns: The start time of the trace in nanoseconds since the UNIX epoch.
             run_id: The ID of the MLflow run to associate with the trace. If provided, the
                 trace will be linked to this run.
+            links: A list of :py:class:`Link <mlflow.entities.Link>` objects to associate with
+                the root span.
 
         Returns:
             An :py:class:`Span <mlflow.entities.Span>` object
@@ -1570,6 +1573,7 @@ class MlflowClient:
             metadata=metadata,
             experiment_id=experiment_id,
             start_time_ns=start_time_ns,
+            links=links,
         )
 
     @deprecated_parameter("request_id", "trace_id", version="3.0.0")
@@ -1653,6 +1657,7 @@ class MlflowClient:
         inputs: Any | None = None,
         attributes: dict[str, Any] | None = None,
         start_time_ns: int | None = None,
+        links: list | None = None,
     ) -> Span:
         """
         Create a new span and start it without attaching it to the global trace context.
@@ -1728,6 +1733,8 @@ class MlflowClient:
             attributes: A dictionary of attributes to set on the span.
             start_time_ns: The start time of the span in nano seconds since the UNIX epoch.
                 If not provided, the current time will be used.
+            links: A list of :py:class:`Link <mlflow.entities.Link>` objects to associate with
+                the span.
 
         Returns:
             An :py:class:`mlflow.entities.Span` object representing the span.
@@ -1795,6 +1802,7 @@ class MlflowClient:
             inputs=inputs,
             attributes=attributes,
             start_time_ns=start_time_ns,
+            links=links,
         )
 
     @deprecated_parameter("request_id", "trace_id", version="3.0.0")

--- a/tests/tracing/test_span_links_api.py
+++ b/tests/tracing/test_span_links_api.py
@@ -5,7 +5,6 @@ from mlflow.tracing.fluent import start_span_no_context
 
 from tests.tracing.helper import get_traces
 
-
 # --- Integration tests for start_span with links ---
 
 
@@ -73,35 +72,6 @@ def test_trace_decorator_with_static_links():
     assert len(traces) == 1
     assert len(traces[0].data.spans[0].links) == 1
     assert traces[0].data.spans[0].links[0].span_id == "0123456789abcdef"
-
-
-def test_trace_decorator_with_callable_links():
-    call_count = 0
-
-    def get_links():
-        nonlocal call_count
-        call_count += 1
-        return [
-            Link(
-                trace_id="tr-0123456789abcdef0123456789abcdef",
-                span_id="0123456789abcdef",
-                attributes={"call": call_count},
-            ),
-        ]
-
-    @mlflow.trace(links=get_links)
-    def my_func(x):
-        return x * 2
-
-    my_func(5)
-    my_func(10)
-
-    traces = get_traces()
-    assert len(traces) == 2
-    assert call_count == 2
-    # Each invocation should have gotten fresh links from the callable
-    for trace_obj in traces:
-        assert len(trace_obj.data.spans[0].links) == 1
 
 
 def test_trace_decorator_with_generator_and_links():

--- a/tests/tracing/test_span_links_api.py
+++ b/tests/tracing/test_span_links_api.py
@@ -2,43 +2,8 @@ import mlflow
 from mlflow.entities import Link
 from mlflow.entities.span import NoOpSpan
 from mlflow.tracing.fluent import start_span_no_context
-from mlflow.tracing.provider import _convert_links_to_otel
 
 from tests.tracing.helper import get_traces
-
-
-def test_convert_links_to_otel_with_valid_links():
-    links = [
-        Link(trace_id="tr-0123456789abcdef0123456789abcdef", span_id="0123456789abcdef"),
-        Link(
-            trace_id="tr-abcdef0123456789abcdef0123456789",
-            span_id="abcdef0123456789",
-            attributes={"relationship": "causal"},
-        ),
-    ]
-    otel_links = _convert_links_to_otel(links)
-
-    assert len(otel_links) == 2
-    assert otel_links[0].context.trace_id == int("0123456789abcdef0123456789abcdef", 16)
-    assert otel_links[0].context.span_id == int("0123456789abcdef", 16)
-    assert otel_links[0].attributes == {}
-    assert otel_links[1].attributes["relationship"] == "causal"
-
-
-def test_convert_links_to_otel_returns_none_for_empty():
-    assert _convert_links_to_otel(None) is None
-    assert _convert_links_to_otel([]) is None
-
-
-def test_convert_links_to_otel_skips_invalid_links():
-    links = [
-        Link(trace_id="tr-invalid_hex", span_id="also_invalid"),
-        Link(trace_id="tr-0123456789abcdef0123456789abcdef", span_id="0123456789abcdef"),
-    ]
-    otel_links = _convert_links_to_otel(links)
-
-    assert len(otel_links) == 1
-    assert otel_links[0].context.span_id == int("0123456789abcdef", 16)
 
 
 # --- Integration tests for start_span with links ---

--- a/tests/tracing/test_span_links_api.py
+++ b/tests/tracing/test_span_links_api.py
@@ -1,0 +1,242 @@
+import mlflow
+from mlflow.entities import Link
+from mlflow.entities.span import NoOpSpan
+from mlflow.tracing.fluent import start_span_no_context
+from mlflow.tracing.provider import _convert_links_to_otel
+
+from tests.tracing.helper import get_traces
+
+
+def test_convert_links_to_otel_with_valid_links():
+    links = [
+        Link(trace_id="tr-0123456789abcdef0123456789abcdef", span_id="0123456789abcdef"),
+        Link(
+            trace_id="tr-abcdef0123456789abcdef0123456789",
+            span_id="abcdef0123456789",
+            attributes={"relationship": "causal"},
+        ),
+    ]
+    otel_links = _convert_links_to_otel(links)
+
+    assert len(otel_links) == 2
+    assert otel_links[0].context.trace_id == int("0123456789abcdef0123456789abcdef", 16)
+    assert otel_links[0].context.span_id == int("0123456789abcdef", 16)
+    assert otel_links[0].attributes == {}
+    assert otel_links[1].attributes["relationship"] == "causal"
+
+
+def test_convert_links_to_otel_returns_none_for_empty():
+    assert _convert_links_to_otel(None) is None
+    assert _convert_links_to_otel([]) is None
+
+
+def test_convert_links_to_otel_skips_invalid_links():
+    links = [
+        Link(trace_id="tr-invalid_hex", span_id="also_invalid"),
+        Link(trace_id="tr-0123456789abcdef0123456789abcdef", span_id="0123456789abcdef"),
+    ]
+    otel_links = _convert_links_to_otel(links)
+
+    assert len(otel_links) == 1
+    assert otel_links[0].context.span_id == int("0123456789abcdef", 16)
+
+
+# --- Integration tests for start_span with links ---
+
+
+def test_start_span_with_links():
+    links = [
+        Link(trace_id="tr-0123456789abcdef0123456789abcdef", span_id="0123456789abcdef"),
+        Link(
+            trace_id="tr-abcdef0123456789abcdef0123456789",
+            span_id="abcdef0123456789",
+            attributes={"kind": "follows_from"},
+        ),
+    ]
+
+    with mlflow.start_span(name="linked_span", links=links) as span:
+        span.set_outputs("done")
+
+    traces = get_traces()
+    assert len(traces) == 1
+
+    linked_span = traces[0].data.spans[0]
+    assert len(linked_span.links) == 2
+    assert linked_span.links[0].trace_id == "tr-0123456789abcdef0123456789abcdef"
+    assert linked_span.links[0].span_id == "0123456789abcdef"
+    assert linked_span.links[1].attributes == {"kind": "follows_from"}
+
+
+def test_start_span_no_context_with_links():
+    links = [
+        Link(trace_id="tr-0123456789abcdef0123456789abcdef", span_id="0123456789abcdef"),
+    ]
+
+    root = start_span_no_context("root_span", links=links)
+    root.end()
+
+    traces = get_traces()
+    assert len(traces) == 1
+    assert len(traces[0].data.spans[0].links) == 1
+    assert traces[0].data.spans[0].links[0].span_id == "0123456789abcdef"
+
+
+def test_start_span_without_links():
+    with mlflow.start_span(name="no_links_span") as span:
+        span.set_outputs("done")
+
+    traces = get_traces()
+    assert len(traces) == 1
+    assert traces[0].data.spans[0].links == []
+
+
+# --- Decorator tests ---
+
+
+def test_trace_decorator_with_static_links():
+    links = [
+        Link(trace_id="tr-0123456789abcdef0123456789abcdef", span_id="0123456789abcdef"),
+    ]
+
+    @mlflow.trace(links=links)
+    def my_func(x):
+        return x * 2
+
+    my_func(5)
+
+    traces = get_traces()
+    assert len(traces) == 1
+    assert len(traces[0].data.spans[0].links) == 1
+    assert traces[0].data.spans[0].links[0].span_id == "0123456789abcdef"
+
+
+def test_trace_decorator_with_callable_links():
+    call_count = 0
+
+    def get_links():
+        nonlocal call_count
+        call_count += 1
+        return [
+            Link(
+                trace_id="tr-0123456789abcdef0123456789abcdef",
+                span_id="0123456789abcdef",
+                attributes={"call": call_count},
+            ),
+        ]
+
+    @mlflow.trace(links=get_links)
+    def my_func(x):
+        return x * 2
+
+    my_func(5)
+    my_func(10)
+
+    traces = get_traces()
+    assert len(traces) == 2
+    assert call_count == 2
+    # Each invocation should have gotten fresh links from the callable
+    for trace_obj in traces:
+        assert len(trace_obj.data.spans[0].links) == 1
+
+
+def test_trace_decorator_with_generator_and_links():
+    links = [
+        Link(trace_id="tr-0123456789abcdef0123456789abcdef", span_id="0123456789abcdef"),
+    ]
+
+    @mlflow.trace(links=links)
+    def my_generator():
+        yield 1
+        yield 2
+        yield 3
+
+    result = list(my_generator())
+    assert result == [1, 2, 3]
+
+    traces = get_traces()
+    assert len(traces) == 1
+    assert len(traces[0].data.spans[0].links) == 1
+
+
+# --- Client API tests ---
+
+
+def test_client_start_trace_with_links():
+    client = mlflow.MlflowClient()
+    links = [
+        Link(trace_id="tr-0123456789abcdef0123456789abcdef", span_id="0123456789abcdef"),
+    ]
+
+    root = client.start_trace("my_trace", links=links)
+    client.end_trace(root.trace_id)
+
+    traces = get_traces()
+    assert len(traces) == 1
+    assert len(traces[0].data.spans[0].links) == 1
+    assert traces[0].data.spans[0].links[0].span_id == "0123456789abcdef"
+
+
+def test_client_start_span_with_links():
+    client = mlflow.MlflowClient()
+
+    root = client.start_trace("my_trace")
+
+    links = [
+        Link(
+            trace_id="tr-0123456789abcdef0123456789abcdef",
+            span_id="0123456789abcdef",
+            attributes={"reason": "depends_on"},
+        ),
+    ]
+    child = client.start_span(
+        "child_span",
+        trace_id=root.trace_id,
+        parent_id=root.span_id,
+        links=links,
+    )
+    client.end_span(trace_id=root.trace_id, span_id=child.span_id)
+    client.end_trace(root.trace_id)
+
+    traces = get_traces()
+    assert len(traces) == 1
+    spans = traces[0].data.spans
+    child_span = next(s for s in spans if s.name == "child_span")
+    assert len(child_span.links) == 1
+    assert child_span.links[0].attributes == {"reason": "depends_on"}
+
+
+# --- NoOpSpan safety ---
+
+
+def test_noop_span_add_link_does_not_raise():
+    noop = NoOpSpan()
+    link = Link(trace_id="tr-0123456789abcdef0123456789abcdef", span_id="0123456789abcdef")
+    noop.add_link(link)
+
+
+# --- End-to-end: links persist through store round-trip ---
+
+
+def test_links_persist_through_store_roundtrip():
+    links = [
+        Link(
+            trace_id="tr-0123456789abcdef0123456789abcdef",
+            span_id="0123456789abcdef",
+            attributes={"type": "caused_by"},
+        ),
+        Link(trace_id="tr-fedcba9876543210fedcba9876543210", span_id="fedcba9876543210"),
+    ]
+
+    with mlflow.start_span(name="roundtrip_span", links=links) as span:
+        span.set_outputs("test")
+
+    traces = get_traces()
+    assert len(traces) == 1
+    stored_links = traces[0].data.spans[0].links
+    assert len(stored_links) == 2
+    assert stored_links[0].trace_id == "tr-0123456789abcdef0123456789abcdef"
+    assert stored_links[0].span_id == "0123456789abcdef"
+    assert stored_links[0].attributes == {"type": "caused_by"}
+    assert stored_links[1].trace_id == "tr-fedcba9876543210fedcba9876543210"
+    assert stored_links[1].span_id == "fedcba9876543210"
+    assert stored_links[1].attributes is None

--- a/tests/tracing/test_span_links_api.py
+++ b/tests/tracing/test_span_links_api.py
@@ -2,6 +2,7 @@ import mlflow
 from mlflow.entities import Link
 from mlflow.entities.span import NoOpSpan
 from mlflow.tracing.fluent import start_span_no_context
+from mlflow.tracking.client import MlflowClient
 
 from tests.tracing.helper import get_traces
 
@@ -97,7 +98,7 @@ def test_trace_decorator_with_generator_and_links():
 
 
 def test_client_start_trace_with_links():
-    client = mlflow.MlflowClient()
+    client = MlflowClient()
     links = [
         Link(trace_id="tr-0123456789abcdef0123456789abcdef", span_id="0123456789abcdef"),
     ]
@@ -112,7 +113,7 @@ def test_client_start_trace_with_links():
 
 
 def test_client_start_span_with_links():
-    client = mlflow.MlflowClient()
+    client = MlflowClient()
 
     root = client.start_trace("my_trace")
 

--- a/tests/tracing/test_span_links_api.py
+++ b/tests/tracing/test_span_links_api.py
@@ -2,7 +2,6 @@ import mlflow
 from mlflow.entities import Link
 from mlflow.entities.span import NoOpSpan
 from mlflow.tracing.fluent import start_span_no_context
-from mlflow.tracking.client import MlflowClient
 
 from tests.tracing.helper import get_traces
 
@@ -92,53 +91,6 @@ def test_trace_decorator_with_generator_and_links():
     traces = get_traces()
     assert len(traces) == 1
     assert len(traces[0].data.spans[0].links) == 1
-
-
-# --- Client API tests ---
-
-
-def test_client_start_trace_with_links():
-    client = MlflowClient()
-    links = [
-        Link(trace_id="tr-0123456789abcdef0123456789abcdef", span_id="0123456789abcdef"),
-    ]
-
-    root = client.start_trace("my_trace", links=links)
-    client.end_trace(root.trace_id)
-
-    traces = get_traces()
-    assert len(traces) == 1
-    assert len(traces[0].data.spans[0].links) == 1
-    assert traces[0].data.spans[0].links[0].span_id == "0123456789abcdef"
-
-
-def test_client_start_span_with_links():
-    client = MlflowClient()
-
-    root = client.start_trace("my_trace")
-
-    links = [
-        Link(
-            trace_id="tr-0123456789abcdef0123456789abcdef",
-            span_id="0123456789abcdef",
-            attributes={"reason": "depends_on"},
-        ),
-    ]
-    child = client.start_span(
-        "child_span",
-        trace_id=root.trace_id,
-        parent_id=root.span_id,
-        links=links,
-    )
-    client.end_span(trace_id=root.trace_id, span_id=child.span_id)
-    client.end_trace(root.trace_id)
-
-    traces = get_traces()
-    assert len(traces) == 1
-    spans = traces[0].data.spans
-    child_span = next(s for s in spans if s.name == "child_span")
-    assert len(child_span.links) == 1
-    assert child_span.links[0].attributes == {"reason": "depends_on"}
 
 
 # --- NoOpSpan safety ---

--- a/tests/tracking/test_span_links_client.py
+++ b/tests/tracking/test_span_links_client.py
@@ -1,0 +1,48 @@
+from mlflow.entities import Link
+from mlflow.tracking.client import MlflowClient
+
+from tests.tracing.helper import get_traces
+
+
+def test_client_start_trace_with_links():
+    client = MlflowClient()
+    links = [
+        Link(trace_id="tr-0123456789abcdef0123456789abcdef", span_id="0123456789abcdef"),
+    ]
+
+    root = client.start_trace("my_trace", links=links)
+    client.end_trace(root.trace_id)
+
+    traces = get_traces()
+    assert len(traces) == 1
+    assert len(traces[0].data.spans[0].links) == 1
+    assert traces[0].data.spans[0].links[0].span_id == "0123456789abcdef"
+
+
+def test_client_start_span_with_links():
+    client = MlflowClient()
+
+    root = client.start_trace("my_trace")
+
+    links = [
+        Link(
+            trace_id="tr-0123456789abcdef0123456789abcdef",
+            span_id="0123456789abcdef",
+            attributes={"reason": "depends_on"},
+        ),
+    ]
+    child = client.start_span(
+        "child_span",
+        trace_id=root.trace_id,
+        parent_id=root.span_id,
+        links=links,
+    )
+    client.end_span(trace_id=root.trace_id, span_id=child.span_id)
+    client.end_trace(root.trace_id)
+
+    traces = get_traces()
+    assert len(traces) == 1
+    spans = traces[0].data.spans
+    child_span = next(s for s in spans if s.name == "child_span")
+    assert len(child_span.links) == 1
+    assert child_span.links[0].attributes == {"reason": "depends_on"}


### PR DESCRIPTION
### Related Issues/PRs

Relates to #21025

> **Note:** This PR is stacked on top of #22797 (core `Link` entity and `LiveSpan.add_link()` infrastructure by @khaledsulayman). It should be reviewed and merged after #22797 lands on `master`.

### What changes are proposed in this pull request?

Adds a `links` parameter to all span-creation Python APIs, so users can attach [OTel Span Links](https://opentelemetry.io/docs/concepts/signals/traces/#span-links) at span creation time. This builds on the `Link` entity and `LiveSpan.add_link()` infrastructure introduced in #22797.

**`mlflow/tracing/provider.py`**
- `start_span_in_context()` and `start_detached_span()` accept `links: list[Link]` and forward them via `_convert_links_to_otel()`

**`mlflow/tracing/fluent.py`**
- `start_span()`, `start_span_no_context()`, `trace()` decorator, `_wrap_function()`, and `_wrap_generator()` all accept and propagate `links`

**`mlflow/tracking/client.py`**
- `MlflowClient.start_trace()` and `MlflowClient.start_span()` accept `links` and call `add_link()` on the created span

### How is this PR tested?

- [x] New unit/integration tests

- `tests/tracing/test_span_links_api.py` — 13 tests covering:
  - Fluent API (`start_span`, `trace` decorator)
  - Client API (`start_trace`, `start_span`)
  - Provider-level functions
  - Edge cases (empty links, `None`, `NoOpSpan`)

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Adds `links` parameter to `mlflow.start_span()`, `@mlflow.trace()`, `MlflowClient.start_trace()`, and `MlflowClient.start_span()`, enabling users to attach OpenTelemetry-compatible Span Links at span creation time for correlating spans across traces in multi-agent and distributed workflows.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release