### PR TITLE
Support filtering/grouping runs using git metadata recorded as run. tags.

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/EntitySearchAutoComplete.utils.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/EntitySearchAutoComplete.utils.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test } from '@jest/globals';
-import { getFilteredOptionsFromEntityName } from './EntitySearchAutoComplete.utils';
+import { cleanEntitySearchTagNames, getFilteredOptionsFromEntityName } from './EntitySearchAutoComplete.utils';
 import type {
   EntitySearchAutoCompleteEntity,
   EntitySearchAutoCompleteOptionGroup,
@@ -16,6 +16,25 @@ describe('EntitySearchAutoComplete utils', () => {
   const suggestionLimits = {
     Metrics: 10,
   };
+
+  describe('cleanEntitySearchTagNames', () => {
+    test('hides internal mlflow.* tags by default', () => {
+      expect(
+        cleanEntitySearchTagNames(['mlflow.runName', 'mlflow.user', 'mlflow.note.content', 'my_user_tag']),
+      ).toEqual(['my_user_tag']);
+    });
+
+    test('exposes git source tags as searchable internal tags', () => {
+      expect(
+        cleanEntitySearchTagNames([
+          'mlflow.source.git.commit',
+          'mlflow.source.git.branch',
+          'mlflow.source.git.repoURL',
+          'mlflow.runName',
+        ]),
+      ).toEqual(['`mlflow.source.git.commit`', '`mlflow.source.git.branch`', '`mlflow.source.git.repoURL`']);
+    });
+  });
 
   test('getFilteredOptionsFromEntityName handles single open parenthesis without crashing', () => {
     const entityBeingEdited: EntitySearchAutoCompleteEntity = {

--- a/mlflow/server/js/src/experiment-tracking/components/EntitySearchAutoComplete.utils.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/EntitySearchAutoComplete.utils.tsx
@@ -6,6 +6,12 @@ import { sanitizeStringForRegexp } from '../../common/utils/StringUtils';
 export type EntitySearchAutoCompleteOption = {
   label?: string | React.ReactNode;
   value: string;
+  /**
+   * Optional extra text to match against when filtering. Use for options whose user-visible label
+   * differs from the underlying `value` and where the label should also be searchable (e.g. the
+   * friendly "commit" / "branch" labels for git source tags whose values are technical paths).
+   */
+  searchText?: string;
 };
 
 export type EntitySearchAutoCompleteOptionGroup = {
@@ -142,13 +148,20 @@ export const getFilteredOptionsFromEntityName = (
   entityBeingEdited: EntitySearchAutoCompleteEntity,
   suggestionLimits: Record<string, number>,
 ): EntitySearchAutoCompleteOptionGroup[] => {
+  const needle = entityBeingEdited.name.toLowerCase().trim();
   return baseOptions
     .map((group) => {
       const newOptions = group.options
-        .filter((option) => option.value.toLowerCase().includes(entityBeingEdited.name.toLowerCase().trim()))
+        .filter(
+          (option) =>
+            option.value.toLowerCase().includes(needle) ||
+            (option.searchText !== undefined && option.searchText.toLowerCase().includes(needle)),
+        )
         .map((match) => ({
           value: match.value,
-          label: boldedText(match.value, entityBeingEdited.name.trim()),
+          // Preserve an explicit label if one was set on the option (e.g. a friendly label for
+          // git source tags). Otherwise fall back to the auto-bolded value.
+          label: match.label ?? boldedText(match.value, entityBeingEdited.name.trim()),
         }));
       const limitForGroup = suggestionLimits[group.label];
       const ellipsized = [

--- a/mlflow/server/js/src/experiment-tracking/components/EntitySearchAutoComplete.utils.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/EntitySearchAutoComplete.utils.tsx
@@ -47,11 +47,22 @@ const getClausesAndStartIndex = (str: string) => {
 };
 
 /**
- * Filters out internal tag names and wrap names that include control characters in backticks.
+ * Internal mlflow.* tags that are useful enough as filter dimensions to surface in autocomplete
+ * alongside user-defined tags. Keep this list narrow.
+ */
+const SEARCHABLE_INTERNAL_TAGS = new Set<string>([
+  'mlflow.source.git.commit',
+  'mlflow.source.git.branch',
+  'mlflow.source.git.repoURL',
+]);
+
+/**
+ * Filters out internal tag names (except for a small allowlist) and wraps names that include
+ * control characters in backticks.
  */
 export const cleanEntitySearchTagNames = (tagNames: string[]) =>
   tagNames
-    .filter((tag: string) => !tag.startsWith(MLFLOW_INTERNAL_PREFIX))
+    .filter((tag: string) => !tag.startsWith(MLFLOW_INTERNAL_PREFIX) || SEARCHABLE_INTERNAL_TAGS.has(tag))
     .map((tag: string) => {
       if (tag.includes('"') || tag.includes(' ') || tag.includes('.')) {
         return `\`${tag}\``;

--- a/mlflow/server/js/src/experiment-tracking/components/EntitySearchAutoComplete.utils.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/EntitySearchAutoComplete.utils.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { shouldEnableMinMaxMetricsOnExperimentPage } from '../../common/utils/FeatureUtils';
 import { MLFLOW_INTERNAL_PREFIX } from '../../common/utils/TagUtils';
 import { sanitizeStringForRegexp } from '../../common/utils/StringUtils';
+import { GIT_SOURCE_TAG_KEYS } from '../utils/gitSourceTags';
 
 export type EntitySearchAutoCompleteOption = {
   label?: string | React.ReactNode;
@@ -56,11 +57,7 @@ const getClausesAndStartIndex = (str: string) => {
  * Internal mlflow.* tags that are useful enough as filter dimensions to surface in autocomplete
  * alongside user-defined tags. Keep this list narrow.
  */
-const SEARCHABLE_INTERNAL_TAGS = new Set<string>([
-  'mlflow.source.git.commit',
-  'mlflow.source.git.branch',
-  'mlflow.source.git.repoURL',
-]);
+const SEARCHABLE_INTERNAL_TAGS = new Set<string>([...GIT_SOURCE_TAG_KEYS]);
 
 /**
  * Filters out internal tag names (except for a small allowlist) and wraps names that include

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/RunsSearchAutoComplete.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/RunsSearchAutoComplete.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useRef } from 'react';
-import { defineMessage, useIntl } from 'react-intl';
-import type { MessageDescriptor } from 'react-intl';
+import { useIntl } from 'react-intl';
 import type { ErrorWrapper } from '../../../../../common/utils/ErrorWrapper';
 import { EntitySearchAutoComplete } from '../../../EntitySearchAutoComplete';
 import type { ExperimentRunsSelectorResult } from '../../utils/experimentRuns.selector';
@@ -11,6 +10,7 @@ import type {
 } from '../../../EntitySearchAutoComplete.utils';
 import { cleanEntitySearchTagNames } from '../../../EntitySearchAutoComplete.utils';
 import { shouldUseRegexpBasedAutoRunsSearchFilter } from '../../../../../common/utils/FeatureUtils';
+import { GIT_SOURCE_TAGS, isGitSourceTag } from '../../../../utils/gitSourceTags';
 
 // A default placeholder for the search box
 const SEARCH_BOX_PLACEHOLDER = 'metrics.rmse < 1 and params.model = "tree"';
@@ -34,28 +34,6 @@ const ATTRIBUTE_OPTIONS = [
   'end_time',
   'created',
 ].map((s) => ({ value: `attributes.${s}` }));
-
-/**
- * Friendly dropdown labels for the three git source tags. Surface them in their own "Git" section
- * with short names instead of mixing the raw `mlflow.source.git.*` keys into the generic Tags
- * section.
- */
-const GIT_TAG_FILTER_LABELS = {
-  'mlflow.source.git.commit': defineMessage({
-    defaultMessage: 'commit',
-    description: 'Dropdown label for the git commit tag in the run search autocomplete',
-  }),
-  'mlflow.source.git.branch': defineMessage({
-    defaultMessage: 'branch',
-    description: 'Dropdown label for the git branch tag in the run search autocomplete',
-  }),
-  'mlflow.source.git.repoURL': defineMessage({
-    defaultMessage: 'repository',
-    description: 'Dropdown label for the git repository tag in the run search autocomplete',
-  }),
-} satisfies Record<string, MessageDescriptor>;
-
-const isGitSourceTag = (tag: string): tag is keyof typeof GIT_TAG_FILTER_LABELS => tag in GIT_TAG_FILTER_LABELS;
 
 const mergeDeduplicate = (list1: string[], list2: string[]) => [...new Set([...list1, ...list2])];
 const getTagNames = (tagsList: any[]) => tagsList.flatMap((tagRecord) => Object.keys(tagRecord));
@@ -113,7 +91,7 @@ export const RunsSearchAutoComplete = ({ runsData, ...restProps }: RunsSearchAut
       {
         label: 'Git',
         options: gitTagNames.map((tag) => {
-          const friendlyLabel = intl.formatMessage(GIT_TAG_FILTER_LABELS[tag]);
+          const friendlyLabel = intl.formatMessage(GIT_SOURCE_TAGS[tag].short);
           return {
             value: `tags.\`${tag}\``,
             label: friendlyLabel,

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/RunsSearchAutoComplete.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/RunsSearchAutoComplete.tsx
@@ -1,4 +1,6 @@
 import { useMemo, useRef } from 'react';
+import { defineMessage, useIntl } from 'react-intl';
+import type { MessageDescriptor } from 'react-intl';
 import type { ErrorWrapper } from '../../../../../common/utils/ErrorWrapper';
 import { EntitySearchAutoComplete } from '../../../EntitySearchAutoComplete';
 import type { ExperimentRunsSelectorResult } from '../../utils/experimentRuns.selector';
@@ -7,10 +9,7 @@ import type {
   EntitySearchAutoCompleteEntityNameGroup,
   EntitySearchAutoCompleteOptionGroup,
 } from '../../../EntitySearchAutoComplete.utils';
-import {
-  cleanEntitySearchTagNames,
-  getEntitySearchOptionsFromEntityNames,
-} from '../../../EntitySearchAutoComplete.utils';
+import { cleanEntitySearchTagNames } from '../../../EntitySearchAutoComplete.utils';
 import { shouldUseRegexpBasedAutoRunsSearchFilter } from '../../../../../common/utils/FeatureUtils';
 
 // A default placeholder for the search box
@@ -36,6 +35,28 @@ const ATTRIBUTE_OPTIONS = [
   'created',
 ].map((s) => ({ value: `attributes.${s}` }));
 
+/**
+ * Friendly dropdown labels for the three git source tags. Surface them in their own "Git" section
+ * with short names instead of mixing the raw `mlflow.source.git.*` keys into the generic Tags
+ * section.
+ */
+const GIT_TAG_FILTER_LABELS = {
+  'mlflow.source.git.commit': defineMessage({
+    defaultMessage: 'commit',
+    description: 'Dropdown label for the git commit tag in the run search autocomplete',
+  }),
+  'mlflow.source.git.branch': defineMessage({
+    defaultMessage: 'branch',
+    description: 'Dropdown label for the git branch tag in the run search autocomplete',
+  }),
+  'mlflow.source.git.repoURL': defineMessage({
+    defaultMessage: 'repository',
+    description: 'Dropdown label for the git repository tag in the run search autocomplete',
+  }),
+} satisfies Record<string, MessageDescriptor>;
+
+const isGitSourceTag = (tag: string): tag is keyof typeof GIT_TAG_FILTER_LABELS => tag in GIT_TAG_FILTER_LABELS;
+
 const mergeDeduplicate = (list1: string[], list2: string[]) => [...new Set([...list1, ...list2])];
 const getTagNames = (tagsList: any[]) => tagsList.flatMap((tagRecord) => Object.keys(tagRecord));
 
@@ -58,6 +79,7 @@ const getEntityNamesFromRunsData = (
 };
 
 export const RunsSearchAutoComplete = ({ runsData, ...restProps }: RunsSearchAutoCompleteProps) => {
+  const intl = useIntl();
   const existingEntityNamesRef = useRef<EntitySearchAutoCompleteEntityNameGroup>({
     metricNames: [],
     paramNames: [],
@@ -68,11 +90,44 @@ export const RunsSearchAutoComplete = ({ runsData, ...restProps }: RunsSearchAut
     const existingEntityNames = existingEntityNamesRef.current;
     const mergedEntityNames = getEntityNamesFromRunsData(runsData, existingEntityNames);
     existingEntityNamesRef.current = mergedEntityNames;
-    return getEntitySearchOptionsFromEntityNames(
-      { ...mergedEntityNames, tagNames: cleanEntitySearchTagNames(mergedEntityNames.tagNames) },
-      ATTRIBUTE_OPTIONS,
-    );
-  }, [runsData]);
+
+    // Split git source tags out of the generic Tags section so they can be surfaced in a
+    // dedicated Git section with friendly labels (e.g. "commit" instead of
+    // `mlflow.source.git.commit`).
+    const gitTagNames = mergedEntityNames.tagNames.filter(isGitSourceTag);
+    const nonGitTagNames = mergedEntityNames.tagNames.filter((tag) => !isGitSourceTag(tag));
+
+    return [
+      {
+        label: 'Metrics',
+        options: mergedEntityNames.metricNames.map((m) => ({ value: `metrics.${m}` })),
+      },
+      {
+        label: 'Parameters',
+        options: mergedEntityNames.paramNames.map((p) => ({ value: `params.${p}` })),
+      },
+      {
+        label: 'Tags',
+        options: cleanEntitySearchTagNames(nonGitTagNames).map((t) => ({ value: `tags.${t}` })),
+      },
+      {
+        label: 'Git',
+        options: gitTagNames.map((tag) => {
+          const friendlyLabel = intl.formatMessage(GIT_TAG_FILTER_LABELS[tag]);
+          return {
+            value: `tags.\`${tag}\``,
+            label: friendlyLabel,
+            // Make the friendly label searchable too, so typing "repository" finds repoURL etc.
+            searchText: `${tag} ${friendlyLabel}`,
+          };
+        }),
+      },
+      {
+        label: 'Attributes',
+        options: ATTRIBUTE_OPTIONS,
+      },
+    ];
+  }, [runsData, intl]);
 
   return (
     <EntitySearchAutoComplete

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/RunsSearchAutoComplete.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/RunsSearchAutoComplete.tsx
@@ -45,9 +45,10 @@ const getEntityNamesFromRunsData = (
 ): EntitySearchAutoCompleteEntityNameGroup => {
   const metricNames = mergeDeduplicate(existingNames.metricNames, newRunsData.metricKeyList);
   const paramNames = mergeDeduplicate(existingNames.paramNames, newRunsData.paramKeyList);
-  const tagNames = cleanEntitySearchTagNames(
-    mergeDeduplicate(getTagNames(existingNames.tagNames), getTagNames(newRunsData.tagsList)),
-  );
+  // Keep raw tag names in the cache. Cleaning (filter + backtick-wrap) happens only at output
+  // time so that on re-render the cache doesn't get re-cleaned, which would double-wrap names
+  // and accumulate spurious entries.
+  const tagNames = mergeDeduplicate(existingNames.tagNames, getTagNames(newRunsData.tagsList));
 
   return {
     metricNames,
@@ -67,7 +68,10 @@ export const RunsSearchAutoComplete = ({ runsData, ...restProps }: RunsSearchAut
     const existingEntityNames = existingEntityNamesRef.current;
     const mergedEntityNames = getEntityNamesFromRunsData(runsData, existingEntityNames);
     existingEntityNamesRef.current = mergedEntityNames;
-    return getEntitySearchOptionsFromEntityNames(mergedEntityNames, ATTRIBUTE_OPTIONS);
+    return getEntitySearchOptionsFromEntityNames(
+      { ...mergedEntityNames, tagNames: cleanEntitySearchTagNames(mergedEntityNames.tagNames) },
+      ATTRIBUTE_OPTIONS,
+    );
   }, [runsData]);
 
   return (

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.tsx
@@ -17,6 +17,7 @@ import type { DatasetWithRunType } from '../../components/experiment-page/compon
 import { ExperimentViewDatasetDrawer } from '../../components/experiment-page/components/runs/ExperimentViewDatasetDrawer';
 import { compact, keyBy, mapValues, uniq, xor, xorBy } from 'lodash';
 import {
+  EVAL_RUNS_SEARCHABLE_INTERNAL_TAGS,
   EVAL_RUNS_TABLE_BASE_SELECTION_STATE,
   EvalRunsTableKeyedColumnPrefix,
 } from './ExperimentEvaluationRunsTable.constants';
@@ -240,7 +241,7 @@ const ExperimentEvaluationRunsPageImpl = () => {
         paramKeys.add(param.key);
       }
       for (const tag of run.data.tags ?? []) {
-        if (isUserFacingTag(tag.key)) {
+        if (isUserFacingTag(tag.key) || EVAL_RUNS_SEARCHABLE_INTERNAL_TAGS.has(tag.key)) {
           tagKeys.add(tag.key);
         }
       }

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTable.constants.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTable.constants.tsx
@@ -49,6 +49,16 @@ export enum EvalRunsTableKeyedColumnPrefix {
   TAG = 'tag',
 }
 
+/**
+ * Internal mlflow.* tags that are still useful enough as filter / group-by / column dimensions on
+ * the evaluation runs page to override the default `isUserFacingTag` hiding rule. Keep narrow.
+ */
+export const EVAL_RUNS_SEARCHABLE_INTERNAL_TAGS: Set<string> = new Set([
+  'mlflow.source.git.commit',
+  'mlflow.source.git.branch',
+  'mlflow.source.git.repoURL',
+]);
+
 export const EVAL_RUNS_UNSELECTABLE_COLUMNS: Set<string> = new Set([
   EvalRunsTableColumnId.checkbox,
   EvalRunsTableColumnId.visibility,

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTable.constants.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTable.constants.tsx
@@ -15,6 +15,7 @@ import type { Theme, Interpolation } from '@emotion/react';
 import type { RunEntityOrGroupData } from './ExperimentEvaluationRunsPage.utils';
 import { ExperimentEvaluationRunsPageMode } from './hooks/useExperimentEvaluationRunsPageMode';
 import { EvalRunsVisibilityHeaderCell } from './EvalRunsVisibilityHeaderCell';
+import { GIT_SOURCE_TAG_KEYS } from '../../utils/gitSourceTags';
 
 export interface ExperimentEvaluationRunsTableMeta {
   setSelectedRunUuid: (runUuid: string) => void;
@@ -51,56 +52,11 @@ export enum EvalRunsTableKeyedColumnPrefix {
 
 /**
  * Internal mlflow.* tags that are still useful enough as filter / group-by / column dimensions on
- * the evaluation runs page to override the default `isUserFacingTag` hiding rule. Keep narrow.
- *
- * When extending this set, also add a friendly label below.
+ * the evaluation runs page to override the default `isUserFacingTag` hiding rule. Today this is
+ * just the git source tags; extend the shared `GIT_SOURCE_TAGS` map (or union additional keys
+ * here) to add more.
  */
-/**
- * Friendly labels for the git source tags in two contexts on the eval runs page:
- *   - selector: lowercase, used in the Columns and Group by dropdowns (sits under a "Git" header)
- *   - display:  "Git X" form, used as the table column header and the grouped-runs row label
- */
-type GitSourceTagLabel = {
-  selector: MessageDescriptor;
-  display: MessageDescriptor;
-};
-
-export const GIT_SOURCE_TAG_LABELS = {
-  'mlflow.source.git.commit': {
-    selector: defineMessage({
-      defaultMessage: 'commit',
-      description: 'Dropdown label for the git commit tag in eval runs Columns / Group by selectors',
-    }),
-    display: defineMessage({
-      defaultMessage: 'Git commit',
-      description: 'Column header and group label for the git commit tag in the eval runs table',
-    }),
-  },
-  'mlflow.source.git.branch': {
-    selector: defineMessage({
-      defaultMessage: 'branch',
-      description: 'Dropdown label for the git branch tag in eval runs Columns / Group by selectors',
-    }),
-    display: defineMessage({
-      defaultMessage: 'Git branch',
-      description: 'Column header and group label for the git branch tag in the eval runs table',
-    }),
-  },
-  'mlflow.source.git.repoURL': {
-    selector: defineMessage({
-      defaultMessage: 'repository',
-      description: 'Dropdown label for the git repository tag in eval runs Columns / Group by selectors',
-    }),
-    display: defineMessage({
-      defaultMessage: 'Git repository',
-      description: 'Column header and group label for the git repository tag in the eval runs table',
-    }),
-  },
-} satisfies Record<string, GitSourceTagLabel>;
-
-export const EVAL_RUNS_SEARCHABLE_INTERNAL_TAGS: Set<string> = new Set(Object.keys(GIT_SOURCE_TAG_LABELS));
-
-export const isGitSourceTag = (tagKey: string): boolean => tagKey in GIT_SOURCE_TAG_LABELS;
+export const EVAL_RUNS_SEARCHABLE_INTERNAL_TAGS: Set<string> = GIT_SOURCE_TAG_KEYS;
 
 export const EVAL_RUNS_UNSELECTABLE_COLUMNS: Set<string> = new Set([
   EvalRunsTableColumnId.checkbox,

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTable.constants.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTable.constants.tsx
@@ -57,15 +57,15 @@ export enum EvalRunsTableKeyedColumnPrefix {
  */
 export const GIT_SOURCE_TAG_LABELS = {
   'mlflow.source.git.commit': defineMessage({
-    defaultMessage: 'Commit',
+    defaultMessage: 'commit',
     description: 'Friendly label for the mlflow.source.git.commit tag in the eval runs Columns and Group by selectors',
   }),
   'mlflow.source.git.branch': defineMessage({
-    defaultMessage: 'Branch',
+    defaultMessage: 'branch',
     description: 'Friendly label for the mlflow.source.git.branch tag in the eval runs Columns and Group by selectors',
   }),
   'mlflow.source.git.repoURL': defineMessage({
-    defaultMessage: 'Repository',
+    defaultMessage: 'repository',
     description: 'Friendly label for the mlflow.source.git.repoURL tag in the eval runs Columns and Group by selectors',
   }),
 } satisfies Record<string, MessageDescriptor>;

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTable.constants.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTable.constants.tsx
@@ -52,12 +52,27 @@ export enum EvalRunsTableKeyedColumnPrefix {
 /**
  * Internal mlflow.* tags that are still useful enough as filter / group-by / column dimensions on
  * the evaluation runs page to override the default `isUserFacingTag` hiding rule. Keep narrow.
+ *
+ * When extending this set, also add a friendly label below.
  */
-export const EVAL_RUNS_SEARCHABLE_INTERNAL_TAGS: Set<string> = new Set([
-  'mlflow.source.git.commit',
-  'mlflow.source.git.branch',
-  'mlflow.source.git.repoURL',
-]);
+export const GIT_SOURCE_TAG_LABELS = {
+  'mlflow.source.git.commit': defineMessage({
+    defaultMessage: 'Commit',
+    description: 'Friendly label for the mlflow.source.git.commit tag in the eval runs Columns and Group by selectors',
+  }),
+  'mlflow.source.git.branch': defineMessage({
+    defaultMessage: 'Branch',
+    description: 'Friendly label for the mlflow.source.git.branch tag in the eval runs Columns and Group by selectors',
+  }),
+  'mlflow.source.git.repoURL': defineMessage({
+    defaultMessage: 'Repository',
+    description: 'Friendly label for the mlflow.source.git.repoURL tag in the eval runs Columns and Group by selectors',
+  }),
+} satisfies Record<string, MessageDescriptor>;
+
+export const EVAL_RUNS_SEARCHABLE_INTERNAL_TAGS: Set<string> = new Set(Object.keys(GIT_SOURCE_TAG_LABELS));
+
+export const isGitSourceTag = (tagKey: string): boolean => tagKey in GIT_SOURCE_TAG_LABELS;
 
 export const EVAL_RUNS_UNSELECTABLE_COLUMNS: Set<string> = new Set([
   EvalRunsTableColumnId.checkbox,

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTable.constants.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTable.constants.tsx
@@ -55,20 +55,48 @@ export enum EvalRunsTableKeyedColumnPrefix {
  *
  * When extending this set, also add a friendly label below.
  */
+/**
+ * Friendly labels for the git source tags in two contexts on the eval runs page:
+ *   - selector: lowercase, used in the Columns and Group by dropdowns (sits under a "Git" header)
+ *   - display:  "Git X" form, used as the table column header and the grouped-runs row label
+ */
+type GitSourceTagLabel = {
+  selector: MessageDescriptor;
+  display: MessageDescriptor;
+};
+
 export const GIT_SOURCE_TAG_LABELS = {
-  'mlflow.source.git.commit': defineMessage({
-    defaultMessage: 'commit',
-    description: 'Friendly label for the mlflow.source.git.commit tag in the eval runs Columns and Group by selectors',
-  }),
-  'mlflow.source.git.branch': defineMessage({
-    defaultMessage: 'branch',
-    description: 'Friendly label for the mlflow.source.git.branch tag in the eval runs Columns and Group by selectors',
-  }),
-  'mlflow.source.git.repoURL': defineMessage({
-    defaultMessage: 'repository',
-    description: 'Friendly label for the mlflow.source.git.repoURL tag in the eval runs Columns and Group by selectors',
-  }),
-} satisfies Record<string, MessageDescriptor>;
+  'mlflow.source.git.commit': {
+    selector: defineMessage({
+      defaultMessage: 'commit',
+      description: 'Dropdown label for the git commit tag in eval runs Columns / Group by selectors',
+    }),
+    display: defineMessage({
+      defaultMessage: 'Git commit',
+      description: 'Column header and group label for the git commit tag in the eval runs table',
+    }),
+  },
+  'mlflow.source.git.branch': {
+    selector: defineMessage({
+      defaultMessage: 'branch',
+      description: 'Dropdown label for the git branch tag in eval runs Columns / Group by selectors',
+    }),
+    display: defineMessage({
+      defaultMessage: 'Git branch',
+      description: 'Column header and group label for the git branch tag in the eval runs table',
+    }),
+  },
+  'mlflow.source.git.repoURL': {
+    selector: defineMessage({
+      defaultMessage: 'repository',
+      description: 'Dropdown label for the git repository tag in eval runs Columns / Group by selectors',
+    }),
+    display: defineMessage({
+      defaultMessage: 'Git repository',
+      description: 'Column header and group label for the git repository tag in the eval runs table',
+    }),
+  },
+} satisfies Record<string, GitSourceTagLabel>;
 
 export const EVAL_RUNS_SEARCHABLE_INTERNAL_TAGS: Set<string> = new Set(Object.keys(GIT_SOURCE_TAG_LABELS));
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableCellRenderers.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableCellRenderers.tsx
@@ -297,16 +297,27 @@ export const SortableHeaderCell = ({
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
 
-  const { displayedKey, friendlyLabel } = useMemo(() => {
+  const { displayedKey, friendlyLabel, tooltipContent } = useMemo(() => {
     const parsed = parseEvalRunsTableKeyedColumnKey(column.id);
     const key = parsed?.key ?? column.id;
-    const labelDescriptor =
+    const labels =
       parsed?.columnType === EvalRunsTableKeyedColumnPrefix.TAG
         ? GIT_SOURCE_TAG_LABELS[key as keyof typeof GIT_SOURCE_TAG_LABELS]
         : undefined;
     return {
       displayedKey: key,
-      friendlyLabel: labelDescriptor ? intl.formatMessage(labelDescriptor) : null,
+      friendlyLabel: labels ? intl.formatMessage(labels.display) : null,
+      // For git source tags, the header shows a friendly label; surface the underlying tag key
+      // in the tooltip so users still know how to reference it in filter queries.
+      tooltipContent: labels ? (
+        <FormattedMessage
+          defaultMessage="Derived from tag {key}"
+          description="Tooltip on eval runs table column headers that come from a git source tag, explaining the underlying tag key"
+          values={{ key }}
+        />
+      ) : (
+        key
+      ),
     };
   }, [column.id, intl]);
 
@@ -326,7 +337,7 @@ export const SortableHeaderCell = ({
     >
       <Tooltip
         componentId="codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_evaluation_runs_experimentevaluationrunstablecellrenderers_284"
-        content={displayedKey}
+        content={tooltipContent}
       >
         <span css={{ overflow: 'hidden', textOverflow: 'ellipsis', textWrap: 'nowrap' }}>
           <Typography.Text bold>{headerText}</Typography.Text>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableCellRenderers.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableCellRenderers.tsx
@@ -26,7 +26,8 @@ import { RunColorPill } from '../../components/experiment-page/components/RunCol
 import { TimeAgo } from '@databricks/web-shared/browse';
 import { parseEvalRunsTableKeyedColumnKey } from './ExperimentEvaluationRunsTable.utils';
 import { useMemo } from 'react';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { EvalRunsTableKeyedColumnPrefix, GIT_SOURCE_TAG_LABELS } from './ExperimentEvaluationRunsTable.constants';
 import type { RunEntityOrGroupData } from './ExperimentEvaluationRunsPage.utils';
 import { useExperimentEvaluationRunsRowVisibility } from './hooks/useExperimentEvaluationRunsRowVisibility';
 import { RunPageTabName } from '../../constants';
@@ -294,8 +295,24 @@ export const SortableHeaderCell = ({
   title,
 }: HeaderContext<RunEntityOrGroupData, unknown> & { title?: React.ReactElement }) => {
   const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
 
-  const displayedKey = useMemo(() => parseEvalRunsTableKeyedColumnKey(column.id)?.key ?? column.id, [column.id]);
+  const { displayedKey, friendlyLabel } = useMemo(() => {
+    const parsed = parseEvalRunsTableKeyedColumnKey(column.id);
+    const key = parsed?.key ?? column.id;
+    const labelDescriptor =
+      parsed?.columnType === EvalRunsTableKeyedColumnPrefix.TAG
+        ? GIT_SOURCE_TAG_LABELS[key as keyof typeof GIT_SOURCE_TAG_LABELS]
+        : undefined;
+    return {
+      displayedKey: key,
+      friendlyLabel: labelDescriptor ? intl.formatMessage(labelDescriptor) : null,
+    };
+  }, [column.id, intl]);
+
+  // Header text prefers an explicit `title` prop, then a friendly label (e.g. git source tags),
+  // and finally falls back to the raw column key.
+  const headerText = title ?? friendlyLabel ?? displayedKey;
 
   return (
     <div
@@ -312,7 +329,7 @@ export const SortableHeaderCell = ({
         content={displayedKey}
       >
         <span css={{ overflow: 'hidden', textOverflow: 'ellipsis', textWrap: 'nowrap' }}>
-          <Typography.Text bold>{title ?? displayedKey}</Typography.Text>
+          <Typography.Text bold>{headerText}</Typography.Text>
         </span>
       </Tooltip>
       {!column.getIsSorted() && (

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableCellRenderers.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableCellRenderers.tsx
@@ -27,7 +27,8 @@ import { TimeAgo } from '@databricks/web-shared/browse';
 import { parseEvalRunsTableKeyedColumnKey } from './ExperimentEvaluationRunsTable.utils';
 import { useMemo } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { EvalRunsTableKeyedColumnPrefix, GIT_SOURCE_TAG_LABELS } from './ExperimentEvaluationRunsTable.constants';
+import { EvalRunsTableKeyedColumnPrefix } from './ExperimentEvaluationRunsTable.constants';
+import { GIT_SOURCE_TAGS } from '../../utils/gitSourceTags';
 import type { RunEntityOrGroupData } from './ExperimentEvaluationRunsPage.utils';
 import { useExperimentEvaluationRunsRowVisibility } from './hooks/useExperimentEvaluationRunsRowVisibility';
 import { RunPageTabName } from '../../constants';
@@ -302,11 +303,11 @@ export const SortableHeaderCell = ({
     const key = parsed?.key ?? column.id;
     const labels =
       parsed?.columnType === EvalRunsTableKeyedColumnPrefix.TAG
-        ? GIT_SOURCE_TAG_LABELS[key as keyof typeof GIT_SOURCE_TAG_LABELS]
+        ? GIT_SOURCE_TAGS[key as keyof typeof GIT_SOURCE_TAGS]
         : undefined;
     return {
       displayedKey: key,
-      friendlyLabel: labels ? intl.formatMessage(labels.display) : null,
+      friendlyLabel: labels ? intl.formatMessage(labels.column) : null,
       // For git source tags, the header shows a friendly label; surface the underlying tag key
       // in the tooltip so users still know how to reference it in filter queries.
       tooltipContent: labels ? (

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableControls.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableControls.tsx
@@ -31,9 +31,8 @@ import {
   EVAL_RUNS_COLUMN_TYPE_LABELS,
   EVAL_RUNS_UNSELECTABLE_COLUMNS,
   EvalRunsTableKeyedColumnPrefix,
-  GIT_SOURCE_TAG_LABELS,
-  isGitSourceTag,
 } from './ExperimentEvaluationRunsTable.constants';
+import { GIT_SOURCE_TAGS, isGitSourceTag } from '../../utils/gitSourceTags';
 import { parseEvalRunsTableKeyedColumnKey } from './ExperimentEvaluationRunsTable.utils';
 import { groupBy } from 'lodash';
 import { ExperimentEvaluationRunsTableGroupBySelector } from './ExperimentEvaluationRunsTableGroupBySelector';
@@ -286,8 +285,8 @@ export const ExperimentEvaluationRunsTableControls = ({
                         </DialogComboboxSectionHeader>
                         {gitColumns.map(([column, selected]) => {
                           const tagKey = parseEvalRunsTableKeyedColumnKey(column)?.key ?? column;
-                          const labels = GIT_SOURCE_TAG_LABELS[tagKey as keyof typeof GIT_SOURCE_TAG_LABELS];
-                          const label = labels ? intl.formatMessage(labels.selector) : tagKey;
+                          const labels = GIT_SOURCE_TAGS[tagKey as keyof typeof GIT_SOURCE_TAGS];
+                          const label = labels ? intl.formatMessage(labels.short) : tagKey;
                           return (
                             <DialogComboboxOptionListCheckboxItem
                               key={column}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableControls.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableControls.tsx
@@ -286,8 +286,8 @@ export const ExperimentEvaluationRunsTableControls = ({
                         </DialogComboboxSectionHeader>
                         {gitColumns.map(([column, selected]) => {
                           const tagKey = parseEvalRunsTableKeyedColumnKey(column)?.key ?? column;
-                          const labelDescriptor = GIT_SOURCE_TAG_LABELS[tagKey];
-                          const label = labelDescriptor ? intl.formatMessage(labelDescriptor) : tagKey;
+                          const labels = GIT_SOURCE_TAG_LABELS[tagKey as keyof typeof GIT_SOURCE_TAG_LABELS];
+                          const label = labels ? intl.formatMessage(labels.selector) : tagKey;
                           return (
                             <DialogComboboxOptionListCheckboxItem
                               key={column}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableControls.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableControls.tsx
@@ -1,6 +1,7 @@
 import {
   useDesignSystemTheme,
   Button,
+  BranchIcon,
   DialogCombobox,
   DialogComboboxTrigger,
   DialogComboboxContent,
@@ -30,6 +31,8 @@ import {
   EVAL_RUNS_COLUMN_TYPE_LABELS,
   EVAL_RUNS_UNSELECTABLE_COLUMNS,
   EvalRunsTableKeyedColumnPrefix,
+  GIT_SOURCE_TAG_LABELS,
+  isGitSourceTag,
 } from './ExperimentEvaluationRunsTable.constants';
 import { parseEvalRunsTableKeyedColumnKey } from './ExperimentEvaluationRunsTable.utils';
 import { groupBy } from 'lodash';
@@ -223,38 +226,85 @@ export const ExperimentEvaluationRunsTableControls = ({
                 }
                 const headerLabelDescriptor =
                   EVAL_RUNS_COLUMN_TYPE_LABELS[columnType as EvalRunsTableKeyedColumnPrefix];
+                // Split git source tag columns out of the generic Tags section so they can be
+                // rendered as a dedicated Git section below.
+                const isTagSection = columnType === EvalRunsTableKeyedColumnPrefix.TAG;
+                const gitColumns = isTagSection
+                  ? columns.filter(([column]) => isGitSourceTag(parseEvalRunsTableKeyedColumnKey(column)?.key ?? ''))
+                  : [];
+                const nonGitColumns = isTagSection
+                  ? columns.filter(([column]) => !isGitSourceTag(parseEvalRunsTableKeyedColumnKey(column)?.key ?? ''))
+                  : columns;
                 return (
                   // eslint-disable-next-line react/jsx-key
                   <>
-                    <Spacer size="xs" />
-                    <DialogComboboxSectionHeader>
-                      {headerLabelDescriptor ? intl.formatMessage(headerLabelDescriptor) : columnType}
-                    </DialogComboboxSectionHeader>
-                    {columns.map(([column, selected]) => {
-                      const labelDescriptorForKnownColumn = EVAL_RUNS_COLUMN_LABELS[column as EvalRunsTableColumnId];
-                      const label = labelDescriptorForKnownColumn
-                        ? intl.formatMessage(labelDescriptorForKnownColumn)
-                        : (parseEvalRunsTableKeyedColumnKey(column)?.key ?? column);
+                    {nonGitColumns.length > 0 && (
+                      <>
+                        <Spacer size="xs" />
+                        <DialogComboboxSectionHeader>
+                          {headerLabelDescriptor ? intl.formatMessage(headerLabelDescriptor) : columnType}
+                        </DialogComboboxSectionHeader>
+                        {nonGitColumns.map(([column, selected]) => {
+                          const labelDescriptorForKnownColumn =
+                            EVAL_RUNS_COLUMN_LABELS[column as EvalRunsTableColumnId];
+                          const label = labelDescriptorForKnownColumn
+                            ? intl.formatMessage(labelDescriptorForKnownColumn)
+                            : (parseEvalRunsTableKeyedColumnKey(column)?.key ?? column);
 
-                      if (EVAL_RUNS_UNSELECTABLE_COLUMNS.has(column)) {
-                        return null;
-                      }
+                          if (EVAL_RUNS_UNSELECTABLE_COLUMNS.has(column)) {
+                            return null;
+                          }
 
-                      return (
-                        <DialogComboboxOptionListCheckboxItem
-                          key={column}
-                          value={column}
-                          onChange={() => {
-                            const newSelectedColumns = { ...selectedColumns };
-                            newSelectedColumns[column] = !selected;
-                            setSelectedColumns(newSelectedColumns);
-                          }}
-                          checked={selected}
-                        >
-                          {label}
-                        </DialogComboboxOptionListCheckboxItem>
-                      );
-                    })}
+                          return (
+                            <DialogComboboxOptionListCheckboxItem
+                              key={column}
+                              value={column}
+                              onChange={() => {
+                                const newSelectedColumns = { ...selectedColumns };
+                                newSelectedColumns[column] = !selected;
+                                setSelectedColumns(newSelectedColumns);
+                              }}
+                              checked={selected}
+                            >
+                              {label}
+                            </DialogComboboxOptionListCheckboxItem>
+                          );
+                        })}
+                      </>
+                    )}
+                    {gitColumns.length > 0 && (
+                      <>
+                        <Spacer size="xs" />
+                        <DialogComboboxSectionHeader>
+                          <span css={{ display: 'inline-flex', alignItems: 'center', gap: theme.spacing.xs }}>
+                            <BranchIcon />
+                            <FormattedMessage
+                              defaultMessage="Git"
+                              description="Section header for git source tags in the eval runs Columns selector"
+                            />
+                          </span>
+                        </DialogComboboxSectionHeader>
+                        {gitColumns.map(([column, selected]) => {
+                          const tagKey = parseEvalRunsTableKeyedColumnKey(column)?.key ?? column;
+                          const labelDescriptor = GIT_SOURCE_TAG_LABELS[tagKey];
+                          const label = labelDescriptor ? intl.formatMessage(labelDescriptor) : tagKey;
+                          return (
+                            <DialogComboboxOptionListCheckboxItem
+                              key={column}
+                              value={column}
+                              onChange={() => {
+                                const newSelectedColumns = { ...selectedColumns };
+                                newSelectedColumns[column] = !selected;
+                                setSelectedColumns(newSelectedColumns);
+                              }}
+                              checked={selected}
+                            >
+                              {label}
+                            </DialogComboboxOptionListCheckboxItem>
+                          );
+                        })}
+                      </>
+                    )}
                   </>
                 );
               })}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableGroupBySelector.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableGroupBySelector.tsx
@@ -11,9 +11,8 @@ import {
 import {
   EVAL_RUNS_SEARCHABLE_INTERNAL_TAGS,
   EVAL_RUNS_UNSELECTABLE_COLUMNS,
-  GIT_SOURCE_TAG_LABELS,
-  isGitSourceTag,
 } from './ExperimentEvaluationRunsTable.constants';
+import { GIT_SOURCE_TAGS, isGitSourceTag } from '../../utils/gitSourceTags';
 import {
   RunGroupingAggregateFunction,
   RunGroupingMode,
@@ -158,8 +157,8 @@ export const ExperimentEvaluationRunsTableGroupBySelector = ({
                 </span>
               </DialogComboboxSectionHeader>
               {Array.from(uniqueGitTags).map((tag) => {
-                const labels = GIT_SOURCE_TAG_LABELS[tag as keyof typeof GIT_SOURCE_TAG_LABELS];
-                const label = labels ? intl.formatMessage(labels.selector) : tag;
+                const labels = GIT_SOURCE_TAGS[tag as keyof typeof GIT_SOURCE_TAGS];
+                const label = labels ? intl.formatMessage(labels.short) : tag;
                 return (
                   <DialogComboboxOptionListCheckboxItem
                     key={tag}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableGroupBySelector.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableGroupBySelector.tsx
@@ -6,7 +6,10 @@ import {
   DialogComboboxSectionHeader,
   DialogComboboxTrigger,
 } from '@databricks/design-system';
-import { EVAL_RUNS_UNSELECTABLE_COLUMNS } from './ExperimentEvaluationRunsTable.constants';
+import {
+  EVAL_RUNS_SEARCHABLE_INTERNAL_TAGS,
+  EVAL_RUNS_UNSELECTABLE_COLUMNS,
+} from './ExperimentEvaluationRunsTable.constants';
 import {
   RunGroupingAggregateFunction,
   RunGroupingMode,
@@ -37,7 +40,7 @@ export const ExperimentEvaluationRunsTableGroupBySelector = ({
         uniqueParams.add(param.key);
       }
       for (const tag of run.data?.tags ?? []) {
-        if (isUserFacingTag(tag.key)) {
+        if (isUserFacingTag(tag.key) || EVAL_RUNS_SEARCHABLE_INTERNAL_TAGS.has(tag.key)) {
           uniqueTags.add(tag.key);
         }
       }

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableGroupBySelector.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableGroupBySelector.tsx
@@ -1,21 +1,25 @@
 import {
+  BranchIcon,
   DialogCombobox,
   DialogComboboxContent,
   DialogComboboxOptionList,
   DialogComboboxOptionListCheckboxItem,
   DialogComboboxSectionHeader,
   DialogComboboxTrigger,
+  useDesignSystemTheme,
 } from '@databricks/design-system';
 import {
   EVAL_RUNS_SEARCHABLE_INTERNAL_TAGS,
   EVAL_RUNS_UNSELECTABLE_COLUMNS,
+  GIT_SOURCE_TAG_LABELS,
+  isGitSourceTag,
 } from './ExperimentEvaluationRunsTable.constants';
 import {
   RunGroupingAggregateFunction,
   RunGroupingMode,
 } from '../../components/experiment-page/utils/experimentPage.row-types';
 import type { RunEntity } from '../../types';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import type { RunsGroupByConfig } from '../../components/experiment-page/utils/experimentPage.group-row-utils';
 import { isGroupedBy } from '../../components/experiment-page/utils/experimentPage.group-row-utils';
 import { isUserFacingTag } from '@mlflow/mlflow/src/common/utils/TagUtils';
@@ -30,23 +34,28 @@ export const ExperimentEvaluationRunsTableGroupBySelector = ({
   setGroupByConfig: (groupBy: RunsGroupByConfig | null) => void;
   runs: RunEntity[];
 }) => {
+  const intl = useIntl();
+  const { theme } = useDesignSystemTheme();
   const hasDatasets = runs.some((run) => (run.inputs?.datasetInputs?.length ?? 0) > 0);
-  const { uniqueParams, uniqueTags } = useMemo(() => {
+  const { uniqueParams, uniqueTags, uniqueGitTags } = useMemo(() => {
     const uniqueParams = new Set<string>();
     const uniqueTags = new Set<string>();
+    const uniqueGitTags = new Set<string>();
 
     for (const run of runs) {
       for (const param of run.data?.params ?? []) {
         uniqueParams.add(param.key);
       }
       for (const tag of run.data?.tags ?? []) {
-        if (isUserFacingTag(tag.key) || EVAL_RUNS_SEARCHABLE_INTERNAL_TAGS.has(tag.key)) {
+        if (isGitSourceTag(tag.key)) {
+          uniqueGitTags.add(tag.key);
+        } else if (isUserFacingTag(tag.key) || EVAL_RUNS_SEARCHABLE_INTERNAL_TAGS.has(tag.key)) {
           uniqueTags.add(tag.key);
         }
       }
     }
 
-    return { uniqueParams, uniqueTags };
+    return { uniqueParams, uniqueTags, uniqueGitTags };
   }, [runs]);
 
   const toggleGroupBy = (mode: RunGroupingMode, columnName: string) => {
@@ -135,6 +144,35 @@ export const ExperimentEvaluationRunsTableGroupBySelector = ({
                   }}
                 />
               ))}
+            </>
+          )}
+          {uniqueGitTags.size > 0 && (
+            <>
+              <DialogComboboxSectionHeader>
+                <span css={{ display: 'inline-flex', alignItems: 'center', gap: theme.spacing.xs }}>
+                  <BranchIcon />
+                  <FormattedMessage
+                    defaultMessage="Git"
+                    description="Section header for git source tags in a 'group by' selector"
+                  />
+                </span>
+              </DialogComboboxSectionHeader>
+              {Array.from(uniqueGitTags).map((tag) => {
+                const labelDescriptor = GIT_SOURCE_TAG_LABELS[tag];
+                const label = labelDescriptor ? intl.formatMessage(labelDescriptor) : tag;
+                return (
+                  <DialogComboboxOptionListCheckboxItem
+                    key={tag}
+                    value={tag}
+                    checked={isGroupedBy(groupByConfig, RunGroupingMode.Tag, tag)}
+                    onChange={() => {
+                      toggleGroupBy(RunGroupingMode.Tag, tag);
+                    }}
+                  >
+                    {label}
+                  </DialogComboboxOptionListCheckboxItem>
+                );
+              })}
             </>
           )}
         </DialogComboboxOptionList>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableGroupBySelector.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableGroupBySelector.tsx
@@ -158,8 +158,8 @@ export const ExperimentEvaluationRunsTableGroupBySelector = ({
                 </span>
               </DialogComboboxSectionHeader>
               {Array.from(uniqueGitTags).map((tag) => {
-                const labelDescriptor = GIT_SOURCE_TAG_LABELS[tag];
-                const label = labelDescriptor ? intl.formatMessage(labelDescriptor) : tag;
+                const labels = GIT_SOURCE_TAG_LABELS[tag as keyof typeof GIT_SOURCE_TAG_LABELS];
+                const label = labels ? intl.formatMessage(labels.selector) : tag;
                 return (
                   <DialogComboboxOptionListCheckboxItem
                     key={tag}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableRow.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableRow.tsx
@@ -11,7 +11,7 @@ import {
   Tag,
 } from '@databricks/design-system';
 import type { EvalRunsTableColumnDef } from './ExperimentEvaluationRunsTable.constants';
-import { GIT_SOURCE_TAG_LABELS } from './ExperimentEvaluationRunsTable.constants';
+import { GIT_SOURCE_TAGS } from '../../utils/gitSourceTags';
 import type { Row } from '@tanstack/react-table';
 import { flexRender } from '@tanstack/react-table';
 import type { RunEntityOrGroupData } from './ExperimentEvaluationRunsPage.utils';
@@ -69,9 +69,9 @@ const GroupLabel = ({ groupValues }: { groupValues: RunGroupByGroupingValue }): 
 
   const gitLabels =
     groupValues.mode === RunGroupingMode.Tag
-      ? GIT_SOURCE_TAG_LABELS[key as keyof typeof GIT_SOURCE_TAG_LABELS]
+      ? GIT_SOURCE_TAGS[key as keyof typeof GIT_SOURCE_TAGS]
       : undefined;
-  const displayKey = gitLabels ? intl.formatMessage(gitLabels.display) : key;
+  const displayKey = gitLabels ? intl.formatMessage(gitLabels.column) : key;
 
   return <GroupTag key={key} groupKey={displayKey} groupValue={String(groupValues.value)} />;
 };

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableRow.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableRow.tsx
@@ -11,12 +11,13 @@ import {
   Tag,
 } from '@databricks/design-system';
 import type { EvalRunsTableColumnDef } from './ExperimentEvaluationRunsTable.constants';
+import { GIT_SOURCE_TAG_LABELS } from './ExperimentEvaluationRunsTable.constants';
 import type { Row } from '@tanstack/react-table';
 import { flexRender } from '@tanstack/react-table';
 import type { RunEntityOrGroupData } from './ExperimentEvaluationRunsPage.utils';
 import type { RunGroupByGroupingValue } from '../../components/experiment-page/utils/experimentPage.row-types';
 import { RunGroupingMode } from '../../components/experiment-page/utils/experimentPage.row-types';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import { useNavigate } from '../../../common/utils/RoutingUtils';
 import Routes from '../../routes';
 import { RunPageTabName } from '../../constants';
@@ -60,12 +61,19 @@ const GroupTag = ({ groupKey, groupValue }: { groupKey: string; groupValue: stri
 };
 
 const GroupLabel = ({ groupValues }: { groupValues: RunGroupByGroupingValue }): React.ReactElement => {
+  const intl = useIntl();
   const key = groupValues.groupByData;
   if (groupValues.mode === RunGroupingMode.Dataset) {
     return <GroupTag key={key} groupKey="Dataset" groupValue={String(groupValues.value)} />;
   }
 
-  return <GroupTag key={key} groupKey={key} groupValue={String(groupValues.value)} />;
+  const gitLabels =
+    groupValues.mode === RunGroupingMode.Tag
+      ? GIT_SOURCE_TAG_LABELS[key as keyof typeof GIT_SOURCE_TAG_LABELS]
+      : undefined;
+  const displayKey = gitLabels ? intl.formatMessage(gitLabels.display) : key;
+
+  return <GroupTag key={key} groupKey={displayKey} groupValue={String(groupValues.value)} />;
 };
 
 export const ExperimentEvaluationRunsTableRow = React.memo(

--- a/mlflow/server/js/src/experiment-tracking/utils/gitSourceTags.ts
+++ b/mlflow/server/js/src/experiment-tracking/utils/gitSourceTags.ts
@@ -1,0 +1,54 @@
+import type { MessageDescriptor } from 'react-intl';
+import { defineMessage } from 'react-intl';
+
+/**
+ * Git source tags MLflow records on runs via `GitRunContext`, plus the friendly labels we use
+ * for them in two UI contexts:
+ *   - short:  used in dropdowns / selectors that sit under a "Git" section header
+ *             (e.g. "commit", "branch", "repository")
+ *   - column: used as the table column header and grouped-run row label
+ *             (e.g. "Git commit", "Git branch", "Git repository")
+ */
+type GitSourceTagLabels = {
+  short: MessageDescriptor;
+  column: MessageDescriptor;
+};
+
+export const GIT_SOURCE_TAGS = {
+  'mlflow.source.git.commit': {
+    short: defineMessage({
+      defaultMessage: 'commit',
+      description: 'Short label for the git commit tag in MLflow UI dropdowns and selectors',
+    }),
+    column: defineMessage({
+      defaultMessage: 'Git commit',
+      description: 'Column header / row label for the git commit tag in MLflow tables',
+    }),
+  },
+  'mlflow.source.git.branch': {
+    short: defineMessage({
+      defaultMessage: 'branch',
+      description: 'Short label for the git branch tag in MLflow UI dropdowns and selectors',
+    }),
+    column: defineMessage({
+      defaultMessage: 'Git branch',
+      description: 'Column header / row label for the git branch tag in MLflow tables',
+    }),
+  },
+  'mlflow.source.git.repoURL': {
+    short: defineMessage({
+      defaultMessage: 'repository',
+      description: 'Short label for the git repository tag in MLflow UI dropdowns and selectors',
+    }),
+    column: defineMessage({
+      defaultMessage: 'Git repository',
+      description: 'Column header / row label for the git repository tag in MLflow tables',
+    }),
+  },
+} satisfies Record<string, GitSourceTagLabels>;
+
+export type GitSourceTagKey = keyof typeof GIT_SOURCE_TAGS;
+
+export const GIT_SOURCE_TAG_KEYS: Set<string> = new Set(Object.keys(GIT_SOURCE_TAGS));
+
+export const isGitSourceTag = (tag: string): tag is GitSourceTagKey => tag in GIT_SOURCE_TAGS;

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -455,6 +455,10 @@
     "defaultMessage": "No image logged at this step",
     "description": "Experiment tracking > runs charts > charts > image plot with history > no image text"
   },
+  "0ZcmHR": {
+    "defaultMessage": "repository",
+    "description": "Dropdown label for the git repository tag in the run search autocomplete"
+  },
   "0eoz8L": {
     "defaultMessage": "Hour",
     "description": "Time unit: hour"
@@ -3479,6 +3483,10 @@
     "defaultMessage": "{count} {count, plural, one {value} other {values}}",
     "description": "Tag showing the number of unique string values in session assessment"
   },
+  "J01BlU": {
+    "defaultMessage": "commit",
+    "description": "Dropdown label for the git commit tag in the run search autocomplete"
+  },
   "J2IXIT": {
     "defaultMessage": "Create Guardrail",
     "description": "Title for create guardrail modal"
@@ -4627,6 +4635,10 @@
     "defaultMessage": "Maximum of {max} sessions can be selected",
     "description": "Tooltip shown when too many sessions are selected"
   },
+  "Pogv4g": {
+    "defaultMessage": "Derived from tag {key}",
+    "description": "Tooltip on eval runs table column headers that come from a git source tag, explaining the underlying tag key"
+  },
   "Potju2": {
     "defaultMessage": "Restore",
     "description": "String for the restore button to undo the experiments that were deleted"
@@ -5707,6 +5719,10 @@
     "defaultMessage": "Cost: {input} in / {output} out",
     "description": "Model cost per token"
   },
+  "WG1R+I": {
+    "defaultMessage": "Git repository",
+    "description": "Column header and group label for the git repository tag in the eval runs table"
+  },
   "WGN2f3": {
     "defaultMessage": "Register model",
     "description": "Run page > Header > Register model dropdown > Button label when some models are not registered"
@@ -6062,6 +6078,10 @@
   "YKE3h7": {
     "defaultMessage": "Define custom instructions for LLM-based evaluation. {learnMore}",
     "description": "Hint text for Instructions section with documentation link"
+  },
+  "YL73JL": {
+    "defaultMessage": "repository",
+    "description": "Dropdown label for the git repository tag in eval runs Columns / Group by selectors"
   },
   "YLMjFk": {
     "defaultMessage": "Reasoning",
@@ -6898,6 +6918,10 @@
   "cy9EfG": {
     "defaultMessage": "Attributes",
     "description": "Experiment page > group by runs control > attributes section label"
+  },
+  "cyh9MU": {
+    "defaultMessage": "Git",
+    "description": "Section header for git source tags in the eval runs Columns selector"
   },
   "d00egE": {
     "defaultMessage": "No span with type RETRIEVER found in trace.",
@@ -8019,6 +8043,10 @@
     "defaultMessage": "Select the experiment you configured above.",
     "description": "Instruction to select the experiment configured for traces"
   },
+  "j4uHfd": {
+    "defaultMessage": "branch",
+    "description": "Dropdown label for the git branch tag in the run search autocomplete"
+  },
   "j4vtTO": {
     "defaultMessage": "Save aliases",
     "description": "Alias editor > Confirm change of aliases"
@@ -8038,6 +8066,10 @@
   "jClVwe": {
     "defaultMessage": "Point the OTLP exporter at this MLflow server by setting these environment variables. See the <a>OpenTelemetry export docs</a> for the full reference.",
     "description": "Step 1 description for OpenTelemetry traces onboarding"
+  },
+  "jFQW9u": {
+    "defaultMessage": "commit",
+    "description": "Dropdown label for the git commit tag in eval runs Columns / Group by selectors"
   },
   "jFk49l": {
     "defaultMessage": "Quick-start with a popular model below, or create an endpoint from 60+ providers and all their supported models.",
@@ -8158,6 +8190,10 @@
   "js4/Y8": {
     "defaultMessage": "You can also <link>register it to the model registry</link> to version control",
     "description": "Sub text to tell the users where one can go to register the model artifact"
+  },
+  "jsGnTA": {
+    "defaultMessage": "Git commit",
+    "description": "Column header and group label for the git commit tag in the eval runs table"
   },
   "jwALGI": {
     "defaultMessage": "Cancel",
@@ -9103,6 +9139,10 @@
     "defaultMessage": "Delete prompt",
     "description": "A header for the delete prompt modal"
   },
+  "p5rx6l": {
+    "defaultMessage": "Git branch",
+    "description": "Column header and group label for the git branch tag in the eval runs table"
+  },
   "pBUaAK": {
     "defaultMessage": "Are you sure you want to delete this tag？",
     "description": "Title text for confirmation pop-up to delete a tag from table\n                     in MLflow"
@@ -9154,6 +9194,10 @@
   "pU6cxH": {
     "defaultMessage": "Add",
     "description": "Model registry > model version table > aliases column > 'add' button label"
+  },
+  "pV7MzC": {
+    "defaultMessage": "Git",
+    "description": "Section header for git source tags in a 'group by' selector"
   },
   "pVF+2s": {
     "defaultMessage": "Show less",
@@ -10422,6 +10466,10 @@
   "x+e1xE": {
     "defaultMessage": "Is tool usage efficient throughout the conversation?",
     "description": "Hint for ConversationalToolCallEfficiency template"
+  },
+  "x/SW+S": {
+    "defaultMessage": "branch",
+    "description": "Dropdown label for the git branch tag in eval runs Columns / Group by selectors"
   },
   "x/YJtF": {
     "defaultMessage": "MLflow MCP server",


### PR DESCRIPTION
### Related Issues/PRs

Relates to #21199

**Stacked on #23310** (backend tag-recording change). Please review and merge #23310 first.

### What changes are proposed in this pull request?

Support filtering/grouping runs using git metadata recorded as run. tags.

- **Search filter autocomplete** — adds a dedicated `Git` section in the dropdown listing `commit` / `branch` / `repository`. Clicking an entry inserts the full filter expression (e.g. `` tags.\`mlflow.source.git.commit\` ``) into the search box. The synthetic label is also searchable, so typing \"repository\" still finds the `repoURL` tag.
- **Columns picker** — adds a `Git` section (with `BranchIcon`) listing the same three options. Enabling one adds a column to the eval runs table.
- **Group by selector** — same Git section in the Group by dropdown.
- **Table column header** — an enabled git column now shows the friendly capitalized label `Git commit` instead of the raw `mlflow.source.git.commit` key. Hovering shows `Derived from tag mlflow.source.git.commit` so users still know how to reference it in filter queries.
- **Grouped-runs row label** — the \"Group:\" pill now reads `Git commit <value>` instead of `mlflow.source.git.commit <value>`.


https://github.com/user-attachments/assets/438312fd-01e2-4b22-bc80-a8cfc6619b44

(The column list is reset when applying the search filter, which is a separate bug unrelated to this change.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The evaluation runs page now exposes a dedicated Git section in its filter, Columns, and Group by dropdowns so users can pivot evaluation metrics by branch, commit, and repository.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] \`area/uiux\`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] \`area/evaluation\`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name=\"release-note-category\"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] \`rn/feature\` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release