### PR TITLE
Show trace archival settings only when enabled on the server

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -5988,6 +5988,20 @@ def _get_server_info():
     from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
 
     store = _get_tracking_store()
+    try:
+        trace_archival_config = get_trace_archival_server_config()
+    except Exception:
+        _logger.warning(
+            "Failed to load trace archival config while serving server-info; "
+            + "defaulting to disabled.",
+            exc_info=True,
+        )
+        trace_archival_config = None
+    trace_archival_enabled = bool(
+        trace_archival_config
+        and trace_archival_config.enabled
+        and _store_supports_trace_archival(store)
+    )
 
     if isinstance(store, FileStore):
         store_type = "FileStore"
@@ -5998,6 +6012,7 @@ def _get_server_info():
     return jsonify({
         "store_type": store_type,
         "workspaces_enabled": MLFLOW_ENABLE_WORKSPACES.get(),
+        "trace_archival_enabled": trace_archival_enabled,
     })
 
 

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/ExperimentViewMetadataEditor.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/ExperimentViewMetadataEditor.test.tsx
@@ -8,6 +8,7 @@ import { MlflowService } from '../../../sdk/MlflowService';
 import { ErrorCodes } from '../../../../common/constants';
 import { ErrorWrapper } from '../../../../common/utils/ErrorWrapper';
 import { encodeTraceArchivalRetentionTag } from '../../../../common/utils/traceArchival';
+import { useTraceArchivalEnabled } from '../../../hooks/useServerInfo';
 
 const mockDispatch = jest.fn((..._args: any[]) => Promise.resolve());
 const mockUseSelector = jest.fn();
