### PR TITLE
gateway: handle missing finish_reason in openai_compatible streaming chunks

### DIFF
--- a/mlflow/gateway/providers/openai_compatible.py
+++ b/mlflow/gateway/providers/openai_compatible.py
@@ -113,7 +113,7 @@ class OpenAICompatibleAdapter(ProviderAdapter):
             choices=[
                 chat.StreamChoice(
                     index=c["index"],
-                    finish_reason=c["finish_reason"],
+                    finish_reason=c.get("finish_reason"),
                     delta=chat.StreamDelta(
                         role=c["delta"].get("role"),
                         content=c["delta"].get("content"),


### PR DESCRIPTION
Closes #23139

## Problem

When the AI Gateway proxies streaming requests to a Claude / Anthropic-compatible `openai_compatible` provider, it crashes with:

```
KeyError: 'finish_reason'
  File "mlflow/gateway/providers/openai_compatible.py", line 116, in model_to_chat_streaming
    finish_reason=c["finish_reason"],
```

Claude omits `finish_reason` on intermediate streaming chunks (only the final chunk carries it). OpenAI always sends `"finish_reason": null` on every chunk, so the existing test only covered the key-present case.

## Fix

One-line change: `c["finish_reason"]` → `c.get("finish_reason")`.

The non-streaming path in the same file (`model_to_chat`) already uses `.get()` correctly on line 81; this aligns the streaming path.

## Changes

`mlflow/gateway/providers/openai_compatible.py` — line 116: use `.get()` so a missing `finish_reason` key yields `None` instead of raising `KeyError`.