### PR TITLE
Record git branch and repo URL on runs in `GitRunContext`

### DIFF
--- a/mlflow/tracking/context/git_context.py
+++ b/mlflow/tracking/context/git_context.py
@@ -2,17 +2,25 @@ import logging
 
 from mlflow.tracking.context.abstract_context import RunContextProvider
 from mlflow.tracking.context.default_context import _get_main_file
-from mlflow.utils.git_utils import get_git_commit
-from mlflow.utils.mlflow_tags import MLFLOW_GIT_COMMIT
+from mlflow.utils.git_utils import get_git_branch, get_git_commit, get_git_repo_url
+from mlflow.utils.mlflow_tags import (
+    MLFLOW_GIT_BRANCH,
+    MLFLOW_GIT_COMMIT,
+    MLFLOW_GIT_REPO_URL,
+)
 
 _logger = logging.getLogger(__name__)
 
 
-def _get_source_version():
+def _resolve_git_info():
     main_file = _get_main_file()
-    if main_file is not None:
-        return get_git_commit(main_file)
-    return None
+    if main_file is None:
+        return {}
+    return {
+        MLFLOW_GIT_COMMIT: get_git_commit(main_file),
+        MLFLOW_GIT_BRANCH: get_git_branch(main_file),
+        MLFLOW_GIT_REPO_URL: get_git_repo_url(main_file),
+    }
 
 
 class GitRunContext(RunContextProvider):
@@ -20,13 +28,13 @@ class GitRunContext(RunContextProvider):
         self._cache = {}
 
     @property
-    def _source_version(self):
-        if "source_version" not in self._cache:
-            self._cache["source_version"] = _get_source_version()
-        return self._cache["source_version"]
+    def _git_info(self):
+        if "git_info" not in self._cache:
+            self._cache["git_info"] = _resolve_git_info()
+        return self._cache["git_info"]
 
     def in_context(self):
-        return self._source_version is not None
+        return self._git_info.get(MLFLOW_GIT_COMMIT) is not None
 
     def tags(self):
-        return {MLFLOW_GIT_COMMIT: self._source_version}
+        return {k: v for k, v in self._git_info.items() if v is not None}

--- a/mlflow/utils/git_utils.py
+++ b/mlflow/utils/git_utils.py
@@ -1,13 +1,31 @@
 import logging
 import os
+from urllib.parse import urlsplit, urlunsplit
 
 _logger = logging.getLogger(__name__)
+
+
+def _strip_credentials_from_url(url: str) -> str:
+    """
+    Strip any embedded userinfo (username/password) from a URL so it's safe to record as a tag.
+
+    HTTP(S) and similar remotes can carry credentials in the form
+    ``https://user:token@host/path``; MLflow records repo URLs as run tags that are stored and
+    displayed to users, so we drop the userinfo before exposing them. URLs without a scheme
+    (e.g. SSH-style ``git@github.com:org/repo.git``) or without userinfo are returned unchanged.
+    """
+    parsed = urlsplit(url)
+    if not parsed.scheme or "@" not in parsed.netloc:
+        return url
+    _, _, host_port = parsed.netloc.rpartition("@")
+    return urlunsplit((parsed.scheme, host_port, parsed.path, parsed.query, parsed.fragment))
 
 
 def get_git_repo_url(path: str) -> str | None:
     """
     Obtains the url of the git repository associated with the specified path,
-    returning ``None`` if the path does not correspond to a git repository.
+    returning ``None`` if the path does not correspond to a git repository. Any embedded
+    credentials (e.g. tokens in HTTPS remotes) are stripped before the URL is returned.
     """
     try:
         from git import Repo
@@ -21,7 +39,8 @@ def get_git_repo_url(path: str) -> str | None:
 
     try:
         repo = Repo(path, search_parent_directories=True)
-        return next((remote.url for remote in repo.remotes), None)
+        url = next((remote.url for remote in repo.remotes), None)
+        return _strip_credentials_from_url(url) if url is not None else None
     except Exception:
         return None
 

