### PR TITLE
Bump nailaopus `mlflow/internal` pin to pick up casing/fallback fixes

### DIFF
--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -153,7 +153,7 @@ jobs:
           # open a new PR that updates this SHA to the latest mlflow/internal
           # main after reviewing the diff. We'll migrate to release tags once
           # the bump cadence is stable; see mlflow/internal for the policy.
-          ref: 48db60bda092b4acd52a93336414b2942992fb17
+          ref: a7e8fef0ac578b26bc5e2179c81b402a7061fa57
           sparse-checkout: |
             nailaopus
           path: internal


### PR DESCRIPTION
### Related Issues/PRs

Picks up [mlflow/internal#30](https://github.com/mlflow/internal/pull/30) (`a7e8fef`).

Previous pin was at `48db60b` from #23313. This is the second SHA-bump on top of the initial pin in #23304.

### What changes are proposed in this pull request?

Single-line update to `.github/workflows/nailaopus.yml`: bump the `ref:` on the `mlflow/internal` checkout step from `48db60b` to `a7e8fef`. The new orchestrator commit ships seven fixes discovered during the live run of NaiLaOpus on [#23220](https://github.com/mlflow/mlflow/pull/23220) after the previous bump landed.

What this bump turns on:

- **Cache check now works.** `already_reviewed_at_sha`'s jq filter was comparing against `"NaiLaOpus[bot]"` (display case) instead of `"nailaopus[bot]"` (GitHub's actual lowercased login). Same-SHA re-runs of `/review-v2` will now early-exit correctly without `--no-cache`.
- **Self-dedup against prior bot inline threads fires.** Same casing fix means `bot_started` is recognized; the SELF_DEDUP rule now skips a finding at a `path:line` the bot already posted at.
- **Cross-SHA fallback dedup fires.** `get_bot_fallback_locations` recovers prior markers and synthesizes them as bot-started review threads, so out-of-hunk fallbacks don't re-post on every push.
- **👍 / 👎 reactions dismiss unanchored fallback comments.** Top-level PR conversation comments have no GitHub "Resolved" thread button, so each fallback body now ends with *React 👍 if you've resolved this, or 👎 if it's not a concern. Either way the bot will not raise it again.* Both reactions surface as `HARD_RESOLVED` (anchored) or `PR_LEVEL_DISMISSED` (PR-level) so the stamp gate also treats them as resolved-by-author.
- **Body-hash dedup for PR-level concerns.** `kind: "review_body"` findings (no `(path, line)` anchor) now embed a `<!-- NaiLaOpus: pr_level body_hash=<hash> -->` marker. The bot recognizes and dedups them across runs instead of re-posting the same concern indefinitely.
- **Cleaner fallback rendering.** The synthesized `**On [path:line](permalink)**:` header was dropped — the reviewer-opinion's voice_rewrite already leads with a code-link, and the bold-at-the-top duplication visually read as a section heading. Fallback comments now flow as a normal paragraph.

End-to-end consequence for stamping: once you resolve all inline bot threads (GitHub Resolved) and 👍/👎 all unanchored fallback comments, a re-run of `/review-v2` on a small (XS/S) PR with no `nailaopus-no-stamp` label and no human `CHANGES_REQUESTED` will auto-approve.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Local `nailaopus 22969 --dry-run` against the new SHA continues to emit clean v5 run-record blocks. End-to-end live posting + dismissal validation lands on the next `/review-v2` invocation after merge.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`
- [ ] `area/models`
- [ ] `area/model-registry`
- [ ] `area/scoring`
- [ ] `area/evaluation`
- [ ] `area/gateway`
- [ ] `area/prompts`
- [ ] `area/tracing`
- [ ] `area/projects`
- [ ] `area/uiux`
- [x] `area/build`
- [ ] `area/docs`

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

-- Claude-drafted, reviewed before posting.
