### PR TITLE
Auto-trigger NaiLaOpus on maintainer PRs at first-ready + bump SHA pin

### DIFF
--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -158,7 +158,7 @@ jobs:
           # open a new PR that updates this SHA to the latest mlflow/internal
           # main after reviewing the diff. We'll migrate to release tags once
           # the bump cadence is stable; see mlflow/internal for the policy.
-          ref: 84470a01acf0a3de0a422d04cf900e390e6371b5
+          ref: 564858ace69e52162b4f07c02626d9f3ced2f4f6
           sparse-checkout: |
             nailaopus
           path: internal

--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -3,18 +3,23 @@ name: NaiLaOpus
 on:
   issue_comment:
     types: [created]
-  # Auto-trigger on PR open/ready is deferred until comment-based runs have
-  # been validated on real PRs. Re-enable by uncommenting these lines.
-  # pull_request:
-  #   types: [opened, ready_for_review]
+  # Auto-run on the first time a maintainer's PR is ready for review.
+  # `opened` fires for non-draft opens; `ready_for_review` fires for the
+  # draft -> ready transition; `reopened` fires when a closed PR is brought
+  # back. `synchronize` is intentionally excluded so subsequent author
+  # pushes don't re-trigger; maintainers can use `/review-v2` for re-runs,
+  # and the orchestrator's head-SHA cache short-circuits same-SHA runs.
+  pull_request:
+    types: [opened, ready_for_review, reopened]
 
 concurrency:
-  # Single group per PR. cancel-in-progress is false so each /review-v2
-  # invocation finishes; subsequent invocations on the same PR queue behind
-  # it. The orchestrator's head_sha cache dedupes against same-SHA runs, so
-  # /review-v2 --no-cache is the only way to force a re-review. The fallback
-  # to github.event.pull_request.number is retained for the commented-out
-  # auto-trigger path.
+  # Single group per PR. cancel-in-progress is false so each invocation
+  # finishes; subsequent invocations on the same PR queue behind it. The
+  # orchestrator's head_sha cache dedupes against same-SHA runs, so an
+  # auto-trigger immediately followed by /review-v2 on the same SHA
+  # short-circuits in the second run. The number coalesce handles both
+  # event payloads: issue_comment uses github.event.issue.number,
+  # pull_request uses github.event.pull_request.number.
   group: nailaopus-${{ github.event.issue.number || github.event.pull_request.number }}
   cancel-in-progress: false
 
@@ -33,24 +38,24 @@ jobs:
     # Two layers of gating, both at the job level so that non-maintainer PRs
     # never load the App-token secret or run any step at all (no observable
     # side effects, no review burden on each step before a runtime gate):
-    #   1. Comment author must be a maintainer (prevents random users from
-    #      triggering the bot via `/review-v2`).
+    #   1. Trigger author must be a maintainer (the commenter on
+    #      `/review-v2`, or the PR author on auto-trigger).
     #   2. PR author must be a maintainer (prevents review of community-
     #      authored PRs whose diff content could contain prompt-injection
     #      attempts against the LLM).
-    # `issue_comment` payloads expose both associations directly, so we
-    # can do this check without an extra `gh api` step.
-    #
-    # The pull_request auto-trigger branch is commented out above; if
-    # re-enabled, the second branch of this `if:` will need to use
-    # `github.event.pull_request.head.repo.full_name == github.repository`
-    # (no fork PRs) and `github.event.pull_request.author_association`.
+    # For the `pull_request` auto-trigger we additionally require the head
+    # ref to live on `mlflow/mlflow` (no fork PRs). `author_association`
+    # alone doesn't prevent a community fork from a maintainer; combining
+    # both ensures the diff cannot come from an untrusted source.
     if: |
