### PR TITLE
[Security] Add MLFLOW_ALLOW_PICKLE_DESERIALIZATION guard to LangChain _load_from_pickle

### DIFF
--- a/mlflow/langchain/utils/logging.py
+++ b/mlflow/langchain/utils/logging.py
@@ -16,6 +16,8 @@ import yaml
 from packaging.version import Version
 
 import mlflow
+from mlflow.environment_variables import MLFLOW_ALLOW_PICKLE_DESERIALIZATION
+from mlflow.exceptions import MlflowException
 from mlflow.models.utils import _validate_and_get_model_code_path
 from mlflow.utils.class_utils import _get_class_from_string
 
@@ -448,6 +450,12 @@ def _save_base_lcs(model, path, loader_fn=None, persist_dir=None):
 
 
 def _load_from_pickle(path):
+    if not MLFLOW_ALLOW_PICKLE_DESERIALIZATION.get():
+        raise MlflowException(
+            "Deserializing LangChain artifacts using pickle is disallowed. "
+            "To allow loading, set environment variable "
+            "'MLFLOW_ALLOW_PICKLE_DESERIALIZATION' to 'true'."
+        )
     with open(path, "rb") as f:
         return cloudpickle.load(f)
 

--- a/tests/langchain/test_logging_utils.py
+++ b/tests/langchain/test_logging_utils.py
@@ -1,0 +1,24 @@
+import cloudpickle
+import pytest
+
+from mlflow.exceptions import MlflowException
+from mlflow.langchain.utils.logging import _load_from_pickle
+
+
+def test_load_from_pickle_disallows_pickle_deserialization(tmp_path, monkeypatch):
+    path = tmp_path / "obj.pkl"
+    with open(path, "wb") as f:
+        cloudpickle.dump({"key": "value"}, f)
+
+    monkeypatch.setenv("MLFLOW_ALLOW_PICKLE_DESERIALIZATION", "false")
+    with pytest.raises(MlflowException, match="MLFLOW_ALLOW_PICKLE_DESERIALIZATION"):
+        _load_from_pickle(path)
+
+
+def test_load_from_pickle_allows_pickle_deserialization(tmp_path, monkeypatch):
+    path = tmp_path / "obj.pkl"
+    with open(path, "wb") as f:
+        cloudpickle.dump({"key": "value"}, f)
+
+    monkeypatch.setenv("MLFLOW_ALLOW_PICKLE_DESERIALIZATION", "true")
+    assert _load_from_pickle(path) == {"key": "value"}


### PR DESCRIPTION
### Related Issues/PRs

Relates to `GHSA-cxjq-35gw-4m9f`

### What changes are proposed in this pull request?

Adds the `MLFLOW_ALLOW_PICKLE_DESERIALIZATION` env-var guard to `_load_from_pickle` in `mlflow/langchain/utils/logging.py`, which previously called `cloudpickle.load` directly without consulting the env var. Putting the check inside the helper covers all call sites with a single fix: `runnables.py:105,526` and `logging.py:529,570`. The existing guard in `mlflow/langchain/model.py:903` sits on a different code path and does not cover these call sites. This continues the rollout that started with PR #18759 and most recently #23183 (which added the guard to `PickleEvaluationArtifact`).

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

The env var default is unchanged during the grace period; only users who explicitly set `MLFLOW_ALLOW_PICKLE_DESERIALIZATION=false` are affected.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

---

Reported by @Carrtik via GitHub Security Advisory GHSA-cxjq-35gw-4m9f.