### PR TITLE
Pick `review.yml` default model from PR size label

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -140,14 +140,16 @@ jobs:
         run: |
           claude --version
 
-      - name: Extract optional prompt and model from comment
-        if: github.event_name == 'issue_comment'
+      - name: Parse review arguments
         id: prompt
         env:
-          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_BODY: ${{ github.event_name == 'issue_comment' && github.event.comment.body || '' }}
+          LABELS_JSON: ${{ toJson(github.event.pull_request.labels || github.event.issue.labels) }}
         run: |
           cat > /tmp/parse_args.py <<'EOF'
           import argparse
+          import json
+          import os
           import secrets
           import sys
 
@@ -161,11 +163,15 @@ jobs:
           ]
           EFFORT_CHOICES = ["low", "medium", "high", "xhigh", "max"]
 
+          labels = {l["name"] for l in json.loads(os.environ["LABELS_JSON"])}
+          big = bool(labels & {"size/M", "size/L", "size/XL"})
+          default_model = "claude-opus-4-6" if big else "claude-sonnet-4-6"
+
           body = sys.stdin.read().removeprefix("/review")
           head, sep, tail = body.partition("\n")
 
           parser = argparse.ArgumentParser(add_help=False)
-          parser.add_argument("-m", "--model", choices=MODEL_CHOICES, default="claude-opus-4-6")
+          parser.add_argument("-m", "--model", choices=MODEL_CHOICES, default=default_model)
           parser.add_argument("-e", "--effort", choices=EFFORT_CHOICES, default="medium")
           args, leftover = parser.parse_known_args(head.split())
 
@@ -188,8 +194,8 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           PROMPT: ${{ steps.prompt.outputs.prompt }}
-          MODEL: ${{ steps.prompt.outputs.model || 'claude-opus-4-6' }}
-          EFFORT: ${{ steps.prompt.outputs.effort || 'medium' }}
+          MODEL: ${{ steps.prompt.outputs.model }}
+          EFFORT: ${{ steps.prompt.outputs.effort }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
           OUTPUT_FILE="/tmp/output.jsonl"


### PR DESCRIPTION
### Related Issues/PRs

Relates to #N/A

### What changes are proposed in this pull request?

Run the `review.yml` parse step on every event (no longer gated to `issue_comment`) and derive the default Claude model from the PR size label:

- `size/M`, `size/L`, `size/XL` -> `claude-opus-4-6`
- `size/XS`, `size/S`, or no size label -> `claude-sonnet-4-6`

An explicit `-m <model>` flag on a `/review` comment still wins. `COMMENT_BODY` is now explicitly `""` for `pull_request` events instead of relying on missing-property behavior. The previous static `claude-opus-4-6` default and the `defaults` indirection step are removed.

### How is this PR tested?

- [x] Manual tests (this PR itself exercises the `pull_request` smoke path of `review.yml`)

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release