### PR TITLE
Add `skills` pre-commit hook to validate `SKILL.md` frontmatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -293,3 +293,11 @@ repos:
         language: fail
         entry: "Filenames must not contain spaces"
         files: " "
+
+      - id: skills
+        name: skills
+        entry: uv run --frozen --only-group lint dev/check_skills.py
+        language: system
+        files: '(^|/)SKILL\.md$'
+        stages: [pre-commit]
+        require_serial: true

--- a/dev/check_skills.py
+++ b/dev/check_skills.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+
+import yaml
+
+REQUIRED = ("name", "description")
+
+
+def parse_frontmatter(text: str) -> dict[str, object] | None:
+    if not text.startswith("---\n"):
+        return None
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return None
+    data = yaml.safe_load(text[4:end])
+    return data if isinstance(data, dict) else None
+
+
+def check(path: Path) -> list[str]:
+    if (fm := parse_frontmatter(path.read_text(encoding="utf-8"))) is None:
+        return ["missing YAML frontmatter"]
+    return [f"missing or empty `{k}`" for k in REQUIRED if not fm.get(k)]
+
+
+def main(argv: list[str]) -> int:
+    failed = 0
+    for arg in argv:
+        if errors := check(Path(arg)):
+            failed += 1
+            for err in errors:
+                print(f"{arg}: {err}")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/dev/check_skills.py
+++ b/dev/check_skills.py
@@ -17,19 +17,19 @@ def parse_frontmatter(text: str) -> dict[str, object] | None:
 
 
 def check(path: Path) -> list[str]:
-    if (fm := parse_frontmatter(path.read_text(encoding="utf-8"))) is None:
+    fm = parse_frontmatter(path.read_text(encoding="utf-8"))
+    if fm is None:
         return ["missing YAML frontmatter"]
     return [f"missing or empty `{k}`" for k in REQUIRED if not fm.get(k)]
 
 
 def main(argv: list[str]) -> int:
-    failed = 0
+    any_failed = False
     for arg in argv:
-        if errors := check(Path(arg)):
-            failed += 1
-            for err in errors:
-                print(f"{arg}: {err}", file=sys.stderr)
-    return 1 if failed else 0
+        for err in check(Path(arg)):
+            print(f"{arg}: {err}", file=sys.stderr)
+            any_failed = True
+    return 1 if any_failed else 0
 
 
 if __name__ == "__main__":

--- a/dev/check_skills.py
+++ b/dev/check_skills.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import yaml
 
+# https://agentskills.io/specification#frontmatter
 REQUIRED = ("name", "description")
 
 

--- a/dev/check_skills.py
+++ b/dev/check_skills.py
@@ -1,3 +1,4 @@
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -5,7 +6,9 @@ from typing import Any
 import yaml
 
 # https://agentskills.io/specification#frontmatter
-REQUIRED = ("name", "description")
+NAME_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+NAME_MAX = 64
+DESCRIPTION_MAX = 1024
 
 
 def parse_frontmatter(text: str) -> dict[str, Any] | None:
@@ -18,11 +21,35 @@ def parse_frontmatter(text: str) -> dict[str, Any] | None:
     return data if isinstance(data, dict) else None
 
 
+def validate_name(name: Any, parent: str) -> list[str]:
+    if not name:
+        return ["missing or empty `name`"]
+    if not isinstance(name, str) or not NAME_RE.fullmatch(name) or len(name) > NAME_MAX:
+        return [
+            f"invalid `name`: must be 1-{NAME_MAX} lowercase alphanumeric/hyphen chars, "
+            "no leading/trailing or consecutive hyphens"
+        ]
+    if name != parent:
+        return [f"`name` {name!r} does not match parent directory {parent!r}"]
+    return []
+
+
+def validate_description(description: Any) -> list[str]:
+    if not description:
+        return ["missing or empty `description`"]
+    if not isinstance(description, str) or len(description) > DESCRIPTION_MAX:
+        return [f"invalid `description`: must be 1-{DESCRIPTION_MAX} characters"]
+    return []
+
+
 def check(path: Path) -> list[str]:
     fm = parse_frontmatter(path.read_text(encoding="utf-8"))
     if fm is None:
         return ["missing frontmatter"]
-    return [f"missing or empty `{k}`" for k in REQUIRED if not fm.get(k)]
+    return [
+        *validate_name(fm.get("name"), path.parent.name),
+        *validate_description(fm.get("description")),
+    ]
 
 
 def main(argv: list[str]) -> bool:

--- a/dev/check_skills.py
+++ b/dev/check_skills.py
@@ -19,7 +19,7 @@ def parse_frontmatter(text: str) -> dict[str, object] | None:
 def check(path: Path) -> list[str]:
     fm = parse_frontmatter(path.read_text(encoding="utf-8"))
     if fm is None:
-        return ["missing YAML frontmatter"]
+        return ["missing frontmatter"]
     return [f"missing or empty `{k}`" for k in REQUIRED if not fm.get(k)]
 
 

--- a/dev/check_skills.py
+++ b/dev/check_skills.py
@@ -1,12 +1,13 @@
 import sys
 from pathlib import Path
+from typing import Any
 
 import yaml
 
 REQUIRED = ("name", "description")
 
 
-def parse_frontmatter(text: str) -> dict[str, object] | None:
+def parse_frontmatter(text: str) -> dict[str, Any] | None:
     if not text.startswith("---\n"):
         return None
     end = text.find("\n---\n", 4)

--- a/dev/check_skills.py
+++ b/dev/check_skills.py
@@ -28,7 +28,7 @@ def main(argv: list[str]) -> int:
         if errors := check(Path(arg)):
             failed += 1
             for err in errors:
-                print(f"{arg}: {err}")
+                print(f"{arg}: {err}", file=sys.stderr)
     return 1 if failed else 0
 
 

--- a/dev/check_skills.py
+++ b/dev/check_skills.py
@@ -12,7 +12,7 @@ def parse_frontmatter(text: str) -> dict[str, object] | None:
     end = text.find("\n---\n", 4)
     if end == -1:
         return None
-    data = yaml.safe_load(text[4:end])
+    data = yaml.safe_load(text[4:end]) or {}
     return data if isinstance(data, dict) else None
 
 

--- a/dev/check_skills.py
+++ b/dev/check_skills.py
@@ -23,13 +23,13 @@ def check(path: Path) -> list[str]:
     return [f"missing or empty `{k}`" for k in REQUIRED if not fm.get(k)]
 
 
-def main(argv: list[str]) -> int:
-    any_failed = False
+def main(argv: list[str]) -> bool:
+    failed = False
     for arg in argv:
         for err in check(Path(arg)):
             print(f"{arg}: {err}", file=sys.stderr)
-            any_failed = True
-    return 1 if any_failed else 0
+            failed = True
+    return failed
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

Adds `dev/check_skills.py` and a `skills` pre-commit hook that validates `SKILL.md` frontmatter against the [Agent Skills spec](https://agentskills.io/specification#frontmatter):

- `name`: required, 1-64 chars, lowercase alphanumeric/hyphen (no leading/trailing or consecutive hyphens), must match parent directory name.
- `description`: required, 1-1024 chars.

The hook is scoped to files matching `(^|/)SKILL\.md$`, so it only runs on the small set of skill files in the repo.

### How is this PR tested?

- [x] Manual tests

Ran the hook against all `.claude/skills/*/SKILL.md` files in the repo (passes), and against synthetic `SKILL.md` files that violate each constraint (missing `description`, invalid `name`, `name` mismatched with parent directory) — each case fails with a targeted error.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release