### PR TITLE
Encourage parallel fetches in `pr-review` skill

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -125,7 +125,7 @@ Determine the review `event`:
 
 ### 4. Emit Review Payload
 
-Write `/tmp/review-payload.json` matching [`review-payload.schema.json`](./review-payload.schema.json). No need to post the review yourself.
+Write `/tmp/review-payload.json` matching [`review-payload.schema.json`](./review-payload.schema.json). Do not post the review yourself.
 
 Authoring rules not captured by the schema:
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -125,9 +125,7 @@ Determine the review `event`:
 
 ### 4. Emit Review Payload
 
-Your only output is `/tmp/review-payload.json`. Do not call any GitHub write APIs (e.g., `gh pr review`, `gh api -X POST /repos/{owner}/{repo}/pulls/{pr}/reviews`).
-
-Write `/tmp/review-payload.json` matching [`review-payload.schema.json`](./review-payload.schema.json) (already read in step 1).
+Write `/tmp/review-payload.json` matching [`review-payload.schema.json`](./review-payload.schema.json). No need to post the review yourself.
 
 Authoring rules not captured by the schema:
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -40,24 +40,28 @@ The `<owner>`/`<repo>`/`<pr_number>` placeholders in the steps below refer to th
 
 ## Instructions
 
-### 1. Fetch PR context
+### 1. Gather context (run in parallel)
 
-Fetch the PR title and description:
+These four reads are independent. Issue them as parallel tool calls in a single turn, not sequentially.
+
+#### PR title and description
 
 ```bash
 gh pr view <pr_number> --repo "<owner>/<repo>" --json title,body
 ```
 
-### 2. Fetch PR Diff
+#### PR diff hunks
 
-Fetch the diff hunks via the `fetch-diff` skill.
+Invoke the [`fetch-diff`](../fetch-diff/SKILL.md) skill.
 
-### 3. Fetch Existing Review Comments
+#### Existing review threads
 
-Fetch up to 100 review threads on the PR (open, resolved, and outdated, with up to 20 comments each) so you can avoid duplicating prior feedback:
+Up to 100 threads (open, resolved, and outdated) with up to 20 comments each, so you can avoid duplicating prior feedback:
 
 ```bash
-gh api graphql -F owner=<owner> -F repo=<repo> -F pr=<pr_number> -f query='
+gh api graphql -F owner=<owner> -F repo=<repo> -F pr=<pr_number> \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes | map(.comments = .comments.nodes)' \
+  -f query='
   query($owner: String!, $repo: String!, $pr: Int!) {
     repository(owner: $owner, name: $repo) {
       pullRequest(number: $pr) {
@@ -77,11 +81,17 @@ gh api graphql -F owner=<owner> -F repo=<repo> -F pr=<pr_number> -f query='
   }'
 ```
 
-### 4. In-Depth Analysis
+#### Payload schema
+
+Read [`review-payload.schema.json`](./review-payload.schema.json) so it's in context for step 4.
+
+### 2. In-Depth Analysis
 
 The working tree holds the PR merged into the base (`refs/pull/<pr>/merge`), so file contents reflect the post-merge state. Explore it for context beyond the diff (existing patterns, call sites of changed symbols, file conventions).
 
 The merge ref's base parent is also reachable as `HEAD^1`. When the diff doesn't show enough (verifying a refactor preserved behavior, reading the full content of a deleted file, or seeing the pre-change version of a heavily modified file), use `git show HEAD^1:<path>` rather than re-fetching via the GitHub API.
+
+Batch independent lookups into a single turn. If you need to read several changed files, grep for a few symbols, or spawn multiple `Explore` agents, issue them as parallel tool calls. Only serialize when a later call depends on an earlier result.
 
 #### Don't comment on
 
@@ -98,7 +108,7 @@ Evaluate the changed code across these dimensions:
 - **Test coverage**: new behavior lacks tests, tests assert on the wrong thing, mocks hide real failures
 - **Style guide**: see `.claude/rules/` for language-specific rules and `CLAUDE.md` for repo conventions
 
-### 5. Decision Point
+### 3. Decision Point
 
 Classify each finding by severity (matches `.github/instructions/code-review.instructions.md`):
 
@@ -113,11 +123,11 @@ Determine the review `event`:
 - **No CRITICAL findings** -> `event: "APPROVE"`
 - **Any CRITICAL finding** -> `event: "COMMENT"`
 
-### 6. Emit Review Payload
+### 4. Emit Review Payload
 
 Your only output is `/tmp/review-payload.json`. Do not call any GitHub write APIs (e.g., `gh pr review`, `gh api -X POST /repos/{owner}/{repo}/pulls/{pr}/reviews`).
 
-Read [`review-payload.schema.json`](./review-payload.schema.json) for the full payload spec (field types, required fields, patterns, enums) and write `/tmp/review-payload.json` matching it.
+Write `/tmp/review-payload.json` matching [`review-payload.schema.json`](./review-payload.schema.json) (already read in step 1).
 
 Authoring rules not captured by the schema:
 


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Restructure the `pr-review` skill's instructions so the four independent context fetches (PR title/body, diff, existing review threads, payload schema) live under a single "Gather context (run in parallel)" section with `####` subheadings. Adds an explicit nudge to issue them as parallel tool calls in a single turn, and a similar nudge for the in-depth analysis step (file reads, greps, `Explore` agents).

Also flattens the `reviewThreads` GraphQL response via `--jq` so the model gets a plain array of threads with comments inlined, and links the `fetch-diff` skill by path.

Why: Opus already runs these fetches in parallel when given the chance. Restructuring the prose makes the parallelism explicit, which should keep cheaper models behaving the same way and shave a few seconds off every review run.

### How is this PR tested?

- [x] Manual tests

Prompt-only change to a skill file. Will be validated by the next `/review` invocation on this PR.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mlflow/codesmith/mlflow/pr/23424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->