### PR TITLE
Deepen `/review` checkout so `pr-review` skill can read pre-change content

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -93,7 +93,7 @@ gh api graphql -F owner=<owner> -F repo=<repo> -F pr=<pr_number> -f query='
 
 The working tree holds the PR merged into the base (`refs/pull/<pr>/merge`), so file contents reflect the post-merge state. Explore it for context beyond the diff (existing patterns, call sites of changed symbols, file conventions).
 
-The base branch is also fetched as `origin/master`. When the diff doesn't show enough (verifying a refactor preserved behavior, reading the full content of a deleted file, or seeing the pre-change version of a heavily modified file), use `git show origin/master:<path>` rather than re-fetching via the GitHub API.
+The merge ref's base parent is also reachable as `HEAD^1`. When the diff doesn't show enough (verifying a refactor preserved behavior, reading the full content of a deleted file, or seeing the pre-change version of a heavily modified file), use `git show HEAD^1:<path>` rather than re-fetching via the GitHub API.
 
 #### Don't comment on
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -93,6 +93,8 @@ gh api graphql -F owner=<owner> -F repo=<repo> -F pr=<pr_number> -f query='
 
 The working tree holds the PR merged into the base (`refs/pull/<pr>/merge`), so file contents reflect the post-merge state. Explore it for context beyond the diff (existing patterns, call sites of changed symbols, file conventions).
 
+The base branch is also fetched as `origin/master`. When the diff doesn't show enough (verifying a refactor preserved behavior, reading the full content of a deleted file, or seeing the pre-change version of a heavily modified file), use `git show origin/master:<path>` rather than re-fetching via the GitHub API.
+
 #### Don't comment on
 
 - Pre-existing code. You may read unchanged/context lines to understand the change, but only file findings against the changed lines (added, modified, or deleted), even if surrounding code looks suboptimal.

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -130,6 +130,11 @@ jobs:
           persist-credentials: false
           token: ${{ steps.app-token-read.outputs.token }}
           ref: refs/pull/${{ github.event.pull_request.number || github.event.issue.number }}/merge
+      # Make origin/master available so the pr-review skill can read pre-change
+      # content via `git show origin/master:<path>` instead of the GitHub API.
+      - name: Fetch base branch
+        run: |
+          git fetch --depth=1 origin master
       - uses: ./.github/actions/setup-python
         with:
           pin-micro-version: false

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -130,11 +130,9 @@ jobs:
           persist-credentials: false
           token: ${{ steps.app-token-read.outputs.token }}
           ref: refs/pull/${{ github.event.pull_request.number || github.event.issue.number }}/merge
-      # Make origin/master available so the pr-review skill can read pre-change
-      # content via `git show origin/master:<path>` instead of the GitHub API.
-      - name: Fetch base branch
-        run: |
-          git fetch --depth=1 origin master
+          # Depth 2 so HEAD^1 (the merge ref's base parent) is reachable, letting
+          # the pr-review skill read pre-change content via `git show HEAD^1:<path>`.
+          fetch-depth: 2
       - uses: ./.github/actions/setup-python
         with:
           pin-micro-version: false


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Sets `fetch-depth: 2` on the `/review` workflow's checkout of `refs/pull/<N>/merge`. The merge ref's first parent is the PR's base tip, so `HEAD^1` becomes a reachable revision the `pr-review` skill can read pre-change file content from via `git show HEAD^1:<path>`.

Motivation: during a `/review` run on #23388, Claude round-tripped through `gh api repos/.../contents/...` (with base64-decode) to read the original JS sidecars the PR deleted, just to verify behavioral equivalence. With the base reachable locally, that becomes a single `git show`. The `HEAD^1` approach is event-agnostic (works for both `pull_request` and `issue_comment` triggers) and correct for PRs targeting any base branch, not just `master`.

### How is this PR tested?

- [x] Existing unit/integration tests

The `pull_request` trigger on this workflow (paths: `.github/workflows/review.yml`, `.claude/skills/pr-review/**`) smoke-tests the change in-repo. The smoke run on this PR confirmed Claude exercised `git show HEAD^1:.github/workflows/review.yml` end-to-end and got the pre-change file content back.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release