@@ -26,6 +27,9 @@ jest.mock('../../../actions', () => ({
 
 jest.mock('../hooks/useExperimentListQuery', () => ({
   useInvalidateExperimentList: () => mockInvalidateExperimentList,
+}));
+jest.mock('../../../hooks/useServerInfo', () => ({
+  useTraceArchivalEnabled: jest.fn(),
 }));
 
 jest.mock('../../../../common/components/EditableNote', () => ({
@@ -48,6 +52,7 @@ const defaultExperiment: ExperimentEntity = {
 describe('ExperimentViewMetadataEditor', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.mocked(useTraceArchivalEnabled).mockReturnValue(true);
     mockUseSelector.mockImplementation((selector: any) =>
       selector({
         entities: {
@@ -123,6 +128,21 @@ describe('ExperimentViewMetadataEditor', () => {
       'id',
       'mlflow.experiment.edit.trace-archival-retention-amount',
     );
+  });
+
+  test('hides trace archival retention when the server disables trace archival', () => {
+    jest.mocked(useTraceArchivalEnabled).mockReturnValue(false);
+
+    renderWithDesignSystem(
+      <ExperimentViewMetadataEditor
+        experiment={defaultExperiment}
+        editing
+        setEditing={jest.fn()}
+        defaultValue="Existing description"
+      />,
+    );
+
+    expect(screen.queryByLabelText('Trace archival retention')).not.toBeInTheDocument();
   });
 
   test('does not save the description when the rename fails', async () => {

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/ExperimentViewMetadataEditor.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/ExperimentViewMetadataEditor.tsx
@@ -30,6 +30,7 @@ import { getExperimentApi, setExperimentTagApi, updateExperimentApi } from '../.
 import { getExperimentNameValidator } from '../../../../common/forms/validations';
 import { useInvalidateExperimentList } from '../hooks/useExperimentListQuery';
 import { canModifyExperiment, canRenameExperiment } from '../utils/experimentPage.common-utils';
+import { useTraceArchivalEnabled } from '../../../hooks/useServerInfo';
 import {
   DEFAULT_TRACE_ARCHIVAL_RETENTION_UNIT,
   decodeTraceArchivalRetentionTag,
@@ -187,6 +188,7 @@ export const ExperimentViewMetadataEditor = ({
   const invalidateExperimentList = useInvalidateExperimentList();
   const canEditMetadata = canModifyExperiment(experiment);
   const canRename = canRenameExperiment(experiment);
+  const traceArchivalEnabled = useTraceArchivalEnabled();
 
   const updateTmpRetention = useCallback(
     ({
@@ -541,7 +543,7 @@ export const ExperimentViewMetadataEditor = ({
               />
             </div>
           )}
-          {canEditMetadata && (
+          {canEditMetadata && traceArchivalEnabled && (
             <div>
               <FormUI.Label htmlFor="mlflow.experiment.edit.trace-archival-retention-amount">
                 <FormattedMessage

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewHeader.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewHeader.tsx
@@ -256,27 +256,29 @@ export const ExperimentViewHeader = React.memo(
             </Tooltip>
             {experimentKindSelector}
             {traceArchivalRetention && shouldShowTraceArchivalBadge && (
-              <Tooltip
-                componentId="mlflow.experiment_view.header.trace_archival_badge_tooltip"
-                content={
-                  <FormattedMessage
-                    defaultMessage="Archived traces remain accessible, but searching within span content no longer works after archival."
-                    description="Tooltip explaining the trace archival badge behavior"
-                  />
-                }
-              >
-                <Tag
-                  componentId="mlflow.experiment_view.header.trace_archival_badge"
-                  color="turquoise"
-                  css={{ margin: 0 }}
+              <div css={{ display: 'flex', alignItems: 'center' }}>
+                <Tooltip
+                  componentId="mlflow.experiment_view.header.trace_archival_badge_tooltip"
+                  content={
+                    <FormattedMessage
+                      defaultMessage="Archived traces remain accessible, but searching within span content no longer works after archival."
+                      description="Tooltip explaining the trace archival badge behavior"
+                    />
+                  }
                 >
-                  <FormattedMessage
-                    defaultMessage="Archive after: {retention}"
-                    description="Badge showing the active trace archival retention for the experiment"
-                    values={{ retention: traceArchivalRetention }}
-                  />
-                </Tag>
-              </Tooltip>
+                  <Tag
+                    componentId="mlflow.experiment_view.header.trace_archival_badge"
+                    color="turquoise"
+                    css={{ margin: 0 }}
+                  >
+                    <FormattedMessage
+                      defaultMessage="Archive after: {retention}"
+                      description="Badge showing the active trace archival retention for the experiment"
+                      values={{ retention: traceArchivalRetention }}
+                    />
+                  </Tag>
+                </Tooltip>
+              </div>
             )}
             {getInfoTooltip()}
           </div>

--- a/mlflow/server/js/src/experiment-tracking/hooks/useServerInfo.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/hooks/useServerInfo.test.tsx
@@ -6,6 +6,7 @@ import { setupServer } from '../../common/utils/setup-msw';
 import {
   useServerInfo,
   useIsFileStore,
+  useTraceArchivalEnabled,
   useWorkspacesEnabled,
   getWorkspacesEnabledSync,
   resetServerInfoCache,
@@ -21,7 +22,7 @@ describe('useServerInfo', () => {
   describe('when backend returns FileStore', () => {
     setupServer(
       rest.get('/ajax-api/3.0/mlflow/server-info', (_req, res, ctx) => {
-        return res(ctx.json({ store_type: 'FileStore', workspaces_enabled: false }));
+        return res(ctx.json({ store_type: 'FileStore', workspaces_enabled: false, trace_archival_enabled: false }));
       }),
     );
 
@@ -39,7 +40,9 @@ describe('useServerInfo', () => {
   describe('when backend returns SqlAlchemyStore', () => {
     setupServer(
       rest.get('/ajax-api/3.0/mlflow/server-info', (_req, res, ctx) => {
-        return res(ctx.json({ store_type: 'SqlAlchemyStore', workspaces_enabled: false }));
+        return res(
+          ctx.json({ store_type: 'SqlAlchemyStore', workspaces_enabled: false, trace_archival_enabled: false }),
+        );
       }),
     );
 
@@ -95,7 +98,7 @@ describe('useIsFileStore', () => {
   describe('when backend uses FileStore', () => {
     setupServer(
       rest.get('/ajax-api/3.0/mlflow/server-info', (_req, res, ctx) => {
-        return res(ctx.json({ store_type: 'FileStore', workspaces_enabled: false }));
+        return res(ctx.json({ store_type: 'FileStore', workspaces_enabled: false, trace_archival_enabled: false }));
       }),
     );
 
@@ -111,12 +114,64 @@ describe('useIsFileStore', () => {
   describe('when backend uses SqlAlchemyStore', () => {
     setupServer(
       rest.get('/ajax-api/3.0/mlflow/server-info', (_req, res, ctx) => {
-        return res(ctx.json({ store_type: 'SqlAlchemyStore', workspaces_enabled: false }));
+        return res(
+          ctx.json({ store_type: 'SqlAlchemyStore', workspaces_enabled: false, trace_archival_enabled: false }),
+        );
       }),
     );
 
     test('should return false', async () => {
       const { result } = renderHook(() => useIsFileStore(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current).toBe(false);
+      });
+    });
+  });
+});
+
+describe('useTraceArchivalEnabled', () => {
+  describe('when backend enables trace archival', () => {
+    setupServer(
+      rest.get('/ajax-api/3.0/mlflow/server-info', (_req, res, ctx) => {
+        return res(ctx.json({ store_type: 'SqlStore', workspaces_enabled: false, trace_archival_enabled: true }));
+      }),
+    );
+
+    test('should return true', async () => {
+      const { result } = renderHook(() => useTraceArchivalEnabled(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current).toBe(true);
+      });
+    });
+  });
+
+  describe('when backend returns an error', () => {
+    setupServer(
+      rest.get('/ajax-api/3.0/mlflow/server-info', (_req, res, ctx) => {
+        return res(ctx.status(500));
+      }),
+    );
+
+    test('should return false', async () => {
+      const { result } = renderHook(() => useTraceArchivalEnabled(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current).toBe(false);
+      });
+    });
+  });
+
+  describe('when backend omits trace archival support information', () => {
+    setupServer(
+      rest.get('/ajax-api/3.0/mlflow/server-info', (_req, res, ctx) => {
+        return res(ctx.json({ store_type: 'SqlStore', workspaces_enabled: false }));
+      }),
+    );
+
+    test('should return false for older servers', async () => {
+      const { result } = renderHook(() => useTraceArchivalEnabled(), { wrapper });
 
       await waitFor(() => {
         expect(result.current).toBe(false);
@@ -170,7 +225,7 @@ describe('useWorkspacesEnabled and getWorkspacesEnabledSync', () => {
   describe('when server returns workspaces enabled', () => {
     setupServer(
       rest.get('/ajax-api/3.0/mlflow/server-info', (_req, res, ctx) => {
-        return res(ctx.json({ store_type: 'SqlStore', workspaces_enabled: true }));
+        return res(ctx.json({ store_type: 'SqlStore', workspaces_enabled: true, trace_archival_enabled: false }));
       }),
     );
 
@@ -189,7 +244,7 @@ describe('useWorkspacesEnabled and getWorkspacesEnabledSync', () => {
   describe('when server returns workspaces disabled', () => {
     setupServer(
       rest.get('/ajax-api/3.0/mlflow/server-info', (_req, res, ctx) => {
-        return res(ctx.json({ store_type: 'SqlStore', workspaces_enabled: false }));
+        return res(ctx.json({ store_type: 'SqlStore', workspaces_enabled: false, trace_archival_enabled: false }));
       }),
     );
 
@@ -246,9 +301,8 @@ describe('useWorkspacesEnabled and getWorkspacesEnabledSync', () => {
   describe('when fetch has not completed', () => {
     setupServer(
       rest.get('/ajax-api/3.0/mlflow/server-info', (_req, res, ctx) => {
-        return res(ctx.json({ store_type: 'SqlStore', workspaces_enabled: false }));
-        // Never resolve to simulate pending request
-        return new Promise(() => {});
+        // Never resolve to simulate a pending request.
+        return res(ctx.delay('infinite'));
       }),
     );
 

--- a/mlflow/server/js/src/experiment-tracking/hooks/useServerInfo.tsx
+++ b/mlflow/server/js/src/experiment-tracking/hooks/useServerInfo.tsx
@@ -9,10 +9,15 @@ const SERVER_INFO_QUERY_KEY = 'serverInfo';
 interface ServerInfoResponse {
   store_type: string | null;
   workspaces_enabled: boolean;
+  trace_archival_enabled: boolean;
 }
 
 // Default response when the API call fails (e.g., older server without this endpoint)
-const DEFAULT_RESPONSE: ServerInfoResponse = { store_type: '', workspaces_enabled: false };
+const DEFAULT_RESPONSE: ServerInfoResponse = {
+  store_type: '',
+  workspaces_enabled: false,
+  trace_archival_enabled: false,
+};
 
 // Module-level reference to the QueryClient for synchronous access
 let queryClientRef: QueryClient | null = null;
@@ -54,6 +59,11 @@ export function useServerInfo() {
 export function useIsFileStore(): boolean | undefined {
   const { data } = useServerInfo();
   return data ? data.store_type === 'FileStore' : undefined;
+}
+
+export function useTraceArchivalEnabled(): boolean {
+  const { data } = useServerInfo();
+  return data?.trace_archival_enabled ?? false;
 }
 
 interface ServerInfoProviderProps {

--- a/mlflow/server/js/src/home/components/CreateWorkspaceModal.test.tsx
+++ b/mlflow/server/js/src/home/components/CreateWorkspaceModal.test.tsx
@@ -5,20 +5,26 @@ import userEvent from '@testing-library/user-event';
 import { useCreateWorkspaceModal } from './CreateWorkspaceModal';
 import { renderWithIntl, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
 import { fetchAPI } from '../../common/utils/FetchUtils';
+import { useTraceArchivalEnabled } from '../../experiment-tracking/hooks/useServerInfo';
 
 jest.mock('../../common/utils/FetchUtils', () => ({
   fetchAPI: jest.fn(() => Promise.resolve({})),
   getAjaxUrl: jest.fn((url: string) => url),
   HTTPMethods: { GET: 'GET', POST: 'POST', PATCH: 'PATCH', DELETE: 'DELETE' },
 }));
+jest.mock('../../experiment-tracking/hooks/useServerInfo', () => ({
+  useTraceArchivalEnabled: jest.fn(),
+}));
 
 describe('CreateWorkspaceModal', () => {
   const mockOnSuccess = jest.fn();
   const mockFetchAPI = jest.mocked(fetchAPI);
+  const mockedUseTraceArchivalEnabled = jest.mocked(useTraceArchivalEnabled);
 
   beforeEach(() => {
     jest.clearAllMocks();
     mockFetchAPI.mockResolvedValue({} as any);
+    mockedUseTraceArchivalEnabled.mockReturnValue(true);
   });
 
   const TestComponent = () => {
@@ -64,6 +70,17 @@ describe('CreateWorkspaceModal', () => {
         'Optional. Override how long traces stay in the tracking store before archival. Leave blank to use the server default.',
       ),
     ).toBeInTheDocument();
+  });
+
+  test('hides trace archival settings when the server disables trace archival', async () => {
+    mockedUseTraceArchivalEnabled.mockReturnValue(false);
+
+    renderComponent();
+    await openModal();
+
+    expect(screen.getByText('Create Workspace')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Trace archival settings' })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Trace Archival Retention')).not.toBeInTheDocument();
   });
 
   test('does not render modal when closed', () => {

--- a/mlflow/server/js/src/home/components/CreateWorkspaceModal.tsx
+++ b/mlflow/server/js/src/home/components/CreateWorkspaceModal.tsx
@@ -11,6 +11,7 @@ import {
   getTraceArchivalRetentionValidationError,
   type TraceArchivalRetentionUnit,
 } from '../../common/utils/traceArchival';
+import { useTraceArchivalEnabled } from '../../experiment-tracking/hooks/useServerInfo';
 import { WorkspaceSettingsFields } from './WorkspaceSettingsFields';
 
 type CreateWorkspaceFormData = {
@@ -30,6 +31,7 @@ export const useCreateWorkspaceModal = ({ onSuccess }: { onSuccess?: (workspaceN
   );
   const [traceArchivalRetentionError, setTraceArchivalRetentionError] = useState<string | undefined>();
   const intl = useIntl();
+  const traceArchivalEnabled = useTraceArchivalEnabled();
 
   const form = useForm<CreateWorkspaceFormData>({
     defaultValues: {
@@ -202,6 +204,7 @@ export const useCreateWorkspaceModal = ({ onSuccess }: { onSuccess?: (workspaceN
               onUnitChange: (unit) => updateTraceArchivalRetention({ unit }),
               unit: traceArchivalRetentionUnit,
             }}
+            showTraceArchivalSettings={traceArchivalEnabled}
           />
         </div>
       </Modal>

--- a/mlflow/server/js/src/home/components/WorkspaceSettingsFields.tsx
+++ b/mlflow/server/js/src/home/components/WorkspaceSettingsFields.tsx
@@ -27,6 +27,7 @@ type WorkspaceSettingsFieldsProps<TFieldValues extends FieldValues> = {
   traceArchivalRetention: TraceArchivalRetentionFieldState;
   descriptionAutoFocus?: boolean;
   showClearHint?: boolean;
+  showTraceArchivalSettings?: boolean;
 };
 
 export const WorkspaceSettingsFields = <TFieldValues extends FieldValues>({
@@ -36,6 +37,7 @@ export const WorkspaceSettingsFields = <TFieldValues extends FieldValues>({
   traceArchivalRetention,
   descriptionAutoFocus = false,
   showClearHint = false,
+  showTraceArchivalSettings = true,
 }: WorkspaceSettingsFieldsProps<TFieldValues>) => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
@@ -86,75 +88,77 @@ export const WorkspaceSettingsFields = <TFieldValues extends FieldValues>({
           })}
         />
       </div>
-      <CollapsibleSection
-        componentId={`${componentId}.trace_archival_section`}
-        title={intl.formatMessage({
-          defaultMessage: 'Trace archival settings',
-          description: 'Accordion title for trace archival workspace settings',
-        })}
-        defaultCollapsed
-        forceOpen={Boolean(locationFieldState.error || traceArchivalRetention.error)}
-      >
-        <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
-          <div>
-            <FormUI.Label htmlFor={`${idPrefix}.trace_archival_location`}>
-              <FormattedMessage
-                defaultMessage="Trace Archival Location"
-                description="Label for workspace trace archival location field"
+      {showTraceArchivalSettings && (
+        <CollapsibleSection
+          componentId={`${componentId}.trace_archival_section`}
+          title={intl.formatMessage({
+            defaultMessage: 'Trace archival settings',
+            description: 'Accordion title for trace archival workspace settings',
+          })}
+          defaultCollapsed
+          forceOpen={Boolean(locationFieldState.error || traceArchivalRetention.error)}
+        >
+          <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
+            <div>
+              <FormUI.Label htmlFor={`${idPrefix}.trace_archival_location`}>
+                <FormattedMessage
+                  defaultMessage="Trace Archival Location"
+                  description="Label for workspace trace archival location field"
+                />
+              </FormUI.Label>
+              <FormUI.Hint>
+                <FormattedMessage
+                  defaultMessage="Optional. Override where archived trace payloads are stored for this workspace. Leave blank to use the server default."
+                  description="Hint for workspace trace archival location field"
+                />
+              </FormUI.Hint>
+              <RHFControlledComponents.Input
+                control={control}
+                id={`${idPrefix}.trace_archival_location`}
+                componentId={`${componentId}.trace_archival_location_input`}
+                name={fieldNames.traceArchivalLocation}
+                rules={{
+                  validate: (value) => {
+                    const result = validateTraceArchivalLocation((value as string | undefined) ?? '', intl);
+                    return result.valid || result.error;
+                  },
+                }}
+                placeholder={intl.formatMessage({
+                  defaultMessage: 'Enter trace archival location URI',
+                  description: 'Placeholder for workspace trace archival location input',
+                })}
+                validationState={locationFieldState.error ? 'error' : undefined}
               />
-            </FormUI.Label>
-            <FormUI.Hint>
-              <FormattedMessage
-                defaultMessage="Optional. Override where archived trace payloads are stored for this workspace. Leave blank to use the server default."
-                description="Hint for workspace trace archival location field"
+              {locationFieldState.error && <FormUI.Message type="error" message={locationFieldState.error.message} />}
+            </div>
+            <div>
+              <FormUI.Label htmlFor={`${idPrefix}.trace_archival_retention_amount`}>
+                <FormattedMessage
+                  defaultMessage="Trace Archival Retention"
+                  description="Label for workspace trace archival retention field"
+                />
+              </FormUI.Label>
+              <FormUI.Hint>
+                <FormattedMessage
+                  defaultMessage="Optional. Override how long traces stay in the tracking store before archival. Leave blank to use the server default."
+                  description="Hint for workspace trace archival retention field"
+                />
+              </FormUI.Hint>
+              <TraceArchivalRetentionInput
+                amount={traceArchivalRetention.amount}
+                amountInputId={`${idPrefix}.trace_archival_retention_amount`}
+                componentId={`${componentId}.trace_archival_retention`}
+                error={Boolean(traceArchivalRetention.error)}
+                onAmountChange={traceArchivalRetention.onAmountChange}
+                onUnitChange={traceArchivalRetention.onUnitChange}
+                unitSelectorId={`${idPrefix}.trace_archival_retention_unit`}
+                unit={traceArchivalRetention.unit}
               />
-            </FormUI.Hint>
-            <RHFControlledComponents.Input
-              control={control}
-              id={`${idPrefix}.trace_archival_location`}
-              componentId={`${componentId}.trace_archival_location_input`}
-              name={fieldNames.traceArchivalLocation}
-              rules={{
-                validate: (value) => {
-                  const result = validateTraceArchivalLocation((value as string | undefined) ?? '', intl);
-                  return result.valid || result.error;
-                },
-              }}
-              placeholder={intl.formatMessage({
-                defaultMessage: 'Enter trace archival location URI',
-                description: 'Placeholder for workspace trace archival location input',
-              })}
-              validationState={locationFieldState.error ? 'error' : undefined}
-            />
-            {locationFieldState.error && <FormUI.Message type="error" message={locationFieldState.error.message} />}
+              {traceArchivalRetention.error && <FormUI.Message type="error" message={traceArchivalRetention.error} />}
+            </div>
           </div>
-          <div>
-            <FormUI.Label htmlFor={`${idPrefix}.trace_archival_retention_amount`}>
-              <FormattedMessage
-                defaultMessage="Trace Archival Retention"
-                description="Label for workspace trace archival retention field"
-              />
-            </FormUI.Label>
-            <FormUI.Hint>
-              <FormattedMessage
-                defaultMessage="Optional. Override how long traces stay in the tracking store before archival. Leave blank to use the server default."
-                description="Hint for workspace trace archival retention field"
-              />
-            </FormUI.Hint>
-            <TraceArchivalRetentionInput
-              amount={traceArchivalRetention.amount}
-              amountInputId={`${idPrefix}.trace_archival_retention_amount`}
-              componentId={`${componentId}.trace_archival_retention`}
-              error={Boolean(traceArchivalRetention.error)}
-              onAmountChange={traceArchivalRetention.onAmountChange}
-              onUnitChange={traceArchivalRetention.onUnitChange}
-              unitSelectorId={`${idPrefix}.trace_archival_retention_unit`}
-              unit={traceArchivalRetention.unit}
-            />
-            {traceArchivalRetention.error && <FormUI.Message type="error" message={traceArchivalRetention.error} />}
-          </div>
-        </div>
-      </CollapsibleSection>
+        </CollapsibleSection>
+      )}
     </div>
   );
 };

--- a/mlflow/server/js/src/home/components/WorkspacesHomeView.test.tsx
+++ b/mlflow/server/js/src/home/components/WorkspacesHomeView.test.tsx
@@ -10,6 +10,7 @@ import { useUpdateWorkspace } from '../../workspaces/hooks/useUpdateWorkspace';
 import { renderWithDesignSystem, screen, waitFor } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
 import { MemoryRouter } from '../../common/utils/RoutingUtils';
 import { QueryClient, QueryClientProvider } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { useTraceArchivalEnabled } from '../../experiment-tracking/hooks/useServerInfo';
 
 jest.mock('../../workspaces/hooks/useWorkspaces');
 jest.mock('../../account/hooks', () => ({
@@ -18,6 +19,9 @@ jest.mock('../../account/hooks', () => ({
   useIsAuthAvailable: jest.fn<() => boolean>(() => true),
 }));
 jest.mock('../../workspaces/hooks/useUpdateWorkspace');
+jest.mock('../../experiment-tracking/hooks/useServerInfo', () => ({
+  useTraceArchivalEnabled: jest.fn(),
+}));
 jest.mock('../../workspaces/utils/WorkspaceUtils', () => {
   const actualWorkspaceUtils = jest.requireActual<typeof import('../../workspaces/utils/WorkspaceUtils')>(
     '../../workspaces/utils/WorkspaceUtils',
@@ -32,6 +36,7 @@ jest.mock('../../workspaces/utils/WorkspaceUtils', () => {
 const mockedAdminWorkspaces = jest.mocked(useCurrentUserAdminWorkspaces);
 const mockedIsAdmin = jest.mocked(useCurrentUserIsAdmin);
 const mockedIsAuthAvailable = jest.mocked(useIsAuthAvailable);
+const mockedUseTraceArchivalEnabled = jest.mocked(useTraceArchivalEnabled);
 
 const reloadMock = jest.fn();
 const mockUpdateWorkspace = jest.fn();
@@ -47,6 +52,7 @@ describe('WorkspacesHomeView', () => {
     mockedAdminWorkspaces.mockReturnValue(new Set());
     mockedIsAdmin.mockReturnValue(false);
     mockedIsAuthAvailable.mockReturnValue(true);
+    mockedUseTraceArchivalEnabled.mockReturnValue(true);
     Object.defineProperty(window, 'location', {
       value: { ...window.location, hash: '', reload: reloadMock },
       writable: true,
@@ -215,6 +221,31 @@ describe('WorkspacesHomeView', () => {
     expect(screen.getByDisplayValue('s3://archive/ml-research')).toBeInTheDocument();
     expect(screen.getByLabelText('Trace Archival Retention')).toHaveValue('30');
     expect(screen.getByText('Clear any optional field and save to remove the workspace override.')).toBeInTheDocument();
+  });
+
+  test('hides trace archival settings in the edit modal when the server disables trace archival', async () => {
+    mockedIsAdmin.mockReturnValue(true);
+    mockedUseTraceArchivalEnabled.mockReturnValue(false);
+    jest.mocked(useWorkspaces).mockReturnValue({
+      workspaces: [
+        {
+          name: 'ml-research',
+          description: 'Research experiments',
+          default_artifact_root: 's3://artifacts/ml-research',
+          trace_archival_config: { location: 's3://archive/ml-research', retention: '30d' },
+        },
+      ],
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn() as any,
+    });
+
+    renderComponent();
+    await userEvent.click(screen.getByRole('button', { name: 'Edit workspace' }));
+
+    expect(screen.getByText('Edit Workspace')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Trace archival settings' })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Trace Archival Retention')).not.toBeInTheDocument();
   });
 
   test('saves updated fields from the edit modal', async () => {

--- a/mlflow/server/js/src/home/components/WorkspacesHomeView.tsx
+++ b/mlflow/server/js/src/home/components/WorkspacesHomeView.tsx
@@ -35,6 +35,7 @@ import {
 } from '../../workspaces/utils/WorkspaceUtils';
 import { useUpdateWorkspace } from '../../workspaces/hooks/useUpdateWorkspace';
 import { WorkspaceSettingsFields } from './WorkspaceSettingsFields';
+import { useTraceArchivalEnabled } from '../../experiment-tracking/hooks/useServerInfo';
 
 type WorkspacesHomeViewProps = {
   onCreateWorkspace: () => void;
@@ -85,6 +86,7 @@ const WorkspaceRow = ({
   canManage,
   showEditColumn,
   showManageColumn,
+  traceArchivalEnabled,
 }: {
   workspace: Workspace;
   isLastUsed: boolean;
@@ -92,6 +94,7 @@ const WorkspaceRow = ({
   canManage: boolean;
   showEditColumn: boolean;
   showManageColumn: boolean;
+  traceArchivalEnabled: boolean;
 }) => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
@@ -422,6 +425,7 @@ const WorkspaceRow = ({
               }}
               descriptionAutoFocus
               showClearHint
+              showTraceArchivalSettings={traceArchivalEnabled}
             />
           </div>
         </Modal>
@@ -435,6 +439,7 @@ const WORKSPACES_PER_PAGE = 10;
 export const WorkspacesHomeView = ({ onCreateWorkspace }: WorkspacesHomeViewProps) => {
   const { theme } = useDesignSystemTheme();
   const { workspaces, isLoading, isError, refetch } = useWorkspaces(true);
+  const traceArchivalEnabled = useTraceArchivalEnabled();
   const lastUsedWorkspace = getLastUsedWorkspace();
   const [currentPage, setCurrentPage] = useState(1);
   // Manage column: shown only to workspace managers — gear icon links to
@@ -578,6 +583,7 @@ export const WorkspacesHomeView = ({ onCreateWorkspace }: WorkspacesHomeViewProp
                   canManage={!isAdmin && adminWorkspaces.has(workspace.name)}
                   showEditColumn={showEditColumn}
                   showManageColumn={showManageColumn}
+                  traceArchivalEnabled={traceArchivalEnabled}
                 />
               ))
             )}

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -393,6 +393,49 @@ def test_server_info():
         data = response.get_json()
         assert data["store_type"] == "SqlStore"
         assert data["workspaces_enabled"] is False
+        assert data["trace_archival_enabled"] is False
+
+
+def test_server_info_trace_archival_enabled(monkeypatch):
+    monkeypatch.setattr(
+        "mlflow.server.handlers.get_trace_archival_server_config",
+        mock.Mock(return_value=mock.Mock(enabled=True)),
+    )
+    monkeypatch.setattr("mlflow.server.handlers._store_supports_trace_archival", lambda store: True)
+
+    with app.test_client() as c:
+        response = c.get("/api/3.0/mlflow/server-info")
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["trace_archival_enabled"] is True
+
+
+def test_server_info_handles_invalid_trace_archival_config(monkeypatch):
+    monkeypatch.setattr(
+        "mlflow.server.handlers.get_trace_archival_server_config",
+        mock.Mock(
+            side_effect=MlflowException.invalid_parameter_value("invalid trace archival config")
+        ),
+    )
+
+    with app.test_client() as c:
+        response = c.get("/api/3.0/mlflow/server-info")
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["trace_archival_enabled"] is False
+
+
+def test_server_info_handles_unexpected_trace_archival_config_error(monkeypatch):
+    monkeypatch.setattr(
+        "mlflow.server.handlers.get_trace_archival_server_config",
+        mock.Mock(side_effect=RuntimeError("unexpected trace archival config error")),
+    )
+
+    with app.test_client() as c:
+        response = c.get("/api/3.0/mlflow/server-info")
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["trace_archival_enabled"] is False
 
 
 def test_get_endpoints():

--- a/tests/server/test_workspace_middleware.py
+++ b/tests/server/test_workspace_middleware.py
@@ -121,6 +121,7 @@ def test_server_info_workspaces_enabled(monkeypatch):
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["workspaces_enabled"] is True
+    assert data["trace_archival_enabled"] is False
 
     # Disable workspaces and ensure the endpoint reflects the change.
     monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "false")
@@ -128,6 +129,7 @@ def test_server_info_workspaces_enabled(monkeypatch):
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["workspaces_enabled"] is False
+    assert data["trace_archival_enabled"] is False
 
 
 def test_server_info_skips_workspace_resolution(monkeypatch):
@@ -145,6 +147,7 @@ def test_server_info_skips_workspace_resolution(monkeypatch):
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["workspaces_enabled"] is True
+    assert data["trace_archival_enabled"] is False
 
 
 def test_server_info_with_workspace_header_when_workspaces_disabled(monkeypatch):
@@ -156,6 +159,7 @@ def test_server_info_with_workspace_header_when_workspaces_disabled(monkeypatch)
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["workspaces_enabled"] is False
+    assert data["trace_archival_enabled"] is False
 
 
 def test_fastapi_wsgi_flask_workspace_propagation(monkeypatch):


### PR DESCRIPTION
### Related Issues/PRs

Closes | Relates to [Trace Archival RFC](https://github.com/mlflow/rfcs/blob/main/rfcs/0001-trace-archival/0001-trace-archival.md)

### What changes are proposed in this pull request?

Hides trace archival settings on the workspace and experiment when trace archival is disabled on the server.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

N/A

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Trace archival settings only show up in the UI when trace archival is enabled on the server.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release