### PR TITLE
Gate `review` workflow on admin/maintain role and check out PR merge ref

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -62,7 +62,7 @@ gh pr view <pr_number> --repo "<owner>/<repo>" --json title,body,author
 
 ### 2. Fetch PR Diff
 
-Fetch the diff hunks via the `fetch-diff` skill. For context beyond the diff (existing patterns, call sites of changed symbols, file conventions), `Read` and `Grep` the working tree. The working tree is master, not the PR head, so don't infer the changed-line state from it.
+Fetch the diff hunks via the `fetch-diff` skill. For context beyond the diff (existing patterns, call sites of changed symbols, file conventions), `Read` and `Grep` the working tree, which holds the PR merged into the base (`refs/pull/<pr>/merge`), so file contents reflect the post-merge state.
 
 ### 3. Fetch Existing Review Comments
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -37,6 +37,10 @@ jobs:
       ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
+       (
+        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association) ||
+        (github.event.issue.user.login == 'Copilot' && github.event.issue.user.type == 'Bot')
+       ) &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
        startsWith(github.event.comment.body, '/review') &&
        !startsWith(github.event.comment.body, '/review-'))

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -17,32 +17,66 @@ defaults:
     shell: bash
 
 jobs:
+  # Auth gate: only users with admin or maintain role on the repo can trigger
+  # the review (plus the Copilot bot). For issue_comment, BOTH the PR author
+  # and the commenter are checked.
+  gate:
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    if: >
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository &&
+       github.event.pull_request.draft == false)
+      ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       startsWith(github.event.comment.body, '/review') &&
+       !startsWith(github.event.comment.body, '/review-'))
+    steps:
+      - name: Check user permission
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
+          PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type || github.event.issue.user.type }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+        run: |
+          check_user() {
+            local user=$1
+            local type=$2
+            if [ "$user" = "Copilot" ] && [ "$type" = "Bot" ]; then
+              echo "::notice::Allowing Copilot bot: $user"
+              return 0
+            fi
+            local role
+            role=$(gh api "repos/$REPO/collaborators/$user/permission" --jq .role_name) \
+              || { echo "::error::Failed to fetch permission for $user"; exit 1; }
+            case "$role" in
+              admin|maintain)
+                echo "::notice::User $user has $role role"
+                ;;
+              *)
+                echo "::error::User $user lacks admin/maintain role (has: $role)"
+                exit 1
+                ;;
+            esac
+          }
+          check_user "$PR_AUTHOR" "$PR_AUTHOR_TYPE"
+          if [ "$EVENT_NAME" = "issue_comment" ]; then
+            check_user "$COMMENTER" "User"
+          fi
+
   review:
+    needs: gate
     runs-on: ubuntu-latest
     # GITHUB_TOKEN is unused — all GitHub API calls go through the app tokens
     # minted below. Grant nothing so any future accidental use of GITHUB_TOKEN
     # fails closed.
     permissions: {}
     timeout-minutes: 30
-    # Security: Only run for authorized users.
-    # - pull_request: Only run for non-fork PRs
-    # - issue_comment: BOTH PR author and commenter must be authorized (can't trust external PRs)
-    if: >
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.head.repo.full_name == github.repository &&
-       github.event.pull_request.draft == false &&
-       (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) ||
-        (github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')))
-      ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
-       (
-        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association) ||
-        (github.event.issue.user.login == 'Copilot' && github.event.issue.user.type == 'Bot')
-       ) &&
-       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
-       startsWith(github.event.comment.body, '/review') &&
-       !startsWith(github.event.comment.body, '/review-'))
     steps:
       # Two app tokens with split scopes:
       # - app-token-read (read-only): used by the Claude step so prompt-injection
@@ -71,19 +105,8 @@ jobs:
           retries: 3
           script: |
             const { comment } = context.payload;
-
-            // Check user association - only allow OWNER, MEMBER, or COLLABORATOR
-            const authorAssociation = comment.author_association;
-            const isAllowed = ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(authorAssociation);
-
-            let message;
-            if (isAllowed) {
-              const workflowUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}?pr=${context.issue.number}`;
-              message = `🚀 [Review running...](${workflowUrl})`;
-            } else {
-              message = `⚠️ Only repository maintainers and collaborators are allowed to trigger this workflow. Your association: ${authorAssociation}`;
-            }
-
+            const workflowUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}?pr=${context.issue.number}`;
+            const message = `🚀 [Review running...](${workflowUrl})`;
             const updatedBody = `${comment.body}\n\n---\n\n${message}`;
 
             await github.rest.issues.updateComment({
@@ -92,14 +115,11 @@ jobs:
               comment_id: comment.id,
               body: updatedBody,
             });
-
-            if (!isAllowed) {
-              throw new Error(`User not allowed to trigger workflow: ${comment.user.login} (association: ${authorAssociation})`);
-            }
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           token: ${{ steps.app-token-read.outputs.token }}
+          ref: refs/pull/${{ github.event.pull_request.number || github.event.issue.number }}/merge
       - uses: ./.github/actions/setup-python
         with:
           pin-micro-version: false

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -25,13 +25,19 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+    # Cheap author_association prefilter so random users can't spawn workflow
+    # runs. The gate step below does the authoritative admin/maintain role
+    # check.
     if: >
       (github.event_name == 'pull_request' &&
        github.event.pull_request.head.repo.full_name == github.repository &&
-       github.event.pull_request.draft == false)
+       github.event.pull_request.draft == false &&
+       (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) ||
+        (github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')))
       ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
        startsWith(github.event.comment.body, '/review') &&
        !startsWith(github.event.comment.body, '/review-'))
     steps:


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Tighten the `review` workflow's auth model and align the checkout with what the `pr-review` skill expects.

- Split out a `gate` job that uses `secrets.GITHUB_TOKEN` to fetch `role_name` from `repos/{repo}/collaborators/{user}/permission` and only passes for `admin`/`maintain` (Copilot bot still bypassed on the PR-author side). For `issue_comment`, both the PR author and the commenter are checked.
- `review` now `needs: gate`. The job-level `if:` prefilter (`OWNER`/`MEMBER`/`COLLABORATOR` or Copilot bot, body starts with `/review`) is preserved on `gate` so random users can't spawn runs; the React step's duplicate `author_association` check is removed since the gate is the source of truth.
- `actions/checkout` pins `ref: refs/pull/<N>/merge`, so `Read`/`Grep` in the working tree match the post-merge state.
- Update the `pr-review` skill's "Fetch PR Diff" step to reflect that the working tree is the PR merged into the base.

### How is this PR tested?

- [x] Manual tests (smoke run from this PR's `pull_request` trigger)

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release