### PR TITLE
Show `system/init` event in `stream.sh` renderer

### DIFF
--- a/.claude/scripts/stream.sh
+++ b/.claude/scripts/stream.sh
@@ -18,6 +18,8 @@ tee "${1:-/dev/null}" \
       .message.content[]?
       | select(.type == "tool_result")
       | "📥 tool_result (\(.content | tostring | length) chars)\(if .is_error then " ❌" else "" end)"
+    elif .type == "system" and .subtype == "init" then
+      "🚀 init: \(.model) (v\(.claude_code_version), session \(.session_id[0:8]))"
     elif .type == "result" then
       "✅ Done (\((.duration_ms / 100 | round) / 10)s, \(.num_turns) turns, \(.usage.input_tokens + .usage.output_tokens) tokens, $\(.total_cost_usd * 100 | round / 100))"
     else


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23256 (review workflow transcript readability)

### What changes are proposed in this pull request?

Adds a `🚀 init` line to `.claude/scripts/stream.sh` so the model, CLI version, and session id from the `system/init` event are surfaced at the top of the Claude transcript emitted by `.github/workflows/review.yml`.

Previously the renderer dropped `system` events into the `else empty end` branch, so transcripts started at the first assistant message and the agent's runtime context (model, version, session) was hidden.

Example output line:

```
🚀 init: claude-sonnet-4-6 (v2.1.128, session e1c2c6d9)
```

### How is this PR tested?

- [x] Manual tests

Piped the captured `output.jsonl` from a recent `/review` run through the updated script and confirmed the new line renders correctly while every other event type still formats as before and the `tee` passthrough preserves the raw JSONL.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release