### PR TITLE
Drop author role check from `pr-review` skill

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -52,10 +52,10 @@ The `<owner>`/`<repo>`/`<pr_number>` placeholders in the steps below refer to th
 
 ### 1. Fetch PR context
 
-Fetch the PR title, description, and author:
+Fetch the PR title and description:
 
 ```bash
-gh pr view <pr_number> --repo "<owner>/<repo>" --json title,body,author
+gh pr view <pr_number> --repo "<owner>/<repo>" --json title,body
 ```
 
 > **Note:** You have a **read-only** GitHub token. Do NOT call write APIs (`gh api ... POST`, `gh pr review`, `gh pr comment`, etc.).
@@ -122,14 +122,8 @@ Classify each finding by severity (matches `.github/instructions/code-review.ins
 
 Determine the review `event`:
 
-- **No CRITICAL findings AND author has `admin`/`maintain` role** -> `event: "APPROVE"`
-- **Any CRITICAL finding, OR author role is anything else (or the API errors, e.g., 404 for non-collaborators)** -> `event: "COMMENT"`. Do not mention the reason for not approving in the review body.
-
-Check the author's role (use the `author.login` from step 1 as `<author>`):
-
-```bash
-gh api repos/<owner>/<repo>/collaborators/<author>/permission --jq '.role_name'
-```
+- **No CRITICAL findings** -> `event: "APPROVE"`
+- **Any CRITICAL finding** -> `event: "COMMENT"`
 
 ### 6. Emit Review Payload
 

--- a/.claude/skills/pr-review/review-payload.schema.json
+++ b/.claude/skills/pr-review/review-payload.schema.json
@@ -8,7 +8,7 @@
   "required": ["event", "body", "comments"],
   "properties": {
     "event": {
-      "description": "Review action. APPROVE only when there are no CRITICAL findings and the PR author has admin/maintain; otherwise COMMENT.",
+      "description": "Review action. APPROVE only when there are no CRITICAL findings; otherwise COMMENT.",
       "type": "string",
       "enum": ["APPROVE", "COMMENT"]
     },


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Simplifies step 5 of `.claude/skills/pr-review/SKILL.md`:

- Removes the `gh api repos/.../collaborators/<author>/permission` lookup.
- Reduces the decision rules to a single condition — `APPROVE` when no CRITICAL findings, `COMMENT` otherwise.
- Drops `author` from the `gh pr view` field list in step 1 since nothing else uses it.

Side effect: Copilot-authored PRs can now be auto-approved when no CRITICAL findings are flagged. Previously the collaborators API returned 404 for the `Copilot` bot and the skill defaulted to `COMMENT`.

### How is this PR tested?

- [x] Manual tests

`/review` will be posted on this PR to exercise the simplified rules end-to-end.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release