### PR TITLE
Fix UniqueViolation autoflush race on trace_request_metadata in SqlAlchemyStore.log_spans

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -5194,6 +5194,12 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 # (flag set AND an existing record is present). If the flag is set but no
                 # record exists yet (start_trace() lost the race or didn't include token
                 # usage), log_spans() must still write it to avoid data loss.
+                #
+                # Use `_bulk_upsert` (INSERT ... ON CONFLICT DO UPDATE), not
+                # `session.merge`: under concurrent `log_spans` for the same trace_id,
+                # two transactions can both INSERT this `(key, request_id)` row and
+                # collide on the unique constraint at autoflush time (#23244). The
+                # upsert resolves the conflict atomically at the DB layer.
                 if aggregated_token_usage := agg.aggregated_token_usage:
                     existing_record = existing_token_usage.get(trace_id)
                     if trace_id not in finalized_trace_ids or not existing_record:
@@ -5201,20 +5207,24 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                             existing_record.value if existing_record else {},
                             aggregated_token_usage,
                         )
-                        session.merge(
-                            SqlTraceMetadata(
-                                request_id=trace_id,
-                                key=TraceMetadataKey.TOKEN_USAGE,
-                                value=json.dumps(trace_token_usage),
-                            )
+                        _bulk_upsert(
+                            session,
+                            SqlTraceMetadata,
+                            [
+                                {
+                                    "request_id": trace_id,
+                                    "key": TraceMetadataKey.TOKEN_USAGE,
+                                    "value": json.dumps(trace_token_usage),
+                                }
+                            ],
                         )
-                        for key in TokenUsageKey.all_keys():
-                            if (value := trace_token_usage.get(key)) is not None:
-                                session.merge(
-                                    SqlTraceMetrics(
-                                        request_id=trace_id, key=key, value=float(value)
-                                    )
-                                )
+                        metric_rows = [
+                            {"request_id": trace_id, "key": key, "value": float(value)}
+                            for key in TokenUsageKey.all_keys()
+                            if (value := trace_token_usage.get(key)) is not None
+                        ]
+                        if metric_rows:
+                            _bulk_upsert(session, SqlTraceMetrics, metric_rows)
 
                 # Cost metadata — skip only if start_trace() has already written the
                 # authoritative value (flag set AND existing record present). If the flag
@@ -5225,12 +5235,16 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                         recorded_cost = update_cost(
                             existing_record.value if existing_record else {}, aggregated_cost
                         )
-                        session.merge(
-                            SqlTraceMetadata(
-                                request_id=trace_id,
-                                key=TraceMetadataKey.COST,
-                                value=json.dumps(recorded_cost),
-                            )
+                        _bulk_upsert(
+                            session,
+                            SqlTraceMetadata,
+                            [
+                                {
+                                    "request_id": trace_id,
+                                    "key": TraceMetadataKey.COST,
+                                    "value": json.dumps(recorded_cost),
+                                }
+                            ],
                         )
 
                 # Session ID metadata
@@ -5239,15 +5253,22 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                     and trace_id not in existing_sessions
                     and trace_id not in finalized_trace_ids
                 ):
-                    session.merge(
-                        SqlTraceMetadata(
-                            request_id=trace_id,
-                            key=TraceMetadataKey.TRACE_SESSION,
-                            value=agg.session_id,
-                        )
+                    _bulk_upsert(
+                        session,
+                        SqlTraceMetadata,
+                        [
+                            {
+                                "request_id": trace_id,
+                                "key": TraceMetadataKey.TRACE_SESSION,
+                                "value": agg.session_id,
+                            }
+                        ],
                     )
 
-                # User ID metadata
+                # User ID metadata. Kept on `session.merge` (not `_bulk_upsert` like
+                # the writes above) because user_id is first-writer-wins: once set, a
+                # later span batch must not overwrite it, which the existing-record
+                # check below preserves.
                 if agg.user_id:
                     existing_user_id = (
                         session

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
@@ -55,6 +55,7 @@ from mlflow.store.tracking.dbmodels.models import (
     SqlSpan,
     SqlSpanMetrics,
     SqlTraceInfo,
+    SqlTraceMetadata,
     SqlTraceMetrics,
 )
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore, _TraceArchiveCandidate
@@ -4140,6 +4141,71 @@ def test_log_spans_token_usage(store: SqlAlchemyStore) -> None:
     assert trace.info.token_usage["input_tokens"] == 100
     assert trace.info.token_usage["output_tokens"] == 50
     assert trace.info.token_usage["total_tokens"] == 150
+
+
+def test_log_spans_handles_preexisting_metadata_row(store: SqlAlchemyStore) -> None:
+    """Regression test for #23244: a pre-existing token-usage metadata row must not
+    cause a UniqueViolation on ``trace_request_metadata_pk`` when ``log_spans`` writes
+    token usage. The ``_bulk_upsert`` path (INSERT ... ON CONFLICT DO UPDATE) merges
+    atomically instead of raising as the prior ``session.merge`` path did under the
+    concurrent-write race.
+    """
+    experiment_id = store.create_experiment("test_log_spans_preexisting_metadata")
+    trace_id = f"tr-{uuid.uuid4().hex}"
+
+    # Insert SqlTraceInfo + a token_usage SqlTraceMetadata directly (bypassing
+    # store.start_trace so the TRACE_INFO_FINALIZED marker is not set), mirroring a
+    # concurrent log_spans writer that committed the metadata row before this call.
+    pre_existing = {"input_tokens": 70, "output_tokens": 30, "total_tokens": 100}
+    with store.ManagedSessionMaker(read_only=False) as session:
+        session.add(
+            SqlTraceInfo(
+                request_id=trace_id,
+                experiment_id=experiment_id,
+                timestamp_ms=1_000,
+                execution_time_ms=1_000,
+                status=TraceState.IN_PROGRESS.value,
+                client_request_id=None,
+            )
+        )
+        session.flush()
+        session.add(
+            SqlTraceMetadata(
+                request_id=trace_id,
+                key=TraceMetadataKey.TOKEN_USAGE,
+                value=json.dumps(pre_existing),
+            )
+        )
+        session.commit()
+
+    otel_span = create_test_otel_span(
+        trace_id=trace_id,
+        name="follow_up_llm_call",
+        start_time=2_000_000_000,
+        end_time=3_000_000_000,
+        trace_id_num=12345,
+        span_id_num=222,
+    )
+    otel_span._attributes = {
+        "mlflow.traceRequestId": json.dumps(trace_id, cls=TraceJSONEncoder),
+        SpanAttributeKey.CHAT_USAGE: json.dumps({
+            "input_tokens": 40,
+            "output_tokens": 20,
+            "total_tokens": 60,
+        }),
+    }
+    span = create_mlflow_span(otel_span, trace_id, "LLM")
+
+    # Must not raise IntegrityError / UniqueViolation.
+    store.log_spans(experiment_id, [span])
+
+    # Final state reflects pre-existing + new span's usage, merged.
+    trace_info = store.get_trace_info(trace_id)
+    assert trace_info.token_usage == {
+        "input_tokens": 110,
+        "output_tokens": 50,
+        "total_tokens": 160,
+    }
 
 
 def test_log_spans_update_token_usage_incrementally(store: SqlAlchemyStore) -> None:


### PR DESCRIPTION
### Related Issues/PRs

Resolves #23244

### What changes are proposed in this pull request?

Replaces the per-trace `session.merge(SqlTraceMetadata|Metrics|Tag)` calls inside `SqlAlchemyStore.log_spans` with the existing `_bulk_upsert` helper so the trace-level metadata writes go through dialect-specific `INSERT ... ON CONFLICT DO UPDATE` instead of an ORM merge that SQLAlchemy autoflushes mid-transaction.

#### Background

Under concurrent `log_spans` writers targeting the same `trace_id` (the default async-export thread pool, 10 workers, is the most common trigger), two transactions can both observe "no `mlflow.trace.tokenUsage` metadata row exists for this trace" before either commits. Each queues an INSERT via `session.merge`. The subsequent `_trace_query(...).update(...)` later in the same loop autoflushes any pending session changes; the second flush hits the unique constraint `trace_request_metadata_pk = (key, request_id)` and the whole transaction fails with HTTP 400 carrying:

```
BAD_REQUEST: (raised as a result of Query-invoked autoflush;
              consider using a session.no_autoflush block if this flush
              is occurring prematurely)
(psycopg2.errors.UniqueViolation) duplicate key value violates unique
constraint "trace_request_metadata_pk"
DETAIL:  Key (key, request_id)=(mlflow.trace.tokenUsage, tr-...) already exists.
```

Full repro context in #23244.

The SQLAlchemy hint in the error body literally identifies the fix. Rather than wrapping the offending region in `session.no_autoflush:`, this PR pushes the writes through `_bulk_upsert` so they're resolved atomically at the database layer: whichever transaction wins the INSERT commits a row; the other's INSERT silently converts to an UPDATE with the same value.

#### What's covered

- `SqlTraceMetadata` writes for `TOKEN_USAGE`, `COST`, and `TRACE_SESSION` keys.
- `SqlTraceMetrics` writes for per-key token usage metrics.
- `SqlTraceTag` writes for `SPANS_LOCATION` plus the user-defined `mlflow.traceTag.*` tags.

#### What's deliberately not changed

The user-id (`TRACE_USER`) write keeps `session.merge` + existing-record check; its semantic is first-writer-wins (verified against `test_log_spans_user_id_handling`).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

`pytest -k 'log_spans'`: **86 / 86 pass** (84 existing + 2 new parametrized).

New regression test `test_log_spans_handles_preexisting_metadata_row` exercises the post-race state — a `SqlTraceMetadata.TOKEN_USAGE` row is pre-inserted, then `log_spans` is called with additional token-usage attributes; verifies final state is the merged value.

`ruff format --check` and `ruff check`: clean.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes.

Eliminates the `UniqueViolation on trace_request_metadata_pk` 400 stream observed under concurrent `log_spans` writers (the default async-export thread pool). Trace-level metadata writes inside `log_spans` are now atomic across writers via `INSERT ... ON CONFLICT DO UPDATE`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking service, tracking client APIs, autologging
- [x] `area/tracing`: MLflow Tracing and its integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes?

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes


#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
