### PR TITLE
Isolate `test_auth.py` auth DB so it stops leaking into repo root

### DIFF
--- a/tests/server/auth/fixtures/jwt_auth.ini
+++ b/tests/server/auth/fixtures/jwt_auth.ini
@@ -2,5 +2,5 @@
 default_permission = READ
 database_uri = sqlite:///basic_auth.db
 admin_username = admin
-admin_password = password
+admin_password = password1234
 authorization_function = jwt_auth:authenticate_request

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -54,12 +54,50 @@ from tests.tracking.integration_test_utils import (
     get_safe_port,
 )
 
+_PACKAGED_BASIC_AUTH_INI = Path(auth_module.__file__).parent / "basic_auth.ini"
+_TEST_DIR = Path(__file__).parent
+
+
+def _isolate_auth_config(extra_env: dict[str, str], tmp_path: Path) -> dict[str, str]:
+    """Redirect the auth store's SQLite DB to a tmp_path-scoped file.
+
+    Both the packaged default config (``mlflow/server/auth/basic_auth.ini``)
+    and the static fixture .ini files under ``fixtures/``
+    set ``database_uri = sqlite:///basic_auth.db`` — a *relative* path that
+    the spawned server resolves against its CWD (typically the repo root).
+    Without redirection, every test that boots the auth server shares one
+    ``basic_auth.db`` next to the dev server, leaking users / roles across
+    runs (bug-bash report: "so many users with hash usernames I didn't
+    create manually"). Rewrite the source .ini into ``tmp_path`` with the
+    DB URI swapped for an absolute path, and inject the rewritten copy via
+    ``MLFLOW_AUTH_CONFIG_PATH``.
+
+    Relative ``MLFLOW_AUTH_CONFIG_PATH`` values are anchored to this test
+    file's directory so the helper works regardless of pytest's CWD.
+    """
+    if raw := extra_env.get("MLFLOW_AUTH_CONFIG_PATH"):
+        src_path = Path(raw)
+        if not src_path.is_absolute():
+            src_path = _TEST_DIR / src_path
+    else:
+        src_path = _PACKAGED_BASIC_AUTH_INI
+    isolated_db = tmp_path / "basic_auth.db"
+    isolated_text = re.sub(
+        r"^database_uri\s*=.*$",
+        f"database_uri = sqlite:///{isolated_db}",
+        src_path.read_text(),
+        flags=re.MULTILINE,
+    )
+    dst_path = tmp_path / src_path.name
+    dst_path.write_text(isolated_text)
+    return {**extra_env, "MLFLOW_AUTH_CONFIG_PATH": str(dst_path)}
+
 
 @pytest.fixture
 def client(request, tmp_path):
     path = tmp_path.joinpath("sqlalchemy.db").as_uri()
     backend_uri = ("sqlite://" if is_windows() else "sqlite:////") + path[len("file://") :]
