### PR TITLE
Tighten `pr-review` skill diff and analysis steps

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -62,7 +62,7 @@ gh pr view <pr_number> --repo "<owner>/<repo>" --json title,body,author
 
 ### 2. Fetch PR Diff
 
-Fetch the diff hunks via the `fetch-diff` skill. For context beyond the diff (existing patterns, call sites of changed symbols, file conventions), `Read` and `Grep` the working tree, which holds the PR merged into the base (`refs/pull/<pr>/merge`), so file contents reflect the post-merge state. When a quick shell command can settle a question, run it instead of speculating from the diff alone.
+Fetch the diff hunks via the `fetch-diff` skill.
 
 ### 3. Fetch Existing Review Comments
 
@@ -90,6 +90,8 @@ gh api graphql -F owner=<owner> -F repo=<repo> -F pr=<pr_number> -f query='
 ```
 
 ### 4. In-Depth Analysis
+
+The working tree holds the PR merged into the base (`refs/pull/<pr>/merge`), so file contents reflect the post-merge state. Explore it for context beyond the diff (existing patterns, call sites of changed symbols, file conventions).
 
 #### Don't comment on
 


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Refines the `pr-review` skill instructions:

- Step 2: delegate diff fetching to the `fetch-diff` skill.
- Move the worktree-state note into step 4, where it actually informs the review.
- Drop the "quick shell command" line: running code to verify can slow review, fail (deps/sandbox), or not apply (external services).

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release