### PR TITLE
Pin nailaopus mlflow/internal checkout to a specific SHA

### DIFF
--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -162,6 +162,12 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: mlflow/internal
+          # Pinned to a specific commit so production reviews are reproducible
+          # and a bad orchestrator change can't silently break the bot. To bump,
+          # open a new PR that updates this SHA to the latest mlflow/internal
+          # main after reviewing the diff. We'll migrate to release tags once
+          # the bump cadence is stable; see mlflow/internal for the policy.
+          ref: 4a973436ee1df41253f7936e64d49cb4e52a4969
           sparse-checkout: |
             nailaopus
           path: internal


### PR DESCRIPTION
### Related Issues/PRs

Relates to [mlflow/internal#26](https://github.com/mlflow/internal/pull/26) (head-SHA permalink fix that this pin picks up)

### What changes are proposed in this pull request?

Adds a `ref:` pin on the `actions/checkout@v6.0.2` step that pulls `mlflow/internal` in `.github/workflows/nailaopus.yml`. Previously the workflow checked out the floating tip of `mlflow/internal:main`, so any change there silently took effect on the next PR review on mlflow/mlflow.

Pinning to commit `4a973436ee1df41253f7936e64d49cb4e52a4969` (current main on mlflow/internal) does two things:

1. Production reviews become reproducible, re-running on the same PR runs identical orchestrator code.
2. Bumping the orchestrator becomes an explicit, PR-reviewed step on this repo rather than an invisible auto-deploy.

This commit also includes the head-SHA permalink fix on mlflow/internal#26, which restores working blob URLs in the bot's posted findings (the previous behavior was to invent placeholder refs like `PR-23220` that 404).

Future bump PRs only need to update the SHA + the line comment. We'll migrate to release tags on mlflow/internal once the bump cadence is stable.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Diff inspection; end-to-end validation happens on the first `/review-v2` invocation after merge (will show a working permalink in the posted findings).

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`
- [ ] `area/models`
- [ ] `area/model-registry`
- [ ] `area/scoring`
- [ ] `area/evaluation`
- [ ] `area/gateway`
- [ ] `area/prompts`
- [ ] `area/tracing`
- [ ] `area/projects`
- [ ] `area/uiux`
- [x] `area/build`
- [ ] `area/docs`

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

-- Claude-drafted, reviewed before posting.