### PR TITLE
Don't reveal user role in `review` gate output

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -66,10 +66,10 @@ jobs:
               || { echo "::error::Failed to fetch permission for $user"; exit 1; }
             case "$role" in
               admin|maintain)
-                echo "::notice::User $user has $role role"
+                echo "::notice::User $user is allowed"
                 ;;
               *)
-                echo "::error::User $user lacks admin/maintain role (has: $role)"
+                echo "::error::User $user is not allowed"
                 exit 1
                 ;;
             esac

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -66,10 +66,10 @@ jobs:
               || { echo "::error::Failed to fetch permission for $user"; exit 1; }
             case "$role" in
               admin|maintain)
-                echo "::notice::User $user is allowed"
+                echo "::notice::User $user is allowed (admin or maintain role)"
                 ;;
               *)
-                echo "::error::User $user is not allowed"
+                echo "::error::User $user is not allowed (admin or maintain role required)"
                 exit 1
                 ;;
             esac


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

The `Check user permission` step in the `review` workflow's gate job echoed the actual role name in both the allow notice (`User foo has admin role`) and the deny error (`User foo lacks admin/maintain role (has: write)`). Workflow logs are public on this repo, so anyone could read off another collaborator's exact GitHub role from a failed or successful gate run.

Replace those messages with a binary `is allowed` / `is not allowed`. The role lookup itself still happens and still gates the job. Only the surfaced output changes.

### How is this PR tested?

- [x] Manual tests

Verified locally that the `case` arms still drive the same exit behavior; only the echoed strings change.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)