### PR TITLE
Pick `review.yml` default model from PR size label

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -175,7 +175,7 @@ jobs:
           parser.add_argument("-e", "--effort", choices=EFFORT_CHOICES, default="medium")
           args, leftover = parser.parse_known_args(head.split())
 
-          prompt = " ".join(leftover) + sep + tail
+          prompt = (" ".join(leftover) + sep + tail).strip()
           # Random delimiter so user input can't terminate the heredoc.
           delim = f"PROMPT_EOF_{secrets.token_hex(8)}"
           sys.stdout.write(

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -283,6 +283,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           JOB_STATUS: ${{ job.status }}
+          MODEL: ${{ steps.prompt.outputs.model }}
         with:
           github-token: ${{ steps.app-token-write.outputs.token }}
           retries: 3
@@ -291,6 +292,7 @@ jobs:
             const { owner, repo } = context.repo;
             const { comment } = context.payload;
             const jobStatus = process.env.JOB_STATUS;
+            const model = process.env.MODEL;
 
             // Read Claude output from file instead of environment variable
             const outputPath = '/tmp/output.jsonl';
@@ -323,7 +325,7 @@ jobs:
               const seconds = (resultEvent.duration_ms / 1000).toFixed(1);
               const tokens = (resultEvent.usage?.input_tokens ?? 0) + (resultEvent.usage?.output_tokens ?? 0);
               const cost = (Math.round(resultEvent.total_cost_usd * 100) / 100).toFixed(2);
-              resultLine += ` (${seconds}s, ${resultEvent.num_turns} turns, ${tokens} tokens, $${cost})`;
+              resultLine += ` (${model}, ${seconds}s, ${resultEvent.num_turns} turns, ${tokens} tokens, $${cost})`;
               const summary = resultEvent.is_error ? 'Error' : 'Result';
               const formatted = JSON.stringify(resultEvent, null, 2);
               resultLine += `\n<details><summary>${summary}</summary>\n\n\`\`\`json\n${formatted}\n\`\`\`\n\n</details>`;

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -140,14 +140,16 @@ jobs:
         run: |
           claude --version
 
-      - name: Extract optional prompt and model from comment
-        if: github.event_name == 'issue_comment'
+      - name: Parse review arguments
         id: prompt
         env:
-          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_BODY: ${{ github.event_name == 'issue_comment' && github.event.comment.body || '' }}
+          LABELS_JSON: ${{ toJson(github.event.pull_request.labels || github.event.issue.labels) }}
         run: |
           cat > /tmp/parse_args.py <<'EOF'
           import argparse
+          import json
+          import os
           import secrets
           import sys
 
@@ -161,11 +163,15 @@ jobs:
           ]
           EFFORT_CHOICES = ["low", "medium", "high", "xhigh", "max"]
 
+          labels = {l["name"] for l in json.loads(os.environ["LABELS_JSON"])}
+          big = bool(labels & {"size/M", "size/L", "size/XL"})
+          default_model = "claude-opus-4-6" if big else "claude-sonnet-4-6"
+
           body = sys.stdin.read().removeprefix("/review")
           head, sep, tail = body.partition("\n")
 
           parser = argparse.ArgumentParser(add_help=False)
-          parser.add_argument("-m", "--model", choices=MODEL_CHOICES, default="claude-opus-4-6")
+          parser.add_argument("-m", "--model", choices=MODEL_CHOICES, default=default_model)
           parser.add_argument("-e", "--effort", choices=EFFORT_CHOICES, default="medium")
           args, leftover = parser.parse_known_args(head.split())
 
@@ -188,8 +194,8 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           PROMPT: ${{ steps.prompt.outputs.prompt }}
-          MODEL: ${{ steps.prompt.outputs.model || 'claude-opus-4-6' }}
-          EFFORT: ${{ steps.prompt.outputs.effort || 'medium' }}
+          MODEL: ${{ steps.prompt.outputs.model }}
+          EFFORT: ${{ steps.prompt.outputs.effort }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
           OUTPUT_FILE="/tmp/output.jsonl"


### PR DESCRIPTION
### Related Issues/PRs

Relates to #N/A

### What changes are proposed in this pull request?

Run the `review.yml` parse step on every event (no longer gated to `issue_comment`) and derive the default Claude model from the PR size label:

- `size/M`, `size/L`, `size/XL` -> `claude-opus-4-6`
- `size/XS`, `size/S`, or no size label -> `claude-sonnet-4-6`

An explicit `-m <model>` flag on a `/review` comment still wins. `COMMENT_BODY` is now explicitly `""` for `pull_request` events instead of relying on missing-property behavior. The previous static `claude-opus-4-6` default and the `defaults` indirection step are removed.

### How is this PR tested?

- [x] Manual tests (this PR itself exercises the `pull_request` smoke path of `review.yml`)

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release