### PR TITLE
RBAC: `default_permission` is a floor; workspace `USE` stops folding into resource lookups

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -548,17 +548,21 @@ def _get_role_permission_or_default(
 ) -> Permission:
     """Fold the role-derived permission against ``default_permission`` as a floor.
 
-    Carve-outs:
-    - ``None`` (no grant matched, workspaces disabled) → return ``default_permission``.
-    - ``NO_PERMISSIONS`` (explicit deny / no presence in workspace) → preserve;
-      the floor must not lift a denial.
-    - Otherwise → ``max(role_permission, default_permission)``.
+    ``NO_PERMISSIONS`` is preserved rather than max'd against ``default_permission``
+    — it's the resolver's "user has no presence in this workspace" signal (no role
+    matches in the resource's workspace and it isn't an autograted default workspace).
+    That's the only place the workspace boundary lives in this chain; lifting it via
+    the floor would silently leak ``default_permission`` (e.g. READ) into every
+    workspace the user has no role in. ``None`` (workspaces disabled, no grant) still
+    falls through to ``default_permission`` as the safety net.
     """
     perm = role_permission_func()
     default = get_permission(auth_config.default_permission)
     if perm is None:
+        # Workspaces disabled, no grant matched.
         return default
     if perm.name == NO_PERMISSIONS.name:
+        # Workspace-boundary deny — see docstring.
         return perm
     return get_permission(max_permission(perm.name, default.name))
 

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -548,12 +548,22 @@ def _get_role_permission_or_default(
 ) -> Permission:
     """
     Resolve a user's permission on a resource by consulting role_permissions via the
-    provided ``role_permission_func`` (see ``_role_permission_for``).
+    provided ``role_permission_func`` (see ``_role_permission_for``) and folding the
+    result against ``auth_config.default_permission`` as a floor.
 
-    Returns whatever ``role_permission_func`` produces if non-None — including
-    ``NO_PERMISSIONS``, which acts as an explicit deny. Falls back to
-    ``auth_config.default_permission`` only when ``role_permission_func`` returns
-    ``None`` (no matching grant at all).
+    Semantics:
+
+    - ``role_permission_func`` returns ``None`` (no grant matched, workspaces
+      disabled): fall through to ``default_permission`` — same as before.
+    - ``role_permission_func`` returns ``NO_PERMISSIONS``: explicit deny survives
+      the floor. This is the "user has no presence in this workspace" or "resource
+      not found" case (see ``_role_permission_for``) — denial is denial, the
+      floor must not lift it.
+    - Otherwise: take the max of the role-derived permission and
+      ``default_permission``. This makes a permissive default ``MANAGE`` lift
+      every lesser specific grant to ``MANAGE`` — operators who want to restrict
+      a user on a particular resource must lower ``default_permission`` and grant
+      up, rather than grant a lesser permission to scope down.
 
     In the unified RBAC model (post-``e5f6a7b8c9d0`` migration), ``role_permissions`` is
     the sole source of truth: per-user grants live under synthetic ``__user_<id>__``
@@ -562,15 +572,18 @@ def _get_role_permission_or_default(
     ``get_role_permission_for_resource`` walks all of the user's role grants and
     returns the max, or ``None`` when nothing matches.
 
-    ``NO_PERMISSIONS`` is no longer accepted as a new grant value (validators reject it
-    on resource-scoped writes; the migration drops legacy ``NO_PERMISSIONS`` rows).
-    Any pre-existing ``NO_PERMISSIONS`` row in ``role_permissions`` from the early RBAC
-    API still resolves correctly via the explicit-deny semantics described above.
+    ``NO_PERMISSIONS`` is not accepted as a new grant value (validators reject it on
+    resource-scoped writes; the migration drops legacy ``NO_PERMISSIONS`` rows).
+    Any pre-existing ``NO_PERMISSIONS`` row in ``role_permissions`` from the early
+    RBAC API still resolves correctly via the explicit-deny carve-out above.
     """
     perm = role_permission_func()
-    if perm is not None:
+    default = get_permission(auth_config.default_permission)
+    if perm is None:
+        return default
+    if perm.name == NO_PERMISSIONS.name:
         return perm
-    return get_permission(auth_config.default_permission)
+    return get_permission(max_permission(perm.name, default.name))
 
 
 def _user_can_create_in_workspace() -> bool:

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -546,36 +546,13 @@ def _user_inherits_default_workspace_grant(workspace_name: str) -> bool:
 def _get_role_permission_or_default(
     role_permission_func: Callable[[], Permission | None],
 ) -> Permission:
-    """
-    Resolve a user's permission on a resource by consulting role_permissions via the
-    provided ``role_permission_func`` (see ``_role_permission_for``) and folding the
-    result against ``auth_config.default_permission`` as a floor.
+    """Fold the role-derived permission against ``default_permission`` as a floor.
 
