### PR TITLE
`/review`: emit JSON review payload, isolate Claude from write token

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools:
   - Grep
   - Glob
   - Agent
-  - Write(//tmp/review-payload.json)
+  - Edit(//tmp/review-payload.json)
 argument-hint: "[extra_context]"
 ---
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools:
   - Grep
   - Glob
   - Agent
-  - Write(/tmp/review-payload.json)
+  - Write(//tmp/review-payload.json)
 argument-hint: "[extra_context]"
 ---
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,14 +1,21 @@
 ---
 name: pr-review
-description: Review a GitHub pull request, add review comments for issues found, and approve if no significant issues exist
+description: Review a GitHub pull request and emit a single review payload (comments + approval decision) for the workflow to validate and post
 disable-model-invocation: true
-allowed-tools: Read, Skill, Bash, Grep, Glob, Agent
+allowed-tools:
+  - Read
+  - Skill
+  - Bash
+  - Grep
+  - Glob
+  - Agent
+  - Write(/tmp/review-payload.json)
 argument-hint: "[extra_context]"
 ---
 
 # Review Pull Request
 
-Automatically review a GitHub pull request across correctness, security, edge cases, efficiency, readability, test coverage, and style. Approves the PR when there are no findings or only MODERATE/NIT findings.
+Automatically review a GitHub pull request across correctness, security, edge cases, efficiency, readability, test coverage, and style. Emits a single `/tmp/review-payload.json` that the workflow validates against [`review-payload.schema.json`](./review-payload.schema.json) and posts via `POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews`. Sets the payload's `event` to `APPROVE` when there are no findings or only MODERATE/NIT findings.
 
 ## Usage
 
@@ -32,6 +39,8 @@ Automatically review a GitHub pull request across correctness, security, edge ca
 ## Important Note
 
 The current local branch may not be the PR branch being reviewed. Always rely on the PR diff fetched via the `fetch-diff` skill.
+
+You have a **read-only** GitHub token. Do NOT call write APIs (`gh api ... POST`, `gh pr review`, `gh pr comment`, etc.) — your only output is `/tmp/review-payload.json`. The workflow's post step holds the write token and submits the review on your behalf.
 
 ## Instructions
 
@@ -102,33 +111,31 @@ Classify each finding by severity (matches `.github/instructions/code-review.ins
 | MODERATE | 🟡    | non-blocking quality concerns where the code works but could be clearer or safer |
 | NIT      | 🟢    | pure style/preference the author can ignore                                      |
 
-Then:
+Determine the review `event`:
 
-- **No findings** -> skip to step 7 (approve)
-- **Only MODERATE/NIT findings** -> step 6 (add comments), then step 7 (approve)
-- **Any CRITICAL finding** -> step 6 (add comments); do NOT approve
+- **No CRITICAL findings AND author has `admin`/`maintain` role** -> `event: "APPROVE"`
+- **Any CRITICAL finding, OR author role is anything else (or the API errors, e.g., 404 for non-collaborators)** -> `event: "COMMENT"`. Do not mention the reason for not approving in the review body.
 
-### 6. Add Review Comments
-
-For each finding, use the `add-review-comment` skill. One comment per distinct finding, anchored to the most relevant changed line. For repeated identical issues, leave a single representative comment rather than flagging every instance.
-
-Every comment MUST use this exact format: `<emoji> **<severity>:** <description>`
-
-Keep comments constructive and specific: state the problem, why it matters, and a concrete suggestion when possible.
-
-### 7. Approve the PR
-
-Approve the PR when there are no findings or only MODERATE/NIT findings, but **only if the PR author has the `admin` or `maintain` role**.
-
-First, check the PR author's role:
+Check the author's role:
 
 ```bash
 author=$(gh api repos/<owner>/<repo>/pulls/<PR_NUMBER> --jq '.user.login')
 gh api repos/<owner>/<repo>/collaborators/"$author"/permission --jq '.role_name'
 ```
 
-- If the role is `admin` or `maintain` -> approve the PR:
-  ```bash
-  gh pr review <PR_NUMBER> --repo <owner/repo> --approve
-  ```
-- Otherwise (including API errors, e.g., 404 for non-collaborators) -> do NOT approve. Do not mention the reason for not approving in the review.
+### 6. Emit Review Payload
+
+Read [`review-payload.schema.json`](./review-payload.schema.json) for the full payload spec (field types, required fields, patterns, enums) and write `/tmp/review-payload.json` matching it.
+
+Authoring rules not captured by the schema:
+
+- One comment per distinct finding, anchored to the most relevant changed line. For repeated identical issues, leave a single representative comment rather than flagging every instance.
+- Keep comments constructive and specific: state the problem, why it matters, and a concrete suggestion when possible.
+- Use suggestion blocks for simple fixes — fence with ` ```suggestion ` and preserve original indentation.
+- If you have no findings, emit an empty `comments` array.
+
+Validate before finishing — fix any errors and re-emit until this passes:
+
+```bash
+uv run --package skills skills validate-review /tmp/review-payload.json
+```

--- a/.claude/skills/pr-review/review-payload.schema.json
+++ b/.claude/skills/pr-review/review-payload.schema.json
@@ -16,7 +16,7 @@
       "description": "Top-level review summary. Must end with the '🤖 Generated with Claude' footer on its own line.",
       "type": "string",
       "minLength": 1,
-      "pattern": "🤖 Generated with Claude\\s*$"
+      "pattern": "(^|\\n)🤖 Generated with Claude\\s*$"
     },
     "commit_id": {
       "description": "Head commit SHA being reviewed. Optional; GitHub defaults to the latest commit when omitted.",

--- a/.claude/skills/pr-review/review-payload.schema.json
+++ b/.claude/skills/pr-review/review-payload.schema.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/mlflow/mlflow/.claude/skills/pr-review/review-payload.schema.json",
+  "title": "PR Review Payload",
+  "description": "Payload emitted by the pr-review skill and posted via POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["event", "body", "comments"],
+  "properties": {
+    "event": {
+      "description": "Review action. APPROVE only when there are no CRITICAL findings and the PR author has admin/maintain; otherwise COMMENT.",
+      "type": "string",
+      "enum": ["APPROVE", "COMMENT"]
+    },
+    "body": {
+      "description": "Top-level review summary. Must end with the '🤖 Generated with Claude' footer on its own line.",
+      "type": "string",
+      "minLength": 1,
+      "pattern": "🤖 Generated with Claude\\s*$"
+    },
+    "commit_id": {
+      "description": "Head commit SHA being reviewed. Optional; GitHub defaults to the latest commit when omitted.",
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "comments": {
+      "description": "Inline review comments. Empty array is allowed (e.g., clean APPROVE).",
+      "type": "array",
+      "items": { "$ref": "#/$defs/comment" }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "event": { "const": "APPROVE" } },
+        "required": ["event"]
+      },
+      "then": {
+        "properties": {
+          "comments": {
+            "items": {
+              "properties": {
+                "body": {
+                  "not": { "pattern": "^🔴 \\*\\*CRITICAL:" }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "side": {
+      "type": "string",
+      "enum": ["LEFT", "RIGHT"]
+    },
+    "comment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "body", "line", "side"],
+      "properties": {
+        "path": {
+          "description": "File path relative to the repo root. Must match a path present in the PR diff.",
+          "type": "string",
+          "minLength": 1
+        },
+        "body": {
+          "description": "Comment body. Must start with '🔴 **CRITICAL:** ', '🟡 **MODERATE:** ', or '🟢 **NIT:** '.",
+          "type": "string",
+          "pattern": "^(🔴 \\*\\*CRITICAL:\\*\\*|🟡 \\*\\*MODERATE:\\*\\*|🟢 \\*\\*NIT:\\*\\*) "
+        },
+        "line": {
+          "description": "Line number to anchor to. For multi-line comments, this is the last line of the range.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "side": {
+          "description": "RIGHT for added/modified lines, LEFT for deleted lines.",
+          "$ref": "#/$defs/side"
+        },
+        "start_line": {
+          "description": "First line of a multi-line comment range. Required together with start_side.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "start_side": {
+          "description": "Side for start_line. Required together with start_line.",
+          "$ref": "#/$defs/side"
+        }
+      },
+      "dependentRequired": {
+        "start_line": ["start_side"],
+        "start_side": ["start_line"]
+      }
+    }
+  }
+}

--- a/.claude/skills/pyproject.toml
+++ b/.claude/skills/pyproject.toml
@@ -2,7 +2,7 @@
 name = "skills"
 version = "0.1.0"
 requires-python = ">=3.10"
-dependencies = ["aiohttp", "pydantic", "typing_extensions"]
+dependencies = ["aiohttp", "jsonschema", "pydantic", "typing_extensions"]
 
 [project.scripts]
 skills = "skills.cli:main"

--- a/.claude/skills/src/skills/cli.py
+++ b/.claude/skills/src/skills/cli.py
@@ -1,6 +1,6 @@
 import argparse
 
-from skills.commands import analyze_ci, fetch_diff, fetch_unresolved_comments
+from skills.commands import analyze_ci, fetch_diff, fetch_unresolved_comments, validate_review
 
 
 def main() -> None:
@@ -10,6 +10,7 @@ def main() -> None:
     analyze_ci.register(subparsers)
     fetch_diff.register(subparsers)
     fetch_unresolved_comments.register(subparsers)
+    validate_review.register(subparsers)
 
     args = parser.parse_args()
     args.func(args)

--- a/.claude/skills/src/skills/commands/validate_review.py
+++ b/.claude/skills/src/skills/commands/validate_review.py
@@ -1,0 +1,55 @@
+# ruff: noqa: T201
+"""Validate a pr-review JSON payload against the schema in ``.claude/skills/pr-review/``."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from jsonschema import Draft202012Validator  # type: ignore[import-untyped]
+
+DEFAULT_SCHEMA = Path(__file__).parents[3] / "pr-review" / "review-payload.schema.json"
+
+
+def format_path(path: list[str | int]) -> str:
+    if not path:
+        return "<root>"
+    out = ""
+    for p in path:
+        if isinstance(p, int):
+            out += f"[{p}]"
+        else:
+            out += f".{p}" if out else str(p)
+    return out
+
+
+def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    parser = subparsers.add_parser(
+        "validate-review",
+        help="Validate a pr-review payload against the JSON schema",
+    )
+    parser.add_argument("payload", type=Path, help="Path to the review payload JSON file")
+    parser.add_argument(
+        "--schema",
+        type=Path,
+        default=DEFAULT_SCHEMA,
+        help=f"Path to the JSON schema (default: {DEFAULT_SCHEMA})",
+    )
+    parser.set_defaults(func=run)
+
+
+def run(args: argparse.Namespace) -> None:
+    schema = json.loads(args.schema.read_text())
+    payload = json.loads(args.payload.read_text())
+
+    validator = Draft202012Validator(schema)
+    if errors := sorted(validator.iter_errors(payload), key=lambda e: list(e.absolute_path)):
+        print(f"ERROR: {args.payload} failed schema validation", file=sys.stderr)
+        for err in errors:
+            print(f"  {format_path(list(err.absolute_path))}: {err.message}", file=sys.stderr)
+        sys.exit(1)
+
+    n = len(payload.get("comments", []))
+    print(f"OK: event={payload['event']}, comments={n}")

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -185,6 +185,9 @@ jobs:
             exit 1
           fi
           uv run --frozen --package skills skills validate-review /tmp/review-payload.json
+          echo "::group::Review payload"
+          jq . /tmp/review-payload.json
+          echo "::endgroup::"
 
       - name: Post review
         if: github.event_name == 'issue_comment'
@@ -223,9 +226,7 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: claude-stream-${{ github.run_id }}-${{ github.run_attempt }}
-          path: |
-            /tmp/output.jsonl
-            /tmp/review-payload.json
+          path: /tmp/output.jsonl
           retention-days: 1
           if-no-files-found: ignore
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -159,21 +159,17 @@ jobs:
         run: |
           OUTPUT_FILE="/tmp/output.jsonl"
 
-          # Safe construction using arrays - PROMPT is passed as separate argument to prevent shell injection
-          EXTRA_FLAGS=()
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            # Smoke test: exercise the Bash tool (and gh CLI + app token) so
-            # sandbox or auth regressions surface here.
-            ARGS=("Run \`gh pr view $PR_NUMBER\` and summarize the PR")
-            EXTRA_FLAGS+=("--allowedTools=Bash(gh pr view:*)")
-          else
-            ARGS=("/pr-review")
-            [ -n "$PROMPT" ] && ARGS+=("$PROMPT")
+          # Safe construction using arrays - PROMPT is passed as separate argument to prevent shell injection.
+          # Both event paths run /pr-review end-to-end against the PR; on
+          # pull_request (smoke), Post is gated off so no review is submitted.
+          ARGS=("/pr-review")
+          if [ "$EVENT_NAME" = "issue_comment" ] && [ -n "$PROMPT" ]; then
+            ARGS+=("$PROMPT")
           fi
 
           EXIT_CODE=0
           # Note: ARGS[*] is intentional - claude CLI expects a single prompt string
-          timeout 20m claude --model "$MODEL" --print --verbose --output-format stream-json "${EXTRA_FLAGS[@]}" "${ARGS[*]}" | .claude/scripts/stream.sh "$OUTPUT_FILE" || EXIT_CODE=$?
+          timeout 20m claude --model "$MODEL" --print --verbose --output-format stream-json "${ARGS[*]}" | .claude/scripts/stream.sh "$OUTPUT_FILE" || EXIT_CODE=$?
           if [ "${EXIT_CODE:-0}" -eq 124 ]; then
             echo "Warning: Claude command timed out after 20 minutes"
           elif [ "${EXIT_CODE:-0}" -ne 0 ]; then
@@ -183,7 +179,6 @@ jobs:
           fi
 
       - name: Validate review payload
-        if: github.event_name == 'issue_comment'
         run: |
           if [ ! -f /tmp/review-payload.json ]; then
             echo "::error::Claude did not produce /tmp/review-payload.json"

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -9,7 +9,7 @@ on:
       - ".claude/skills/pr-review/**"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: true
 
 defaults:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -19,8 +19,10 @@ defaults:
 jobs:
   review:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
+    # GITHUB_TOKEN is unused — all GitHub API calls go through the app tokens
+    # minted below. Grant nothing so any future accidental use of GITHUB_TOKEN
+    # fails closed.
+    permissions: {}
     timeout-minutes: 30
     # Security: Only run for authorized users.
     # - pull_request: Only run for non-fork PRs
@@ -42,8 +44,20 @@ jobs:
        startsWith(github.event.comment.body, '/review') &&
        !startsWith(github.event.comment.body, '/review-'))
     steps:
+      # Two app tokens with split scopes:
+      # - app-token-read (read-only): used by the Claude step so prompt-injection
+      #   in a diff can't trigger comments, approvals, or any PR mutation.
+      # - app-token-write (write): used by React/Post/Report (code we control).
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
-        id: app-token
+        id: app-token-read
+        with:
+          client-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: read
+          permission-pull-requests: read
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        if: github.event_name == 'issue_comment'
+        id: app-token-write
         with:
           client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -53,7 +67,7 @@ jobs:
         if: github.event_name == 'issue_comment'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ steps.app-token-write.outputs.token }}
           retries: 3
           script: |
             const { comment } = context.payload;
@@ -85,7 +99,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.app-token-read.outputs.token }}
       - uses: ./.github/actions/setup-python
         with:
           pin-micro-version: false
@@ -135,7 +149,8 @@ jobs:
       - name: Review
         id: review
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          # Read-only token: Claude can fetch PR/diff/comments but cannot post anything.
+          GH_TOKEN: ${{ steps.app-token-read.outputs.token }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           PROMPT: ${{ steps.prompt.outputs.prompt }}
@@ -167,11 +182,30 @@ jobs:
             exit $EXIT_CODE
           fi
 
+      - name: Validate review payload
+        if: github.event_name == 'issue_comment'
+        run: |
+          if [ ! -f /tmp/review-payload.json ]; then
+            echo "::error::Claude did not produce /tmp/review-payload.json"
+            exit 1
+          fi
+          uv run --frozen --package skills skills validate-review /tmp/review-payload.json
+
+      - name: Post review
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ steps.app-token-write.outputs.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          gh api --method POST repos/"$REPO"/pulls/"$PR_NUMBER"/reviews --input /tmp/review-payload.json
+
       - name: Redact secrets from transcript
         if: always()
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN_READ: ${{ steps.app-token-read.outputs.token }}
+          GH_TOKEN_WRITE: ${{ steps.app-token-write.outputs.token }}
         run: |
           python <<'PY'
           import os
@@ -182,7 +216,7 @@ jobs:
           if not path.exists():
               sys.exit(0)
           data = path.read_text()
-          for name in ("ANTHROPIC_API_KEY", "GH_TOKEN"):
+          for name in ("ANTHROPIC_API_KEY", "GH_TOKEN_READ", "GH_TOKEN_WRITE"):
               if val := os.environ.get(name):
                   data = data.replace(val, "***")
           path.write_text(data)
@@ -194,7 +228,9 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: claude-stream-${{ github.run_id }}-${{ github.run_attempt }}
-          path: /tmp/output.jsonl
+          path: |
+            /tmp/output.jsonl
+            /tmp/review-payload.json
           retention-days: 1
           if-no-files-found: ignore
 
@@ -202,7 +238,7 @@ jobs:
         if: github.event_name == 'issue_comment'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ steps.app-token-write.outputs.token }}
           retries: 3
           script: |
             const fs = require('fs');

--- a/uv.lock
+++ b/uv.lock
@@ -8055,6 +8055,7 @@ version = "0.1.0"
 source = { editable = ".claude/skills" }
 dependencies = [
     { name = "aiohttp" },
+    { name = "jsonschema" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
@@ -8062,6 +8063,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp" },
+    { name = "jsonschema" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23084 (Bridge 1/2: the `/review` workflow)

### What changes are proposed in this pull request?

The `/review` workflow no longer hands Claude a write-scoped GitHub token. Instead of having Claude call `add-review-comment` per finding, Claude writes a single `/tmp/review-payload.json` and a trusted workflow step posts it via `POST /pulls/.../reviews`. A prompt injection inside a PR diff can no longer reach a write token, even if it convinces Claude to misbehave.

Key pieces:

- **Two app tokens.** `app-token-read` (read-only) is the only token Claude sees; `app-token-write` is held by the React/Post/Report steps.
- **Schema-validated payload.** `.claude/skills/pr-review/review-payload.schema.json` defines the payload shape; a new `skills validate-review` subcommand checks it before the Post step submits.
- **Path-scoped file write.** The `pr-review` skill now allows `Edit(//tmp/review-payload.json)`. Per Claude Code permissions docs, path-specifier syntax is documented for `Read` and `Edit` rules only — and `Edit` rules cover all built-in tools that edit files (Write, Edit, NotebookEdit). The `//` prefix is the documented form for absolute filesystem paths. Verified end-to-end via the `pull_request` smoke (no `permission_denials`).
- **Job permissions.** Downgraded to `permissions: {}` since GITHUB_TOKEN is no longer used anywhere.

### How is this PR tested?

- [x] Manual tests

Validator smoke-tested locally against a valid payload and a deliberately broken one (catches missing footer, missing severity prefix, APPROVE + CRITICAL finding, invalid `side`, dangling `start_line`, `line < 1`). End-to-end test happens when this PR triggers the updated `/review` workflow against itself.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
