### PR TITLE
[Security] Reject private-IP http(s) artifact_location values

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1358,6 +1358,15 @@ _MLFLOW_WEBHOOK_ALLOW_PRIVATE_IPS = _BooleanEnvironmentVariable(
 )
 
 
+#: Allow http(s) artifact_location values that resolve to non-public IPs (loopback,
+#: link-local, private ranges, etc.). Useful for in-house HTTP artifact servers reachable
+#: only via internal addresses. Default: ``False``. When ``True``, the artifact_location
+#: validator skips the private-IP check for http/https schemes.
+MLFLOW_ARTIFACT_LOCATION_ALLOW_PRIVATE_IPS = _BooleanEnvironmentVariable(
+    "MLFLOW_ARTIFACT_LOCATION_ALLOW_PRIVATE_IPS", False
+)
+
+
 #: Whether to disable telemetry collection in MLflow. If set to True, no telemetry
 #: data will be collected. (default: ``False``)
 MLFLOW_DISABLE_TELEMETRY = _BooleanEnvironmentVariable("MLFLOW_DISABLE_TELEMETRY", False)

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -1,11 +1,13 @@
 # Define all the service endpoint handlers here.
 import io
+import ipaddress
 import json
 import logging
 import os
 import pathlib
 import posixpath
 import re
+import socket
 import tempfile
 import threading
 import time
