### PR TITLE
Hide workspace columns in admin tables when workspaces are disabled

### DIFF
--- a/mlflow/server/js/src/admin/components/UserRolesCell.test.tsx
+++ b/mlflow/server/js/src/admin/components/UserRolesCell.test.tsx
@@ -1,9 +1,23 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import React from 'react';
 import { renderWithDesignSystem, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
 
 import { UserRolesCell } from './UserRolesCell';
 import type { Role } from '../types';
+import { useWorkspacesEnabled } from '../../experiment-tracking/hooks/useServerInfo';
+
+// ``useWorkspacesEnabled`` hits a React Query under the hood; mock it to
+// keep these tests provider-free. Cases override the return per-test via
+// ``mockReturnValue`` to exercise both the multi- and single-tenant paths.
+jest.mock('../../experiment-tracking/hooks/useServerInfo', () => ({
+  useWorkspacesEnabled: jest.fn(),
+}));
+
+const mockUseWorkspacesEnabled = jest.mocked(useWorkspacesEnabled);
+
+beforeEach(() => {
+  mockUseWorkspacesEnabled.mockReturnValue({ workspacesEnabled: true, loading: false });
+});
 
 const role = (overrides: Partial<Role>): Role => ({
   id: 1,
@@ -80,6 +94,26 @@ describe('UserRolesCell', () => {
       />,
     );
     expect(screen.queryByText(/__user_1__/)).not.toBeInTheDocument();
+    expect(screen.getByText(/editor/)).toBeInTheDocument();
+  });
+
+  it('renders only the role name (no workspace prefix) in single-tenant mode', () => {
+    mockUseWorkspacesEnabled.mockReturnValue({ workspacesEnabled: false, loading: false });
+    renderWithDesignSystem(
+      <UserRolesCell roles={[role({ id: 1, name: 'editor', workspace: 'default' })]} scopeWorkspace={null} />,
+    );
+    expect(screen.getByText('editor')).toBeInTheDocument();
+    expect(screen.queryByText('default')).not.toBeInTheDocument();
+  });
+
+  it('keeps the workspace prefix while the server-info query is loading', () => {
+    // Avoids a hide-then-show flicker: until we know the server is
+    // single-tenant, render the multi-tenant layout.
+    mockUseWorkspacesEnabled.mockReturnValue({ workspacesEnabled: false, loading: true });
+    renderWithDesignSystem(
+      <UserRolesCell roles={[role({ id: 1, name: 'editor', workspace: 'foo' })]} scopeWorkspace={null} />,
+    );
+    expect(screen.getByText('foo')).toBeInTheDocument();
     expect(screen.getByText(/editor/)).toBeInTheDocument();
   });
 });

