### PR TITLE
Render multi-select summary once in `DialogCombobox` triggers

### DIFF
--- a/mlflow/server/js/src/admin/components/RoleAssignmentForm.test.tsx
+++ b/mlflow/server/js/src/admin/components/RoleAssignmentForm.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { PointerEventsCheckLevel } from '@testing-library/user-event';
+import userEventGlobal from '@testing-library/user-event';
+import React from 'react';
+import { renderWithDesignSystem, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
+import { RoleAssignmentForm } from './RoleAssignmentForm';
+
+// DialogCombobox masks pointer-event hit detection on its overlay; disable
+// the check so userEvent.click can reach the trigger.
+const userEvent = userEventGlobal.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });
+
+// ``jest.mock`` is hoisted above imports by the Jest transformer, so these
+// mocks apply before ``./RoleAssignmentForm`` reaches in to ``../hooks``.
+jest.mock('../hooks', () => ({
+  useCurrentUserIsAdmin: () => true,
+  useRolesQuery: () => ({
+    data: {
+      roles: [
+        { id: 1, name: 'reader', workspace: 'default', description: null, permissions: [] },
+        { id: 2, name: 'writer', workspace: 'default', description: null, permissions: [] },
+        { id: 3, name: 'admin', workspace: 'default', description: null, permissions: [] },
+      ],
+    },
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+jest.mock('../../workspaces/utils/WorkspaceUtils', () => ({
+  useActiveWorkspace: () => null,
+}));
+
+describe('RoleAssignmentForm — multi-select trigger', () => {
+  // Regression for #23399: the trigger used to call ``renderDisplayedValue``
+  // once per entry in the ``value`` array, producing "N roles selected, N
+  // roles selected, …" repeated N times. The fix collapses ``value`` to a
+  // single-element array carrying the summarised label so the count text
+  // renders exactly once.
+
+  it('renders "N roles selected" exactly once when multiple roles are picked', () => {
+    renderWithDesignSystem(<RoleAssignmentForm value={{ roleIds: [1, 2, 3] }} onChange={() => {}} />);
+    const summary = screen.getAllByText('3 roles selected');
+    expect(summary).toHaveLength(1);
+  });
+
+  it('renders the single role label (not "1 roles selected") when only one is picked', () => {
+    renderWithDesignSystem(<RoleAssignmentForm value={{ roleIds: [2] }} onChange={() => {}} />);
+    expect(screen.getByText('default/writer')).toBeInTheDocument();
+    expect(screen.queryByText(/roles selected/)).not.toBeInTheDocument();
+  });
+
+  it('falls through to the placeholder when nothing is picked', () => {
+    renderWithDesignSystem(<RoleAssignmentForm value={{ roleIds: [] }} onChange={() => {}} />);
+    expect(screen.getByText('Select one or more roles')).toBeInTheDocument();
+    expect(screen.queryByText(/roles selected/)).not.toBeInTheDocument();
+  });
+
+  it('renders pre-selected items as aria-selected when the dropdown is opened', async () => {
+    // Pins that each item's explicit ``checked`` prop — not the parent's
+    // ``value`` array — drives ``aria-selected`` after the trigger fix.
+    renderWithDesignSystem(<RoleAssignmentForm value={{ roleIds: [1, 3] }} onChange={() => {}} />);
+    await userEvent.click(screen.getByRole('combobox'));
+    const readerOption = await screen.findByRole('option', { name: /default\/reader/ });
+    const writerOption = await screen.findByRole('option', { name: /default\/writer/ });
+    const adminOption = await screen.findByRole('option', { name: /default\/admin/ });
+    expect(readerOption).toHaveAttribute('aria-selected', 'true');
+    expect(writerOption).toHaveAttribute('aria-selected', 'false');
+    expect(adminOption).toHaveAttribute('aria-selected', 'true');
+  });
+});

--- a/mlflow/server/js/src/admin/components/RoleAssignmentForm.tsx
+++ b/mlflow/server/js/src/admin/components/RoleAssignmentForm.tsx
@@ -77,6 +77,13 @@ export const RoleAssignmentForm = ({ value, onChange, disabled }: RoleAssignment
     return `${selectedRoles.length} roles selected`;
   }, [selectedRoles]);
 
+  // ``DialogCombobox`` calls ``renderDisplayedValue`` once per entry in
+  // ``value`` (joined by ``,``); collapse to a single summary label so the
+  // count text renders once. Items' checked state is driven by each
+  // ``DialogComboboxOptionListCheckboxItem``'s explicit ``checked`` prop —
+  // pinned by ``RoleAssignmentForm.test.tsx``.
+  const triggerValue = useMemo(() => (triggerText ? [triggerText] : []), [triggerText]);
+
   const toggleRole = (roleId: number) => {
     const next = value.roleIds.includes(roleId)
       ? value.roleIds.filter((id) => id !== roleId)
@@ -101,16 +108,10 @@ export const RoleAssignmentForm = ({ value, onChange, disabled }: RoleAssignment
         ) : roles.length === 0 ? (
           <Typography.Text color="secondary">No roles available. Create a role first.</Typography.Text>
         ) : (
-          <DialogCombobox
-            componentId="admin.role_assignment.roles"
-            label="Roles"
-            multiSelect
-            value={selectedRoles.map(formatRoleLabel)}
-          >
+          <DialogCombobox componentId="admin.role_assignment.roles" label="Roles" multiSelect value={triggerValue}>
             <DialogComboboxTrigger
               withInlineLabel={false}
               placeholder="Select one or more roles"
-              renderDisplayedValue={() => triggerText}
               onClear={() => onChange({ roleIds: [] })}
               width="100%"
               disabled={disabled}

--- a/mlflow/server/js/src/admin/components/RoleUsersSection.test.tsx
+++ b/mlflow/server/js/src/admin/components/RoleUsersSection.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { PointerEventsCheckLevel } from '@testing-library/user-event';
+import userEventGlobal from '@testing-library/user-event';
+import React from 'react';
+import { renderWithDesignSystem, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
+import { RoleUsersSection } from './RoleUsersSection';
+
+// DialogCombobox masks pointer-event hit detection on its overlay; disable
+// the check so userEvent.click can reach the trigger.
+const userEvent = userEventGlobal.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });
+
+// ``jest.mock`` is hoisted above imports by the Jest transformer, so this
+// mock applies before ``./RoleUsersSection`` reaches in to ``../hooks``.
+jest.mock('../hooks', () => ({
+  useUsersQuery: () => ({
+    data: {
+      users: [
+        { id: 1, username: 'alice', is_admin: false, roles: [] },
+        { id: 2, username: 'bob', is_admin: false, roles: [] },
+        { id: 3, username: 'carol', is_admin: false, roles: [] },
+      ],
+    },
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+describe('RoleUsersSection — multi-select trigger', () => {
+  // Regression for #23399: see ``RoleAssignmentForm.test.tsx`` for the bug
+  // description. Both pickers share the same `triggerValue` collapsing
+  // pattern; this exercises the user-multi-select half.
+
+  it('renders "N users selected" exactly once when multiple users are picked', () => {
+    renderWithDesignSystem(<RoleUsersSection value={['alice', 'bob', 'carol']} onChange={() => {}} />);
+    const summary = screen.getAllByText('3 users selected');
+    expect(summary).toHaveLength(1);
+  });
+
+  it('renders the single username (not "1 users selected") when only one is picked', () => {
+    renderWithDesignSystem(<RoleUsersSection value={['bob']} onChange={() => {}} />);
+    expect(screen.getByText('bob')).toBeInTheDocument();
+    expect(screen.queryByText(/users selected/)).not.toBeInTheDocument();
+  });
+
+  it('falls through to the placeholder when nothing is picked', () => {
+    renderWithDesignSystem(<RoleUsersSection value={[]} onChange={() => {}} />);
+    expect(screen.getByText('Select one or more users')).toBeInTheDocument();
+    expect(screen.queryByText(/users selected/)).not.toBeInTheDocument();
+  });
+
+  it('renders pre-selected users as aria-selected when the dropdown is opened', async () => {
+    // See ``RoleAssignmentForm.test.tsx`` — same value-vs-item decoupling.
+    renderWithDesignSystem(<RoleUsersSection value={['alice', 'carol']} onChange={() => {}} />);
+    await userEvent.click(screen.getByRole('combobox'));
+    const aliceOption = await screen.findByRole('option', { name: /alice/ });
+    const bobOption = await screen.findByRole('option', { name: /bob/ });
+    const carolOption = await screen.findByRole('option', { name: /carol/ });
+    expect(aliceOption).toHaveAttribute('aria-selected', 'true');
+    expect(bobOption).toHaveAttribute('aria-selected', 'false');
+    expect(carolOption).toHaveAttribute('aria-selected', 'true');
+  });
+});

--- a/mlflow/server/js/src/admin/components/RoleUsersSection.tsx
+++ b/mlflow/server/js/src/admin/components/RoleUsersSection.tsx
@@ -47,6 +47,13 @@ export const RoleUsersSection = ({ value, onChange, disabled }: RoleUsersSection
     return `${value.length} users selected`;
   }, [value]);
 
+  // ``DialogCombobox`` calls ``renderDisplayedValue`` once per entry in
+  // ``value`` (joined by ``,``); collapse to a single summary label so the
+  // count text renders once. Items' checked state is driven by each
+  // ``DialogComboboxOptionListCheckboxItem``'s explicit ``checked`` prop —
+  // pinned by ``RoleUsersSection.test.tsx``.
+  const triggerValue = useMemo(() => (triggerText ? [triggerText] : []), [triggerText]);
+
   const toggleUser = (username: string) => {
     if (selectedSet.has(username)) {
       onChange(value.filter((u) => u !== username));
@@ -65,11 +72,10 @@ export const RoleUsersSection = ({ value, onChange, disabled }: RoleUsersSection
       ) : users.length === 0 ? (
         <Typography.Text color="secondary">No users available.</Typography.Text>
       ) : (
-        <DialogCombobox componentId="admin.role_users.users" label="Users" multiSelect value={value}>
+        <DialogCombobox componentId="admin.role_users.users" label="Users" multiSelect value={triggerValue}>
           <DialogComboboxTrigger
             withInlineLabel={false}
             placeholder="Select one or more users"
-            renderDisplayedValue={() => triggerText}
             onClear={() => onChange([])}
             width="100%"
             disabled={disabled}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/23399/files) to review incremental changes.
- [stack/rbac-ui-no-self-delete](https://github.com/mlflow/mlflow/pull/23398) [[Files changed](https://github.com/mlflow/mlflow/pull/23398/files)] [MERGED]
  - [**stack/rbac-ui-fix-selected-count**](https://github.com/mlflow/mlflow/pull/23399) [[Files changed](https://github.com/mlflow/mlflow/pull/23399/files)]
    - [stack/rbac-ui-assign-users-rename](https://github.com/mlflow/mlflow/pull/23406) [[Files changed](https://github.com/mlflow/mlflow/pull/23406/files/d51d0a4215153e7255dc985fce4524448bcaf40c..faf18cfc2a8e32a20e2ab5006cc7770173750207)]
      - [stack/rbac-ui-permission-options](https://github.com/mlflow/mlflow/pull/23407) [[Files changed](https://github.com/mlflow/mlflow/pull/23407/files/faf18cfc2a8e32a20e2ab5006cc7770173750207..c57ea95a93dbcb6e3d4d0dd832dad9c62946c83a)]
        - [stack/rbac-ui-hide-gateway-model-def](https://github.com/mlflow/mlflow/pull/23408) [[Files changed](https://github.com/mlflow/mlflow/pull/23408/files/c57ea95a93dbcb6e3d4d0dd832dad9c62946c83a..b3e70c2b4165f2e7237c3521aeeb6abe5c6a08e3)]
          - [stack/rbac-ui-resource-type-labels](https://github.com/mlflow/mlflow/pull/23409) [[Files changed](https://github.com/mlflow/mlflow/pull/23409/files/b3e70c2b4165f2e7237c3521aeeb6abe5c6a08e3..d9c34ff9ee244da9996a7304d301fb8361e5b555)]
            - [stack/rbac-ui-hide-synthetic-roles](https://github.com/mlflow/mlflow/pull/23410) [[Files changed](https://github.com/mlflow/mlflow/pull/23410/files/d9c34ff9ee244da9996a7304d301fb8361e5b555..7488695f29a0ada3809b0fabbaa7266251d9f671)]
              - [stack/rbac-ui-drop-optional-subtitle](https://github.com/mlflow/mlflow/pull/23412) [[Files changed](https://github.com/mlflow/mlflow/pull/23412/files/7488695f29a0ada3809b0fabbaa7266251d9f671..87b9a905d7c39a019346fb5d4ccc9c764d789752)]
                - [stack/rbac-reject-same-password](https://github.com/mlflow/mlflow/pull/23413) [[Files changed](https://github.com/mlflow/mlflow/pull/23413/files/87b9a905d7c39a019346fb5d4ccc9c764d789752..f36c37071853053f3b7d77fcfb37e6c809dc344e)]
                  - [stack/rbac-ui-hide-workspace-cols](https://github.com/mlflow/mlflow/pull/23414) [[Files changed](https://github.com/mlflow/mlflow/pull/23414/files/f36c37071853053f3b7d77fcfb37e6c809dc344e..5213c15c76ed311665ee69042e5bced93127d348)]
                    - [stack/rbac-ui-error-near-submit](https://github.com/mlflow/mlflow/pull/23415) [[Files changed](https://github.com/mlflow/mlflow/pull/23415/files/5213c15c76ed311665ee69042e5bced93127d348..34674e09a807f80337ad6720a4cf49dc83da4ab6)]
                      - [stack/rbac-isolate-auth-db](https://github.com/mlflow/mlflow/pull/23417) [[Files changed](https://github.com/mlflow/mlflow/pull/23417/files/34674e09a807f80337ad6720a4cf49dc83da4ab6..e5c5907aaf70b289cd4933ed6751a1b57cec46a2)]
                        - [stack/rbac-ui-scorer-picker](https://github.com/mlflow/mlflow/pull/23420) [[Files changed](https://github.com/mlflow/mlflow/pull/23420/files/e5c5907aaf70b289cd4933ed6751a1b57cec46a2..0c1f561f22375cc830639f193d4eae12c407ca85)]

---------
### Related Issues/PRs

Second paper-cut from the RBAC bugbash. Stacked on #23398. Replaces #23397, which was opened without `git stack`.

### What changes are proposed in this pull request?

When assigning multiple users to a role (or multiple roles to a user), the picker trigger displayed the selected-count text once per selected item, e.g. "6 users selected, 6 users selected, 6 users selected, …".

Root cause: `DialogCombobox` from `@databricks/design-system` calls `renderDisplayedValue` once per entry in the `value` array and joins them with `,`. The picker passed the raw selection array plus a constant `renderDisplayedValue={() => triggerText}`, so the constant text got emitted N times.

Fix: collapse the trigger value to a single-element array carrying the already-summarised label (`"6 users selected"`) and drop the constant `renderDisplayedValue`. The summary now renders once. Applied to both:

- `RoleUsersSection` — the user picker on the role detail page.
- `RoleAssignmentForm` — the role picker on user create / edit access.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests — verified on the local dev server that the trigger shows "6 users selected" once (not 6 times); 0-selected shows placeholder; 1-selected shows that user's name.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release