### PR TITLE
Default `/review` to `claude-opus-4-6` and add `-e/--effort` flag

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -122,7 +122,7 @@ jobs:
           import secrets
           import sys
 
-          CHOICES = [
+          MODEL_CHOICES = [
               "opus",
               "sonnet",
               "haiku",
@@ -130,18 +130,22 @@ jobs:
               "claude-sonnet-4-6",
               "claude-haiku-4-5",
           ]
+          EFFORT_CHOICES = ["low", "medium", "high", "xhigh", "max"]
 
           body = sys.stdin.read().removeprefix("/review")
           head, sep, tail = body.partition("\n")
 
           parser = argparse.ArgumentParser(add_help=False)
-          parser.add_argument("-m", "--model", choices=CHOICES, default="opus")
+          parser.add_argument("-m", "--model", choices=MODEL_CHOICES, default="claude-opus-4-6")
+          parser.add_argument("-e", "--effort", choices=EFFORT_CHOICES, default="medium")
           args, leftover = parser.parse_known_args(head.split())
 
           prompt = " ".join(leftover) + sep + tail
           # Random delimiter so user input can't terminate the heredoc.
           delim = f"PROMPT_EOF_{secrets.token_hex(8)}"
-          sys.stdout.write(f"prompt<<{delim}\n{prompt}\n{delim}\nmodel={args.model}\n")
+          sys.stdout.write(
+              f"prompt<<{delim}\n{prompt}\n{delim}\nmodel={args.model}\neffort={args.effort}\n"
+          )
           EOF
 
           echo "$COMMENT_BODY" | python /tmp/parse_args.py >> "$GITHUB_OUTPUT"
@@ -154,7 +158,8 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           PROMPT: ${{ steps.prompt.outputs.prompt }}
-          MODEL: ${{ steps.prompt.outputs.model || 'opus' }}
+          MODEL: ${{ steps.prompt.outputs.model || 'claude-opus-4-6' }}
+          EFFORT: ${{ steps.prompt.outputs.effort || 'medium' }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
           OUTPUT_FILE="/tmp/output.jsonl"
@@ -169,7 +174,14 @@ jobs:
 
           EXIT_CODE=0
           # Note: ARGS[*] is intentional - claude CLI expects a single prompt string
-          timeout 20m claude --model "$MODEL" --print --verbose --output-format stream-json "${ARGS[*]}" | .claude/scripts/stream.sh "$OUTPUT_FILE" || EXIT_CODE=$?
+          timeout 20m claude \
+            --model "$MODEL" \
+            --effort "$EFFORT" \
+            --print \
+            --verbose \
+            --output-format stream-json \
+            "${ARGS[*]}" \
+            | .claude/scripts/stream.sh "$OUTPUT_FILE" || EXIT_CODE=$?
           if [ "${EXIT_CODE:-0}" -eq 124 ]; then
             echo "Warning: Claude command timed out after 20 minutes"
           elif [ "${EXIT_CODE:-0}" -ne 0 ]; then


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23283

### What changes are proposed in this pull request?

Two changes to the `/review` GitHub Actions workflow (`.github/workflows/review.yml`):

1. **Default model pinned to `claude-opus-4-6`** — instead of the floating `opus` alias, which currently resolves to Opus 4.7. Opus 4.7 with high thinking budget is too expensive for the default review pass; reviewers can still opt in per comment via `/review -m opus`.
2. **New `-e/--effort` flag** with default `medium`. Lets reviewers experiment with thinking budget per comment, e.g. `/review -e high`, `/review -m haiku -e low`. Choices match the Claude CLI: `low`, `medium`, `high`, `xhigh`, `max`.

The argparse defaults are mirrored in the env-var fallbacks (`MODEL`, `EFFORT`) so the `pull_request` smoke path (which doesn't run the parser) uses the same values.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Triggered `/review`, `/review -m sonnet`, and `/review -m haiku` on this PR to exercise both default and override paths.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release