### PR TITLE
Adding metric filter to AI Gateway overview usage and endpoint usage tab

### DIFF
--- a/mlflow/server/js/src/common/components/MetricsFilter.utils.test.ts
+++ b/mlflow/server/js/src/common/components/MetricsFilter.utils.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, jest } from '@jest/globals';
 import {
   isCompleteFilter,
   translateToMetricsFilters,
+  translateToTableFilters,
   translateToTracesPageFilters,
   type MetricFilter,
 } from './MetricsFilter.utils';
@@ -194,6 +195,57 @@ describe('translateToTracesPageFilters', () => {
       'state::=::ERROR',
       'git_branch::=::main',
       'git_commit::=::abc1234',
+    ]);
+  });
+});
+
+describe('translateToTableFilters', () => {
+  it('returns undefined for an empty filters array', () => {
+    expect(translateToTableFilters([])).toBeUndefined();
+  });
+
+  it('returns undefined when all filters are incomplete', () => {
+    const filters: MetricFilter[] = [
+      { column: 'user', value: '' },
+      { column: '' as MetricFilter['column'], value: 'alice' },
+    ];
+    expect(translateToTableFilters(filters)).toBeUndefined();
+  });
+
+  it('translates a user filter to a TableFilter object', () => {
+    expect(translateToTableFilters([{ column: 'user', value: 'alice' }])).toEqual([
+      { column: 'user', operator: '=', value: 'alice' },
+    ]);
+  });
+
+  it('skips incomplete filters and returns the rest', () => {
+    const filters: MetricFilter[] = [
+      { column: 'user', value: 'alice' },
+      { column: 'user', value: '' },
+    ];
+    expect(translateToTableFilters(filters)).toEqual([{ column: 'user', operator: '=', value: 'alice' }]);
+  });
+
+  it('translates a state filter to a TableFilter object with the state column id', () => {
+    expect(translateToTableFilters([{ column: 'state', value: 'ERROR' }])).toEqual([
+      { column: 'state', operator: '=', value: 'ERROR' },
+    ]);
+  });
+
+  it('translates a heterogeneous mix preserving order', () => {
+    const filters: MetricFilter[] = [
+      { column: 'user', value: 'alice' },
+      { column: 'session', value: 'sess-123' },
+      { column: 'state', value: 'ERROR' },
+      { column: 'git_branch', value: 'main' },
+      { column: 'git_commit', value: 'abc1234' },
+    ];
+    expect(translateToTableFilters(filters)).toEqual([
+      { column: 'user', operator: '=', value: 'alice' },
+      { column: 'session', operator: '=', value: 'sess-123' },
+      { column: 'state', operator: '=', value: 'ERROR' },
+      { column: 'git_branch', operator: '=', value: 'main' },
+      { column: 'git_commit', operator: '=', value: 'abc1234' },
     ]);
   });
 });

--- a/mlflow/server/js/src/common/components/MetricsFilter.utils.test.ts
+++ b/mlflow/server/js/src/common/components/MetricsFilter.utils.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, jest } from '@jest/globals';
 import {
   isCompleteFilter,
   translateToMetricsFilters,
-  translateToTableFilters,
   translateToTracesPageFilters,
   type MetricFilter,
 } from './MetricsFilter.utils';
@@ -195,57 +194,6 @@ describe('translateToTracesPageFilters', () => {
       'state::=::ERROR',
       'git_branch::=::main',
       'git_commit::=::abc1234',
-    ]);
-  });
-});
-
-describe('translateToTableFilters', () => {
-  it('returns undefined for an empty filters array', () => {
-    expect(translateToTableFilters([])).toBeUndefined();
-  });
-
-  it('returns undefined when all filters are incomplete', () => {
-    const filters: MetricFilter[] = [
-      { column: 'user', value: '' },
-      { column: '' as MetricFilter['column'], value: 'alice' },
-    ];
-    expect(translateToTableFilters(filters)).toBeUndefined();
-  });
-
-  it('translates a user filter to a TableFilter object', () => {
-    expect(translateToTableFilters([{ column: 'user', value: 'alice' }])).toEqual([
-      { column: 'user', operator: '=', value: 'alice' },
-    ]);
-  });
-
-  it('skips incomplete filters and returns the rest', () => {
-    const filters: MetricFilter[] = [
-      { column: 'user', value: 'alice' },
-      { column: 'user', value: '' },
-    ];
-    expect(translateToTableFilters(filters)).toEqual([{ column: 'user', operator: '=', value: 'alice' }]);
-  });
-
-  it('translates a state filter to a TableFilter object with the state column id', () => {
-    expect(translateToTableFilters([{ column: 'state', value: 'ERROR' }])).toEqual([
-      { column: 'state', operator: '=', value: 'ERROR' },
-    ]);
-  });
-
-  it('translates a heterogeneous mix preserving order', () => {
-    const filters: MetricFilter[] = [
-      { column: 'user', value: 'alice' },
-      { column: 'session', value: 'sess-123' },
-      { column: 'state', value: 'ERROR' },
-      { column: 'git_branch', value: 'main' },
-      { column: 'git_commit', value: 'abc1234' },
-    ];
-    expect(translateToTableFilters(filters)).toEqual([
-      { column: 'user', operator: '=', value: 'alice' },
-      { column: 'session', operator: '=', value: 'sess-123' },
-      { column: 'state', operator: '=', value: 'ERROR' },
-      { column: 'git_branch', operator: '=', value: 'main' },
-      { column: 'git_commit', operator: '=', value: 'abc1234' },
     ]);
   });
 });

