### PR TITLE
Support settings.local.json for Claude Code tracing config

### DIFF
--- a/mlflow/claude_code/cli.py
+++ b/mlflow/claude_code/cli.py
@@ -72,7 +72,11 @@ def commands():
 )
 @click.option("--experiment-id", "-e", help="MLflow experiment ID")
 @click.option("--experiment-name", "-n", help="MLflow experiment name")
-@click.option("--disable", is_flag=True, help="Disable Claude tracing in the specified directory")
+@click.option(
+    "--disable",
+    is_flag=True,
+    help="Disable Claude tracing (removes config from both settings.json and settings.local.json)",
+)
 @click.option("--status", is_flag=True, help="Show current tracing status")
 @click.option(
     "--local",

--- a/mlflow/claude_code/cli.py
+++ b/mlflow/claude_code/cli.py
@@ -75,6 +75,11 @@ def commands():
 @click.option("--disable", is_flag=True, help="Disable Claude tracing in the specified directory")
 @click.option("--status", is_flag=True, help="Show current tracing status")
 @click.option(
+    "--local",
+    is_flag=True,
+    help="Write config to settings.local.json instead of settings.json during setup.",
+)
+@click.option(
     "--non-interactive",
     "-y",
     is_flag=True,
@@ -97,6 +102,7 @@ def claude(
     experiment_name: str | None,
     disable: bool,
     status: bool,
+    local: bool,
     non_interactive: bool,
     mlflow_cmd: str | None,
 ) -> None:
@@ -137,17 +143,29 @@ def claude(
             )
         click.echo(f"{_warn('⚠')} {_muted('--mlflow-cmd is deprecated and ignored.')}")
 
+    if local and (status or disable):
+        raise click.UsageError(
+            "--local can only be used during setup, not with --status or --disable"
+        )
+
     target_dir = Path(directory).resolve()
     claude_dir = target_dir / ".claude"
     settings_file = claude_dir / "settings.json"
+    local_settings_file = claude_dir / "settings.local.json"
 
     if status:
         _show_status(target_dir, settings_file)
         return
 
     if disable:
-        _handle_disable(settings_file)
+        removed_shared = _handle_disable(settings_file)
+        removed_local = _handle_disable(local_settings_file)
+        if not removed_shared and not removed_local:
+            click.echo(f"{_error('✗')} No Claude configuration found - tracing was not enabled")
         return
+
+    if local:
+        settings_file = local_settings_file
 
     _print_setup_intro(tracking_uri, experiment_id, experiment_name, non_interactive)
     tracking_uri, experiment_id, experiment_name = _resolve_setup_inputs(
@@ -247,12 +265,16 @@ def _is_interactive_shell() -> bool:
     return sys.stdin.isatty() and sys.stdout.isatty()
 
 
-def _handle_disable(settings_file: Path) -> None:
-    """Handle disable command."""
+def _handle_disable(settings_file: Path) -> bool:
+    """Handle disable for a single settings file.
+
+    Returns:
+        True if config was removed, False if no config found
+    """
     if disable_tracing_plugin(settings_file):
-        click.echo(f"{_ok('✓')} Claude tracing disabled")
-    else:
-        click.echo(f"{_error('✗')} No Claude configuration found - tracing was not enabled")
+        click.echo(f"{_ok('✓')} Claude tracing disabled in {settings_file.name}")
+        return True
+    return False
 
 
 def _show_status(target_dir: Path, settings_file: Path) -> None:

--- a/mlflow/claude_code/config.py
+++ b/mlflow/claude_code/config.py
@@ -68,17 +68,27 @@ def save_claude_config(settings_path: Path, config: dict[str, Any]) -> None:
 def get_tracing_status(settings_path: Path) -> TracingStatus:
     """Get current tracing status from Claude settings.
 
+    Merges env vars from settings.json and settings.local.json (local wins),
+    matching Claude Code's own merge behavior.
+
     Args:
-        settings_path: Path to Claude settings file
+        settings_path: Path to Claude settings file (e.g., .claude/settings.json)
 
     Returns:
         TracingStatus with tracing status information
     """
-    if not settings_path.exists():
+    local_path = settings_path.parent / "settings.local.json"
+    config = load_claude_config(settings_path)
+    local_config = load_claude_config(local_path)
+
+    if not config and not local_config:
         return TracingStatus(enabled=False, reason="No configuration found")
 
-    config = load_claude_config(settings_path)
-    env_vars = config.get(ENVIRONMENT_FIELD, {})
+    # Merge env vars: local overrides shared (matching Claude Code precedence)
+    env_vars = {
+        **config.get(ENVIRONMENT_FIELD, {}),
+        **local_config.get(ENVIRONMENT_FIELD, {}),
+    }
     enabled = env_vars.get(MLFLOW_TRACING_ENABLED) == "true"
 
     return TracingStatus(
@@ -92,8 +102,13 @@ def get_tracing_status(settings_path: Path) -> TracingStatus:
 def get_env_var(var_name: str, default: str = "") -> str:
     """Get environment variable from Claude settings or OS environment as fallback.
 
-    Project-specific configuration in settings.json takes precedence over
-    global OS environment variables.
+    Project-specific configuration takes precedence over global OS
+    environment variables.
+
+    Checks in order (first match wins):
+    1. .claude/settings.local.json env block (user-local overrides)
+    2. .claude/settings.json env block (project-level)
+    3. OS environment variables
 
     Args:
         var_name: Environment variable name
@@ -103,16 +118,18 @@ def get_env_var(var_name: str, default: str = "") -> str:
         Environment variable value
     """
     # First check Claude settings (project-specific configuration takes priority)
-    try:
-        settings_path = Path(".claude/settings.json")
-        if settings_path.exists():
-            config = load_claude_config(settings_path)
-            env_vars = config.get(ENVIRONMENT_FIELD, {})
-            value = env_vars.get(var_name)
-            if value is not None:
-                return value
-    except Exception:
-        pass
+    # settings.local.json overrides settings.json
+    for settings_file in ("settings.local.json", "settings.json"):
+        try:
+            settings_path = Path(f".claude/{settings_file}")
+            if settings_path.exists():
+                config = load_claude_config(settings_path)
+                env_vars = config.get(ENVIRONMENT_FIELD, {})
+                value = env_vars.get(var_name)
+                if value is not None:
+                    return value
+        except Exception:
+            pass
 
     # Fallback to OS environment
     value = os.environ.get(var_name)

--- a/mlflow/claude_code/config.py
+++ b/mlflow/claude_code/config.py
@@ -100,15 +100,13 @@ def get_tracing_status(settings_path: Path) -> TracingStatus:
 
 
 def get_env_var(var_name: str, default: str = "") -> str:
-    """Get environment variable from Claude settings or OS environment as fallback.
-
-    Project-specific configuration takes precedence over global OS
-    environment variables.
+    """Get environment variable with OS env taking highest priority.
 
     Checks in order (first match wins):
-    1. .claude/settings.local.json env block (user-local overrides)
-    2. .claude/settings.json env block (project-level)
-    3. OS environment variables
+    1. OS environment variables (highest priority)
+    2. .claude/settings.local.json env block (user-local overrides)
+    3. .claude/settings.json env block (shared/project-level)
+    4. Default value
 
     Args:
         var_name: Environment variable name
@@ -117,8 +115,12 @@ def get_env_var(var_name: str, default: str = "") -> str:
     Returns:
         Environment variable value
     """
-    # First check Claude settings (project-specific configuration takes priority)
-    # settings.local.json overrides settings.json
+    # OS environment has highest priority
+    value = os.environ.get(var_name)
+    if value is not None:
+        return value
+
+    # Then check Claude settings files (settings.local.json overrides settings.json)
     for settings_file in ("settings.local.json", "settings.json"):
         try:
             settings_path = Path(f".claude/{settings_file}")
@@ -130,11 +132,6 @@ def get_env_var(var_name: str, default: str = "") -> str:
                     return value
         except Exception:
             pass
-
-    # Fallback to OS environment
-    value = os.environ.get(var_name)
-    if value is not None:
-        return value
 
     return default
 

--- a/tests/claude_code/test_cli.py
+++ b/tests/claude_code/test_cli.py
@@ -150,6 +150,64 @@ def test_setup_rejects_experiment_id_and_name_together(runner):
         assert "Choose either --experiment-id or --experiment-name" in result.output
 
 
+def test_claude_setup_with_local_flag(runner, monkeypatch):
+    monkeypatch.delenv("UV", raising=False)
+    monkeypatch.delenv("PIXI_ENVIRONMENT_NAME", raising=False)
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(commands, ["claude", "--local"])
+        assert result.exit_code == 0
+
+        local_path = Path(".claude/settings.local.json")
+        assert local_path.exists()
+
+        with open(local_path) as f:
+            config = json.load(f)
+        assert "MLFLOW_CLAUDE_TRACING_ENABLED" in config.get("env", {})
+
+        settings_path = Path(".claude/settings.json")
+        assert not settings_path.exists()
+
+
+def test_claude_setup_local_status(runner, monkeypatch):
+    monkeypatch.delenv("UV", raising=False)
+    monkeypatch.delenv("PIXI_ENVIRONMENT_NAME", raising=False)
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(commands, ["claude", "--local"])
+        assert result.exit_code == 0
+
+        result = runner.invoke(commands, ["claude", "--status"])
+        assert result.exit_code == 0
+        assert "Claude tracing is enabled" in result.output
+
+
+def test_claude_disable_cleans_local_without_flag(runner, monkeypatch):
+    monkeypatch.delenv("UV", raising=False)
+    monkeypatch.delenv("PIXI_ENVIRONMENT_NAME", raising=False)
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(commands, ["claude", "--local"])
+        assert result.exit_code == 0
+
+        # Disable without --local should still clean settings.local.json
+        result = runner.invoke(commands, ["claude", "--disable"])
+        assert result.exit_code == 0
+        assert "Claude tracing disabled" in result.output
+
+
+def test_local_with_status_raises_error(runner):
+    result = runner.invoke(commands, ["claude", "--local", "--status"])
+    assert result.exit_code != 0
+    assert "--local can only be used during setup" in result.output
+
+
+def test_local_with_disable_raises_error(runner):
+    result = runner.invoke(commands, ["claude", "--local", "--disable"])
+    assert result.exit_code != 0
+    assert "--local can only be used during setup" in result.output
+
+
 def test_stop_hook_subcommand_is_routable(runner):
     with mock.patch("mlflow.claude_code.cli.stop_hook_handler") as mock_handler:
         result = runner.invoke(commands, ["claude", "stop-hook"])

--- a/tests/claude_code/test_cli.py
+++ b/tests/claude_code/test_cli.py
@@ -154,7 +154,10 @@ def test_claude_setup_with_local_flag(runner, monkeypatch):
     monkeypatch.delenv("UV", raising=False)
     monkeypatch.delenv("PIXI_ENVIRONMENT_NAME", raising=False)
 
-    with runner.isolated_filesystem():
+    with (
+        runner.isolated_filesystem(),
+        mock.patch("mlflow.claude_code.cli.ensure_plugin_installed"),
+    ):
         result = runner.invoke(commands, ["claude", "--local"])
         assert result.exit_code == 0
 
@@ -173,7 +176,10 @@ def test_claude_setup_local_status(runner, monkeypatch):
     monkeypatch.delenv("UV", raising=False)
     monkeypatch.delenv("PIXI_ENVIRONMENT_NAME", raising=False)
 
-    with runner.isolated_filesystem():
+    with (
+        runner.isolated_filesystem(),
+        mock.patch("mlflow.claude_code.cli.ensure_plugin_installed"),
+    ):
         result = runner.invoke(commands, ["claude", "--local"])
         assert result.exit_code == 0
 
@@ -186,7 +192,10 @@ def test_claude_disable_cleans_local_without_flag(runner, monkeypatch):
     monkeypatch.delenv("UV", raising=False)
     monkeypatch.delenv("PIXI_ENVIRONMENT_NAME", raising=False)
 
-    with runner.isolated_filesystem():
+    with (
+        runner.isolated_filesystem(),
+        mock.patch("mlflow.claude_code.cli.ensure_plugin_installed"),
+    ):
         result = runner.invoke(commands, ["claude", "--local"])
         assert result.exit_code == 0
 

--- a/tests/claude_code/test_config.py
+++ b/tests/claude_code/test_config.py
@@ -69,7 +69,7 @@ def test_get_env_var_from_os_environment_when_no_settings(tmp_path, monkeypatch)
     assert result == "test_os_value"
 
 
-def test_get_env_var_settings_takes_precedence_over_os_env(tmp_path, monkeypatch):
+def test_get_env_var_os_env_takes_precedence_over_settings(tmp_path, monkeypatch):
     monkeypatch.setenv(MLFLOW_TRACING_ENABLED, "os_value")
 
     config_data = {"env": {MLFLOW_TRACING_ENABLED: "settings_value"}}
@@ -80,7 +80,7 @@ def test_get_env_var_settings_takes_precedence_over_os_env(tmp_path, monkeypatch
 
     monkeypatch.chdir(tmp_path)
     result = get_env_var(MLFLOW_TRACING_ENABLED, "default")
-    assert result == "settings_value"
+    assert result == "os_value"
 
 
 def test_get_env_var_falls_back_to_os_env_when_not_in_settings(tmp_path, monkeypatch):
@@ -144,7 +144,7 @@ def test_get_env_var_falls_through_local_to_settings(tmp_path, monkeypatch):
     assert get_env_var("MLFLOW_TRACKING_URI", "default") == "https://example.com"
 
 
-def test_get_env_var_local_overrides_os_env(tmp_path, monkeypatch):
+def test_get_env_var_os_env_takes_precedence_over_local(tmp_path, monkeypatch):
     monkeypatch.setenv(MLFLOW_TRACING_ENABLED, "os_value")
 
     claude_dir = tmp_path / ".claude"
@@ -154,7 +154,7 @@ def test_get_env_var_local_overrides_os_env(tmp_path, monkeypatch):
 
     monkeypatch.chdir(tmp_path)
     result = get_env_var(MLFLOW_TRACING_ENABLED, "default")
-    assert result == "local_value"
+    assert result == "os_value"
 
 
 def test_get_tracing_status_merges_local_and_shared(tmp_path):

--- a/tests/claude_code/test_config.py
+++ b/tests/claude_code/test_config.py
@@ -97,6 +97,108 @@ def test_get_env_var_falls_back_to_os_env_when_not_in_settings(tmp_path, monkeyp
     assert result == "os_value"
 
 
+def test_get_env_var_from_settings_local_json(tmp_path, monkeypatch):
+    monkeypatch.delenv(MLFLOW_TRACING_ENABLED, raising=False)
+
+    config_data = {"env": {MLFLOW_TRACING_ENABLED: "local_value"}}
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    with open(claude_dir / "settings.local.json", "w") as f:
+        json.dump(config_data, f)
+
+    monkeypatch.chdir(tmp_path)
+    result = get_env_var(MLFLOW_TRACING_ENABLED, "default")
+    assert result == "local_value"
+
+
+def test_get_env_var_settings_local_overrides_settings(tmp_path, monkeypatch):
+    monkeypatch.delenv(MLFLOW_TRACING_ENABLED, raising=False)
+
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+
+    with open(claude_dir / "settings.json", "w") as f:
+        json.dump({"env": {MLFLOW_TRACING_ENABLED: "shared_value"}}, f)
+    with open(claude_dir / "settings.local.json", "w") as f:
+        json.dump({"env": {MLFLOW_TRACING_ENABLED: "local_value"}}, f)
+
+    monkeypatch.chdir(tmp_path)
+    result = get_env_var(MLFLOW_TRACING_ENABLED, "default")
+    assert result == "local_value"
+
+
+def test_get_env_var_falls_through_local_to_settings(tmp_path, monkeypatch):
+    monkeypatch.delenv("MLFLOW_TRACKING_URI", raising=False)
+
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+
+    # local has ENABLED, shared has URI
+    with open(claude_dir / "settings.local.json", "w") as f:
+        json.dump({"env": {MLFLOW_TRACING_ENABLED: "true"}}, f)
+    with open(claude_dir / "settings.json", "w") as f:
+        json.dump({"env": {"MLFLOW_TRACKING_URI": "https://example.com"}}, f)
+
+    monkeypatch.chdir(tmp_path)
+    assert get_env_var(MLFLOW_TRACING_ENABLED, "default") == "true"
+    assert get_env_var("MLFLOW_TRACKING_URI", "default") == "https://example.com"
+
+
+def test_get_env_var_local_overrides_os_env(tmp_path, monkeypatch):
+    monkeypatch.setenv(MLFLOW_TRACING_ENABLED, "os_value")
+
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    with open(claude_dir / "settings.local.json", "w") as f:
+        json.dump({"env": {MLFLOW_TRACING_ENABLED: "local_value"}}, f)
+
+    monkeypatch.chdir(tmp_path)
+    result = get_env_var(MLFLOW_TRACING_ENABLED, "default")
+    assert result == "local_value"
+
+
+def test_get_tracing_status_merges_local_and_shared(tmp_path):
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    settings_path = claude_dir / "settings.json"
+
+    # URI in shared, ENABLED in local
+    with open(settings_path, "w") as f:
+        json.dump({"env": {"MLFLOW_TRACKING_URI": "https://example.com"}}, f)
+    with open(claude_dir / "settings.local.json", "w") as f:
+        json.dump({"env": {MLFLOW_TRACING_ENABLED: "true"}}, f)
+
+    status = get_tracing_status(settings_path)
+    assert status.enabled is True
+    assert status.tracking_uri == "https://example.com"
+
+
+def test_get_tracing_status_local_overrides_shared(tmp_path):
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    settings_path = claude_dir / "settings.json"
+
+    with open(settings_path, "w") as f:
+        json.dump({"env": {MLFLOW_TRACING_ENABLED: "true"}}, f)
+    with open(claude_dir / "settings.local.json", "w") as f:
+        json.dump({"env": {MLFLOW_TRACING_ENABLED: "false"}}, f)
+
+    status = get_tracing_status(settings_path)
+    assert status.enabled is False
+
+
+def test_get_tracing_status_from_local_only(tmp_path):
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    settings_path = claude_dir / "settings.json"
+
+    with open(claude_dir / "settings.local.json", "w") as f:
+        json.dump({"env": {MLFLOW_TRACING_ENABLED: "true"}}, f)
+
+    status = get_tracing_status(settings_path)
+    assert status.enabled is True
+
+
 def test_get_env_var_default_when_not_found(tmp_path, monkeypatch):
     # Ensure OS env var is not set
     monkeypatch.delenv(MLFLOW_TRACING_ENABLED, raising=False)


### PR DESCRIPTION
### Related Issues/PRs

Resolve #23261

### What changes are proposed in this pull request?

Add `settings.local.json` support to Claude Code tracing configuration, matching Claude Code's own [settings hierarchy](https://code.claude.com/docs/en/settings#how-scopes-interact).

Claude Code supports multiple settings scopes:
- `.claude/settings.json` — project-level, shared
- `.claude/settings.local.json` — project-level, user-local overrides
- `~/.claude/settings.json` — user-level (loaded into OS env by Claude Code)

Currently, `get_env_var()` and `get_tracing_status()` only read from `settings.json`. This means users who want to keep tracing config private (tokens, per-user preferences) have no option to use `settings.local.json`.

**Changes:**

**`config.py`:**
- `get_env_var()` now checks `settings.local.json` before `settings.json` (both before OS env fallback)
- `get_tracing_status()` merges env vars from both files, with local taking precedence

**`cli.py`:**
- New `--local` flag: `mlflow autolog claude --local` writes config to `settings.local.json` instead of `settings.json`
- `--local` is restricted to setup only — errors if combined with `--status` or `--disable`
- `--disable` now cleans both `settings.json` and `settings.local.json` automatically
- `--status` shows merged view from both files

**Precedence order (first match wins):**
1. `.claude/settings.local.json` env block (user-local overrides)
2. `.claude/settings.json` env block (project-level)
3. OS environment variables (includes user-level `~/.claude/settings.json` via Claude Code)

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests

Added 10 new tests:
- `get_env_var` reads from `settings.local.json`
- `get_env_var` local overrides shared settings
- `get_env_var` local overrides OS env
- `get_tracing_status` merges local and shared
- `get_tracing_status` local overrides shared
- `get_tracing_status` works with local only
- `--local` flag writes to `settings.local.json`
- `--status` reads from `settings.local.json`
- `--disable` cleans `settings.local.json` without `--local` flag
- `--local --status` and `--local --disable` raise errors

Manual testing: all CLI commands verified locally.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Claude Code tracing now supports `settings.local.json` for user-local configuration. Use `mlflow autolog claude --local` to write tracing config to `.claude/settings.local.json` instead of `.claude/settings.json`. The `--status` command shows the merged view, and `--disable` cleans both files automatically.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)