-    Semantics:
-
-    - ``role_permission_func`` returns ``None`` (no grant matched, workspaces
-      disabled): fall through to ``default_permission`` — same as before.
-    - ``role_permission_func`` returns ``NO_PERMISSIONS``: explicit deny survives
-      the floor. This is the "user has no presence in this workspace" or "resource
-      not found" case (see ``_role_permission_for``) — denial is denial, the
-      floor must not lift it.
-    - Otherwise: take the max of the role-derived permission and
-      ``default_permission``. This makes a permissive default ``MANAGE`` lift
-      every lesser specific grant to ``MANAGE`` — operators who want to restrict
-      a user on a particular resource must lower ``default_permission`` and grant
-      up, rather than grant a lesser permission to scope down.
-
-    In the unified RBAC model (post-``e5f6a7b8c9d0`` migration), ``role_permissions`` is
-    the sole source of truth: per-user grants live under synthetic ``__user_<id>__``
-    roles, workspace-wide grants live in the unified ``('workspace', '*')`` slot
-    (USE for regular workspace members, MANAGE for workspace admins).
-    ``get_role_permission_for_resource`` walks all of the user's role grants and
-    returns the max, or ``None`` when nothing matches.
-
-    ``NO_PERMISSIONS`` is not accepted as a new grant value (validators reject it on
-    resource-scoped writes; the migration drops legacy ``NO_PERMISSIONS`` rows).
-    Any pre-existing ``NO_PERMISSIONS`` row in ``role_permissions`` from the early
-    RBAC API still resolves correctly via the explicit-deny carve-out above.
+    Carve-outs:
+    - ``None`` (no grant matched, workspaces disabled) → return ``default_permission``.
+    - ``NO_PERMISSIONS`` (explicit deny / no presence in workspace) → preserve;
+      the floor must not lift a denial.
+    - Otherwise → ``max(role_permission, default_permission)``.
     """
     perm = role_permission_func()
     default = get_permission(auth_config.default_permission)

--- a/mlflow/server/auth/sqlalchemy_store.py
+++ b/mlflow/server/auth/sqlalchemy_store.py
@@ -2022,18 +2022,9 @@ class SqlAlchemyStore:
             best_permission_name: str | None = None
             for role in roles:
                 for rp in role.permissions:
-                    # Workspace-wide permission slot. The unified ``('workspace', '*')``
-                    # row accepts USE (regular member) or MANAGE (workspace admin).
-                    #
-                    # Folding into a resource-type query is *tier-dependent*:
-                    # - MANAGE always folds — a workspace admin sees and edits every
-                    #   resource in the workspace, by design.
-                    # - USE folds only for workspace-tier queries (the membership /
-                    #   create-rights signal). For resource-type queries (experiment,
-                    #   registered_model, …) workspace USE does **not** participate —
-                    #   it means "member can join + create their own", not "member can
-                    #   read every resource". To read another user's resource a member
-                    #   needs an explicit grant (per-resource or type-wildcard).
+                    # (workspace, *) folds into resource-type queries only for
+                    # MANAGE (workspace admin); USE is the "member can join +
+                    # create" signal and folds only for workspace-tier queries.
                     if rp.resource_type == RESOURCE_TYPE_WORKSPACE and rp.resource_pattern == "*":
                         if resource_type == RESOURCE_TYPE_WORKSPACE or rp.permission == MANAGE.name:
                             best_permission_name = (

--- a/mlflow/server/auth/sqlalchemy_store.py
+++ b/mlflow/server/auth/sqlalchemy_store.py
@@ -2022,16 +2022,25 @@ class SqlAlchemyStore:
             best_permission_name: str | None = None
             for role in roles:
                 for rp in role.permissions:
-                    # Workspace-wide permission — applies to every resource type.
-                    # The unified ``('workspace', '*')`` slot accepts either USE
-                    # (regular workspace member) or MANAGE (workspace admin); the
-                    # permission tier alone distinguishes the two.
+                    # Workspace-wide permission slot. The unified ``('workspace', '*')``
+                    # row accepts USE (regular member) or MANAGE (workspace admin).
+                    #
+                    # Folding into a resource-type query is *tier-dependent*:
+                    # - MANAGE always folds — a workspace admin sees and edits every
+                    #   resource in the workspace, by design.
+                    # - USE folds only for workspace-tier queries (the membership /
+                    #   create-rights signal). For resource-type queries (experiment,
+                    #   registered_model, …) workspace USE does **not** participate —
+                    #   it means "member can join + create their own", not "member can
+                    #   read every resource". To read another user's resource a member
+                    #   needs an explicit grant (per-resource or type-wildcard).
                     if rp.resource_type == RESOURCE_TYPE_WORKSPACE and rp.resource_pattern == "*":
-                        best_permission_name = (
-                            max_permission(best_permission_name, rp.permission)
-                            if best_permission_name is not None
-                            else rp.permission
-                        )
+                        if resource_type == RESOURCE_TYPE_WORKSPACE or rp.permission == MANAGE.name:
+                            best_permission_name = (
+                                max_permission(best_permission_name, rp.permission)
+                                if best_permission_name is not None
+                                else rp.permission
+                            )
                         continue
                     # Resource-type-specific permission.
                     if rp.resource_type != resource_type:

--- a/tests/server/auth/test_auth_workspace.py
+++ b/tests/server/auth/test_auth_workspace.py
@@ -10,7 +10,7 @@ from mlflow.environment_variables import MLFLOW_ENABLE_WORKSPACES
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
 from mlflow.server import auth as auth_module
-from mlflow.server.auth.permissions import MANAGE, NO_PERMISSIONS, READ, USE
+from mlflow.server.auth.permissions import EDIT, MANAGE, NO_PERMISSIONS, READ, USE
 from mlflow.server.auth.routes import (
     CREATE_PROMPTLAB_RUN,
     GET_ARTIFACT,
@@ -660,12 +660,13 @@ def test_experiment_validators_allow_role_based_workspace_manage(workspace_permi
         assert auth_module.validate_can_create_experiment()
 
 
-def test_experiment_validators_use_permission_allows_read_create_but_blocks_writes(
+def test_experiment_validators_workspace_use_allows_create_but_blocks_reads_on_others(
     workspace_permission_setup,
 ):
-    """Under the simplified model, ``USE`` is the non-admin workspace tier:
-    it allows reading every resource and creating new ones, but blocks
-    updates / deletes / role-admin actions on resources owned by others.
+    """Workspace ``USE`` is the "member" tier: it confers workspace access and
+    create rights, but does not unlock read/write on resources owned by others.
+    The member needs an explicit per-resource grant (or creator-as-owner via the
+    after-request handler) for any capability on a specific resource.
     """
     store = workspace_permission_setup["store"]
     username = workspace_permission_setup["username"]
@@ -674,7 +675,10 @@ def test_experiment_validators_use_permission_allows_read_create_but_blocks_writ
     with auth_module.app.test_request_context(
         "/api/2.0/mlflow/experiments/get", method="GET", query_string={"experiment_id": "exp-1"}
     ):
-        assert auth_module.validate_can_read_experiment()
+        # Workspace USE no longer folds into resource-level lookups. With no
+        # specific grant on exp-1 in this workspace, the resolver yields
+        # NO_PERMISSIONS (the explicit-deny carve-out skips the floor).
+        assert not auth_module.validate_can_read_experiment()
         assert not auth_module.validate_can_update_experiment()
         assert not auth_module.validate_can_delete_experiment()
         assert not auth_module.validate_can_manage_experiment()
