### PR TITLE
Tighten dependency version floors

### DIFF
--- a/dev/pyproject.py
+++ b/dev/pyproject.py
@@ -369,7 +369,7 @@ def build(package_type: PackageType) -> None:
                 "gateway": gateways_requirements,
                 "genai": genai_requirements,
                 # click 8.3.0 causes MLflow MCP server to fail: https://github.com/mlflow/mlflow/issues/18747
-                "mcp": ["fastmcp<4,>=2.0.0", "click!=8.3.0"],
+                "mcp": ["fastmcp<4,>=3.2.0", "click!=8.3.0"],
                 "azure": [
                     # Required to log artifacts and models to Azure Blob Storage
                     "azure-storage-blob>=12",

--- a/libs/skinny/pyproject.toml
+++ b/libs/skinny/pyproject.toml
@@ -30,17 +30,17 @@ dependencies = [
   "cloudpickle<4",
   "databricks-sdk<1,>=0.20.0",
   "fastapi<1",
-  "gitpython<4,>=3.1.9",
+  "gitpython<4,>=3.1.47",
   "importlib_metadata<10,>=3.7.0,!=4.7.0",
   "opentelemetry-api<3,>=1.9.0",
   "opentelemetry-proto<3,>=1.9.0",
   "opentelemetry-sdk<3,>=1.9.0",
   "packaging<27",
-  "protobuf<8,>=3.12.0",
+  "protobuf<8,>=6.33.5",
   "pydantic<3,>=2.0.0",
-  "python-dotenv<2,>=0.19.0",
+  "python-dotenv<2,>=1.2.2",
   "pyyaml<7,>=5.1",
-  "requests<3,>=2.17.3",
+  "requests<3,>=2.33.0",
   "sqlparse<1,>=0.4.0",
   "starlette<1",
   "typing-extensions<5,>=4.0.0",
@@ -93,7 +93,7 @@ genai = [
   "uvicorn[standard]<1",
   "watchfiles<2",
 ]
-mcp = ["fastmcp<4,>=2.0.0", "click!=8.3.0"]
+mcp = ["fastmcp<4,>=3.2.0", "click!=8.3.0"]
 azure = ["azure-storage-blob>=12", "azure-identity>=1.6.1"]
 sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]

--- a/libs/tracing/pyproject.toml
+++ b/libs/tracing/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "opentelemetry-proto<3,>=1.9.0",
   "opentelemetry-sdk<3,>=1.9.0",
   "packaging<27",
-  "protobuf<8,>=3.12.0",
+  "protobuf<8,>=6.33.5",
   "pydantic<3,>=2.0.0",
 ]
 [[project.maintainers]]

--- a/pyproject.release.toml
+++ b/pyproject.release.toml
@@ -95,7 +95,7 @@ genai = [
   "uvicorn[standard]<1",
   "watchfiles<2",
 ]
-mcp = ["fastmcp<4,>=2.0.0", "click!=8.3.0"]
+mcp = ["fastmcp<4,>=3.2.0", "click!=8.3.0"]
 azure = ["azure-storage-blob>=12", "azure-identity>=1.6.1"]
 sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "databricks-sdk<1,>=0.20.0",
   "docker<8,>=4.0.0",
   "fastapi<1",
-  "gitpython<4,>=3.1.9",
+  "gitpython<4,>=3.1.47",
   "graphene<4",
   "gunicorn<26; platform_system != 'Windows'",
   "huey<3,>=2.5.4",
@@ -50,12 +50,12 @@ dependencies = [
   "opentelemetry-sdk<3,>=1.9.0",
   "packaging<27",
   "pandas<3",
-  "protobuf<8,>=3.12.0",
+  "protobuf<8,>=6.33.5",
   "pyarrow<24,>=4.0.0",
   "pydantic<3,>=2.0.0",
-  "python-dotenv<2,>=0.19.0",
+  "python-dotenv<2,>=1.2.2",
   "pyyaml<7,>=5.1",
-  "requests<3,>=2.17.3",
+  "requests<3,>=2.33.0",
   "scikit-learn<2",
   "scipy<2",
   "skops<1",
@@ -113,7 +113,7 @@ genai = [
   "uvicorn[standard]<1",
   "watchfiles<2",
 ]
-mcp = ["fastmcp<4,>=2.0.0", "click!=8.3.0"]
+mcp = ["fastmcp<4,>=3.2.0", "click!=8.3.0"]
 azure = ["azure-storage-blob>=12", "azure-identity>=1.6.1"]
 sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]

--- a/requirements/skinny-requirements.yaml
+++ b/requirements/skinny-requirements.yaml
@@ -15,12 +15,12 @@ cloudpickle:
 
 python-dotenv:
   pip_release: python-dotenv
-  minimum: "0.19.0"
+  minimum: "1.2.2"
   max_major_version: 1
 
 gitpython:
   pip_release: gitpython
-  minimum: "3.1.9"
+  minimum: "3.1.47"
   max_major_version: 3
 
 pyyaml:
@@ -30,12 +30,12 @@ pyyaml:
 
 protobuf:
   pip_release: protobuf
-  minimum: "3.12.0"
+  minimum: "6.33.5"
   max_major_version: 7
 
 requests:
   pip_release: requests
