### PR TITLE
Hide synthetic `__user_N__` roles in RBAC admin UI

### DIFF
--- a/mlflow/server/js/src/admin/components/EditAccessModal.tsx
+++ b/mlflow/server/js/src/admin/components/EditAccessModal.tsx
@@ -24,7 +24,7 @@ import {
   useUsersQuery,
 } from '../hooks';
 import { AccountQueryKeys } from '../../account/hooks';
-import { isSyntheticUserRole } from '../../account/types';
+import { isSyntheticUserRole } from '../types';
 import { useActiveWorkspace } from '../../workspaces/utils/WorkspaceUtils';
 import { RoleAssignmentForm, ROLE_ASSIGNMENT_DEFAULT, type RoleAssignmentValue } from './RoleAssignmentForm';
 import { type DirectGrantResourceType } from './DirectPermissionForm';
@@ -79,7 +79,13 @@ export const EditAccessModal = ({ open, onClose, username, onCreateRoleForAllOfT
   const rolesListEnabled = isCurrentUserAdmin || Boolean(activeWorkspace);
   const { data: rolesListData } = useRolesQuery(rolesListWorkspace, { enabled: rolesListEnabled });
 
-  const currentRoleIds = useMemo<number[]>(() => (rolesData?.roles ?? []).map((r) => r.id), [rolesData]);
+  // Synthetic ``__user_N__`` roles anchor direct grants — must not enter the
+  // editable set, or the picker's "Clear" would unassign them and orphan
+  // every direct grant.
+  const currentRoleIds = useMemo<number[]>(
+    () => (rolesData?.roles ?? []).filter((r) => !isSyntheticUserRole(r.name)).map((r) => r.id),
+    [rolesData],
+  );
   const currentDirectPerms = useMemo<StagedDirectPermission[]>(
     () =>
       (directPermsData?.permissions ?? [])

--- a/mlflow/server/js/src/admin/components/RoleAssignmentForm.test.tsx
+++ b/mlflow/server/js/src/admin/components/RoleAssignmentForm.test.tsx
@@ -19,6 +19,8 @@ jest.mock('../hooks', () => ({
         { id: 1, name: 'reader', workspace: 'default', description: null, permissions: [] },
         { id: 2, name: 'writer', workspace: 'default', description: null, permissions: [] },
         { id: 3, name: 'admin', workspace: 'default', description: null, permissions: [] },
+        // Synthetic per-user role — must be filtered out of the dropdown.
+        { id: 99, name: '__user_99__', workspace: 'default', description: null, permissions: [] },
       ],
     },
     isLoading: false,
@@ -66,5 +68,12 @@ describe('RoleAssignmentForm — multi-select trigger', () => {
     expect(readerOption).toHaveAttribute('aria-selected', 'true');
     expect(writerOption).toHaveAttribute('aria-selected', 'false');
     expect(adminOption).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('hides synthetic __user_N__ roles from the dropdown options', async () => {
+    renderWithDesignSystem(<RoleAssignmentForm value={{ roleIds: [] }} onChange={() => {}} />);
+    await userEvent.click(screen.getByRole('combobox'));
+    await screen.findByRole('option', { name: /default\/reader/ });
+    expect(screen.queryByRole('option', { name: /__user_99__/ })).not.toBeInTheDocument();
   });
 });

--- a/mlflow/server/js/src/admin/components/RoleAssignmentForm.tsx
+++ b/mlflow/server/js/src/admin/components/RoleAssignmentForm.tsx
@@ -13,7 +13,7 @@ import {
 import { FieldLabel } from './FieldLabel';
 import { useCurrentUserIsAdmin, useRolesQuery } from '../hooks';
 import { useActiveWorkspace } from '../../workspaces/utils/WorkspaceUtils';
-import type { Role } from '../types';
+import { isSyntheticUserRole, type Role } from '../types';
 
 export interface RoleAssignmentValue {
   roleIds: number[];
@@ -48,7 +48,10 @@ export const RoleAssignmentForm = ({ value, onChange, disabled }: RoleAssignment
   const queryWorkspace = isAdmin ? undefined : (activeWorkspace ?? undefined);
   const queryEnabled = isAdmin || Boolean(activeWorkspace);
   const { data: rolesData, isLoading, error } = useRolesQuery(queryWorkspace, { enabled: queryEnabled });
-  const roles = useMemo(() => rolesData?.roles ?? [], [rolesData]);
+  // Synthetic ``__user_N__`` roles back per-user direct grants. They
+  // shouldn't appear in the role picker — picking them would assign a
+  // role tied to another user's direct grants.
+  const roles = useMemo(() => (rolesData?.roles ?? []).filter((r) => !isSyntheticUserRole(r.name)), [rolesData]);
 
   // Pin "default" workspace's roles first; sort the rest alphabetically
   // by workspace then by role name, so the dropdown order is stable.

--- a/mlflow/server/js/src/admin/components/UserRolesCell.test.tsx
+++ b/mlflow/server/js/src/admin/components/UserRolesCell.test.tsx
@@ -66,4 +66,20 @@ describe('UserRolesCell', () => {
     expect(screen.getByText('foo')).toBeInTheDocument();
     expect(screen.getByText('bar')).toBeInTheDocument();
   });
+
+  it('hides synthetic __user_N__ roles regardless of scopeWorkspace', () => {
+    // Synthetic per-user roles back direct grants; they must never appear in
+    // the cell. Pin both the unscoped and the workspace-scoped paths.
+    renderWithDesignSystem(
+      <UserRolesCell
+        roles={[
+          role({ id: 1, name: '__user_1__', workspace: 'default' }),
+          role({ id: 2, name: 'editor', workspace: 'default' }),
+        ]}
+        scopeWorkspace={null}
+      />,
+    );
+    expect(screen.queryByText(/__user_1__/)).not.toBeInTheDocument();
+    expect(screen.getByText(/editor/)).toBeInTheDocument();
+  });
 });

--- a/mlflow/server/js/src/admin/components/UserRolesCell.tsx
+++ b/mlflow/server/js/src/admin/components/UserRolesCell.tsx
@@ -1,5 +1,5 @@
 import { Typography, useDesignSystemTheme } from '@databricks/design-system';
-import type { Role } from '../types';
+import { isSyntheticUserRole, type Role } from '../types';
 
 export interface UserRolesCellProps {
   roles: readonly Role[];
@@ -13,10 +13,13 @@ export interface UserRolesCellProps {
  * managers see only roles in workspaces they administer).
  * ``scopeWorkspace`` further narrows to the active workspace for the
  * per-workspace admin page, so the cell matches the page scope.
+ * Synthetic ``__user_N__`` roles are filtered out — they're per-user
+ * direct-grant bookkeeping, not real role assignments.
  */
 export const UserRolesCell = ({ roles: allRoles, scopeWorkspace }: UserRolesCellProps) => {
   const { theme } = useDesignSystemTheme();
-  const roles = scopeWorkspace ? allRoles.filter((r) => r.workspace === scopeWorkspace) : allRoles;
+  const visibleRoles = allRoles.filter((r) => !isSyntheticUserRole(r.name));
+  const roles = scopeWorkspace ? visibleRoles.filter((r) => r.workspace === scopeWorkspace) : visibleRoles;
   if (roles.length === 0) {
     return <Typography.Text color="secondary">—</Typography.Text>;
   }

--- a/mlflow/server/js/src/admin/pages/AdminPage.tsx
+++ b/mlflow/server/js/src/admin/pages/AdminPage.tsx
@@ -34,7 +34,7 @@ import {
   useDeleteRole,
   useWithSettingsReturnTo,
 } from '../hooks';
-import { isWorkspaceAdminRole } from '../types';
+import { isSyntheticUserRole, isWorkspaceAdminRole } from '../types';
 import { CreateUserModal } from '../components/CreateUserModal';
 import { CreateRoleModal } from '../components/CreateRoleModal';
 import { UserRolesCell } from '../components/UserRolesCell';
@@ -305,7 +305,10 @@ const RolesTab = () => {
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const roles = useMemo(() => rolesData?.roles ?? [], [rolesData]);
+  // Hide synthetic ``__user_N__`` roles: they're a backend bookkeeping
+  // device for per-user direct grants, not real role definitions an admin
+  // would manage from this table.
+  const roles = useMemo(() => (rolesData?.roles ?? []).filter((r) => !isSyntheticUserRole(r.name)), [rolesData]);
   const {
     visibleSelected: visibleSelectedRoleIds,
     isAllSelected: allSelected,

--- a/mlflow/server/js/src/admin/pages/UserDetailPage.tsx
+++ b/mlflow/server/js/src/admin/pages/UserDetailPage.tsx
@@ -28,8 +28,7 @@ import { useWorkspacesEnabled } from '../../experiment-tracking/hooks/useServerI
 import AdminRoutes from '../routes';
 import { EditAccessModal } from '../components/EditAccessModal';
 import { PermissionsSection } from '../../account/PermissionsSection';
-import { isSyntheticUserRole } from '../../account/types';
-import { isWorkspaceAdminRole } from '../types';
+import { isSyntheticUserRole, isWorkspaceAdminRole } from '../types';
 
 const UserDetailPage = () => {
   const { theme } = useDesignSystemTheme();
@@ -65,7 +64,9 @@ const UserDetailPage = () => {
   const [editAccessOpen, setEditAccessOpen] = useState(false);
 
   const user = useMemo(() => usersData?.users?.find((u) => u.username === username), [usersData, username]);
-  const allRoles = rolesData?.roles ?? [];
+  // Strip synthetic ``__user_N__`` roles — they back per-user direct
+  // grants and are rendered separately by the Permissions section.
+  const allRoles = useMemo(() => (rolesData?.roles ?? []).filter((r) => !isSyntheticUserRole(r.name)), [rolesData]);
   const roles = isAdmin || !activeWorkspace ? allRoles : allRoles.filter((r) => r.workspace === activeWorkspace);
   // ``GET /users/permissions/list`` returns every permission across every
   // role the user holds; filter to the synthetic ``__user_<id>__`` role to

--- a/mlflow/server/js/src/admin/types.ts
+++ b/mlflow/server/js/src/admin/types.ts
@@ -8,6 +8,7 @@ export {
   ALL_RESOURCE_PATTERN_LABEL,
   DEFAULT_WORKSPACE_NAME,
   formatResourcePattern,
+  isSyntheticUserRole,
   isWorkspaceAdminRole,
   parseResourcePattern,
 } from '../account/types';


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/23410/files) to review incremental changes.
- [stack/rbac-ui-no-self-delete](https://github.com/mlflow/mlflow/pull/23398) [[Files changed](https://github.com/mlflow/mlflow/pull/23398/files)] [MERGED]
  - [stack/rbac-ui-fix-selected-count](https://github.com/mlflow/mlflow/pull/23399) [[Files changed](https://github.com/mlflow/mlflow/pull/23399/files)] [MERGED]
    - [stack/rbac-ui-assign-users-rename](https://github.com/mlflow/mlflow/pull/23406) [[Files changed](https://github.com/mlflow/mlflow/pull/23406/files)] [MERGED]
      - [stack/rbac-ui-permission-options](https://github.com/mlflow/mlflow/pull/23407) [[Files changed](https://github.com/mlflow/mlflow/pull/23407/files)] [MERGED]
        - [stack/rbac-ui-hide-gateway-model-def](https://github.com/mlflow/mlflow/pull/23408) [[Files changed](https://github.com/mlflow/mlflow/pull/23408/files)] [MERGED]
          - [stack/rbac-ui-resource-type-labels](https://github.com/mlflow/mlflow/pull/23409) [[Files changed](https://github.com/mlflow/mlflow/pull/23409/files)] [MERGED]
            - [**stack/rbac-ui-hide-synthetic-roles**](https://github.com/mlflow/mlflow/pull/23410) [[Files changed](https://github.com/mlflow/mlflow/pull/23410/files)]
              - [stack/rbac-ui-drop-optional-subtitle](https://github.com/mlflow/mlflow/pull/23412) [[Files changed](https://github.com/mlflow/mlflow/pull/23412/files/c20ba20c2878f8bd2bfc4f4fdcd79e0c9f5383ad..9afca8d44914c5bef7ed9c2dcdd6aedf23b07572)]
                - [stack/rbac-reject-same-password](https://github.com/mlflow/mlflow/pull/23413) [[Files changed](https://github.com/mlflow/mlflow/pull/23413/files/9afca8d44914c5bef7ed9c2dcdd6aedf23b07572..02381f68cda1e5cb5399519176de4325bcf9303e)]
                  - [stack/rbac-ui-hide-workspace-cols](https://github.com/mlflow/mlflow/pull/23414) [[Files changed](https://github.com/mlflow/mlflow/pull/23414/files/02381f68cda1e5cb5399519176de4325bcf9303e..5291debcb8275afd2aeab6eef358247ca72efb66)]
                    - [stack/rbac-ui-error-near-submit](https://github.com/mlflow/mlflow/pull/23415) [[Files changed](https://github.com/mlflow/mlflow/pull/23415/files/5291debcb8275afd2aeab6eef358247ca72efb66..9d9f7ed11724422fe7ab38ce2b00a409defb9818)]
                      - [stack/rbac-isolate-auth-db](https://github.com/mlflow/mlflow/pull/23417) [[Files changed](https://github.com/mlflow/mlflow/pull/23417/files/9d9f7ed11724422fe7ab38ce2b00a409defb9818..146e8fecaab86c7c9356a88dc7cc8392df17ac46)]
                        - [stack/rbac-ui-scorer-picker](https://github.com/mlflow/mlflow/pull/23420) [[Files changed](https://github.com/mlflow/mlflow/pull/23420/files/146e8fecaab86c7c9356a88dc7cc8392df17ac46..d3dbf20a77c7658fd6307e1e9b3c17d710791ad8)]
                          - [stack/rbac-reserve-user-prefix](https://github.com/mlflow/mlflow/pull/23496) [[Files changed](https://github.com/mlflow/mlflow/pull/23496/files/d3dbf20a77c7658fd6307e1e9b3c17d710791ad8..e60732a01606d348656e6ef68be556bf6b1bd0f6)]

---------
### Related Issues/PRs

RBAC bugbash paper-cut. Reported by Tomu Hirata twice — "I'm not sure if we should display the synthetic role in this table" (Roles tab) and "Can we not display these synthetic roles from this selectbox?" (role picker). See the [bugbash doc](https://docs.google.com/document/d/17BWoF5n_a8Y1bafsQp1NDmSONe6uC9MDMPsCXn85aXg/edit). Stacks on #23409.

### What changes are proposed in this pull request?

The backend keeps a hidden per-user role named `__user_<id>__` (see `sqlalchemy_store._SYNTHETIC_ROLE_NAME_RE`) to anchor a user's direct grants. It's an implementation detail — admins shouldn't see it in role tables or pick it from role-assignment selects.

Add `isSyntheticUserRole` to `admin/types.ts` and filter synthetic roles out of:

- the Roles table on the admin page (`AdminPage.tsx`)
- the role multi-select in `RoleAssignmentForm.tsx` (user create / edit access)
- the per-user roles cell on the admin Users tab (`UserRolesCell.tsx`)
- the roles table on the user detail page (`UserDetailPage.tsx`)

The user's direct grants still render via `PermissionsSection` on the user detail page, so no information is lost — just the synthetic role bookkeeping is hidden.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/uiux`

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release