### PR TITLE
Improve misleading DB SDK auth error

### DIFF
--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -776,6 +776,7 @@ def get_databricks_host_creds(server_uri=None):
 
     .. Warning:: This API is deprecated. In the future it might be removed.
     """
+    sdk_init_error = None
 
     if MLFLOW_ENABLE_DB_SDK.get():
         from databricks.sdk import WorkspaceClient
@@ -823,11 +824,9 @@ def get_databricks_host_creds(server_uri=None):
             # Only pass profile if explicitly set. Passing profile=None causes the SDK to skip
             # environment-variable-based auth methods like OIDC (file-oidc auth type).
             ws = WorkspaceClient(profile=profile) if profile else WorkspaceClient()
-            use_databricks_sdk = True
-            databricks_auth_profile = profile
-            workspace_id = ws.config.workspace_id
         except Exception as e:
             _logger.debug(f"Failed to create databricks SDK workspace client, error: {e!r}")
+            sdk_init_error = repr(e)
             use_databricks_sdk = False
             databricks_auth_profile = None
             # Config resolves workspace_id from env vars, .databrickscfg, or host
@@ -836,9 +835,18 @@ def get_databricks_host_creds(server_uri=None):
             try:
                 from databricks.sdk.config import Config as DatabricksConfig
 
-                workspace_id = DatabricksConfig(profile=profile).workspace_id
+                workspace_id = getattr(DatabricksConfig(profile=profile), "workspace_id", None)
             except Exception:
                 workspace_id = None
+        else:
+            use_databricks_sdk = True
+            databricks_auth_profile = profile
+            # workspace_id is best-effort. Older databricks-sdk releases (<0.30) don't have
+            # Config.workspace_id; pre-fix versions of this function let the resulting
+            # AttributeError nuke `use_databricks_sdk`, which made OAuth M2M fall through
+            # to the legacy auth path and surface a misleading "set MLFLOW_ENABLE_DB_SDK"
+            # error to the user even though they had already set it.
+            workspace_id = getattr(ws.config, "workspace_id", None)
     else:
         use_databricks_sdk = False
         databricks_auth_profile = None
@@ -871,6 +879,7 @@ def get_databricks_host_creds(server_uri=None):
         use_databricks_sdk=use_databricks_sdk,
         databricks_auth_profile=databricks_auth_profile,
         workspace_id=workspace_id,
+        sdk_init_error=sdk_init_error,
     )
 
 

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -776,8 +776,6 @@ def get_databricks_host_creds(server_uri=None):
 
     .. Warning:: This API is deprecated. In the future it might be removed.
     """
-    sdk_init_error = None
-
     if MLFLOW_ENABLE_DB_SDK.get():
         from databricks.sdk import WorkspaceClient
 
@@ -825,8 +823,10 @@ def get_databricks_host_creds(server_uri=None):
             # environment-variable-based auth methods like OIDC (file-oidc auth type).
             ws = WorkspaceClient(profile=profile) if profile else WorkspaceClient()
         except Exception as e:
-            _logger.debug(f"Failed to create databricks SDK workspace client, error: {e!r}")
-            sdk_init_error = repr(e)
+            _logger.warning(
+                f"Failed to create databricks SDK workspace client, error: {e!r}. "
+                "Falling back to legacy authentication."
+            )
             use_databricks_sdk = False
             databricks_auth_profile = None
             # Config resolves workspace_id from env vars, .databrickscfg, or host
@@ -879,7 +879,6 @@ def get_databricks_host_creds(server_uri=None):
         use_databricks_sdk=use_databricks_sdk,
         databricks_auth_profile=databricks_auth_profile,
         workspace_id=workspace_id,
-        sdk_init_error=sdk_init_error,
     )
 
 

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -790,7 +790,7 @@ def get_databricks_host_creds(server_uri=None):
                     token=config.token,
                     use_databricks_sdk=True,
                     use_secret_scope_token=True,
