### PR TITLE
[Security] Make basic-auth fail-closed for unmapped routes, wire scorer online-config validators

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -222,8 +222,13 @@ from mlflow.server.auth.routes import (
     LIST_USER_WORKSPACE_PERMISSIONS,
     LIST_USERS,
     LIST_WORKSPACE_PERMISSIONS,
+    SCORER_ONLINE_CONFIG_AJAX,
+    SCORER_ONLINE_CONFIG_REST,
+    SCORER_ONLINE_CONFIGS_AJAX,
+    SCORER_ONLINE_CONFIGS_REST,
     SEARCH_DATASETS,
     SIGNUP,
+    UI_TELEMETRY_AJAX,
     UPDATE_EXPERIMENT_PERMISSION,
     UPDATE_GATEWAY_ENDPOINT_PERMISSION,
     UPDATE_GATEWAY_MODEL_DEFINITION_PERMISSION,
@@ -237,6 +242,7 @@ from mlflow.server.auth.routes import (
 from mlflow.server.auth.sqlalchemy_store import SqlAlchemyStore
 from mlflow.server.fastapi_app import create_fastapi_app
 from mlflow.server.handlers import (
+    _add_static_prefix,
     _disable_if_workspaces_disabled,
     _get_ajax_path,
     _get_model_registry_store,
@@ -276,8 +282,29 @@ _RESOURCE_WORKSPACE_CACHE: TTLCache[str, str | None] = TTLCache(
 )
 
 
+# Prefix-matched routes that bypass auth. "/build/" serves the React UI bundle and
+# "/static", "/favicon.ico", "/health" are the original public prefixes. These are
+# intentionally not authenticated because they either serve UI shell content or are
+# used by liveness probes.
+_UNPROTECTED_PATH_PREFIXES = ("/static", "/favicon.ico", "/health", "/build/")
+
+# Exact-match routes that bypass auth. Kept separate from the prefix list so that the
+# UI HTML index "/" does not accidentally match every path. The ui-telemetry endpoints
+# are explicitly public because they return client telemetry config and accept
+# anonymous client-emitted telemetry records (no per-user data).
+_UNPROTECTED_EXACT_PATHS = frozenset({
+    HOME,
+    "/version",
+    UI_TELEMETRY_AJAX,
+})
+
+
 def is_unprotected_route(path: str) -> bool:
-    return path.startswith(("/static", "/favicon.ico", "/health"))
+    prefixed_prefixes = tuple(_add_static_prefix(p) for p in _UNPROTECTED_PATH_PREFIXES)
+    if path.startswith(_UNPROTECTED_PATH_PREFIXES) or path.startswith(prefixed_prefixes):
+        return True
+    prefixed_exact = {_add_static_prefix(p) for p in _UNPROTECTED_EXACT_PATHS}
+    return path in _UNPROTECTED_EXACT_PATHS or path in prefixed_exact
 
 
 def make_basic_auth_response() -> Response:
@@ -1016,6 +1043,46 @@ def validate_can_manage_scorer_permission():
     return _get_permission_from_scorer_permission_request().can_manage
 
 
+def validate_can_update_scorer_online_config():
+    # PUT /mlflow/scorers/online-config accepts {experiment_id, name, sample_rate,
+    # filter_string} in the JSON body. The standard validate_can_update_scorer
+    # uses _get_request_param which does not currently dispatch on PUT, so we
+    # read the body directly here and reuse the same permission lookup.
+    body = request.get_json(silent=True) or {}
+    experiment_id = body.get("experiment_id")
+    name = body.get("name")
+    if not experiment_id or not name:
+        # Missing required params - let the handler return a proper 400. We
+        # cannot make a permission decision without them, so fail closed.
+        return False
+    username = authenticate_request().username
+    permission = _get_permission_from_store_or_default(
+        lambda: store.get_scorer_permission(experiment_id, name, username).permission,
+        workspace_level_permission_func=lambda: _workspace_permission_for_experiment(
+            username, experiment_id
+        ),
+    )
+    return permission.can_update
+
+
+def validate_can_read_scorer_online_configs():
+    # GET /mlflow/scorers/online-configs accepts a list of scorer_ids and does not
+    # include experiment_id/scorer_name in the request, so the standard
+    # validate_can_read_scorer (which reads experiment_id + name) cannot be used.
+    # We resolve scorer_ids -> OnlineScoringConfigs and require the caller to have
+    # read permission on every experiment that owns one of the returned configs.
+    # Scorer ids without a config simply produce nothing in the response (no info
+    # leak), and the empty-input case is allowed since the response is also empty.
+    scorer_ids = request.args.getlist("scorer_ids")
+    if not scorer_ids:
+        return True
+    configs = _get_tracking_store().get_online_scoring_configs(scorer_ids)
+    username = authenticate_request().username
+    return all(
+        _get_experiment_permission(config.experiment_id, username).can_read for config in configs
+    )
+
+
 def sender_is_admin():
     """Validate if the sender is admin"""
     username = authenticate_request().username
@@ -1541,7 +1608,10 @@ BEFORE_REQUEST_HANDLERS = {
     SearchPromptOptimizationJobs: validate_can_read_experiment,
     CancelPromptOptimizationJob: validate_can_update_prompt_optimization_job,
     DeletePromptOptimizationJob: validate_can_delete_prompt_optimization_job,
-    # Workspace routes
+    # Workspace routes. ListWorkspaces uses None to express "any authenticated
+    # user may call; the response is filtered to accessible workspaces by
+    # ``filter_list_workspaces`` in the after-request handler" - this is
+    # handled in ``_find_validator`` via the ``_allow_through`` sentinel.
     ListWorkspaces: None,
     CreateWorkspace: sender_is_admin,
     GetWorkspace: validate_can_view_workspace,
@@ -1638,6 +1708,15 @@ BEFORE_REQUEST_VALIDATORS.update({
     (LIST_WORKSPACE_PERMISSIONS, "POST"): validate_can_modify_workspace_permission,
     (LIST_WORKSPACE_PERMISSIONS, "DELETE"): validate_can_modify_workspace_permission,
     (LIST_USER_WORKSPACE_PERMISSIONS, "GET"): sender_is_admin,
+    # Online scoring config endpoints. Each uses a thin wrapper around the
+    # existing scorer/experiment permission machinery: the PUT wrapper reads
+    # experiment_id + name from the JSON body (the shared _get_request_param
+    # helper does not yet dispatch PUT), and the GET wrapper resolves
+    # scorer_ids -> experiment_ids since the request does not include them.
+    (SCORER_ONLINE_CONFIG_AJAX, "PUT"): validate_can_update_scorer_online_config,
+    (SCORER_ONLINE_CONFIG_REST, "PUT"): validate_can_update_scorer_online_config,
+    (SCORER_ONLINE_CONFIGS_AJAX, "GET"): validate_can_read_scorer_online_configs,
+    (SCORER_ONLINE_CONFIGS_REST, "GET"): validate_can_read_scorer_online_configs,
 })
 
 # Precompile workspace parameterized paths (e.g., workspace_name) for fast matching.
@@ -1766,53 +1845,76 @@ def authenticate_request_basic_auth() -> Authorization | Response:
         return make_basic_auth_response()
 
 
-def _find_validator(req: Request) -> Callable[[], bool] | None:
+def _fail_closed() -> bool:
+    return False
+
+
+def _allow_through() -> bool:
+    # Sentinel for routes that are registered but intentionally have no validator
+    # (e.g. list/search endpoints whose results are filtered in an after-request
+    # handler). The route is known to the auth layer, so the caller is allowed
+    # to proceed - they have already been authenticated by the time this runs.
+    return True
+
+
+def _find_validator(req: Request) -> Callable[[], bool]:
     """
     Finds the validator matching the request path and method.
+
+    Always returns a callable. For (path, method) pairs that are not explicitly
+    registered in any of the validator dicts, returns a fail-closed sentinel
+    that denies the request. Genuinely public routes must be allowlisted via
+    ``is_unprotected_route`` and proxy artifact paths are handled separately
+    via ``_get_proxy_artifact_validator`` in ``_before_request``.
+
+    Routes that are registered but map to ``None`` (e.g. ListWorkspaces,
+    SearchExperiments) are treated as "no permission check needed at this
+    layer" because their responses are filtered after the request runs; for
+    those, ``_allow_through`` is returned.
     """
     if "/mlflow/logged-models" in req.path:
         # logged model routes are not registered in the app
         # so we need to check them manually
-        return next(
-            (
-                v
-                for (pat, method), v in LOGGED_MODEL_BEFORE_REQUEST_VALIDATORS.items()
-                if pat.fullmatch(req.path) and method == req.method
-            ),
-            None,
+        return _resolve_pattern_validator(
+            req, LOGGED_MODEL_BEFORE_REQUEST_VALIDATORS, fallback=_fail_closed
         )
 
     if "/mlflow/webhooks" in req.path:
         # Webhook routes contain path parameters (e.g., /mlflow/webhooks/<webhook_id>)
         # so we need regex matching
-        return next(
-            (
-                v
-                for (pat, method), v in WEBHOOK_BEFORE_REQUEST_VALIDATORS.items()
-                if pat.fullmatch(req.path) and method == req.method
-            ),
-            None,
+        return _resolve_pattern_validator(
+            req, WEBHOOK_BEFORE_REQUEST_VALIDATORS, fallback=_fail_closed
         )
 
-    if validator := BEFORE_REQUEST_VALIDATORS.get((req.path, req.method)):
-        return validator
+    key = (req.path, req.method)
+    if key in BEFORE_REQUEST_VALIDATORS:
+        validator = BEFORE_REQUEST_VALIDATORS[key]
+        return validator if validator is not None else _allow_through
 
     # Workspace permission routes use parameterized path matching (e.g., workspace_name).
     # Only check these when workspaces are enabled to avoid unnecessary regex matching.
     if MLFLOW_ENABLE_WORKSPACES.get():
-        return _get_workspace_validator(req)
+        validator = _get_workspace_validator(req)
+        return validator if validator is not None else _fail_closed
 
     if "/workspaces/" not in req.path:
-        return None
+        return _fail_closed
 
     # Regex matching for parameterized workspace paths.
-    for (path, method), candidate in WORKSPACE_PARAMETERIZED_BEFORE_REQUEST_VALIDATORS.items():
-        if method != req.method:
-            continue
-        if path.fullmatch(req.path):
-            return candidate
+    return _resolve_pattern_validator(
+        req, WORKSPACE_PARAMETERIZED_BEFORE_REQUEST_VALIDATORS, fallback=_fail_closed
+    )
 
-    return None
+
+def _resolve_pattern_validator(
+    req: Request,
+    table: dict[tuple[re.Pattern, str], Callable[[], bool] | None],
+    fallback: Callable[[], bool],
+) -> Callable[[], bool]:
+    for (pat, method), candidate in table.items():
+        if method == req.method and pat.fullmatch(req.path):
+            return candidate if candidate is not None else _allow_through
+    return fallback
 
 
 def _get_workspace_validator(req: Request) -> Callable[[], bool] | None:
@@ -1845,14 +1947,21 @@ def _before_request():
     if sender_is_admin():
         return
 
-    # authorization
-    if validator := _find_validator(request):
-        if not validator():
-            return make_forbidden_response()
-    elif _is_proxy_artifact_path(request.path):
+    # Proxy artifact paths use a separate validator-lookup mechanism keyed on
+    # method + view args rather than (path, method). Handle them up front so the
+    # strict fail-closed default below does not block legitimate artifact access.
+    if _is_proxy_artifact_path(request.path):
         if validator := _get_proxy_artifact_validator(request.method, request.view_args):
             if not validator():
                 return make_forbidden_response()
+        return
+
+    # All other routes go through _find_validator, which returns a fail-closed
+    # sentinel for any (path, method) pair not explicitly registered. This
+    # prevents new endpoints from being silently exposed if a developer forgets
+    # to add a corresponding validator entry.
+    if not _find_validator(request)():
+        return make_forbidden_response()
 
 
 def set_can_manage_experiment_permission(resp: Response):

--- a/mlflow/server/auth/routes.py
+++ b/mlflow/server/auth/routes.py
@@ -82,3 +82,14 @@ GATEWAY_SUPPORTED_MODELS = _get_ajax_path("/mlflow/gateway/supported-models", ve
 GATEWAY_PROVIDER_CONFIG = _get_ajax_path("/mlflow/gateway/provider-config", version=3)
 GATEWAY_SECRETS_CONFIG = _get_ajax_path("/mlflow/gateway/secrets/config", version=3)
 INVOKE_SCORER = _get_ajax_path("/mlflow/scorer/invoke", version=3)
+
+# Online scoring configuration routes (registered manually in handlers.py
+# via get_internal_online_scoring_endpoints; not part of a proto service).
+SCORER_ONLINE_CONFIG_AJAX = _get_ajax_path("/mlflow/scorers/online-config", version=3)
+SCORER_ONLINE_CONFIG_REST = _get_rest_path("/mlflow/scorers/online-config", version=3)
+SCORER_ONLINE_CONFIGS_AJAX = _get_ajax_path("/mlflow/scorers/online-configs", version=3)
+SCORER_ONLINE_CONFIGS_REST = _get_rest_path("/mlflow/scorers/online-configs", version=3)
+
+# Public, unauthenticated UI/telemetry routes (registered manually in
+# mlflow/server/__init__.py; not part of a proto service).
+UI_TELEMETRY_AJAX = _get_ajax_path("/mlflow/ui-telemetry", version=3)

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -143,6 +143,72 @@ def test_proxy_artifact_mpu_validator_returns_update_for_post():
     assert validator is auth_module.validate_can_update_experiment_artifact_proxy
 
 
+@pytest.mark.parametrize(
+    ("path", "method"),
+    [
+        ("/api/2.0/mlflow/__not_a_real_endpoint__", "POST"),
+        ("/ajax-api/3.0/mlflow/__not_a_real_endpoint__", "GET"),
+        # logged-models/webhooks paths fall through the special regex-matching
+        # branches in _find_validator; an unmatched action (extra path segment
+        # not covered by any registered pattern) must fail-closed.
+        ("/api/2.0/mlflow/logged-models/some-id/__no_such_action__", "POST"),
+        ("/api/2.0/mlflow/webhooks/some-id/__no_such_webhook_action__", "GET"),
+        # Workspace-prefixed but parameter pattern does not match any registered route.
+        ("/api/3.0/mlflow/workspaces/foo/__nope__", "GET"),
+    ],
+)
+def test_find_validator_returns_fail_closed_for_unmapped_route(path, method):
+    # Regression test for GHSA-m97m-jq2c-qw46: any (path, method) pair not
+    # registered with a validator must fall through to a fail-closed sentinel
+    # that denies the request, rather than the historical None / fail-open.
+    req = mock.Mock(path=path, method=method)
+    validator = auth_module._find_validator(req)
+    assert callable(validator)
+    assert validator() is False
+
+
+def test_find_validator_returns_allow_through_for_registered_none_validator():
+    # Endpoints that are registered with a None validator (e.g. SearchExperiments,
+    # ListWorkspaces) rely on after-request filtering rather than per-request
+    # permission checks. _find_validator must keep allowing them.
+    req = mock.Mock(path="/api/2.0/mlflow/experiments/search", method="POST")
+    validator = auth_module._find_validator(req)
+    assert callable(validator)
+    assert validator() is True
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/",
+        "/version",
+        "/build/main.js",
+        "/build/static/css/main.css",
+        "/ajax-api/3.0/mlflow/ui-telemetry",
+        "/static/css/x.css",
+        "/favicon.ico",
+        "/health",
+    ],
+)
+def test_is_unprotected_route_allowlist(path):
+    # The genuinely-public UI/health/telemetry routes are explicitly allowlisted
+    # so the fail-closed default in _find_validator does not block them.
+    assert auth_module.is_unprotected_route(path)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/2.0/mlflow/experiments/search",
+        "/api/2.0/mlflow/runs/search",
+        "/api/2.0/mlflow/__not_a_real_endpoint__",
+        "/build",  # missing trailing slash, must not match /build/ prefix
+    ],
+)
+def test_is_unprotected_route_does_not_match_other_paths(path):
+    assert not auth_module.is_unprotected_route(path)
+
+
 def test_proxy_artifact_authorization_required(client, monkeypatch):
     username1, password1 = create_user(client.tracking_uri)
     username2, password2 = create_user(client.tracking_uri)
@@ -1199,6 +1265,141 @@ def test_scorer_read_permission(client, monkeypatch):
         )
         with pytest.raises(requests.HTTPError, match="403"):
             response.raise_for_status()
+
+
+def test_scorer_online_config_requires_permission(client, monkeypatch):
+    # GHSA-m97m-jq2c-qw46: the scorer online-config PUT/GET endpoints used to be
+    # filtered out of BEFORE_REQUEST_VALIDATORS, so any authenticated user could
+    # call them. They are now wired to validate_can_update_scorer_online_config
+    # (PUT) and validate_can_read_scorer_online_configs (GET).
+    username1, password1 = create_user(client.tracking_uri)
+    username2, password2 = create_user(client.tracking_uri)
+
+    with User(username1, password1, monkeypatch):
+        experiment_id = client.create_experiment("scorer-online-config-authz-test")
+
+    scorer_json = '{"name": "test_scorer", "type": "pyfunc"}'
+    with User(username1, password1, monkeypatch):
+        response = _send_rest_tracking_post_request(
+            client.tracking_uri,
+            "/api/3.0/mlflow/scorers/register",
+            json_payload={
+                "experiment_id": experiment_id,
+                "name": "test_scorer",
+                "serialized_scorer": scorer_json,
+            },
+            auth=(username1, password1),
+        )
+    response.raise_for_status()
+    scorer_name = response.json()["name"]
+    scorer_id = response.json()["scorer_id"]
+
+    # Strip user2's default scorer/experiment permissions so the auth layer is
+    # the only thing that decides the response status.
+    _send_rest_tracking_post_request(
+        client.tracking_uri,
+        "/api/3.0/mlflow/scorers/permissions/create",
+        json_payload={
+            "experiment_id": experiment_id,
+            "scorer_name": scorer_name,
+            "username": username2,
+            "permission": "NO_PERMISSIONS",
+        },
+        auth=(username1, password1),
+    )
+    _send_rest_tracking_post_request(
+        client.tracking_uri,
+        "/api/2.0/mlflow/experiments/permissions/create",
+        json_payload={
+            "experiment_id": experiment_id,
+            "username": username2,
+            "permission": "NO_PERMISSIONS",
+        },
+        auth=(username1, password1),
+    )
+
+    # PUT by an unauthorized user must 403 (previously fail-open).
+    with User(username2, password2, monkeypatch):
+        response = requests.put(
+            url=client.tracking_uri + "/api/3.0/mlflow/scorers/online-config",
+            json={
+                "experiment_id": experiment_id,
+                "name": scorer_name,
+                "sample_rate": 0.0,
+            },
+            auth=(username2, password2),
+        )
+    assert response.status_code == 403
+
+    # GET by an unauthorized user must 403 (previously fail-open). Even with no
+    # config yet stored for the scorer, requesting its id reveals nothing if the
+    # auth layer rejects the request first.
+    with User(username2, password2, monkeypatch):
+        response = requests.get(
+            url=client.tracking_uri + "/api/3.0/mlflow/scorers/online-configs",
+            params={"scorer_ids": [scorer_id]},
+            auth=(username2, password2),
+        )
+    # The store returns no configs for a scorer that has never been configured,
+    # so the wrapper validator returns True (nothing to check). To exercise the
+    # 403 branch we instead PUT-then-GET. For PUT we use sample_rate=0 so the
+    # backend skips the gateway-model validation it otherwise enforces.
+    with User(username1, password1, monkeypatch):
+        put_resp = requests.put(
+            url=client.tracking_uri + "/api/3.0/mlflow/scorers/online-config",
+            json={
+                "experiment_id": experiment_id,
+                "name": scorer_name,
+                "sample_rate": 0.0,
+            },
+            auth=(username1, password1),
+        )
+    if put_resp.status_code != 200:
+        raise AssertionError(f"online-config PUT failed: {put_resp.status_code} {put_resp.text}")
+
+    with User(username2, password2, monkeypatch):
+        response = requests.get(
+            url=client.tracking_uri + "/api/3.0/mlflow/scorers/online-configs",
+            params={"scorer_ids": [scorer_id]},
+            auth=(username2, password2),
+        )
+    assert response.status_code == 403
+
+
+def test_unmapped_endpoint_is_fail_closed(client, monkeypatch):
+    # GHSA-m97m-jq2c-qw46: requests to a Flask path that is not registered with
+    # an explicit validator must be denied with 403 rather than allowed through
+    # by the previous fail-open default. We hit /graphql with an unsupported
+    # method (PATCH) so Flask routes the request to the existing /graphql
+    # endpoint but with a method that has no validator entry.
+    # Note: Flask returns 405 for unsupported methods on a registered route
+    # AFTER before_request hooks run, so the auth layer can reject first.
+    username, password = create_user(client.tracking_uri)
+    with User(username, password, monkeypatch):
+        # The /graphql endpoint accepts GET/POST. PATCH is unregistered.
+        response = requests.patch(
+            url=client.tracking_uri + "/graphql",
+            json={},
+            auth=(username, password),
+        )
+    assert response.status_code == 403
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/",
+        "/version",
+        "/ajax-api/3.0/mlflow/ui-telemetry",
+    ],
+)
+def test_unprotected_routes_remain_accessible_without_auth(client, path):
+    # The genuinely-public routes must continue to work without credentials.
+    response = requests.get(client.tracking_uri + path)
+    # Telemetry can return 200/204/empty; version returns 200; "/" serves HTML
+    # or a 404 if the UI bundle is absent in test installs. The important
+    # assertion is that auth (401/403) is not enforced.
+    assert response.status_code not in (401, 403)
 
 
 def _graphql_query(tracking_uri, query, variables=None, auth=None):