-  minimum: "2.17.3"
+  minimum: "2.33.0"
   max_major_version: 2
 
 packaging:

--- a/requirements/tracing-requirements.yaml
+++ b/requirements/tracing-requirements.yaml
@@ -6,7 +6,7 @@
 
 protobuf:
   pip_release: protobuf
-  minimum: "3.12.0"
+  minimum: "6.33.5"
   max_major_version: 7
 
 packaging:

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-27T01:42:28.513167086Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
@@ -4491,11 +4491,11 @@ requires-dist = [
     { name = "fastapi", specifier = "<1" },
     { name = "fastapi", marker = "extra == 'gateway'", specifier = "<1" },
     { name = "fastapi", marker = "extra == 'genai'", specifier = "<1" },
-    { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=2.0.0,<4" },
+    { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=3.2.0,<4" },
     { name = "flask", specifier = "<4" },
     { name = "flask-cors", specifier = "<7" },
     { name = "flask-wtf", marker = "extra == 'auth'", specifier = "<2" },
-    { name = "gitpython", specifier = ">=3.1.9,<4" },
+    { name = "gitpython", specifier = ">=3.1.47,<4" },
     { name = "google-cloud-storage", marker = "extra == 'databricks'", specifier = ">=1.30.0" },
     { name = "google-cloud-storage", marker = "extra == 'extras'", specifier = ">=1.30.0" },
     { name = "graphene", specifier = "<4" },
@@ -4517,7 +4517,7 @@ requires-dist = [
     { name = "packaging", specifier = "<27" },
     { name = "pandas", specifier = "<3" },
     { name = "prometheus-flask-exporter", marker = "extra == 'extras'" },
-    { name = "protobuf", specifier = ">=3.12.0,<8" },
+    { name = "protobuf", specifier = ">=6.33.5,<8" },
     { name = "psycopg2-binary", marker = "extra == 'db'" },
     { name = "pyarrow", specifier = ">=4.0.0,<24" },
     { name = "pyarrow", marker = "extra == 'extras'" },
@@ -4525,9 +4525,9 @@ requires-dist = [
     { name = "pymssql", marker = "extra == 'db'" },
     { name = "pymysql", marker = "extra == 'db'" },
     { name = "pysftp", marker = "extra == 'extras'" },
-    { name = "python-dotenv", specifier = ">=0.19.0,<2" },
+    { name = "python-dotenv", specifier = ">=1.2.2,<2" },
     { name = "pyyaml", specifier = ">=5.1,<7" },
-    { name = "requests", specifier = ">=2.17.3,<3" },
+    { name = "requests", specifier = ">=2.33.0,<3" },
     { name = "requests-auth-aws-sigv4", marker = "extra == 'extras'" },
     { name = "scikit-learn", specifier = "<2" },
     { name = "scipy", specifier = "<2" },


### PR DESCRIPTION
### Related Issues/PRs

  Closes #23061

  ### What changes are proposed in this pull request?

  This PR raises the minimum allowed versions for dependencies listed in #23061:

  - `gitpython`: `3.1.9` -> `3.1.47`
  - `protobuf`: `3.12.0` -> `6.33.5`
  - `python-dotenv`: `0.19.0` -> `1.2.2`
  - `requests`: `2.17.3` -> `2.33.0`
  - `fastmcp`: `2.0.0` -> `3.2.0`

  The source dependency definitions were updated and generated metadata was regenerated, including `pyproject.toml`,
  package-specific `pyproject.toml` files, and `uv.lock`.

  ### How is this PR tested?

  - [ ] Existing unit/integration tests
  - [x] Manual tests

  Manual tests:

  - `python dev/pyproject.py`
  - `uv lock`
  - `python -m ruff format .`
  - `python -m ruff check .`
  - `python -m pip install --dry-run -e ".[extras]"`
    - resolved `gitpython 3.1.50`, `protobuf 6.33.6`, `python-dotenv 1.2.2`, and `requests 2.34.0`
  - `python -m pip install --dry-run -e ".[mcp]"`
    - resolved `fastmcp 3.2.4`
  - `python -m pip check`
  - Import smoke tests for `mlflow`, `requests`, `git`, `dotenv`, `google.protobuf`, and `fastmcp`
  - Protobuf smoke test importing `mlflow.protos.service_pb2`

  I also attempted:

  - `pytest tests --quiet --requires-ssh --ignore-flavors --serve-wheel --ignore=tests/examples --ignore=tests/
  evaluate`

  This did not complete locally. Test collection stopped with environment-related errors due to missing optional test
  dependencies/services, including missing packages such as `dspy` and unavailable Docker/SageMaker-related services.

  ### Does this PR require documentation update?

  - [x] No.

  ### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

  - [x] No.

  ### Release Notes

  #### Is this a user-facing change?

  - [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

  MLflow now requires newer minimum versions of several dependencies to avoid allowing vulnerable older versions in
  its package metadata.

  #### What component(s), interfaces, languages, and integrations does this PR affect?

  Components

  - [x] `area/build`: Build and test infrastructure for MLflow

  <a name="release-note-category"></a>

  #### How should the PR be classified in the release notes? Choose one:

  - [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

  #### Is this PR a critical bugfix or security fix that should go into the next patch release?

  - [ ] This PR is critical and needs to be in the next patch release
  - [x] This PR can wait for the next minor release