### PR TITLE
Polish RBAC resource type and permission display

### DIFF
--- a/mlflow/server/js/src/account/types.ts
+++ b/mlflow/server/js/src/account/types.ts
@@ -93,3 +93,25 @@ export const parseResourcePattern = (input: string): string => {
   const trimmed = input.trim();
   return trimmed.toLowerCase() === ALL_RESOURCE_PATTERN_LABEL ? ALL_RESOURCE_PATTERN : trimmed;
 };
+
+/**
+ * User-facing display labels for canonical (snake_case) backend resource
+ * types. Admin tables and pickers render via ``formatResourceType`` so
+ * the UI never leaks raw wire names like ``registered_model``.
+ *
+ * ``gateway_secret`` reads as "LLM connection": the wire-level identifier
+ * stays ``gateway_secret`` (backend enums depend on it) but the product
+ * term is ``LLM connection``.
+ */
+export const RESOURCE_TYPE_LABEL: Record<string, string> = {
+  experiment: 'Experiment',
+  registered_model: 'Registered model',
+  scorer: 'Scorer',
+  gateway_secret: 'LLM connection',
+  gateway_endpoint: 'Gateway endpoint',
+  gateway_model_definition: 'Gateway model definition',
+  workspace: 'Workspace',
+};
+
+export const formatResourceType = (resourceType: string): string =>
+  RESOURCE_TYPE_LABEL[resourceType] ?? resourceType;

--- a/mlflow/server/js/src/admin/components/DirectPermissionForm.tsx
+++ b/mlflow/server/js/src/admin/components/DirectPermissionForm.tsx
@@ -15,12 +15,15 @@ import {
 } from '@databricks/design-system';
 import { FieldLabel } from './FieldLabel';
 import { useResourceOptionsQuery } from '../hooks';
-import { PERMISSIONS } from '../types';
+import { formatResourceType, PERMISSIONS } from '../types';
 
 // Resource types eligible for per-user direct grants. ``workspace`` is excluded
 // (it's role-only), and ``scorer`` is excluded because its identifier is
 // composite (experiment_id + scorer_name) and the form below assumes a single
