### PR TITLE
Add `Agent` to `pr-review` skill allowed-tools

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -2,7 +2,7 @@
 name: pr-review
 description: Review a GitHub pull request, add review comments for issues found, and approve if no significant issues exist
 disable-model-invocation: true
-allowed-tools: Read, Skill, Bash, Grep, Glob, Agent, WebFetch
+allowed-tools: Read, Skill, Bash, Grep, Glob, Agent
 argument-hint: "[extra_context]"
 ---
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -2,7 +2,7 @@
 name: pr-review
 description: Review a GitHub pull request, add review comments for issues found, and approve if no significant issues exist
 disable-model-invocation: true
-allowed-tools: Read, Skill, Bash, Grep, Glob
+allowed-tools: Read, Skill, Bash, Grep, Glob, Agent, WebFetch
 argument-hint: "[extra_context]"
 ---
 


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Add `Agent` to `allowed-tools` in the `pr-review` skill so the reviewer can spawn `Explore` subagents to check cross-file claims (callers, similar patterns, existing tests) without bloating the main context.

`WebFetch` was considered but dropped: outbound HTTP from a PR-reviewing skill creates a data-exfiltration surface (a prompt injection in an untrusted diff could coerce a fetch to an attacker URL carrying diff content or secrets), and the marginal quality win from doc lookups isn't worth that risk.

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)