### PR TITLE
artifact: skip S3 directory-marker objects in `list_artifacts`

### DIFF
--- a/mlflow/store/artifact/optimized_s3_artifact_repo.py
+++ b/mlflow/store/artifact/optimized_s3_artifact_repo.py
@@ -327,6 +327,11 @@ class OptimizedS3ArtifactRepository(CloudArtifactRepository):
             # Objects listed directly will be files
             for obj in result.get("Contents", []):
                 file_path = obj.get("Key")
+                # Skip directory-marker objects (0-byte keys ending in "/") that the S3
+                # console and some S3-compatible backends (e.g. Hitachi HCP) create.
+                # They surface as phantom files and may 404 on download.
+                if file_path.endswith("/") and int(obj.get("Size", 0)) == 0:
+                    continue
                 self._verify_listed_object_contains_artifact_path_prefix(
                     listed_object_path=file_path, artifact_path=artifact_path
                 )

--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -425,16 +425,12 @@ class S3ArtifactRepository(
                 subdir_rel_path = posixpath.relpath(path=subdir_path, start=artifact_path)
                 subdir_rel_path = subdir_rel_path.removesuffix("/")
                 infos.append(FileInfo(subdir_rel_path, True, None))
-            # Objects listed directly will be files.
-            # Skip 0-byte objects whose key ends with "/" — these are directory markers
-            # created by the S3 console or some S3-compatible backends (e.g. Hitachi HCP).
-            # Treating them as regular files produces confusing listings and download
-            # failures (the backend may return 404 for the marker object).
             for obj in result.get("Contents", []):
                 file_path = obj.get("Key")
+                # Skip directory-marker objects (0-byte keys ending in "/") that the S3
+                # console and some S3-compatible backends (e.g. Hitachi HCP) create.
+                # They surface as phantom files and may 404 on download.
                 if file_path.endswith("/") and int(obj.get("Size", 0)) == 0:
-                    # Directory marker — already represented as a CommonPrefix entry;
-                    # skip to avoid duplicate / phantom file entries.
                     continue
                 self._verify_listed_object_contains_artifact_path_prefix(
                     listed_object_path=file_path, artifact_path=artifact_path

--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -425,9 +425,17 @@ class S3ArtifactRepository(
                 subdir_rel_path = posixpath.relpath(path=subdir_path, start=artifact_path)
                 subdir_rel_path = subdir_rel_path.removesuffix("/")
                 infos.append(FileInfo(subdir_rel_path, True, None))
-            # Objects listed directly will be files
+            # Objects listed directly will be files.
+            # Skip 0-byte objects whose key ends with "/" — these are directory markers
+            # created by the S3 console or some S3-compatible backends (e.g. Hitachi HCP).
+            # Treating them as regular files produces confusing listings and download
+            # failures (the backend may return 404 for the marker object).
             for obj in result.get("Contents", []):
                 file_path = obj.get("Key")
+                if file_path.endswith("/") and int(obj.get("Size", 0)) == 0:
+                    # Directory marker — already represented as a CommonPrefix entry;
+                    # skip to avoid duplicate / phantom file entries.
+                    continue
                 self._verify_listed_object_contains_artifact_path_prefix(
                     listed_object_path=file_path, artifact_path=artifact_path
                 )

--- a/tests/store/artifact/test_s3_artifact_repo.py
+++ b/tests/store/artifact/test_s3_artifact_repo.py
@@ -250,6 +250,31 @@ def test_file_and_directories_artifacts_are_logged_and_listed_successfully_in_ba
     assert nested_artifacts_listing == [("nested/c.txt", False, 1)]
 
 
+@pytest.mark.parametrize("repo_cls", [S3ArtifactRepository, OptimizedS3ArtifactRepository])
+def test_list_artifacts_skips_directory_marker_objects(s3_artifact_root, repo_cls):
+    repo = repo_cls(posixpath.join(s3_artifact_root, "some/path"))
+
+    mock_s3 = mock.Mock()
+    mock_paginator = mock.Mock()
+    mock_s3.get_paginator.return_value = mock_paginator
+    mock_paginator.paginate.return_value = [
+        {
+            "Contents": [
+                {"Key": "some/path/", "Size": 0},
+                {"Key": "some/path/empty_dir/", "Size": 0},
+                {"Key": "some/path/a.txt", "Size": 1},
+            ],
+            "CommonPrefixes": [{"Prefix": "some/path/empty_dir/"}],
+        }
+    ]
+
+    with mock.patch.object(repo, "_get_s3_client", return_value=mock_s3):
+        infos = repo.list_artifacts()
+
+    listing = sorted((f.path, f.is_dir, f.file_size) for f in infos)
+    assert listing == [("a.txt", False, 1), ("empty_dir", True, None)]
+
+
 def test_download_directory_artifact_succeeds_when_artifact_root_is_s3_bucket_root(
     s3_artifact_root, tmp_path
 ):


### PR DESCRIPTION
### Related Issues/PRs

Closes #23284

### What changes are proposed in this pull request?

Some S3-compatible backends create 0-byte objects whose key ends with `/` as directory markers:

- **AWS S3 console** — created explicitly when a user creates a "folder"
- **Hitachi HCP, MinIO** — created implicitly for every path prefix when uploading

`S3ArtifactRepository.list_artifacts` iterated every entry in the `Contents` response as a regular file. This caused:

1. **Phantom entries** in the artifact browser (`""` or `"artifacts/"` appearing as files alongside real artifacts)
2. **Download failures** — some backends return HTTP 404 for the marker key, propagating as a 500 from MLflow

**Fix:** In the `Contents` loop inside `list_artifacts`, skip any object whose key ends with `/` and whose `Size` is `0`. These paths are already represented as `CommonPrefixes` when the S3 request uses a delimiter, so no information is lost.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

The guard is a simple two-condition check (`key.endswith("/") and size == 0`). Existing S3 listing tests cover the normal file path; the directory-marker case is only reproducible with an S3-compatible backend that emits these objects.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed artifact listing on S3-compatible backends (Hitachi HCP, MinIO, AWS S3 console-created folders) that expose directory-marker objects (0-byte keys ending in `/`). These were previously treated as regular files, producing phantom entries in the UI and download failures.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release