### PR TITLE
Filter permission picker options to match backend validator

### DIFF
--- a/mlflow/server/js/src/admin/components/DirectPermissionForm.test.tsx
+++ b/mlflow/server/js/src/admin/components/DirectPermissionForm.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { PointerEventsCheckLevel } from '@testing-library/user-event';
+import userEventGlobal from '@testing-library/user-event';
+import React from 'react';
+import { renderWithDesignSystem, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
+import { DirectPermissionForm, DIRECT_PERMISSION_DEFAULT } from './DirectPermissionForm';
+
+jest.mock('../hooks', () => ({
+  useResourceOptionsQuery: () => ({ options: [], isLoading: false, error: null }),
+}));
+
+const userEvent = userEventGlobal.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });
+
+describe('DirectPermissionForm — permission picker filtering', () => {
+  it('coerces permission to a gateway-grantable value when switching from experiment to gateway_secret', async () => {
+    // ``USE`` is only meaningful on gateway resources; switching the other
+    // direction (gateway → experiment with permission=USE) must coerce
+    // the now-invalid USE down to READ. Cover that path too.
+    const onChange = jest.fn();
+    renderWithDesignSystem(
+      <DirectPermissionForm
+        value={{ ...DIRECT_PERMISSION_DEFAULT, resourceType: 'gateway_secret', permission: 'USE' }}
+        onChange={onChange}
+      />,
+    );
+    const resourceTypeTrigger = document.getElementById('admin-direct-permission-resource-type')!;
+    await userEvent.click(resourceTypeTrigger);
+    await userEvent.click(await screen.findByRole('option', { name: 'Experiment' }));
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ resourceType: 'experiment', permission: 'READ' }));
+  });
+});

--- a/mlflow/server/js/src/admin/components/DirectPermissionForm.tsx
+++ b/mlflow/server/js/src/admin/components/DirectPermissionForm.tsx
@@ -15,7 +15,7 @@ import {
 } from '@databricks/design-system';
 import { FieldLabel } from './FieldLabel';
 import { useResourceOptionsQuery } from '../hooks';
-import { PERMISSIONS } from '../types';
+import { PERMISSIONS, getGrantablePermissions } from '../types';
 
 // Resource types eligible for per-user direct grants. ``workspace`` is excluded
 // (it's role-only), and ``scorer`` is excluded because its identifier is
