### PR TITLE
Support settings.local.json for Claude Code tracing config

### DIFF
--- a/mlflow/claude_code/config.py
+++ b/mlflow/claude_code/config.py
@@ -66,29 +66,43 @@ def save_claude_config(settings_path: Path, config: dict[str, Any]) -> None:
 def get_tracing_status(settings_path: Path) -> TracingStatus:
     """Get current tracing status from Claude settings.
 
+    Checks both settings.json and settings.local.json, with local taking
+    precedence for env vars (matching Claude Code's own precedence).
+
     Args:
-        settings_path: Path to Claude settings file
+        settings_path: Path to Claude settings file (e.g., .claude/settings.json)
 
     Returns:
         TracingStatus with tracing status information
     """
-    if not settings_path.exists():
+    local_path = settings_path.parent / "settings.local.json"
+    config = load_claude_config(settings_path)
+    local_config = load_claude_config(local_path)
+
+    if not config and not local_config:
         return TracingStatus(enabled=False, reason="No configuration found")
 
-    config = load_claude_config(settings_path)
     env_vars = config.get(ENVIRONMENT_FIELD, {})
-    enabled = env_vars.get(MLFLOW_TRACING_ENABLED) == "true"
+    local_env_vars = local_config.get(ENVIRONMENT_FIELD, {})
+    merged_env = {**env_vars, **local_env_vars}
+
+    enabled = merged_env.get(MLFLOW_TRACING_ENABLED) == "true"
 
     return TracingStatus(
         enabled=enabled,
-        tracking_uri=env_vars.get(MLFLOW_TRACKING_URI.name),
-        experiment_id=env_vars.get(MLFLOW_EXPERIMENT_ID.name),
-        experiment_name=env_vars.get(MLFLOW_EXPERIMENT_NAME.name),
+        tracking_uri=merged_env.get(MLFLOW_TRACKING_URI.name),
+        experiment_id=merged_env.get(MLFLOW_EXPERIMENT_ID.name),
+        experiment_name=merged_env.get(MLFLOW_EXPERIMENT_NAME.name),
     )
 
 
 def get_env_var(var_name: str, default: str = "") -> str:
     """Get environment variable from OS or Claude settings as fallback.
+
+    Checks in order (first match wins):
+    1. OS environment variables (set by Claude Code from settings at startup)
+    2. .claude/settings.local.json env block (user-local, not committed)
+    3. .claude/settings.json env block (project-level, may be committed)
 
     Args:
         var_name: Environment variable name
@@ -102,15 +116,18 @@ def get_env_var(var_name: str, default: str = "") -> str:
     if value is not None:
         return value
 
-    # Fallback to Claude settings
-    try:
-        settings_path = Path(".claude/settings.json")
-        if settings_path.exists():
-            config = load_claude_config(settings_path)
-            env_vars = config.get(ENVIRONMENT_FIELD, {})
-            return env_vars.get(var_name, default)
-    except Exception:
-        pass
+    # Check settings.local.json (user-local overrides, not committed to git)
+    for settings_file in ("settings.local.json", "settings.json"):
+        try:
+            settings_path = Path(f".claude/{settings_file}")
+            if settings_path.exists():
+                config = load_claude_config(settings_path)
+                env_vars = config.get(ENVIRONMENT_FIELD, {})
+                value = env_vars.get(var_name)
+                if value is not None:
+                    return value
+        except Exception:
+            pass
 
     return default
 

--- a/tests/claude_code/test_config.py
+++ b/tests/claude_code/test_config.py
@@ -93,6 +93,80 @@ def test_get_env_var_from_claude_settings_fallback(tmp_path, monkeypatch):
     assert result == "claude_value"
 
 
+def test_get_env_var_from_settings_local_json(tmp_path, monkeypatch):
+    """Test get_env_var reads from settings.local.json."""
+    monkeypatch.delenv(MLFLOW_TRACING_ENABLED, raising=False)
+
+    config_data = {"environment": {MLFLOW_TRACING_ENABLED: "local_value"}}
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    with open(claude_dir / "settings.local.json", "w") as f:
+        json.dump(config_data, f)
+
+    monkeypatch.chdir(tmp_path)
+    result = get_env_var(MLFLOW_TRACING_ENABLED, "default")
+    assert result == "local_value"
+
+
+def test_get_env_var_settings_local_overrides_settings(tmp_path, monkeypatch):
+    """Test settings.local.json takes precedence over settings.json."""
+    monkeypatch.delenv(MLFLOW_TRACING_ENABLED, raising=False)
+
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+
+    with open(claude_dir / "settings.json", "w") as f:
+        json.dump({"environment": {MLFLOW_TRACING_ENABLED: "shared_value"}}, f)
+    with open(claude_dir / "settings.local.json", "w") as f:
+        json.dump({"environment": {MLFLOW_TRACING_ENABLED: "local_value"}}, f)
+
+    monkeypatch.chdir(tmp_path)
+    result = get_env_var(MLFLOW_TRACING_ENABLED, "default")
+    assert result == "local_value"
+
+
+def test_get_env_var_os_env_overrides_local(tmp_path, monkeypatch):
+    """Test OS env takes precedence over settings.local.json."""
+    monkeypatch.setenv(MLFLOW_TRACING_ENABLED, "os_value")
+
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    with open(claude_dir / "settings.local.json", "w") as f:
+        json.dump({"environment": {MLFLOW_TRACING_ENABLED: "local_value"}}, f)
+
+    monkeypatch.chdir(tmp_path)
+    result = get_env_var(MLFLOW_TRACING_ENABLED, "default")
+    assert result == "os_value"
+
+
+def test_get_tracing_status_from_local(tmp_path):
+    """Test get_tracing_status reads from settings.local.json."""
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    settings_path = claude_dir / "settings.json"
+
+    with open(claude_dir / "settings.local.json", "w") as f:
+        json.dump({"environment": {MLFLOW_TRACING_ENABLED: "true"}}, f)
+
+    status = get_tracing_status(settings_path)
+    assert status.enabled is True
+
+
+def test_get_tracing_status_local_overrides_settings(tmp_path):
+    """Test settings.local.json overrides settings.json for tracing status."""
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    settings_path = claude_dir / "settings.json"
+
+    with open(settings_path, "w") as f:
+        json.dump({"environment": {MLFLOW_TRACING_ENABLED: "true"}}, f)
+    with open(claude_dir / "settings.local.json", "w") as f:
+        json.dump({"environment": {MLFLOW_TRACING_ENABLED: "false"}}, f)
+
+    status = get_tracing_status(settings_path)
+    assert status.enabled is False
+
+
 def test_get_env_var_default_when_not_found(tmp_path, monkeypatch):
     """Test get_env_var returns default when variable not found anywhere."""
     # Ensure OS env var is not set


### PR DESCRIPTION
### Related Issues/PRs

<!-- No existing issue — this is a new enhancement -->

### What changes are proposed in this pull request?

Add `settings.local.json` support to Claude Code tracing configuration.

Claude Code supports two project-level settings files:
- `.claude/settings.json` — shared, typically committed to git
- `.claude/settings.local.json` — user-local, gitignored, never committed

Currently, `get_env_var()` and `get_tracing_status()` only read from `settings.json`. This means users who want to keep tracing config private (tokens, per-user preferences like disabling tracing) must use `settings.json`, which risks accidentally committing secrets like `MLFLOW_TRACKING_TOKEN`.

**Changes:**
- `get_env_var()` now checks `settings.local.json` before `settings.json` (after OS env)
- `get_tracing_status()` merges env vars from both files, with local taking precedence

**Precedence order (first match wins):**
1. OS environment variables (set by Claude Code from settings at startup)
2. `.claude/settings.local.json` env block
3. `.claude/settings.json` env block
4. Default value

This matches Claude Code's own precedence where local settings override shared settings.

### How is this PR tested?

- [x] New unit/integration tests

Added 5 new tests covering:
- Reading from `settings.local.json`
- Local overriding shared settings
- OS env overriding local
- `get_tracing_status` with local config
- `get_tracing_status` local overriding shared

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Claude Code tracing now reads configuration from `.claude/settings.local.json` in addition to `.claude/settings.json`. This allows users to keep tracing tokens and per-user preferences (like disabling tracing) out of version control.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)