### PR TITLE
Fix `analyze-ci` skill: declare `arguments` and clean up examples

### DIFF
--- a/.claude/skills/analyze-ci/SKILL.md
+++ b/.claude/skills/analyze-ci/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: analyze-ci
 description: Analyze failed GitHub Action jobs for a pull request.
-arguments: [urls]
+argument-hint: "url(s) of failed GitHub Action jobs, workflow runs, or PRs"
 context: fork
 allowed-tools:
   - Bash(uv run --package skills skills fetch-logs:*)

--- a/.claude/skills/analyze-ci/SKILL.md
+++ b/.claude/skills/analyze-ci/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: analyze-ci
 description: Analyze failed GitHub Action jobs for a pull request.
-model: haiku
+arguments: [urls]
 context: fork
-agent: general-purpose
 allowed-tools:
   - Bash(uv run --package skills skills fetch-logs:*)
   - Read
@@ -50,11 +49,14 @@ Fetch logs from failed GitHub Action jobs and produce a focused per-job failure 
 
 ```bash
 # All failed jobs on a PR
-/analyze-ci 'https://github.com/mlflow/mlflow/pull/19601'
+/analyze-ci https://github.com/mlflow/mlflow/pull/19601
 
 # All failed jobs in one workflow run
-/analyze-ci 'https://github.com/mlflow/mlflow/actions/runs/22626454465'
+/analyze-ci https://github.com/mlflow/mlflow/actions/runs/22626454465
 
 # Specific job by URL
-/analyze-ci 'https://github.com/mlflow/mlflow/actions/runs/12345/job/67890'
+/analyze-ci https://github.com/mlflow/mlflow/actions/runs/12345/job/67890
+
+# Multiple URLs at once
+/analyze-ci https://github.com/mlflow/mlflow/actions/runs/123/job/456 https://github.com/mlflow/mlflow/actions/runs/789/job/012
 ```


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23315

### What changes are proposed in this pull request?

Small fixes to `.claude/skills/analyze-ci/SKILL.md`:

- Removed `model: haiku`. Haiku didn't honor frontmatter argument substitution, so `/analyze-ci <url>` wasn't picking up the URL.
- Added `argument-hint` so the autocomplete shows what to type. Skipped a named `arguments:` declaration because the skill is variadic (multi-URL), which only `$ARGUMENTS` can express.
- Dropped the redundant `agent: general-purpose` line (it's the default when `context: fork` is set).
- Cleaned up invocation examples: unquoted URLs and added a multi-URL example.

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)