### PR TITLE
Bump nailaopus `mlflow/internal` pin to pick up four-stack bug fixes

### DIFF
--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -153,7 +153,7 @@ jobs:
           # open a new PR that updates this SHA to the latest mlflow/internal
           # main after reviewing the diff. We'll migrate to release tags once
           # the bump cadence is stable; see mlflow/internal for the policy.
-          ref: f36ec2a96d3b94d6fced6f98ef49831a9a245090
+          ref: 6e90fa245775525c824f7b67211083ea6dbe59e3
           sparse-checkout: |
             nailaopus
           path: internal


### PR DESCRIPTION
### Related Issues/PRs

Picks up the following four PRs that landed on `mlflow/internal` main between the previous bump (`f36ec2a`) and this one (`6e90fa2`):

- [mlflow/internal#36](https://github.com/mlflow/internal/pull/36) — Stack 1/4: Normalize bot login between REST and GraphQL forms
- [mlflow/internal#37](https://github.com/mlflow/internal/pull/37) — Stack 2/4: Filter out-of-hunk nit/ask findings
- [mlflow/internal#38](https://github.com/mlflow/internal/pull/38) — Stack 3/4: Retry grammar-compilation timeouts (API-layer defense)
- [mlflow/internal#39](https://github.com/mlflow/internal/pull/39) — Stack 4/4: Reviewer-opinion tool-budget guardrails (input-side defense)

Previous pin landed in #23316 at `a7e8fef`; subsequent bump landed in #23322 at `f36ec2a`. This is the third SHA-bump on top of the initial pin from #23304.

### What changes are proposed in this pull request?

Single-line update to `.github/workflows/nailaopus.yml`: bump the `ref:` on the `mlflow/internal` checkout step from `f36ec2a` to `6e90fa2`. The new orchestrator commit ships four stacks of bug fixes addressing real failure modes observed on production review runs:

**Stack 1 — bot-login GraphQL/REST normalization.** Fixes the cross-SHA duplicate-posting bug observed on [mlflow/mlflow#22502](https://github.com/mlflow/mlflow/pull/22502) where the bot re-posted the same inline concern at the same line on a re-review. Root cause: GitHub returns App account logins differently across APIs (REST: `<name>[bot]`, GraphQL: `<name>`). The orchestrator stored `bot_login` in REST form and compared raw everywhere; `get_review_threads` uses GraphQL so `SELF_DEDUP` never fired on inline review threads.

**Stack 2 — out-of-hunk nit/ask filter.** Two-layer defense against drive-by nits that anchor on unchanged code adjacent to the diff. Reviewer prompt skips them by default; orchestrator backstop drops them deterministically with a new `SkipReason.OUT_OF_HUNK_LOW_SEVERITY`. Validated against [mlflow/mlflow#23310](https://github.com/mlflow/mlflow/pull/23310): both fallback comments on that PR would be dropped.

**Stack 3 — grammar-compilation-timeout retry (API-layer).** Defends against the `400 Bad Request: \"Grammar compilation timed out.\"` error observed on [mlflow/mlflow#23248](https://github.com/mlflow/mlflow/pull/23248) where the orchestrator died after ~43 successful tool-use roundtrips on a 681-line RBAC PR. Two-stage policy: retry the same-shape request on the timeout, then escalate to forced finalization (strip `tools`, append the \"emit final JSON now\" hint) when retries exhaust. Lowers reviewer-opinion's tool-loop iteration cap from 30 to 20.

**Stack 4 — tool-budget guardrails (input-side).** Complementary to Stack 3. Sorts spotter findings by severity descending before sending to the reviewer so the tool budget is spent on high-impact concerns first; if the budget runs out mid-walk, under-validated findings are the lowest-severity. Strips the spotter's `evidence` array from the reviewer's input (preserved in the run record for post-run debugging) to shrink the grammar-compilation surface by ~1-3KB per finding. With evidence stripped, raises the iteration cap back to 25.

Combined effect on a PR-23248-class PR: ~20-50K tokens lighter at the schema-constrained final call vs the configuration that crashed.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Each stack landed independently with its own unit-test suite on `mlflow/internal`. Suite total post-stack-4: 267 passing, 4 skipped. End-to-end live posting / stamping validates on the next `/review-v2` invocation after merge.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`
- [ ] `area/models`
- [ ] `area/model-registry`
- [ ] `area/scoring`
- [ ] `area/evaluation`
- [ ] `area/gateway`
- [ ] `area/prompts`
- [ ] `area/tracing`
- [ ] `area/projects`
- [ ] `area/uiux`
- [x] `area/build`
- [ ] `area/docs`

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

-- Claude-drafted, reviewed before posting.