### PR TITLE
[Security] Reject fork-source workflow_run events in preview-docs

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -14,7 +14,16 @@ defaults:
 
 jobs:
   main:
-    if: github.repository == 'mlflow/mlflow'
+    # Reject fork-source workflow_run events. Without this gate, a `docs` run
+    # triggered by a fork PR would cause this privileged workflow to deploy
+    # PR-controlled content to MLflow's Netlify preview site, with the bot
+    # posting the resulting link from `github-actions[bot]`. The Netlify token
+    # itself isn't exposed (the deploy step only uploads static files), but
+    # the official `mlflow-docs-preview.netlify.app` hostname can be abused
+    # for phishing or impersonation.
+    if: |
+      github.repository == 'mlflow/mlflow' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write # To post comments on PRs


### PR DESCRIPTION
### Related Issues/PRs

Relates to private security advisory `GHSA-7rc5-r96w-x8xx`.

### What changes are proposed in this pull request?

The `preview-docs` workflow runs in the base repository context with `NETLIFY_AUTH_TOKEN` and `NETLIFY_SITE_ID` available, but only gates on `github.repository == 'mlflow/mlflow'`. That predicate is always true for `workflow_run` events triggered by `docs` runs, so a fork PR's `docs` run causes this privileged workflow to deploy PR-controlled artifact contents to `*.mlflow-docs-preview.netlify.app` and post the resulting link from `github-actions[bot]`.

The Netlify token isn't exfiltrated through this path (the deploy step only uploads static files from the artifact, no execution), but the official preview hostname can be abused for phishing or impersonation since it's then linked by a trusted bot comment under MLflow's repository.

This PR gates the job on `github.event.workflow_run.head_repository.full_name == github.repository` so only same-repository PR runs (and `push` to master) reach the deploy step. Fork contributors lose docs previews under this minimal patch; a follow-up could route them through a separate unprivileged preview site.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

YAML syntax verified locally. CI changes can only be exercised against `master` after merge.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`
- [ ] `area/models`
- [ ] `area/model-registry`
- [ ] `area/scoring`
- [ ] `area/evaluation`
- [ ] `area/gateway`
- [ ] `area/prompts`
- [ ] `area/tracing`
- [ ] `area/projects`
- [ ] `area/uiux`
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included
- [ ] `rn/breaking-change`
- [ ] `rn/feature`
- [ ] `rn/bug-fix`
- [ ] `rn/documentation`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

Reported by @dinakars777 via GitHub Security Advisory GHSA-7rc5-r96w-x8xx.