### PR TITLE
Fix `_get_experiment_id` NameError under `mlflow-tracing`

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -11,6 +11,7 @@ import io
 import logging
 import os
 import threading
+import warnings
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Generator, Literal, Optional, Union, overload
 
@@ -3436,6 +3437,24 @@ def _get_or_start_run():
 def _get_experiment_id_from_env():
     experiment_name = MLFLOW_EXPERIMENT_NAME.get()
     experiment_id = MLFLOW_EXPERIMENT_ID.get()
+    if IS_TRACING_SDK_ONLY:
+        # The lightweight `mlflow-tracing` package excludes `MlflowClient` and the
+        # tracking store layer, so we cannot resolve an experiment name to an id
+        # or cross-check an id against an experiment name. Pass ids through as-is;
+        # for names, warn (once per process via Python's default warning filter)
+        # and fall through so the trace processor degrades gracefully.
+        if experiment_id is not None:
+            return experiment_id
+        if experiment_name is not None:
+            warnings.warn(
+                f"{MLFLOW_EXPERIMENT_NAME.name} cannot be resolved to an experiment "
+                f"id under the lightweight `mlflow-tracing` package. Set "
+                f"{MLFLOW_EXPERIMENT_ID.name} instead, or call "
+                "`mlflow.set_experiment()` before creating traces.",
+                category=UserWarning,
+                stacklevel=2,
+            )
+        return None
     if experiment_name is not None:
         if exp := MlflowClient().get_experiment_by_name(experiment_name):
             if experiment_id and experiment_id != exp.experiment_id:
@@ -3465,8 +3484,9 @@ def _get_experiment_id_from_env():
 def _get_experiment_id() -> str | None:
     if _active_experiment_id:
         return _active_experiment_id
-    else:
-        return _get_experiment_id_from_env() or default_experiment_registry.get_experiment_id()
+    if IS_TRACING_SDK_ONLY:
+        return _get_experiment_id_from_env()
+    return _get_experiment_id_from_env() or default_experiment_registry.get_experiment_id()
 
 
 @autologging_integration("mlflow")

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -6,6 +6,7 @@ import sys
 import threading
 import time
 import uuid
+import warnings
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import asdict
 from datetime import datetime
@@ -26,7 +27,12 @@ from mlflow.entities import (
 )
 from mlflow.entities.trace_location import TraceLocation, UCSchemaLocation
 from mlflow.entities.trace_state import TraceState
-from mlflow.environment_variables import MLFLOW_TRACE_SAMPLING_RATIO, MLFLOW_TRACKING_USERNAME
+from mlflow.environment_variables import (
+    MLFLOW_EXPERIMENT_ID,
+    MLFLOW_EXPERIMENT_NAME,
+    MLFLOW_TRACE_SAMPLING_RATIO,
+    MLFLOW_TRACKING_USERNAME,
+)
 from mlflow.exceptions import MlflowException
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.tracking import SEARCH_TRACES_DEFAULT_MAX_RESULTS
@@ -46,7 +52,7 @@ from mlflow.tracing.provider import (
     safe_set_span_in_context,
     set_destination,
 )
-from mlflow.tracking.fluent import _get_experiment_id
+from mlflow.tracking.fluent import _get_experiment_id, _get_experiment_id_from_env
 from mlflow.version import IS_TRACING_SDK_ONLY
 
 from tests.tracing.helper import (
@@ -55,6 +61,41 @@ from tests.tracing.helper import (
     purge_traces,
     skip_when_testing_trace_sdk,
 )
+
+
+def test_get_experiment_id_from_env_under_tracing_sdk_only(monkeypatch):
+    # Regression test for https://github.com/mlflow/mlflow/issues/17619.
+    # Under the lightweight `mlflow-tracing` package, `MlflowClient` and the
+    # tracking store layer are not importable, so env-var configured experiments
+    # must resolve without a backend round-trip: ids pass through, names warn.
+    monkeypatch.setattr("mlflow.tracking.fluent.IS_TRACING_SDK_ONLY", True)
+    monkeypatch.setattr("mlflow.tracking.fluent._active_experiment_id", None)
+    monkeypatch.delenv(MLFLOW_EXPERIMENT_NAME.name, raising=False)
+    monkeypatch.delenv(MLFLOW_EXPERIMENT_ID.name, raising=False)
+
+    # Neither env var set: no client lookup is needed; both functions return None.
+    assert _get_experiment_id_from_env() is None
+    assert _get_experiment_id() is None
+
+    # MLFLOW_EXPERIMENT_ID passes through without backend validation.
+    monkeypatch.setenv(MLFLOW_EXPERIMENT_ID.name, "12345")
+    assert _get_experiment_id_from_env() == "12345"
+    assert _get_experiment_id() == "12345"
+
+    # MLFLOW_EXPERIMENT_NAME alone cannot be resolved without a client: warn,
+    # return None, and let the trace processor degrade gracefully.
+    monkeypatch.delenv(MLFLOW_EXPERIMENT_ID.name)
+    monkeypatch.setenv(MLFLOW_EXPERIMENT_NAME.name, "some-experiment-name")
+    with pytest.warns(UserWarning, match=r"cannot be resolved to an experiment id"):
+        assert _get_experiment_id_from_env() is None
+    assert _get_experiment_id() is None
+
+    # Both env vars set: id wins (we cannot cross-check against the name without
+    # a client), no warning.
+    monkeypatch.setenv(MLFLOW_EXPERIMENT_ID.name, "12345")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        assert _get_experiment_id_from_env() == "12345"
 
 
 class DefaultTestModel:


### PR DESCRIPTION
### Related Issues/PRs

Closes #17619

### What changes are proposed in this pull request?

`MlflowClient` and `default_experiment_registry` live behind the `if not IS_TRACING_SDK_ONLY:` gate at `mlflow/tracking/fluent.py:102`, so under the lightweight `mlflow-tracing` distribution they are not imported at runtime. `_get_experiment_id_from_env` and `_get_experiment_id` referenced both names unconditionally — any env-var configured trace path raised `NameError: name 'MlflowClient' is not defined`.

`mlflow-tracing` cannot perform name→id resolution without the client + tracking-store layer (importing `MlflowClient` itself transitively requires `yaml` / `sqlparse`, which are intentionally excluded from the slim deps). Under that surface this PR:

- returns `MLFLOW_EXPERIMENT_ID` as-is (no backend round-trip)
- warns once (`warnings.warn(category=UserWarning)`, deduped by Python's default per-location filter) when only `MLFLOW_EXPERIMENT_NAME` is set, then returns `None` so the trace processor degrades gracefully (it already logs a debug and creates the trace without an experiment id at `mlflow/tracing/processor/mlflow_v3.py:38-42`)
- skips the `default_experiment_registry` fallback in `_get_experiment_id`

Full-`mlflow` behavior is unchanged.

### How is this PR tested?

- [x] New unit/integration tests — `tests/tracing/test_fluent.py::test_get_experiment_id_from_env_under_tracing_sdk_only` covers all four env-var combinations and the warning behavior. Located in `tests/tracing/` so it runs under both full-mlflow and the slim `mlflow-tracing` CI job.
- [x] Manual tests — installed `libs/tracing/` into an isolated venv (the slim install, no full mlflow); confirmed pre-fix `NameError` on both code paths, post-fix all four env-var combinations return correct values with the expected warning.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fixes a `NameError` that prevented `mlflow-tracing` users from configuring an experiment via the `MLFLOW_EXPERIMENT_ID` / `MLFLOW_EXPERIMENT_NAME` environment variables.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release