### PR TITLE
Add OpenAI `/responses/compact` passthrough route to AI Gateway

### DIFF
--- a/mlflow/gateway/providers/base.py
+++ b/mlflow/gateway/providers/base.py
@@ -25,6 +25,7 @@ class PassthroughAction(str, Enum):
     OPENAI_CHAT = "openai_chat"
     OPENAI_EMBEDDINGS = "openai_embeddings"
     OPENAI_RESPONSES = "openai_responses"
+    OPENAI_RESPONSES_COMPACT = "openai_responses_compact"
     ANTHROPIC_MESSAGES = "anthropic_messages"
     GEMINI_GENERATE_CONTENT = "gemini_generate_content"
     GEMINI_STREAM_GENERATE_CONTENT = "gemini_stream_generate_content"
@@ -35,6 +36,7 @@ PASSTHROUGH_ROUTES = {
     PassthroughAction.OPENAI_CHAT: "/openai/v1/chat/completions",
     PassthroughAction.OPENAI_EMBEDDINGS: "/openai/v1/embeddings",
     PassthroughAction.OPENAI_RESPONSES: "/openai/v1/responses",
+    PassthroughAction.OPENAI_RESPONSES_COMPACT: "/openai/v1/responses/compact",
     PassthroughAction.ANTHROPIC_MESSAGES: "/anthropic/v1/messages",
     PassthroughAction.GEMINI_GENERATE_CONTENT: "/gemini/v1beta/models/{endpoint_name}:generateContent",  # noqa: E501
     PassthroughAction.GEMINI_STREAM_GENERATE_CONTENT: "/gemini/v1beta/models/{endpoint_name}:streamGenerateContent",  # noqa: E501

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -158,6 +158,7 @@ class OpenAIProvider(BaseProvider):
         PassthroughAction.OPENAI_CHAT: "chat/completions",
         PassthroughAction.OPENAI_EMBEDDINGS: "embeddings",
         PassthroughAction.OPENAI_RESPONSES: "responses",
+        PassthroughAction.OPENAI_RESPONSES_COMPACT: "responses/compact",
     }
 
     def __init__(self, config: EndpointConfig, enable_tracing: bool = False) -> None:
@@ -554,7 +555,10 @@ class OpenAIProvider(BaseProvider):
         if not usage:
             return None
 