--- a/mlflow/utils/git_utils.py
+++ b/mlflow/utils/git_utils.py
@@ -32,12 +32,14 @@ def get_git_repo_url(path: str) -> str | None:
     except ImportError as e:
         _logger.warning(
             "Failed to import Git (the Git executable is probably not on your PATH),"
-            " so Git SHA is not available. Error: %s",
+            " so Git repository URL is not available. Error: %s",
             e,
         )
         return None
 
     try:
+        if os.path.isfile(path):
+            path = os.path.dirname(os.path.abspath(path))
         repo = Repo(path, search_parent_directories=True)
         url = next((remote.url for remote in repo.remotes), None)
         return _strip_credentials_from_url(url) if url is not None else None
@@ -81,14 +83,14 @@ def get_git_branch(path: str) -> str | None:
     except ImportError as e:
         _logger.warning(
             "Failed to import Git (the Git executable is probably not on your PATH),"
-            " so Git SHA is not available. Error: %s",
+            " so Git branch is not available. Error: %s",
             e,
         )
         return None
 
     try:
         if os.path.isfile(path):
-            path = os.path.dirname(path)
+            path = os.path.dirname(os.path.abspath(path))
         repo = Repo(path, search_parent_directories=True)
         return repo.active_branch.name
     except Exception:

--- a/tests/tracking/context/test_git_context.py
+++ b/tests/tracking/context/test_git_context.py
@@ -72,8 +72,7 @@ def test_git_run_context_caching(patch_script_name):
         context = GitRunContext()
         context.in_context()
         context.tags()
-
-    assert mock_repo.call_count == 3
-    context.in_context()
-    context.tags()
-    assert mock_repo.call_count == 3
+        assert mock_repo.call_count == 3
+        context.in_context()
+        context.tags()
+        assert mock_repo.call_count == 3

--- a/tests/tracking/context/test_git_context.py
+++ b/tests/tracking/context/test_git_context.py
@@ -4,10 +4,16 @@ import git
 import pytest
 
 from mlflow.tracking.context.git_context import GitRunContext
-from mlflow.utils.mlflow_tags import MLFLOW_GIT_COMMIT
+from mlflow.utils.mlflow_tags import (
+    MLFLOW_GIT_BRANCH,
+    MLFLOW_GIT_COMMIT,
+    MLFLOW_GIT_REPO_URL,
+)
 
 MOCK_SCRIPT_NAME = "/path/to/script.py"
 MOCK_COMMIT_HASH = "commit-hash"
+MOCK_BRANCH_NAME = "feature/test"
+MOCK_REPO_URL = "git@github.com:mlflow/mlflow.git"
 
 
 @pytest.fixture
@@ -22,7 +28,11 @@ def patch_script_name():
 def patch_git_repo():
     mock_repo = mock.Mock()
     mock_repo.head.commit.hexsha = MOCK_COMMIT_HASH
+    mock_repo.active_branch.name = MOCK_BRANCH_NAME
     mock_repo.ignored.return_value = []
+    mock_remote = mock.Mock()
+    mock_remote.url = MOCK_REPO_URL
+    mock_repo.remotes = [mock_remote]
     with mock.patch("git.Repo", return_value=mock_repo):
         yield mock_repo
 
@@ -37,7 +47,24 @@ def test_git_run_context_in_context_false(patch_script_name):
 
 
 def test_git_run_context_tags(patch_script_name, patch_git_repo):
-    assert GitRunContext().tags() == {MLFLOW_GIT_COMMIT: MOCK_COMMIT_HASH}
+    assert GitRunContext().tags() == {
+        MLFLOW_GIT_COMMIT: MOCK_COMMIT_HASH,
+        MLFLOW_GIT_BRANCH: MOCK_BRANCH_NAME,
+        MLFLOW_GIT_REPO_URL: MOCK_REPO_URL,
+    }
+
+
+def test_git_run_context_tags_omits_missing_fields(patch_script_name):
+    mock_repo = mock.Mock()
+    mock_repo.head.commit.hexsha = MOCK_COMMIT_HASH
+    mock_repo.active_branch.name = MOCK_BRANCH_NAME
+    mock_repo.ignored.return_value = []
+    mock_repo.remotes = []
+    with mock.patch("git.Repo", return_value=mock_repo):
+        assert GitRunContext().tags() == {
+            MLFLOW_GIT_COMMIT: MOCK_COMMIT_HASH,
+            MLFLOW_GIT_BRANCH: MOCK_BRANCH_NAME,
+        }
 
 
 def test_git_run_context_caching(patch_script_name):
