### PR TITLE
fix: correct trace UI typo

### DIFF
--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -143,6 +143,10 @@
     "defaultMessage": "Fallback",
     "description": "Gateway > Endpoint details > Label on connector between fallback model sections"
   },
+  "+o0xUA": {
+    "defaultMessage": "An error occurred while attempting to fetch trace data (ID: {traceId}). Please ensure that the MLflow tracking server is running, and that the trace data exists. Error details:",
+    "description": "An error message explaining that an error occurred while fetching trace data"
+  },
   "+tURAJ": {
     "defaultMessage": "Cancel",
     "description": "Button text for canceling evaluation"
@@ -5250,10 +5254,6 @@
   "UCQwvo": {
     "defaultMessage": "Registered prompts",
     "description": "Run page > Overview > Run prompts section label"
-  },
-  "UD4Z+e": {
-    "defaultMessage": "An error occurred while attempting to fetch trace data (ID: {traceId}). Please ensure that the MLflow tracking server is running, and that the trace data exists. Error details:",
-    "description": "An error message explaining that an error occured while fetching trace data"
   },
   "UEDu0c": {
     "defaultMessage": "MLflow UI automatically fetches metric histories for active runs and updates the metrics plot with a {interval} second interval.",
@@ -10755,10 +10755,6 @@
     "defaultMessage": "Application user who triggered the trace",
     "description": "Tooltip description for the User column in the traces table"
   },
-  "zhzZUu": {
-    "defaultMessage": "An error occured while attempting to delete traces. Please refresh the page and try again.",
-    "description": "Experiment page > traces view controls > Delete traces modal > Error message"
-  },
   "ziIhFQ": {
     "defaultMessage": "Loaded {allRuns} {allRuns, plural, =1 {run} other {runs}}, including {childRuns} child {childRuns, plural, =1 {run} other {runs}}",
     "description": "Experiment page > loaded more runs notification > loaded both parent and child runs"
@@ -10798,6 +10794,10 @@
   "zxfWCx": {
     "defaultMessage": "Add/Edit Prompt Version Metadata",
     "description": "Title for a modal that allows the user to add or edit metadata tags on prompt versions."
+  },
+  "zyPq2R": {
+    "defaultMessage": "An error occurred while attempting to delete traces. Please refresh the page and try again.",
+    "description": "Experiment page > traces view controls > Delete traces modal > Error message"
   },
   "zzuzri": {
     "defaultMessage": "Description",

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/GenAiDeleteTraceModal.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/GenAiDeleteTraceModal.tsx
@@ -30,7 +30,7 @@ export const GenAiDeleteTraceModal = ({
     } catch (e: any) {
       setErrorMessage(
         intl.formatMessage({
-          defaultMessage: 'An error occured while attempting to delete traces. Please refresh the page and try again.',
+          defaultMessage: 'An error occurred while attempting to delete traces. Please refresh the page and try again.',
           description: 'Experiment page > traces view controls > Delete traces modal > Error message',
         }),
       );

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/oss-notebook-renderer/ModelTraceExplorerOSSNotebookRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/oss-notebook-renderer/ModelTraceExplorerOSSNotebookRenderer.tsx
@@ -76,7 +76,7 @@ export const ModelTraceExplorerOSSNotebookRenderer = () => {
     );
   }
 
-  // some error occured
+  // some error occurred
   if (!traceData) {
     return (
       <div css={{ paddingTop: theme.spacing.md, width: 'calc(100% - 2px)' }}>
@@ -87,7 +87,7 @@ export const ModelTraceExplorerOSSNotebookRenderer = () => {
               <Typography.Paragraph>
                 <FormattedMessage
                   defaultMessage="An error occurred while attempting to fetch trace data (ID: {traceId}). Please ensure that the MLflow tracking server is running, and that the trace data exists. Error details:"
-                  description="An error message explaining that an error occured while fetching trace data"
+                  description="An error message explaining that an error occurred while fetching trace data"
                   values={{ traceId: traceIds[activeTraceIndex] }}
                 />
               </Typography.Paragraph>


### PR DESCRIPTION
### Related Issues/PRs

Same change as [#23158](https://github.com/mlflow/mlflow/pull/23158) (closed by automation for incomplete PR template and missing DCO). This PR restores the typo fix with a [`Signed-off-by`](https://developercertificate.org/) line and a complete description.

### What changes are proposed in this pull request?

Fixes a small spelling typo in GenAI trace UI copy and related metadata:

- `occured` → `occurred` in the delete traces error message (`GenAiDeleteTraceModal.tsx`)
- `occured` → `occurred` in the trace fetch error description/comment (`ModelTraceExplorerOSSNotebookRenderer.tsx`)

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] Manual tests

- `git diff --check`
- `grep -RIn "occured" <touched files>` confirms the typo no longer appears in the changed files

The full frontend test suite was not run because this is a spelling-only copy change in two TSX files.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Corrects the spelling of “occurred” in GenAI trace UI error messages so copy reads properly.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

Made with [Cursor](https://cursor.com)