-                    workspace_id=ws.config.workspace_id,
+                    workspace_id=getattr(ws.config, "workspace_id", None),
                 )
             except Exception as e:
                 raise MlflowException(

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -263,19 +263,11 @@ def http_request(
             f"'{MLFLOW_ENABLE_DB_SDK.get()}'."
         )
         if MLFLOW_ENABLE_DB_SDK.get():
-            if host_creds.sdk_init_error:
-                message += (
-                    " The SDK was enabled but failed to initialize with error: "
-                    f"{host_creds.sdk_init_error}. Ensure 'databricks-sdk' is installed "
-                    "at a recent version and that DATABRICKS_HOST, DATABRICKS_CLIENT_ID, "
-                    "and DATABRICKS_CLIENT_SECRET are correctly set."
-                )
-            else:
-                message += (
-                    " The SDK appears enabled but auth fell through to the legacy path "
-                    "anyway. Set MLFLOW_LOGGING_LEVEL=DEBUG and retry to see the "
-                    "underlying error."
-                )
+            message += (
+                " The SDK is enabled but failed to initialize. See the preceding "
+                "'Failed to create databricks SDK workspace client' warning for the "
+                "underlying error."
+            )
         else:
             message += f" Set '{MLFLOW_ENABLE_DB_SDK.name}' to true."
         raise MlflowException(message, error_code=CUSTOMER_UNAUTHORIZED)
@@ -743,10 +735,6 @@ class MlflowHostCreds:
             authentication.
         client_id: The client ID used by Databricks OAuth
         client_secret: The client secret used by Databricks OAuth
-        sdk_init_error: When ``MLFLOW_ENABLE_DB_SDK`` is true but Databricks SDK
-            initialization failed, the string representation of the underlying error.
-            Used to produce a more actionable error message if OAuth auth is later
-            attempted via the legacy path.
     """
 
     def __init__(
@@ -766,7 +754,6 @@ class MlflowHostCreds:
         client_secret=None,
         use_secret_scope_token=False,
         workspace_id=None,
-        sdk_init_error=None,
     ):
         if not host:
             raise MlflowException(
@@ -799,7 +786,6 @@ class MlflowHostCreds:
         self.client_secret = client_secret
         self.use_secret_scope_token = use_secret_scope_token
         self.workspace_id = workspace_id
-        self.sdk_init_error = sdk_init_error
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -273,8 +273,8 @@ def http_request(
             else:
                 message += (
                     " The SDK appears enabled but auth fell through to the legacy path "
-                    "anyway. Enable DEBUG logging on 'mlflow.utils.databricks_utils' to "
-                    "see why."
+                    "anyway. Set MLFLOW_LOGGING_LEVEL=DEBUG and retry to see the "
+                    "underlying error."
                 )
         else:
             message += f" Set '{MLFLOW_ENABLE_DB_SDK.name}' to true."

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -256,11 +256,29 @@ def http_request(
     elif host_creds.token:
         auth_str = f"Bearer {host_creds.token}"
     elif host_creds.client_secret:
-        raise MlflowException(
-            "To use OAuth authentication, set environmental variable "
-            f"'{MLFLOW_ENABLE_DB_SDK.name}' to true",
-            error_code=CUSTOMER_UNAUTHORIZED,
+        message = (
+            "OAuth authentication using DATABRICKS_CLIENT_ID and DATABRICKS_CLIENT_SECRET "
+            "requires the Databricks SDK to be enabled and successfully initialized. "
+            f"{MLFLOW_ENABLE_DB_SDK.name} is currently set to "
+            f"'{MLFLOW_ENABLE_DB_SDK.get()}'."
         )
+        if MLFLOW_ENABLE_DB_SDK.get():
+            if host_creds.sdk_init_error:
+                message += (
+                    " The SDK was enabled but failed to initialize with error: "
+                    f"{host_creds.sdk_init_error}. Ensure 'databricks-sdk' is installed "
+                    "at a recent version and that DATABRICKS_HOST, DATABRICKS_CLIENT_ID, "
+                    "and DATABRICKS_CLIENT_SECRET are correctly set."
+                )
+            else:
+                message += (
+                    " The SDK appears enabled but auth fell through to the legacy path "
+                    "anyway. Enable DEBUG logging on 'mlflow.utils.databricks_utils' to "
+                    "see why."
+                )
+        else:
+            message += f" Set '{MLFLOW_ENABLE_DB_SDK.name}' to true."
+        raise MlflowException(message, error_code=CUSTOMER_UNAUTHORIZED)
 
     if auth_str:
         headers["Authorization"] = auth_str
@@ -725,6 +743,10 @@ class MlflowHostCreds:
             authentication.
         client_id: The client ID used by Databricks OAuth
         client_secret: The client secret used by Databricks OAuth
+        sdk_init_error: When ``MLFLOW_ENABLE_DB_SDK`` is true but Databricks SDK
+            initialization failed, the string representation of the underlying error.
+            Used to produce a more actionable error message if OAuth auth is later
+            attempted via the legacy path.
     """
 
     def __init__(
@@ -744,6 +766,7 @@ class MlflowHostCreds:
         client_secret=None,
         use_secret_scope_token=False,
         workspace_id=None,
+        sdk_init_error=None,
     ):
         if not host:
             raise MlflowException(
@@ -776,6 +799,7 @@ class MlflowHostCreds:
         self.client_secret = client_secret
         self.use_secret_scope_token = use_secret_scope_token
         self.workspace_id = workspace_id
+        self.sdk_init_error = sdk_init_error
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -189,15 +189,21 @@ def test_databricks_host_creds_falls_back_when_sdk_fails(monkeypatch):
     monkeypatch.setenv("DATABRICKS_TOKEN", "test-token")
     monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
 
-    with mock.patch("databricks.sdk.WorkspaceClient", side_effect=Exception("SDK auth failed")):
+    with (
+        mock.patch("databricks.sdk.WorkspaceClient", side_effect=Exception("SDK auth failed")),
+        mock.patch.object(databricks_utils._logger, "warning") as mock_warning,
+    ):
         creds = databricks_utils.get_databricks_host_creds("databricks")
         # Should fall back to legacy and use env vars
         assert creds.host == "https://test.databricks.com"
         assert creds.token == "test-token"
         assert not creds.use_databricks_sdk
-        # SDK init error must be captured so callers can surface it later.
-        assert creds.sdk_init_error is not None
-        assert "SDK auth failed" in creds.sdk_init_error
+        # SDK init failure must surface as a WARNING so callers can correlate it with
+        # any downstream OAuth error.
+        mock_warning.assert_called_once()
+        msg = mock_warning.call_args.args[0]
+        assert "Failed to create databricks SDK workspace client" in msg
+        assert "SDK auth failed" in msg
 
 
 def test_databricks_host_creds_keeps_sdk_when_workspace_id_attr_missing(monkeypatch):
@@ -223,7 +229,6 @@ def test_databricks_host_creds_keeps_sdk_when_workspace_id_attr_missing(monkeypa
         creds = databricks_utils.get_databricks_host_creds("databricks")
         assert creds.use_databricks_sdk
         assert creds.workspace_id is None
-        assert creds.sdk_init_error is None
 
 
 def test_sdk_respects_env_var_priority(monkeypatch):

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -195,6 +195,35 @@ def test_databricks_host_creds_falls_back_when_sdk_fails(monkeypatch):
         assert creds.host == "https://test.databricks.com"
         assert creds.token == "test-token"
         assert not creds.use_databricks_sdk
+        # SDK init error must be captured so callers can surface it later.
+        assert creds.sdk_init_error is not None
+        assert "SDK auth failed" in creds.sdk_init_error
+
+
+def test_databricks_host_creds_keeps_sdk_when_workspace_id_attr_missing(monkeypatch):
+    # Older databricks-sdk releases don't have Config.workspace_id. The legacy behavior
+    # let the resulting AttributeError nuke use_databricks_sdk, breaking OAuth M2M auth
+    # for users who had MLFLOW_ENABLE_DB_SDK=true correctly set. workspace_id must
+    # degrade to None without dropping the SDK auth path. See ES-1918390.
+    monkeypatch.setenv("MLFLOW_ENABLE_DB_SDK", "true")
+    monkeypatch.setenv("DATABRICKS_HOST", "https://test.databricks.com")
+    monkeypatch.setenv("DATABRICKS_CLIENT_ID", "test-client-id")
+    monkeypatch.setenv("DATABRICKS_CLIENT_SECRET", "test-client-secret")
+    monkeypatch.delenv("DATABRICKS_TOKEN", raising=False)
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+
+    # Use a real object (not MagicMock) so getattr fallback is exercised.
+    class OldSdkConfig:
+        host = "https://test.databricks.com"
+
+    mock_ws = mock.MagicMock()
+    mock_ws.config = OldSdkConfig()
+
+    with mock.patch("databricks.sdk.WorkspaceClient", return_value=mock_ws):
+        creds = databricks_utils.get_databricks_host_creds("databricks")
+        assert creds.use_databricks_sdk
+        assert creds.workspace_id is None
+        assert creds.sdk_init_error is None
 
 
 def test_sdk_respects_env_var_priority(monkeypatch):

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -979,10 +979,9 @@ def test_mlflow_host_creds_workspace_id_equality():
 
 
 def test_oauth_error_when_sdk_enabled(monkeypatch):
-    # Regression for ES-1918390: when MLFLOW_ENABLE_DB_SDK=true and the SDK failed to
-    # initialize, the OAuth error must acknowledge the env var is set and point at the
-    # preceding SDK warning, instead of telling the user to set an env var they have
-    # already set.
+    # When MLFLOW_ENABLE_DB_SDK=true and the SDK failed to initialize, the OAuth error
+    # must acknowledge the env var is set and point at the preceding SDK warning, instead
+    # of telling the user to set an env var they have already set.
     monkeypatch.setenv("MLFLOW_ENABLE_DB_SDK", "true")
     creds = MlflowHostCreds(
         "http://my-host",

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -978,6 +978,38 @@ def test_mlflow_host_creds_workspace_id_equality():
     assert hash(creds1) != hash(creds3)
 
 
+def test_oauth_error_includes_sdk_init_error(monkeypatch):
+    # Regression for ES-1918390: when MLFLOW_ENABLE_DB_SDK=true and the SDK fails to
+    # initialize, the OAuth error must surface the underlying SDK error and not just
+    # tell the user to set an env var they have already set.
+    monkeypatch.setenv("MLFLOW_ENABLE_DB_SDK", "true")
+    creds = MlflowHostCreds(
+        "http://my-host",
+        client_id="some-id",
+        client_secret="some-secret",
+        sdk_init_error="AttributeError(\"'Config' object has no attribute 'workspace_id'\")",
+    )
+    with pytest.raises(MlflowException, match="failed to initialize with error") as exc:
+        http_request(creds, "/my/endpoint", "GET")
+    msg = str(exc.value)
+    assert "MLFLOW_ENABLE_DB_SDK is currently set to 'True'" in msg
+    assert "AttributeError" in msg
+    assert "workspace_id" in msg
+
+
+def test_oauth_error_when_sdk_disabled(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ENABLE_DB_SDK", "false")
+    creds = MlflowHostCreds(
+        "http://my-host",
+        client_id="some-id",
+        client_secret="some-secret",
+    )
+    with pytest.raises(MlflowException, match="Set 'MLFLOW_ENABLE_DB_SDK' to true") as exc:
+        http_request(creds, "/my/endpoint", "GET")
+    msg = str(exc.value)
+    assert "MLFLOW_ENABLE_DB_SDK is currently set to 'False'" in msg
+
+
 @pytest.mark.parametrize(
     ("timeout", "retry_timeout_seconds", "should_warn"),
     [

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -978,23 +978,22 @@ def test_mlflow_host_creds_workspace_id_equality():
     assert hash(creds1) != hash(creds3)
 
 
-def test_oauth_error_includes_sdk_init_error(monkeypatch):
-    # Regression for ES-1918390: when MLFLOW_ENABLE_DB_SDK=true and the SDK fails to
-    # initialize, the OAuth error must surface the underlying SDK error and not just
-    # tell the user to set an env var they have already set.
+def test_oauth_error_when_sdk_enabled(monkeypatch):
+    # Regression for ES-1918390: when MLFLOW_ENABLE_DB_SDK=true and the SDK failed to
+    # initialize, the OAuth error must acknowledge the env var is set and point at the
+    # preceding SDK warning, instead of telling the user to set an env var they have
+    # already set.
     monkeypatch.setenv("MLFLOW_ENABLE_DB_SDK", "true")
     creds = MlflowHostCreds(
         "http://my-host",
         client_id="some-id",
         client_secret="some-secret",
-        sdk_init_error="AttributeError(\"'Config' object has no attribute 'workspace_id'\")",
     )
-    with pytest.raises(MlflowException, match="failed to initialize with error") as exc:
+    with pytest.raises(MlflowException, match="SDK is enabled but failed to initialize") as exc:
         http_request(creds, "/my/endpoint", "GET")
     msg = str(exc.value)
     assert "MLFLOW_ENABLE_DB_SDK is currently set to 'True'" in msg
-    assert "AttributeError" in msg
-    assert "workspace_id" in msg
+    assert "Failed to create databricks SDK workspace client" in msg
 
 
 def test_oauth_error_when_sdk_disabled(monkeypatch):


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

When ``MLFLOW_ENABLE_DB_SDK=true`` but ``WorkspaceClient()`` initialization fails (e.g. an older ``databricks-sdk`` lacking ``Config.workspace_id``), MLflow silently falls back to legacy auth, then raises ``\"To use OAuth authentication, set environmental variable 'MLFLOW_ENABLE_DB_SDK' to true\"`` — even though the user already set it.

Two fixes:

1. ``mlflow/utils/databricks_utils.py``: split ``ws.config.workspace_id`` retrieval out of the SDK-init ``try`` block and read it via ``getattr(..., None)`` so older SDK versions don't nuke ``use_databricks_sdk``. Log the SDK init failure at WARNING (was DEBUG) so it actually surfaces in logs.
2. ``mlflow/utils/rest_utils.py``: rewrite the OAuth error to show the current value of ``MLFLOW_ENABLE_DB_SDK`` and point at the preceding SDK-init warning instead of telling the user to set an env var they've already set.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Improve the error message when Databricks SDK auth fails so it points at the underlying SDK initialization error instead of suggesting the user enable an env var they've already enabled.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] ``area/tracking``: Tracking Service, tracking client APIs, autologging
- [x] ``area/tracing``: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] ``rn/bug-fix`` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release