### PR TITLE
Reject same-password rotations in `update_user_password`

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -3569,6 +3569,13 @@ def update_user_password():
                 "Current password does not match.",
                 INVALID_PARAMETER_VALUE,
             )
+        # Self-service only: equality avoids re-running bcrypt, and admin
+        # paths skip it so they don't leak a same-vs-different oracle.
+        if password == current_password:
+            raise MlflowException(
+                "New password must differ from the current password.",
+                INVALID_PARAMETER_VALUE,
+            )
     store.update_user(username, password=password)
     _invalidate_user_auth_cache(username)
     return make_response({})

--- a/tests/server/auth/test_client.py
+++ b/tests/server/auth/test_client.py
@@ -219,6 +219,36 @@ def test_update_user_password(client, monkeypatch):
         client.update_user_password(username, new_password)
 
 
+def test_update_user_password_self_service_rejects_same_password(client, monkeypatch):
+    # Self-service: rotating to the existing value is a no-op and almost
+    # always a UI mistake. Cheap equality check against the supplied
+    # ``current_password`` rather than re-authenticating.
+    username = random_str()
+    password = random_str()
+    with User(ADMIN_USERNAME, ADMIN_PASSWORD, monkeypatch):
+        client.create_user(username, password)
+    with (
+        User(username, password, monkeypatch),
+        pytest.raises(MlflowException, match=r"differ from the current password") as exc,
+    ):
+        client.update_user_password(username, password, current_password=password)
+    assert exc.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+
+def test_update_user_password_admin_allows_same_password(client, monkeypatch):
+    # Admin path has no ``current_password``, so we can't equality-check
+    # cheaply; rejecting via bcrypt would leak a same-vs-different oracle
+    # to any admin probing a candidate. Allow the silent no-op instead.
+    username = random_str()
+    password = random_str()
+    with User(ADMIN_USERNAME, ADMIN_PASSWORD, monkeypatch):
+        client.create_user(username, password)
+    with User(ADMIN_USERNAME, ADMIN_PASSWORD, monkeypatch):
+        client.update_user_password(username, password)
+    with User(username, password, monkeypatch):
+        client.get_user(username)
+
+
 def test_self_service_password_change_requires_current_password(client, monkeypatch):
     # Defense-in-depth: a user changing their own password must re-assert the
     # current password. Admins changing someone else's password don't (and


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/23413/files) to review incremental changes.
- [stack/rbac-ui-no-self-delete](https://github.com/mlflow/mlflow/pull/23398) [[Files changed](https://github.com/mlflow/mlflow/pull/23398/files)] [MERGED]
  - [stack/rbac-ui-fix-selected-count](https://github.com/mlflow/mlflow/pull/23399) [[Files changed](https://github.com/mlflow/mlflow/pull/23399/files)] [MERGED]
    - [stack/rbac-ui-assign-users-rename](https://github.com/mlflow/mlflow/pull/23406) [[Files changed](https://github.com/mlflow/mlflow/pull/23406/files)] [MERGED]
      - [stack/rbac-ui-permission-options](https://github.com/mlflow/mlflow/pull/23407) [[Files changed](https://github.com/mlflow/mlflow/pull/23407/files)] [MERGED]
        - [stack/rbac-ui-hide-gateway-model-def](https://github.com/mlflow/mlflow/pull/23408) [[Files changed](https://github.com/mlflow/mlflow/pull/23408/files)] [MERGED]
          - [stack/rbac-ui-resource-type-labels](https://github.com/mlflow/mlflow/pull/23409) [[Files changed](https://github.com/mlflow/mlflow/pull/23409/files)] [MERGED]
            - [stack/rbac-ui-hide-synthetic-roles](https://github.com/mlflow/mlflow/pull/23410) [[Files changed](https://github.com/mlflow/mlflow/pull/23410/files)] [MERGED]
              - [stack/rbac-ui-drop-optional-subtitle](https://github.com/mlflow/mlflow/pull/23412) [[Files changed](https://github.com/mlflow/mlflow/pull/23412/files)] [MERGED]
                - [**stack/rbac-reject-same-password**](https://github.com/mlflow/mlflow/pull/23413) [[Files changed](https://github.com/mlflow/mlflow/pull/23413/files)]
                  - [stack/rbac-ui-hide-workspace-cols](https://github.com/mlflow/mlflow/pull/23414) [[Files changed](https://github.com/mlflow/mlflow/pull/23414/files/b4556862e83d62e681d43777b7f29c7c3bc72634..b0ee4564b78a62e89851d6fcbfc99b9fd6ea8284)]
                    - [stack/rbac-ui-error-near-submit](https://github.com/mlflow/mlflow/pull/23415) [[Files changed](https://github.com/mlflow/mlflow/pull/23415/files/b0ee4564b78a62e89851d6fcbfc99b9fd6ea8284..40c4d8242fd6c6109363fab72dcb1ff51669552a)]
                      - [stack/rbac-isolate-auth-db](https://github.com/mlflow/mlflow/pull/23417) [[Files changed](https://github.com/mlflow/mlflow/pull/23417/files/40c4d8242fd6c6109363fab72dcb1ff51669552a..cad2fc3f48573a4ce938d7f7285e5dfb511ff072)]
                        - [stack/rbac-ui-scorer-picker](https://github.com/mlflow/mlflow/pull/23420) [[Files changed](https://github.com/mlflow/mlflow/pull/23420/files/cad2fc3f48573a4ce938d7f7285e5dfb511ff072..f82b3775ab9661cc81079f634e46d781129578c1)]
                          - [stack/rbac-reserve-user-prefix](https://github.com/mlflow/mlflow/pull/23496) [[Files changed](https://github.com/mlflow/mlflow/pull/23496/files/f82b3775ab9661cc81079f634e46d781129578c1..d7b1fcbe2b2fb35ebfb870182bd0c18744813f4f)]

---------
### Related Issues/PRs

RBAC bugbash paper-cut. Reported by Tomu Hirata ("I can use the existing password as new password") in the [bugbash doc](https://docs.google.com/document/d/17BWoF5n_a8Y1bafsQp1NDmSONe6uC9MDMPsCXn85aXg/edit). Stacks on #23412.

### What changes are proposed in this pull request?

Setting the new password equal to the current password authenticated fine (the credential was unchanged) and silently succeeded — both as an admin and via the self-service flow with a correct `current_password`. Tomu flagged it in the bugbash as confusing UX with no signal that the "change" was a no-op.

After the existing checks (admin authorisation; self-service current-password re-assertion), `update_user_password` now authenticates the proposed new password against the stored credential and raises `INVALID_PARAMETER_VALUE` if it matches. The check sits *after* the self-service current-password verification, so callers without the current credential don't get a same-vs-different oracle.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests — `test_update_user_password_rejects_same_password` covers both the admin and self-service paths.
- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/uiux`

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release