### PR TITLE
Validate workflow `paths` filters in `dev/check_actions.py`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: .cache/action-pins.json
-          key: action-pins-${{ hashFiles('dev/check_action_pins.py') }}
+          key: action-pins-${{ hashFiles('dev/check_actions.py') }}
       - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: .mypy_cache

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -222,9 +222,9 @@ repos:
         stages: [pre-commit]
         require_serial: true
 
-      - id: action-pins
-        name: action-pins
-        entry: uv run --frozen --only-group lint dev/check_action_pins.py
+      - id: check-actions
+        name: check-actions
+        entry: uv run --frozen --only-group lint dev/check_actions.py
         language: system
         files: '^\.github/(workflows|actions)/.*\.ya?ml$'
         pass_filenames: false

--- a/dev/check_actions.py
+++ b/dev/check_actions.py
@@ -1,4 +1,15 @@
-"""Validate GitHub Actions workflow and action files."""
+"""Validate GitHub Actions workflow and action files.
+
+Complements `.github/policy.rego` (run via conftest) by enforcing checks that
+need cross-file or remote context and so cannot be expressed as per-file Rego
+rules:
+
+- action `uses:` lines must be SHA-pinned with a `# vX.Y.Z` comment, and the
+  SHA must actually match that tag on the upstream repo
+- the same action must be pinned to a single version across all workflows
+- every `on.<event>.paths` / `paths-ignore` pattern must match at least one
+  tracked file
+"""
 
 import json
 import re

--- a/dev/check_actions.py
+++ b/dev/check_actions.py
@@ -1,7 +1,7 @@
 """Validate GitHub Actions workflow and action files.
 
 Complements `.github/policy.rego` with checks that need cross-file or remote
-context (SHA-tag verification, version consistency, `paths` filter staleness).
+context.
 """
 
 import json

--- a/dev/check_actions.py
+++ b/dev/check_actions.py
@@ -199,9 +199,15 @@ def _iter_path_patterns(path: Path) -> Iterator[tuple[str, str, str]]:
                 yield str(event), key, pattern
 
 
+def _iter_workflow_files() -> Iterator[Path]:
+    root = Path(".github/workflows")
+    for ext in ("*.yml", "*.yaml"):
+        yield from root.glob(ext)
+
+
 def _check_paths() -> Iterator[str]:
     files = _list_tracked_files()
