### PR TITLE
Drop GitHub Actions annotation syntax from `review` gate

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -58,18 +58,18 @@ jobs:
             local user=$1
             local type=$2
             if [ "$user" = "Copilot" ] && [ "$type" = "Bot" ]; then
-              echo "::notice::Allowing Copilot bot: $user"
+              echo "Allowing Copilot bot: $user"
               return 0
             fi
             local role
             role=$(gh api "repos/$REPO/collaborators/$user/permission" --jq .role_name) \
-              || { echo "::error::Failed to fetch permission for $user"; exit 1; }
+              || { echo "Failed to fetch permission for $user"; exit 1; }
             case "$role" in
               admin|maintain)
-                echo "::notice::User $user is allowed (admin or maintain role)"
+                echo "User $user is allowed (admin or maintain role)"
                 ;;
               *)
-                echo "::error::User $user is not allowed (admin or maintain role required)"
+                echo "User $user is not allowed (admin or maintain role required)"
                 exit 1
                 ;;
             esac


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

The `gate` job in `.github/workflows/review.yml` was using `::notice::` and `::error::` annotation syntax in its `check_user` shell function. These surface as annotations on the workflow summary page, but they're noisy and add no real signal here. Replace them with plain `echo` so the messages just appear in the step log.

### How is this PR tested?

- [x] Manual tests

Workflow-only change; behavior is unchanged aside from log/annotation rendering.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release