@@ -46,4 +73,7 @@ def test_git_run_context_caching(patch_script_name):
         context.in_context()
         context.tags()
 
-    mock_repo.assert_called_once()
+    assert mock_repo.call_count == 3
+    context.in_context()
+    context.tags()
+    assert mock_repo.call_count == 3

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -1845,7 +1845,9 @@ def test_initialize_logged_model_tags_from_context():
         ) as m_get_source_type,
         mock.patch(
             "mlflow.tracking.context.git_context._resolve_git_info",
-            return_value={mlflow_tags.MLFLOW_GIT_COMMIT: expected_tags[mlflow_tags.MLFLOW_GIT_COMMIT]},
+            return_value={
+                mlflow_tags.MLFLOW_GIT_COMMIT: expected_tags[mlflow_tags.MLFLOW_GIT_COMMIT]
+            },
         ) as m_get_source_version,
     ):
         model = mlflow.initialize_logged_model()

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -567,7 +567,8 @@ def test_start_run_defaults(empty_active_run_stack):
     )
     mock_source_version = mock.Mock()
     source_version_patch = mock.patch(
-        "mlflow.tracking.context.git_context._get_source_version", return_value=mock_source_version
+        "mlflow.tracking.context.git_context._resolve_git_info",
+        return_value={mlflow_tags.MLFLOW_GIT_COMMIT: mock_source_version},
     )
     run_name = "my name"
 
@@ -612,7 +613,8 @@ def test_start_run_defaults_databricks_notebook(
     )
     mock_source_version = mock.Mock()
     source_version_patch = mock.patch(
-        "mlflow.tracking.context.git_context._get_source_version", return_value=mock_source_version
+        "mlflow.tracking.context.git_context._resolve_git_info",
+        return_value={mlflow_tags.MLFLOW_GIT_COMMIT: mock_source_version},
     )
     mock_notebook_id = mock.Mock()
     notebook_id_patch = mock.patch(
@@ -696,7 +698,8 @@ def test_start_run_creates_new_run_with_user_specified_tags():
     )
     mock_source_version = mock.Mock()
     source_version_patch = mock.patch(
-        "mlflow.tracking.context.git_context._get_source_version", return_value=mock_source_version
+        "mlflow.tracking.context.git_context._resolve_git_info",
+        return_value={mlflow_tags.MLFLOW_GIT_COMMIT: mock_source_version},
     )
     user_specified_tags = {
         "ml_task": "regression",
@@ -907,7 +910,8 @@ def test_start_run_with_description(empty_active_run_stack):
     )
     mock_source_version = mock.Mock()
     source_version_patch = mock.patch(
-        "mlflow.tracking.context.git_context._get_source_version", return_value=mock_source_version
+        "mlflow.tracking.context.git_context._resolve_git_info",
+        return_value={mlflow_tags.MLFLOW_GIT_COMMIT: mock_source_version},
     )
 
     description = "Test description"
@@ -1840,8 +1844,8 @@ def test_initialize_logged_model_tags_from_context():
             return_value=SourceType.from_string(expected_tags[mlflow_tags.MLFLOW_SOURCE_TYPE]),
         ) as m_get_source_type,
         mock.patch(
-            "mlflow.tracking.context.git_context._get_source_version",
-            return_value=expected_tags[mlflow_tags.MLFLOW_GIT_COMMIT],
+            "mlflow.tracking.context.git_context._resolve_git_info",
+            return_value={mlflow_tags.MLFLOW_GIT_COMMIT: expected_tags[mlflow_tags.MLFLOW_GIT_COMMIT]},
         ) as m_get_source_version,
     ):
         model = mlflow.initialize_logged_model()