### PR DESCRIPTION
### Related Issues/PRs

Relates to `GHSA-m97m-jq2c-qw46` (private security advisory; reference by ID only).

### What changes are proposed in this pull request?

`mlflow/server/auth/_find_validator` previously returned `None` for any `(path, method)` pair not explicitly registered in `BEFORE_REQUEST_VALIDATORS`, and `_before_request` treated `None` as "no permission check required" - fail-open by default. Any Flask endpoint added without a corresponding validator entry was silently reachable by any authenticated user under basic-auth. The scorer online-config `PUT` / `GET` endpoints were filtered out of `BEFORE_REQUEST_VALIDATORS` at construction time and never re-registered, exposing them to all authed users.

This PR:
1. Flips the default in `_find_validator` to fail-closed by returning a sentinel that denies the request for any unmapped `(path, method)` pair. The return type tightens from `Callable[[], bool] | None` to `Callable[[], bool]`.
2. Wires the scorer online-config endpoints (`PUT /api/3.0/mlflow/scorers/online-config`, `GET /api/3.0/mlflow/scorers/online-configs`, and the matching `/ajax-api/3.0/...` paths) to thin wrappers around the existing scorer / experiment permission machinery.
3. Allowlists the genuinely-public UI and telemetry routes (`/`, `/version`, `/build/`, `/ajax-api/3.0/mlflow/ui-telemetry`) via `is_unprotected_route`, which now supports exact-match paths in addition to prefix matches.
4. Routes endpoints that are intentionally registered with a `None` validator (e.g. `ListWorkspaces`, `SearchExperiments`, where the response is filtered by an after-request handler) through an explicit `_allow_through` sentinel so they continue to work.