@@ -68,6 +70,7 @@ from mlflow.entities.trace_metrics import MetricAggregation, MetricViewType
 from mlflow.entities.trace_status import TraceStatus
 from mlflow.entities.webhook import WebhookAction, WebhookEntity, WebhookEvent, WebhookStatus
 from mlflow.environment_variables import (
+    MLFLOW_ARTIFACT_LOCATION_ALLOW_PRIVATE_IPS,
     MLFLOW_CREATE_MODEL_VERSION_SOURCE_VALIDATION_REGEX,
     MLFLOW_DEPLOYMENTS_TARGET,
     MLFLOW_ENABLE_WORKSPACES,
@@ -1100,12 +1103,57 @@ def _workspace_not_supported(message: str) -> MlflowException:
     return MlflowException(message, FEATURE_DISABLED)
 
 
+_HTTP_ARTIFACT_LOCATION_SCHEMES = frozenset(["http", "https"])
+
+
+def _validate_artifact_location_http_host(
+    parsed: urllib.parse.ParseResult, field_name: str
+) -> None:
+    """Reject http(s) artifact_location values that resolve to non-public IPs.
+
+    Prevents SSRF where an attacker sets artifact_location to a private/loopback/IMDS
+    address and triggers the outbound fetch via /get-artifact. Mirrors the
+    _validate_webhook_url pattern in mlflow/utils/validation.py.
+    """
+    hostname = parsed.hostname
+    if not hostname:
+        raise MlflowException.invalid_parameter_value(
+            f"'{field_name}' with scheme {parsed.scheme!r} must include a hostname."
+        )
+
+    if MLFLOW_ARTIFACT_LOCATION_ALLOW_PRIVATE_IPS.get():
+        return
+
+    try:
+        addr_infos = socket.getaddrinfo(hostname, None)
+    except socket.gaierror as e:
+        raise MlflowException.invalid_parameter_value(
+            f"Cannot resolve '{field_name}' hostname {hostname!r}: {e}"
+        ) from e
+
+    for addr_info in addr_infos:
+        try:
+            ip = ipaddress.ip_address(addr_info[4][0])
+        except ValueError as e:
+            raise MlflowException.invalid_parameter_value(
+                f"'{field_name}' hostname {hostname!r} resolved to an invalid IP address: {e}"
+            ) from e
+        if not ip.is_global:
+            raise MlflowException.invalid_parameter_value(
+                f"'{field_name}' must not resolve to a non-public IP address. "
+                f"{hostname!r} resolves to {ip}."
+            )
+
+
 def _validate_artifact_root_uri(value: str, field_name: str) -> str:
     parsed = urllib.parse.urlparse(value)
     if parsed.fragment or parsed.params:
         raise MlflowException.invalid_parameter_value(
             f"'{field_name}' URL can't include fragments or params."
         )
+
+    if parsed.scheme in _HTTP_ARTIFACT_LOCATION_SCHEMES:
+        _validate_artifact_location_http_host(parsed, field_name)
 
     validate_query_string(parsed.query)
     _validate_experiment_artifact_location(value)

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -1,4 +1,5 @@
 import json
+import socket
 import uuid
 from dataclasses import asdict
 from datetime import datetime, timezone
@@ -201,6 +202,7 @@ from mlflow.server.handlers import (
     _update_model_version,
     _update_registered_model,
     _upsert_dataset_records_handler,
+    _validate_artifact_root_uri,
     _validate_source_run,
     catch_mlflow_exception,
     get_artifact_handler,
@@ -5467,3 +5469,94 @@ def test_get_rest_path_respects_static_prefix(monkeypatch):
         _get_ajax_path("/mlflow/experiments/search")
         == "/myapp/ajax-api/2.0/mlflow/experiments/search"
     )
+
+
+# -- _validate_artifact_root_uri tests --
+
+
+def _mock_getaddrinfo_returning(ip_str):
+    return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", (ip_str, 0))]
+
+
+@pytest.mark.parametrize(
+    ("url", "resolved_ip"),
+    [
+        ("http://169.254.169.254/latest/meta-data", "169.254.169.254"),
+        ("http://localhost/foo", "127.0.0.1"),
+        ("http://127.0.0.1/foo", "127.0.0.1"),
+        ("http://10.0.0.1/foo", "10.0.0.1"),
+        ("http://192.168.1.1/foo", "192.168.1.1"),
+        ("https://metadata.google.internal/computeMetadata/v1/", "169.254.169.254"),
+    ],
+)
+def test_validate_artifact_root_uri_rejects_private_http_hosts(url, resolved_ip):
+    with mock.patch(
+        "mlflow.server.handlers.socket.getaddrinfo",
+        return_value=_mock_getaddrinfo_returning(resolved_ip),
+    ) as mock_getaddrinfo:
+        with pytest.raises(MlflowException, match="must not resolve to a non-public IP"):
+            _validate_artifact_root_uri(url, "artifact_location")
+        mock_getaddrinfo.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "s3://bucket/path",
+        "gs://bucket/path",
+        "file:///tmp/artifacts",
+        "mlflow-artifacts:/path",
+        "dbfs:/path",
+    ],
+)
+def test_validate_artifact_root_uri_allows_non_http_schemes(url):
+    with mock.patch("mlflow.server.handlers.socket.getaddrinfo") as mock_getaddrinfo:
+        assert _validate_artifact_root_uri(url, "artifact_location") == url
+        mock_getaddrinfo.assert_not_called()
+
+
+def test_validate_artifact_root_uri_allows_public_https_host():
+    with mock.patch(
+        "mlflow.server.handlers.socket.getaddrinfo",
+        return_value=_mock_getaddrinfo_returning("1.2.3.4"),
+    ) as mock_getaddrinfo:
+        url = "https://artifacts.example.com/path"
+        assert _validate_artifact_root_uri(url, "artifact_location") == url
+        mock_getaddrinfo.assert_called_once()
+
+
+def test_validate_artifact_root_uri_rejects_unresolvable_http_hostname():
+    with mock.patch(
+        "mlflow.server.handlers.socket.getaddrinfo",
+        side_effect=socket.gaierror("Name or service not known"),
+    ) as mock_getaddrinfo:
+        with pytest.raises(MlflowException, match="Cannot resolve 'artifact_location' hostname"):
+            _validate_artifact_root_uri("http://does-not-exist.invalid/path", "artifact_location")
+        mock_getaddrinfo.assert_called_once()
+
+
+def test_validate_artifact_root_uri_rejects_if_any_resolved_address_is_private():
+    multi_resolve = [
+        (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("8.8.8.8", 0)),
+        (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("10.0.0.1", 0)),
+    ]
+    with mock.patch(
+        "mlflow.server.handlers.socket.getaddrinfo",
+        return_value=multi_resolve,
+    ) as mock_getaddrinfo:
+        with pytest.raises(MlflowException, match="must not resolve to a non-public IP"):
+            _validate_artifact_root_uri("https://dual-homed.example.com/path", "artifact_location")
+        mock_getaddrinfo.assert_called_once()
+
+
+def test_validate_artifact_root_uri_allow_private_ips_env_var(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ARTIFACT_LOCATION_ALLOW_PRIVATE_IPS", "true")
+    with mock.patch("mlflow.server.handlers.socket.getaddrinfo") as mock_getaddrinfo:
+        url = "http://internal-host/path"
+        assert _validate_artifact_root_uri(url, "artifact_location") == url
+        mock_getaddrinfo.assert_not_called()
+
+
+def test_validate_artifact_root_uri_rejects_http_without_hostname():
+    with pytest.raises(MlflowException, match="must include a hostname"):
+        _validate_artifact_root_uri("http:///path", "artifact_location")


### PR DESCRIPTION
### Related Issues/PRs

Relates to `GHSA-vf52-gj9c-hw99`

### What changes are proposed in this pull request?

`_validate_artifact_root_uri` in `mlflow/server/handlers.py` did not restrict http(s) hostnames in `artifact_location`. Because `http`/`https` are registered as `HttpArtifactRepository`, any user with `CreateExperiment` access could set `artifact_location=http://169.254.169.254/...` and trigger an outbound fetch via `/get-artifact?run_id=...&path=...`, returning the response to the caller (SSRF into IMDS, internal services, etc.).

This PR mirrors the `_validate_webhook_url` pattern (PR #20747): when the `artifact_location` scheme is `http` or `https`, resolve the hostname and reject any address where `ip.is_global` is false. A new env var `MLFLOW_ARTIFACT_LOCATION_ALLOW_PRIVATE_IPS` (default `false`) lets operators opt out for legitimate in-house HTTP artifact servers reachable only via internal addresses. Non-http(s) schemes (`s3://`, `gs://`, `file://`, `dbfs:/`, `mlflow-artifacts:/`, etc.) are unaffected.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Rejects `http(s)` `artifact_location` values that resolve to non-public IPs (loopback, link-local, private ranges, cloud metadata endpoints). The existing legitimate use case of an in-house HTTP artifact server reachable only via an internal address requires setting `MLFLOW_ARTIFACT_LOCATION_ALLOW_PRIVATE_IPS=true`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

---

Reported by @thesecguy45 via GitHub Security Advisory GHSA-vf52-gj9c-hw99.