### PR TITLE
Bump nailaopus `mlflow/internal` pin to pick up diff-relation triage + fallback

### DIFF
--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -153,7 +153,7 @@ jobs:
           # open a new PR that updates this SHA to the latest mlflow/internal
           # main after reviewing the diff. We'll migrate to release tags once
           # the bump cadence is stable; see mlflow/internal for the policy.
-          ref: 4a973436ee1df41253f7936e64d49cb4e52a4969
+          ref: 48db60bda092b4acd52a93336414b2942992fb17
           sparse-checkout: |
             nailaopus
           path: internal


### PR DESCRIPTION
### Related Issues/PRs

Picks up [mlflow/internal#29](https://github.com/mlflow/internal/pull/29) (`48db60b`).

Earlier pin landed in #23304 at `4a97343`; this is the second bump on top of that.

### What changes are proposed in this pull request?

Single-line update to `.github/workflows/nailaopus.yml`: bump the `ref:` on the `mlflow/internal` checkout step from `4a97343` to `48db60b`. The new orchestrator commit fixes two post-mortem findings from the most recent live run (5 of 6 inline findings 422'd at GitHub).

New behavior this turns on:

- **Spotter `diff_relation` triage.** Spotter must classify every finding as `caused_by_diff`, `interacts_with_diff`, or `pre_existing` with a `path:line` citation. The reviewer-opinion agent mechanically validates the citation against the diff before applying policy; mislabeled findings are skipped with the new substantive skip reason `"Spotter mislabeled diff_relation; cited path:line not in this diff."`
- **Review-body fallback on inline 422.** Findings whose anchors are outside the diff hunk (the GitHub inline-comment API's hard limit) get posted as top-level PR conversation comments with a permalink and a hidden marker so subsequent runs can self-dedup against them.
- **Cross-SHA dedup for fallback comments.** Fallbacks embed `<!-- NaiLaOpus: fallback path=<path> line=<line> -->` so they're recoverable across head SHAs.
- **Run record schema v3 -> v5.** New top-level blocks: `post_outcome.{inline, review_body, failed}` (ground-truth-on-GH counts), `spotter_findings_breakdown` (counts by `diff_relation`), `reviewer_opinion_breakdown` (raised/skipped + verbatim skip_reason buckets). Reviewer-pass skips were invisible before; now the spotter mislabel rate is measurable across runs.

Validated with a local dry-run on PR 22969 before this bump: spotter emitted 4 findings (3 `caused_by_diff`, 1 `interacts_with_diff`); reviewer raised 1 and skipped 3 with substantive reasons; one skip explicitly cited the spotter's `diff_relation` label and treated it as adjacency-only, exactly the validation behavior we added.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Local `nailaopus 22969 --dry-run` on the bumped SHA produced the v5 run record cleanly with all new blocks populated. End-to-end live posting validation lands on the next `/review-v2` invocation after merge.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`
- [ ] `area/models`
- [ ] `area/model-registry`
- [ ] `area/scoring`
- [ ] `area/evaluation`
- [ ] `area/gateway`
- [ ] `area/prompts`
- [ ] `area/tracing`
- [ ] `area/projects`
- [ ] `area/uiux`
- [x] `area/build`
- [ ] `area/docs`

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

-- Claude-drafted, reviewed before posting.