### PR TITLE
Restore `mistralai` support

### DIFF
--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -553,26 +553,13 @@ def validate_requirements(
             )
 
 
-# Packages temporarily excluded from PyPI lookups. The reference YAML is read
-# from master, so an entry that has been removed from the current branch may
-# still appear here until master catches up.
-# - mistralai: supply chain compromise — https://github.com/mistralai/client-python/issues/523
-_SKIPPED_PIP_RELEASES = {"mistralai"}
-
-
 async def expand_config(config: dict[str, Any], *, is_ref: bool = False) -> set[MatrixItem]:
     matrix = set()
-    pip_releases = list({
-        fc.package_info.pip_release
-        for fc in config.values()
-        if fc.package_info.pip_release not in _SKIPPED_PIP_RELEASES
-    })
+    pip_releases = list({fc.package_info.pip_release for fc in config.values()})
     packages = dict(zip(pip_releases, await get_packages(pip_releases)))
     for name, flavor_config in config.items():
         flavor = get_flavor(name)
         package_info = flavor_config.package_info
-        if package_info.pip_release in _SKIPPED_PIP_RELEASES:
-            continue
         package = packages[package_info.pip_release]
         all_versions = get_released_versions(package)
         free_disk_space = package_info.pip_release in (

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -80,9 +80,7 @@ google-genai
 # Required by mlflow.groq
 groq
 # Required by mlflow.mistral
-# Temporarily disabled due to supply chain compromise in 2.4.6.
-# See https://github.com/mistralai/client-python/issues/523
-# mistralai
+mistralai
 # Required by mlflow.autogen
 autogen-agentchat
 # Required by mlflow.semantic_kernel

--- a/tests/tracking/fluent/test_fluent_autolog.py
+++ b/tests/tracking/fluent/test_fluent_autolog.py
@@ -17,10 +17,7 @@ import lightgbm
 import lightning
 import litellm
 import llama_index.core
-
-# Disabled due to supply chain compromise in mistralai 2.4.6.
-# See https://github.com/mistralai/client-python/issues/523
-# import mistralai
+import mistralai
 import openai
 import pyspark
 import pyspark.ml
@@ -77,7 +74,7 @@ library_to_mlflow_module_genai = {
     google.genai: mlflow.gemini,
     boto3: mlflow.bedrock,
     groq: mlflow.groq,
-    # mistralai: mlflow.mistral,
+    mistralai: mlflow.mistral,
     autogen: mlflow.ag2,
     # TODO: once Python 3.10 is introduced, enable smolagents
     # smolagents: mlflow.smolagents,
@@ -109,10 +106,6 @@ def reset_global_states():
 
     # setfit may not be in library_to_mlflow_module when incompatible with transformers 5.x
     mlflow.utils.import_hooks._post_import_hooks.pop("setfit", None)
-    # mistralai is removed from library_to_mlflow_module while the package is
-    # disabled (see https://github.com/mistralai/client-python/issues/523), but
-    # mlflow.autolog() still registers a post-import hook for it via fluent.py.
-    mlflow.utils.import_hooks._post_import_hooks.pop("mistralai", None)
 
     assert all(v == {} for v in AUTOLOGGING_INTEGRATIONS.values())
     assert mlflow.utils.import_hooks._post_import_hooks == {}
@@ -139,8 +132,6 @@ def reset_global_states():
     mlflow.utils.import_hooks._post_import_hooks.pop("haystack", None)
     # setfit may not be in library_to_mlflow_module when incompatible with transformers 5.x
     mlflow.utils.import_hooks._post_import_hooks.pop("setfit", None)
-    # mistralai is disabled — see https://github.com/mistralai/client-python/issues/523
-    mlflow.utils.import_hooks._post_import_hooks.pop("mistralai", None)
     # TODO: Remove this line when we stop supporting google.generativeai
     mlflow.utils.import_hooks._post_import_hooks.pop("google.generativeai", None)
 
@@ -514,8 +505,6 @@ def test_autolog_genai_import(disable, flavor_and_module):
         "agno",
         "strands",
         "haystack",
-        # mistral is disabled - see https://github.com/mistralai/client-python/issues/523
-        "mistral",
     }:
         return
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23227, #23233

### What changes are proposed in this pull request?

Restore `mistralai` to the supported integrations. This reverts the temporary disablement from #23227 and #23233:

- `requirements/extra-ml-requirements.txt`: re-add `mistralai`
- `dev/set_matrix.py`: remove the `_SKIPPED_PIP_RELEASES` carve-out
- `tests/tracking/fluent/test_fluent_autolog.py`: restore the `mistralai` import, the `library_to_mlflow_module_genai` entry, drop the post-import-hook pops, and remove the `mistral` skip from `test_autolog_genai_import`

`guardrails-ai` is still unavailable on PyPI, so the corresponding install/test skip in `.github/workflows/master.yml` is left in place.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)