### PR TITLE
[Security] Remove dead cloudpickle.load fallback in job subprocess entry

### DIFF
--- a/mlflow/server/jobs/_job_subproc_entry.py
+++ b/mlflow/server/jobs/_job_subproc_entry.py
@@ -14,8 +14,6 @@ import threading
 import traceback
 from contextlib import nullcontext
 
-import cloudpickle
-
 from mlflow.environment_variables import MLFLOW_WORKSPACE
 from mlflow.server.jobs.logging_utils import configure_logging_for_jobs
 from mlflow.server.jobs.progress import JobTracker, _set_job_tracker
@@ -63,21 +61,15 @@ def _main():
         _set_job_tracker(JobTracker(job_id))
 
     transient_error_classes = []
-    try:
-        with open(transient_error_classes_path, "rb") as f:
-            transient_error_classes = cloudpickle.load(f)
-        if transient_error_classes is None:
-            transient_error_classes = []
-    except Exception:
-        with open(transient_error_classes_path) as f:
-            content = f.read()
+    with open(transient_error_classes_path) as f:
+        content = f.read()
 
-        for cls_str in content.split("\n"):
-            if not cls_str:
-                continue
-            *module_parts, cls_name = cls_str.split(".")
-            module = importlib.import_module(".".join(module_parts))
-            transient_error_classes.append(getattr(module, cls_name))
+    for cls_str in content.split("\n"):
+        if not cls_str:
+            continue
+        *module_parts, cls_name = cls_str.split(".")
+        module = importlib.import_module(".".join(module_parts))
+        transient_error_classes.append(getattr(module, cls_name))
 
     try:
         with ctx:


### PR DESCRIPTION
### Related Issues/PRs

Relates to `GHSA-35fm-7435-2hhh` (private advisory, reference by ID only).

### What changes are proposed in this pull request?

The job subprocess writer at `mlflow/server/jobs/utils.py:233-235` emits `transient_error_classes` as plain text (`f"{cls.__module__}.{cls.__name__}\n"`), not pickle (https://github.com/mlflow/mlflow/blob/58895f77b7f24f6cc5d4722377e7327d796ca770/mlflow/server/jobs/utils.py#L234-L236). The reader in `mlflow/server/jobs/_job_subproc_entry.py` previously tried `cloudpickle.load` first and fell back to text parsing on exception, but because the writer never produces pickle bytes the cloudpickle branch is dead code unreachable via the public API. This PR removes that dead `cloudpickle.load` path (and its now-unused import) so the reader uses the text parser directly, aligning it with the writer's actual format. As defense in depth this also eliminates a theoretical local-filesystem attack vector where a process with write access to the server's tmp directory could plant pickle bytes that would be deserialized.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

Verified locally with `uv run pytest tests/server/jobs/ -v` (all 76 tests pass).

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

---

Reported by @jeongbeannnn via GitHub Security Advisory GHSA-35fm-7435-2hhh.