### PR TITLE
Sticky + flicker-free partial-failure error Alert in admin modals

### DIFF
--- a/mlflow/server/js/src/admin/components/CreateRoleModal.tsx
+++ b/mlflow/server/js/src/admin/components/CreateRoleModal.tsx
@@ -53,6 +53,9 @@ export const CreateRoleModal = ({ open, onClose }: CreateRoleModalProps) => {
   const [usernames, setUsernames] = useState<string[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Set after the role lands; lets retries skip ``createRole`` and
+  // just re-run the failed best-effort follow-ups.
+  const [createdRoleId, setCreatedRoleId] = useState<number | null>(null);
 
   const workspaceOptions = useMemo(() => {
     const others = new Set<string>();
@@ -71,34 +74,40 @@ export const CreateRoleModal = ({ open, onClose }: CreateRoleModalProps) => {
       setUsernames([]);
       setSubmitting(false);
       setError(null);
+      setCreatedRoleId(null);
     }
   }, [open]);
 
-  const canSubmit = name.trim().length > 0;
+  // Retry mode skips the name guard (the field is also disabled).
+  const canSubmit = createdRoleId !== null || name.trim().length > 0;
 
   const handleSubmit = useCallback(async () => {
-    setError(null);
+    // No ``setError(null)`` upfront — would hide/show flicker as the
+    // async path resets it. Every branch below replaces or closes.
     const trimmedName = name.trim();
-    if (!trimmedName) {
+    if (createdRoleId === null && !trimmedName) {
       setError('Role name cannot be empty');
       return;
     }
 
     setSubmitting(true);
 
-    let roleId: number;
-    try {
-      const request: CreateRoleRequest = {
-        name: trimmedName,
-        workspace,
-        description: description || undefined,
-      };
-      const created = await createRole.mutateAsync(request);
-      roleId = created.role.id;
-    } catch (e: any) {
-      setError(e?.message || 'Failed to create role');
-      setSubmitting(false);
-      return;
+    let roleId = createdRoleId;
+    if (roleId === null) {
+      try {
+        const request: CreateRoleRequest = {
+          name: trimmedName,
+          workspace,
+          description: description || undefined,
+        };
+        const created = await createRole.mutateAsync(request);
+        roleId = created.role.id;
+        setCreatedRoleId(roleId);
+      } catch (e: any) {
+        setError(e?.message || 'Failed to create role');
+        setSubmitting(false);
+        return;
+      }
     }
 
     // Best-effort: partial failures are surfaced, but the role itself
@@ -138,7 +147,7 @@ export const CreateRoleModal = ({ open, onClose }: CreateRoleModalProps) => {
         `\nFinish wiring up the role from the role detail page.`,
     );
     setSubmitting(false);
-  }, [name, workspace, description, permissions, usernames, createRole, onClose]);
+  }, [name, workspace, description, permissions, usernames, createdRoleId, createRole, onClose]);
 
   return (
     <Modal
@@ -159,19 +168,25 @@ export const CreateRoleModal = ({ open, onClose }: CreateRoleModalProps) => {
             loading={submitting}
             disabled={!canSubmit}
           >
-            Create role
+            {createdRoleId !== null ? 'Retry failed grants' : 'Create role'}
           </Button>
         </div>
       }
     >
       {error && (
+        // Sticky so partial-failure errors stay visible during scroll.
         <Alert
           componentId="admin.create_role_modal.error"
           type="error"
           message={error}
           closable
           onClose={() => setError(null)}
-          css={{ marginBottom: theme.spacing.md }}
+          css={{
+            marginBottom: theme.spacing.md,
+            position: 'sticky',
+            top: 0,
+            zIndex: 1,
+          }}
         />
       )}
       <LongFormSection title="Role details">
@@ -184,7 +199,7 @@ export const CreateRoleModal = ({ open, onClose }: CreateRoleModalProps) => {
               onChange={(e) => setName(e.target.value)}
               placeholder="Enter role name"
               autoFocus
-              disabled={submitting}
+              disabled={submitting || createdRoleId !== null}
             />
           </div>
           {workspacesEnabled && (
@@ -195,7 +210,7 @@ export const CreateRoleModal = ({ open, onClose }: CreateRoleModalProps) => {
                 componentId="admin.create_role_modal.workspace"
                 value={workspace}
                 onChange={({ target }) => setWorkspace(target.value)}
-                disabled={submitting}
+                disabled={submitting || createdRoleId !== null}
               >
                 {workspaceOptions.map((w) => (
                   <SimpleSelectOption key={w} value={w}>
@@ -212,7 +227,7 @@ export const CreateRoleModal = ({ open, onClose }: CreateRoleModalProps) => {
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               placeholder="Enter description (optional)"
-              disabled={submitting}
+              disabled={submitting || createdRoleId !== null}
             />
           </div>
           <Typography.Paragraph css={{ color: theme.colors.textSecondary, marginTop: theme.spacing.sm }}>

--- a/mlflow/server/js/src/admin/components/CreateUserModal.tsx
+++ b/mlflow/server/js/src/admin/components/CreateUserModal.tsx
@@ -39,6 +39,9 @@ export const CreateUserModal = ({ open, onClose }: CreateUserModalProps) => {
   const [directPermissions, setDirectPermissions] = useState<StagedDirectPermission[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Set after the user lands; lets retries skip ``createUser`` and
+  // just re-run the failed best-effort follow-ups.
+  const [createdUsername, setCreatedUsername] = useState<string | null>(null);
 
   useEffect(() => {
     if (open) {
@@ -49,28 +52,36 @@ export const CreateUserModal = ({ open, onClose }: CreateUserModalProps) => {
       setDirectPermissions([]);
       setSubmitting(false);
       setError(null);
+      setCreatedUsername(null);
     }
   }, [open]);
 
   const wantsRoles = roleValue.roleIds.length > 0;
   const wantsDirect = directPermissions.length > 0;
-  const canSubmit = Boolean(username.trim() && password);
+  // Retry mode skips the credential guard (the fields are also disabled).
+  const canSubmit = createdUsername !== null || Boolean(username.trim() && password);
 
   const handleSubmit = useCallback(async () => {
-    setError(null);
+    // No ``setError(null)`` upfront — would hide/show flicker as the
+    // async path resets it. Every branch below replaces or closes.
     const trimmedUsername = username.trim();
-    if (!trimmedUsername || !password) {
+    if (createdUsername === null && (!trimmedUsername || !password)) {
       setError('Username and password are required');
       return;
     }
 
     setSubmitting(true);
-    try {
-      await createUser.mutateAsync({ username: trimmedUsername, password });
-    } catch (e: any) {
-      setError(e?.message || 'Failed to create user');
-      setSubmitting(false);
-      return;
+    // Skip the create step if a prior submission already landed it; we
+    // only need to retry the failed best-effort follow-ups.
+    if (createdUsername === null) {
+      try {
+        await createUser.mutateAsync({ username: trimmedUsername, password });
+        setCreatedUsername(trimmedUsername);
+      } catch (e: any) {
+        setError(e?.message || 'Failed to create user');
+        setSubmitting(false);
+        return;
+      }
     }
 
     // The user exists. Treat the follow-up steps as best-effort: surface
@@ -134,6 +145,7 @@ export const CreateUserModal = ({ open, onClose }: CreateUserModalProps) => {
     wantsDirect,
     roleValue.roleIds,
     directPermissions,
+    createdUsername,
     createUser,
     queryClient,
     grantPermission,
@@ -159,19 +171,29 @@ export const CreateUserModal = ({ open, onClose }: CreateUserModalProps) => {
             loading={submitting}
             disabled={!canSubmit}
           >
-            {isAdmin || wantsRoles || wantsDirect ? 'Create user and grant access' : 'Create user'}
+            {createdUsername !== null
+              ? 'Retry failed grants'
+              : isAdmin || wantsRoles || wantsDirect
+                ? 'Create user and grant access'
+                : 'Create user'}
           </Button>
         </div>
       }
     >
       {error && (
+        // Sticky so partial-failure errors stay visible during scroll.
         <Alert
           componentId="admin.create_user_modal.error"
           type="error"
           message={error}
           closable
           onClose={() => setError(null)}
-          css={{ marginBottom: theme.spacing.md }}
+          css={{
+            marginBottom: theme.spacing.md,
+            position: 'sticky',
+            top: 0,
+            zIndex: 1,
+          }}
         />
       )}
       <LongFormSection title="User details">
@@ -184,7 +206,7 @@ export const CreateUserModal = ({ open, onClose }: CreateUserModalProps) => {
               onChange={(e) => setUsername(e.target.value)}
               placeholder="Enter username"
               autoFocus
-              disabled={submitting}
+              disabled={submitting || createdUsername !== null}
             />
           </div>
           <div>
@@ -195,7 +217,7 @@ export const CreateUserModal = ({ open, onClose }: CreateUserModalProps) => {
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               placeholder="Enter password"
-              disabled={submitting}
+              disabled={submitting || createdUsername !== null}
             />
           </div>
         </div>

--- a/mlflow/server/js/src/admin/components/EditAccessModal.tsx
+++ b/mlflow/server/js/src/admin/components/EditAccessModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Alert,
   Button,
@@ -117,18 +117,36 @@ export const EditAccessModal = ({ open, onClose, username, onCreateRoleForAllOfT
 
   const stateLoaded = !rolesLoading && !directPermsLoading && !usersLoading;
 
-  // Re-pre-fill whenever the modal opens or the backing data resolves.
+  // ``prefilledRef`` gates the data-fill effect against background
+  // refetches that would clobber in-progress edits.
+  const prefilledRef = useRef(false);
+
+  // Reset transient UI state only on open — refetches must not bounce
+  // the user back to edit or wipe a partial-failure error.
   useEffect(() => {
     if (!open) {
       return;
     }
     setStep('edit');
+    setSubmitting(false);
+    setError(null);
+    prefilledRef.current = false;
+  }, [open]);
+
+  // Pre-fill editable fields once per open, after backing queries resolve.
+  useEffect(() => {
+    if (!open) {
+      prefilledRef.current = false;
+      return;
+    }
+    if (prefilledRef.current || !stateLoaded) {
+      return;
+    }
     setRoleValue({ roleIds: [...currentRoleIds] });
     setDirectPermissions([...currentDirectPerms]);
     setIsAdmin(currentIsAdmin);
-    setSubmitting(false);
-    setError(null);
-  }, [open, currentRoleIds, currentDirectPerms, currentIsAdmin]);
+    prefilledRef.current = true;
+  }, [open, stateLoaded, currentRoleIds, currentDirectPerms, currentIsAdmin]);
 
   // --- Diff computation ---
   const diff = useMemo<AccessDiff>(() => {
@@ -186,7 +204,8 @@ export const EditAccessModal = ({ open, onClose, username, onCreateRoleForAllOfT
   );
 
   const handleConfirm = useCallback(async () => {
-    setError(null);
+    // ``error`` is already cleared by the "Review changes" transition;
+    // skipping a redundant reset here also avoids the flicker.
     setSubmitting(true);
     const failures: string[] = [];
 
@@ -283,7 +302,10 @@ export const EditAccessModal = ({ open, onClose, username, onCreateRoleForAllOfT
             <Button
               componentId="admin.edit_access_modal.review"
               type="primary"
-              onClick={() => setStep('review')}
+              onClick={() => {
+                setError(null);
+                setStep('review');
+              }}
               disabled={!hasAnyChange || !stateLoaded}
             >
               Review changes
@@ -313,16 +335,21 @@ export const EditAccessModal = ({ open, onClose, username, onCreateRoleForAllOfT
       }
     >
       {error && (
+        // Sticky so partial-failure errors stay visible during scroll.
         <Alert
           componentId="admin.edit_access_modal.error"
           type="error"
           message={error}
           closable
           onClose={() => setError(null)}
-          css={{ marginBottom: theme.spacing.md }}
+          css={{
+            marginBottom: theme.spacing.md,
+            position: 'sticky',
+            top: 0,
+            zIndex: 1,
+          }}
         />
       )}
-
       {step === 'edit' ? (
         <>
           <Typography.Text color="secondary" css={{ display: 'block', marginBottom: theme.spacing.md }}>

--- a/mlflow/server/js/src/admin/components/EditRoleModal.tsx
+++ b/mlflow/server/js/src/admin/components/EditRoleModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Alert,
   Button,
@@ -108,18 +108,37 @@ export const EditRoleModal = ({ open, onClose, roleId }: EditRoleModalProps) => 
 
   const stateLoaded = !roleLoading && !assignmentsLoading && !usersLoading;
 
+  // ``prefilledRef`` gates the data-fill effect against background
+  // refetches that would clobber in-progress edits.
+  const prefilledRef = useRef(false);
+
+  // Reset transient UI state only on open — refetches must not bounce
+  // the user back to edit or wipe a partial-failure error.
   useEffect(() => {
     if (!open) {
       return;
     }
     setStep('edit');
+    setSubmitting(false);
+    setError(null);
+    prefilledRef.current = false;
+  }, [open]);
+
+  // Pre-fill editable fields once per open, after backing queries resolve.
+  useEffect(() => {
+    if (!open) {
+      prefilledRef.current = false;
+      return;
+    }
+    if (prefilledRef.current || !stateLoaded) {
+      return;
+    }
     setName(currentName);
     setDescription(currentDescription);
     setPermissions([...currentPermissions]);
     setUsernames([...currentUsernames]);
-    setSubmitting(false);
-    setError(null);
-  }, [open, currentName, currentDescription, currentPermissions, currentUsernames]);
+    prefilledRef.current = true;
+  }, [open, stateLoaded, currentName, currentDescription, currentPermissions, currentUsernames]);
 
   // --- Diff ---
   const diff = useMemo<RoleDiff>(() => {
@@ -173,7 +192,8 @@ export const EditRoleModal = ({ open, onClose, roleId }: EditRoleModalProps) => 
   }, [currentPermissions]);
 
   const handleConfirm = useCallback(async () => {
-    setError(null);
+    // ``error`` is already cleared by the "Review changes" transition;
+    // skipping a redundant reset here also avoids the flicker.
     setSubmitting(true);
     const failures: string[] = [];
 
@@ -270,7 +290,10 @@ export const EditRoleModal = ({ open, onClose, roleId }: EditRoleModalProps) => 
             <Button
               componentId="admin.edit_role_modal.review"
               type="primary"
-              onClick={() => setStep('review')}
+              onClick={() => {
+                setError(null);
+                setStep('review');
+              }}
               disabled={!hasAnyChange || !stateLoaded || !name.trim()}
             >
               Review changes
@@ -300,13 +323,19 @@ export const EditRoleModal = ({ open, onClose, roleId }: EditRoleModalProps) => 
       }
     >
       {error && (
+        // Sticky so partial-failure errors stay visible during scroll.
         <Alert
           componentId="admin.edit_role_modal.error"
           type="error"
           message={error}
           closable
           onClose={() => setError(null)}
-          css={{ marginBottom: theme.spacing.md }}
+          css={{
+            marginBottom: theme.spacing.md,
+            position: 'sticky',
+            top: 0,
+            zIndex: 1,
+          }}
         />
       )}
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/23415/files) to review incremental changes.
- [stack/rbac-ui-no-self-delete](https://github.com/mlflow/mlflow/pull/23398) [[Files changed](https://github.com/mlflow/mlflow/pull/23398/files)] [MERGED]
  - [stack/rbac-ui-fix-selected-count](https://github.com/mlflow/mlflow/pull/23399) [[Files changed](https://github.com/mlflow/mlflow/pull/23399/files)] [MERGED]
    - [stack/rbac-ui-assign-users-rename](https://github.com/mlflow/mlflow/pull/23406) [[Files changed](https://github.com/mlflow/mlflow/pull/23406/files)] [MERGED]
      - [stack/rbac-ui-permission-options](https://github.com/mlflow/mlflow/pull/23407) [[Files changed](https://github.com/mlflow/mlflow/pull/23407/files)] [MERGED]
        - [stack/rbac-ui-hide-gateway-model-def](https://github.com/mlflow/mlflow/pull/23408) [[Files changed](https://github.com/mlflow/mlflow/pull/23408/files)] [MERGED]
          - [stack/rbac-ui-resource-type-labels](https://github.com/mlflow/mlflow/pull/23409) [[Files changed](https://github.com/mlflow/mlflow/pull/23409/files)] [MERGED]
            - [stack/rbac-ui-hide-synthetic-roles](https://github.com/mlflow/mlflow/pull/23410) [[Files changed](https://github.com/mlflow/mlflow/pull/23410/files)] [MERGED]
              - [stack/rbac-ui-drop-optional-subtitle](https://github.com/mlflow/mlflow/pull/23412) [[Files changed](https://github.com/mlflow/mlflow/pull/23412/files)] [MERGED]
                - [stack/rbac-reject-same-password](https://github.com/mlflow/mlflow/pull/23413) [[Files changed](https://github.com/mlflow/mlflow/pull/23413/files)] [MERGED]
                  - [stack/rbac-ui-hide-workspace-cols](https://github.com/mlflow/mlflow/pull/23414) [[Files changed](https://github.com/mlflow/mlflow/pull/23414/files)] [MERGED]
                    - [**stack/rbac-ui-error-near-submit**](https://github.com/mlflow/mlflow/pull/23415) [[Files changed](https://github.com/mlflow/mlflow/pull/23415/files)]
                      - [stack/rbac-isolate-auth-db](https://github.com/mlflow/mlflow/pull/23417) [[Files changed](https://github.com/mlflow/mlflow/pull/23417/files/bae7be9e5faf81c42144e8fd39e6f76a1e0ad01b..8ddd9f70da0d5824c97bf500c737c1a2071865ff)]
                        - [stack/rbac-ui-scorer-picker](https://github.com/mlflow/mlflow/pull/23420) [[Files changed](https://github.com/mlflow/mlflow/pull/23420/files/8ddd9f70da0d5824c97bf500c737c1a2071865ff..1a7023e9631d4a0a605224dcb705fdf86a21278a)]
                          - [stack/rbac-reserve-user-prefix](https://github.com/mlflow/mlflow/pull/23496) [[Files changed](https://github.com/mlflow/mlflow/pull/23496/files/1a7023e9631d4a0a605224dcb705fdf86a21278a..47873b13534cf384c929b7ecf5f6773e4d514803)]

---------
### Related Issues/PRs

RBAC bugbash paper-cut. Reported by Serena Ruan ("the error message after clicking 'Create user and grant access' button shows up at the top of the modal, it's not visible") in the [bugbash doc](https://docs.google.com/document/d/17BWoF5n_a8Y1bafsQp1NDmSONe6uC9MDMPsCXn85aXg/edit). Stacks on #23414.

### What changes are proposed in this pull request?

`CreateUserModal` and `EditAccessModal` render the partial-failure error `<Alert>` at the top of the modal body — matching `CreateWorkspaceModal` and the rest of the codebase. The original report (Serena, bugbash) was that the error landed offscreen above the fold when the user had scrolled into the optional role / direct-permission / admin sections to click Submit.

**Approach considered + rejected**: an earlier revision moved the Alert into the modal footer to keep it next to the submit button. Manual testing showed that footer placement pushed the action buttons offscreen on smaller viewports when the error was multi-line — worse trade-off.

**Approach taken**: keep the Alert at body top, pin it with `position: sticky; top: 0` so it stays visible while the user is scrolled into the optional sections. Sticky-inside-scroll-container is used elsewhere in the codebase (`EndpointFormRenderer.tsx`, `DifferenceViewPlot.tsx`); the Alert's opaque background prevents bleed-through.

`EditAccessModal` also picks up two correctness fixes uncovered during review:
1. Split the open-effect so a background data refetch no longer wipes `step` / `submitting` / `error` while the user is reading them.
2. Clear `error` on the "Review changes" transition so a stale partial-failure message doesn't follow the user back into review.

### How is this PR tested?

- [x] Existing unit/integration tests — `yarn test --testPathPattern admin/` (30/30 pass).
- [x] Manual: open Create User on a tall modal, scroll to the bottom optional sections, submit with a deliberately-failing role assignment; confirm the error Alert pins to the top of the scrollable body and remains visible while scrolling. Same flow for Edit access (edit + review steps).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/uiux`

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release