### PR TITLE
Tighten guidance for pr-review summary body

### DIFF
--- a/.claude/skills/pr-review/review-payload.schema.json
+++ b/.claude/skills/pr-review/review-payload.schema.json
@@ -13,7 +13,7 @@
       "enum": ["APPROVE", "COMMENT"]
     },
     "body": {
-      "description": "Top-level review summary. Must end with the '🤖 Generated with Claude' footer on its own line.",
+      "description": "Concise top-level review summary — 2-3 sentences capturing the overall assessment. Do not restate individual findings (those belong in inline comments). Must end with the '🤖 Generated with Claude' footer on its own line.",
       "type": "string",
       "minLength": 1,
       "pattern": "(^|\\n)🤖 Generated with Claude\\s*$"

--- a/.claude/skills/pr-review/review-payload.schema.json
+++ b/.claude/skills/pr-review/review-payload.schema.json
@@ -13,7 +13,7 @@
       "enum": ["APPROVE", "COMMENT"]
     },
     "body": {
-      "description": "Concise top-level review summary — 2-3 sentences capturing the overall assessment. Do not restate individual findings (those belong in inline comments). Must end with the '🤖 Generated with Claude' footer on its own line.",
+      "description": "Concise top-level review summary in 2-3 sentences capturing the overall assessment. Do not restate individual findings (those belong in inline comments). Must end with the '🤖 Generated with Claude' footer on its own line.",
       "type": "string",
       "minLength": 1,
       "pattern": "(^|\\n)🤖 Generated with Claude\\s*$"


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

Updates the `body` field description in `.claude/skills/pr-review/review-payload.schema.json` so review summaries stay short. Steers agents toward 2-3 sentences and explicitly tells them not to restate individual findings (those belong in inline comments).

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the \"Small Bugfixes and Documentation Updates\" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)