### PR TITLE
Fix NaiLaOpus `--mlflow-tree` path resolution

### DIFF
--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -148,9 +148,10 @@ jobs:
           ref: refs/pull/${{ steps.ctx.outputs.pr }}/head
           # Full checkout (shallow by default) so the orchestrator's agents
           # can use Read/Grep/Glob bounded to this worktree via
-          # `--mlflow-tree mlflow` below. The agents grep sibling files at
-          # PR head to validate or refute concerns, which gave a meaningful
-          # recall lift in the 81-PR eval vs. API-only reads.
+          # `--mlflow-tree "$GITHUB_WORKSPACE/mlflow"` below. The agents grep
+          # sibling files at PR head to validate or refute concerns, which
+          # gave a meaningful recall lift in the 81-PR eval vs. API-only
+          # reads.
           path: mlflow
           token: ${{ steps.app_token.outputs.token }}
           # Read-only checkout; we never push from the workflow. Avoid
@@ -205,7 +206,7 @@ jobs:
         # from the orchestrator package without a separate `uv pip install`
         # step; uv caches the env between invocations.
         run: |
-          uv run --directory internal/nailaopus nailaopus "$PR" --repo "$REPO" --mlflow-tree mlflow $FLAGS
+          uv run --directory internal/nailaopus nailaopus "$PR" --repo "$REPO" --mlflow-tree "$GITHUB_WORKSPACE/mlflow" $FLAGS
 
       - name: React +1 on success (comment-triggered only)
         if: success() && steps.ctx.outputs.trigger == 'comment'


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23084 (Bridge 1, which introduced the bug) and #23085 (Bridge 2, which also carries this fix transitively).

### What changes are proposed in this pull request?

Fix the `--mlflow-tree` path passed to the `nailaopus` CLI in `.github/workflows/nailaopus.yml`.

Bridge 1 (#23084) passed `--mlflow-tree mlflow` as a relative path, but `uv run --directory internal/nailaopus` changes cwd, so the CLI resolved `mlflow` against `internal/nailaopus/` instead of the workspace root. Caught when `/review-v2` was attempted on PR #23220 post-Bridge-1-merge; the CLI errored with:

```
nailaopus: error: --mlflow-tree must point to a directory:
  /home/runner/work/mlflow/mlflow/internal/nailaopus/mlflow
```

Pass the absolute path `$GITHUB_WORKSPACE/mlflow` so the worktree location is unambiguous regardless of `uv run --directory`. Comment on the checkout step updated to match.

This is a standalone fix landing ahead of Bridge 2 (#23085) so `/review-v2` dry-run testing on master is unblocked. Bridge 2's diff includes the same fix; once both land, the rebase deduplicates cleanly.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Plan: after merge, `/review-v2` on a recent maintainer-authored non-fork PR. Workflow should reach the "Run NaiLaOpus" step successfully and emit the `<<<NAILAOPUS_RUN_JSON>>>` block (still dry-run until Bridge 2 lands).

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

-- Claude-drafted, reviewed before posting.