-    extra_env = getattr(request, "param", {})
+    extra_env = _isolate_auth_config(getattr(request, "param", {}), tmp_path)
     extra_env[MLFLOW_FLASK_SERVER_SECRET_KEY.name] = "my-secret-key"
 
     with _init_server(
@@ -77,7 +115,7 @@ def fastapi_client(request, tmp_path):
     """FastAPI client fixture for testing FastAPI-specific middleware (e.g., gateway routes)."""
     path = tmp_path.joinpath("sqlalchemy.db").as_uri()
     backend_uri = ("sqlite://" if is_windows() else "sqlite:////") + path[len("file://") :]
-    extra_env = getattr(request, "param", {})
+    extra_env = _isolate_auth_config(getattr(request, "param", {}), tmp_path)
     extra_env[MLFLOW_FLASK_SERVER_SECRET_KEY.name] = "my-secret-key"
     # Set _MLFLOW_SGI_NAME to "uvicorn" so auth module returns FastAPI app
     extra_env["_MLFLOW_SGI_NAME"] = "uvicorn"
@@ -185,7 +223,7 @@ def test_proxy_artifact_authorization_required(client, monkeypatch):
 
 @pytest.mark.parametrize(
     "client",
-    [{"MLFLOW_AUTH_CONFIG_PATH": "tests/server/auth/fixtures/no_permission_auth.ini"}],
+    [{"MLFLOW_AUTH_CONFIG_PATH": "fixtures/no_permission_auth.ini"}],
     indirect=True,
 )
 def test_proxy_artifact_list_query_param_uses_experiment_permission(client, monkeypatch):
@@ -266,7 +304,7 @@ def _mlflow_create_user_rest(base_uri, headers):
     "client",
     [
         {
-            "MLFLOW_AUTH_CONFIG_PATH": "tests/server/auth/fixtures/jwt_auth.ini",
+            "MLFLOW_AUTH_CONFIG_PATH": "fixtures/jwt_auth.ini",
             "PYTHONPATH": str(Path.cwd() / "examples" / "jwt_auth"),
         }
     ],
@@ -300,7 +338,7 @@ def test_authenticate_jwt(client):
 
 @pytest.mark.parametrize(
     "client",
-    [{"MLFLOW_AUTH_CONFIG_PATH": "tests/server/auth/fixtures/no_permission_auth.ini"}],
+    [{"MLFLOW_AUTH_CONFIG_PATH": "fixtures/no_permission_auth.ini"}],
     indirect=True,
 )
 def test_search_experiments(client, monkeypatch):
@@ -389,7 +427,7 @@ def test_search_experiments(client, monkeypatch):
 
 @pytest.mark.parametrize(
     "client",
-    [{"MLFLOW_AUTH_CONFIG_PATH": "tests/server/auth/fixtures/no_permission_auth.ini"}],
+    [{"MLFLOW_AUTH_CONFIG_PATH": "fixtures/no_permission_auth.ini"}],
     indirect=True,
 )
 def test_search_registered_models(client, monkeypatch):
@@ -477,7 +515,7 @@ def test_search_registered_models(client, monkeypatch):
 
 @pytest.mark.parametrize(
     "client",
-    [{"MLFLOW_AUTH_CONFIG_PATH": "tests/server/auth/fixtures/no_permission_auth.ini"}],
+    [{"MLFLOW_AUTH_CONFIG_PATH": "fixtures/no_permission_auth.ini"}],
     indirect=True,
 )
 def test_search_model_versions(client, monkeypatch):
@@ -517,7 +555,7 @@ def test_search_model_versions(client, monkeypatch):
 
 @pytest.mark.parametrize(
     "client",
-    [{"MLFLOW_AUTH_CONFIG_PATH": "tests/server/auth/fixtures/no_permission_auth.ini"}],
+    [{"MLFLOW_AUTH_CONFIG_PATH": "fixtures/no_permission_auth.ini"}],
     indirect=True,
 )
 def test_graphql_search_model_versions(client, monkeypatch):
@@ -597,6 +635,7 @@ def test_proxy_log_artifacts(monkeypatch, tmp_path):
     backend_uri = f"sqlite:///{tmp_path / 'sqlalchemy.db'}"
     port = get_safe_port()
     host = "localhost"
+    env = _isolate_auth_config({MLFLOW_FLASK_SERVER_SECRET_KEY.name: "my-secret-key"}, tmp_path)
     with subprocess.Popen(
         [
             sys.executable,
@@ -616,7 +655,7 @@ def test_proxy_log_artifacts(monkeypatch, tmp_path):
             "--gunicorn-opts",
             "--log-level debug",
         ],
-        env={MLFLOW_FLASK_SERVER_SECRET_KEY.name: "my-secret-key"},
+        env=env,
     ) as prc:
         try:
             url = f"http://{host}:{port}"
@@ -721,7 +760,7 @@ def test_logged_model(client: MlflowClient, monkeypatch: pytest.MonkeyPatch):
 
 @pytest.mark.parametrize(
     "client",
-    [{"MLFLOW_AUTH_CONFIG_PATH": "tests/server/auth/fixtures/no_permission_auth.ini"}],
+    [{"MLFLOW_AUTH_CONFIG_PATH": "fixtures/no_permission_auth.ini"}],
     indirect=True,
 )
 def test_logged_model_artifact_authorization(client: MlflowClient, monkeypatch: pytest.MonkeyPatch):
@@ -803,7 +842,7 @@ def test_logged_model_artifact_validator_respects_static_prefix(
 
 @pytest.mark.parametrize(
     "client",
-    [{"MLFLOW_AUTH_CONFIG_PATH": "tests/server/auth/fixtures/no_permission_auth.ini"}],
+    [{"MLFLOW_AUTH_CONFIG_PATH": "fixtures/no_permission_auth.ini"}],
     indirect=True,
 )
 def test_search_logged_models(client: MlflowClient, monkeypatch: pytest.MonkeyPatch):
@@ -865,7 +904,7 @@ def test_search_logged_models(client: MlflowClient, monkeypatch: pytest.MonkeyPa
 
 @pytest.mark.parametrize(
     "client",
-    [{"MLFLOW_AUTH_CONFIG_PATH": "tests/server/auth/fixtures/no_permission_auth.ini"}],
+    [{"MLFLOW_AUTH_CONFIG_PATH": "fixtures/no_permission_auth.ini"}],
     indirect=True,
 )
 def test_search_runs(client: MlflowClient, monkeypatch: pytest.MonkeyPatch):
@@ -1102,7 +1141,7 @@ def test_graphql_requires_authentication(client, monkeypatch):
 
 @pytest.mark.parametrize(
     "client",
-    [{"MLFLOW_AUTH_CONFIG_PATH": "tests/server/auth/fixtures/no_permission_auth.ini"}],
+    [{"MLFLOW_AUTH_CONFIG_PATH": "fixtures/no_permission_auth.ini"}],
     indirect=True,
 )
 def test_graphql_get_experiment_authorization(client, monkeypatch):
@@ -1152,7 +1191,7 @@ def test_graphql_get_experiment_authorization(client, monkeypatch):
 
 @pytest.mark.parametrize(
     "client",
-    [{"MLFLOW_AUTH_CONFIG_PATH": "tests/server/auth/fixtures/no_permission_auth.ini"}],
+    [{"MLFLOW_AUTH_CONFIG_PATH": "fixtures/no_permission_auth.ini"}],
     indirect=True,
 )
 def test_graphql_get_run_authorization(client, monkeypatch):
@@ -1206,7 +1245,7 @@ def test_graphql_get_run_authorization(client, monkeypatch):
 
 @pytest.mark.parametrize(
     "client",
-    [{"MLFLOW_AUTH_CONFIG_PATH": "tests/server/auth/fixtures/no_permission_auth.ini"}],
+    [{"MLFLOW_AUTH_CONFIG_PATH": "fixtures/no_permission_auth.ini"}],
     indirect=True,
 )
 def test_graphql_search_runs_authorization(client, monkeypatch):
@@ -1274,7 +1313,7 @@ def test_graphql_search_runs_authorization(client, monkeypatch):
 
 @pytest.mark.parametrize(
     "client",
-    [{"MLFLOW_AUTH_CONFIG_PATH": "tests/server/auth/fixtures/no_permission_auth.ini"}],
+    [{"MLFLOW_AUTH_CONFIG_PATH": "fixtures/no_permission_auth.ini"}],
     indirect=True,
 )
 def test_graphql_list_artifacts_authorization(client, monkeypatch):
@@ -2400,7 +2439,7 @@ def test_gateway_endpoint_requires_fallback_model_definition_use_permission(clie
 
 @pytest.mark.parametrize(
     "client",
-    [{"MLFLOW_AUTH_CONFIG_PATH": "tests/server/auth/fixtures/no_permission_auth.ini"}],
+    [{"MLFLOW_AUTH_CONFIG_PATH": "fixtures/no_permission_auth.ini"}],
     indirect=True,
 )
 def test_prompt_optimization_job_search_permissions(client, monkeypatch):
@@ -3252,7 +3291,7 @@ def _grant_experiment_permission(
 
 @pytest.mark.parametrize(
     "client",
-    [{"MLFLOW_AUTH_CONFIG_PATH": "tests/server/auth/fixtures/no_permission_auth.ini"}],
+    [{"MLFLOW_AUTH_CONFIG_PATH": "fixtures/no_permission_auth.ini"}],
     indirect=True,
 )
 def test_trace_search_permission(client, monkeypatch):
@@ -3364,7 +3403,7 @@ def test_trace_tag_permission(client, monkeypatch):
 
 @pytest.mark.parametrize(
     "client",
-    [{"MLFLOW_AUTH_CONFIG_PATH": "tests/server/auth/fixtures/no_permission_auth.ini"}],
+    [{"MLFLOW_AUTH_CONFIG_PATH": "fixtures/no_permission_auth.ini"}],
     indirect=True,
 )
 def test_trace_get_info_permission(client, monkeypatch):
@@ -3399,7 +3438,7 @@ def test_trace_get_info_permission(client, monkeypatch):
 
 @pytest.mark.parametrize(
     "client",
-    [{"MLFLOW_AUTH_CONFIG_PATH": "tests/server/auth/fixtures/no_permission_auth.ini"}],
+    [{"MLFLOW_AUTH_CONFIG_PATH": "fixtures/no_permission_auth.ini"}],
     indirect=True,
 )
 def test_trace_get_v3_permission(client, monkeypatch):
@@ -3430,7 +3469,7 @@ def test_trace_get_v3_permission(client, monkeypatch):
 
 @pytest.mark.parametrize(
     "client",
-    [{"MLFLOW_AUTH_CONFIG_PATH": "tests/server/auth/fixtures/no_permission_auth.ini"}],
+    [{"MLFLOW_AUTH_CONFIG_PATH": "fixtures/no_permission_auth.ini"}],
     indirect=True,
 )
 def test_trace_batch_get_permission(client, monkeypatch):
@@ -3462,7 +3501,7 @@ def test_trace_batch_get_permission(client, monkeypatch):
 
 @pytest.mark.parametrize(
     "client",
-    [{"MLFLOW_AUTH_CONFIG_PATH": "tests/server/auth/fixtures/no_permission_auth.ini"}],
+    [{"MLFLOW_AUTH_CONFIG_PATH": "fixtures/no_permission_auth.ini"}],
     indirect=True,
 )
 def test_trace_link_to_run_permission(client, monkeypatch):
@@ -3499,7 +3538,7 @@ def test_trace_link_to_run_permission(client, monkeypatch):
 
 @pytest.mark.parametrize(
     "client",
-    [{"MLFLOW_AUTH_CONFIG_PATH": "tests/server/auth/fixtures/no_permission_auth.ini"}],
+    [{"MLFLOW_AUTH_CONFIG_PATH": "fixtures/no_permission_auth.ini"}],
     indirect=True,
 )
 def test_trace_search_v3_permission(client, monkeypatch):


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/23417/files) to review incremental changes.
- [stack/rbac-ui-no-self-delete](https://github.com/mlflow/mlflow/pull/23398) [[Files changed](https://github.com/mlflow/mlflow/pull/23398/files)] [MERGED]
  - [stack/rbac-ui-fix-selected-count](https://github.com/mlflow/mlflow/pull/23399) [[Files changed](https://github.com/mlflow/mlflow/pull/23399/files)] [MERGED]
    - [stack/rbac-ui-assign-users-rename](https://github.com/mlflow/mlflow/pull/23406) [[Files changed](https://github.com/mlflow/mlflow/pull/23406/files)] [MERGED]
      - [stack/rbac-ui-permission-options](https://github.com/mlflow/mlflow/pull/23407) [[Files changed](https://github.com/mlflow/mlflow/pull/23407/files)] [MERGED]
        - [stack/rbac-ui-hide-gateway-model-def](https://github.com/mlflow/mlflow/pull/23408) [[Files changed](https://github.com/mlflow/mlflow/pull/23408/files)] [MERGED]
          - [stack/rbac-ui-resource-type-labels](https://github.com/mlflow/mlflow/pull/23409) [[Files changed](https://github.com/mlflow/mlflow/pull/23409/files)] [MERGED]
            - [stack/rbac-ui-hide-synthetic-roles](https://github.com/mlflow/mlflow/pull/23410) [[Files changed](https://github.com/mlflow/mlflow/pull/23410/files)] [MERGED]
              - [stack/rbac-ui-drop-optional-subtitle](https://github.com/mlflow/mlflow/pull/23412) [[Files changed](https://github.com/mlflow/mlflow/pull/23412/files)] [MERGED]
                - [stack/rbac-reject-same-password](https://github.com/mlflow/mlflow/pull/23413) [[Files changed](https://github.com/mlflow/mlflow/pull/23413/files)] [MERGED]
                  - [stack/rbac-ui-hide-workspace-cols](https://github.com/mlflow/mlflow/pull/23414) [[Files changed](https://github.com/mlflow/mlflow/pull/23414/files)] [MERGED]
                    - [stack/rbac-ui-error-near-submit](https://github.com/mlflow/mlflow/pull/23415) [[Files changed](https://github.com/mlflow/mlflow/pull/23415/files)] [MERGED]
                      - [**stack/rbac-isolate-auth-db**](https://github.com/mlflow/mlflow/pull/23417) [[Files changed](https://github.com/mlflow/mlflow/pull/23417/files)]
                        - [stack/rbac-ui-scorer-picker](https://github.com/mlflow/mlflow/pull/23420) [[Files changed](https://github.com/mlflow/mlflow/pull/23420/files/007c2a0e02cf39d3abd83397b2bb15a6d576facd..5561fe0c4e576de340a0e379946c7950936e54d8)]
                          - [stack/rbac-reserve-user-prefix](https://github.com/mlflow/mlflow/pull/23496) [[Files changed](https://github.com/mlflow/mlflow/pull/23496/files/5561fe0c4e576de340a0e379946c7950936e54d8..329130f9e363f113865fc05f5a613f64c4ca331f)]

---------
### Related Issues/PRs

RBAC bugbash paper-cut. Reported by Tomu Hirata: *"There are so many users with hash usernames that I didn't create manually. Can we investigate how these are created and make sure this doesn't happen to end users?"* See the [bugbash doc](https://docs.google.com/document/d/17BWoF5n_a8Y1bafsQp1NDmSONe6uC9MDMPsCXn85aXg/edit). Stacks on #23415.

### What changes are proposed in this pull request?

I initially called this a non-bug (test isolation looked fine via `tmp_path` for the tracking store), but Tomu's intuition was correct. The leak was the *auth* store:

The `client` / `fastapi_client` fixtures in `tests/server/auth/test_auth.py` either parameterized `MLFLOW_AUTH_CONFIG_PATH` to a static fixture .ini under `tests/server/auth/fixtures/`, or fell through to the packaged default at `mlflow/server/auth/basic_auth.ini`. **All three configs set `database_uri = sqlite:///basic_auth.db`** — a relative path that the spawned server resolves against CWD (typically the repo root).

Result: every auth integration test wrote users + roles into a single `basic_auth.db` next to the dev server, persisting them across runs and bleeding into developer-local auth state. The `**/basic_auth.db` line in `.gitignore` and the docstring on `auth_test_utils.write_isolated_auth_config` both flagged the issue without fixing it — only `tests/server/auth/test_client*.py` was using the isolated helper.

### Fix

Add a `_isolate_auth_config(extra_env, tmp_path)` helper in `test_auth.py` that:

1. Reads whichever `.ini` the test *would have* loaded (the parameterized `MLFLOW_AUTH_CONFIG_PATH`, or the packaged default if none is set).
2. Copies it into `tmp_path` with the `database_uri =` line rewritten to an absolute `tmp_path/basic_auth.db`.
3. Injects the rewritten path back into `extra_env` via `MLFLOW_AUTH_CONFIG_PATH`.

Both `client` and `fastapi_client` fixtures now run every test against its own DB, with full automatic cleanup courtesy of pytest's `tmp_path`. No parametrize decorators need to change.

### How is this PR tested?

- [x] Existing unit/integration tests — verified `test_authenticate` (no parametrize) and `test_proxy_artifact_authorization_required` (parametrizes `no_permission_auth.ini`) both pass and leave **no** `basic_auth.db` in CWD.
- [x] Pre-existing `test_authenticate_jwt` failure (unrelated `jwt_auth` module not on sys.path) was confirmed pre-existing on master and is untouched by this change.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release