--- a/mlflow/server/js/src/common/components/MetricsFilter.utils.ts
+++ b/mlflow/server/js/src/common/components/MetricsFilter.utils.ts
@@ -19,8 +19,8 @@ import {
 
 /**
  * Curated list of columns the metrics API can filter on with `=`.
- * Add a new entry here AND in `translateToMetricsFilters` and
- * `translateToTracesPageFilters` to expose more dimensions
+ * Add a new entry here AND in `COLUMN_TO_METRICS_FILTER_BUILDER` and
+ * `COLUMN_TO_TRACES_COLUMN_ID` to expose more dimensions.
  */
 export type MetricFilterColumn = 'user' | 'session' | 'state' | 'git_branch' | 'git_commit';
 

--- a/mlflow/server/js/src/common/components/MetricsFilter.utils.ts
+++ b/mlflow/server/js/src/common/components/MetricsFilter.utils.ts
@@ -19,10 +19,8 @@ import {
 
 /**
  * Curated list of columns the metrics API can filter on with `=`.
- * Adding a new entry here triggers TypeScript errors at every translator
- * mapping (`COLUMN_TO_METRICS_FILTER_BUILDER`, `COLUMN_TO_TRACES_COLUMN_ID`)
- * until all transports are wired up — fill those in to expose the new
- * dimension end to end.
+ * Add a new entry here AND in `translateToMetricsFilters` and
+ * `translateToTracesPageFilters` to expose more dimensions
  */
 export type MetricFilterColumn = 'user' | 'session' | 'state' | 'git_branch' | 'git_commit';
 
@@ -94,12 +92,6 @@ const COLUMN_TO_TRACES_COLUMN_ID: Record<MetricFilterColumn, string> = {
  * column group (e.g. assessment filters); top-level columns like `user` emit
  * the 3-segment form.
  *
- * NOTE: A previous `translateToTableFilters` helper (producing in-memory
- * `TableFilter` objects for `TracesV3Logs.additionalFilters`) was removed
- * because it caused a dual-source-of-truth bug: filters injected via
- * `additionalFilters` are not editable from the Logs tab UI, so the user could
- * not remove them by clicking the filter chip. URL params are the only
- * supported cross-tab propagation channel for MetricsFilter rows.
  */
 export const translateToTracesPageFilters = (filters: MetricFilter[]): string[] | undefined => {
   const result = filters

--- a/mlflow/server/js/src/common/components/MetricsFilter.utils.ts
+++ b/mlflow/server/js/src/common/components/MetricsFilter.utils.ts
@@ -5,7 +5,6 @@ import {
   SESSION_COLUMN_ID,
   STATE_COLUMN_ID,
   USER_COLUMN_ID,
-  type TableFilter,
 } from '@databricks/web-shared/genai-traces-table';
 import {
   MLFLOW_GIT_BRANCH_KEY,
@@ -70,9 +69,8 @@ export const translateToMetricsFilters = (filters: MetricFilter[]): string[] | u
 };
 
 /**
- * Mapping from MetricFilter column to the corresponding traces-table column id.
- * Shared by `translateToTracesPageFilters` (URL string form) and
- * `translateToTableFilters` (TableFilter object form)
+ * Mapping from MetricFilter column to the corresponding traces-table column id,
+ * used by `translateToTracesPageFilters` to forward filters via URL params.
  *
  * The `Record<MetricFilterColumn, ...>` type makes adding a new
  * MetricFilterColumn a compile error until the mapping is filled in.
@@ -95,28 +93,17 @@ const COLUMN_TO_TRACES_COLUMN_ID: Record<MetricFilterColumn, string> = {
  * segment is optional and only used for filters that disambiguate within a
  * column group (e.g. assessment filters); top-level columns like `user` emit
  * the 3-segment form.
+ *
+ * NOTE: A previous `translateToTableFilters` helper (producing in-memory
+ * `TableFilter` objects for `TracesV3Logs.additionalFilters`) was removed
+ * because it caused a dual-source-of-truth bug: filters injected via
+ * `additionalFilters` are not editable from the Logs tab UI, so the user could
+ * not remove them by clicking the filter chip. URL params are the only
+ * supported cross-tab propagation channel for MetricsFilter rows.
  */
 export const translateToTracesPageFilters = (filters: MetricFilter[]): string[] | undefined => {
   const result = filters
     .filter(isCompleteFilter)
     .map((f) => [COLUMN_TO_TRACES_COLUMN_ID[f.column], FilterOperator.EQUALS, f.value].join('::'));
-  return result.length > 0 ? result : undefined;
-};
-
-/**
- * Translates user-driven filter rows from MetricsFilter into in-memory
- * `TableFilter` objects, the shape consumed by `TracesV3Logs.additionalFilters`.
- * Use this when a page needs to apply the same filters to a same-page logs view
- * (no URL round-trip), which complements `translateToTracesPageFilters` for the
- * chart-tooltip navigation case.
- */
-export const translateToTableFilters = (filters: MetricFilter[]): TableFilter[] | undefined => {
-  const result = filters.filter(isCompleteFilter).map(
-    (f): TableFilter => ({
-      column: COLUMN_TO_TRACES_COLUMN_ID[f.column],
-      operator: FilterOperator.EQUALS,
-      value: f.value,
-    }),
-  );
   return result.length > 0 ? result : undefined;
 };

--- a/mlflow/server/js/src/common/components/MetricsFilter.utils.ts
+++ b/mlflow/server/js/src/common/components/MetricsFilter.utils.ts
@@ -5,6 +5,7 @@ import {
   SESSION_COLUMN_ID,
   STATE_COLUMN_ID,
   USER_COLUMN_ID,
+  type TableFilter,
 } from '@databricks/web-shared/genai-traces-table';
 import {
   MLFLOW_GIT_BRANCH_KEY,
@@ -19,8 +20,10 @@ import {
 
 /**
  * Curated list of columns the metrics API can filter on with `=`.
- * Add a new entry here AND in `translateToMetricsFilters` and
- * `translateToTracesPageFilters` to expose more dimensions.
+ * Adding a new entry here triggers TypeScript errors at every translator
+ * mapping (`COLUMN_TO_METRICS_FILTER_BUILDER`, `COLUMN_TO_TRACES_COLUMN_ID`)
+ * until all transports are wired up — fill those in to expose the new
+ * dimension end to end.
  */
 export type MetricFilterColumn = 'user' | 'session' | 'state' | 'git_branch' | 'git_commit';
 
@@ -40,32 +43,46 @@ export const TRACE_STATE_VALUES = [TraceStatus.IN_PROGRESS, TraceStatus.OK, Trac
 export const isCompleteFilter = (filter: MetricFilter): boolean => Boolean(filter.column) && Boolean(filter.value);
 
 /**
+ * Builder for each column's metrics-API DSL filter string. Each entry is a
+ * closure so columns can pick *which* helper to call (most use
+ * `createTraceMetadataFilter` with a metadata key; `state` uses
+ * `createTraceFilter` with a `TraceFilterKey`) without forcing the mapping
+ * into a uniform shape.
+ *
+ * The `Record<MetricFilterColumn, ...>` type makes adding a new
+ * MetricFilterColumn a compile error until the builder is filled in.
+ */
+const COLUMN_TO_METRICS_FILTER_BUILDER: Record<MetricFilterColumn, (value: string) => string> = {
+  user: (v) => createTraceMetadataFilter(MLFLOW_TRACE_USER_KEY, v),
+  session: (v) => createTraceMetadataFilter(SESSION_ID_METADATA_KEY, v),
+  state: (v) => createTraceFilter(TraceFilterKey.STATUS, v),
+  git_branch: (v) => createTraceMetadataFilter(MLFLOW_GIT_BRANCH_KEY, v),
+  git_commit: (v) => createTraceMetadataFilter(MLFLOW_GIT_COMMIT_KEY, v),
+};
+
+/**
  * Translates user-driven filter rows from MetricsFilter into metrics-API DSL
  * filter strings consumed by useTraceMetricsQuery via OverviewChartProvider.
- *
- * Add a new case here when adding a new column option in MetricsFilter.
  */
 export const translateToMetricsFilters = (filters: MetricFilter[]): string[] | undefined => {
-  const result = filters
-    .map((f) => {
-      if (!f.column || !f.value) return null;
-      switch (f.column) {
-        case 'user':
-          return createTraceMetadataFilter(MLFLOW_TRACE_USER_KEY, f.value);
-        case 'session':
-          return createTraceMetadataFilter(SESSION_ID_METADATA_KEY, f.value);
-        case 'state':
-          return createTraceFilter(TraceFilterKey.STATUS, f.value);
-        case 'git_branch':
-          return createTraceMetadataFilter(MLFLOW_GIT_BRANCH_KEY, f.value);
-        case 'git_commit':
-          return createTraceMetadataFilter(MLFLOW_GIT_COMMIT_KEY, f.value);
-        default:
-          return null;
-      }
-    })
-    .filter((s): s is string => s !== null);
+  const result = filters.filter(isCompleteFilter).map((f) => COLUMN_TO_METRICS_FILTER_BUILDER[f.column](f.value));
   return result.length > 0 ? result : undefined;
+};
+
+/**
+ * Mapping from MetricFilter column to the corresponding traces-table column id.
+ * Shared by `translateToTracesPageFilters` (URL string form) and
+ * `translateToTableFilters` (TableFilter object form)
+ *
+ * The `Record<MetricFilterColumn, ...>` type makes adding a new
+ * MetricFilterColumn a compile error until the mapping is filled in.
+ */
+const COLUMN_TO_TRACES_COLUMN_ID: Record<MetricFilterColumn, string> = {
+  user: USER_COLUMN_ID,
+  session: SESSION_COLUMN_ID,
+  state: STATE_COLUMN_ID,
+  git_branch: GIT_BRANCH_COLUMN_ID,
+  git_commit: GIT_COMMIT_COLUMN_ID,
 };
 
 /**
@@ -78,28 +95,28 @@ export const translateToMetricsFilters = (filters: MetricFilter[]): string[] | u
  * segment is optional and only used for filters that disambiguate within a
  * column group (e.g. assessment filters); top-level columns like `user` emit
  * the 3-segment form.
- *
- * Add a new case here when adding a new column option in MetricsFilter.
  */
 export const translateToTracesPageFilters = (filters: MetricFilter[]): string[] | undefined => {
   const result = filters
-    .map((f) => {
-      if (!f.column || !f.value) return null;
-      switch (f.column) {
-        case 'user':
-          return [USER_COLUMN_ID, FilterOperator.EQUALS, f.value].join('::');
-        case 'session':
-          return [SESSION_COLUMN_ID, FilterOperator.EQUALS, f.value].join('::');
-        case 'state':
-          return [STATE_COLUMN_ID, FilterOperator.EQUALS, f.value].join('::');
-        case 'git_branch':
-          return [GIT_BRANCH_COLUMN_ID, FilterOperator.EQUALS, f.value].join('::');
-        case 'git_commit':
-          return [GIT_COMMIT_COLUMN_ID, FilterOperator.EQUALS, f.value].join('::');
-        default:
-          return null;
-      }
-    })
-    .filter((s): s is string => s !== null);
+    .filter(isCompleteFilter)
+    .map((f) => [COLUMN_TO_TRACES_COLUMN_ID[f.column], FilterOperator.EQUALS, f.value].join('::'));
+  return result.length > 0 ? result : undefined;
+};
+
+/**
+ * Translates user-driven filter rows from MetricsFilter into in-memory
+ * `TableFilter` objects, the shape consumed by `TracesV3Logs.additionalFilters`.
+ * Use this when a page needs to apply the same filters to a same-page logs view
+ * (no URL round-trip), which complements `translateToTracesPageFilters` for the
+ * chart-tooltip navigation case.
+ */
+export const translateToTableFilters = (filters: MetricFilter[]): TableFilter[] | undefined => {
+  const result = filters.filter(isCompleteFilter).map(
+    (f): TableFilter => ({
+      column: COLUMN_TO_TRACES_COLUMN_ID[f.column],
+      operator: FilterOperator.EQUALS,
+      value: f.value,
+    }),
+  );
   return result.length > 0 ? result : undefined;
 };

--- a/mlflow/server/js/src/gateway/components/edit-endpoint/EditEndpointFormRenderer.tsx
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/EditEndpointFormRenderer.tsx
@@ -147,7 +147,7 @@ export const EditEndpointFormRenderer = ({
   const isTracesTabDisabled = !experimentId && activeTab !== 'traces';
 
   // Kept as local component state (not URL-backed) to mirror the GatewayUsagePage
-  // pattern: filters affect harts immediately and propagate to the Logs tab only
+  // pattern: filters affect charts immediately and propagate to the Logs tab only
   // when the user clicks a chart-tooltip "View logs" link.
   const [metricFilters, setMetricFilters] = useState<MetricFilter[]>([]);
 

--- a/mlflow/server/js/src/gateway/components/edit-endpoint/EditEndpointFormRenderer.tsx
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/EditEndpointFormRenderer.tsx
@@ -14,7 +14,7 @@ import {
 import { FormattedMessage, useIntl } from 'react-intl';
 import type { UseFormReturn } from 'react-hook-form';
 import { Controller } from 'react-hook-form';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import GatewayRoutes from '../../routes';
 import Routes from '../../../experiment-tracking/routes';
 import { SETTINGS_SECTION_LLM_CONNECTIONS } from '../../../settings/settingsSectionConstants';
@@ -32,6 +32,15 @@ import { TracesV3Logs } from '../../../experiment-tracking/components/experiment
 import { MonitoringConfigProvider } from '../../../experiment-tracking/hooks/useMonitoringConfig';
 import { useMonitoringFiltersTimeRange } from '../../../experiment-tracking/hooks/useMonitoringFilters';
 import { TracesV3DateSelector } from '../../../experiment-tracking/components/experiment-page/components/traces-v3/TracesV3DateSelector';
+import { ExperimentViewTracesStatusLabels } from '@databricks/web-shared/genai-traces-table';
+import { MetricsFilter } from '../../../common/components/MetricsFilter';
+import {
+  translateToMetricsFilters,
+  translateToTracesPageFilters,
+  TRACE_STATE_VALUES,
+  type MetricFilter,
+  type MetricFilterColumnOption,
+} from '../../../common/components/MetricsFilter.utils';
 
 /**
  * Returns the provider string to pass to StarterCodeCard.
@@ -137,6 +146,31 @@ export const EditEndpointFormRenderer = ({
   const isUsageTabDisabled = !experimentId && activeTab !== 'usage';
   const isTracesTabDisabled = !experimentId && activeTab !== 'traces';
 
+  // Kept as local component state (not URL-backed) to mirror the GatewayUsagePage
+  // pattern: filters affect harts immediately and propagate to the Logs tab only
+  // when the user clicks a chart-tooltip "View logs" link.
+  const [metricFilters, setMetricFilters] = useState<MetricFilter[]>([]);
+
+  const chartFilters = useMemo(() => translateToMetricsFilters(metricFilters), [metricFilters]);
+  const tracesNavigationFilters = useMemo(() => translateToTracesPageFilters(metricFilters), [metricFilters]);
+
+  const metricsFilterColumnOptions = useMemo<MetricFilterColumnOption[]>(
+    () => [
+      {
+        value: 'state',
+        label: intl.formatMessage({
+          defaultMessage: 'State',
+          description: 'Gateway endpoint usage > metrics filter > state column option label',
+        }),
+        valueOptions: TRACE_STATE_VALUES.map((value) => ({
+          value,
+          label: intl.formatMessage(ExperimentViewTracesStatusLabels[value]),
+        })),
+      },
+    ],
+    [intl],
+  );
+
   const tooltipLinkUrlBuilder = useMemo(() => {
     if (!endpoint) return undefined;
     return (_experimentId: string, timestampMs: number, timeIntervalSeconds: number) =>
@@ -144,8 +178,9 @@ export const EditEndpointFormRenderer = ({
         tab: 'traces',
         startTime: new Date(timestampMs).toISOString(),
         endTime: new Date(timestampMs + timeIntervalSeconds * 1000).toISOString(),
+        filters: tracesNavigationFilters,
       });
-  }, [endpoint]);
+  }, [endpoint, tracesNavigationFilters]);
 
   const totalWeight = trafficSplitModels.reduce((sum, m) => sum + m.weight, 0);
   const isValidTotal = Math.abs(totalWeight - 100) < 0.01;
@@ -399,7 +434,18 @@ export const EditEndpointFormRenderer = ({
 
             <Tabs.Content value="usage">
               {experimentId && (
-                <GatewayUsageSection experimentId={experimentId} tooltipLinkUrlBuilder={tooltipLinkUrlBuilder} />
+                <GatewayUsageSection
+                  experimentId={experimentId}
+                  tooltipLinkUrlBuilder={tooltipLinkUrlBuilder}
+                  additionalControls={
+                    <MetricsFilter
+                      filters={metricFilters}
+                      setFilters={setMetricFilters}
+                      columnOptions={metricsFilterColumnOptions}
+                    />
+                  }
+                  filters={chartFilters}
+                />
               )}
             </Tabs.Content>
 

--- a/mlflow/server/js/src/gateway/components/edit-endpoint/GatewayUsageSection.tsx
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/GatewayUsageSection.tsx
@@ -6,9 +6,16 @@ import { prefixRouteWithWorkspace } from '../../../workspaces/utils/WorkspaceUti
 interface GatewayUsageSectionProps {
   experimentId: string;
   tooltipLinkUrlBuilder?: (experimentId: string, timestampMs: number, timeIntervalSeconds: number) => string;
+  additionalControls?: React.ReactNode;
+  filters?: string[];
 }
 
-export const GatewayUsageSection = ({ experimentId, tooltipLinkUrlBuilder }: GatewayUsageSectionProps) => {
+export const GatewayUsageSection = ({
+  experimentId,
+  tooltipLinkUrlBuilder,
+  additionalControls,
+  filters,
+}: GatewayUsageSectionProps) => {
   const { theme } = useDesignSystemTheme();
 
   return (
@@ -35,6 +42,7 @@ export const GatewayUsageSection = ({ experimentId, tooltipLinkUrlBuilder }: Gat
       <GatewayChartsPanel
         experimentIds={[experimentId]}
         showTokenStats
+        additionalControls={additionalControls}
         tooltipLinkUrlBuilder={tooltipLinkUrlBuilder}
         tooltipLinkText={
           tooltipLinkUrlBuilder ? (
@@ -44,6 +52,7 @@ export const GatewayUsageSection = ({ experimentId, tooltipLinkUrlBuilder }: Gat
             />
           ) : undefined
         }
+        filters={filters}
       />
     </div>
   );

--- a/mlflow/server/js/src/gateway/pages/GatewayUsagePage.test.tsx
+++ b/mlflow/server/js/src/gateway/pages/GatewayUsagePage.test.tsx
@@ -162,6 +162,12 @@ describe('GatewayUsagePage', () => {
       expect(screen.queryByText('User:')).not.toBeInTheDocument();
       expect(screen.getByText('Endpoint:')).toBeInTheDocument();
     });
+
+    test('renders MetricsFilter button on Usage tab', () => {
+      renderComponent();
+
+      expect(screen.getByRole('button', { name: /Filters/ })).toBeInTheDocument();
+    });
   });
 
   describe('when no endpoints have usage tracking enabled', () => {

--- a/mlflow/server/js/src/gateway/pages/GatewayUsagePage.tsx
+++ b/mlflow/server/js/src/gateway/pages/GatewayUsagePage.tsx
@@ -26,7 +26,6 @@ import { ExperimentViewTracesStatusLabels, FilterOperator } from '@databricks/we
 import { MetricsFilter } from '../../common/components/MetricsFilter';
 import {
   translateToMetricsFilters,
-  translateToTableFilters,
   translateToTracesPageFilters,
   TRACE_STATE_VALUES,
   type MetricFilter,
@@ -155,19 +154,10 @@ export const GatewayUsagePage = () => {
     return result.length > 0 ? result : undefined;
   }, [selectedUserId, metricFilters]);
 
-  // Build table filters from selected auth user ID and MetricsFilter rows
-  // (TableFilter format for TracesV3Logs).
   const tableFilters = useMemo((): TableFilter[] | undefined => {
-    const result: TableFilter[] = [];
-    if (selectedUserId) {
-      result.push({ column: 'user', operator: FilterOperator.EQUALS, value: selectedUserId });
-    }
-    const metricTableFilters = translateToTableFilters(metricFilters);
-    if (metricTableFilters) {
-      result.push(...metricTableFilters);
-    }
-    return result.length > 0 ? result : undefined;
-  }, [selectedUserId, metricFilters]);
+    if (!selectedUserId) return undefined;
+    return [{ column: 'user', operator: FilterOperator.EQUALS, value: selectedUserId }];
+  }, [selectedUserId]);
 
   // URL filter strings (column::operator::value) appended to chart-tooltip
   // navigation so the Logs tab opens with the same filter set after a click on

--- a/mlflow/server/js/src/gateway/pages/GatewayUsagePage.tsx
+++ b/mlflow/server/js/src/gateway/pages/GatewayUsagePage.tsx
@@ -11,7 +11,7 @@ import {
   useDesignSystemTheme,
 } from '@databricks/design-system';
 import { GatewayLabel } from '../../common/components/GatewayNewTag';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import { createTraceMetadataFilter, AUTH_USER_ID_METADATA_KEY } from '@databricks/web-shared/model-trace-explorer';
 import { useEndpointsQuery } from '../hooks/useEndpointsQuery';
 import { useUsersQuery } from '../hooks/useUsersQuery';
@@ -22,7 +22,14 @@ import { MonitoringConfigProvider } from '../../experiment-tracking/hooks/useMon
 import { useMonitoringFiltersTimeRange } from '../../experiment-tracking/hooks/useMonitoringFilters';
 import { TracesV3DateSelector } from '../../experiment-tracking/components/experiment-page/components/traces-v3/TracesV3DateSelector';
 import type { TableFilter } from '@databricks/web-shared/genai-traces-table';
-import { FilterOperator } from '@databricks/web-shared/genai-traces-table';
+import { ExperimentViewTracesStatusLabels, FilterOperator } from '@databricks/web-shared/genai-traces-table';
+import { MetricsFilter } from '../../common/components/MetricsFilter';
+import {
+  translateToMetricsFilters,
+  TRACE_STATE_VALUES,
+  type MetricFilter,
+  type MetricFilterColumnOption,
+} from '../../common/components/MetricsFilter.utils';
 
 const GatewayLogsContent = ({
   experimentIds,
@@ -97,9 +104,11 @@ const UsageEmptyState = ({
 
 export const GatewayUsagePage = () => {
   const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
   const [searchParams, setSearchParams] = useSearchParams();
   const [selectedEndpointId, setSelectedEndpointId] = useState<string | null>(null);
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
+  const [metricFilters, setMetricFilters] = useState<MetricFilter[]>([]);
 
   const VALID_TABS = ['usage', 'logs'] as const;
   const tabParam = searchParams.get('tab');
@@ -142,17 +151,42 @@ export const GatewayUsagePage = () => {
     };
   }, []);
 
-  // Build chart filters from selected user ID (string format for chart APIs)
+  // Build chart filters from selected user ID and MetricsFilter rows.
   const chartFilters = useMemo(() => {
-    if (!selectedUserId) return undefined;
-    return [createTraceMetadataFilter(AUTH_USER_ID_METADATA_KEY, selectedUserId)];
-  }, [selectedUserId]);
+    const result: string[] = [];
+    if (selectedUserId) {
+      result.push(createTraceMetadataFilter(AUTH_USER_ID_METADATA_KEY, selectedUserId));
+    }
+    const metricFilterStrings = translateToMetricsFilters(metricFilters);
+    if (metricFilterStrings) {
+      result.push(...metricFilterStrings);
+    }
+    return result.length > 0 ? result : undefined;
+  }, [selectedUserId, metricFilters]);
 
   // Build table filters from selected user ID (TableFilter format for TracesV3Logs)
   const tableFilters = useMemo((): TableFilter[] | undefined => {
     if (!selectedUserId) return undefined;
     return [{ column: 'user', operator: FilterOperator.EQUALS, value: selectedUserId }];
   }, [selectedUserId]);
+
+  // Column options exposed in the MetricsFilter dropdown
+  const metricsFilterColumnOptions = useMemo<MetricFilterColumnOption[]>(
+    () => [
+      {
+        value: 'state',
+        label: intl.formatMessage({
+          defaultMessage: 'State',
+          description: 'Gateway usage overview > metrics filter > state column option label',
+        }),
+        valueOptions: TRACE_STATE_VALUES.map((value) => ({
+          value,
+          label: intl.formatMessage(ExperimentViewTracesStatusLabels[value]),
+        })),
+      },
+    ],
+    [intl],
+  );
 
   const hasEndpoints = endpointsWithExperiments.length > 0;
 
@@ -315,6 +349,13 @@ export const GatewayUsagePage = () => {
             <GatewayChartsPanel
               experimentIds={experimentIds}
               showTokenStats
+              additionalControls={
+                <MetricsFilter
+                  filters={metricFilters}
+                  setFilters={setMetricFilters}
+                  columnOptions={metricsFilterColumnOptions}
+                />
+              }
               tooltipLinkUrlBuilder={tooltipLinkUrlBuilder}
               tooltipLinkText={
                 <FormattedMessage

--- a/mlflow/server/js/src/gateway/pages/GatewayUsagePage.tsx
+++ b/mlflow/server/js/src/gateway/pages/GatewayUsagePage.tsx
@@ -26,6 +26,8 @@ import { ExperimentViewTracesStatusLabels, FilterOperator } from '@databricks/we
 import { MetricsFilter } from '../../common/components/MetricsFilter';
 import {
   translateToMetricsFilters,
+  translateToTableFilters,
+  translateToTracesPageFilters,
   TRACE_STATE_VALUES,
   type MetricFilter,
   type MetricFilterColumnOption,
@@ -140,17 +142,6 @@ export const GatewayUsagePage = () => {
     return selectedEndpoint?.experiment_id ? [selectedEndpoint.experiment_id] : [];
   }, [showAllEndpoints, endpointsWithExperiments, selectedEndpoint]);
 
-  const tooltipLinkUrlBuilder = useMemo(() => {
-    return (_experimentId: string, timestampMs: number, timeIntervalSeconds: number) => {
-      const params = new URLSearchParams();
-      params.set('tab', 'logs');
-      params.set('startTimeLabel', 'CUSTOM');
-      params.set('startTime', new Date(timestampMs).toISOString());
-      params.set('endTime', new Date(timestampMs + timeIntervalSeconds * 1000).toISOString());
-      return `${GatewayRoutes.usagePageRoute}?${params.toString()}`;
-    };
-  }, []);
-
   // Build chart filters from selected user ID and MetricsFilter rows.
   const chartFilters = useMemo(() => {
     const result: string[] = [];
@@ -164,11 +155,36 @@ export const GatewayUsagePage = () => {
     return result.length > 0 ? result : undefined;
   }, [selectedUserId, metricFilters]);
 
-  // Build table filters from selected user ID (TableFilter format for TracesV3Logs)
+  // Build table filters from selected auth user ID and MetricsFilter rows
+  // (TableFilter format for TracesV3Logs).
   const tableFilters = useMemo((): TableFilter[] | undefined => {
-    if (!selectedUserId) return undefined;
-    return [{ column: 'user', operator: FilterOperator.EQUALS, value: selectedUserId }];
-  }, [selectedUserId]);
+    const result: TableFilter[] = [];
+    if (selectedUserId) {
+      result.push({ column: 'user', operator: FilterOperator.EQUALS, value: selectedUserId });
+    }
+    const metricTableFilters = translateToTableFilters(metricFilters);
+    if (metricTableFilters) {
+      result.push(...metricTableFilters);
+    }
+    return result.length > 0 ? result : undefined;
+  }, [selectedUserId, metricFilters]);
+
+  // URL filter strings (column::operator::value) appended to chart-tooltip
+  // navigation so the Logs tab opens with the same filter set after a click on
+  // a chart bucket.
+  const tracesNavigationFilters = useMemo(() => translateToTracesPageFilters(metricFilters), [metricFilters]);
+
+  const tooltipLinkUrlBuilder = useMemo(() => {
+    return (_experimentId: string, timestampMs: number, timeIntervalSeconds: number) => {
+      const params = new URLSearchParams();
+      params.set('tab', 'logs');
+      params.set('startTimeLabel', 'CUSTOM');
+      params.set('startTime', new Date(timestampMs).toISOString());
+      params.set('endTime', new Date(timestampMs + timeIntervalSeconds * 1000).toISOString());
+      tracesNavigationFilters?.forEach((f) => params.append('filter', f));
+      return `${GatewayRoutes.usagePageRoute}?${params.toString()}`;
+    };
+  }, [tracesNavigationFilters]);
 
   // Column options exposed in the MetricsFilter dropdown
   const metricsFilterColumnOptions = useMemo<MetricFilterColumnOption[]>(

--- a/mlflow/server/js/src/gateway/routes.ts
+++ b/mlflow/server/js/src/gateway/routes.ts
@@ -60,7 +60,10 @@ class GatewayRoutes {
     return GatewayRoutePaths.createEndpointPage;
   }
 
-  static getEndpointDetailsRoute(endpointId: string, options?: { tab?: string; startTime?: string; endTime?: string }) {
+  static getEndpointDetailsRoute(
+    endpointId: string,
+    options?: { tab?: string; startTime?: string; endTime?: string; filters?: string[] },
+  ) {
     const path = generatePath(GatewayRoutePaths.endpointDetailsPage, { endpointId });
     if (!options) return path;
     const params = new URLSearchParams();
@@ -70,6 +73,7 @@ class GatewayRoutes {
       params.set('startTime', options.startTime);
       params.set('endTime', options.endTime);
     }
+    options.filters?.forEach((f) => params.append('filter', f));
     const query = params.toString();
     return query ? `${path}?${query}` : path;
   }

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -4743,6 +4743,10 @@
     "defaultMessage": "On",
     "description": "Runs charts > line chart > display points > on setting label"
   },
+  "QWcxD+": {
+    "defaultMessage": "State",
+    "description": "Gateway usage overview > metrics filter > state column option label"
+  },
   "QXLV8h": {
     "defaultMessage": "Error",
     "description": "Title for error fallback component in the MLflow experiment chat sessions page"

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -399,6 +399,10 @@
     "defaultMessage": "No retrieval logged",
     "description": "Evaluation review > retrieval section > no values"
   },
+  "0BguZN": {
+    "defaultMessage": "State",
+    "description": "Gateway endpoint usage > metrics filter > state column option label"
+  },
   "0ElvS9": {
     "defaultMessage": "Y-axis:",
     "description": "Label text for y-axis in contour plot comparison in MLflow"


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Relates to:
- https://github.com/mlflow/mlflow/pull/23120
- https://github.com/mlflow/mlflow/pull/23239

### What changes are proposed in this pull request?

- Adds the metric filter component into AI Gateway Usage Overview & Endpoint Usage tab
- Minor refactor on MetricsFilter.utils to improve code quality

Purpose of the PR is to extend the MetricFilter component used in Experiments Overview to AI Gateway. Introduced only the basic filter key (state) for now since other traces metadata keys are not tracked by Gateway (e.g. `mlflow.trace.user` / `mlflow.trace.session`) unlike Usage in Experiments.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

**AI Gateway Usage Overview page:**

https://github.com/user-attachments/assets/bc9b24af-311f-47f5-88b4-fed50ff43ecb

**AI Gateway Endpoint Usage tab:**

https://github.com/user-attachments/assets/0854f9ca-f978-44aa-ad12-7d87af02372c

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

Users are now able to filter by Traces state within the AI Gateway Usage pages

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mlflow/codesmith/mlflow/pr/23423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->