-      github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request != null &&
-      startsWith(github.event.comment.body, '/review-v2') &&
-      contains(fromJSON('["MEMBER", "COLLABORATOR", "OWNER"]'), github.event.comment.author_association) &&
-      contains(fromJSON('["MEMBER", "COLLABORATOR", "OWNER"]'), github.event.issue.author_association)
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request != null &&
+       startsWith(github.event.comment.body, '/review-v2') &&
+       contains(fromJSON('["MEMBER", "COLLABORATOR", "OWNER"]'), github.event.comment.author_association) &&
+       contains(fromJSON('["MEMBER", "COLLABORATOR", "OWNER"]'), github.event.issue.author_association)) ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository &&
+       contains(fromJSON('["MEMBER", "COLLABORATOR", "OWNER"]'), github.event.pull_request.author_association))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -153,7 +158,7 @@ jobs:
           # open a new PR that updates this SHA to the latest mlflow/internal
           # main after reviewing the diff. We'll migrate to release tags once
           # the bump cadence is stable; see mlflow/internal for the policy.
-          ref: 6e90fa245775525c824f7b67211083ea6dbe59e3
+          ref: 84470a01acf0a3de0a422d04cf900e390e6371b5
           sparse-checkout: |
             nailaopus
           path: internal

--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -54,6 +54,7 @@ jobs:
        contains(fromJSON('["MEMBER", "COLLABORATOR", "OWNER"]'), github.event.comment.author_association) &&
        contains(fromJSON('["MEMBER", "COLLABORATOR", "OWNER"]'), github.event.issue.author_association)) ||
       (github.event_name == 'pull_request' &&
+       !github.event.pull_request.draft &&
        github.event.pull_request.head.repo.full_name == github.repository &&
        contains(fromJSON('["MEMBER", "COLLABORATOR", "OWNER"]'), github.event.pull_request.author_association))
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Related Issues/PRs

Relates to mlflow/internal#45 (tokens-line fix), mlflow/internal#46 (M-size stamping), and mlflow/internal#47 (don't link the anchored location). All three merged to `mlflow/internal` `main` at `564858a`; this PR pins to that commit.

### What changes are proposed in this pull request?

Two changes to `.github/workflows/nailaopus.yml`:

1. **Auto-trigger on maintainer PRs at first-ready.** Add a `pull_request` trigger with types `[opened, ready_for_review, reopened]` alongside the existing `issue_comment` (`/review-v2`) trigger. `synchronize` is intentionally excluded so subsequent author pushes don't re-trigger; maintainers can use `/review-v2` for re-runs, and the orchestrator's head-SHA cache short-circuits same-SHA runs.

   Gating: PR author must be `MEMBER`/`COLLABORATOR`/`OWNER`, AND the head ref must live on `mlflow/mlflow` (no fork PRs). `author_association` alone doesn't prevent a community fork from a maintainer's account; combining both ensures the diff cannot come from an untrusted source. Same maintainer-only gate as the existing `/review-v2` path.

2. **Bump `mlflow/internal` SHA pin** from `6e90fa2` to `564858a` (current `main`), which now contains:
   - `mlflow/internal#45`: tokens-line summary fix (`123 in (2.8M cached)` becomes `2.8M input (99.99% from cache)`)
   - `mlflow/internal#46`: M-size stamping (`STAMP_ELIGIBLE_SIZES` now includes `M`)
   - `mlflow/internal#47`: reviewer-opinion no longer leads with anchor permalinks (and the review-body fallback path synthesizes one inline since PR-level comments don't get GitHub's anchor rail)

### How is this PR tested?

- [x] Existing unit/integration tests (the workflow change has no Python code; orchestrator-side tests for all three upstream PRs pass at 269/269 on `mlflow/internal`)
- [ ] New unit/integration tests
- [x] Manual tests

Manual validation plan once this merges:
- Open a draft maintainer PR, mark ready: confirm bot fires on `ready_for_review`
- Open a non-draft maintainer PR: confirm bot fires on `opened`
- Open a community-authored fork PR: confirm bot does NOT fire (gated out)
- `/review-v2` on any maintainer PR: confirm comment-triggered path still works
- Confirm inline-comment bodies no longer lead with `[path:line](permalink)` (per #47)
- Confirm a same-SHA `/review-v2` after dismissing prior bot comments fires the stamp on an XS/S/M PR (per #46)

### Does this PR require documentation update?

- [x] No.

The maintainer-facing `rules-of-the-road.html` (Databricks-internal) was updated alongside `mlflow/internal#46`. No `mlflow/mlflow` user-facing docs change.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

Internal bot infrastructure; not user-facing.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mlflow/codesmith/mlflow/pr/23422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->