### PR TITLE
Hide synthetic `__user_<id>__` roles from admin and account views

### DIFF
--- a/mlflow/server/js/src/account/hooks.test.tsx
+++ b/mlflow/server/js/src/account/hooks.test.tsx
@@ -133,6 +133,28 @@ describe('useUserRolesQuery (gated on truthy username)', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(mockedApi.listUserRoles).toHaveBeenCalledWith('pat');
   });
+
+  it('drops synthetic __user_<id>__ roles from the response', async () => {
+    const namedRole = {
+      id: 7,
+      name: 'editors',
+      workspace: 'default',
+      description: '',
+      permissions: [],
+    };
+    const syntheticRole = {
+      id: 42,
+      name: '__user_1__',
+      workspace: 'default',
+      description: '',
+      permissions: [],
+    };
+    mockedApi.listUserRoles.mockResolvedValueOnce({ roles: [namedRole, syntheticRole] });
+
+    const { result } = renderHook(() => useUserRolesQuery('pat'), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.roles).toEqual([namedRole]);
+  });
 });
 
 describe('useCurrentUserIsWorkspaceAdmin', () => {

--- a/mlflow/server/js/src/account/hooks.ts
+++ b/mlflow/server/js/src/account/hooks.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { useMutation, useQuery } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
 import { AccountApi } from './api';
-import { isWorkspaceAdminRole } from './types';
+import { isSyntheticUserRole, isWorkspaceAdminRole } from './types';
 import type { UpdatePasswordRequest } from './types';
 
 export const useCurrentUserQuery = () => {
@@ -104,7 +104,13 @@ export const useUpdatePassword = () => {
 export const useUserRolesQuery = (username: string, options: { enabled?: boolean } = {}) => {
   return useQuery({
     queryKey: AccountQueryKeys.userRoles(username),
-    queryFn: () => AccountApi.listUserRoles(username),
+    queryFn: async () => {
+      const data = await AccountApi.listUserRoles(username);
+      // Synthetic ``__user_<id>__`` roles back direct grants and are not
+      // human-facing. Drop them so the per-user roles list never leaks
+      // its own bookkeeping row.
+      return { ...data, roles: data.roles.filter((r) => !isSyntheticUserRole(r.name)) };
+    },
     retry: false,
     refetchOnWindowFocus: false,
     // Callers pass ``enabled: false`` to skip a fetch they know will 403.

--- a/mlflow/server/js/src/admin/hooks.test.tsx
+++ b/mlflow/server/js/src/admin/hooks.test.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { QueryClient, QueryClientProvider } from '@databricks/web-shared/query-client';
 
 import { AdminApi } from './api';
-import { useResourceOptionsQuery } from './hooks';
+import { useResourceOptionsQuery, useRolesQuery, useUsersQuery } from './hooks';
 
 jest.mock('./api', () => ({
   ...jest.requireActual<typeof import('./api')>('./api'),
@@ -15,6 +15,8 @@ jest.mock('./api', () => ({
     listScorersLite: jest.fn(),
     listGatewaySecretsLite: jest.fn(),
     listGatewayEndpointsLite: jest.fn(),
+    listUsers: jest.fn(),
+    listRoles: jest.fn(),
   },
 }));
 
@@ -236,5 +238,46 @@ describe('useResourceOptionsQuery — wildcard collision guard', () => {
     });
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.options.map((o) => o.id)).toEqual(['greeting']);
+  });
+});
+
+const namedRole = {
+  id: 7,
+  name: 'editors',
+  workspace: 'default',
+  description: '',
+  permissions: [],
+};
+const syntheticRole = {
+  id: 42,
+  name: '__user_1__',
+  workspace: 'default',
+  description: '',
+  permissions: [],
+};
+
+describe('useUsersQuery', () => {
+  it('drops synthetic __user_<id>__ roles from each user', async () => {
+    mockedApi.listUsers.mockResolvedValueOnce({
+      users: [
+        { id: 1, username: 'pat', is_admin: false, roles: [namedRole, syntheticRole] },
+        { id: 2, username: 'alex', is_admin: false, roles: [syntheticRole] },
+      ],
+    });
+
+    const { result } = renderHook(() => useUsersQuery(), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.users[0].roles).toEqual([namedRole]);
+    expect(result.current.data?.users[1].roles).toEqual([]);
+  });
+});
+
+describe('useRolesQuery', () => {
+  it('drops synthetic __user_<id>__ roles from the response', async () => {
+    mockedApi.listRoles.mockResolvedValueOnce({ roles: [namedRole, syntheticRole] });
+
+    const { result } = renderHook(() => useRolesQuery(), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.roles).toEqual([namedRole]);
   });
 });

--- a/mlflow/server/js/src/admin/hooks.ts
+++ b/mlflow/server/js/src/admin/hooks.ts
@@ -4,6 +4,7 @@ import { useSearchParams } from '../common/utils/RoutingUtils';
 import { SETTINGS_RETURN_TO_PARAM } from '../settings/settingsSectionConstants';
 import { AccountQueryKeys } from '../account/hooks';
 import { AdminApi, scorerResourcePattern } from './api';
+import { isSyntheticUserRole } from '../account/types';
 import type {
   AddPermissionRequest,
   CreateRoleRequest,
@@ -72,7 +73,19 @@ export const useUserPermissionsQuery = (username: string) => {
 export const useUsersQuery = () => {
   return useQuery({
     queryKey: AdminQueryKeys.users,
-    queryFn: AdminApi.listUsers,
+    queryFn: async () => {
+      const data = await AdminApi.listUsers();
+      // Drop synthetic ``__user_<id>__`` roles from each user's roles
+      // list. They're a backend implementation detail for direct grants
+      // and shouldn't appear in human-facing user/role tables.
+      return {
+        ...data,
+        users: data.users.map((u) => ({
+          ...u,
+          roles: u.roles?.filter((r) => !isSyntheticUserRole(r.name)),
+        })),
+      };
+    },
     retry: false,
     refetchOnWindowFocus: false,
   });
@@ -124,7 +137,13 @@ export const useRolesQuery = (workspaces?: string | readonly string[], options: 
   }, [workspaces]);
   return useQuery({
     queryKey: [...AdminQueryKeys.roles, normalized],
-    queryFn: () => AdminApi.listRoles(normalized),
+    queryFn: async () => {
+      const data = await AdminApi.listRoles(normalized);
+      // Synthetic ``__user_<id>__`` roles back direct grants and are not
+      // human-facing. Drop them at the source so every consumer
+      // (tables, dropdowns, name lookups) stays in sync.
+      return { ...data, roles: data.roles.filter((r) => !isSyntheticUserRole(r.name)) };
+    },
     retry: false,
     refetchOnWindowFocus: false,
     // Callers pass ``enabled: false`` to skip a fetch they know will 403.


### PR DESCRIPTION
### Related Issues/PRs

Relates to RBAC bug bash (bugs 16, 21).

### What changes are proposed in this pull request?

The backend reserves the `__user_<id>__` namespace for synthetic per-user roles that back direct (non-role) permission grants. These rows are an implementation detail and should never appear in human-facing role tables, role-selection dropdowns, or per-user role lists.

Adds an `isSyntheticRoleName` helper mirrored from the backend regex and applies it at the query layer so every consumer stays in sync:

- `useRolesQuery`: strips synthetic rows from the global roles list (AdminPage table, RoleAssignmentForm dropdown, EditAccessModal review step).
- `useUserRolesQuery`: strips them from a user's roles list (AccountPage, UserDetailPage).
- `useUsersQuery`: strips them from each user's nested `roles`.

Direct grants continue to surface through the per-user permission APIs (`useUserPermissionsQuery` / `useMyPermissionsQuery`), which are unaffected.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New unit test covers `useUserRolesQuery` stripping synthetic rows.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request was AI-assisted by Claude Code.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mlflow/codesmith/mlflow/pr/23405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->