### PR TITLE
Remove unused `claude-agent-sdk` from `lint` dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -256,6 +256,9 @@ constraint-dependencies = [
   # litellm 1.82.7 and 1.82.8 contain a malicious .pth file that steals credentials
   # https://github.com/BerriAI/litellm/issues/24512
   "litellm<=1.82.6",
+  # starlette 1.0.0 dropped the `on_startup` parameter from `Router.__init__`, breaking
+  # older fastapi versions (<=0.115.x) that still pass it.
+  "starlette<1",
 ]
 # Prevent third-party libraries from installing uv to avoid conflicts with uv installed
 # by the standalone installer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,7 +191,6 @@ lint = [
   "types-PyYAML",
   "packaging>=25.0",
   "aiohttp",
-  "claude-agent-sdk",
   "pytest",
   "types-requests",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1183,25 +1183,6 @@ wheels = [
 ]
 
 [[package]]
-name = "claude-agent-sdk"
-version = "0.1.68"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "mcp" },
-    { name = "sniffio" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/27/cb/a3e2250bba1d6e7a41e34f832dbb1427ec1391d59897189d429b2875952a/claude_agent_sdk-0.1.68.tar.gz", hash = "sha256:5f8c9e29f08852878ed8ba9f91cff0287d069002b9522497c3229a5bd3e483ac", size = 239251, upload-time = "2026-04-25T02:06:35.599Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/84/347e9ecc4e293b6a0a80557a5527d0e0b28bfdd6c4ce9fac907436a606b9/claude_agent_sdk-0.1.68-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4e5228ffeae2bfa195e2526c446b5a926a1f4015da35e3efd142f817cf2c6dfb", size = 63221614, upload-time = "2026-04-25T02:06:38.805Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/18/e83cdf6c1e7025e735b546b83ff88fcb9762082e61b068a9e52c280caee6/claude_agent_sdk-0.1.68-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:4aeb266002b7ca97167072cf04bc3098db5bc8d2daa08a6f84ed29f2d48e2545", size = 65187622, upload-time = "2026-04-25T02:06:42.245Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/6c/70769392db3f8717afd48d0c2a5f1b8524f030ef42f203bac4f07f2ab443/claude_agent_sdk-0.1.68-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:2053151067347dd2b980f59632478f14b5323b627efb97fea41233e8bf891831", size = 76635725, upload-time = "2026-04-25T02:06:46.448Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/61/4b6f08a5d92a8077e5a29af1ba69f04c9465082781061b9271e981092287/claude_agent_sdk-0.1.68-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:59c7873e39ac7aa572fae25466abc5c34abb3da64eaf60790ed9ddd6dd4759b7", size = 76613056, upload-time = "2026-04-25T02:06:50.427Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/c1/3bd1f00529aa1b43f6f57d18ebe5272c3f4cec4bc25f543d78562639a932/claude_agent_sdk-0.1.68-py3-none-win_amd64.whl", hash = "sha256:6f06b744bf20a82d937a3ac705b26807f14936ec1b0c79349208e11a2e89413b", size = 78349055, upload-time = "2026-04-25T02:06:53.919Z" },
-]
-
-[[package]]
 name = "click"
 version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -4366,7 +4347,6 @@ build = [
 dev = [
     { name = "aiohttp" },
     { name = "build" },
-    { name = "claude-agent-sdk" },
     { name = "clint" },
     { name = "mlflow-test-plugin" },
     { name = "mypy" },
@@ -4428,7 +4408,6 @@ docs = [
 ]
 lint = [
     { name = "aiohttp" },
-    { name = "claude-agent-sdk" },
     { name = "clint" },
     { name = "mypy" },
     { name = "packaging" },
@@ -4559,7 +4538,6 @@ build = [
 dev = [
     { name = "aiohttp" },
     { name = "build" },
-    { name = "claude-agent-sdk" },
     { name = "clint", editable = "dev/clint" },
     { name = "mlflow-test-plugin", editable = "tests/resources/mlflow-test-plugin" },
     { name = "mypy", specifier = "==1.17.1" },
@@ -4619,7 +4597,6 @@ docs = [
 ]
 lint = [
     { name = "aiohttp" },
-    { name = "claude-agent-sdk" },
     { name = "clint", editable = "dev/clint" },
     { name = "mypy", specifier = "==1.17.1" },
     { name = "packaging", specifier = ">=25.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -30,6 +30,7 @@ constraints = [
     { name = "litellm", specifier = "<=1.82.6" },
     { name = "pyspark", specifier = "<4.1.0" },
     { name = "setuptools", specifier = "<82" },
+    { name = "starlette", specifier = "<1" },
     { name = "xgboost", specifier = "<3.1.0" },
 ]
 excludes = ["uv"]


### PR DESCRIPTION
### Related Issues/PRs

Relates to #19900

### What changes are proposed in this pull request?

Drops `claude-agent-sdk` from the `lint` dependency group in `pyproject.toml`. The only consumer was the `analyze-ci` skill's Python module, which was migrated to the unified `claude -p` CLI in #19900. No other file under `dev/`, `bin/`, or `.claude/skills/` imports `claude_agent_sdk`, so the lint group dependency has been dead since that migration.

Removing it also shaves a ~60–75 MB per-platform wheel out of the lint env.

### How is this PR tested?

- [x] Manual tests

Locally re-synced the `lint` group without `claude-agent-sdk` and ran the affected pre-commit hooks:

- `pre-commit run --all-files mypy` → Passed
- `pre-commit run --all-files unresolved-import` → Passed

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)