@@ -109,13 +109,17 @@ export const DirectPermissionForm = ({
           id="admin-direct-permission-resource-type"
           componentId="admin.direct_permission.resource_type"
           value={value.resourceType}
-          onChange={({ target }) =>
+          onChange={({ target }) => {
+            const next = target.value as DirectGrantResourceType;
+            const nextGrantable = getGrantablePermissions(next);
+            const nextPermission = nextGrantable.includes(value.permission) ? value.permission : nextGrantable[0];
             onChange({
               ...value,
-              resourceType: target.value as DirectGrantResourceType,
+              resourceType: next,
               resourceId: '',
-            })
-          }
+              permission: nextPermission,
+            });
+          }}
           disabled={disabled}
         >
           {DIRECT_GRANT_RESOURCE_TYPES.map((rt) => (
@@ -220,7 +224,7 @@ export const DirectPermissionForm = ({
           onChange={({ target }) => onChange({ ...value, permission: target.value })}
           disabled={disabled}
         >
-          {PERMISSIONS.map((p) => (
+          {getGrantablePermissions(value.resourceType).map((p) => (
             <SimpleSelectOption key={p} value={p}>
               {p}
             </SimpleSelectOption>

--- a/mlflow/server/js/src/admin/components/RolePermissionForm.test.tsx
+++ b/mlflow/server/js/src/admin/components/RolePermissionForm.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { PointerEventsCheckLevel } from '@testing-library/user-event';
+import userEventGlobal from '@testing-library/user-event';
+import React from 'react';
+import { renderWithDesignSystem, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
+import { RolePermissionForm, ROLE_PERMISSION_DRAFT_DEFAULT } from './RolePermissionForm';
+
+jest.mock('../hooks', () => ({
+  useResourceOptionsQuery: () => ({ options: [], isLoading: false, error: null }),
+}));
+
+const userEvent = userEventGlobal.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });
+
+describe('RolePermissionForm — permission picker filtering', () => {
+  it('coerces permission to a workspace-grantable value when resource type switches to workspace', async () => {
+    // Workspace scope only accepts USE/MANAGE — READ would 400 on submit.
+    const onChange = jest.fn();
+    renderWithDesignSystem(
+      <RolePermissionForm value={{ ...ROLE_PERMISSION_DRAFT_DEFAULT, permission: 'READ' }} onChange={onChange} />,
+    );
+    const resourceTypeTrigger = document.getElementById('admin-role-permission-form-resource-type')!;
+    await userEvent.click(resourceTypeTrigger);
+    await userEvent.click(await screen.findByRole('option', { name: 'workspace' }));
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ resourceType: 'workspace', permission: 'USE' }));
+  });
+});

--- a/mlflow/server/js/src/admin/components/RolePermissionForm.tsx
+++ b/mlflow/server/js/src/admin/components/RolePermissionForm.tsx
@@ -15,7 +15,7 @@ import {
 } from '@databricks/design-system';
 import { FieldLabel } from './FieldLabel';
 import { useResourceOptionsQuery } from '../hooks';
-import { ALL_RESOURCE_PATTERN_LABEL, PERMISSIONS, RESOURCE_TYPES } from '../types';
+import { ALL_RESOURCE_PATTERN_LABEL, PERMISSIONS, RESOURCE_TYPES, getGrantablePermissions } from '../types';
 import { DIRECT_GRANT_RESOURCE_TYPES, type DirectGrantResourceType } from './DirectPermissionForm';
 
 export type RolePermissionScope = 'specific' | 'all';
@@ -117,12 +117,17 @@ export const RolePermissionForm = ({ value, onChange, workspace, disabled }: Rol
           onChange={({ target }) => {
             const next = target.value;
             // Reset scope/resourceId when switching types so a stale
-            // resource id doesn't leak across resource types.
+            // resource id doesn't leak across resource types. Also coerce
+            // ``permission`` into the new type's grantable set — e.g.
+            // ``READ`` is invalid at workspace scope.
+            const nextGrantable = getGrantablePermissions(next);
+            const nextPermission = nextGrantable.includes(value.permission) ? value.permission : nextGrantable[0];
             onChange({
               ...value,
               resourceType: next,
               scope: 'all',
               resourceId: '',
+              permission: nextPermission,
             });
           }}
           disabled={disabled}
@@ -247,7 +252,7 @@ export const RolePermissionForm = ({ value, onChange, workspace, disabled }: Rol
           onChange={({ target }) => onChange({ ...value, permission: target.value })}
           disabled={disabled}
         >
-          {PERMISSIONS.map((p) => (
+          {getGrantablePermissions(value.resourceType).map((p) => (
             <SimpleSelectOption key={p} value={p}>
               {p}
             </SimpleSelectOption>

--- a/mlflow/server/js/src/admin/types.test.ts
+++ b/mlflow/server/js/src/admin/types.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from '@jest/globals';
+import { getGrantablePermissions } from './types';
+
+describe('getGrantablePermissions', () => {
+  // Mirrors the backend's `_validate_permission_for_resource_type` in
+  // `mlflow/server/auth/permissions.py`. Keep this table in sync.
+  it.each([
+    ['experiment', ['READ', 'EDIT', 'MANAGE']],
+    ['registered_model', ['READ', 'EDIT', 'MANAGE']],
+    ['prompt', ['READ', 'EDIT', 'MANAGE']],
+    ['scorer', ['READ', 'EDIT', 'MANAGE']],
+    ['gateway_secret', ['READ', 'USE', 'EDIT', 'MANAGE']],
+    ['gateway_endpoint', ['READ', 'USE', 'EDIT', 'MANAGE']],
+    ['gateway_model_definition', ['READ', 'USE', 'EDIT', 'MANAGE']],
+    ['workspace', ['USE', 'MANAGE']],
+  ])('returns the backend-allowed set for %s', (resourceType, expected) => {
+    expect(getGrantablePermissions(resourceType)).toEqual(expected);
+  });
+
+  it('never includes NO_PERMISSIONS for any known type', () => {
+    const types = [
+      'experiment',
+      'registered_model',
+      'prompt',
+      'scorer',
+      'gateway_secret',
+      'gateway_endpoint',
+      'gateway_model_definition',
+      'workspace',
+    ];
+    for (const t of types) {
+      expect(getGrantablePermissions(t)).not.toContain('NO_PERMISSIONS');
+    }
+  });
+
+  it('falls back to the resource-level set for unknown types', () => {
+    // Keeps future backend resource types safe by default (no USE, no
+    // NO_PERMISSIONS) until they're added explicitly.
+    expect(getGrantablePermissions('something_new')).toEqual(['READ', 'EDIT', 'MANAGE']);
+  });
+});

--- a/mlflow/server/js/src/admin/types.ts
+++ b/mlflow/server/js/src/admin/types.ts
@@ -87,6 +87,7 @@ export interface ResourceOption {
 export const RESOURCE_TYPES = [
   'experiment',
   'registered_model',
+  'prompt',
   'scorer',
   'gateway_secret',
   'gateway_endpoint',
@@ -95,3 +96,28 @@ export const RESOURCE_TYPES = [
 ] as const;
 
 export const PERMISSIONS = ['READ', 'USE', 'EDIT', 'MANAGE', 'NO_PERMISSIONS'] as const;
+
+/**
+ * Permission levels the picker should expose per resource type, mirroring
+ * the backend's ``_validate_permission_for_resource_type``:
+ * ``workspace`` is ``USE`` / ``MANAGE`` only; gateway types expose ``USE``;
+ * other types hide ``USE`` (no-op over ``READ``); ``NO_PERMISSIONS`` is
+ * hidden everywhere.
+ */
+export const PERMISSIONS_FOR_RESOURCE_TYPE = {
+  experiment: ['READ', 'EDIT', 'MANAGE'],
+  registered_model: ['READ', 'EDIT', 'MANAGE'],
+  prompt: ['READ', 'EDIT', 'MANAGE'],
+  scorer: ['READ', 'EDIT', 'MANAGE'],
+  gateway_secret: ['READ', 'USE', 'EDIT', 'MANAGE'],
+  gateway_endpoint: ['READ', 'USE', 'EDIT', 'MANAGE'],
+  gateway_model_definition: ['READ', 'USE', 'EDIT', 'MANAGE'],
+  workspace: ['USE', 'MANAGE'],
+} satisfies Record<string, readonly string[]>;
+
+export const getGrantablePermissions = (resourceType: string): readonly string[] =>
+  PERMISSIONS_FOR_RESOURCE_TYPE[resourceType as keyof typeof PERMISSIONS_FOR_RESOURCE_TYPE] ?? [
+    'READ',
+    'EDIT',
+    'MANAGE',
+  ];


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/23407/files) to review incremental changes.
- [stack/rbac-ui-no-self-delete](https://github.com/mlflow/mlflow/pull/23398) [[Files changed](https://github.com/mlflow/mlflow/pull/23398/files)] [MERGED]
  - [stack/rbac-ui-fix-selected-count](https://github.com/mlflow/mlflow/pull/23399) [[Files changed](https://github.com/mlflow/mlflow/pull/23399/files)] [MERGED]
    - [stack/rbac-ui-assign-users-rename](https://github.com/mlflow/mlflow/pull/23406) [[Files changed](https://github.com/mlflow/mlflow/pull/23406/files)] [MERGED]
      - [**stack/rbac-ui-permission-options**](https://github.com/mlflow/mlflow/pull/23407) [[Files changed](https://github.com/mlflow/mlflow/pull/23407/files)]
        - [stack/rbac-ui-hide-gateway-model-def](https://github.com/mlflow/mlflow/pull/23408) [[Files changed](https://github.com/mlflow/mlflow/pull/23408/files/c0ed9b39395c8f677204e4352fc8c716b0e9c430..6c3beb23f85b41cc4056deaca0569b9a0654392d)]
          - [stack/rbac-ui-resource-type-labels](https://github.com/mlflow/mlflow/pull/23409) [[Files changed](https://github.com/mlflow/mlflow/pull/23409/files/6c3beb23f85b41cc4056deaca0569b9a0654392d..a11b1bc07acc7a2d690b056773fe1dd25e64a0bc)]
            - [stack/rbac-ui-hide-synthetic-roles](https://github.com/mlflow/mlflow/pull/23410) [[Files changed](https://github.com/mlflow/mlflow/pull/23410/files/a11b1bc07acc7a2d690b056773fe1dd25e64a0bc..d1d4644c6e0d211caff7c1686f0a90c3ac0a99ac)]
              - [stack/rbac-ui-drop-optional-subtitle](https://github.com/mlflow/mlflow/pull/23412) [[Files changed](https://github.com/mlflow/mlflow/pull/23412/files/d1d4644c6e0d211caff7c1686f0a90c3ac0a99ac..8b319163d9109b71bc8ab1a03d7901fddd1d54e2)]
                - [stack/rbac-reject-same-password](https://github.com/mlflow/mlflow/pull/23413) [[Files changed](https://github.com/mlflow/mlflow/pull/23413/files/8b319163d9109b71bc8ab1a03d7901fddd1d54e2..918e3804c16f10104df4691f2e74f7a57e692c01)]
                  - [stack/rbac-ui-hide-workspace-cols](https://github.com/mlflow/mlflow/pull/23414) [[Files changed](https://github.com/mlflow/mlflow/pull/23414/files/918e3804c16f10104df4691f2e74f7a57e692c01..823fe65df386a6231bb8f0ac89b5de9dcb628ab0)]
                    - [stack/rbac-ui-error-near-submit](https://github.com/mlflow/mlflow/pull/23415) [[Files changed](https://github.com/mlflow/mlflow/pull/23415/files/823fe65df386a6231bb8f0ac89b5de9dcb628ab0..8c669b1d055b25f06435d7934d2890bb08811b03)]
                      - [stack/rbac-isolate-auth-db](https://github.com/mlflow/mlflow/pull/23417) [[Files changed](https://github.com/mlflow/mlflow/pull/23417/files/8c669b1d055b25f06435d7934d2890bb08811b03..dda5e8b16ccea62a3d34b06da00012fbbd0aef77)]
                        - [stack/rbac-ui-scorer-picker](https://github.com/mlflow/mlflow/pull/23420) [[Files changed](https://github.com/mlflow/mlflow/pull/23420/files/dda5e8b16ccea62a3d34b06da00012fbbd0aef77..e4d7888c3d6471de9b57b9452117d1604eb5cd31)]

---------
### Related Issues/PRs

RBAC bugbash paper-cut. Reported by Harutaka Kawamura ("what does `USE` mean?") and Serena Ruan ("can we hide `NO_PERMISSIONS`?") in the [bugbash doc](https://docs.google.com/document/d/17BWoF5n_a8Y1bafsQp1NDmSONe6uC9MDMPsCXn85aXg/edit). Stacks on #23406.

### What changes are proposed in this pull request?

The permission picker exposed every value from `PERMISSIONS` regardless of the chosen resource type:

- `NO_PERMISSIONS` — the backend rejects an explicit `NO_PERMISSIONS` grant on any resource; absence + `default_permission` already expresses "no access". Picking it just produced a 400 on submit.
- `USE` on `experiment` / `registered_model` / `prompt` / `scorer` — no-op over `READ` (Pat's reply in the doc: *"For experiments it don't give anything extra from READ"*). Users could only meaningfully pick `USE` for gateway resources.
- `READ` / `EDIT` on `workspace` — the backend rejects these at workspace scope (only `USE` / `MANAGE` are valid).

Add `PERMISSIONS_FOR_RESOURCE_TYPE` mirroring the backend's `_validate_permission_for_resource_type` (in `mlflow/server/auth/permissions.py`) and drive both `RolePermissionForm` and `DirectPermissionForm` selects from it. Switching resource type also coerces `permission` into the new type's grantable set so a stale tier (e.g. `READ` left over after switching to `workspace`) doesn't leak across types.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests — verified the picker matches the backend's allowed set across all resource types.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/uiux`

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release