### PR TITLE
Use larger runners for collaborator PRs (python/windows)

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -68,7 +68,12 @@ jobs:
 
   python:
     if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association))
+        && 'ubuntu-latest-large' || 'ubuntu-latest'
+      }}
     timeout-minutes: 120
     permissions:
       contents: read
@@ -385,7 +390,12 @@ jobs:
 
   windows:
     if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
-    runs-on: windows-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association))
+        && 'windows-latest-large' || 'windows-latest'
+      }}
     timeout-minutes: 120
     permissions:
       contents: read


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Route the `python` and `windows` jobs in `master.yml` to larger hosted runners (`ubuntu-latest-large`, `windows-latest-large`: 8 vCPU / 32 GB RAM / 300 GB disk) when the event is a `pull_request` authored by an OWNER / MEMBER / COLLABORATOR. Pushes to `master` and fork PRs fall back to the default `ubuntu-latest` / `windows-latest`.

Both jobs have 120-minute timeouts and matrix splits, so faster cores should shorten CI wall time on collaborator PRs. Fork PRs stay on default runners to avoid surprise costs from untrusted contributors.

`windows-latest-large` was just provisioned at the org level (group 1, max 50, Windows Latest 2025 image). `ubuntu-latest-large` already existed.

### How is this PR tested?

- [x] Manual tests

Will validate by watching this PR's own CI: the `python` and `windows` jobs should resolve to the `-large` variants in their job logs.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mlflow/codesmith/mlflow/pr/23421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->