### PR TITLE
Bump nailaopus `mlflow/internal` pin: pick up logging + cache-hit stamp + cross-location dedup

### DIFF
--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -153,7 +153,7 @@ jobs:
           # open a new PR that updates this SHA to the latest mlflow/internal
           # main after reviewing the diff. We'll migrate to release tags once
           # the bump cadence is stable; see mlflow/internal for the policy.
-          ref: a7e8fef0ac578b26bc5e2179c81b402a7061fa57
+          ref: f36ec2a96d3b94d6fced6f98ef49831a9a245090
           sparse-checkout: |
             nailaopus
           path: internal


### PR DESCRIPTION
### Related Issues/PRs

Picks up [mlflow/internal#33](https://github.com/mlflow/internal/pull/33) (`f36ec2a`).

Previous pin was `a7e8fef` from #23316. Third SHA bump on the initial pin from #23304.

### What changes are proposed in this pull request?

Single-line update to `.github/workflows/nailaopus.yml`: bump the `ref:` on the `mlflow/internal` checkout step from `a7e8fef` to `f36ec2a`. The new orchestrator commit bundles four follow-ups plus self-review fixes plus logging-gap closures.

What this bump turns on:

- **Per-finding analytics in the run record (schema v5 → v6).** New top-level blocks `spotter_findings: [...]`, `reviewer_opinions: [...]`, and `matched_thread` on each `posted`/`skipped` entry. Answers "what did the spotter find?", "which finding did the reviewer skip and why?", and "which prior thread caused each dedup skip?" from the JSON record without re-running.

- **Cache-hit stamp gate.** A maintainer who dismisses comments (resolve inline threads + 👍/👎 fallback comments) can re-run `/review-v2` at $0 LLM cost and get a stamp. Previously cache-hit was a strict no-op that required `--no-cache` (paying for a full LLM review) to re-evaluate.

- **Cross-location semantic dedup against bot-authored threads.** The bot won't re-raise shuffled-anchor variants of concerns it already raised and the user dismissed, regardless of whether the new anchor is in the same file >10 lines away or in a different file entirely. Capped at `MAX_BOT_THREADS_FOR_SEMANTIC_DEDUP = 50` to prevent runaway LLM cost on PRs with deep bot-comment history.

- **Stamp gate refuses with open bot threads.** No longer relies on the spotter happening to re-raise the concern to fail SELF_DEDUP. Any bot-authored thread that isn't resolved/soft-resolved blocks the stamp.

- **Body-hash dedup removed.** PR #30's body-hash mechanism is subsumed by semantic match AND handles the wording-drift case body-hash misses (reviewer-opinion `voice_rewrite` varies across runs even for the same concern). PR-level fallback marker simplified to `<!-- NaiLaOpus: pr_level -->`.

End-to-end validation: ran `--no-cache` and cache-hit dry-runs locally against PR 22464 before this bump. Cross-location dedup caught 2/5 findings; cache-hit returned `would_stamp: true` at $0 cost.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Local validation as above. End-to-end live posting / stamping lands on the next `/review-v2` invocation after merge.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`
- [ ] `area/models`
- [ ] `area/model-registry`
- [ ] `area/scoring`
- [ ] `area/evaluation`
- [ ] `area/gateway`
- [ ] `area/prompts`
- [ ] `area/tracing`
- [ ] `area/projects`
- [ ] `area/uiux`
- [x] `area/build`
- [ ] `area/docs`

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

-- Claude-drafted, reviewed before posting.