### PR TITLE
Pass repo/PR as `/pr-review` args

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -40,7 +40,7 @@ Automatically review a GitHub pull request across correctness, security, edge ca
 
 ## Important Note
 
-Always rely on the PR diff fetched via the `fetch-diff` skill. The local working tree is the workflow's own checkout, not the PR head.
+Fetch the diff hunks via the `fetch-diff` skill. For context beyond the diff (existing patterns, call sites of changed symbols, file conventions), `Read` and `Grep` the working tree. The working tree is master, not the PR head, so don't infer the changed-line state from it.
 
 You have a **read-only** GitHub token. Do NOT call write APIs (`gh api ... POST`, `gh pr review`, `gh pr comment`, etc.) — your only output is `/tmp/review-payload.json`. The workflow's post step holds the write token and submits the review on your behalf.
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -40,7 +40,7 @@ Automatically review a GitHub pull request across correctness, security, edge ca
 
 ## Important Note
 
-The PR head is checked out into the working tree, so you may `Read`/`Grep` files for surrounding context. For the diff itself, use the `fetch-diff` skill.
+Always rely on the PR diff fetched via the `fetch-diff` skill. The local working tree is the workflow's own checkout, not the PR head.
 
 You have a **read-only** GitHub token. Do NOT call write APIs (`gh api ... POST`, `gh pr review`, `gh pr comment`, etc.) — your only output is `/tmp/review-payload.json`. The workflow's post step holds the write token and submits the review on your behalf.
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -10,7 +10,8 @@ allowed-tools:
   - Glob
   - Agent
   - Edit(//tmp/review-payload.json)
-argument-hint: "[extra_context]"
+argument-hint: "<owner>/<repo> <pr_number> [extra_context]"
+arguments: [repo, pr_number, extra_context]
 ---
 
 # Review Pull Request
@@ -20,39 +21,46 @@ Automatically review a GitHub pull request across correctness, security, edge ca
 ## Usage
 
 ```
-/pr-review [extra_context]
+/pr-review <owner>/<repo> <pr_number> [extra_context]
 ```
 
 ## Arguments
 
-- `extra_context` (optional): Additional instructions or filtering context (e.g., focus on specific issues or areas)
+- `<owner>/<repo>` (required): repository slug, e.g. `mlflow/mlflow`
+- `<pr_number>` (required): pull request number
+- `[extra_context]` (optional): additional filtering or focus instructions (e.g., a specific concern or file type)
 
 ## Examples
 
 ```
-/pr-review                                    # Review all changes
-/pr-review Please focus on security issues    # Focus on security
-/pr-review Only review Python files           # Filter specific file types
-/pr-review Check for performance issues       # Focus on specific concern
+/pr-review mlflow/mlflow 23320
+/pr-review mlflow/mlflow 23320 Please focus on security issues
+/pr-review mlflow/mlflow 23320 Only review Python files
 ```
 
 ## Important Note
 
-The current local branch may not be the PR branch being reviewed. Always rely on the PR diff fetched via the `fetch-diff` skill.
+The PR head is checked out into the working tree, so you may `Read`/`Grep` files for surrounding context. For the diff itself, use the `fetch-diff` skill.
 
 You have a **read-only** GitHub token. Do NOT call write APIs (`gh api ... POST`, `gh pr review`, `gh pr comment`, etc.) — your only output is `/tmp/review-payload.json`. The workflow's post step holds the write token and submits the review on your behalf.
 
 ## Instructions
 
-### 1. Auto-detect PR context
+This invocation is reviewing:
 
-- First check for environment variables:
-  - If `PR_NUMBER` and `GITHUB_REPOSITORY` are set, parse `GITHUB_REPOSITORY` as `owner/repo` and use `PR_NUMBER`
-  - Then use `gh pr view <PR_NUMBER> --repo <owner/repo> --json 'title,body'` to retrieve the PR title and description
-- Otherwise:
-  - Use `gh pr view --json 'title,body,url,number'` to get PR info for the current branch
-  - Parse the output to extract owner, repo, PR number, title, and description
-- If neither method works, inform the user that no PR was found and exit
+- Repo: `$repo`
+- PR number: `$pr_number`
+- Extra context: `$extra_context`
+
+Substitute the placeholders (`<owner>`, `<repo>`, `<pr_number>`) in the steps below with the values above.
+
+### 1. Fetch PR context
+
+Fetch the PR title, description, and author:
+
+```bash
+gh pr view <pr_number> --repo <owner>/<repo> --json title,body,author
+```
 
 ### 2. Fetch PR Diff
 
@@ -63,7 +71,7 @@ Run the `fetch-diff` skill to fetch the PR diff for the identified PR.
 Fetch up to 100 review threads on the PR (open, resolved, and outdated, with up to 20 comments each) so you can avoid duplicating prior feedback:
 
 ```bash
-gh api graphql -F owner=<owner> -F repo=<repo> -F pr=<PR_NUMBER> -f query='
+gh api graphql -F owner=<owner> -F repo=<repo> -F pr=<pr_number> -f query='
   query($owner: String!, $repo: String!, $pr: Int!) {
     repository(owner: $owner, name: $repo) {
       pullRequest(number: $pr) {
@@ -117,11 +125,10 @@ Determine the review `event`:
 - **No CRITICAL findings AND author has `admin`/`maintain` role** -> `event: "APPROVE"`
 - **Any CRITICAL finding, OR author role is anything else (or the API errors, e.g., 404 for non-collaborators)** -> `event: "COMMENT"`. Do not mention the reason for not approving in the review body.
 
-Check the author's role:
+Check the author's role (use the `author.login` from step 1 as `<author>`):
 
 ```bash
-author=$(gh api repos/<owner>/<repo>/pulls/<PR_NUMBER> --jq '.user.login')
-gh api repos/<owner>/<repo>/collaborators/"$author"/permission --jq '.role_name'
+gh api repos/<owner>/<repo>/collaborators/<author>/permission --jq '.role_name'
 ```
 
 ### 6. Emit Review Payload

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -10,8 +10,8 @@ allowed-tools:
   - Glob
   - Agent
   - Edit(//tmp/review-payload.json)
-argument-hint: "<owner> <repo> <pr_number> [extra_context]"
-arguments: [owner, repo, pr_number, extra_context]
+argument-hint: "<owner_repo> <pr_number> [extra_context]"
+arguments: [owner_repo, pr_number, extra_context]
 ---
 
 # Review Pull Request
@@ -21,34 +21,32 @@ Automatically review a GitHub pull request across correctness, security, edge ca
 ## Usage
 
 ```
-/pr-review <owner> <repo> <pr_number> [extra_context]
+/pr-review <owner_repo> <pr_number> [extra_context]
 ```
 
 ## Arguments
 
-- `<owner>` (required): repository owner, e.g. `mlflow`
-- `<repo>` (required): repository name, e.g. `mlflow`
+- `<owner_repo>` (required): repository slug, e.g. `mlflow/mlflow`
 - `<pr_number>` (required): pull request number
 - `[extra_context]` (optional): additional filtering or focus instructions (e.g., a specific concern or file type)
 
 ## Examples
 
 ```
-/pr-review mlflow mlflow 23320
-/pr-review mlflow mlflow 23320 Please focus on security issues
-/pr-review mlflow mlflow 23320 Only review Python files
+/pr-review mlflow/mlflow 23320
+/pr-review mlflow/mlflow 23320 Please focus on security issues
+/pr-review mlflow/mlflow 23320 Only review Python files
 ```
 
 ## Inputs
 
 This invocation is reviewing:
 
-- Owner: `$owner`
-- Repo: `$repo`
+- Owner/Repo: `$owner_repo`
 - PR number: `$pr_number`
 - Extra context: `$extra_context`
 
-The `<owner>`/`<repo>`/`<pr_number>` placeholders in the steps below refer to the values above.
+The `<owner>`/`<repo>`/`<pr_number>` placeholders in the steps below refer to the values above (split `$owner_repo` on `/` for `<owner>` and `<repo>`).
 
 ## Instructions
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -10,8 +10,8 @@ allowed-tools:
   - Glob
   - Agent
   - Edit(//tmp/review-payload.json)
-argument-hint: "<owner>/<repo> <pr_number> [extra_context]"
-arguments: [repo, pr_number, extra_context]
+argument-hint: "<owner> <repo> <pr_number> [extra_context]"
+arguments: [owner, repo, pr_number, extra_context]
 ---
 
 # Review Pull Request
@@ -21,50 +21,50 @@ Automatically review a GitHub pull request across correctness, security, edge ca
 ## Usage
 
 ```
-/pr-review <owner>/<repo> <pr_number> [extra_context]
+/pr-review <owner> <repo> <pr_number> [extra_context]
 ```
 
 ## Arguments
 
-- `<owner>/<repo>` (required): repository slug, e.g. `mlflow/mlflow`
+- `<owner>` (required): repository owner, e.g. `mlflow`
+- `<repo>` (required): repository name, e.g. `mlflow`
 - `<pr_number>` (required): pull request number
 - `[extra_context]` (optional): additional filtering or focus instructions (e.g., a specific concern or file type)
 
 ## Examples
 
 ```
-/pr-review mlflow/mlflow 23320
-/pr-review mlflow/mlflow 23320 Please focus on security issues
-/pr-review mlflow/mlflow 23320 Only review Python files
+/pr-review mlflow mlflow 23320
+/pr-review mlflow mlflow 23320 Please focus on security issues
+/pr-review mlflow mlflow 23320 Only review Python files
 ```
 
-## Important Note
-
-Fetch the diff hunks via the `fetch-diff` skill. For context beyond the diff (existing patterns, call sites of changed symbols, file conventions), `Read` and `Grep` the working tree. The working tree is master, not the PR head, so don't infer the changed-line state from it.
-
-You have a **read-only** GitHub token. Do NOT call write APIs (`gh api ... POST`, `gh pr review`, `gh pr comment`, etc.) — your only output is `/tmp/review-payload.json`. The workflow's post step holds the write token and submits the review on your behalf.
-
-## Instructions
+## Inputs
 
 This invocation is reviewing:
 
+- Owner: `$owner`
 - Repo: `$repo`
 - PR number: `$pr_number`
 - Extra context: `$extra_context`
 
-Substitute the placeholders (`<owner>`, `<repo>`, `<pr_number>`) in the steps below with the values above.
+The `<owner>`/`<repo>`/`<pr_number>` placeholders in the steps below refer to the values above.
+
+## Instructions
 
 ### 1. Fetch PR context
 
 Fetch the PR title, description, and author:
 
 ```bash
-gh pr view <pr_number> --repo <owner>/<repo> --json title,body,author
+gh pr view <pr_number> --repo "<owner>/<repo>" --json title,body,author
 ```
+
+> **Note:** You have a **read-only** GitHub token. Do NOT call write APIs (`gh api ... POST`, `gh pr review`, `gh pr comment`, etc.).
 
 ### 2. Fetch PR Diff
 
-Run the `fetch-diff` skill to fetch the PR diff for the identified PR.
+Fetch the diff hunks via the `fetch-diff` skill. For context beyond the diff (existing patterns, call sites of changed symbols, file conventions), `Read` and `Grep` the working tree. The working tree is master, not the PR head, so don't infer the changed-line state from it.
 
 ### 3. Fetch Existing Review Comments
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -100,6 +100,7 @@ jobs:
         with:
           persist-credentials: false
           token: ${{ steps.app-token-read.outputs.token }}
+          ref: refs/pull/${{ github.event.pull_request.number || github.event.issue.number }}/head
       - uses: ./.github/actions/setup-python
         with:
           pin-micro-version: false
@@ -156,6 +157,7 @@ jobs:
           # Read-only token: Claude can fetch PR/diff/comments but cannot post anything.
           GH_TOKEN: ${{ steps.app-token-read.outputs.token }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           PROMPT: ${{ steps.prompt.outputs.prompt }}
           MODEL: ${{ steps.prompt.outputs.model || 'claude-opus-4-6' }}
@@ -167,7 +169,7 @@ jobs:
           # Safe construction using arrays - PROMPT is passed as separate argument to prevent shell injection.
           # Both event paths run /pr-review end-to-end against the PR; on
           # pull_request (smoke), Post is gated off so no review is submitted.
-          ARGS=("/pr-review")
+          ARGS=("/pr-review" "$REPO" "$PR_NUMBER")
           if [ "$EVENT_NAME" = "issue_comment" ] && [ -n "$PROMPT" ]; then
             ARGS+=("$PROMPT")
           fi

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -156,8 +156,7 @@ jobs:
           # Read-only token: Claude can fetch PR/diff/comments but cannot post anything.
           GH_TOKEN: ${{ steps.app-token-read.outputs.token }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          OWNER: ${{ github.repository_owner }}
-          REPO: ${{ github.event.repository.name }}
+          REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           PROMPT: ${{ steps.prompt.outputs.prompt }}
           MODEL: ${{ steps.prompt.outputs.model || 'claude-opus-4-6' }}
@@ -169,7 +168,7 @@ jobs:
           # Safe construction using arrays - PROMPT is passed as separate argument to prevent shell injection.
           # Both event paths run /pr-review end-to-end against the PR; on
           # pull_request (smoke), Post is gated off so no review is submitted.
-          ARGS=("/pr-review" "$OWNER" "$REPO" "$PR_NUMBER")
+          ARGS=("/pr-review" "$REPO" "$PR_NUMBER")
           if [ "$EVENT_NAME" = "issue_comment" ] && [ -n "$PROMPT" ]; then
             ARGS+=("$PROMPT")
           fi

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -100,7 +100,6 @@ jobs:
         with:
           persist-credentials: false
           token: ${{ steps.app-token-read.outputs.token }}
-          ref: refs/pull/${{ github.event.pull_request.number || github.event.issue.number }}/head
       - uses: ./.github/actions/setup-python
         with:
           pin-micro-version: false

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -156,7 +156,8 @@ jobs:
           # Read-only token: Claude can fetch PR/diff/comments but cannot post anything.
           GH_TOKEN: ${{ steps.app-token-read.outputs.token }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          REPO: ${{ github.repository }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           PROMPT: ${{ steps.prompt.outputs.prompt }}
           MODEL: ${{ steps.prompt.outputs.model || 'claude-opus-4-6' }}
@@ -168,7 +169,7 @@ jobs:
           # Safe construction using arrays - PROMPT is passed as separate argument to prevent shell injection.
           # Both event paths run /pr-review end-to-end against the PR; on
           # pull_request (smoke), Post is gated off so no review is submitted.
-          ARGS=("/pr-review" "$REPO" "$PR_NUMBER")
+          ARGS=("/pr-review" "$OWNER" "$REPO" "$PR_NUMBER")
           if [ "$EVENT_NAME" = "issue_comment" ] && [ -n "$PROMPT" ]; then
             ARGS+=("$PROMPT")
           fi


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23320 (recently merged).

### What changes are proposed in this pull request?

Refactor the `pr-review` skill so it takes `<owner>/<repo>` and `<pr_number>` as positional arguments instead of relying on `PR_NUMBER`/`GITHUB_REPOSITORY` env vars and current-branch detection. The args are bound once at the top of `SKILL.md` (`Repo`, `PR number`, `Extra context`), and the rest of the skill uses plain `<owner>`/`<repo>`/`<pr_number>`/`<author>` placeholders. This also lets us drop the redundant `gh api .../pulls/<n>` author lookup in the decision step, since `gh pr view --json author` already returns it.

The workflow's `ARGS` array now passes `"$REPO" "$PR_NUMBER"` to `/pr-review` so the skill receives them positionally.

(An earlier revision also checked out the PR head ref so the agent could read full file context. That was reverted after the bot's `/review` flagged it as a real concern: executing PR-head scripts like `install-claude.sh` in a workflow with `ANTHROPIC_API_KEY` in env elevates unreviewed code to secret-handling trust. The agent can still `Read`/`Grep` the workflow's checkout (master) for surrounding context.)

### How is this PR tested?

Docs-only / workflow change. The `pull_request` smoke job in `review.yml` runs `/pr-review` end-to-end against this PR (no review is posted) and will fail if the new args are wired incorrectly.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)