-        if action == PassthroughAction.OPENAI_RESPONSES:
+        if action in (
+            PassthroughAction.OPENAI_RESPONSES,
+            PassthroughAction.OPENAI_RESPONSES_COMPACT,
+        ):
             return self._extract_token_usage_from_dict(
                 usage,
                 "input_tokens",

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -1085,6 +1085,75 @@ async def openai_passthrough_responses(request: Request):
         raise HTTPException(status_code=400, detail=str(e))
 
 
+@gateway_router.post(
+    PASSTHROUGH_ROUTES[PassthroughAction.OPENAI_RESPONSES_COMPACT], response_model=None
+)
+@translate_http_exception
+@_record_gateway_invocation(GatewayInvocationType.OPENAI_PASSTHROUGH_RESPONSES)
+async def openai_passthrough_responses_compact(request: Request):
+    """
+    OpenAI passthrough endpoint for the Responses API ``/compact`` route.
+
+    Mirrors :func:`openai_passthrough_responses` for session compaction calls
+    (e.g. those issued by the OpenAI Agents SDK's ``OpenAIResponsesCompactionSession``).
+    Compaction is a unary request — there is no streaming variant.
+
+    Example:
+        POST /gateway/openai/v1/responses/compact
+        {
+            "model": "my-openai-endpoint",
+            "previous_response_id": "resp_abc123"
+        }
+    """
+    body = await _get_request_body(request)
+    user_metadata = _get_user_metadata(request)
+
+    endpoint_name = _extract_endpoint_name_from_model(body)
+    body.pop("model")
+    store = _get_store()
+    workspace = get_request_workspace()
+    _validate_store(store)
+    headers = dict(request.headers)
+    provider, endpoint_config = _create_provider_from_endpoint_name(
+        store, endpoint_name, EndpointType.LLM_V1_CHAT
+    )
+    _set_gateway_telemetry_state(request, endpoint_config)
+    check_budget_limit(store, endpoint_config, workspace=workspace)
+    guardrails, auth_headers = _get_guardrails_and_auth(store, endpoint_config, request)
+
+    async def _guarded_passthrough(body: dict[str, Any]) -> dict[str, Any]:
+        body = await run_pre_llm_guardrails(
+            guardrails,
+            body,
+            auth_headers=auth_headers,
+            usage_tracking=endpoint_config.usage_tracking,
+        )
+        response = await provider.passthrough(
+            action=PassthroughAction.OPENAI_RESPONSES_COMPACT,
+            payload=body,
+            headers=headers,
+        )
+        return await run_post_llm_guardrails_passthrough(
+            guardrails,
+            body,
+            response,
+            auth_headers=auth_headers,
+            usage_tracking=endpoint_config.usage_tracking,
+        )
+
+    try:
+        return await maybe_traced_gateway_call(
+            _guarded_passthrough,
+            endpoint_config,
+            user_metadata,
+            request_headers=headers,
+            request_type=GatewayRequestType.PASSTHROUGH_MODEL_OPENAI_RESPONSES,
+            on_complete=make_budget_on_complete(store, workspace),
+        )(body)
+    except GuardrailViolation as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
 @gateway_router.post(PASSTHROUGH_ROUTES[PassthroughAction.ANTHROPIC_MESSAGES], response_model=None)
 @translate_http_exception
 @_record_gateway_invocation(GatewayInvocationType.ANTHROPIC_PASSTHROUGH_MESSAGES)

--- a/tests/server/test_gateway_api.py
+++ b/tests/server/test_gateway_api.py
@@ -57,6 +57,7 @@ from mlflow.server.gateway_api import (
     openai_passthrough_chat,
     openai_passthrough_embeddings,
     openai_passthrough_responses,
+    openai_passthrough_responses_compact,
 )
 from mlflow.store.tracking.gateway.entities import GatewayEndpointConfig, GatewayModelConfig
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
@@ -1517,6 +1518,74 @@ async def test_openai_passthrough_responses(store: SqlAlchemyStore):
         assert response["object"] == "response"
         assert response["status"] == "completed"
         assert response["output"][0]["content"][0]["text"] == "Response from Responses API"
+
+
+@pytest.mark.asyncio
+async def test_openai_passthrough_responses_compact(store: SqlAlchemyStore):
+    secret = store.create_gateway_secret(
+        secret_name="openai-responses-compact-key",
+        secret_value={"api_key": "sk-test-responses-compact"},
+        provider="openai",
+    )
+    model_def = store.create_gateway_model_definition(
+        name="openai-responses-compact-model",
+        secret_id=secret.secret_id,
+        provider="openai",
+        model_name="gpt-4o",
+    )
+    store.create_gateway_endpoint(
+        name="openai-responses-compact-endpoint",
+        model_configs=[
+            GatewayEndpointModelConfig(
+                model_definition_id=model_def.model_definition_id,
+                linkage_type=GatewayModelLinkageType.PRIMARY,
+                weight=1.0,
+            ),
+        ],
+    )
+
+    # Mock OpenAI Responses-compact response: same shape as /responses output
+    mock_response = {
+        "id": "resp-compact-123",
+        "object": "response",
+        "created": 1234567890,
+        "model": "gpt-4o",
+        "status": "completed",
+        "output": [
+            {
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "Compacted summary"}],
+            }
+        ],
+        "usage": {"input_tokens": 50, "output_tokens": 10, "total_tokens": 60},
+    }
+
+    # Compaction request — typical body carries `previous_response_id` and `model`
+    mock_request = create_mock_request()
+    mock_request.json = AsyncMock(
+        return_value={
+            "model": "openai-responses-compact-endpoint",
+            "previous_response_id": "resp_abc123",
+        }
+    )
+
+    with mock.patch(
+        "mlflow.gateway.providers.openai.send_request", return_value=mock_response
+    ) as mock_send:
+        response = await openai_passthrough_responses_compact(mock_request)
+
+        # Verify send_request was called with the /compact upstream path
+        assert mock_send.called
+        call_kwargs = mock_send.call_args[1]
+        assert call_kwargs["path"] == "responses/compact"
+        assert call_kwargs["payload"]["model"] == "gpt-4o"
+        assert call_kwargs["payload"]["previous_response_id"] == "resp_abc123"
+
+        # Verify response is the raw OpenAI Responses-compact format
+        assert response["id"] == "resp-compact-123"
+        assert response["object"] == "response"
+        assert response["status"] == "completed"
+        assert response["output"][0]["content"][0]["text"] == "Compacted summary"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Related Issues/PRs