--- a/mlflow/server/js/src/admin/components/UserRolesCell.tsx
+++ b/mlflow/server/js/src/admin/components/UserRolesCell.tsx
@@ -1,4 +1,5 @@
 import { Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { useWorkspacesEnabled } from '../../experiment-tracking/hooks/useServerInfo';
 import { isSyntheticUserRole, type Role } from '../types';
 
 export interface UserRolesCellProps {
@@ -14,10 +15,18 @@ export interface UserRolesCellProps {
  * ``scopeWorkspace`` further narrows to the active workspace for the
  * per-workspace admin page, so the cell matches the page scope.
  * Synthetic ``__user_N__`` roles are filtered out — they're per-user
- * direct-grant bookkeeping, not real role assignments.
+ * direct-grant bookkeeping, not real role assignments. When the server is
+ * in single-tenant mode (workspaces disabled), the workspace prefix is
+ * dropped since every role lives in ``default``.
  */
 export const UserRolesCell = ({ roles: allRoles, scopeWorkspace }: UserRolesCellProps) => {
   const { theme } = useDesignSystemTheme();
+  const { workspacesEnabled, loading } = useWorkspacesEnabled();
+  // While the server-info query is in-flight, default to the multi-tenant
+  // layout so the cell doesn't flicker from name-only to prefixed once the
+  // value settles. Single-tenant servers briefly show the prefix on a cold
+  // load, then drop it.
+  const showWorkspacePrefix = loading || workspacesEnabled;
   const visibleRoles = allRoles.filter((r) => !isSyntheticUserRole(r.name));
   const roles = scopeWorkspace ? visibleRoles.filter((r) => r.workspace === scopeWorkspace) : visibleRoles;
   if (roles.length === 0) {
@@ -27,7 +36,13 @@ export const UserRolesCell = ({ roles: allRoles, scopeWorkspace }: UserRolesCell
     <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs / 2 }}>
       {roles.map((role) => (
         <Typography.Text key={role.id} size="sm">
-          <code>{role.workspace}</code> → {role.name}
+          {showWorkspacePrefix ? (
+            <>
+              <code>{role.workspace}</code> → {role.name}
+            </>
+          ) : (
+            role.name
+          )}
         </Typography.Text>
       ))}
     </div>

--- a/mlflow/server/js/src/admin/pages/AdminPage.tsx
+++ b/mlflow/server/js/src/admin/pages/AdminPage.tsx
@@ -19,6 +19,7 @@ import {
 import { FormattedMessage } from 'react-intl';
 import { ScrollablePageWrapper } from '@mlflow/mlflow/src/common/components/ScrollablePageWrapper';
 import { Link, useLocation, useSearchParams } from '../../common/utils/RoutingUtils';
+import { useWorkspacesEnabled } from '../../experiment-tracking/hooks/useServerInfo';
 import { useActiveWorkspace } from '../../workspaces/utils/WorkspaceUtils';
 import { ConfirmationModal } from '../ConfirmationModal';
 import AdminRoutes, { AdminRoutePaths } from '../routes';
@@ -294,6 +295,13 @@ const RolesTab = () => {
   const isAdmin = useCurrentUserIsAdmin();
   const adminWorkspaces = useCurrentUserAdminWorkspaces();
   const activeWorkspace = useActiveWorkspace();
+  // Hide the per-workspace columns in single-tenant mode. The admin-vs-not
+  // distinction stays meaningful — relabel "Workspace Manager" → "Admin"
+  // to match the user-detail page. Default to the multi-tenant layout
+  // while the server-info query is in-flight so columns don't reflow.
+  const { workspacesEnabled, loading: workspacesEnabledLoading } = useWorkspacesEnabled();
+  const showWorkspaceColumn = workspacesEnabledLoading || workspacesEnabled;
+  const adminTagLabel = workspacesEnabled || workspacesEnabledLoading ? 'Manager' : 'Admin';
   const canManageRoles = isAdmin || (activeWorkspace !== null && adminWorkspaces.has(activeWorkspace));
   const queryWorkspace = isAdmin ? undefined : (activeWorkspace ?? undefined);
   const queryEnabled = isAdmin || Boolean(activeWorkspace);
@@ -454,17 +462,26 @@ const RolesTab = () => {
           <TableHeader componentId="admin.roles.name_header" css={{ flex: 2 }}>
             <FormattedMessage defaultMessage="Name" description="Roles table name header" />
           </TableHeader>
-          <TableHeader componentId="admin.roles.workspace_header" css={{ flex: 1 }}>
-            <FormattedMessage defaultMessage="Workspace" description="Roles table workspace header" />
-          </TableHeader>
+          {showWorkspaceColumn && (
+            <TableHeader componentId="admin.roles.workspace_header" css={{ flex: 1 }}>
+              <FormattedMessage defaultMessage="Workspace" description="Roles table workspace header" />
+            </TableHeader>
+          )}
           <TableHeader componentId="admin.roles.description_header" css={{ flex: 2 }}>
             <FormattedMessage defaultMessage="Description" description="Roles table description header" />
           </TableHeader>
           <TableHeader componentId="admin.roles.admin_role_header" css={{ flex: 1 }}>
-            <FormattedMessage
-              defaultMessage="Workspace Manager"
-              description="Roles table column flagging roles that grant workspace-level MANAGE"
-            />
+            {showWorkspaceColumn ? (
+              <FormattedMessage
+                defaultMessage="Workspace Manager"
+                description="Roles table column flagging roles that grant workspace-level MANAGE"
+              />
+            ) : (
+              <FormattedMessage
+                defaultMessage="Admin"
+                description="Roles table column flagging admin roles when workspaces are disabled"
+              />
+            )}
           </TableHeader>
         </TableRow>
         {roles.map((role) => (
@@ -484,12 +501,12 @@ const RolesTab = () => {
                 {role.name}
               </Link>
             </TableCell>
-            <TableCell css={{ flex: 1 }}>{role.workspace}</TableCell>
+            {showWorkspaceColumn && <TableCell css={{ flex: 1 }}>{role.workspace}</TableCell>}
             <TableCell css={{ flex: 2 }}>{role.description || '-'}</TableCell>
             <TableCell css={{ flex: 1 }}>
               {isWorkspaceAdminRole(role) ? (
                 <Tag componentId="admin.roles.admin_tag" color="indigo">
-                  Manager
+                  {adminTagLabel}
                 </Tag>
               ) : null}
             </TableCell>

--- a/mlflow/server/js/src/admin/pages/RoleDetailPage.tsx
+++ b/mlflow/server/js/src/admin/pages/RoleDetailPage.tsx
@@ -18,6 +18,7 @@ import { ScrollablePageWrapper } from '@mlflow/mlflow/src/common/components/Scro
 import { Link, useParams, useSearchParams } from '../../common/utils/RoutingUtils';
 import AdminRoutes from '../routes';
 import { useRoleDetailQuery, useRoleUsersQuery, useUsersQuery, useWithSettingsReturnTo } from '../hooks';
+import { useWorkspacesEnabled } from '../../experiment-tracking/hooks/useServerInfo';
 import { formatResourcePattern, isWorkspaceAdminRole } from '../types';
 import { EditRoleModal } from '../components/EditRoleModal';
 
@@ -159,6 +160,10 @@ const RoleDetailPage = () => {
   const isValidRoleId = Number.isFinite(roleId);
 
   const { data: roleData, isLoading, error: loadError } = useRoleDetailQuery(roleId);
+  // Default to the multi-tenant labels while server-info is in-flight so
+  // the tag and subtitle don't reflow once the query settles.
+  const { workspacesEnabled, loading: workspacesEnabledLoading } = useWorkspacesEnabled();
+  const showWorkspaceLabels = workspacesEnabledLoading || workspacesEnabled;
   const withReturnTo = useWithSettingsReturnTo();
   const [searchParams, setSearchParams] = useSearchParams();
   const tabFromUrl = searchParams.get('tab');
@@ -242,15 +247,16 @@ const RoleDetailPage = () => {
                   {role.name}
                 </Typography.Title>
                 {isWorkspaceAdminRole(role) && (
-                  // Match the rolesTable column header ("Workspace Manager")
-                  // and the per-row tag text ("Manager") used elsewhere.
+                  // Mirror the AdminPage roles table: "Manager" in multi-tenant
+                  // mode, "Admin" in single-tenant.
                   <Tag componentId="admin.role.admin_tag" color="indigo">
-                    Manager
+                    {showWorkspaceLabels ? 'Manager' : 'Admin'}
                   </Tag>
                 )}
               </div>
               <Typography.Text color="secondary">
-                {role.description || 'No description'} · Workspace: {role.workspace}
+                {role.description || 'No description'}
+                {showWorkspaceLabels ? ` · Workspace: ${role.workspace}` : ''}
               </Typography.Text>
             </div>
             <Button componentId="admin.role.edit_button" type="primary" onClick={() => setEditRoleOpen(true)}>

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -5419,6 +5419,10 @@
     "defaultMessage": "Create endpoint",
     "description": "Page title for create endpoint"
   },
+  "UlkINy": {
+    "defaultMessage": "Admin",
+    "description": "Roles table column flagging admin roles when workspaces are disabled"
+  },
   "UmwZQv": {
     "defaultMessage": "using Prompt Engineering",
     "description": "String for creating a new run with prompt engineering modal"


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/23414/files) to review incremental changes.
- [stack/rbac-ui-no-self-delete](https://github.com/mlflow/mlflow/pull/23398) [[Files changed](https://github.com/mlflow/mlflow/pull/23398/files)] [MERGED]
  - [stack/rbac-ui-fix-selected-count](https://github.com/mlflow/mlflow/pull/23399) [[Files changed](https://github.com/mlflow/mlflow/pull/23399/files)] [MERGED]
    - [stack/rbac-ui-assign-users-rename](https://github.com/mlflow/mlflow/pull/23406) [[Files changed](https://github.com/mlflow/mlflow/pull/23406/files)] [MERGED]
      - [stack/rbac-ui-permission-options](https://github.com/mlflow/mlflow/pull/23407) [[Files changed](https://github.com/mlflow/mlflow/pull/23407/files)] [MERGED]
        - [stack/rbac-ui-hide-gateway-model-def](https://github.com/mlflow/mlflow/pull/23408) [[Files changed](https://github.com/mlflow/mlflow/pull/23408/files)] [MERGED]
          - [stack/rbac-ui-resource-type-labels](https://github.com/mlflow/mlflow/pull/23409) [[Files changed](https://github.com/mlflow/mlflow/pull/23409/files)] [MERGED]
            - [stack/rbac-ui-hide-synthetic-roles](https://github.com/mlflow/mlflow/pull/23410) [[Files changed](https://github.com/mlflow/mlflow/pull/23410/files)] [MERGED]
              - [stack/rbac-ui-drop-optional-subtitle](https://github.com/mlflow/mlflow/pull/23412) [[Files changed](https://github.com/mlflow/mlflow/pull/23412/files)] [MERGED]
                - [stack/rbac-reject-same-password](https://github.com/mlflow/mlflow/pull/23413) [[Files changed](https://github.com/mlflow/mlflow/pull/23413/files)] [MERGED]
                  - [**stack/rbac-ui-hide-workspace-cols**](https://github.com/mlflow/mlflow/pull/23414) [[Files changed](https://github.com/mlflow/mlflow/pull/23414/files)]
                    - [stack/rbac-ui-error-near-submit](https://github.com/mlflow/mlflow/pull/23415) [[Files changed](https://github.com/mlflow/mlflow/pull/23415/files/56470e1acb954e814b5a3a07578069fb2fd13be3..16fe409f6bf62b21469b67974961dad751346e11)]
                      - [stack/rbac-isolate-auth-db](https://github.com/mlflow/mlflow/pull/23417) [[Files changed](https://github.com/mlflow/mlflow/pull/23417/files/16fe409f6bf62b21469b67974961dad751346e11..a61a07269e7c564b37942e46575d718fc222d535)]
                        - [stack/rbac-ui-scorer-picker](https://github.com/mlflow/mlflow/pull/23420) [[Files changed](https://github.com/mlflow/mlflow/pull/23420/files/a61a07269e7c564b37942e46575d718fc222d535..5c2039297c33e2a460d5f10bff8ab4ad9f38d656)]
                          - [stack/rbac-reserve-user-prefix](https://github.com/mlflow/mlflow/pull/23496) [[Files changed](https://github.com/mlflow/mlflow/pull/23496/files/5c2039297c33e2a460d5f10bff8ab4ad9f38d656..9a9649122e75428e41eb58a916ce2a5610e136f9)]

---------
### Related Issues/PRs

RBAC bugbash paper-cut. Reported by Serena Ruan ("we shouldn't display Workspace and Workspace Manager columns when there is no workspace enabled") and seconded by Tomu Hirata in the [bugbash doc](https://docs.google.com/document/d/17BWoF5n_a8Y1bafsQp1NDmSONe6uC9MDMPsCXn85aXg/edit). Stacks on #23413.

### What changes are proposed in this pull request?

The Roles tab on the admin page rendered the `Workspace` and `Workspace Manager` columns unconditionally — but when the server is in single-tenant mode (`workspacesEnabled === false`) every role lives in `default` and "Workspace Manager" loses meaning (admin-vs-not is the only distinction).

Gate both columns on `useWorkspacesEnabled()` so the Roles table matches the user-detail Roles table, which already conditioned the same columns.

Also drop the workspace prefix in `UserRolesCell` when workspaces are disabled — rendering `default → admin` on every row of the Users tab was just noise.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests — verified the Roles tab and Users tab render correctly with and without `--enable-workspaces`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/uiux`

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release