### PR TITLE
Preserve eval runs column selection when search filter changes

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.tsx
@@ -15,7 +15,7 @@ import evalRunsEmptyImg from '@mlflow/mlflow/src/common/static/eval-runs-empty.s
 import Utils from '@mlflow/mlflow/src/common/utils/Utils';
 import type { DatasetWithRunType } from '../../components/experiment-page/components/runs/ExperimentViewDatasetDrawer';
 import { ExperimentViewDatasetDrawer } from '../../components/experiment-page/components/runs/ExperimentViewDatasetDrawer';
-import { compact, keyBy, mapValues, uniq, xor, xorBy } from 'lodash';
+import { compact, uniq, xorBy } from 'lodash';
 import {
   EVAL_RUNS_TABLE_BASE_SELECTION_STATE,
   EvalRunsTableKeyedColumnPrefix,
@@ -39,7 +39,7 @@ import {
   RunGroupingAggregateFunction,
   RunGroupingMode,
 } from '../../components/experiment-page/utils/experimentPage.row-types';
-import { getGroupByRunsData } from './ExperimentEvaluationRunsPage.utils';
+import { getGroupByRunsData, reconcileSelectedColumns } from './ExperimentEvaluationRunsPage.utils';
 import {
   ExperimentEvaluationRunsPageMode,
   useExperimentEvaluationRunsPageMode,
@@ -256,28 +256,21 @@ const ExperimentEvaluationRunsPageImpl = () => {
     ];
   }, [runs]);
 
-  const baseColumns = useMemo(() => Object.keys(EVAL_RUNS_TABLE_BASE_SELECTION_STATE), []);
-  const existingColumns = useMemo(
-    () => Object.keys(selectedColumns).filter((column) => !baseColumns.includes(column)),
-    [baseColumns, selectedColumns],
-  );
-  const columnDifference = useMemo(() => xor(existingColumns, uniqueColumns), [existingColumns, uniqueColumns]);
-  // if there is a difference between the existing column state and
-  // the unique metrics (e.g. the user performed a search and the
-  // list of available metrics changed), reset the selected columns
-  // to the default state to avoid displaying columns that don't exist
-  if (columnDifference.length > 0) {
-    const metricColumns = uniqueColumns.filter((col) => col.startsWith(EvalRunsTableKeyedColumnPrefix.METRIC + '.'));
-    // When flag is ON, limit default visible metrics to 5; when OFF, show all (original behavior)
-    const defaultEnabledMetrics = enableImprovedComparison
-      ? new Set(metricColumns.slice(0, DEFAULT_VISIBLE_METRIC_COLUMNS))
-      : new Set(metricColumns);
-
-    setSelectedColumns({
-      ...EVAL_RUNS_TABLE_BASE_SELECTION_STATE,
-      ...mapValues(keyBy(uniqueColumns), (_, key) => defaultEnabledMetrics.has(key)),
-    });
-  }
+  // Reconcile selectedColumns with the current uniqueColumns whenever the set of
+  // available metric/param/tag columns shifts (e.g. the user performed a search).
+  // We preserve the user's existing choices for columns that still exist, drop
+  // columns that have disappeared, and apply defaults only to newly-appeared
+  // columns. Wrapped in useEffect to avoid setting state during render.
+  useEffect(() => {
+    setSelectedColumns((prev) =>
+      reconcileSelectedColumns({
+        previous: prev,
+        uniqueColumns,
+        defaultVisibleMetricColumns: DEFAULT_VISIBLE_METRIC_COLUMNS,
+        enableImprovedComparison,
+      }),
+    );
+  }, [uniqueColumns, enableImprovedComparison]);
 
   const isEmpty = runUuids.length === 0 && !searchFilter && !isLoading;
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.utils.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from '@jest/globals';
 import type { ExperimentEvaluationRunsGroupData } from './ExperimentEvaluationRunsPage.utils';
