### PR TITLE
chore: fix duplicated words in pyspark and pyfunc comments

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1967,7 +1967,7 @@ def build_model_env(model_uri, save_path, env_manager=_EnvManager.VIRTUALENV):
         versions or different platform machines. As such, if you connect to a different cluster
         that is running a different runtime version on Databricks, you will need to execute this
         API in a notebook and retrieve the generated archive to your local machine. Each
-        environment snapshot is unique to the the model, the runtime version of your remote
+        environment snapshot is unique to the model, the runtime version of your remote
         Databricks cluster, and the specification of the udf execution environment.
         When using the prebuilt env in `mlflow.pyfunc.spark_udf`, MLflow will verify
         whether the spark UDF sandbox environment matches the prebuilt env requirements and will

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -137,7 +137,7 @@ _log_model_allowlist = None
 
 def _get_warning_msg_for_skip_log_model(model):
     return (
-        f"Model {model.uid} will not be autologged because it is not allowlisted or or because "
+        f"Model {model.uid} will not be autologged because it is not allowlisted or because "
         "one or more of its nested models are not allowlisted. Call mlflow.spark.log_model() "
         "to explicitly log the model, or specify a custom allowlist via the "
         "spark.mlflow.pysparkml.autolog.logModelAllowlistFile Spark conf "
@@ -826,7 +826,7 @@ def autolog(
     **Logged information**
       **Parameters**
         - Parameters obtained by ``estimator.params``. If a param value is also an ``Estimator``,
-          then params in the the wrapped estimator will also be logged, the nested param key
+          then params in the wrapped estimator will also be logged, the nested param key
           will be `{estimator_uid}.{param_name}`
 
       **Tags**


### PR DESCRIPTION
Three small comment-only typos: doubled `or or` and `the the` in `mlflow/pyspark/ml/__init__.py`, and doubled `the the` in `mlflow/pyfunc/__init__.py`. No functional or API change.