### PR TITLE
Replace `bin/.installed_versions.json` with runtime version check

### DIFF
--- a/bin/install.py
+++ b/bin/install.py
@@ -7,8 +7,8 @@ import argparse
 import gzip
 import hashlib
 import http.client
-import json
 import platform
+import re
 import shutil
 import subprocess
 import tarfile
@@ -20,14 +20,15 @@ from pathlib import Path
 from typing import Literal
 from urllib.error import HTTPError, URLError
 
-INSTALLED_VERSIONS_FILE = ".installed_versions.json"
-
 # Type definitions
 PlatformKey = tuple[
     Literal["linux", "darwin"],
     Literal["x86_64", "arm64"],
 ]
 ExtractType = Literal["gzip", "tar", "binary"]
+
+
+VERSION_REGEX = re.compile(r"(\d+\.\d+\.\d+)")
 
 
 @dataclass
@@ -43,6 +44,21 @@ class Tool:
     def get_version_args(self) -> list[str]:
         """Get version check arguments, defaulting to --version."""
         return self.version_args or ["--version"]
+
+    def get_installed_version(self, binary_path: Path) -> str | None:
+        """Run the binary's version command and extract the first X.Y.Z in its output."""
+        try:
+            output = subprocess.check_output(
+                [binary_path, *self.get_version_args()],
+                stderr=subprocess.STDOUT,
+                text=True,
+                timeout=5,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
+        if match := VERSION_REGEX.search(output):
+            return match.group(1)
+        return None
 
     def get_extract_type(self, url: str) -> ExtractType:
         """Infer extract type from URL file extension."""
@@ -221,15 +237,17 @@ def extract_tar(download_path: Path, dest: Path, binary_name: str) -> None:
 
 
 def install_tool(tool: Tool, dest_dir: Path, force: bool = False) -> None:
-    # Check if tool already exists
     binary_path = dest_dir / tool.name
     if binary_path.exists():
-        if not force:
-            print(f"  ✓ {tool.name} already installed")
+        installed_version = tool.get_installed_version(binary_path)
+        if not force and installed_version == tool.version:
+            print(f"  ✓ {tool.name} {tool.version} already installed")
             return
+        if installed_version and installed_version != tool.version:
+            print(f"  Replacing {tool.name} {installed_version} with {tool.version}...")
         else:
             print(f"  Removing existing {tool.name}...")
-            binary_path.unlink()
+        binary_path.unlink()
 
     platform_key = get_platform_key()
 
@@ -249,7 +267,6 @@ def install_tool(tool: Tool, dest_dir: Path, force: bool = False) -> None:
         )
     url, expected_sha256 = asset
 
-    binary_path = dest_dir / tool.name
     with tempfile.TemporaryDirectory() as tmp_dir:
         download_path = Path(tmp_dir) / "download"
         download_and_verify(url, download_path, expected_sha256)
@@ -271,18 +288,6 @@ def install_tool(tool: Tool, dest_dir: Path, force: bool = False) -> None:
     version_cmd = [binary_path] + tool.get_version_args()
     subprocess.check_call(version_cmd, timeout=5)
     print(f"Successfully installed {tool.name} to {binary_path}")
-
-
-def load_installed_versions(dest_dir: Path) -> dict[str, str]:
-    f = dest_dir / INSTALLED_VERSIONS_FILE
-    if f.exists():
-        return json.loads(f.read_text())
-    return {}
-
-
-def save_installed_versions(dest_dir: Path, versions: dict[str, str]) -> None:
-    f = dest_dir / INSTALLED_VERSIONS_FILE
-    f.write_text(json.dumps(versions, indent=2, sort_keys=True) + "\n")
 
 
 def main() -> None:
@@ -316,27 +321,15 @@ def main() -> None:
     dest_dir = Path(__file__).resolve().parent
     dest_dir.mkdir(parents=True, exist_ok=True)
 
-    installed_versions = load_installed_versions(dest_dir)
-    outdated_tools = sorted(
-        t.name for t in tools_to_install if installed_versions.get(t.name) != t.version
-    )
-    force_all = args.force_reinstall
-
-    if force_all:
+    if args.force_reinstall:
         print("Force reinstall: removing existing tools and reinstalling...")
-    elif outdated_tools:
-        print(f"Version changes detected for: {', '.join(outdated_tools)}")
     else:
         print("Installing tools to bin/ directory...")
 
     for tool in tools_to_install:
-        # Force reinstall if globally forced or if this tool's version changed
-        force = force_all or tool.name in outdated_tools
         print(f"\nInstalling {tool.name}...")
-        install_tool(tool, dest_dir, force=force)
-        installed_versions[tool.name] = tool.version
+        install_tool(tool, dest_dir, force=args.force_reinstall)
 
-    save_installed_versions(dest_dir, installed_versions)
     print("\nDone!")
 
 


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

`bin/install.py` no longer relies on a `.installed_versions.json` sidecar to decide whether to reinstall a tool. Each `Tool` now exposes `get_installed_version()`, which runs the binary's version command (`--version`, or `version` for `regal`), captures stdout+stderr via `subprocess.check_output(stderr=STDOUT)`, and extracts the first `X.Y.Z` match with a shared `VERSION_REGEX`. `install_tool()` skips when the reported version equals `tool.version` and replaces otherwise.

Trade-off vs. the old cache: a single file read (~1 ms) becomes six subprocess calls (~60 ms total in the warm path). In return the check can no longer drift from reality if a binary is swapped out by hand.

### How is this PR tested?

- [x] Manual tests

Manual verification on darwin/arm64:

- Warm run (all six binaries present at expected versions) prints `✓ <tool> <version> already installed` for each tool. Wall clock ~170 ms total.
- Fresh run after deleting `bin/rg`: rg downloads and reinstalls, the other five are skipped.
- `ruff check` and `ruff format --check` pass on `bin/install.py`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release