### PR TITLE
Document `sparse-checkout` rule in `.claude/rules/github-actions.md`

### DIFF
--- a/.claude/rules/github-actions.md
+++ b/.claude/rules/github-actions.md
@@ -26,8 +26,8 @@ use `gh` CLI instead of `actions/github-script`. It avoids the need for
 
 ```yaml
 # Bad
-- uses: actions/checkout@v4
-- uses: actions/github-script@v8
+- uses: actions/checkout@...
+- uses: actions/github-script@...
   with:
     script: |
       const script = require(".github/workflows/my-script.js");
@@ -39,6 +39,36 @@ use `gh` CLI instead of `actions/github-script`. It avoids the need for
   run: |
     gh pr comment ...
 ```
+
+## Use `sparse-checkout` When Only a Subset of Files Is Needed
+
+When a workflow only needs a small subset of the repo (e.g., a single script under `.github/`), pass `sparse-checkout` to `actions/checkout` instead of cloning the whole tree. A full checkout of this repo takes around 10 seconds on average; a sparse checkout finishes in a fraction of that.
+
+```yaml
+# Bad: clones the entire repo just to run one script
+- uses: actions/checkout@...
+- run: bash .github/scripts/my-script.sh
+
+# Good: only fetches what the job actually reads
+- uses: actions/checkout@...
+  with:
+    sparse-checkout: |
+      .github/scripts/my-script.sh
+    sparse-checkout-cone-mode: false
+- run: bash .github/scripts/my-script.sh
+```
+
+When listing directories, leave cone mode on (the default):
+
+```yaml
+- uses: actions/checkout@...
+  with:
+    sparse-checkout: |
+      .github/scripts
+      dev
+```
+
+Set `sparse-checkout-cone-mode: false` only when you need to target individual files or non-prefix glob patterns.
 
 ## `pipefail` Is Already On
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

Adds a new section to `.claude/rules/github-actions.md` describing when and how to use `sparse-checkout` on `actions/checkout`:

- Explains the cost (~10s full checkout vs a fraction of that for sparse) and shows both modes.
- Non-cone-mode example for targeting individual files (`.github/scripts/my-script.sh`).
- Default cone-mode example for targeting directories (`.github/scripts`, `dev`).
- Closing line on when to flip `sparse-checkout-cone-mode: false`.

Also normalizes the existing `actions/checkout@v4` and `actions/github-script@v8` example pins to `@...` so the doc focuses on the rule rather than a version that will go stale.

Documentation-only change; no workflows are modified.

### How is this PR tested?

- [x] Manual tests

Reviewed the rendered markdown locally.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release