### PR TITLE
Defer MLflow version-mismatch warning until load failure

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -584,6 +584,7 @@ from mlflow.utils.model_utils import (
 )
 from mlflow.utils.nfs_on_spark import get_nfs_cache_root_dir
 from mlflow.utils.requirements_utils import (
+    _get_dependency_requirement_mismatches_message,
     _parse_requirements,
     warn_dependency_requirement_mismatches,
 )
@@ -1070,6 +1071,12 @@ def _get_pip_requirements_from_model_path(model_path: str):
     return [req.req_str for req in _parse_requirements(req_file_path, is_constraint=False)]
 
 
+def _append_mismatch_message(error_message: str, mismatch_message: str | None) -> str:
+    if not mismatch_message:
+        return error_message
+    return f"{error_message}\n\n{mismatch_message}"
+
+
 @trace_disabled  # Suppress traces while loading model
 def load_model(
     model_uri: str,
@@ -1132,9 +1139,14 @@ def load_model(
         artifact_uri=model_uri, output_path=dst_path, lineage_header_info=lineage_header_info
     )
 
+    # Capture any dependency mismatch info upfront, but defer surfacing it until/unless the
+    # model fails to load. MLflow guarantees backwards compatibility for model loading, so the
+    # mismatch is only noteworthy if loading actually fails. Eagerly warning on every load
+    # creates noise for users who load successfully (the common case). See ML-52626.
+    mismatch_message = None
     if not suppress_warnings:
         model_requirements = _get_pip_requirements_from_model_path(local_path)
-        warn_dependency_requirement_mismatches(model_requirements)
+        mismatch_message = _get_dependency_requirement_mismatches_message(model_requirements)
 
     model_meta = Model.load(os.path.join(local_path, MLMODEL_FILE_NAME))
 
@@ -1178,13 +1190,24 @@ def load_model(
         # databricks module errors will just be re-raised.
         if conf[MAIN] == _DATABRICKS_FS_LOADER_MODULE and e.name.startswith("databricks"):
             raise MlflowException(
-                f"{e.msg}; "
-                "Note: mlflow.pyfunc.load_model is not supported for Feature Store models. "
-                "spark_udf() and predict() will not work as expected. Use "
-                "score_batch for offline predictions.",
+                _append_mismatch_message(
+                    f"{e.msg}; "
+                    "Note: mlflow.pyfunc.load_model is not supported for Feature Store models. "
+                    "spark_udf() and predict() will not work as expected. Use "
+                    "score_batch for offline predictions.",
+                    mismatch_message,
+                ),
                 BAD_REQUEST,
             ) from None
+        if mismatch_message:
+            _logger.warning(mismatch_message)
         raise e
+    except Exception:
+        # Surface the dependency mismatch info (if any) as a warning so that users can see it
+        # alongside the load failure traceback. See ML-52626.
+        if mismatch_message:
+            _logger.warning(mismatch_message)
+        raise
     finally:
         # clean up the dependencies schema which is set to global state after loading the model.
         # This avoids the schema being used by other models loaded in the same process.

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -659,10 +659,13 @@ def _check_requirement_satisfied(requirement_str: str) -> _MismatchedPackageInfo
     return None
 
 
-def warn_dependency_requirement_mismatches(model_requirements: list[str]):
+def _get_dependency_requirement_mismatches_message(model_requirements: list[str]) -> str | None:
     """
-    Inspects the model's dependencies and prints a warning if the current Python environment
-    doesn't satisfy them.
+    Inspects the model's dependencies and returns a message describing any mismatches
+    between the model's required dependencies and the current Python environment.
+
+    Returns ``None`` when no mismatches are detected or when an unexpected error occurs while
+    detecting mismatches (in which case the error is logged at warning level).
     """
     # Suppress databricks-feature-lookup warning for feature store cases
     # Suppress databricks-chains, databricks-rag, and databricks-agents warnings for RAG
@@ -692,18 +695,27 @@ def warn_dependency_requirement_mismatches(model_requirements: list[str]):
 
         if len(mismatch_infos) > 0:
             mismatch_str = " - " + "\n - ".join(mismatch_infos)
-            warning_msg = (
+            return (
                 "Detected one or more mismatches between the model's dependencies and the current "
                 f"Python environment:\n{mismatch_str}\n"
                 "To fix the mismatches, call `mlflow.pyfunc.get_model_dependencies(model_uri)` "
                 "to fetch the model's environment and install dependencies using the resulting "
                 "environment file."
             )
-            _logger.warning(warning_msg)
-
+        return None
     except Exception as e:
         _logger.warning(
             f"Encountered an unexpected error ({e!r}) while detecting model dependency "
             "mismatches. Set logging level to DEBUG to see the full traceback."
         )
         _logger.debug("", exc_info=True)
+        return None
+
+
+def warn_dependency_requirement_mismatches(model_requirements: list[str]):
+    """
+    Inspects the model's dependencies and prints a warning if the current Python environment
+    doesn't satisfy them.
+    """
+    if (msg := _get_dependency_requirement_mismatches_message(model_requirements)) is not None:
+        _logger.warning(msg)

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -366,3 +366,73 @@ def test_log_loader_module_model_does_not_emit_pickle_warning(sklearn_knn_model,
         in msg
         for msg in warning_messages
     )
+
+
+def test_load_model_does_not_warn_on_dependency_mismatch_when_load_succeeds(
+    sklearn_knn_model, iris_data, tmp_path
+):
+    """When a dependency version mismatch exists but loading succeeds, no warning should be
+    emitted (MLflow guarantees backwards compatibility for model loading). See ML-52626.
+    """
+    sk_model_path = os.path.join(tmp_path, "knn.pkl")
+    with open(sk_model_path, "wb") as f:
+        pickle.dump(sklearn_knn_model, f)
+
+    model_path = os.path.join(tmp_path, "model")
+    mlflow.pyfunc.save_model(
+        path=model_path,
+        data_path=sk_model_path,
+        loader_module=__name__,
+        code_paths=[__file__],
+    )
+
+    with (
+        mock.patch(
+            "mlflow.pyfunc._get_dependency_requirement_mismatches_message",
+            return_value="Detected one or more mismatches between the model's dependencies",
+        ),
+        mock.patch("mlflow.pyfunc._logger.warning") as mock_log_warning,
+    ):
+        loaded = mlflow.pyfunc.load_model(model_path)
+
+    assert loaded is not None
+    warning_messages = [args[0] for args, _ in mock_log_warning.call_args_list if args]
+    assert not any("Detected one or more mismatches" in msg for msg in warning_messages)
+
+
+def test_load_model_warns_with_dependency_mismatch_when_load_fails(
+    sklearn_knn_model, iris_data, tmp_path
+):
+    """When loading fails, the captured dependency mismatch message should be surfaced as a
+    warning to help users diagnose the failure. See ML-52626.
+    """
+    sk_model_path = os.path.join(tmp_path, "knn.pkl")
+    with open(sk_model_path, "wb") as f:
+        pickle.dump(sklearn_knn_model, f)
+
+    model_path = os.path.join(tmp_path, "model")
+    mlflow.pyfunc.save_model(
+        path=model_path,
+        data_path=sk_model_path,
+        loader_module=__name__,
+        code_paths=[__file__],
+    )
+
+    mismatch_message = (
+        "Detected one or more mismatches between the model's dependencies and the current "
+        "Python environment:\n - mlflow (current: 9.9.9, required: mlflow==1.2.3)"
+    )
+
+    with (
+        mock.patch(
+            "mlflow.pyfunc._get_dependency_requirement_mismatches_message",
+            return_value=mismatch_message,
+        ),
+        mock.patch(f"{__name__}._load_pyfunc", side_effect=RuntimeError("simulated load failure")),
+        mock.patch("mlflow.pyfunc._logger.warning") as mock_log_warning,
+        pytest.raises(RuntimeError, match="simulated load failure"),
+    ):
+        mlflow.pyfunc.load_model(model_path)
+
+    warning_messages = [args[0] for args, _ in mock_log_warning.call_args_list if args]
+    assert any("Detected one or more mismatches" in msg for msg in warning_messages)

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -170,7 +170,9 @@ def test_spark_udf(spark, model_path):
         code_paths=[os.path.dirname(tests.__file__)],
     )
 
-    with mock.patch("mlflow.pyfunc.warn_dependency_requirement_mismatches") as mock_check_fn:
+    with mock.patch(
+        "mlflow.pyfunc._get_dependency_requirement_mismatches_message"
+    ) as mock_check_fn:
         reloaded_pyfunc_model = mlflow.pyfunc.load_model(model_path)
         mock_check_fn.assert_called_once()
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to [ML-52626](https://databricks.atlassian.net/browse/ML-52626)

### What changes are proposed in this pull request?

`mlflow.pyfunc.load_model` previously printed a "Detected one or more mismatches between the model's dependencies and the current Python environment" warning on every load when the runtime MLflow (or any other) version differs from the logged requirements. The warning fired even when the load succeeded without issue, which is the common case since MLflow guarantees backwards compatibility for model loading. Users have repeatedly flagged this as noisy (see ML-52626 / postmortem-followup-long-term).

This PR defers the warning until/unless `_load_pyfunc` actually fails:

- `mlflow/utils/requirements_utils.py`: extracts a new `_get_dependency_requirement_mismatches_message` helper that returns the warning text (or `None`). The public `warn_dependency_requirement_mismatches` is preserved as a thin wrapper, so save-time call sites in `mlflow/utils/environment.py` and the `spark_udf` `env_manager="local"` path are unchanged.
- `mlflow/pyfunc/__init__.py`: `load_model` now captures the mismatch message instead of logging it eagerly. On a failing `_load_pyfunc`, the message is either appended to the Feature-Store-specific `MlflowException` body or logged as a warning before re-raising, so users still get the diagnostic context when it actually matters.
- The existing `suppress_warnings=True` short-circuit is preserved.

Note: this is intentionally a behavior change. Tooling that relied on detecting the warning string on successful loads will no longer see it. The text and trigger conditions for failure paths are unchanged.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added two tests in `tests/pyfunc/test_model_export_with_loader_module_and_data_path.py`:

- `test_load_model_does_not_warn_on_dependency_mismatch_when_load_succeeds`: confirms no warning is emitted when the mismatch message is non-empty but loading succeeds.
- `test_load_model_warns_with_dependency_mismatch_when_load_fails`: confirms the captured mismatch message is logged as a warning when `_load_pyfunc` raises.

Updated `tests/pyfunc/test_spark.py::test_spark_udf` to mock the new helper instead of the wrapper.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. `mlflow.pyfunc.load_model` no longer prints a "Detected one or more mismatches between the model's dependencies and the current Python environment" warning when the load succeeds. The mismatch information is still surfaced if loading fails.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release