### PR TITLE
Surface review workflow errors in the trigger comment

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -274,8 +274,10 @@ jobs:
           if-no-files-found: ignore
 
       - name: Report review results
-        if: github.event_name == 'issue_comment'
+        if: always() && github.event_name == 'issue_comment'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{ steps.app-token-write.outputs.token }}
           retries: 3
@@ -283,6 +285,7 @@ jobs:
             const fs = require('fs');
             const { owner, repo } = context.repo;
             const { comment } = context.payload;
+            const jobStatus = process.env.JOB_STATUS;
 
             // Read Claude output from file instead of environment variable
             const outputPath = '/tmp/output.jsonl';
@@ -295,24 +298,31 @@ jobs:
               console.log('Failed to read Claude output file:', e);
             }
 
-            const workflowUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}?pr=${context.issue.number}`;
-            let resultLine = `✅ [Review](${workflowUrl}) completed`;
-
-            // Extract and display Claude's result from JSON output
+            let resultEvent = null;
             if (claudeOutput) {
               try {
                 const events = claudeOutput.trim().split('\n').filter(Boolean).map(JSON.parse);
-                const resultEvent = events.findLast(({ type }) => type === 'result');
-                if (resultEvent) {
-                  const seconds = (resultEvent.duration_ms / 1000).toFixed(1);
-                  const tokens = (resultEvent.usage?.input_tokens ?? 0) + (resultEvent.usage?.output_tokens ?? 0);
-                  const cost = (Math.round(resultEvent.total_cost_usd * 100) / 100).toFixed(2);
-                  resultLine += ` (${seconds}s, ${resultEvent.num_turns} turns, ${tokens} tokens, $${cost})`;
-                  resultLine += `\n<details><summary>Review Output</summary>\n\n${resultEvent.result}\n\n</details>`;
-                }
+                resultEvent = events.findLast(({ type }) => type === 'result');
               } catch (e) {
                 console.log('Failed to parse Claude output as JSON:', e);
               }
+            }
+
+            const workflowUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}?pr=${context.issue.number}`;
+            const failed = jobStatus !== 'success' || resultEvent?.is_error;
+            const icon = failed ? '❌' : '✅';
+            const verb = failed ? 'failed' : 'completed';
+            let resultLine = `${icon} [Review](${workflowUrl}) ${verb}`;
+
+            if (resultEvent) {
+              const seconds = (resultEvent.duration_ms / 1000).toFixed(1);
+              const tokens = (resultEvent.usage?.input_tokens ?? 0) + (resultEvent.usage?.output_tokens ?? 0);
+              const cost = (Math.round(resultEvent.total_cost_usd * 100) / 100).toFixed(2);
+              resultLine += ` (${seconds}s, ${resultEvent.num_turns} turns, ${tokens} tokens, $${cost})`;
+              const summary = resultEvent.is_error ? 'Error' : 'Review Output';
+              resultLine += `\n<details><summary>${summary}</summary>\n\n${resultEvent.result}\n\n</details>`;
+            } else if (failed) {
+              resultLine += `\n\nSee [workflow logs](${workflowUrl}) for details.`;
             }
 
             console.log('Result line to post:', resultLine);


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

When the Claude CLI invoked by the `review` workflow fails (e.g., HTTP 529 Overloaded from the Anthropic API), the trigger comment was left stuck at `🚀 Review running...` with no indication of what went wrong, because the `Report review results` step only ran on success.

This PR:

- Runs the report step on `always()` (still gated by `issue_comment`).
- Passes `job.status` so the script can distinguish success from failure.
- Switches the icon to `❌` and the details summary to `Error` when the job failed or the Claude result event has `is_error: true`. The 529 case emits exactly such a result event, so the original API error message is surfaced inline.
- Falls back to a "See workflow logs" link when there is no result event at all (e.g., early-step failure).

Secret redaction still runs `if: always()` before this step, so any sensitive values in the Claude stream are scrubbed before being read back into the comment body.

### How is this PR tested?

- [x] Manual tests

Validated locally by re-reading the failure log for run 25893404763: the result event carries the 529 error in `result` with `is_error: true`, which the updated script renders as an `❌` line plus an `Error` details block.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)