### PR TITLE
tracking: add missing ON DELETE CASCADE to experiment_id FKs on trace_info and logged_model_* tables

### DIFF
--- a/mlflow/store/db_migrations/versions/a1b2c3d4e5f6_add_cascade_deletion_to_experiment_fks.py
+++ b/mlflow/store/db_migrations/versions/a1b2c3d4e5f6_add_cascade_deletion_to_experiment_fks.py
@@ -1,0 +1,79 @@
+"""add cascade deletion to experiment_id foreign keys
+
+Missing ON DELETE CASCADE on four experiment_id FK constraints:
+  - trace_info.experiment_id
+  - logged_model_metrics.experiment_id
+  - logged_model_params.experiment_id
+  - logged_model_tags.experiment_id
+
+Create Date: 2025-05-14 00:00:00.000000
+
+"""
+
+from alembic import op
+
+from mlflow.store.tracking.dbmodels.models import (
+    SqlLoggedModelMetric,
+    SqlLoggedModelParam,
+    SqlLoggedModelTag,
+    SqlTraceInfo,
+)
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f6"
+down_revision = "f5a4f2784254"
+branch_labels = None
+depends_on = None
+
+# (table_name, fk_constraint_name, fk_column, ref_table, ref_column)
+_FK_SPECS = [
+    (
+        SqlTraceInfo.__tablename__,
+        "fk_trace_info_experiment_id",
+        "experiment_id",
+        "experiments",
+        "experiment_id",
+    ),
+    (
+        SqlLoggedModelMetric.__tablename__,
+        "fk_logged_model_metrics_experiment_id",
+        "experiment_id",
+        "experiments",
+        "experiment_id",
+    ),
+    (
+        SqlLoggedModelParam.__tablename__,
+        "fk_logged_model_params_experiment_id",
+        "experiment_id",
+        "experiments",
+        "experiment_id",
+    ),
+    (
+        SqlLoggedModelTag.__tablename__,
+        "fk_logged_model_tags_experiment_id",
+        "experiment_id",
+        "experiments",
+        "experiment_id",
+    ),
+]
+
+
+def upgrade():
+    for table, constraint_name, local_col, ref_table, ref_col in _FK_SPECS:
+        # batch_alter_table is required for SQLite compatibility (SQLite does not
+        # support ALTER TABLE ... DROP/ADD CONSTRAINT outside a batch operation).
+        with op.batch_alter_table(table, schema=None) as batch_op:
+            batch_op.drop_constraint(constraint_name, type_="foreignkey")
+            batch_op.create_foreign_key(
+                constraint_name,
+                ref_table,
+                [local_col],
+                [ref_col],
+                ondelete="CASCADE",
+            )
+
+
+def downgrade():
+    # Intentionally left as a no-op; removing CASCADE is a safe no-op
+    # (it only affects what happens when the referenced row is deleted).
+    pass

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -724,7 +724,7 @@ class SqlTraceInfo(Base):
     Trace ID: `String` (limit 50 characters). *Primary Key* for ``trace_info`` table.
     Named as "trace_id" in V3 format.
     """
-    experiment_id = Column(Integer, ForeignKey("experiments.experiment_id"), nullable=False)
+    experiment_id = Column(Integer, ForeignKey("experiments.experiment_id", ondelete="CASCADE"), nullable=False)
     """
     Experiment ID to which this trace belongs: *Foreign Key* into ``experiments`` table.
     """
@@ -1418,6 +1418,7 @@ class SqlLoggedModelMetric(Base):
         ForeignKeyConstraint(
             ["experiment_id"],
             ["experiments.experiment_id"],
+            ondelete="CASCADE",
             name="fk_logged_model_metrics_experiment_id",
         ),
         ForeignKeyConstraint(
@@ -1480,6 +1481,7 @@ class SqlLoggedModelParam(Base):
         ForeignKeyConstraint(
             ["experiment_id"],
             ["experiments.experiment_id"],
+            ondelete="CASCADE",
             name="fk_logged_model_params_experiment_id",
         ),
     )
@@ -1526,6 +1528,7 @@ class SqlLoggedModelTag(Base):
         ForeignKeyConstraint(
             ["experiment_id"],
             ["experiments.experiment_id"],
+            ondelete="CASCADE",
             name="fk_logged_model_tags_experiment_id",
         ),
     )


### PR DESCRIPTION
Closes #23109

## Problem

Four `ForeignKey` constraints referencing `experiments.experiment_id` are missing `ON DELETE CASCADE`:

| Table | Constraint name |
|---|---|
| `trace_info` | `fk_trace_info_experiment_id` |
| `logged_model_metrics` | `fk_logged_model_metrics_experiment_id` |
| `logged_model_params` | `fk_logged_model_params_experiment_id` |
| `logged_model_tags` | `fk_logged_model_tags_experiment_id` |

Other FK constraints on the same column (`runs`, `logged_models`, `datasets`) correctly carry `CASCADE`. The trace sub-tables (`trace_tags`, `trace_metadata`) were fixed in migration `5b0e9adcef9c`; these four were missed.

**Effect:**
- **PostgreSQL**: deleting an experiment row raises `ForeignKeyViolation` when child rows exist — breaks experiment GC and any external cleanup
- **SQLite / MySQL**: child rows are silently orphaned

## Fix

### `mlflow/store/tracking/dbmodels/models.py`

- `SqlTraceInfo.experiment_id` column: add `ondelete="CASCADE"` to the inline `ForeignKey`
- `SqlLoggedModelMetric`, `SqlLoggedModelParam`, `SqlLoggedModelTag`: add `ondelete="CASCADE"` to their `ForeignKeyConstraint` entries in `__table_args__`

### `mlflow/store/db_migrations/versions/a1b2c3d4e5f6_add_cascade_deletion_to_experiment_fks.py` (new)

Alembic migration that drops and re-creates the four constraints with `ON DELETE CASCADE` using `batch_alter_table` (required for SQLite compatibility, following the pattern of `5b0e9adcef9c`).

`down_revision = "f5a4f2784254"` (the current head migration).