### PR TITLE
Drop `chardet<6.0` pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -246,9 +246,6 @@ constraint-dependencies = [
   # xgboost 3.1.0 changed base_score format to vector for multi-output models, breaking shap compatibility
   # https://xgboost.readthedocs.io/en/latest/changes/v3.1.0.html#multi-target-class-intercept
   "xgboost<3.1.0",
-  # TODO: remove once requests officially supports chardet >= 6
-  # https://github.com/psf/requests/pull/7239
-  "chardet<6.0",
   # pyspark 4.1.0 causes issues with documentation build
   "pyspark<4.1.0",
   # setuptools 82.0.0 removed pkg_resources, breaking packages that depend on it (e.g., sphinx)

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -2,9 +2,6 @@ pytest==9.0.2
 # xgboost 3.1.0 changed base_score format to vector for multi-output models, breaking shap compatibility
 # https://xgboost.readthedocs.io/en/latest/changes/v3.1.0.html#multi-target-class-intercept
 xgboost<3.1.0
-# TODO: remove once requests officially supports chardet >= 6
-# https://github.com/psf/requests/pull/7239
-chardet<6.0
 # litellm 1.82.7 and 1.82.8 contain a malicious .pth file that steals credentials
 # https://github.com/BerriAI/litellm/issues/24512
 litellm<=1.82.6

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-08T12:51:03.296478604Z"
+exclude-newer = "2026-05-08T14:46:51.745819Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -26,7 +26,6 @@ members = [
     "skills",
 ]
 constraints = [
-    { name = "chardet", specifier = "<6.0" },
     { name = "litellm", specifier = "<=1.82.6" },
     { name = "pyspark", specifier = "<4.1.0" },
     { name = "setuptools", specifier = "<82" },


### PR DESCRIPTION
### Related Issues/PRs

Relates to #21862

### What changes are proposed in this pull request?

Removes the `chardet<6.0` constraint added in #21862 from both `pyproject.toml` and `requirements/constraints.txt`.

The pin was added to silence `RequestsDependencyWarning` in CI logs when a transitive dep pulled in `chardet>=6` while `requests` still capped at `<6`. That upstream cap has since been raised twice (psf/requests#7239 landed in v2.33.0), and the currently-locked `requests==2.33.1` accepts `chardet>=3.0.2,<8.0.0`, so the warning no longer fires for `chardet` 6.x or 7.x.

Verified locally with `python -W error -c 'import requests'` against `chardet==7.1.0` + `requests==2.33.1` — no warning. CI will start installing chardet 7.x transitively (previously 5.2.0 due to the pin).

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release