### PR TITLE
Skip linter-covered findings in `pr-review` skill

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -85,9 +85,10 @@ gh api graphql -F owner=<owner> -F repo=<repo> -F pr=<PR_NUMBER> -f query='
 
 ### 4. In-Depth Analysis
 
-**Apply additional filtering** from user instructions if provided (e.g., focus on specific issues or areas).
+#### Don't comment on
 
-You may read unchanged/context lines to understand the change, but only file findings against the changed lines (added, modified, or deleted). Pre-existing code is not in scope, even if it looks suboptimal.
+- Pre-existing code. You may read unchanged/context lines to understand the change, but only file findings against the changed lines (added, modified, or deleted), even if surrounding code looks suboptimal.
+- Issues already caught by formatters or linters (unused imports, formatting, line length, simple typos, etc.).
 
 Evaluate the changed code across these dimensions:
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23276

### What changes are proposed in this pull request?

The `pr-review` skill (run by `mlflow-app[bot]`) has been filing NIT comments for issues already caught by Ruff/Clint/typos/pre-commit (e.g., [this comment](https://github.com/mlflow/mlflow/pull/23276#discussion_r3240309344) flagging an unused import that Ruff F401 would catch in CI). These comments add noise without value.

This PR adds a "Don't comment on" subsection to `.claude/skills/pr-review/SKILL.md` that explicitly excludes:

- Pre-existing code (was previously a standalone paragraph; folded into the new list).
- Issues already caught by formatters or linters (unused imports, formatting, line length, simple typos, etc.).

### How is this PR tested?

Docs-only change to a skill prompt; no code paths affected.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)