### PR TITLE
Drop CI cache inputs from `setup-python` / `setup-node` composites

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -5,15 +5,6 @@ inputs:
     description: "Node version to use."
     default: 24
     required: false
-  # NOTE: `cache` / `cache-dependency-path` are currently ignored; caching is hardcoded off below.
-  cache:
-    description: "Package manager to cache (e.g., npm, yarn)."
-    default: ""
-    required: false
-  cache-dependency-path:
-    description: "Path to dependency file(s) for cache key generation."
-    default: ""
-    required: false
 
 runs:
   using: "composite"
@@ -21,9 +12,6 @@ runs:
     - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: ${{ inputs.node-version }}
-        # Hardcoded to empty to avoid cache-poisoning exposure. To re-enable, wire back to ${{ inputs.cache }} / ${{ inputs.cache-dependency-path }}.
-        cache: ""
-        cache-dependency-path: ""
     - run: |
         # min-release-age requires npm >= 11.10.0 (https://github.com/npm/cli/releases/tag/v11.10.0)
         npm install -g npm@"^11.10.0"

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -8,11 +8,6 @@ inputs:
     description: "Whether to pin to a specific micro version for Anaconda compatibility. Set to false for workflows that don't need conda/pyenv to hit the runner's pre-installed Python cache and avoid a ~9s download."
     required: false
     default: "true"
-  # NOTE: `enable-uv-cache` is currently ignored; caching is hardcoded off below.
-  enable-uv-cache:
-    description: "Enable uv's built-in cache. Set to false for short jobs where cache restore/save overhead isn't worth it."
-    required: false
-    default: "true"
 outputs:
   python-version:
     description: "The installed python version"
@@ -60,7 +55,7 @@ runs:
     - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
       with:
         version: "0.11.7"
-        # Hardcoded to false to avoid cache-poisoning exposure. To re-enable, wire back to ${{ inputs.enable-uv-cache }}.
+        # Caching disabled to avoid cache-poisoning exposure across CI workflows.
         enable-cache: false
     - run: |
         # The default `first-index` strategy is too strict. Use `unsafe-first-match` instead.

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -77,7 +77,6 @@ jobs:
       - uses: ./.github/actions/setup-python
         with:
           pin-micro-version: false
-          enable-uv-cache: false
       - name: Install dependencies
         run: |
           uv pip install --system -r dev/requirements.txt

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -31,9 +31,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-node
-        with:
-          cache: "npm"
-          cache-dependency-path: docs/package-lock.json
       - name: Install dependencies
         run: |
           npm ci

--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -162,6 +162,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          enable-cache: false
 
       - name: Parse review flags (comment-triggered only)
         id: flags

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -133,7 +133,6 @@ jobs:
       - uses: ./.github/actions/setup-python
         with:
           pin-micro-version: false
-          enable-uv-cache: false
       - name: Install Claude CLI
         run: |
           .claude/scripts/install-claude.sh

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -55,8 +55,6 @@ jobs:
         uses: ./.github/actions/setup-node
         with:
           node-version: ${{ matrix.node-version }}
-          cache: npm
-          cache-dependency-path: libs/typescript/package-lock.json
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/uv.yml
+++ b/.github/workflows/uv.yml
@@ -43,7 +43,6 @@ jobs:
           token: ${{ steps.app-token.outputs.token || github.token }}
       - uses: ./.github/actions/setup-python
         with:
-          enable-uv-cache: false
           pin-micro-version: false
       - name: Run uv lock --upgrade
         run: |


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23240

### What changes are proposed in this pull request?

Follow-up to #23240, which hardcoded `enable-cache: false` on `astral-sh/setup-uv` and `cache: ""` on `actions/setup-node` inside the shared composites. Three days in, no CI regressions have surfaced, so the composite inputs (`enable-uv-cache`, `cache`, `cache-dependency-path`) are now dead weight that just hint at a re-enable path we don't want.

This PR:

- Removes the `enable-uv-cache` input from `.github/actions/setup-python/action.yml` and the `cache` / `cache-dependency-path` inputs from `.github/actions/setup-node/action.yml`.
- Strips the corresponding args from every caller (`cross-version-tests.yml`, `link-checker.yml`, `review.yml`, `typescript.yml`, `uv.yml`).
- Adds an explicit `enable-cache: false` to the direct `astral-sh/setup-uv` call in `nailaopus.yml` so the cache-poisoning guard is consistent across both composite and direct usages.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release