### PR TITLE
Reduce package release cooldown from 14 to 7 days

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -69,9 +69,9 @@ runs:
         # Disable progress bars and spinners to reduce CI log clutter
         # https://docs.astral.sh/uv/reference/environment/#uv_no_progress
         echo "UV_NO_PROGRESS=1" >> $GITHUB_ENV
-        # Exclude packages newer than 14 days to guard against supply chain attacks
+        # Exclude packages newer than 7 days to guard against supply chain attacks
         # https://docs.astral.sh/uv/reference/environment/#uv_exclude_newer
-        echo "UV_EXCLUDE_NEWER=P14D" >> $GITHUB_ENV
+        echo "UV_EXCLUDE_NEWER=P7D" >> $GITHUB_ENV
         # Disable Hugging Face download progress bars to reduce CI log clutter
         # https://huggingface.co/docs/huggingface_hub/package_reference/environment_variables#hfhubdisableprogressbars
         echo "HF_HUB_DISABLE_PROGRESS_BARS=1" >> $GITHUB_ENV

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -65,7 +65,7 @@ jobs:
           ALIAS: ${{ steps.alias.outputs.value }}
           RUN_ID: ${{ github.run_id }}
         run: |-
-          OUTPUT=$(npx --min-release-age=14 --yes netlify-cli deploy \
+          OUTPUT=$(npx --min-release-age=7 --yes netlify-cli deploy \
             --dir="$DOCS_BUILD_DIR" \
             --no-build \
             --message="Preview ${ALIAS} - GitHub Run ID: $RUN_ID" \

--- a/dev/js.sh
+++ b/dev/js.sh
@@ -38,7 +38,7 @@ done
 case "$cmd" in
   fmt)
     # Use npx to avoid slow `yarn install --immutable`
-    [ ${#files[@]} -gt 0 ] && npx --min-release-age=14 "prettier@$(jq -r '.devDependencies.prettier' package.json)" --write --ignore-unknown "${files[@]}"
+    [ ${#files[@]} -gt 0 ] && npx --min-release-age=7 "prettier@$(jq -r '.devDependencies.prettier' package.json)" --write --ignore-unknown "${files[@]}"
     ;;
   # TODO: Add eslint, i18n, type-check commands if needed
   *)

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -186,7 +186,7 @@ def read_yaml(location, if_error=None):
         raise
 
 
-RELEASE_CUTOFF_DAYS = 14
+RELEASE_CUTOFF_DAYS = 7
 
 
 def get_released_versions(package: Package) -> list[Version]:

--- a/dev/update_ml_package_versions.py
+++ b/dev/update_ml_package_versions.py
@@ -34,7 +34,7 @@ def save_file(src, path):
         f.write(src)
 
 
-RELEASE_CUTOFF_DAYS = 14
+RELEASE_CUTOFF_DAYS = 7
 PYPI_URL = os.environ.get("PYPI_URL", "https://pypi.org").rstrip("/")
 
 

--- a/dev/update_requirements.py
+++ b/dev/update_requirements.py
@@ -14,7 +14,7 @@ import yaml
 from pypi import Package, get_packages
 
 PACKAGE_NAMES = ["tracing", "skinny", "core", "gateway"]
-RELEASE_CUTOFF_DAYS = 14
+RELEASE_CUTOFF_DAYS = 7
 PYPI_URL = os.environ.get("PYPI_URL", "https://pypi.org").rstrip("/")
 
 

--- a/docs/.npmrc
+++ b/docs/.npmrc
@@ -1,2 +1,2 @@
-min-release-age=14
+min-release-age=7
 omit-lockfile-registry-resolved=true

--- a/libs/typescript/.npmrc
+++ b/libs/typescript/.npmrc
@@ -1,2 +1,2 @@
-min-release-age=14
+min-release-age=7
 omit-lockfile-registry-resolved=true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -239,7 +239,7 @@ docs = [
 ]
 
 [tool.uv]
-exclude-newer = "P14D"
+exclude-newer = "P7D"
 exclude-newer-package = { torch = false, torchvision = false }
 required-version = ">=0.11.7"
 constraint-dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -10,8 +10,8 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-30T01:45:07.132567285Z"
-exclude-newer-span = "P14D"
+exclude-newer = "2026-05-08T12:02:28.463313Z"
+exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
 torchvision = false


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

Lower every supply-chain release-cooldown gate in the repo from **14 days** to **7 days** so they all share one consistent window. 7 days is the de-facto standard across the Python/uv ecosystem (most public `pyproject.toml` configs that use `exclude-newer` set `P7D`) and is high enough to catch most yanked or compromised releases while remaining fresh enough not to block legitimate updates.

Files touched:

- **Python / uv side**
  - `pyproject.toml` — `[tool.uv] exclude-newer = "P7D"`
  - `.github/actions/setup-python/action.yml` — `UV_EXCLUDE_NEWER=P7D` (and the comment above it)
- **Dev scripts** — `RELEASE_CUTOFF_DAYS` constants used when filtering PyPI release lists
  - `dev/set_matrix.py`
  - `dev/update_ml_package_versions.py`
  - `dev/update_requirements.py`
- **JS / npm side**
  - `dev/js.sh` — `npx --min-release-age=7` for prettier
  - `.github/workflows/preview-docs.yml` — `npx --min-release-age=7` for `netlify-cli`
  - `docs/.npmrc`, `libs/typescript/.npmrc` — `min-release-age=7`
- `uv.lock` regenerated by the `uv-lock` pre-commit hook against the new window.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release