### PR TITLE
[Security] Require explicit trust_remote_code=True in mlflow.transformers.load_model

### DIFF
--- a/docs/docs/classic-ml/deep-learning/transformers/guide/index.mdx
+++ b/docs/docs/classic-ml/deep-learning/transformers/guide/index.mdx
@@ -319,6 +319,26 @@ The transformers flavor has two different primary mechanisms for saving and load
 Saving transformers models with custom code (i.e. models that require `trust_remote_code=True`) requires `transformers >= 4.26.0`.
 :::
 
+:::warning Loading models with custom code
+Some Transformers models (e.g. MPT, certain Falcon variants, DeepSeek-R1) ship a custom architecture or component
+referenced via `auto_map` in `config.json`. Loading these artifacts executes arbitrary Python from the model
+repository.
+
+To match the Hugging Face library default, MLflow does **not** enable this by default. Calling
+<APILink fn="mlflow.transformers.load_model" /> on a custom-code artifact will raise an `MlflowException` with
+actionable guidance. To load such a model, pass `trust_remote_code=True` explicitly:
+
+```python
+loaded = mlflow.transformers.load_model(model_uri, trust_remote_code=True)
+```
+
+Only set `trust_remote_code=True` for models from sources you trust. Pyfunc loading does not accept this
+parameter, so custom-code artifacts must be loaded via `mlflow.transformers.load_model` directly.
+
+This default changed in MLflow `<next-version>`. Prior versions silently enabled remote code execution for
+custom-architecture models.
+:::
+
 **Pipelines**
 
 Pipelines, in the context of the Transformers library, are high-level objects that combine pre-trained models and tokenizers

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -1125,6 +1125,7 @@ def load_model(
     return_type="pipeline",
     device=None,
     base_model_path: str | None = None,
+    trust_remote_code: bool = False,
     **kwargs,
 ):
     """
@@ -1173,6 +1174,28 @@ def load_model(
             artifact at save time. This is useful when the base model is located at a
             different path at load time than it was at save time (e.g. different mount
             points across environments).
+        trust_remote_code: Whether to allow executing custom code embedded in
+            the model artifact. Hugging Face Transformers uses this flag as an
+            explicit consent boundary for importing custom architecture or
+            component modules referenced via ``auto_map`` in ``config.json``.
+
+            Default is ``False``. When ``False``, MLflow refuses to load
+            artifacts that require custom code and raises a clear error
+            with instructions. When ``True``, MLflow forwards the trust
+            decision to Hugging Face and executes the embedded code.
+
+            .. warning::
+
+                Setting ``trust_remote_code=True`` executes arbitrary
+                Python from the model artifact. Only enable this for models
+                from sources you trust.
+
+            .. note::
+
+                Prior to MLflow <next-version>, MLflow silently enabled
+                ``trust_remote_code=True`` for custom-architecture models,
+                without any caller opt-in. This was a behavior change in
+                <next-version>.
         kwargs: Optional configuration options for loading of a ``transformers`` object.
             For information on parameters and their usage, see
             `transformers documentation <https://huggingface.co/docs/transformers/index>`_.
@@ -1233,6 +1256,7 @@ def load_model(
         return_type,
         device,
         base_model_path=base_model_path,
+        trust_remote_code=trust_remote_code,
         **kwargs,
     )
 
@@ -1368,6 +1392,7 @@ def _load_model(
     return_type: str,
     device=None,
     base_model_path: str | None = None,
+    trust_remote_code: bool = False,
     **kwargs,
 ):
     """