@@ -702,7 +706,7 @@ def test_workspace_permission_max_merges_legacy_and_role(workspace_permission_se
         assert auth_module.validate_can_create_experiment()
 
 
-def test_use_workspace_permission_allows_create_but_blocks_others_writes(
+def test_use_workspace_permission_allows_create_but_blocks_reads_and_writes_on_others(
     workspace_permission_setup,
 ):
     store = workspace_permission_setup["store"]
@@ -710,14 +714,17 @@ def test_use_workspace_permission_allows_create_but_blocks_others_writes(
     _set_workspace_permission(store, username, USE.name)
 
     with workspace_context.WorkspaceContext("team-a"):
+        # Workspace USE confers create rights and workspace visibility.
         assert auth_module.validate_can_create_experiment()
         assert auth_module.validate_can_create_registered_model()
 
     with auth_module.app.test_request_context(
         "/api/2.0/mlflow/experiments/get", method="GET", query_string={"experiment_id": "exp-1"}
     ):
-        # USE preserves read; non-owned resources stay read-only.
-        assert auth_module.validate_can_read_experiment()
+        # Workspace USE no longer participates in resource-level resolution —
+        # members can join + create their own, but cannot read others' resources
+        # without an explicit per-resource grant.
+        assert not auth_module.validate_can_read_experiment()
         assert not auth_module.validate_can_update_experiment()
         assert not auth_module.validate_can_delete_experiment()
         assert not auth_module.validate_can_manage_experiment()
@@ -727,7 +734,7 @@ def test_use_workspace_permission_allows_create_but_blocks_others_writes(
         method="GET",
         query_string={"experiment_name": "Primary Experiment"},
     ):
-        assert auth_module.validate_can_read_experiment_by_name()
+        assert not auth_module.validate_can_read_experiment_by_name()
 
     with (
         workspace_context.WorkspaceContext("team-a"),
@@ -738,7 +745,7 @@ def test_use_workspace_permission_allows_create_but_blocks_others_writes(
         ),
     ):
         # Same property for registered models.
-        assert auth_module.validate_can_read_registered_model()
+        assert not auth_module.validate_can_read_registered_model()
         assert not auth_module.validate_can_update_registered_model()
         assert not auth_module.validate_can_delete_registered_model()
         assert not auth_module.validate_can_manage_registered_model()
@@ -815,7 +822,8 @@ def test_experiment_artifact_proxy_validators_respect_permissions(workspace_perm
         method="GET",
     ):
         request.view_args = {"artifact_path": "1/path"}
-        assert auth_module.validate_can_read_experiment_artifact_proxy()
+        # Workspace USE no longer folds into resource-level lookups.
+        assert not auth_module.validate_can_read_experiment_artifact_proxy()
         assert not auth_module.validate_can_update_experiment_artifact_proxy()
         assert not auth_module.validate_can_delete_experiment_artifact_proxy()
 
@@ -938,7 +946,9 @@ def test_run_validators_allow_manage_permission(workspace_permission_setup):
         assert auth_module.validate_can_manage_run()
 
 
-def test_run_validators_read_permission_blocks_writes(workspace_permission_setup):
+def test_run_validators_workspace_use_blocks_reads_and_writes(workspace_permission_setup):
+    # Workspace USE no longer confers read on others' runs; a member needs an
+    # explicit per-resource grant (or to be the run's owner via creator-as-owner).
     store = workspace_permission_setup["store"]
     username = workspace_permission_setup["username"]
     _set_workspace_permission(store, username, USE.name)
@@ -946,7 +956,7 @@ def test_run_validators_read_permission_blocks_writes(workspace_permission_setup
     with auth_module.app.test_request_context(
         "/api/2.0/mlflow/runs/get", method="GET", query_string={"run_id": "run-1"}
     ):
-        assert auth_module.validate_can_read_run()
+        assert not auth_module.validate_can_read_run()
         assert not auth_module.validate_can_update_run()
         assert not auth_module.validate_can_delete_run()
         assert not auth_module.validate_can_manage_run()
@@ -973,7 +983,8 @@ def test_logged_model_validators_respect_permissions(workspace_permission_setup)
         method="GET",
         query_string={"model_id": "model-1"},
     ):
-        assert auth_module.validate_can_read_logged_model()
+        # Workspace USE no longer folds into resource-level lookups.
+        assert not auth_module.validate_can_read_logged_model()
         assert not auth_module.validate_can_update_logged_model()
         assert not auth_module.validate_can_delete_logged_model()
         assert not auth_module.validate_can_manage_logged_model()
@@ -1007,7 +1018,9 @@ def test_scorer_validators_use_workspace_permissions(workspace_permission_setup)
         assert auth_module.validate_can_manage_scorer_permission()
 
 
-def test_scorer_validators_read_permission_blocks_writes(workspace_permission_setup):
+def test_scorer_validators_workspace_use_blocks_reads_and_writes(workspace_permission_setup):
+    # Workspace USE no longer folds into resource-level lookups; reading a scorer
+    # owned by someone else requires an explicit per-resource grant.
     store = workspace_permission_setup["store"]
     username = workspace_permission_setup["username"]
     _set_workspace_permission(store, username, USE.name)
@@ -1017,7 +1030,7 @@ def test_scorer_validators_read_permission_blocks_writes(workspace_permission_se
         method="GET",
         query_string={"experiment_id": "exp-1", "name": "score-1"},
     ):
-        assert auth_module.validate_can_read_scorer()
+        assert not auth_module.validate_can_read_scorer()
         assert not auth_module.validate_can_update_scorer()
         assert not auth_module.validate_can_delete_scorer()
         assert not auth_module.validate_can_manage_scorer()
@@ -1061,12 +1074,14 @@ def test_registered_model_validators_require_manage_for_writes(workspace_permiss
             method="GET",
             query_string={"name": "model-xyz"},
         ):
-            assert auth_module.validate_can_read_registered_model()
+            # Workspace USE doesn't fold into resource lookups — member can't
+            # read others' models without an explicit grant.
+            assert not auth_module.validate_can_read_registered_model()
             assert not auth_module.validate_can_update_registered_model()
             assert not auth_module.validate_can_delete_registered_model()
             assert not auth_module.validate_can_manage_registered_model()
-        # USE confers create rights under the simplified workspace model — the
-        # creator-as-owner mechanism then grants MANAGE on what user creates.
+        # USE still confers create rights; creator-as-owner gives MANAGE on
+        # whatever the user creates.
         assert auth_module.validate_can_create_registered_model()
 
 
@@ -1094,7 +1109,8 @@ def test_prompt_validators_require_manage_for_writes(workspace_permission_setup,
             method="GET",
             query_string={"name": "prompt-xyz"},
         ):
-            assert auth_module.validate_can_read_prompt()
+            # Workspace USE doesn't fold into resource lookups for prompts either.
+            assert not auth_module.validate_can_read_prompt()
             assert not auth_module.validate_can_update_prompt()
             assert not auth_module.validate_can_delete_prompt()
             assert not auth_module.validate_can_manage_prompt()
@@ -1679,13 +1695,15 @@ def test_prompt_optimization_job_validators_use_workspace_permissions(
         assert auth_module.validate_can_delete_prompt_optimization_job()
 
 
-def test_prompt_optimization_job_validators_read_permission_blocks_writes(
+def test_prompt_optimization_job_validators_workspace_use_blocks_reads_and_writes(
     workspace_permission_setup, monkeypatch
 ):
+    # Job auth gates on the parent experiment's permission. Workspace USE no
+    # longer folds into the experiment lookup, so a member with only USE is
+    # denied on jobs they don't own.
     store = workspace_permission_setup["store"]
     username = workspace_permission_setup["username"]
 
-    # Mock get_job to return a job associated with exp-1 (in team-a)
     mock_job = SimpleNamespace(params='{"experiment_id": "exp-1"}')
     monkeypatch.setattr(auth_module, "get_job", lambda job_id: mock_job)
 
@@ -1696,7 +1714,7 @@ def test_prompt_optimization_job_validators_read_permission_blocks_writes(
         method="GET",
         query_string={"job_id": "job-1"},
     ):
-        assert auth_module.validate_can_read_prompt_optimization_job()
+        assert not auth_module.validate_can_read_prompt_optimization_job()
         assert not auth_module.validate_can_update_prompt_optimization_job()
         assert not auth_module.validate_can_delete_prompt_optimization_job()
 
@@ -1900,16 +1918,21 @@ def test_role_grant_permission_level_determines_use_capability(
 # ---- Workspace-wide role grants on gateway resources ----
 
 
-@pytest.mark.parametrize("granted", ["USE", "MANAGE"])
-def test_role_workspace_wide_grant_applies_to_gateway_endpoints(
-    workspace_permission_setup, granted
+@pytest.mark.parametrize(
+    ("granted", "expected_read", "expected_manage"),
+    [
+        # Workspace USE no longer folds into resource-level lookups, so it
+        # doesn't confer access to gateway endpoints owned by others. A member
+        # who needs to invoke or manage an endpoint needs an explicit grant.
+        ("USE", False, False),
+        # Workspace MANAGE continues to fold — workspace admins see and manage
+        # every resource in the workspace, including gateway endpoints.
+        ("MANAGE", True, True),
+    ],
+)
+def test_role_workspace_wide_grant_folds_for_manage_only_on_gateway_endpoints(
+    workspace_permission_setup, granted, expected_read, expected_manage
 ):
-    """``('workspace', '*', X)`` grants apply to every resource type in the
-    workspace — including gateway endpoints. Confirms the workspace-wide
-    short-circuit isn't accidentally gated behind resource_type=='experiment'
-    or similar, which would silently lock workspace admins out of gateway
-    resources. The simplified workspace slot accepts only USE / MANAGE.
-    """
     store = workspace_permission_setup["store"]
     username = workspace_permission_setup["username"]
     _set_workspace_permission(store, username, NO_PERMISSIONS.name)
@@ -1921,22 +1944,24 @@ def test_role_workspace_wide_grant_applies_to_gateway_endpoints(
         method="GET",
         query_string={"endpoint_id": "endpoint-1"},
     ):
-        # Both levels grant READ.
-        assert auth_module.validate_can_read_gateway_endpoint() is True
-
-        # Only MANAGE grants can_delete / can_manage.
-        assert auth_module.validate_can_delete_gateway_endpoint() is (granted == "MANAGE")
-        assert auth_module.validate_can_manage_gateway_endpoint() is (granted == "MANAGE")
+        assert auth_module.validate_can_read_gateway_endpoint() is expected_read
+        assert auth_module.validate_can_delete_gateway_endpoint() is expected_manage
+        assert auth_module.validate_can_manage_gateway_endpoint() is expected_manage
 
 
-@pytest.mark.parametrize("granted", ["USE", "MANAGE"])
-def test_role_workspace_wide_grant_implies_use_on_gateway_endpoint(
-    workspace_permission_setup, granted
+@pytest.mark.parametrize(
+    ("granted", "expected_use"),
+    [
+        # Workspace USE no longer folds into gateway endpoint lookups — a member
+        # cannot invoke an endpoint without an explicit per-endpoint grant.
+        ("USE", False),
+        # Workspace MANAGE still implies USE on every resource in the workspace.
+        ("MANAGE", True),
+    ],
+)
+def test_role_workspace_wide_grant_invocation_tier_dependent(
+    workspace_permission_setup, granted, expected_use
 ):
-    """``('workspace', '*', {USE, MANAGE})`` both imply USE → gateway endpoint
-    invocation allowed. The simplified model collapses the prior READ workspace
-    tier into USE, so a workspace-wide grant always confers can_use.
-    """
     store = workspace_permission_setup["store"]
     username = workspace_permission_setup["username"]
     _set_workspace_permission(store, username, NO_PERMISSIONS.name)
@@ -1944,7 +1969,7 @@ def test_role_workspace_wide_grant_implies_use_on_gateway_endpoint(
     _assign_role_with_permission(store, username, "team-a", "workspace", granted)
 
     with auth_module.app.test_request_context("/"):
-        assert auth_module._validate_gateway_use_permission("endpoint-1", username) is True
+        assert auth_module._validate_gateway_use_permission("endpoint-1", username) is expected_use
 
 
 # ---- Gateway secret and model definition parity ----
@@ -2902,6 +2927,60 @@ def test_list_current_user_permissions_returns_caller_rows_and_admin_flag(tmp_pa
     assert len(payload["permissions"]) == 1
     assert payload["permissions"][0]["workspace"] == "team-a"
     assert payload["permissions"][0]["role_name"] == "viewer"
+
+
+def test_default_permission_floors_lesser_role_grant(monkeypatch):
+    # default_permission is a floor, not a fallback: a higher default lifts a
+    # lower role-derived grant. With default=EDIT and a role-derived READ grant
+    # on the resource, the effective permission is EDIT.
+    monkeypatch.setattr(
+        auth_module,
+        "auth_config",
+        auth_module.auth_config._replace(default_permission=EDIT.name),
+        raising=False,
+    )
+    perm = auth_module._get_role_permission_or_default(lambda: READ)
+    assert perm.name == EDIT.name
+
+
+def test_default_permission_does_not_downgrade_higher_role_grant(monkeypatch):
+    # The floor does not downgrade — a role-derived MANAGE grant stays MANAGE
+    # even when default_permission is lower.
+    monkeypatch.setattr(
+        auth_module,
+        "auth_config",
+        auth_module.auth_config._replace(default_permission=READ.name),
+        raising=False,
+    )
+    perm = auth_module._get_role_permission_or_default(lambda: MANAGE)
+    assert perm.name == MANAGE.name
+
+
+def test_default_permission_does_not_override_explicit_no_permissions(monkeypatch):
+    # NO_PERMISSIONS from the role resolver is the explicit-deny carve-out — it
+    # MUST survive the floor. Otherwise the "user has no presence in this
+    # workspace" deny silently flips to default_permission's level.
+    monkeypatch.setattr(
+        auth_module,
+        "auth_config",
+        auth_module.auth_config._replace(default_permission=MANAGE.name),
+        raising=False,
+    )
+    perm = auth_module._get_role_permission_or_default(lambda: NO_PERMISSIONS)
+    assert perm.name == NO_PERMISSIONS.name
+
+
+def test_default_permission_kicks_in_when_no_grant_matches(monkeypatch):
+    # When the resolver returns None (no grant matched at all — typically the
+    # workspaces-disabled path), default_permission is returned as-is.
+    monkeypatch.setattr(
+        auth_module,
+        "auth_config",
+        auth_module.auth_config._replace(default_permission=EDIT.name),
+        raising=False,
+    )
+    perm = auth_module._get_role_permission_or_default(lambda: None)
+    assert perm.name == EDIT.name
 
 
 def test_user_can_create_in_default_workspace_via_autogrant(monkeypatch):

--- a/tests/server/auth/test_auth_workspace.py
+++ b/tests/server/auth/test_auth_workspace.py
@@ -663,11 +663,8 @@ def test_experiment_validators_allow_role_based_workspace_manage(workspace_permi
 def test_experiment_validators_workspace_use_allows_create_but_blocks_reads_on_others(
     workspace_permission_setup,
 ):
-    """Workspace ``USE`` is the "member" tier: it confers workspace access and
-    create rights, but does not unlock read/write on resources owned by others.
-    The member needs an explicit per-resource grant (or creator-as-owner via the
-    after-request handler) for any capability on a specific resource.
-    """
+    # Workspace USE confers create + workspace access, not read on others'
+    # resources — that needs an explicit per-resource grant.
     store = workspace_permission_setup["store"]
     username = workspace_permission_setup["username"]
     _set_workspace_permission(store, username, USE.name)
@@ -675,9 +672,6 @@ def test_experiment_validators_workspace_use_allows_create_but_blocks_reads_on_o
     with auth_module.app.test_request_context(
         "/api/2.0/mlflow/experiments/get", method="GET", query_string={"experiment_id": "exp-1"}
     ):
-        # Workspace USE no longer folds into resource-level lookups. With no
-        # specific grant on exp-1 in this workspace, the resolver yields
-        # NO_PERMISSIONS (the explicit-deny carve-out skips the floor).
         assert not auth_module.validate_can_read_experiment()
         assert not auth_module.validate_can_update_experiment()
         assert not auth_module.validate_can_delete_experiment()
@@ -714,16 +708,12 @@ def test_use_workspace_permission_allows_create_but_blocks_reads_and_writes_on_o
     _set_workspace_permission(store, username, USE.name)
 
     with workspace_context.WorkspaceContext("team-a"):
-        # Workspace USE confers create rights and workspace visibility.
         assert auth_module.validate_can_create_experiment()
         assert auth_module.validate_can_create_registered_model()
 
     with auth_module.app.test_request_context(
         "/api/2.0/mlflow/experiments/get", method="GET", query_string={"experiment_id": "exp-1"}
     ):
-        # Workspace USE no longer participates in resource-level resolution —
-        # members can join + create their own, but cannot read others' resources
-        # without an explicit per-resource grant.
         assert not auth_module.validate_can_read_experiment()
         assert not auth_module.validate_can_update_experiment()
         assert not auth_module.validate_can_delete_experiment()
@@ -744,7 +734,6 @@ def test_use_workspace_permission_allows_create_but_blocks_reads_and_writes_on_o
             query_string={"name": "model-xyz"},
         ),
     ):
-        # Same property for registered models.
         assert not auth_module.validate_can_read_registered_model()
         assert not auth_module.validate_can_update_registered_model()
         assert not auth_module.validate_can_delete_registered_model()
@@ -822,7 +811,6 @@ def test_experiment_artifact_proxy_validators_respect_permissions(workspace_perm
         method="GET",
     ):
         request.view_args = {"artifact_path": "1/path"}
-        # Workspace USE no longer folds into resource-level lookups.
         assert not auth_module.validate_can_read_experiment_artifact_proxy()
         assert not auth_module.validate_can_update_experiment_artifact_proxy()
         assert not auth_module.validate_can_delete_experiment_artifact_proxy()
@@ -947,8 +935,6 @@ def test_run_validators_allow_manage_permission(workspace_permission_setup):
 
 
 def test_run_validators_workspace_use_blocks_reads_and_writes(workspace_permission_setup):
-    # Workspace USE no longer confers read on others' runs; a member needs an
-    # explicit per-resource grant (or to be the run's owner via creator-as-owner).
     store = workspace_permission_setup["store"]
     username = workspace_permission_setup["username"]
     _set_workspace_permission(store, username, USE.name)
@@ -983,7 +969,6 @@ def test_logged_model_validators_respect_permissions(workspace_permission_setup)
         method="GET",
         query_string={"model_id": "model-1"},
     ):
-        # Workspace USE no longer folds into resource-level lookups.
         assert not auth_module.validate_can_read_logged_model()
         assert not auth_module.validate_can_update_logged_model()
         assert not auth_module.validate_can_delete_logged_model()
@@ -1019,8 +1004,6 @@ def test_scorer_validators_use_workspace_permissions(workspace_permission_setup)
 
 
 def test_scorer_validators_workspace_use_blocks_reads_and_writes(workspace_permission_setup):
-    # Workspace USE no longer folds into resource-level lookups; reading a scorer
-    # owned by someone else requires an explicit per-resource grant.
     store = workspace_permission_setup["store"]
     username = workspace_permission_setup["username"]
     _set_workspace_permission(store, username, USE.name)
@@ -1074,14 +1057,11 @@ def test_registered_model_validators_require_manage_for_writes(workspace_permiss
             method="GET",
             query_string={"name": "model-xyz"},
         ):
-            # Workspace USE doesn't fold into resource lookups — member can't
-            # read others' models without an explicit grant.
             assert not auth_module.validate_can_read_registered_model()
             assert not auth_module.validate_can_update_registered_model()
             assert not auth_module.validate_can_delete_registered_model()
             assert not auth_module.validate_can_manage_registered_model()
-        # USE still confers create rights; creator-as-owner gives MANAGE on
-        # whatever the user creates.
+        # USE still confers create rights via creator-as-owner.
         assert auth_module.validate_can_create_registered_model()
 
 
@@ -1109,7 +1089,6 @@ def test_prompt_validators_require_manage_for_writes(workspace_permission_setup,
             method="GET",
             query_string={"name": "prompt-xyz"},
         ):
-            # Workspace USE doesn't fold into resource lookups for prompts either.
             assert not auth_module.validate_can_read_prompt()
             assert not auth_module.validate_can_update_prompt()
             assert not auth_module.validate_can_delete_prompt()
@@ -1698,9 +1677,7 @@ def test_prompt_optimization_job_validators_use_workspace_permissions(
 def test_prompt_optimization_job_validators_workspace_use_blocks_reads_and_writes(
     workspace_permission_setup, monkeypatch
 ):
-    # Job auth gates on the parent experiment's permission. Workspace USE no
-    # longer folds into the experiment lookup, so a member with only USE is
-    # denied on jobs they don't own.
+    # Job auth gates on parent experiment permission; workspace USE no longer folds.
     store = workspace_permission_setup["store"]
     username = workspace_permission_setup["username"]
 
@@ -1921,12 +1898,8 @@ def test_role_grant_permission_level_determines_use_capability(
 @pytest.mark.parametrize(
     ("granted", "expected_read", "expected_manage"),
     [
-        # Workspace USE no longer folds into resource-level lookups, so it
-        # doesn't confer access to gateway endpoints owned by others. A member
-        # who needs to invoke or manage an endpoint needs an explicit grant.
+        # USE doesn't fold into resource lookups; MANAGE does.
         ("USE", False, False),
-        # Workspace MANAGE continues to fold — workspace admins see and manage
-        # every resource in the workspace, including gateway endpoints.
         ("MANAGE", True, True),
     ],
 )
@@ -1952,10 +1925,8 @@ def test_role_workspace_wide_grant_folds_for_manage_only_on_gateway_endpoints(
 @pytest.mark.parametrize(
     ("granted", "expected_use"),
     [
-        # Workspace USE no longer folds into gateway endpoint lookups — a member
-        # cannot invoke an endpoint without an explicit per-endpoint grant.
+        # USE doesn't fold into resource lookups; MANAGE does.
         ("USE", False),
-        # Workspace MANAGE still implies USE on every resource in the workspace.
         ("MANAGE", True),
     ],
 )
@@ -2930,9 +2901,6 @@ def test_list_current_user_permissions_returns_caller_rows_and_admin_flag(tmp_pa
 
 
 def test_default_permission_floors_lesser_role_grant(monkeypatch):
-    # default_permission is a floor, not a fallback: a higher default lifts a
-    # lower role-derived grant. With default=EDIT and a role-derived READ grant
-    # on the resource, the effective permission is EDIT.
     monkeypatch.setattr(
         auth_module,
         "auth_config",
@@ -2944,8 +2912,6 @@ def test_default_permission_floors_lesser_role_grant(monkeypatch):
 
 
 def test_default_permission_does_not_downgrade_higher_role_grant(monkeypatch):
-    # The floor does not downgrade — a role-derived MANAGE grant stays MANAGE
-    # even when default_permission is lower.
     monkeypatch.setattr(
         auth_module,
         "auth_config",
@@ -2957,9 +2923,7 @@ def test_default_permission_does_not_downgrade_higher_role_grant(monkeypatch):
 
 
 def test_default_permission_does_not_override_explicit_no_permissions(monkeypatch):
-    # NO_PERMISSIONS from the role resolver is the explicit-deny carve-out — it
-    # MUST survive the floor. Otherwise the "user has no presence in this
-    # workspace" deny silently flips to default_permission's level.
+    # NO_PERMISSIONS is the explicit-deny carve-out — must survive the floor.
     monkeypatch.setattr(
         auth_module,
         "auth_config",
@@ -2971,8 +2935,7 @@ def test_default_permission_does_not_override_explicit_no_permissions(monkeypatc
 
 
 def test_default_permission_kicks_in_when_no_grant_matches(monkeypatch):
-    # When the resolver returns None (no grant matched at all — typically the
-    # workspaces-disabled path), default_permission is returned as-is.
+    # None (no grant matched, workspaces disabled) → fall through to default.
     monkeypatch.setattr(
         auth_module,
         "auth_config",

--- a/tests/server/auth/test_client_workspace.py
+++ b/tests/server/auth/test_client_workspace.py
@@ -249,9 +249,8 @@ def test_run_access_controls_across_workspaces(workspace_setup, monkeypatch):
     exp_b = _create_experiment(tracking_uri, workspace_b, auth=(username, password))
     run_b = _create_run(tracking_uri, workspace_b, exp_b, auth=(username, password))
 
-    # Use a separate limited user who is workspace admin in workspace A only.
-    # Workspace MANAGE folds into resource-level lookups (workspace USE does
-    # not), so MANAGE is the simplest "see everything in this workspace" grant.
+    # Limited user is workspace admin in workspace A only (MANAGE folds into
+    # resource lookups; USE does not, so MANAGE is the simplest read-all grant).
     limited_user, limited_password = create_user(tracking_uri)
     grant_role_permission(
         tracking_uri, limited_user, "workspace", "*", "MANAGE", workspace=workspace_a
@@ -314,8 +313,7 @@ def test_registered_model_access_controls_across_workspaces(workspace_setup, mon
     _create_registered_model(tracking_uri, workspace_b, model_b, auth=(username, password))
     _create_model_version(tracking_uri, workspace_b, model_b, run_b, auth=(username, password))
 
-    # Workspace MANAGE folds into resource lookups; workspace USE does not, so
-    # MANAGE is the test grant for "limited user with full read in workspace A".
+    # MANAGE folds into resource lookups; USE does not.
     limited_user, limited_password = create_user(tracking_uri)
     grant_role_permission(
         tracking_uri, limited_user, "workspace", "*", "MANAGE", workspace=workspace_a

--- a/tests/server/auth/test_client_workspace.py
+++ b/tests/server/auth/test_client_workspace.py
@@ -249,10 +249,12 @@ def test_run_access_controls_across_workspaces(workspace_setup, monkeypatch):
     exp_b = _create_experiment(tracking_uri, workspace_b, auth=(username, password))
     run_b = _create_run(tracking_uri, workspace_b, exp_b, auth=(username, password))
 
-    # Use a separate limited user who only has access to workspace A.
+    # Use a separate limited user who is workspace admin in workspace A only.
+    # Workspace MANAGE folds into resource-level lookups (workspace USE does
+    # not), so MANAGE is the simplest "see everything in this workspace" grant.
     limited_user, limited_password = create_user(tracking_uri)
     grant_role_permission(
-        tracking_uri, limited_user, "workspace", "*", "USE", workspace=workspace_a
+        tracking_uri, limited_user, "workspace", "*", "MANAGE", workspace=workspace_a
     )
 
     # Positive: limited user can read run in workspace A.
@@ -312,9 +314,11 @@ def test_registered_model_access_controls_across_workspaces(workspace_setup, mon
     _create_registered_model(tracking_uri, workspace_b, model_b, auth=(username, password))
     _create_model_version(tracking_uri, workspace_b, model_b, run_b, auth=(username, password))
 
+    # Workspace MANAGE folds into resource lookups; workspace USE does not, so
+    # MANAGE is the test grant for "limited user with full read in workspace A".
     limited_user, limited_password = create_user(tracking_uri)
     grant_role_permission(
-        tracking_uri, limited_user, "workspace", "*", "USE", workspace=workspace_a
+        tracking_uri, limited_user, "workspace", "*", "MANAGE", workspace=workspace_a
     )
 
     # Positive: limited user can read model in authorized workspace.

--- a/tests/server/auth/test_sqlalchemy_store_rbac.py
+++ b/tests/server/auth/test_sqlalchemy_store_rbac.py
@@ -444,27 +444,47 @@ def test_get_role_permission_workspace_admin(store, user):
     assert result == MANAGE
 
 
-def test_workspace_permission_applies_across_resource_types(store, user):
+def test_workspace_use_does_not_fold_into_resource_lookups(store, user):
+    # Workspace USE is the "member" tier — confers workspace access and create
+    # rights, but does NOT propagate to resource-level lookups. A member needs
+    # explicit per-resource grants for read/write capability.
     role = store.create_role(name="user", workspace="ws1")
     store.add_role_permission(role.id, "workspace", "*", "USE")
     store.assign_role_to_user(user.id, role.id)
 
-    # USE on the workspace-wide grant form propagates to every resource type.
-    assert store.get_role_permission_for_resource(user.id, "experiment", "1", "ws1") == USE
-    assert store.get_role_permission_for_resource(user.id, "registered_model", "m1", "ws1") == USE
-    assert store.get_role_permission_for_resource(user.id, "gateway_endpoint", "e1", "ws1") == USE
+    assert store.get_role_permission_for_resource(user.id, "experiment", "1", "ws1") is None
+    assert store.get_role_permission_for_resource(user.id, "registered_model", "m1", "ws1") is None
+    assert store.get_role_permission_for_resource(user.id, "gateway_endpoint", "e1", "ws1") is None
+    # Workspace-tier lookup still finds the grant (used by _user_can_create_in_workspace).
+    assert store.get_role_permission_for_resource(user.id, "workspace", "*", "ws1") == USE
 
 
-def test_workspace_permission_respects_union_with_specific(store, user):
+def test_workspace_manage_folds_across_resource_types(store, user):
+    # Workspace MANAGE still propagates to every resource type — workspace admins
+    # see and manage everything in the workspace, by design.
+    role = store.create_role(name="ws-admin", workspace="ws1")
+    store.add_role_permission(role.id, "workspace", "*", "MANAGE")
+    store.assign_role_to_user(user.id, role.id)
+
+    assert store.get_role_permission_for_resource(user.id, "experiment", "1", "ws1") == MANAGE
+    assert (
+        store.get_role_permission_for_resource(user.id, "registered_model", "m1", "ws1") == MANAGE
+    )
+    assert (
+        store.get_role_permission_for_resource(user.id, "gateway_endpoint", "e1", "ws1") == MANAGE
+    )
+
+
+def test_workspace_use_plus_specific_grant_returns_specific(store, user):
+    # Workspace USE no longer participates in resource lookups, so the specific
+    # EDIT grant stands alone for experiment 42, and other experiments yield None.
     role = store.create_role(name="mixed", workspace="ws1")
     store.add_role_permission(role.id, "workspace", "*", "USE")
     store.add_role_permission(role.id, "experiment", "42", "EDIT")
     store.assign_role_to_user(user.id, role.id)
 
-    # Experiment 42: max(workspace USE, specific EDIT) = EDIT
     assert store.get_role_permission_for_resource(user.id, "experiment", "42", "ws1") == EDIT
-    # Other experiments: just workspace USE
-    assert store.get_role_permission_for_resource(user.id, "experiment", "99", "ws1") == USE
+    assert store.get_role_permission_for_resource(user.id, "experiment", "99", "ws1") is None
 
 
 def test_is_workspace_admin(store, user):
@@ -698,16 +718,15 @@ def test_resolver_workspace_grant_promotes_to_every_resource_type(store, user, r
 @pytest.mark.parametrize(
     ("granted", "expected"),
     [
-        ("USE", USE),
+        # Workspace USE is the "member" tier — no longer folds into resource-level
+        # lookups. Members can join + create their own resources, but cannot read
+        # others' resources without explicit per-resource grants.
+        ("USE", None),
+        # Workspace MANAGE still folds into every concrete resource type.
         ("MANAGE", MANAGE),
     ],
 )
-def test_resolver_workspace_grant_propagates_at_every_level(store, user, granted, expected):
-    """``(*, *, X)`` where X ∈ {USE, MANAGE} (the workspace-grantable tiers in
-    the simplified model) promotes X to every concrete resource type. This is
-    the blanket-baseline form the seeded ``user`` role uses for read+create
-    access across the workspace.
-    """
+def test_resolver_workspace_grant_folds_for_manage_only(store, user, granted, expected):
     role = store.create_role(name=f"ws-{granted}", workspace="ws1")
     store.add_role_permission(role.id, "workspace", "*", granted)
     store.assign_role_to_user(user.id, role.id)
@@ -797,11 +816,10 @@ def test_resolver_union_picks_max_across_roles(store, user):
     assert store.get_role_permission_for_resource(user.id, "experiment", "1", "ws1") == MANAGE
 
 
-def test_resolver_union_mixes_workspace_and_resource_grants(store, user):
-    """A workspace-wide USE + a specific experiment READ → resolver still
-    surfaces USE for that experiment, because the workspace grant already
-    covers it. Specific grants only promote, never downgrade.
-    """
+def test_resolver_union_mixes_workspace_use_and_resource_grants(store, user):
+    # Workspace USE no longer folds into resource lookups, so a specific
+    # experiment READ grant stands alone — the resolver returns READ, not USE.
+    # Contrast with workspace MANAGE, which would still fold and dominate.
     r_ws = store.create_role(name="ws-user", workspace="ws1")
     store.add_role_permission(r_ws.id, "workspace", "*", "USE")
     store.assign_role_to_user(user.id, r_ws.id)
@@ -810,7 +828,20 @@ def test_resolver_union_mixes_workspace_and_resource_grants(store, user):
     store.add_role_permission(r_specific.id, "experiment", "42", "READ")
     store.assign_role_to_user(user.id, r_specific.id)
 
-    assert store.get_role_permission_for_resource(user.id, "experiment", "42", "ws1") == USE
+    assert store.get_role_permission_for_resource(user.id, "experiment", "42", "ws1") == READ
+
+
+def test_resolver_union_mixes_workspace_manage_and_resource_grants(store, user):
+    # Workspace MANAGE still folds — wins against any lesser specific grant.
+    r_ws = store.create_role(name="ws-admin", workspace="ws1")
+    store.add_role_permission(r_ws.id, "workspace", "*", "MANAGE")
+    store.assign_role_to_user(user.id, r_ws.id)
+
+    r_specific = store.create_role(name="one-reader", workspace="ws1")
+    store.add_role_permission(r_specific.id, "experiment", "42", "READ")
+    store.assign_role_to_user(user.id, r_specific.id)
+
+    assert store.get_role_permission_for_resource(user.id, "experiment", "42", "ws1") == MANAGE
 
 
 # ---- Legacy workspace_permissions as workspace admin source ----

--- a/tests/server/auth/test_sqlalchemy_store_rbac.py
+++ b/tests/server/auth/test_sqlalchemy_store_rbac.py
@@ -445,9 +445,7 @@ def test_get_role_permission_workspace_admin(store, user):
 
 
 def test_workspace_use_does_not_fold_into_resource_lookups(store, user):
-    # Workspace USE is the "member" tier — confers workspace access and create
-    # rights, but does NOT propagate to resource-level lookups. A member needs
-    # explicit per-resource grants for read/write capability.
+    # USE is the "member" tier: confers create + workspace-tier access only.
     role = store.create_role(name="user", workspace="ws1")
     store.add_role_permission(role.id, "workspace", "*", "USE")
     store.assign_role_to_user(user.id, role.id)
@@ -455,13 +453,12 @@ def test_workspace_use_does_not_fold_into_resource_lookups(store, user):
     assert store.get_role_permission_for_resource(user.id, "experiment", "1", "ws1") is None
     assert store.get_role_permission_for_resource(user.id, "registered_model", "m1", "ws1") is None
     assert store.get_role_permission_for_resource(user.id, "gateway_endpoint", "e1", "ws1") is None
-    # Workspace-tier lookup still finds the grant (used by _user_can_create_in_workspace).
+    # Workspace-tier query still finds it (used by _user_can_create_in_workspace).
     assert store.get_role_permission_for_resource(user.id, "workspace", "*", "ws1") == USE
 
 
 def test_workspace_manage_folds_across_resource_types(store, user):
-    # Workspace MANAGE still propagates to every resource type — workspace admins
-    # see and manage everything in the workspace, by design.
+    # MANAGE still folds — workspace admins see and manage every resource.
     role = store.create_role(name="ws-admin", workspace="ws1")
     store.add_role_permission(role.id, "workspace", "*", "MANAGE")
     store.assign_role_to_user(user.id, role.id)
@@ -476,8 +473,7 @@ def test_workspace_manage_folds_across_resource_types(store, user):
 
 
 def test_workspace_use_plus_specific_grant_returns_specific(store, user):
-    # Workspace USE no longer participates in resource lookups, so the specific
-    # EDIT grant stands alone for experiment 42, and other experiments yield None.
+    # USE doesn't fold; the specific EDIT grant stands alone.
     role = store.create_role(name="mixed", workspace="ws1")
     store.add_role_permission(role.id, "workspace", "*", "USE")
     store.add_role_permission(role.id, "experiment", "42", "EDIT")
@@ -718,11 +714,7 @@ def test_resolver_workspace_grant_promotes_to_every_resource_type(store, user, r
 @pytest.mark.parametrize(
     ("granted", "expected"),
     [
-        # Workspace USE is the "member" tier — no longer folds into resource-level
-        # lookups. Members can join + create their own resources, but cannot read
-        # others' resources without explicit per-resource grants.
         ("USE", None),
-        # Workspace MANAGE still folds into every concrete resource type.
         ("MANAGE", MANAGE),
     ],
 )
@@ -817,9 +809,7 @@ def test_resolver_union_picks_max_across_roles(store, user):
 
 
 def test_resolver_union_mixes_workspace_use_and_resource_grants(store, user):
-    # Workspace USE no longer folds into resource lookups, so a specific
-    # experiment READ grant stands alone — the resolver returns READ, not USE.
-    # Contrast with workspace MANAGE, which would still fold and dominate.
+    # USE doesn't fold; specific READ wins.
     r_ws = store.create_role(name="ws-user", workspace="ws1")
     store.add_role_permission(r_ws.id, "workspace", "*", "USE")
     store.assign_role_to_user(user.id, r_ws.id)
@@ -832,7 +822,7 @@ def test_resolver_union_mixes_workspace_use_and_resource_grants(store, user):
 
 
 def test_resolver_union_mixes_workspace_manage_and_resource_grants(store, user):
-    # Workspace MANAGE still folds — wins against any lesser specific grant.
+    # MANAGE folds and wins against any lesser specific grant.
     r_ws = store.create_role(name="ws-admin", workspace="ws1")
     store.add_role_permission(r_ws.id, "workspace", "*", "MANAGE")
     store.assign_role_to_user(user.id, r_ws.id)


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23247, #23337. Lands after both to keep stack reviews clean.

### What changes are proposed in this pull request?

Two resolver changes that distinguish workspace-tier from resource-tier semantics.

**1. `default_permission` is a floor, not a fallback.** `_get_role_permission_or_default` now folds the role-derived permission against `default_permission` via max, instead of returning the role grant as-is. A permissive default (`MANAGE`) is no longer silently overridden by a specific lesser grant.

Carve-outs:
- `None` (no grant, workspaces disabled) → `default_permission` unchanged.
- `NO_PERMISSIONS` (explicit deny / no presence in workspace) → preserved; the floor must not lift a denial.

**2. Workspace `USE` no longer folds into resource-level lookups.** `SqlAlchemyStore.get_role_permission_for_resource` now only folds `(workspace, *)` for MANAGE (workspace admin) or when the query itself is workspace-tier. Members with workspace USE get workspace access + create rights without auto-reading every resource.

#### Breaking change

Operators relying on the PR #22941 "contributor pattern" (workspace USE = read all + create own) need to update roles. Members now need explicit per-resource grants for read on resources they don't own. Creator-as-owner still gives MANAGE on their own creations. Workspace MANAGE is unchanged.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

`tests/server/auth/test_auth_workspace.py` — 9 tests rewritten for new USE semantics; 4 new tests pinning floor behavior. `tests/server/auth/test_sqlalchemy_store_rbac.py` — 4 store tests rewritten, 2 added. `tests/server/auth/test_client_workspace.py` — 2 integration tests changed limited-user grant from USE → MANAGE.

```bash
uv run --frozen pytest tests/server/auth/  # 533 passed
```

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [x] Instructions

`rbac.mdx` *Permission resolution* + seeded-role description updates land separately on #23133.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`default_permission` now acts as a floor (folded into the max with role-derived grants) rather than a fallback. Workspace `USE` no longer folds into per-resource permission lookups — members get workspace access + create rights without auto-reading other members' resources. Workspace `MANAGE` is unchanged.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
