### PR TITLE
Trim redundant sections from `pr-review` skill

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -115,6 +115,8 @@ Determine the review `event`:
 
 ### 6. Emit Review Payload
 
+Your only output is `/tmp/review-payload.json`. Do not call any GitHub write APIs (e.g., `gh pr review`, `gh api -X POST /repos/{owner}/{repo}/pulls/{pr}/reviews`).
+
 Read [`review-payload.schema.json`](./review-payload.schema.json) for the full payload spec (field types, required fields, patterns, enums) and write `/tmp/review-payload.json` matching it.
 
 Authoring rules not captured by the schema:

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -16,8 +16,6 @@ arguments: [owner_repo, pr_number, extra_context]
 
 # Review Pull Request
 
-Automatically review a GitHub pull request across correctness, security, edge cases, efficiency, readability, test coverage, and style. Emits a single `/tmp/review-payload.json` that the workflow validates against [`review-payload.schema.json`](./review-payload.schema.json) and posts via `POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews`. Sets the payload's `event` to `APPROVE` when there are no findings or only MODERATE/NIT findings.
-
 ## Usage
 
 ```
@@ -29,14 +27,6 @@ Automatically review a GitHub pull request across correctness, security, edge ca
 - `<owner_repo>` (required): repository slug, e.g. `mlflow/mlflow`
 - `<pr_number>` (required): pull request number
 - `[extra_context]` (optional): additional filtering or focus instructions (e.g., a specific concern or file type)
-
-## Examples
-
-```
-/pr-review mlflow/mlflow 23320
-/pr-review mlflow/mlflow 23320 Please focus on security issues
-/pr-review mlflow/mlflow 23320 Only review Python files
-```
 
 ## Inputs
 
@@ -57,8 +47,6 @@ Fetch the PR title and description:
 ```bash
 gh pr view <pr_number> --repo "<owner>/<repo>" --json title,body
 ```
-
-> **Note:** You have a **read-only** GitHub token. Do NOT call write APIs (`gh api ... POST`, `gh pr review`, `gh pr comment`, etc.).
 
 ### 2. Fetch PR Diff
 
@@ -109,8 +97,6 @@ Evaluate the changed code across these dimensions:
 - **Readability & maintainability**: unclear names, dead code, premature abstractions, comments that restate the code
 - **Test coverage**: new behavior lacks tests, tests assert on the wrong thing, mocks hide real failures
 - **Style guide**: see `.claude/rules/` for language-specific rules and `CLAUDE.md` for repo conventions
-
-**Workspace awareness reminder**: If the diff touches the SQLAlchemy tracking store or other tracking persistence layers, verify workspace-aware behavior remains intact and that new functionality includes matching workspace-aware tests (e.g., additions in `tests/store/tracking/test_sqlalchemy_store_workspace.py`).
 
 ### 5. Decision Point
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23390

### What changes are proposed in this pull request?

Trim four redundant sections from `.claude/skills/pr-review/SKILL.md`:

- Intro paragraph under `# Review Pull Request` (already covered by the frontmatter `description` and Step 6).
- Read-only-token note under Step 1 (the skill never calls write APIs in its own instructions).
- `## Examples` block (the model substitutes args automatically; humans don't invoke this skill manually).
- "Workspace awareness reminder" under Step 4 (duplicates `CLAUDE.md`, which is always loaded).

### How is this PR tested?

- [x] Manual tests

Confirmed `skills` pre-commit hook still passes against the updated SKILL.md.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release