@@ -1439,6 +1464,7 @@ def _load_model(
             accelerate_conf=accelerate_model_conf,
             device=device,
             base_model_path=base_model_path,
+            trust_remote_code=trust_remote_code,
         )
     elif FlavorKey.MODEL_REVISION not in flavor_config:
         model_and_components = load_model_and_components_from_local(
@@ -1446,10 +1472,14 @@ def _load_model(
             flavor_conf=flavor_config,
             accelerate_conf=accelerate_model_conf,
             device=device,
+            trust_remote_code=trust_remote_code,
         )
     else:
         model_and_components = load_model_and_components_from_huggingface_hub(
-            flavor_conf=flavor_config, accelerate_conf=accelerate_model_conf, device=device
+            flavor_conf=flavor_config,
+            accelerate_conf=accelerate_model_conf,
+            device=device,
+            trust_remote_code=trust_remote_code,
         )
 
     # Load and apply PEFT adaptor if saved
@@ -1787,7 +1817,14 @@ def _get_model_config(local_path, pyfunc_config):
 
 def _load_pyfunc(path, model_config: dict[str, Any] | None = None):
     """
-    Loads the model as pyfunc model
+    Loads the model as pyfunc model.
+
+    Note: pyfunc loading does not accept a ``trust_remote_code`` argument, so
+    models that require custom code (custom architectures or components
+    referenced via ``auto_map`` in ``config.json``) will fail to load by
+    default. Users who need to load such artifacts should call
+    ``mlflow.transformers.load_model(model_uri, trust_remote_code=True)``
+    directly after independently verifying that the model source is trusted.
     """
     local_path = pathlib.Path(path)
     flavor_configuration = _get_flavor_configuration(local_path, FLAVOR_NAME)
@@ -1795,7 +1832,7 @@ def _load_pyfunc(path, model_config: dict[str, Any] | None = None):
     prompt_template = _get_prompt_template(local_path)
 
     return _TransformersWrapper(
-        _load_model(str(local_path), flavor_configuration, "pipeline"),
+        _load_model(str(local_path), flavor_configuration, "pipeline", trust_remote_code=False),
         flavor_configuration,
         model_config,
         prompt_template,

--- a/mlflow/transformers/model_io.py
+++ b/mlflow/transformers/model_io.py
@@ -23,6 +23,24 @@ _MODEL_BINARY_FILE_NAME = "model"
 _COMPONENTS_BINARY_DIR_NAME = "components"
 _PROCESSOR_BINARY_DIR_NAME = "processor"
 
+# Shared error message used when a model artifact requires custom (remote) code
+# but the caller did not opt in via ``trust_remote_code=True``. Prior to the
+# behavior change, MLflow silently enabled ``trust_remote_code=True`` for
+# custom-architecture models. We now require an explicit opt-in to match the
+# Hugging Face library default.
+_TRUST_REMOTE_CODE_ERROR_MESSAGE = (
+    "This Transformers model contains custom code (a custom architecture or "
+    "component referenced via `auto_map` in `config.json`). Loading it "
+    "requires executing arbitrary Python code from the model artifact.\n\n"
+    "MLflow does not enable this by default for security reasons. If you "
+    "trust the source of this model and want to load it, pass "
+    "`trust_remote_code=True` to `mlflow.transformers.load_model`:\n\n"
+    "    mlflow.transformers.load_model(model_uri, trust_remote_code=True)\n\n"
+    "Note: this changed in MLflow <next-version> to match the Hugging Face "
+    "library default. Previously, MLflow silently enabled remote code "
+    "execution for custom-architecture models."
+)
+
 
 def save_pipeline_pretrained_weights(path, pipeline, flavor_conf, processor=None):
     """
@@ -108,6 +126,7 @@ def load_model_and_components_from_local_base_path(
     accelerate_conf: dict[str, Any],
     device: str | int | None = None,
     base_model_path: str | None = None,
+    trust_remote_code: bool = False,
 ) -> dict[str, Any]:
     """
     Load the base model from an external local path and pipeline components from the
@@ -122,11 +141,19 @@ def load_model_and_components_from_local_base_path(
         base_model_path: Optional override for the base model path stored in the flavor
             config. When provided, the base model is loaded from this path instead of
             the path stored at save time.
+        trust_remote_code: Whether to allow executing custom code embedded in the model
+            artifact. See ``mlflow.transformers.load_model`` for details.
     """
     loaded = {}
 
     base_model_path = base_model_path or flavor_conf[FlavorKey.MODEL_LOCAL_BASE]
-    loaded[FlavorKey.MODEL] = _load_model(base_model_path, flavor_conf, accelerate_conf, device)
+    loaded[FlavorKey.MODEL] = _load_model(
+        base_model_path,
+        flavor_conf,
+        accelerate_conf,
+        device,
+        trust_remote_code=trust_remote_code,
+    )
 
     components = flavor_conf.get(FlavorKey.COMPONENTS, [])
     if FlavorKey.PROCESSOR_TYPE in flavor_conf:
@@ -135,13 +162,18 @@ def load_model_and_components_from_local_base_path(
     for component_key in components:
         component_path = path.joinpath(_COMPONENTS_BINARY_DIR_NAME, component_key)
         loaded[component_key] = _load_component(
-            flavor_conf, component_key, local_path=component_path
+            flavor_conf,
+            component_key,
+            local_path=component_path,
+            trust_remote_code=trust_remote_code,
         )
 
     return loaded
 
 
-def load_model_and_components_from_local(path, flavor_conf, accelerate_conf, device=None):
+def load_model_and_components_from_local(
+    path, flavor_conf, accelerate_conf, device=None, trust_remote_code: bool = False
+):
     """
     Load the model and components of a Transformer pipeline from the specified local path.
 
@@ -150,6 +182,8 @@ def load_model_and_components_from_local(path, flavor_conf, accelerate_conf, dev
         flavor_conf: The flavor configuration
         accelerate_conf: The configuration for the accelerate library
         device: The device to load the model onto
+        trust_remote_code: Whether to allow executing custom code embedded in the model
+            artifact. See ``mlflow.transformers.load_model`` for details.
     """
     loaded = {}
 
@@ -159,7 +193,13 @@ def load_model_and_components_from_local(path, flavor_conf, accelerate_conf, dev
     #     "artifacts/pipeline/*" path. In order to load the older formats after the change, the
     #     presence of the new path key is checked.
     model_path = path.joinpath(flavor_conf.get(FlavorKey.MODEL_BINARY, "pipeline"))
-    loaded[FlavorKey.MODEL] = _load_model(model_path, flavor_conf, accelerate_conf, device)
+    loaded[FlavorKey.MODEL] = _load_model(
+        model_path,
+        flavor_conf,
+        accelerate_conf,
+        device,
+        trust_remote_code=trust_remote_code,
+    )
 
     components = flavor_conf.get(FlavorKey.COMPONENTS, [])
     if FlavorKey.PROCESSOR_TYPE in flavor_conf:
@@ -168,13 +208,18 @@ def load_model_and_components_from_local(path, flavor_conf, accelerate_conf, dev
     for component_key in components:
         component_path = path.joinpath(_COMPONENTS_BINARY_DIR_NAME, component_key)
         loaded[component_key] = _load_component(
-            flavor_conf, component_key, local_path=component_path
+            flavor_conf,
+            component_key,
+            local_path=component_path,
+            trust_remote_code=trust_remote_code,
         )
 
     return loaded
 
 
-def load_model_and_components_from_huggingface_hub(flavor_conf, accelerate_conf, device=None):
+def load_model_and_components_from_huggingface_hub(
+    flavor_conf, accelerate_conf, device=None, trust_remote_code: bool = False
+):
     """
     Load the model and components of a Transformer pipeline from HuggingFace Hub.
 
@@ -182,6 +227,8 @@ def load_model_and_components_from_huggingface_hub(flavor_conf, accelerate_conf,
         flavor_conf: The flavor configuration
         accelerate_conf: The configuration for the accelerate library
         device: The device to load the model onto
+        trust_remote_code: Whether to allow executing custom code embedded in the model
+            artifact. See ``mlflow.transformers.load_model`` for details.
     """
     loaded = {}
 
@@ -197,7 +244,12 @@ def load_model_and_components_from_huggingface_hub(flavor_conf, accelerate_conf,
         )
 
     loaded[FlavorKey.MODEL] = _load_model(
-        model_repo, flavor_conf, accelerate_conf, device, revision=model_revision
+        model_repo,
+        flavor_conf,
+        accelerate_conf,
+        device,
+        revision=model_revision,
+        trust_remote_code=trust_remote_code,
     )
 
     components = flavor_conf.get(FlavorKey.COMPONENTS, [])
@@ -205,12 +257,12 @@ def load_model_and_components_from_huggingface_hub(flavor_conf, accelerate_conf,
         components.append("processor")
 
     for name in components:
-        loaded[name] = _load_component(flavor_conf, name)
+        loaded[name] = _load_component(flavor_conf, name, trust_remote_code=trust_remote_code)
 
     return loaded
 
 
-def _load_component(flavor_conf, name, local_path=None, repo_id=None):
+def _load_component(flavor_conf, name, local_path=None, repo_id=None, trust_remote_code=False):
     import transformers
 
     _COMPONENT_TO_AUTOCLASS_MAP = {
@@ -232,6 +284,8 @@ def _load_component(flavor_conf, name, local_path=None, repo_id=None):
                 "definition. Make sure your model was saved with "
                 "save_pretrained=True."
             )
+        if not trust_remote_code:
+            raise MlflowException(_TRUST_REMOTE_CODE_ERROR_MESSAGE)
         cls = _COMPONENT_TO_AUTOCLASS_MAP[name]
         trust_remote = True
 
@@ -245,7 +299,9 @@ def _load_component(flavor_conf, name, local_path=None, repo_id=None):
         return cls.from_pretrained(repo, revision=revision, trust_remote_code=trust_remote)
 
 
-def _load_class_from_transformers_config(model_name_or_path, revision=None):
+def _load_class_from_transformers_config(
+    model_name_or_path, revision=None, trust_remote_code: bool = False
+):
     """
     This method retrieves the Transformers AutoClass from the transformers config.
     Using the correct AutoClass allows us to leverage Transformers' model loading
@@ -254,15 +310,22 @@ def _load_class_from_transformers_config(model_name_or_path, revision=None):
     import transformers
     from transformers import AutoConfig
 
-    config = AutoConfig.from_pretrained(
-        model_name_or_path,
-        revision=revision,
-        # trust_remote_code is set to True in order to
-        # make sure the config gets loaded as the correct
-        # class. if this is not set for custom models, the
-        # base class will be loaded instead of the custom one.
-        trust_remote_code=True,
-    )
+    try:
+        config = AutoConfig.from_pretrained(
+            model_name_or_path,
+            revision=revision,
+            # ``trust_remote_code`` is forwarded from the caller. When the
+            # caller passes ``False`` (the default) and the artifact contains
+            # custom code referenced via ``auto_map``, Hugging Face raises a
+            # ``ValueError`` instructing the user to set
+            # ``trust_remote_code=True``. We surface that as an MlflowException
+            # with actionable guidance below.
+            trust_remote_code=trust_remote_code,
+        )
+    except ValueError as e:
+        if "trust_remote_code" in str(e):
+            raise MlflowException(_TRUST_REMOTE_CODE_ERROR_MESSAGE) from e
+        raise
 
     # the model's class name (e.g. "MPTForCausalLM")
     # is stored in the `architectures` field. it
@@ -291,11 +354,26 @@ def _load_class_from_transformers_config(model_name_or_path, revision=None):
         auto_class = auto_classes[0]
         cls = getattr(transformers, auto_class)
 
+        # The model requires custom code to load. If the caller did not opt
+        # in via ``trust_remote_code=True``, refuse with a friendly error.
+        # Note: in practice, ``AutoConfig.from_pretrained`` above would have
+        # raised first, but we keep this as a defense-in-depth check in case
+        # a transformers version differs in behavior.
+        if not trust_remote_code:
+            raise MlflowException(_TRUST_REMOTE_CODE_ERROR_MESSAGE)
+
         # we will need to trust remote code when loading the model
         return cls, True
 
 
-def _load_model(model_name_or_path, flavor_conf, accelerate_conf, device, revision=None):
+def _load_model(
+    model_name_or_path,
+    flavor_conf,
+    accelerate_conf,
+    device,
+    revision=None,
+    trust_remote_code: bool = False,
+):
     """
     Try to load a model with various loading strategies.
       1. Try to load the model with accelerate
@@ -309,7 +387,7 @@ def _load_model(model_name_or_path, flavor_conf, accelerate_conf, device, revisi
         trust_remote = False
     else:
         cls, trust_remote = _load_class_from_transformers_config(
-            model_name_or_path, revision=revision
+            model_name_or_path, revision=revision, trust_remote_code=trust_remote_code
         )
 
     load_kwargs = {"revision": revision} if revision else {}

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -1374,14 +1374,31 @@ def test_custom_code_pipeline(custom_code_pipeline, model_path):
         signature=signature,
     )
 
-    # just test that it doesn't blow up when performing inference
-    pyfunc_loaded = mlflow.pyfunc.load_model(model_path)
-    pyfunc_pred = pyfunc_loaded.predict(data)
-    assert isinstance(pyfunc_pred[0][0], float)
+    # pyfunc cannot opt into trust_remote_code, so loading a custom-code
+    # model via pyfunc should now refuse by default.
+    with pytest.raises(MlflowException, match="trust_remote_code"):
+        mlflow.pyfunc.load_model(model_path)
 
-    transformers_loaded = mlflow.transformers.load_model(model_path)
+    transformers_loaded = mlflow.transformers.load_model(model_path, trust_remote_code=True)
     transformers_pred = transformers_loaded(data)
-    assert pyfunc_pred[0][0] == transformers_pred[0][0][0]
+    assert isinstance(transformers_pred[0][0][0], float)
+
+
+def test_custom_code_pipeline_refused_without_trust_remote_code(custom_code_pipeline, model_path):
+    data = "hello"
+
+    signature = infer_signature(
+        data, mlflow.transformers.generate_signature_output(custom_code_pipeline, data)
+    )
+
+    mlflow.transformers.save_model(
+        custom_code_pipeline,
+        path=model_path,
+        signature=signature,
+    )
+
+    with pytest.raises(MlflowException, match="trust_remote_code"):
+        mlflow.transformers.load_model(model_path)
 
 
 def test_custom_components_pipeline(custom_components_pipeline, model_path):
@@ -1401,18 +1418,124 @@ def test_custom_components_pipeline(custom_components_pipeline, model_path):
         transformers_model=components, path=model_path, signature=signature
     )
 
-    pyfunc_loaded = mlflow.pyfunc.load_model(model_path)
-    pyfunc_pred = pyfunc_loaded.predict(data)
-    assert isinstance(pyfunc_pred[0][0], float)
+    # pyfunc cannot opt into trust_remote_code, so loading a custom-code
+    # model via pyfunc should now refuse by default.
+    with pytest.raises(MlflowException, match="trust_remote_code"):
+        mlflow.pyfunc.load_model(model_path)
 
-    transformers_loaded = mlflow.transformers.load_model(model_path)
+    transformers_loaded = mlflow.transformers.load_model(model_path, trust_remote_code=True)
     transformers_pred = transformers_loaded(data)
-    assert pyfunc_pred[0][0] == transformers_pred[0][0][0]
+    assert isinstance(transformers_pred[0][0][0], float)
 
     # assert that all the reloaded components exist
     # and have the same class name as pre-save
     for name, component in components.items():
         assert component.__class__.__name__ == getattr(transformers_loaded, name).__class__.__name__
+
+
+_HF_TRUST_REMOTE_CODE_ERROR = ValueError(
+    "Loading this model requires you to execute custom code contained in the "
+    "model repository on your local machine. Please set the option "
+    "`trust_remote_code=True` to permit loading of this model."
+)
+
+
+def test_load_class_from_transformers_config_default_passes_false_to_autoconfig():
+    from mlflow.transformers.model_io import _load_class_from_transformers_config
+
+    # Use a real built-in architecture name so the function takes the
+    # ``hasattr(transformers, class_name)`` True branch and returns immediately.
+    fake_config = mock.MagicMock()
+    fake_config.architectures = ["BertForQuestionAnswering"]
+
+    with mock.patch(
+        "transformers.AutoConfig.from_pretrained",
+        return_value=fake_config,
+    ) as mock_autoconfig:
+        cls, trust_remote = _load_class_from_transformers_config("some/path")
+
+        assert cls is transformers.BertForQuestionAnswering
+        assert trust_remote is False
+        mock_autoconfig.assert_called_once()
+        _, kwargs = mock_autoconfig.call_args
+        assert kwargs.get("trust_remote_code") is False
+
+
+def test_load_class_from_transformers_config_passes_true_when_opted_in():
+    from mlflow.transformers.model_io import _load_class_from_transformers_config
+
+    fake_config = mock.MagicMock()
+    fake_config.architectures = ["BertForQuestionAnswering"]
+
+    with mock.patch(
+        "transformers.AutoConfig.from_pretrained",
+        return_value=fake_config,
+    ) as mock_autoconfig:
+        _load_class_from_transformers_config("some/path", trust_remote_code=True)
+
+        mock_autoconfig.assert_called_once()
+        _, kwargs = mock_autoconfig.call_args
+        assert kwargs.get("trust_remote_code") is True
+
+
+def test_load_class_from_transformers_config_translates_hf_trust_remote_code_error():
+    from mlflow.transformers.model_io import _load_class_from_transformers_config
+
+    with mock.patch(
+        "transformers.AutoConfig.from_pretrained",
+        side_effect=_HF_TRUST_REMOTE_CODE_ERROR,
+    ) as mock_autoconfig:
+        with pytest.raises(MlflowException, match="trust_remote_code") as exc_info:
+            _load_class_from_transformers_config("some/path")
+
+        assert exc_info.value.__cause__ is _HF_TRUST_REMOTE_CODE_ERROR
+        mock_autoconfig.assert_called_once()
+
+
+def test_load_class_from_transformers_config_propagates_unrelated_value_error():
+    from mlflow.transformers.model_io import _load_class_from_transformers_config
+
+    other_error = ValueError("Some other problem")
+    with mock.patch(
+        "transformers.AutoConfig.from_pretrained",
+        side_effect=other_error,
+    ) as mock_autoconfig:
+        with pytest.raises(ValueError, match="Some other problem"):
+            _load_class_from_transformers_config("some/path")
+        mock_autoconfig.assert_called_once()
+
+
+def test_load_model_passes_trust_remote_code_through_to_internal_loader(
+    text_generation_pipeline, model_path
+):
+    mlflow.transformers.save_model(text_generation_pipeline, path=model_path)
+
+    sentinel = object()
+    with mock.patch(
+        "mlflow.transformers._load_model",
+        return_value=sentinel,
+    ) as mock_internal_load:
+        result = mlflow.transformers.load_model(model_path, trust_remote_code=True)
+
+        assert result is sentinel
+        mock_internal_load.assert_called_once()
+        _, kwargs = mock_internal_load.call_args
+        assert kwargs.get("trust_remote_code") is True
+
+
+def test_load_model_default_passes_false_to_internal_loader(text_generation_pipeline, model_path):
+    mlflow.transformers.save_model(text_generation_pipeline, path=model_path)
+
+    sentinel = object()
+    with mock.patch(
+        "mlflow.transformers._load_model",
+        return_value=sentinel,
+    ) as mock_internal_load:
+        mlflow.transformers.load_model(model_path)
+
+        mock_internal_load.assert_called_once()
+        _, kwargs = mock_internal_load.call_args
+        assert kwargs.get("trust_remote_code") is False
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Related Issues/PRs

Relates to `GHSA-4m5w-mxvg-c86f`

### What changes are proposed in this pull request?

MLflow's transformers loader currently passes `trust_remote_code=True` unconditionally to `AutoConfig.from_pretrained` and propagates it to the model load when a custom architecture is detected, executing arbitrary Python from the model artifact with no caller opt-in. HuggingFace introduced `trust_remote_code=False` as the safer default in transformers 4.x.

This PR adds an explicit `trust_remote_code: bool = False` parameter to `mlflow.transformers.load_model`, matching the Hugging Face default. The flag is threaded through the model and component loaders in `mlflow/transformers/model_io.py` so the consent decision flows down to every `AutoConfig` / `AutoModel` / `AutoTokenizer` call. When custom code is required and `trust_remote_code=False`, MLflow refuses with a clear `MlflowException` explaining the option, and translates the underlying Hugging Face `ValueError` with `__cause__` so the original traceback is preserved.

This is a breaking change for users loading custom-architecture models (MPT, certain Falcon variants, DeepSeek, etc.); they must now pass `trust_remote_code=True` explicitly. Pyfunc loading does not accept caller kwargs, so custom-code artifacts loaded via `mlflow.pyfunc.load_model` will fail by default and must be loaded through `mlflow.transformers.load_model` directly.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added unit tests in `tests/transformers/test_transformers_model_export.py`:
- `test_load_class_from_transformers_config_default_passes_false_to_autoconfig`
- `test_load_class_from_transformers_config_passes_true_when_opted_in`
- `test_load_class_from_transformers_config_translates_hf_trust_remote_code_error` (also verifies `__cause__` chaining)
- `test_load_class_from_transformers_config_propagates_unrelated_value_error`
- `test_load_model_passes_trust_remote_code_through_to_internal_loader`
- `test_load_model_default_passes_false_to_internal_loader`
- `test_custom_code_pipeline_refused_without_trust_remote_code` (end-to-end with the real `hf-internal-testing/test_dynamic_model_with_util` artifact)

Existing `test_custom_code_pipeline` and `test_custom_components_pipeline` were updated to pass `trust_remote_code=True` and to assert that pyfunc loading now refuses by default.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [x] Instructions

Updated `mlflow.transformers.load_model` docstring with a `trust_remote_code` section including a security warning and a behavior-change note. Updated the transformers flavor guide (`docs/docs/classic-ml/deep-learning/transformers/guide/index.mdx`) with a `:::warning:::` admonition explaining the new default and how to opt in.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`mlflow.transformers.load_model` no longer enables `trust_remote_code=True` automatically when an artifact requires custom code. Users loading models with custom architectures or components (MPT, certain Falcon variants, DeepSeek, etc.) must now pass `trust_remote_code=True` explicitly, matching the Hugging Face Transformers default. Migration: `mlflow.transformers.load_model(uri)` -> `mlflow.transformers.load_model(uri, trust_remote_code=True)`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

---

Reported by @kennethkcox via GitHub Security Advisory GHSA-4m5w-mxvg-c86f.