Closes #23334

<sub>This is a re-submit of #23335, which was auto-closed for not matching the PR template. Body now follows the template exactly. No code changes from that PR.</sub>

### What changes are proposed in this pull request?

Wires the OpenAI Responses API `/compact` endpoint through the AI Gateway's existing OpenAI passthrough machinery. Today the gateway exposes `/openai/v1/chat/completions`, `/openai/v1/embeddings`, and `/openai/v1/responses`, but not `/openai/v1/responses/compact`. Any client using the OpenAI Python SDK's session-compaction feature (e.g. the [OpenAI Agents SDK's](https://github.com/openai/openai-agents-python) `OpenAIResponsesCompactionSession`) hits a 404 when its requests are routed through the gateway:

```
httpx.HTTPStatusError: Client error '404 Not Found' for url
  'http://<gateway>/gateway/openai/v1/responses/compact'
```

Concrete edits:

| File | Change |
|---|---|
| `mlflow/gateway/providers/base.py` | Add `PassthroughAction.OPENAI_RESPONSES_COMPACT` and its `/openai/v1/responses/compact` entry in `PASSTHROUGH_ROUTES`. |
| `mlflow/gateway/providers/openai.py` | Map the action to upstream OpenAI path `responses/compact`. Extend the Responses-style token-usage extractor (`input_tokens`/`output_tokens` shape) to cover the new action — `/compact` shares the same usage schema as `/responses`. |
| `mlflow/server/gateway_api.py` | Add `openai_passthrough_responses_compact` — mirrors `openai_passthrough_responses` minus the streaming branch (compact is unary). Reuses `PASSTHROUGH_MODEL_OPENAI_RESPONSES` for telemetry so all Responses-API traffic groups together. |
| `tests/server/test_gateway_api.py` | New `test_openai_passthrough_responses_compact` modelled on the existing `/responses` test. |

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

```
$ uv run pytest tests/server/test_gateway_api.py -k "openai_passthrough" -q
10 passed, 61 deselected, 1 warning in 4.46s
```

Nine existing OpenAI passthrough tests + the new `/compact` test all pass. Ruff `check` and `format --check` clean on the four modified files.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

The new endpoint follows the same shape and conventions as the existing `/openai/v1/responses` passthrough, which has no dedicated docs page beyond the route signature being discoverable via the gateway router. No API-reference or examples change is needed for this purely additive route.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

This PR adds a server-side passthrough route only. Clients (including the OpenAI Python SDK and openai-agents) already know about `/responses/compact` and target it directly through the configured `base_url`; no Skills-side instructions change.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The MLflow AI Gateway now exposes the OpenAI Responses API's `/compact` endpoint as a passthrough route (`POST /gateway/openai/v1/responses/compact`), enabling client SDKs that rely on session compaction (e.g. the OpenAI Agents SDK) to route through the gateway end-to-end.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release