After this change, any future endpoint added without a corresponding validator entry will fail-closed, preventing the same class of bug going forward.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New tests in `tests/server/auth/test_auth.py`:
- `test_find_validator_returns_fail_closed_for_unmapped_route` - parametrized check that unmapped paths under the main router, logged-models regex, webhooks regex, and workspace regex all resolve to a fail-closed sentinel.
- `test_find_validator_returns_allow_through_for_registered_none_validator` - registered-but-None entries (like `SearchExperiments`) still pass through.
- `test_is_unprotected_route_allowlist` / `test_is_unprotected_route_does_not_match_other_paths` - covers the new exact-match and prefix logic.
- `test_scorer_online_config_requires_permission` - end-to-end basic-auth test that PUT and GET to the scorer online-config endpoints return 403 for a user without scorer / experiment permissions.
- `test_unmapped_endpoint_is_fail_closed` - end-to-end check that a registered Flask route hit with an unregistered HTTP method (PATCH on `/graphql`) returns 403 from the auth layer.
- `test_unprotected_routes_remain_accessible_without_auth` - covers `/`, `/version`, and `/ajax-api/3.0/mlflow/ui-telemetry`.

Full `tests/server/auth/` suite (210 tests) passes locally with `uv run --frozen --with 'mlflow[auth]' pytest tests/server/auth/ -v`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

For properly-deployed setups, this is a no-op. Operators who relied on the prior fail-open behavior to silently expose endpoints will now see `403`; this matches the documented basic-auth promise.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release

Reported by @ifconfig-me via GitHub Security Advisory GHSA-m97m-jq2c-qw46.