### PR TITLE
artifact: skip S3 directory-marker objects when listing artifacts

### DIFF
--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -425,9 +425,17 @@ class S3ArtifactRepository(
                 subdir_rel_path = posixpath.relpath(path=subdir_path, start=artifact_path)
                 subdir_rel_path = subdir_rel_path.removesuffix("/")
                 infos.append(FileInfo(subdir_rel_path, True, None))
-            # Objects listed directly will be files
+            # Objects listed directly will be files.
+            # Skip 0-byte objects whose key ends with "/" — these are directory markers
+            # created by the S3 console or some S3-compatible backends (e.g. Hitachi HCP).
+            # Treating them as regular files produces confusing listings and download
+            # failures (the backend may return 404 for the marker object).
             for obj in result.get("Contents", []):
                 file_path = obj.get("Key")
+                if file_path.endswith("/") and int(obj.get("Size", 0)) == 0:
+                    # Directory marker — already represented as a CommonPrefix entry;
+                    # skip to avoid duplicate / phantom file entries.
+                    continue
                 self._verify_listed_object_contains_artifact_path_prefix(
                     listed_object_path=file_path, artifact_path=artifact_path
                 )


### PR DESCRIPTION
Closes #23284

## Problem

Some S3-compatible backends create 0-byte objects whose key ends with `/` as directory markers — the AWS S3 console does this explicitly; backends like Hitachi HCP create them implicitly when uploading objects with path-like prefixes.

MLflow's `S3ArtifactRepository.list_artifacts` treated every entry in the `Contents` response as a regular file. This caused:

- **Phantom file entries** in the artifact browser (empty names like `""` or `"artifacts/"` appearing as files alongside real artifacts)
- **Download failures**: some backends return HTTP 404 for the marker key, which propagates as a 500 from MLflow

## Fix

In the `Contents` loop inside `list_artifacts`, skip any object whose key ends with `/` and whose `Size` is `0`. These paths are already represented as `CommonPrefixes` when the S3 request uses a delimiter, so no information is lost.

```python
# before (no guard)
for obj in result.get("Contents", []):
    file_path = obj.get("Key")
    ...

# after
for obj in result.get("Contents", []):
    file_path = obj.get("Key")
    if file_path.endswith("/") and int(obj.get("Size", 0)) == 0:
        continue  # directory marker — skip
    ...
```

## Changes

`mlflow/store/artifact/s3_artifact_repo.py` — add guard in `list_artifacts` to skip 0-byte trailing-slash objects.