-// string id.
+// string id. ``gateway_model_definition`` stays in the tuple so existing grants
+// from earlier RBAC versions still display correctly, but it's filtered out of
+// ``PICKER_RESOURCE_TYPES`` below since it's an internal primitive that ships
+// behind ``gateway_endpoint`` and shouldn't be a new-grant option.
 export const DIRECT_GRANT_RESOURCE_TYPES = [
   'experiment',
   'registered_model',
@@ -31,13 +34,9 @@ export const DIRECT_GRANT_RESOURCE_TYPES = [
 
 export type DirectGrantResourceType = (typeof DIRECT_GRANT_RESOURCE_TYPES)[number];
 
-const RESOURCE_TYPE_LABEL: Record<DirectGrantResourceType, string> = {
-  experiment: 'Experiment',
-  registered_model: 'Registered model',
-  gateway_secret: 'Gateway secret',
-  gateway_endpoint: 'Gateway endpoint',
-  gateway_model_definition: 'Gateway model definition',
-};
+const PICKER_RESOURCE_TYPES: readonly DirectGrantResourceType[] = DIRECT_GRANT_RESOURCE_TYPES.filter(
+  (rt) => rt !== 'gateway_model_definition',
+);
 
 export type DirectPermissionScope = 'specific' | 'all';
 
@@ -99,7 +98,7 @@ export const DirectPermissionForm = ({
 
   const selectedOption = resourceOptions.find((o) => o.id === value.resourceId);
   const renderOption = (o: { id: string; name: string }) => (o.name === o.id ? o.name : `${o.name} (${o.id})`);
-  const typeLabel = RESOURCE_TYPE_LABEL[value.resourceType];
+  const typeLabel = formatResourceType(value.resourceType);
 
   return (
     <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
@@ -118,9 +117,9 @@ export const DirectPermissionForm = ({
           }
           disabled={disabled}
         >
-          {DIRECT_GRANT_RESOURCE_TYPES.map((rt) => (
+          {PICKER_RESOURCE_TYPES.map((rt) => (
             <SimpleSelectOption key={rt} value={rt}>
-              {RESOURCE_TYPE_LABEL[rt]}
+              {formatResourceType(rt)}
             </SimpleSelectOption>
           ))}
         </SimpleSelect>

--- a/mlflow/server/js/src/admin/components/RolePermissionForm.tsx
+++ b/mlflow/server/js/src/admin/components/RolePermissionForm.tsx
@@ -15,8 +15,8 @@ import {
 } from '@databricks/design-system';
 import { FieldLabel } from './FieldLabel';
 import { useResourceOptionsQuery } from '../hooks';
-import { ALL_RESOURCE_PATTERN_LABEL, PERMISSIONS, RESOURCE_TYPES } from '../types';
-import { DIRECT_GRANT_RESOURCE_TYPES, type DirectGrantResourceType } from './DirectPermissionForm';
+import { useWorkspacesEnabled } from '../../experiment-tracking/hooks/useServerInfo';
+import { ALL_RESOURCE_PATTERN_LABEL, formatResourceType, PERMISSIONS, RESOURCE_TYPES } from '../types';
 
 export type RolePermissionScope = 'specific' | 'all';
 
@@ -54,17 +54,6 @@ export const ROLE_PERMISSION_DRAFT_DEFAULT: RolePermissionDraft = {
   permission: PERMISSIONS[0],
 };
 
-const RESOURCE_TYPE_LABEL: Record<DirectGrantResourceType, string> = {
-  experiment: 'Experiment',
-  registered_model: 'Registered model',
-  gateway_secret: 'Gateway secret',
-  gateway_endpoint: 'Gateway endpoint',
-  gateway_model_definition: 'Gateway model definition',
-};
-
-const isPickableResourceType = (rt: string): rt is DirectGrantResourceType =>
-  (DIRECT_GRANT_RESOURCE_TYPES as readonly string[]).includes(rt);
-
 /**
  * Add a permission to a role. Mirrors ``DirectPermissionForm``'s
  * (resource type + scope radio + resource picker) shape so the
@@ -74,7 +63,8 @@ const isPickableResourceType = (rt: string): rt is DirectGrantResourceType =>
  * Two role-only special cases:
  * - ``workspace``: the only valid pattern is ``*`` (the role's own
  *   workspace), so the scope radio is hidden and we render a static
- *   "Workspace: <name>" line.
+ *   "Workspace: <name>" line. The resource type itself is omitted from
+ *   the dropdown when workspaces are disabled at the server level.
  * - ``scorer``: no pre-built picker exists for composite scorer ids,
  *   so the scope radio is hidden and we fall back to a free-text
  *   pattern input. ``RolePermissionsSection`` reads the typed value
@@ -83,11 +73,14 @@ const isPickableResourceType = (rt: string): rt is DirectGrantResourceType =>
 export const RolePermissionForm = ({ value, onChange, workspace, disabled }: RolePermissionFormProps) => {
   const { theme } = useDesignSystemTheme();
   const [resourceSearch, setResourceSearch] = useState('');
+  const { workspacesEnabled } = useWorkspacesEnabled();
 
-  const isPickable = isPickableResourceType(value.resourceType);
-  const typeLabel = isPickable
-    ? RESOURCE_TYPE_LABEL[value.resourceType as DirectGrantResourceType]
-    : value.resourceType;
+  const visibleResourceTypes = useMemo(
+    () => RESOURCE_TYPES.filter((rt) => workspacesEnabled || rt !== 'workspace'),
+    [workspacesEnabled],
+  );
+
+  const typeLabel = formatResourceType(value.resourceType);
 
   const {
     options: resourceOptions,
@@ -127,9 +120,9 @@ export const RolePermissionForm = ({ value, onChange, workspace, disabled }: Rol
           }}
           disabled={disabled}
         >
-          {RESOURCE_TYPES.map((rt) => (
+          {visibleResourceTypes.map((rt) => (
             <SimpleSelectOption key={rt} value={rt}>
-              {rt}
+              {formatResourceType(rt)}
             </SimpleSelectOption>
           ))}
         </SimpleSelect>

--- a/mlflow/server/js/src/admin/components/RolePermissionsSection.tsx
+++ b/mlflow/server/js/src/admin/components/RolePermissionsSection.tsx
@@ -11,7 +11,7 @@ import {
   useDesignSystemTheme,
 } from '@databricks/design-system';
 import { FieldLabel } from './FieldLabel';
-import { formatResourcePattern } from '../types';
+import { formatResourcePattern, formatResourceType } from '../types';
 import {
   RolePermissionForm,
   ROLE_PERMISSION_DRAFT_DEFAULT,
@@ -110,7 +110,7 @@ export const RolePermissionsSection = ({ value, onChange, workspace, disabled }:
           {value.map((p, i) => (
             <TableRow key={`${p.resourceType}-${p.resourcePattern}-${p.permission}-${i}`}>
               <TableCell css={{ flex: 1 }}>
-                <Tag componentId="admin.role_permissions.staged_type_tag">{p.resourceType}</Tag>
+                <Tag componentId="admin.role_permissions.staged_type_tag">{formatResourceType(p.resourceType)}</Tag>
               </TableCell>
               <TableCell css={{ flex: 1 }}>
                 <code>{formatResourcePattern(p.resourcePattern)}</code>

--- a/mlflow/server/js/src/admin/types.ts
+++ b/mlflow/server/js/src/admin/types.ts
@@ -8,8 +8,10 @@ export {
   ALL_RESOURCE_PATTERN_LABEL,
   DEFAULT_WORKSPACE_NAME,
   formatResourcePattern,
+  formatResourceType,
   isWorkspaceAdminRole,
   parseResourcePattern,
+  RESOURCE_TYPE_LABEL,
 } from '../account/types';
 
 export interface UserRoleAssignment {
@@ -84,14 +86,31 @@ export interface ResourceOption {
   name: string;
 }
 
+/**
+ * Resource types offered in the admin UI's role/permission pickers.
+ *
+ * ``gateway_model_definition`` is intentionally omitted: it's an internal
+ * primitive that ships behind ``gateway_endpoint`` and is not user-facing.
+ * Callers that need to render historical rows whose ``resource_type``
+ * still references it should fall through ``formatResourceType`` (which
+ * resolves the label from ``RESOURCE_TYPE_LABEL``), not iterate this
+ * tuple.
+ */
 export const RESOURCE_TYPES = [
   'experiment',
   'registered_model',
   'scorer',
   'gateway_secret',
   'gateway_endpoint',
-  'gateway_model_definition',
   'workspace',
 ] as const;
 
-export const PERMISSIONS = ['READ', 'USE', 'EDIT', 'MANAGE', 'NO_PERMISSIONS'] as const;
+/**
+ * Permissions offered in the admin UI's permission pickers.
+ *
+ * ``NO_PERMISSIONS`` is intentionally omitted: it's a server-only sentinel
+ * (explicit deny) that the backend rejects as a new grant. The legacy
+ * tuple is still resolvable when rendering rows, but it's not a choice
+ * an admin should be able to assign.
+ */
+export const PERMISSIONS = ['READ', 'USE', 'EDIT', 'MANAGE'] as const;


### PR DESCRIPTION
### Related Issues/PRs

Relates to RBAC bug bash (bugs 3, 5, 6, 10).

### What changes are proposed in this pull request?

- Centralize `RESOURCE_TYPE_LABEL` in `account/types.ts` so admin tables and form pickers render user-facing labels (`Registered model`, `LLM connection`) instead of raw snake_case wire names. (bug 10)
- Hide `gateway_model_definition` from resource-type pickers; it's an internal primitive that ships behind `gateway_endpoint`. The tuple still exposes it for historical row display so existing grants render through `formatResourceType`. (bug 5)
- Hide `NO_PERMISSIONS` from the permission picker. It is a server-only sentinel rejected as a new grant. (bug 6)
- Hide the `workspace` resource type from the role-permission picker when the server has not enabled workspaces. (bug 10 followup)
- Rename "Gateway secret" to "LLM connection" via the shared label map. (bug 3)

### How is this PR tested?

- [x] Manual tests

Tested by inspecting role-creation and direct-permission forms in the dev server.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request was AI-assisted by Claude Code.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mlflow/codesmith/mlflow/pr/23402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->