-import { getGroupByRunsData } from './ExperimentEvaluationRunsPage.utils';
+import { getGroupByRunsData, reconcileSelectedColumns } from './ExperimentEvaluationRunsPage.utils';
 import type { RunDatasetWithTags, RunEntity } from '../../types';
 import type { KeyValueEntity } from '../../../common/types';
 import type { RunsGroupByConfig } from '../../components/experiment-page/utils/experimentPage.group-row-utils';
@@ -8,6 +8,10 @@ import {
   RunGroupingMode,
   RunGroupingAggregateFunction,
 } from '../../components/experiment-page/utils/experimentPage.row-types';
+import {
+  EVAL_RUNS_TABLE_BASE_SELECTION_STATE,
+  EvalRunsTableKeyedColumnPrefix,
+} from './ExperimentEvaluationRunsTable.constants';
 
 const createMockDataset = (digest: string): RunDatasetWithTags => ({
   dataset: {
@@ -214,6 +218,177 @@ describe('ExperimentEvaluationRunsPage.utils', () => {
       const result = getGroupByRunsData([], groupBy);
 
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('reconcileSelectedColumns', () => {
+    const metric = (key: string) => `${EvalRunsTableKeyedColumnPrefix.METRIC}.${key}`;
+    const param = (key: string) => `${EvalRunsTableKeyedColumnPrefix.PARAM}.${key}`;
+
+    it('initializes defaults when previous state only has base columns', () => {
+      const previous = { ...EVAL_RUNS_TABLE_BASE_SELECTION_STATE };
+      const uniqueColumns = [metric('a'), metric('b'), metric('c')];
+
+      const result = reconcileSelectedColumns({
+        previous,
+        uniqueColumns,
+        defaultVisibleMetricColumns: 5,
+        enableImprovedComparison: true,
+      });
+
+      // Base columns still present
+      for (const baseKey of Object.keys(EVAL_RUNS_TABLE_BASE_SELECTION_STATE)) {
+        expect(result).toHaveProperty(baseKey, EVAL_RUNS_TABLE_BASE_SELECTION_STATE[baseKey]);
+      }
+      // New metric columns enabled by default
+      expect(result[metric('a')]).toBe(true);
+      expect(result[metric('b')]).toBe(true);
+      expect(result[metric('c')]).toBe(true);
+    });
+
+    it("preserves the user's choice for columns that still exist when uniqueColumns changes", () => {
+      // User had A, B, C and explicitly disabled B
+      const previous = {
+        ...EVAL_RUNS_TABLE_BASE_SELECTION_STATE,
+        [metric('a')]: true,
+        [metric('b')]: false,
+        [metric('c')]: true,
+      };
+      // Filter narrows to A, B (C disappeared)
+      const uniqueColumns = [metric('a'), metric('b')];
+
+      const result = reconcileSelectedColumns({
+        previous,
+        uniqueColumns,
+        defaultVisibleMetricColumns: 5,
+        enableImprovedComparison: true,
+      });
+
+      // User's disabled choice for B is preserved
+      expect(result[metric('b')]).toBe(false);
+      // A still enabled
+      expect(result[metric('a')]).toBe(true);
+      // C dropped because it no longer exists
+      expect(metric('c') in result).toBe(false);
+    });
+
+    it('drops columns that no longer appear in uniqueColumns', () => {
+      const previous = {
+        ...EVAL_RUNS_TABLE_BASE_SELECTION_STATE,
+        [metric('a')]: true,
+        [metric('b')]: true,
+        [param('p1')]: true,
+      };
+      const uniqueColumns = [metric('a')];
+
+      const result = reconcileSelectedColumns({
+        previous,
+        uniqueColumns,
+        defaultVisibleMetricColumns: 5,
+        enableImprovedComparison: true,
+      });
+
+      expect(result[metric('a')]).toBe(true);
+      expect(metric('b') in result).toBe(false);
+      expect(param('p1') in result).toBe(false);
+    });
+
+    it('applies default-enabled state for newly-appeared metric columns', () => {
+      // User had A enabled, B disabled
+      const previous = {
+        ...EVAL_RUNS_TABLE_BASE_SELECTION_STATE,
+        [metric('a')]: true,
+        [metric('b')]: false,
+      };
+      // Filter widens to A, B, C, D (C and D are new)
+      const uniqueColumns = [metric('a'), metric('b'), metric('c'), metric('d')];
+
+      const result = reconcileSelectedColumns({
+        previous,
+        uniqueColumns,
+        defaultVisibleMetricColumns: 5,
+        enableImprovedComparison: true,
+      });
+
+      // Existing user choices preserved
+      expect(result[metric('a')]).toBe(true);
+      expect(result[metric('b')]).toBe(false);
+      // Newly-appeared metric columns enabled by default (within visible limit)
+      expect(result[metric('c')]).toBe(true);
+      expect(result[metric('d')]).toBe(true);
+    });
+
+    it('respects the visible metric limit only for newly-appeared columns when flag is on', () => {
+      const previous = { ...EVAL_RUNS_TABLE_BASE_SELECTION_STATE };
+      const uniqueColumns = [metric('a'), metric('b'), metric('c'), metric('d'), metric('e'), metric('f'), metric('g')];
+
+      const result = reconcileSelectedColumns({
+        previous,
+        uniqueColumns,
+        defaultVisibleMetricColumns: 5,
+        enableImprovedComparison: true,
+      });
+
+      // First five metrics enabled
+      expect(result[metric('a')]).toBe(true);
+      expect(result[metric('b')]).toBe(true);
+      expect(result[metric('c')]).toBe(true);
+      expect(result[metric('d')]).toBe(true);
+      expect(result[metric('e')]).toBe(true);
+      // Beyond the limit, default to disabled
+      expect(result[metric('f')]).toBe(false);
+      expect(result[metric('g')]).toBe(false);
+    });
+
+    it('enables all metric columns by default when the improved comparison flag is off', () => {
+      const previous = { ...EVAL_RUNS_TABLE_BASE_SELECTION_STATE };
+      const uniqueColumns = [metric('a'), metric('b'), metric('c'), metric('d'), metric('e'), metric('f'), metric('g')];
+
+      const result = reconcileSelectedColumns({
+        previous,
+        uniqueColumns,
+        defaultVisibleMetricColumns: 5,
+        enableImprovedComparison: false,
+      });
+
+      for (const col of uniqueColumns) {
+        expect(result[col]).toBe(true);
+      }
+    });
+
+    it('defaults newly-appeared non-metric columns (params, tags) to disabled', () => {
+      const previous = { ...EVAL_RUNS_TABLE_BASE_SELECTION_STATE };
+      const uniqueColumns = [param('p1'), `${EvalRunsTableKeyedColumnPrefix.TAG}.t1`];
+
+      const result = reconcileSelectedColumns({
+        previous,
+        uniqueColumns,
+        defaultVisibleMetricColumns: 5,
+        enableImprovedComparison: true,
+      });
+
+      expect(result[param('p1')]).toBe(false);
+      expect(result[`${EvalRunsTableKeyedColumnPrefix.TAG}.t1`]).toBe(false);
+    });
+
+    it("preserves the user's overrides to base columns", () => {
+      const previous = {
+        ...EVAL_RUNS_TABLE_BASE_SELECTION_STATE,
+        // User toggled model_version on
+        model_version: true,
+        // User hid status
+        status: false,
+      };
+
+      const result = reconcileSelectedColumns({
+        previous,
+        uniqueColumns: [],
+        defaultVisibleMetricColumns: 5,
+        enableImprovedComparison: true,
+      });
+
+      expect(result['model_version']).toBe(true);
+      expect(result['status']).toBe(false);
     });
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.utils.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.utils.ts
@@ -2,6 +2,10 @@ import type { RunEntity } from '../../types';
 import type { RunsGroupByConfig } from '../../components/experiment-page/utils/experimentPage.group-row-utils';
 import type { RunGroupByGroupingValue } from '../../components/experiment-page/utils/experimentPage.row-types';
 import { RunGroupingMode } from '../../components/experiment-page/utils/experimentPage.row-types';
+import {
+  EVAL_RUNS_TABLE_BASE_SELECTION_STATE,
+  EvalRunsTableKeyedColumnPrefix,
+} from './ExperimentEvaluationRunsTable.constants';
 
 export type ExperimentEvaluationRunsGroupData = {
   groupKey: string;
@@ -59,6 +63,43 @@ const getGroupValues = (run: RunEntity, groupBy: RunsGroupByConfig): RunGroupByG
   }
 
   return values;
+};
+
+/**
+ * Reconcile the user's selected column state against the latest set of unique
+ * metric/param/tag columns. Columns that still exist keep their selected state
+ * (preserving the user's choices), columns that have disappeared are dropped,
+ * and newly-appeared columns get a sensible default (metrics within the visible
+ * limit are enabled; everything else is disabled).
+ */
+export const reconcileSelectedColumns = ({
+  previous,
+  uniqueColumns,
+  defaultVisibleMetricColumns,
+  enableImprovedComparison,
+}: {
+  previous: { [key: string]: boolean };
+  uniqueColumns: string[];
+  defaultVisibleMetricColumns: number;
+  enableImprovedComparison: boolean;
+}): { [key: string]: boolean } => {
+  const metricColumns = uniqueColumns.filter((col) => col.startsWith(EvalRunsTableKeyedColumnPrefix.METRIC + '.'));
+  // When flag is ON, limit default visible metrics; when OFF, show all (original behavior)
+  const defaultEnabledMetrics = enableImprovedComparison
+    ? new Set(metricColumns.slice(0, defaultVisibleMetricColumns))
+    : new Set(metricColumns);
+
+  const next: { [key: string]: boolean } = { ...EVAL_RUNS_TABLE_BASE_SELECTION_STATE };
+  // Preserve any user overrides for the base columns
+  for (const baseKey of Object.keys(EVAL_RUNS_TABLE_BASE_SELECTION_STATE)) {
+    if (baseKey in previous) {
+      next[baseKey] = previous[baseKey];
+    }
+  }
+  for (const col of uniqueColumns) {
+    next[col] = col in previous ? previous[col] : defaultEnabledMetrics.has(col);
+  }
+  return next;
 };
 
 export const getGroupByRunsData = (runs: RunEntity[], groupBy: RunsGroupByConfig | null): RunEntityOrGroupData[] => {


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

`ExperimentEvaluationRunsPage` previously wiped the entire `selectedColumns` state to defaults whenever the set of unique metric/param/tag columns shifted (e.g. when the user typed into the search filter). The reset was also performed during render via `setSelectedColumns(...)`, which React StrictMode flags as an anti-pattern.

This PR reconciles `selectedColumns` instead of wholesale-resetting:

- Columns that still exist in `uniqueColumns` keep the user's current selected/unselected state.
- Columns that have disappeared are dropped from state.
- Newly-appeared metric columns are enabled by default (capped by `DEFAULT_VISIBLE_METRIC_COLUMNS` when the improved-comparison flag is on); newly-appeared param/tag columns default to disabled.
- The reconciliation now runs from a `useEffect`, not during render.

To make the logic directly testable, the reconciliation was extracted as a pure utility `reconcileSelectedColumns` in `ExperimentEvaluationRunsPage.utils.ts`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added 8 unit tests in `ExperimentEvaluationRunsPage.utils.test.ts` covering: initialization defaults, preserving the user's choices when filtering narrows the column set, dropping disappearing columns, defaults for newly-appeared metrics/params/tags, respecting the visible-metric cap when the flag is on, enabling all metrics when the flag is off, and preserving overrides to base columns. Existing `ExperimentEvaluationRunsPage.test.tsx` tests still pass.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The evaluation runs page no longer resets the user's column selection when the filter changes; columns that still exist keep their selected/unselected state.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release