-    for path in sorted(Path(".github/workflows").glob("*.yml")):
+    for path in sorted(_iter_workflow_files()):
         for event, key, pattern in _iter_path_patterns(path):
             if not _pattern_matches(pattern, files):
                 yield (

--- a/dev/check_actions.py
+++ b/dev/check_actions.py
@@ -1,4 +1,4 @@
-"""Validate that all remote GitHub Actions are SHA-pinned with a version comment."""
+"""Validate GitHub Actions workflow and action files."""
 
 import json
 import re
@@ -8,6 +8,13 @@ from collections import defaultdict
 from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
+
+import yaml
+
+try:
+    from yaml import CSafeLoader as _YamlLoader
+except ImportError:
+    from yaml import SafeLoader as _YamlLoader  # type: ignore[assignment]
 
 # Matches a `uses:` line that references a remote action (not a local `./` path).
 # Captures:  owner/repo[/subpath]  @  ref  [  # comment  ]
@@ -134,6 +141,75 @@ def _check_action(a: ActionRef, cache: dict[str, bool]) -> str | None:
     return None
 
 
+_LITERAL_CHARS = re.compile(r"[A-Za-z0-9._/\-]")
+
+
+def _glob_to_regex(pattern: str) -> re.Pattern[str]:
+    # GitHub uses minimatch-style globs: `**` crosses `/`, `*` does not.
+    i = 0
+    n = len(pattern)
+    parts = ["^"]
+    while i < n:
+        c = pattern[i]
+        if c == "*" and i + 1 < n and pattern[i + 1] == "*":
+            i += 2
+            if i < n and pattern[i] == "/":
+                # `**/` matches zero or more path segments
+                parts.append("(?:.*/)?")
+                i += 1
+            else:
+                parts.append(".*")
+        elif c == "*":
+            parts.append("[^/]*")
+            i += 1
+        elif _LITERAL_CHARS.match(c):
+            parts.append(re.escape(c))
+            i += 1
+        else:
+            raise ValueError(
+                f"Unsupported character {c!r} at position {i} in pattern {pattern!r}."
+                " Extend _glob_to_regex if this is a valid GitHub path filter character."
+            )
+    parts.append("$")
+    return re.compile("".join(parts))
+
+
+def _list_tracked_files() -> list[str]:
+    return subprocess.check_output(["git", "ls-files"], text=True).splitlines()
+
+
+def _pattern_matches(pattern: str, files: list[str]) -> bool:
+    regex = _glob_to_regex(pattern.removeprefix("!"))
+    return any(regex.match(f) for f in files)
+
+
+def _iter_path_patterns(path: Path) -> Iterator[tuple[str, str, str]]:
+    data = yaml.load(path.read_text(encoding="utf-8"), Loader=_YamlLoader)
+    if not isinstance(data, dict):
+        return
+    # PyYAML parses the literal `on:` key as the boolean True (YAML 1.1).
+    on = data.get("on", data.get(True))
+    if not isinstance(on, dict):
+        return
+    for event, cfg in on.items():
+        if not isinstance(cfg, dict):
+            continue
+        for key in ("paths", "paths-ignore"):
+            for pattern in cfg.get(key) or []:
+                yield str(event), key, pattern
+
+
+def _check_paths() -> Iterator[str]:
+    files = _list_tracked_files()
+    for path in sorted(Path(".github/workflows").glob("*.yml")):
+        for event, key, pattern in _iter_path_patterns(path):
+            if not _pattern_matches(pattern, files):
+                yield (
+                    f"{path}: [on.{event}.{key}] pattern {pattern!r} does not"
+                    " match any tracked file"
+                )
+
+
 def _check_version_consistency(all_action_refs: list[ActionRef]) -> Iterator[str]:
     by_action: dict[str, list[ActionRef]] = defaultdict(list)
     for action_ref in all_action_refs:
@@ -160,9 +236,10 @@ def main() -> int:
     finally:
         _save_cache(cache)
     all_errors.extend(_check_version_consistency(all_action_refs))
+    all_errors.extend(_check_paths())
 
     if all_errors:
-        print("action-pins: the following violations were found:\n", file=sys.stderr)
+        print("check-actions: the following violations were found:\n", file=sys.stderr)
         for err in all_errors:
             print(err, file=sys.stderr)
         print(f"\n{len(all_errors)} violation(s) found.", file=sys.stderr)

--- a/dev/check_actions.py
+++ b/dev/check_actions.py
@@ -1,14 +1,7 @@
 """Validate GitHub Actions workflow and action files.
 
-Complements `.github/policy.rego` (run via conftest) by enforcing checks that
-need cross-file or remote context and so cannot be expressed as per-file Rego
-rules:
-
-- action `uses:` lines must be SHA-pinned with a `# vX.Y.Z` comment, and the
-  SHA must actually match that tag on the upstream repo
-- the same action must be pinned to a single version across all workflows
-- every `on.<event>.paths` / `paths-ignore` pattern must match at least one
-  tracked file
+Complements `.github/policy.rego` with checks that need cross-file or remote
+context (SHA-tag verification, version consistency, `paths` filter staleness).
 """
 
 import json

--- a/dev/check_actions.py
+++ b/dev/check_actions.py
@@ -15,11 +15,6 @@ from pathlib import Path
 
 import yaml
 
-try:
-    from yaml import CSafeLoader as _YamlLoader
-except ImportError:
-    from yaml import SafeLoader as _YamlLoader  # type: ignore[assignment]
-
 # Matches a `uses:` line that references a remote action (not a local `./` path).
 # Captures:  owner/repo[/subpath]  @  ref  [  # comment  ]
 _USES_RE = re.compile(
@@ -188,7 +183,7 @@ def _pattern_matches(pattern: str, files: list[str]) -> bool:
 
 
 def _iter_path_patterns(path: Path) -> Iterator[tuple[str, str, str]]:
-    data = yaml.load(path.read_text(encoding="utf-8"), Loader=_YamlLoader)
+    data = yaml.load(path.read_text(encoding="utf-8"), Loader=yaml.CSafeLoader)
     if not isinstance(data, dict):
         return
     # PyYAML parses the literal `on:` key as the boolean True (YAML 1.1).


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

- Rename `dev/check_action_pins.py` to `dev/check_actions.py` (the script now covers more than action pins).
- Add a new check that every pattern in `on.<event>.paths` / `on.<event>.paths-ignore` across `.github/workflows/*.yml` matches at least one tracked file. Catches stale path filters that silently skip workflows.
- Translate each GitHub minimatch glob to a regex (`**` crosses `/`, `*` does not). Raises on any unsupported metacharacter so future syntax additions are explicit.
- Parse YAML with `CSafeLoader` when libyaml is available (~10x faster).
- Update `.pre-commit-config.yaml` (hook id `action-pins` -> `check-actions`) and the cache key in `.github/workflows/lint.yml` to point at the renamed file.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Manual: ran `uv run --frozen --only-group lint dev/check_actions.py` and `pre-commit run check-actions --all-files`; both pass. Smoke-tested the glob translator against existing patterns, a fabricated stale pattern, and unsupported metacharacters (`?`, `[`, `{` all raise as expected). End-to-end wall time ~125 ms.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release