### PR TITLE
Enforce explicit `fail-fast` on `strategy.matrix`

### DIFF
--- a/.github/policy.rego
+++ b/.github/policy.rego
@@ -414,6 +414,24 @@ deny_upload_artifact_without_if_no_files_found contains msg if {
 	)
 }
 
+deny_matrix_without_fail_fast contains msg if {
+	some job_id, job in input.jobs
+	job.strategy.matrix
+	not has_explicit_fail_fast(job.strategy)
+	msg := sprintf(
+		"strategy.matrix in job '%s' must set 'fail-fast' explicitly (either true or false).",
+		[job_id],
+	)
+}
+
+has_explicit_fail_fast(strategy) if {
+	strategy["fail-fast"] == false
+}
+
+has_explicit_fail_fast(strategy) if {
+	strategy["fail-fast"] == true
+}
+
 deny_mutable_install contains msg if {
 	some job_id, job in input.jobs
 	some step in job.steps

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -47,6 +47,7 @@ jobs:
     permissions:
       contents: read
     strategy:
+      fail-fast: false
       matrix:
         tls: [false, true]
     name: e2e (tls=${{ matrix.tls }})

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -47,7 +47,7 @@ jobs:
     permissions:
       contents: read
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         tls: [false, true]
     name: e2e (tls=${{ matrix.tls }})

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -47,7 +47,7 @@ jobs:
     permissions:
       contents: read
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         tls: [false, true]
     name: e2e (tls=${{ matrix.tls }})


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

Adds a conftest rule that fails when a job defines `strategy.matrix` without an explicit `fail-fast` value. Only literal `true` or `false` are accepted.

Most matrix jobs in the repo already set `fail-fast: false`; this prevents new matrix jobs from silently inheriting GitHub's default of `true`, which cancels sibling shards on the first failure and tends to hide flakes.

Also fixes `helm.yml`'s `e2e` job — the only existing matrix job missing the field — by adding `fail-fast: false` to match the project convention.

### How is this PR tested?

- [x] Manual tests

Ran the `conftest` pre-commit hook locally:

- Before adding `fail-fast: false` to `helm.yml`: 1 failure on the `e2e` job (as expected).
- After: 2450 tests, all passing.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)