--- a/tests/utils/test_git_utils.py
+++ b/tests/utils/test_git_utils.py
@@ -1,0 +1,34 @@
+import pytest
+
+from mlflow.utils.git_utils import _strip_credentials_from_url
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        # HTTPS with username + password (token)
+        ("https://user:token@github.com/foo/bar.git", "https://github.com/foo/bar.git"),
+        # HTTPS with token-only userinfo (GitHub PAT style)
+        ("https://ghp_abc123@github.com/foo/bar.git", "https://github.com/foo/bar.git"),
+        # HTTP variant
+        ("http://user:pass@example.com/repo.git", "http://example.com/repo.git"),
+        # ssh:// URL form with explicit user
+        ("ssh://git@github.com/foo/bar.git", "ssh://github.com/foo/bar.git"),
+        # git:// URL form with embedded userinfo
+        ("git://user:secret@host/repo.git", "git://host/repo.git"),
+        # Preserve port
+        ("https://user:token@host.example.com:8080/repo.git", "https://host.example.com:8080/repo.git"),
+        # Preserve query + fragment
+        ("https://user@host/repo.git?foo=bar#section", "https://host/repo.git?foo=bar#section"),
+        # No-op: HTTPS without credentials
+        ("https://github.com/foo/bar.git", "https://github.com/foo/bar.git"),
+        # No-op: SSH-style scp URL (no scheme to parse)
+        ("git@github.com:foo/bar.git", "git@github.com:foo/bar.git"),
+        # No-op: local file path
+        ("/local/path/to/repo", "/local/path/to/repo"),
+        # No-op: empty string
+        ("", ""),
+    ],
+)
+def test_strip_credentials_from_url(url: str, expected: str):
+    assert _strip_credentials_from_url(url) == expected

--- a/tests/utils/test_git_utils.py
+++ b/tests/utils/test_git_utils.py
@@ -17,7 +17,10 @@ from mlflow.utils.git_utils import _strip_credentials_from_url
         # git:// URL form with embedded userinfo
         ("git://user:secret@host/repo.git", "git://host/repo.git"),
         # Preserve port
-        ("https://user:token@host.example.com:8080/repo.git", "https://host.example.com:8080/repo.git"),
+        (
+            "https://user:token@host.example.com:8080/repo.git",
+            "https://host.example.com:8080/repo.git",
+        ),
         # Preserve query + fragment
         ("https://user@host/repo.git?foo=bar#section", "https://host/repo.git?foo=bar#section"),
         # No-op: HTTPS without credentials


### PR DESCRIPTION
### Related Issues/PRs

Relates to #21199

### What changes are proposed in this pull request?

- `GitRunContext.tags()` (`mlflow/tracking/context/git_context.py`) now emits `mlflow.source.git.branch` and `mlflow.source.git.repoURL` alongside the existing `mlflow.source.git.commit` tag, bringing runs to parity with traces (which already capture all three via `mlflow/tracing/utils/environment.py`).
- This means metrics logged into runs by `mlflow.models.evaluate` can now be grouped/filtered by branch and repo, not just by commit hash.
- New helper `_resolve_git_info` consolidates the three git lookups and stays cached per `GitRunContext` instance, so the run-start cost is one-time.
- Removed the now-unused `_get_source_version` shim.

This is the **backend** half of a stacked PR. The frontend half (#23295) builds on this to surface the new tags in the evaluation runs UI.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Extended `tests/tracking/context/test_git_context.py` to assert branch and repo URL are returned, added a case for partial git info (commit + branch but no remote), and updated the caching test to reflect the new call count. Updated `tests/tracking/fluent/test_fluent.py` patch sites to target `_resolve_git_info` instead of the removed `_get_source_version`.

Smoke-tested locally inside this repo: `GitRunContext().tags()` returns all three fields with real values pulled from the working tree.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Runs now automatically tag `mlflow.source.git.branch` and `mlflow.source.git.repoURL` in addition to `mlflow.source.git.commit`, making it easier to group evaluation metrics by branch and repository.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release