### PR TITLE
Expose existing `/api/2.0` endpoints at `/api/v3/mlflow`

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -584,6 +584,7 @@ from mlflow.utils.model_utils import (
 )
 from mlflow.utils.nfs_on_spark import get_nfs_cache_root_dir
 from mlflow.utils.requirements_utils import (
+    _get_dependency_requirement_mismatches_message,
     _parse_requirements,
     warn_dependency_requirement_mismatches,
 )
@@ -1070,6 +1071,12 @@ def _get_pip_requirements_from_model_path(model_path: str):
     return [req.req_str for req in _parse_requirements(req_file_path, is_constraint=False)]
 
 
+def _append_mismatch_message(error_message: str, mismatch_message: str | None) -> str:
+    if not mismatch_message:
+        return error_message
+    return f"{error_message}\n\n{mismatch_message}"
+
+
 @trace_disabled  # Suppress traces while loading model
 def load_model(
     model_uri: str,
@@ -1132,9 +1139,14 @@ def load_model(
         artifact_uri=model_uri, output_path=dst_path, lineage_header_info=lineage_header_info
     )
 
+    # Capture any dependency mismatch info upfront, but defer surfacing it until/unless the
+    # model fails to load. MLflow guarantees backwards compatibility for model loading, so the
+    # mismatch is only noteworthy if loading actually fails. Eagerly warning on every load
+    # creates noise for users who load successfully (the common case). See ML-52626.
+    mismatch_message = None
     if not suppress_warnings:
         model_requirements = _get_pip_requirements_from_model_path(local_path)
-        warn_dependency_requirement_mismatches(model_requirements)
+        mismatch_message = _get_dependency_requirement_mismatches_message(model_requirements)
 
     model_meta = Model.load(os.path.join(local_path, MLMODEL_FILE_NAME))
 
@@ -1178,13 +1190,24 @@ def load_model(
         # databricks module errors will just be re-raised.
         if conf[MAIN] == _DATABRICKS_FS_LOADER_MODULE and e.name.startswith("databricks"):
             raise MlflowException(
-                f"{e.msg}; "
-                "Note: mlflow.pyfunc.load_model is not supported for Feature Store models. "
-                "spark_udf() and predict() will not work as expected. Use "
-                "score_batch for offline predictions.",
+                _append_mismatch_message(
+                    f"{e.msg}; "
+                    "Note: mlflow.pyfunc.load_model is not supported for Feature Store models. "
+                    "spark_udf() and predict() will not work as expected. Use "
+                    "score_batch for offline predictions.",
+                    mismatch_message,
+                ),
                 BAD_REQUEST,
             ) from None
+        if mismatch_message:
+            _logger.warning(mismatch_message)
         raise e
+    except Exception:
+        # Surface the dependency mismatch info (if any) as a warning so that users can see it
+        # alongside the load failure traceback. See ML-52626.
+        if mismatch_message:
+            _logger.warning(mismatch_message)
+        raise
     finally:
         # clean up the dependencies schema which is set to global state after loading the model.
         # This avoids the schema being used by other models loaded in the same process.

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -6139,6 +6139,23 @@ def _get_ajax_path(base_path, version=2):
     return _add_static_prefix(f"/ajax-api/{version}.0{base_path}")
 
 
+def _get_v3_alias_path(base_path):
+    """
+    Returns the ``/api/v3`` alias for an endpoint currently registered under
+    ``/api/2.0/mlflow/...``.
+
+    Existing OSS tracking endpoints are exposed at ``/api/2.0/mlflow/...``. We
+    additionally register them at ``/api/v3/mlflow/...`` so callers can target a
+    stable, version-prefixed path (e.g. ``/api/v3/mlflow/experiments/create``). The
+    original ``/api/2.0`` routes are unchanged.
+
+    Only base paths starting with ``/mlflow/`` are aliased; sibling namespaces such
+    as ``/mlflow-artifacts/`` have route-specific auth handling and are not part of
+    the ``/api/v3/mlflow`` surface described in ML-52147.
+    """
+    return _add_static_prefix(f"/api/v3{base_path}")
+
+
 def _add_static_prefix(route: str) -> str:
     if prefix := os.environ.get(STATIC_PREFIX_ENV_VAR):
         return prefix.rstrip("/") + route
@@ -6149,10 +6166,15 @@ def _get_paths(base_path, version=2):
     """
     A service endpoints base path is typically something like /mlflow/experiment.
     We should register paths like /api/2.0/mlflow/experiment and
-    /ajax-api/2.0/mlflow/experiment in the Flask router.
+    /ajax-api/2.0/mlflow/experiment in the Flask router. Endpoints registered at
+    ``/api/2.0`` are additionally aliased under ``/api/v3`` so callers can use the
+    new prefix (e.g. ``/api/v3/mlflow/experiments/create``) interchangeably.
     """
     base_path = _convert_path_parameter_to_flask_format(base_path)
-    return [_get_rest_path(base_path, version), _get_ajax_path(base_path, version)]
+    paths = [_get_rest_path(base_path, version), _get_ajax_path(base_path, version)]
+    if version == 2 and base_path.startswith("/mlflow/"):
+        paths.append(_get_v3_alias_path(base_path))
+    return paths
 
 
 def _convert_path_parameter_to_flask_format(path):

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -659,10 +659,13 @@ def _check_requirement_satisfied(requirement_str: str) -> _MismatchedPackageInfo
     return None
 
 
-def warn_dependency_requirement_mismatches(model_requirements: list[str]):
+def _get_dependency_requirement_mismatches_message(model_requirements: list[str]) -> str | None:
     """
-    Inspects the model's dependencies and prints a warning if the current Python environment
-    doesn't satisfy them.
+    Inspects the model's dependencies and returns a message describing any mismatches
+    between the model's required dependencies and the current Python environment.
+
+    Returns ``None`` when no mismatches are detected or when an unexpected error occurs while
+    detecting mismatches (in which case the error is logged at warning level).
     """
     # Suppress databricks-feature-lookup warning for feature store cases
     # Suppress databricks-chains, databricks-rag, and databricks-agents warnings for RAG
@@ -692,18 +695,27 @@ def warn_dependency_requirement_mismatches(model_requirements: list[str]):
 
         if len(mismatch_infos) > 0:
             mismatch_str = " - " + "\n - ".join(mismatch_infos)
-            warning_msg = (
+            return (
                 "Detected one or more mismatches between the model's dependencies and the current "
                 f"Python environment:\n{mismatch_str}\n"
                 "To fix the mismatches, call `mlflow.pyfunc.get_model_dependencies(model_uri)` "
                 "to fetch the model's environment and install dependencies using the resulting "
                 "environment file."
             )
-            _logger.warning(warning_msg)
-
+        return None
     except Exception as e:
         _logger.warning(
             f"Encountered an unexpected error ({e!r}) while detecting model dependency "
             "mismatches. Set logging level to DEBUG to see the full traceback."
         )
         _logger.debug("", exc_info=True)
+        return None
+
+
+def warn_dependency_requirement_mismatches(model_requirements: list[str]):
+    """
+    Inspects the model's dependencies and prints a warning if the current Python environment
+    doesn't satisfy them.
+    """
+    if (msg := _get_dependency_requirement_mismatches_message(model_requirements)) is not None:
+        _logger.warning(msg)

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -366,3 +366,73 @@ def test_log_loader_module_model_does_not_emit_pickle_warning(sklearn_knn_model,
         in msg
         for msg in warning_messages
     )
+
+
+def test_load_model_does_not_warn_on_dependency_mismatch_when_load_succeeds(
+    sklearn_knn_model, iris_data, tmp_path
+):
+    """When a dependency version mismatch exists but loading succeeds, no warning should be
+    emitted (MLflow guarantees backwards compatibility for model loading). See ML-52626.
+    """
+    sk_model_path = os.path.join(tmp_path, "knn.pkl")
+    with open(sk_model_path, "wb") as f:
+        pickle.dump(sklearn_knn_model, f)
+
+    model_path = os.path.join(tmp_path, "model")
+    mlflow.pyfunc.save_model(
+        path=model_path,
+        data_path=sk_model_path,
+        loader_module=__name__,
+        code_paths=[__file__],
+    )
+
+    with (
+        mock.patch(
+            "mlflow.pyfunc._get_dependency_requirement_mismatches_message",
+            return_value="Detected one or more mismatches between the model's dependencies",
+        ),
+        mock.patch("mlflow.pyfunc._logger.warning") as mock_log_warning,
+    ):
+        loaded = mlflow.pyfunc.load_model(model_path)
+
+    assert loaded is not None
+    warning_messages = [args[0] for args, _ in mock_log_warning.call_args_list if args]
+    assert not any("Detected one or more mismatches" in msg for msg in warning_messages)
+
+
+def test_load_model_warns_with_dependency_mismatch_when_load_fails(
+    sklearn_knn_model, iris_data, tmp_path
+):
+    """When loading fails, the captured dependency mismatch message should be surfaced as a
+    warning to help users diagnose the failure. See ML-52626.
+    """
+    sk_model_path = os.path.join(tmp_path, "knn.pkl")
+    with open(sk_model_path, "wb") as f:
+        pickle.dump(sklearn_knn_model, f)
+
+    model_path = os.path.join(tmp_path, "model")
+    mlflow.pyfunc.save_model(
+        path=model_path,
+        data_path=sk_model_path,
+        loader_module=__name__,
+        code_paths=[__file__],
+    )
+
+    mismatch_message = (
+        "Detected one or more mismatches between the model's dependencies and the current "
+        "Python environment:\n - mlflow (current: 9.9.9, required: mlflow==1.2.3)"
+    )
+
+    with (
+        mock.patch(
+            "mlflow.pyfunc._get_dependency_requirement_mismatches_message",
+            return_value=mismatch_message,
+        ),
+        mock.patch(f"{__name__}._load_pyfunc", side_effect=RuntimeError("simulated load failure")),
+        mock.patch("mlflow.pyfunc._logger.warning") as mock_log_warning,
+        pytest.raises(RuntimeError, match="simulated load failure"),
+    ):
+        mlflow.pyfunc.load_model(model_path)
+
+    warning_messages = [args[0] for args, _ in mock_log_warning.call_args_list if args]
+    assert any("Detected one or more mismatches" in msg for msg in warning_messages)

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -170,7 +170,9 @@ def test_spark_udf(spark, model_path):
         code_paths=[os.path.dirname(tests.__file__)],
     )
 
-    with mock.patch("mlflow.pyfunc.warn_dependency_requirement_mismatches") as mock_check_fn:
+    with mock.patch(
+        "mlflow.pyfunc._get_dependency_requirement_mismatches_message"
+    ) as mock_check_fn:
         reloaded_pyfunc_model = mlflow.pyfunc.load_model(model_path)
         mock_check_fn.assert_called_once()
 

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -441,7 +441,40 @@ def test_server_info_handles_unexpected_trace_archival_config_error(monkeypatch)
 def test_get_endpoints():
     endpoints = get_endpoints()
     create_experiment_endpoint = [e for e in endpoints if e[1] == _create_experiment]
-    assert len(create_experiment_endpoint) == 2
+    # /api/2.0/mlflow/experiments/create, /ajax-api/2.0/mlflow/experiments/create,
+    # and the /api/v3/mlflow/experiments/create alias (ML-52147).
+    assert len(create_experiment_endpoint) == 3
+    paths = {e[0] for e in create_experiment_endpoint}
+    assert paths == {
+        "/api/2.0/mlflow/experiments/create",
+        "/ajax-api/2.0/mlflow/experiments/create",
+        "/api/v3/mlflow/experiments/create",
+    }
+
+
+def test_v3_alias_only_for_mlflow_namespace():
+    # /mlflow-artifacts/... is intentionally not aliased to /api/v3 (ML-52147 scope).
+    endpoints = get_endpoints()
+    v3_paths = [path for path, _, _ in endpoints if path.startswith("/api/v3/")]
+    assert v3_paths, "expected at least one /api/v3 alias to be registered"
+    assert all(path.startswith("/api/v3/mlflow/") for path in v3_paths)
+
+
+def test_v3_alias_routes_dispatch_to_existing_handler(
+    mock_get_request_message, mock_tracking_store
+):
+    mock_get_request_message.return_value = CreateExperiment(name="exp")
+    mock_tracking_store.create_experiment.return_value = "0"
+
+    with app.test_client() as c:
+        response = c.post(
+            "/api/v3/mlflow/experiments/create",
+            json={"name": "exp"},
+        )
+
+    assert response.status_code == 200
+    assert response.get_json() == {"experiment_id": "0"}
+    mock_tracking_store.create_experiment.assert_called_once()
 
 
 def test_convert_path_parameter_to_flask_format():


### PR DESCRIPTION
### Related Issues/PRs

Relates to [ML-52147](https://databricks.atlassian.net/browse/ML-52147).

### What changes are proposed in this pull request?

Adds an `/api/v3` alias for every tracking-server endpoint currently registered under `/api/2.0/mlflow/...`. For example, `/api/2.0/mlflow/experiments/create` is now also reachable at `/api/v3/mlflow/experiments/create`. The original `/api/2.0` routes are unchanged, so existing clients are unaffected.

The alias is wired into the existing `_get_paths` helper in `mlflow/server/handlers.py`, so it flows automatically through:

- Flask URL registration in `mlflow/server/__init__.py`
- `BEFORE_REQUEST_VALIDATORS` and friends in `mlflow/server/auth/__init__.py` (built from `get_endpoints`), so basic-auth permission checks apply to the v3 alias as well.

Scope note: only base paths starting with `/mlflow/` are aliased (i.e. tracking, model-registry, webhooks, server-info). `/mlflow-artifacts/...` is intentionally **not** aliased - those endpoints have route-specific auth handling and are not part of the `/api/v3/mlflow` surface described in the Jira.

### How is this PR tested?

- [x] Existing unit/integration tests (`tests/server/test_handlers.py`, `tests/server/test_security.py`, `tests/tracking/test_rest_tracking.py` sqlalchemy variants)
- [x] New unit/integration tests
  - `test_v3_alias_only_for_mlflow_namespace` - confirms `/mlflow-artifacts/` is excluded.
  - `test_v3_alias_routes_dispatch_to_existing_handler` - hits `/api/v3/mlflow/experiments/create` through the Flask test client and asserts it lands in the existing `_create_experiment` handler.
  - Updated `test_get_endpoints` to assert all three registrations (`/api/2.0`, `/ajax-api/2.0`, `/api/v3`).
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. MLflow tracking REST endpoints under `/api/2.0/mlflow/...` are now also available at `/api/v3/mlflow/...`. The `/api/2.0` routes are unchanged.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release