### PR TITLE
gateway: handle missing `finish_reason` in `openai_compatible` streaming chunks

### DIFF
--- a/mlflow/gateway/providers/openai_compatible.py
+++ b/mlflow/gateway/providers/openai_compatible.py
@@ -113,7 +113,7 @@ class OpenAICompatibleAdapter(ProviderAdapter):
             choices=[
                 chat.StreamChoice(
                     index=c["index"],
-                    finish_reason=c["finish_reason"],
+                    finish_reason=c.get("finish_reason"),
                     delta=chat.StreamDelta(
                         role=c["delta"].get("role"),
                         content=c["delta"].get("content"),


### PR DESCRIPTION
### Related Issues/PRs

Closes #23139

### What changes are proposed in this pull request?

Claude / Anthropic-compatible endpoints omit `finish_reason` on intermediate streaming chunks (only the final chunk carries it). OpenAI always sends `"finish_reason": null` on every chunk, so the bug only surfaces with Anthropic-compatible upstreams.

`model_to_chat_streaming` in `openai_compatible.py` used `c["finish_reason"]` (key access), which raises `KeyError` when the key is absent. The non-streaming path `model_to_chat` in the same file already uses `c.get("finish_reason")` correctly.

**Change:** one-line fix — `c["finish_reason"]` → `c.get("finish_reason")` in `model_to_chat_streaming`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

The existing streaming test in `tests/gateway/providers/test_openai_compatible.py` covers `"finish_reason": null` (key present). A follow-up test covering the key-absent case would also be valid, but the fix itself is a one-liner with no logic branching.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a `KeyError: 'finish_reason'` crash in the AI Gateway when proxying streaming requests to Claude / Anthropic-compatible `openai_compatible` providers.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release