### PR TITLE
Show raw `resultEvent` JSON in review workflow comment

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -319,8 +319,9 @@ jobs:
               const tokens = (resultEvent.usage?.input_tokens ?? 0) + (resultEvent.usage?.output_tokens ?? 0);
               const cost = (Math.round(resultEvent.total_cost_usd * 100) / 100).toFixed(2);
               resultLine += ` (${seconds}s, ${resultEvent.num_turns} turns, ${tokens} tokens, $${cost})`;
-              const summary = resultEvent.is_error ? 'Error' : 'Review Output';
-              resultLine += `\n<details><summary>${summary}</summary>\n\n${resultEvent.result}\n\n</details>`;
+              const summary = resultEvent.is_error ? 'Error' : 'Result';
+              const formatted = JSON.stringify(resultEvent, null, 2);
+              resultLine += `\n<details><summary>${summary}</summary>\n\n\`\`\`json\n${formatted}\n\`\`\`\n\n</details>`;
             } else if (failed) {
               resultLine += `\n\nSee [workflow logs](${workflowUrl}) for details.`;
             }


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

The review workflow's PR comment renders `resultEvent.result` (the model's textual reply) inside the `<details>` block. That field is often empty or just an echo of the posted review, which makes the dropdown look broken when reviewers click in.

Replace it with a pretty-printed JSON dump of the full `resultEvent` (wrapped in a `json` code block) so the dropdown surfaces useful debug info: duration, turn count, token usage, cost breakdown, stop reason, etc. Rename the summary from "Review Output" to "Result" to reflect the new contents.

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)