### PR TITLE
RBAC: extend `prompt` resource_type to after-request handlers

### DIFF
--- a/mlflow/entities/model_registry/model_version.py
+++ b/mlflow/entities/model_registry/model_version.py
@@ -6,6 +6,7 @@ from mlflow.entities.model_registry.model_version_deployment_job_state import (
 )
 from mlflow.entities.model_registry.model_version_status import ModelVersionStatus
 from mlflow.entities.model_registry.model_version_tag import ModelVersionTag
+from mlflow.prompt.constants import IS_PROMPT_TAG_KEY
 from mlflow.protos.model_registry_pb2 import ModelVersion as ProtoModelVersion
 from mlflow.protos.model_registry_pb2 import ModelVersionTag as ProtoModelVersionTag
 from mlflow.utils.workspace_utils import resolve_entity_workspace_name
@@ -143,6 +144,10 @@ class ModelVersion(_ModelRegistryEntity):
     def tags(self) -> dict[str, str]:
         """Dictionary of tag key (string) -> tag value for the current model version."""
         return self._tags
+
+    def _is_prompt(self):
+        """Check if the model version is a prompt version."""
+        return self._tags.get(IS_PROMPT_TAG_KEY, "false").lower() == "true"
 
     @property
     def aliases(self) -> list[str]:

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -2591,7 +2591,7 @@ def delete_can_manage_registered_model_permission(resp: Response):
     now. Names are unique within the registry, so exactly one of the two
     sweeps applies and the other is a no-op.
     """
-    # ``silent=True`` returns ``None`` on missing / unparseable bodies; the
+    # ``silent=True`` returns ``None`` on missing / unparsable bodies; the
     # ``or {}`` guard prevents a ``TypeError`` from leaking out as a 500.
     data = request.get_json(force=True, silent=True) or {}
     name = data.get("name")
@@ -3097,7 +3097,7 @@ def rename_registered_model_permission(resp: Response):
     ``(prompt, old_name, ...)`` grants. Names are unique within the registry,
     so exactly one of the two renames applies and the other is a no-op.
     """
-    # ``silent=True`` returns ``None`` on missing / unparseable bodies; ``or
+    # ``silent=True`` returns ``None`` on missing / unparsable bodies; ``or
     # {}`` plus the explicit value checks below prevent ``None`` from
     # propagating to ``resource_pattern`` and silently rewriting rows.
     data = request.get_json(force=True, silent=True) or {}

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -1485,12 +1485,22 @@ def validate_can_get_user_permission() -> bool:
     return store.is_workspace_admin(requester_user.id, workspace_name)
 
 
-def _proto_is_prompt(proto) -> bool:
-    """True if a ``RegisteredModel`` / ``ModelVersion`` proto carries the
-    ``mlflow.prompt.is_prompt`` tag. Mirrors ``RegisteredModel._is_prompt``
-    for response-side classification where we only have the proto in hand.
+def _entity_is_prompt(entity) -> bool:
+    """True if a ``RegisteredModel`` / ``ModelVersion`` entity is prompt-flagged.
+
+    Unifies the two response-filtering paths in ``filter_search_*`` — initial
+    response rows arrive as protos (via ``parse_dict``), refetched rows arrive
+    as ORM entities (``PagedList[RegisteredModel]``). Dispatch order matters:
+    ``RegisteredModel.tags`` strips the ``mlflow.prompt.is_prompt`` tag from
+    its public dict so users don't see it, so we must call ``_is_prompt()``
+    on that entity rather than reading ``.tags`` directly.
     """
-    return any(t.key == IS_PROMPT_TAG_KEY and t.value.lower() == "true" for t in proto.tags)
+    if hasattr(entity, "_is_prompt"):
+        return entity._is_prompt()
+    tags = entity.tags
+    if isinstance(tags, dict):
+        return tags.get(IS_PROMPT_TAG_KEY, "false").lower() == "true"
+    return any(t.key == IS_PROMPT_TAG_KEY and t.value.lower() == "true" for t in tags)
 
 
 def _role_based_read_predicate(username: str, resource_type: str) -> Callable[[str], bool]:
@@ -2553,11 +2563,20 @@ def set_can_manage_experiment_permission(resp: Response):
 
 
 def set_can_manage_registered_model_permission(resp: Response):
+    # ``CreateRegisteredModel`` is shared with prompt creation; the response
+    # carries the persisted ``mlflow.prompt.is_prompt`` tag, so we can classify
+    # the entity authoritatively here and grant MANAGE in the matching
+    # namespace. Granting unconditionally on ``registered_model`` would leave
+    # the prompt creator without ``(prompt, name, MANAGE)`` and lock them out
+    # of the entity they just created via the prompt-side validators.
     response_message = CreateRegisteredModel.Response()
     parse_dict(resp.json, response_message)
     name = response_message.registered_model.name
+    resource_type = (
+        "prompt" if _entity_is_prompt(response_message.registered_model) else "registered_model"
+    )
     username = authenticate_request().username
-    store.grant_user_permission(username, "registered_model", name, MANAGE.name)
+    store.grant_user_permission(username, resource_type, name, MANAGE.name)
 
 
 def delete_can_manage_registered_model_permission(resp: Response):
@@ -2572,7 +2591,15 @@ def delete_can_manage_registered_model_permission(resp: Response):
     now. Names are unique within the registry, so exactly one of the two
     sweeps applies and the other is a no-op.
     """
-    name = request.get_json(force=True, silent=True)["name"]
+    # ``silent=True`` returns ``None`` on missing / unparseable bodies; the
+    # ``or {}`` guard prevents a ``TypeError`` from leaking out as a 500.
+    data = request.get_json(force=True, silent=True) or {}
+    name = data.get("name")
+    if not name:
+        raise MlflowException(
+            "Missing value for required parameter 'name'.",
+            INVALID_PARAMETER_VALUE,
+        )
     store.delete_grants_for_resource("registered_model", name, workspace_scoped=True)
     store.delete_grants_for_resource("prompt", name, workspace_scoped=True)
 
@@ -2994,8 +3021,8 @@ def filter_search_registered_models(resp: Response):
     can_read_rm = _role_based_read_predicate(username, "registered_model")
     can_read_prompt = _role_based_read_predicate(username, "prompt")
 
-    def can_read(rm) -> bool:
-        return (can_read_prompt if _proto_is_prompt(rm) else can_read_rm)(rm.name)
+    def can_read(entity) -> bool:
+        return (can_read_prompt if _entity_is_prompt(entity) else can_read_rm)(entity.name)
 
     # filter out unreadable
     for rm in list(response_message.registered_models):
@@ -3023,11 +3050,10 @@ def filter_search_registered_models(resp: Response):
             response_message.next_page_token = ""
             break
 
-        refetched_readable_proto = [
-            rm.to_proto()
-            for rm in refetched
-            if (can_read_prompt if rm._is_prompt() else can_read_rm)(rm.name)
-        ]
+        # ``can_read`` accepts both protos and ORM entities; reuse it here so
+        # refetched ORM rows go through the same classification as the initial
+        # JSON-parsed proto rows above.
+        refetched_readable_proto = [rm.to_proto() for rm in refetched if can_read(rm)]
         response_message.registered_models.extend(refetched_readable_proto)
 
         # recalculate next page token
@@ -3055,7 +3081,7 @@ def filter_search_model_versions(resp: Response):
     can_read_prompt = _role_based_read_predicate(username, "prompt")
     # filter out model versions whose parent model is unreadable
     for mv in list(response_message.model_versions):
-        check = can_read_prompt if _proto_is_prompt(mv) else can_read_rm
+        check = can_read_prompt if _entity_is_prompt(mv) else can_read_rm
         if not check(mv.name):
             response_message.model_versions.remove(mv)
 
@@ -3071,9 +3097,17 @@ def rename_registered_model_permission(resp: Response):
     ``(prompt, old_name, ...)`` grants. Names are unique within the registry,
     so exactly one of the two renames applies and the other is a no-op.
     """
-    data = request.get_json(force=True, silent=True)
+    # ``silent=True`` returns ``None`` on missing / unparseable bodies; ``or
+    # {}`` plus the explicit value checks below prevent ``None`` from
+    # propagating to ``resource_pattern`` and silently rewriting rows.
+    data = request.get_json(force=True, silent=True) or {}
     old_name = data.get("name")
     new_name = data.get("new_name")
+    if not old_name or not new_name:
+        raise MlflowException(
+            "Missing value for required parameter 'name' or 'new_name'.",
+            INVALID_PARAMETER_VALUE,
+        )
     store.rename_grants_for_resource("registered_model", old_name, new_name, workspace_scoped=True)
     store.rename_grants_for_resource("prompt", old_name, new_name, workspace_scoped=True)
 

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -1490,17 +1490,27 @@ def _entity_is_prompt(entity) -> bool:
 
     Unifies the two response-filtering paths in ``filter_search_*`` — initial
     response rows arrive as protos (via ``parse_dict``), refetched rows arrive
-    as ORM entities (``PagedList[RegisteredModel]``). Dispatch order matters:
-    ``RegisteredModel.tags`` strips the ``mlflow.prompt.is_prompt`` tag from
-    its public dict so users don't see it, so we must call ``_is_prompt()``
-    on that entity rather than reading ``.tags`` directly.
+    as ORM entities (``PagedList[RegisteredModel]`` / ``[ModelVersion]``).
+    Both ORM entities expose ``_is_prompt()``; protos don't, so we fall back
+    to scanning the repeated ``.tags`` field for the prompt marker.
     """
     if hasattr(entity, "_is_prompt"):
         return entity._is_prompt()
-    tags = entity.tags
-    if isinstance(tags, dict):
-        return tags.get(IS_PROMPT_TAG_KEY, "false").lower() == "true"
-    return any(t.key == IS_PROMPT_TAG_KEY and t.value.lower() == "true" for t in tags)
+    return any(t.key == IS_PROMPT_TAG_KEY and t.value.lower() == "true" for t in entity.tags)
+
+
+def _rm_or_prompt_read_predicate(username: str) -> Callable[[Any], bool]:
+    """Build a ``p(entity) -> bool`` for filtering shared registered-model /
+    model-version search responses. Classifies each row by its
+    ``mlflow.prompt.is_prompt`` tag and consults the matching grant namespace.
+    """
+    can_read_rm = _role_based_read_predicate(username, "registered_model")
+    can_read_prompt = _role_based_read_predicate(username, "prompt")
+
+    def can_read(entity) -> bool:
+        return (can_read_prompt if _entity_is_prompt(entity) else can_read_rm)(entity.name)
+
+    return can_read
 
 
 def _role_based_read_predicate(username: str, resource_type: str) -> Callable[[str], bool]:
@@ -3018,11 +3028,7 @@ def filter_search_registered_models(resp: Response):
     # row by its ``mlflow.prompt.is_prompt`` tag and check the correct grant
     # namespace. Without this, a user holding only a ``(prompt, foo, READ)``
     # grant would have prompt ``foo`` silently filtered out of the response.
-    can_read_rm = _role_based_read_predicate(username, "registered_model")
-    can_read_prompt = _role_based_read_predicate(username, "prompt")
-
-    def can_read(entity) -> bool:
-        return (can_read_prompt if _entity_is_prompt(entity) else can_read_rm)(entity.name)
+    can_read = _rm_or_prompt_read_predicate(username)
 
     # filter out unreadable
     for rm in list(response_message.registered_models):
@@ -3077,11 +3083,7 @@ def filter_search_model_versions(resp: Response):
     # Prompt versions and model versions share the same REST surface; classify
     # each row by its ``mlflow.prompt.is_prompt`` tag so a prompt-version
     # carrying a ``(prompt, name, READ)`` grant isn't dropped on the floor.
-    can_read_rm = _role_based_read_predicate(username, "registered_model")
-    can_read_prompt = _role_based_read_predicate(username, "prompt")
-
-    def can_read(entity) -> bool:
-        return (can_read_prompt if _entity_is_prompt(entity) else can_read_rm)(entity.name)
+    can_read = _rm_or_prompt_read_predicate(username)
 
     # filter out model versions whose parent model is unreadable
     for mv in list(response_message.model_versions):

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -3079,10 +3079,13 @@ def filter_search_model_versions(resp: Response):
     # carrying a ``(prompt, name, READ)`` grant isn't dropped on the floor.
     can_read_rm = _role_based_read_predicate(username, "registered_model")
     can_read_prompt = _role_based_read_predicate(username, "prompt")
+
+    def can_read(entity) -> bool:
+        return (can_read_prompt if _entity_is_prompt(entity) else can_read_rm)(entity.name)
+
     # filter out model versions whose parent model is unreadable
     for mv in list(response_message.model_versions):
-        check = can_read_prompt if _entity_is_prompt(mv) else can_read_rm
-        if not check(mv.name):
+        if not can_read(mv):
             response_message.model_versions.remove(mv)
 
     resp.data = message_to_json(response_message)

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -51,6 +51,7 @@ from mlflow.environment_variables import (
     MLFLOW_RBAC_SEED_DEFAULT_ROLES,
     MLFLOW_SERVER_ENABLE_GRAPHQL_AUTH,
 )
+from mlflow.prompt.constants import IS_PROMPT_TAG_KEY
 from mlflow.protos.databricks_pb2 import (
     BAD_REQUEST,
     INTERNAL_ERROR,
@@ -1484,6 +1485,14 @@ def validate_can_get_user_permission() -> bool:
     return store.is_workspace_admin(requester_user.id, workspace_name)
 
 
+def _proto_is_prompt(proto) -> bool:
+    """True if a ``RegisteredModel`` / ``ModelVersion`` proto carries the
+    ``mlflow.prompt.is_prompt`` tag. Mirrors ``RegisteredModel._is_prompt``
+    for response-side classification where we only have the proto in hand.
+    """
+    return any(t.key == IS_PROMPT_TAG_KEY and t.value.lower() == "true" for t in proto.tags)
+
+
 def _role_based_read_predicate(username: str, resource_type: str) -> Callable[[str], bool]:
     """
     Build a ``p(resource_id) -> bool`` predicate from ``username``'s role
@@ -2553,12 +2562,19 @@ def set_can_manage_registered_model_permission(resp: Response):
 
 def delete_can_manage_registered_model_permission(resp: Response):
     """
-    Sweep registered-model grants when the model is deleted. The model's primary
-    key is its name (unlike experiments which use a UUID), so a future model
-    with the same name would otherwise inherit stale grants.
+    Sweep registered-model and prompt grants when the entity is deleted.
+
+    The model registry's primary key is the entity name (unlike experiments
+    which use a UUID), so a future entity with the same name would otherwise
+    inherit stale grants. ``DeleteRegisteredModel`` is shared between
+    registered models and prompts on the REST surface; the entity is already
+    gone by the time this after-request hook runs, so we cannot classify it
+    now. Names are unique within the registry, so exactly one of the two
+    sweeps applies and the other is a no-op.
     """
     name = request.get_json(force=True, silent=True)["name"]
     store.delete_grants_for_resource("registered_model", name, workspace_scoped=True)
+    store.delete_grants_for_resource("prompt", name, workspace_scoped=True)
 
 
 # ---- Role management handlers (RBAC) ----
@@ -2971,10 +2987,19 @@ def filter_search_registered_models(resp: Response):
     parse_dict(resp.json, response_message)
 
     username = authenticate_request().username
-    can_read = _role_based_read_predicate(username, "registered_model")
+    # The registered-model REST surface is shared with prompts; classify each
+    # row by its ``mlflow.prompt.is_prompt`` tag and check the correct grant
+    # namespace. Without this, a user holding only a ``(prompt, foo, READ)``
+    # grant would have prompt ``foo`` silently filtered out of the response.
+    can_read_rm = _role_based_read_predicate(username, "registered_model")
+    can_read_prompt = _role_based_read_predicate(username, "prompt")
+
+    def can_read(rm) -> bool:
+        return (can_read_prompt if _proto_is_prompt(rm) else can_read_rm)(rm.name)
+
     # filter out unreadable
     for rm in list(response_message.registered_models):
-        if not can_read(rm.name):
+        if not can_read(rm):
             response_message.registered_models.remove(rm)
 
     # re-fetch to fill max results
@@ -2998,7 +3023,11 @@ def filter_search_registered_models(resp: Response):
             response_message.next_page_token = ""
             break
 
-        refetched_readable_proto = [rm.to_proto() for rm in refetched if can_read(rm.name)]
+        refetched_readable_proto = [
+            rm.to_proto()
+            for rm in refetched
+            if (can_read_prompt if rm._is_prompt() else can_read_rm)(rm.name)
+        ]
         response_message.registered_models.extend(refetched_readable_proto)
 
         # recalculate next page token
@@ -3019,10 +3048,15 @@ def filter_search_model_versions(resp: Response):
     parse_dict(resp.json, response_message)
 
     username = authenticate_request().username
-    can_read = _role_based_read_predicate(username, "registered_model")
+    # Prompt versions and model versions share the same REST surface; classify
+    # each row by its ``mlflow.prompt.is_prompt`` tag so a prompt-version
+    # carrying a ``(prompt, name, READ)`` grant isn't dropped on the floor.
+    can_read_rm = _role_based_read_predicate(username, "registered_model")
+    can_read_prompt = _role_based_read_predicate(username, "prompt")
     # filter out model versions whose parent model is unreadable
     for mv in list(response_message.model_versions):
-        if not can_read(mv.name):
+        check = can_read_prompt if _proto_is_prompt(mv) else can_read_rm
+        if not check(mv.name):
             response_message.model_versions.remove(mv)
 
     resp.data = message_to_json(response_message)
@@ -3030,17 +3064,18 @@ def filter_search_model_versions(resp: Response):
 
 def rename_registered_model_permission(resp: Response):
     """
-    A model registry can be assigned to multiple users with different permissions.
+    Propagate a registered-model rename to RBAC grants.
 
-    Changing the model registry name must be propagated to all users.
+    ``RenameRegisteredModel`` is shared between registered models and prompts;
+    sweep both namespaces so a prompt rename doesn't orphan its
+    ``(prompt, old_name, ...)`` grants. Names are unique within the registry,
+    so exactly one of the two renames applies and the other is a no-op.
     """
     data = request.get_json(force=True, silent=True)
-    store.rename_grants_for_resource(
-        "registered_model",
-        data.get("name"),
-        data.get("new_name"),
-        workspace_scoped=True,
-    )
+    old_name = data.get("name")
+    new_name = data.get("new_name")
+    store.rename_grants_for_resource("registered_model", old_name, new_name, workspace_scoped=True)
+    store.rename_grants_for_resource("prompt", old_name, new_name, workspace_scoped=True)
 
 
 def set_can_manage_scorer_permission(resp: Response):

--- a/tests/server/auth/test_auth_workspace.py
+++ b/tests/server/auth/test_auth_workspace.py
@@ -8,7 +8,9 @@ from flask import Response, request
 
 from mlflow.environment_variables import MLFLOW_ENABLE_WORKSPACES
 from mlflow.exceptions import MlflowException
+from mlflow.prompt.constants import IS_PROMPT_TAG_KEY
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
+from mlflow.protos.model_registry_pb2 import SearchModelVersions, SearchRegisteredModels
 from mlflow.server import auth as auth_module
 from mlflow.server.auth.permissions import EDIT, MANAGE, NO_PERMISSIONS, READ, USE
 from mlflow.server.auth.routes import (
@@ -1250,6 +1252,195 @@ def test_request_targets_prompt_propagates_unexpected_errors(
         ):
             with pytest.raises(RuntimeError, match="registry store backend is down"):
                 auth_module._request_targets_prompt()
+
+
+def _build_search_registered_models_response(entries):
+    """Build a ``SearchRegisteredModels.Response()`` from ``(name, is_prompt)`` pairs."""
+    resp = SearchRegisteredModels.Response()
+    for name, is_prompt in entries:
+        rm = resp.registered_models.add()
+        rm.name = name
+        if is_prompt:
+            rm.tags.add(key=IS_PROMPT_TAG_KEY, value="true")
+    return resp
+
+
+def _build_search_model_versions_response(entries):
+    """Build a ``SearchModelVersions.Response()`` from ``(name, is_prompt)`` pairs."""
+    resp = SearchModelVersions.Response()
+    for name, is_prompt in entries:
+        mv = resp.model_versions.add()
+        mv.name = name
+        if is_prompt:
+            mv.tags.add(key=IS_PROMPT_TAG_KEY, value="true")
+    return resp
+
+
+def test_filter_search_registered_models_uses_prompt_grant_for_prompt_rows(
+    workspace_permission_setup, monkeypatch
+):
+    # A user holding only ``(prompt, foo, READ)`` previously had prompt ``foo``
+    # silently filtered out of ``SearchRegisteredModels`` results because the
+    # filter checked the ``registered_model`` namespace exclusively. With the
+    # per-row classify, the prompt grant satisfies the prompt row.
+    monkeypatch.setattr(auth_module, "sender_is_admin", lambda: False)
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    _set_workspace_permission(store, username, NO_PERMISSIONS.name)
+    role = store.create_role(name="prompt-reader", workspace="team-a")
+    store.add_role_permission(role.id, "prompt", "foo", READ.name)
+    store.assign_role_to_user(store.get_user(username).id, role.id)
+
+    payload = json.dumps({
+        "registered_models": [
+            {"name": "foo", "tags": [{"key": IS_PROMPT_TAG_KEY, "value": "true"}]},
+            {"name": "bar", "tags": []},
+        ],
+        "next_page_token": "",
+    })
+    flask_resp = Response(payload, mimetype="application/json")
+
+    with auth_module.app.test_request_context(
+        "/api/2.0/mlflow/registered-models/search",
+        method="GET",
+        query_string={"max_results": "100"},
+    ):
+        auth_module.filter_search_registered_models(flask_resp)
+
+    out = json.loads(flask_resp.get_data(as_text=True))
+    names = [rm["name"] for rm in out.get("registered_models", [])]
+    # Prompt ``foo`` is kept (grant satisfies prompt namespace); ``bar`` is filtered out.
+    assert names == ["foo"]
+
+
+def test_filter_search_registered_models_does_not_satisfy_prompt_with_rm_grant(
+    workspace_permission_setup, monkeypatch
+):
+    # Inverse direction: a ``(registered_model, foo, READ)`` grant must NOT
+    # leak through and make a prompt row readable. Pins cross-namespace
+    # isolation on the response-filtering path.
+    monkeypatch.setattr(auth_module, "sender_is_admin", lambda: False)
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    _set_workspace_permission(store, username, NO_PERMISSIONS.name)
+    role = store.create_role(name="rm-reader", workspace="team-a")
+    store.add_role_permission(role.id, "registered_model", "foo", READ.name)
+    store.assign_role_to_user(store.get_user(username).id, role.id)
+
+    payload = json.dumps({
+        "registered_models": [
+            {"name": "foo", "tags": [{"key": IS_PROMPT_TAG_KEY, "value": "true"}]},
+        ],
+        "next_page_token": "",
+    })
+    flask_resp = Response(payload, mimetype="application/json")
+
+    with auth_module.app.test_request_context(
+        "/api/2.0/mlflow/registered-models/search",
+        method="GET",
+        query_string={"max_results": "100"},
+    ):
+        auth_module.filter_search_registered_models(flask_resp)
+
+    out = json.loads(flask_resp.get_data(as_text=True))
+    assert out.get("registered_models", []) == []
+
+
+def test_filter_search_model_versions_uses_prompt_grant_for_prompt_versions(
+    workspace_permission_setup, monkeypatch
+):
+    # Same gap on ``SearchModelVersions``: prompt versions carry the
+    # ``mlflow.prompt.is_prompt`` tag and must be checked against ``prompt``
+    # grants, not ``registered_model`` grants.
+    monkeypatch.setattr(auth_module, "sender_is_admin", lambda: False)
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    _set_workspace_permission(store, username, NO_PERMISSIONS.name)
+    role = store.create_role(name="prompt-reader", workspace="team-a")
+    store.add_role_permission(role.id, "prompt", "foo", READ.name)
+    store.assign_role_to_user(store.get_user(username).id, role.id)
+
+    payload = json.dumps({
+        "model_versions": [
+            {"name": "foo", "tags": [{"key": IS_PROMPT_TAG_KEY, "value": "true"}]},
+            {"name": "bar", "tags": []},
+        ],
+    })
+    flask_resp = Response(payload, mimetype="application/json")
+
+    with auth_module.app.test_request_context(
+        "/api/2.0/mlflow/model-versions/search", method="GET"
+    ):
+        auth_module.filter_search_model_versions(flask_resp)
+
+    out = json.loads(flask_resp.get_data(as_text=True))
+    names = [mv["name"] for mv in out.get("model_versions", [])]
+    assert names == ["foo"]
+
+
+def test_rename_registered_model_permission_sweeps_prompt_namespace(
+    workspace_permission_setup,
+):
+    # Renaming a prompt must propagate to ``(prompt, old_name, ...)`` grants.
+    # Without sweeping both namespaces, the rename leaves those grants orphaned
+    # under the old name and creates nothing under the new one.
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    store.grant_user_permission(username, "prompt", "foo", READ.name)
+    # Confirm the seed grant landed where we expect.
+    user_id = store.get_user(username).id
+    before = {
+        (rp.resource_type, rp.resource_pattern)
+        for role in store.list_user_roles(user_id)
+        for rp in role.permissions
+    }
+    assert ("prompt", "foo") in before
+
+    with auth_module.app.test_request_context(
+        "/api/2.0/mlflow/registered-models/rename",
+        method="POST",
+        json={"name": "foo", "new_name": "bar"},
+    ):
+        auth_module.rename_registered_model_permission(Response(status=200))
+
+    after = {
+        (rp.resource_type, rp.resource_pattern)
+        for role in store.list_user_roles(user_id)
+        for rp in role.permissions
+    }
+    assert ("prompt", "foo") not in after
+    assert ("prompt", "bar") in after
+
+
+def test_delete_can_manage_registered_model_permission_sweeps_prompt_namespace(
+    workspace_permission_setup,
+):
+    # Deleting a prompt must sweep its ``(prompt, name, ...)`` grants.
+    # Without the prompt-side delete, those rows would leak permanently.
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    store.grant_user_permission(username, "prompt", "foo", READ.name)
+    user_id = store.get_user(username).id
+    before = {
+        (rp.resource_type, rp.resource_pattern)
+        for role in store.list_user_roles(user_id)
+        for rp in role.permissions
+    }
+    assert ("prompt", "foo") in before
+
+    with auth_module.app.test_request_context(
+        "/api/2.0/mlflow/registered-models/delete",
+        method="DELETE",
+        json={"name": "foo"},
+    ):
+        auth_module.delete_can_manage_registered_model_permission(Response(status=200))
+
+    after = {
+        (rp.resource_type, rp.resource_pattern)
+        for role in store.list_user_roles(user_id)
+        for rp in role.permissions
+    }
+    assert ("prompt", "foo") not in after
 
 
 def test_validate_can_view_workspace_requires_access(workspace_permission_setup):

--- a/tests/server/auth/test_auth_workspace.py
+++ b/tests/server/auth/test_auth_workspace.py
@@ -10,7 +10,6 @@ from mlflow.environment_variables import MLFLOW_ENABLE_WORKSPACES
 from mlflow.exceptions import MlflowException
 from mlflow.prompt.constants import IS_PROMPT_TAG_KEY
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
-from mlflow.protos.model_registry_pb2 import SearchModelVersions, SearchRegisteredModels
 from mlflow.server import auth as auth_module
 from mlflow.server.auth.permissions import EDIT, MANAGE, NO_PERMISSIONS, READ, USE
 from mlflow.server.auth.routes import (
@@ -1254,28 +1253,6 @@ def test_request_targets_prompt_propagates_unexpected_errors(
                 auth_module._request_targets_prompt()
 
 
-def _build_search_registered_models_response(entries):
-    """Build a ``SearchRegisteredModels.Response()`` from ``(name, is_prompt)`` pairs."""
-    resp = SearchRegisteredModels.Response()
-    for name, is_prompt in entries:
-        rm = resp.registered_models.add()
-        rm.name = name
-        if is_prompt:
-            rm.tags.add(key=IS_PROMPT_TAG_KEY, value="true")
-    return resp
-
-
-def _build_search_model_versions_response(entries):
-    """Build a ``SearchModelVersions.Response()`` from ``(name, is_prompt)`` pairs."""
-    resp = SearchModelVersions.Response()
-    for name, is_prompt in entries:
-        mv = resp.model_versions.add()
-        mv.name = name
-        if is_prompt:
-            mv.tags.add(key=IS_PROMPT_TAG_KEY, value="true")
-    return resp
-
-
 def test_filter_search_registered_models_uses_prompt_grant_for_prompt_rows(
     workspace_permission_setup, monkeypatch
 ):
@@ -1441,6 +1418,167 @@ def test_delete_can_manage_registered_model_permission_sweeps_prompt_namespace(
         for rp in role.permissions
     }
     assert ("prompt", "foo") not in after
+
+
+def test_set_can_manage_registered_model_permission_grants_prompt_for_prompt_entity(
+    workspace_permission_setup,
+):
+    # ``CreateRegisteredModel`` is shared with prompt creation. When the
+    # created entity is a prompt, the creator-default MANAGE grant must land
+    # in the ``prompt`` namespace — otherwise the prompt-side validators
+    # immediately lock the creator out of their own prompt.
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    user_id = store.get_user(username).id
+
+    flask_resp = Response(
+        json.dumps({
+            "registered_model": {
+                "name": "my-prompt",
+                "tags": [{"key": IS_PROMPT_TAG_KEY, "value": "true"}],
+            }
+        }),
+        mimetype="application/json",
+    )
+    with auth_module.app.test_request_context(
+        "/api/2.0/mlflow/registered-models/create",
+        method="POST",
+        json={"name": "my-prompt"},
+    ):
+        auth_module.set_can_manage_registered_model_permission(flask_resp)
+
+    grants = {
+        (rp.resource_type, rp.resource_pattern, rp.permission)
+        for role in store.list_user_roles(user_id)
+        for rp in role.permissions
+    }
+    assert ("prompt", "my-prompt", MANAGE.name) in grants
+    assert ("registered_model", "my-prompt", MANAGE.name) not in grants
+
+
+def test_set_can_manage_registered_model_permission_grants_registered_model_for_plain_entity(
+    workspace_permission_setup,
+):
+    # Inverse: a non-prompt registered model still grants in the
+    # ``registered_model`` namespace — pins that the new classification path
+    # didn't accidentally flip the default for normal models.
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    user_id = store.get_user(username).id
+
+    flask_resp = Response(
+        json.dumps({"registered_model": {"name": "my-model", "tags": []}}),
+        mimetype="application/json",
+    )
+    with auth_module.app.test_request_context(
+        "/api/2.0/mlflow/registered-models/create",
+        method="POST",
+        json={"name": "my-model"},
+    ):
+        auth_module.set_can_manage_registered_model_permission(flask_resp)
+
+    grants = {
+        (rp.resource_type, rp.resource_pattern, rp.permission)
+        for role in store.list_user_roles(user_id)
+        for rp in role.permissions
+    }
+    assert ("registered_model", "my-model", MANAGE.name) in grants
+    assert ("prompt", "my-model", MANAGE.name) not in grants
+
+
+def test_filter_search_registered_models_classifies_refetched_rows(
+    workspace_permission_setup, monkeypatch
+):
+    # The initial filter pass works on protos; if it doesn't fill
+    # ``max_results``, the loop refetches more rows as ORM
+    # ``RegisteredModel`` entities. Those ORM rows have ``.tags`` that hide
+    # the ``mlflow.prompt.is_prompt`` key, so naive ``_proto_is_prompt`` on
+    # them would misclassify every prompt as a registered_model. Pins that
+    # ``_entity_is_prompt`` dispatches to ``_is_prompt()`` on the ORM side.
+    from mlflow.entities.model_registry import RegisteredModel
+    from mlflow.entities.model_registry.registered_model_tag import RegisteredModelTag
+    from mlflow.store.entities import PagedList
+    from mlflow.utils.search_utils import SearchUtils
+
+    monkeypatch.setattr(auth_module, "sender_is_admin", lambda: False)
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    _set_workspace_permission(store, username, NO_PERMISSIONS.name)
+    role = store.create_role(name="prompt-reader", workspace="team-a")
+    store.add_role_permission(role.id, "prompt", "refetched-prompt", READ.name)
+    store.assign_role_to_user(store.get_user(username).id, role.id)
+
+    # Initial response is empty + has a next_page_token so the refetch loop
+    # runs. Then a fake registry returns one prompt + one registered_model.
+    refetched_rows = [
+        RegisteredModel(
+            name="refetched-prompt",
+            tags=[RegisteredModelTag(key=IS_PROMPT_TAG_KEY, value="true")],
+        ),
+        RegisteredModel(name="refetched-model", tags=[]),
+    ]
+    # First refetch returns the seed rows; subsequent calls return an empty
+    # page so the loop terminates instead of spinning on the same fake page.
+    calls = {"count": 0}
+
+    def fake_search(**_kwargs):
+        calls["count"] += 1
+        return PagedList(refetched_rows if calls["count"] == 1 else [], token=None)
+
+    fake_registry = SimpleNamespace(search_registered_models=fake_search)
+    monkeypatch.setattr(auth_module, "_get_model_registry_store", lambda: fake_registry)
+
+    # ``SearchUtils.parse_start_offset_from_page_token`` requires a real
+    # base64-encoded JSON token; use the project's helper so the loop's
+    # offset-bookkeeping doesn't reject our seed.
+    seed_token = SearchUtils.create_page_token(1).decode("utf-8")
+    flask_resp = Response(
+        json.dumps({"registered_models": [], "next_page_token": seed_token}),
+        mimetype="application/json",
+    )
+    with auth_module.app.test_request_context(
+        "/api/2.0/mlflow/registered-models/search",
+        method="GET",
+        query_string={"max_results": "10"},
+    ):
+        auth_module.filter_search_registered_models(flask_resp)
+
+    out = json.loads(flask_resp.get_data(as_text=True))
+    names = [rm["name"] for rm in out.get("registered_models", [])]
+    # The refetched prompt row is kept (prompt grant satisfies it); the
+    # plain registered_model row is filtered out.
+    assert names == ["refetched-prompt"]
+
+
+def test_delete_can_manage_registered_model_permission_rejects_missing_name(
+    workspace_permission_setup,
+):
+    # ``request.get_json(silent=True)`` returns ``None`` on missing /
+    # unparseable bodies; the guard must surface a clean 400 instead of a
+    # ``TypeError`` -> 500.
+    with auth_module.app.test_request_context(
+        "/api/2.0/mlflow/registered-models/delete",
+        method="DELETE",
+        data="",  # empty body
+        content_type="application/json",
+    ):
+        with pytest.raises(MlflowException, match="Missing value for required parameter 'name'"):
+            auth_module.delete_can_manage_registered_model_permission(Response(status=200))
+
+
+def test_rename_registered_model_permission_rejects_missing_fields(
+    workspace_permission_setup,
+):
+    # Missing ``name`` / ``new_name`` must raise INVALID_PARAMETER_VALUE
+    # rather than silently forwarding ``None`` to
+    # ``rename_grants_for_resource`` where it would corrupt grants.
+    with auth_module.app.test_request_context(
+        "/api/2.0/mlflow/registered-models/rename",
+        method="POST",
+        json={"name": "foo"},  # no new_name
+    ):
+        with pytest.raises(MlflowException, match="Missing value for required parameter"):
+            auth_module.rename_registered_model_permission(Response(status=200))
 
 
 def test_validate_can_view_workspace_requires_access(workspace_permission_setup):

--- a/tests/server/auth/test_auth_workspace.py
+++ b/tests/server/auth/test_auth_workspace.py
@@ -1554,7 +1554,7 @@ def test_delete_can_manage_registered_model_permission_rejects_missing_name(
     workspace_permission_setup,
 ):
     # ``request.get_json(silent=True)`` returns ``None`` on missing /
-    # unparseable bodies; the guard must surface a clean 400 instead of a
+    # unparsable bodies; the guard must surface a clean 400 instead of a
     # ``TypeError`` -> 500.
     with auth_module.app.test_request_context(
         "/api/2.0/mlflow/registered-models/delete",


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23248

### What changes are proposed in this pull request?

Follow-up to #23248 (which promoted `prompt` to a first-class RBAC `resource_type`). The before-request dispatchers were already prompt-aware, but four after-request handlers still operated in the `registered_model` namespace exclusively — flagged in NaiLaOpus's review after merge:

| Handler | Gap before this PR |
|---|---|
| `filter_search_registered_models` (`__init__.py:2845`) | `_role_based_read_predicate(username, "registered_model")` only — a user holding `(prompt, foo, READ)` had prompt `foo` silently filtered out of search results. |
| `filter_search_model_versions` (`__init__.py:2893`) | Same gap for prompt-backed model versions. |
| `rename_registered_model_permission` (`__init__.py:2909`) | `rename_grants_for_resource("registered_model", ...)` only — renaming a prompt orphaned `(prompt, old_name, ...)` grants. |
| `delete_can_manage_registered_model_permission` (`__init__.py:2432`) | `delete_grants_for_resource("registered_model", ...)` only — deleting a prompt leaked `(prompt, name, ...)` rows permanently. |

**Search filters** now classify each row by its persisted `mlflow.prompt.is_prompt` tag (proto-side via new `_proto_is_prompt`; ORM-side via `RegisteredModel._is_prompt()`) and dispatch to the matching predicate. Cross-namespace grants do not leak through in either direction.

**Rename and delete** sweep both `registered_model` and `prompt` namespaces unconditionally. Names are unique within the model registry, so exactly one of the two sweeps applies and the other is a no-op — avoids needing to classify at after-request time, when the entity is already gone (delete) or renamed (rename).

### How is this PR tested?

- [x] New unit/integration tests
- [ ] Manual tests

Five tests in `tests/server/auth/test_auth_workspace.py`:
- `test_filter_search_registered_models_uses_prompt_grant_for_prompt_rows` — prompt READ grant satisfies prompt row.
- `test_filter_search_registered_models_does_not_satisfy_prompt_with_rm_grant` — `registered_model` grant does NOT leak to prompt namespace (regression guard).
- `test_filter_search_model_versions_uses_prompt_grant_for_prompt_versions` — `ModelVersion` mirror.
- `test_rename_registered_model_permission_sweeps_prompt_namespace` — rename propagates to `(prompt, ...)` grants.
- `test_delete_can_manage_registered_model_permission_sweeps_prompt_namespace` — delete sweeps `(prompt, ...)` grants.

Full `tests/server/auth/test_auth_workspace.py` is green (165/165). Ruff + Clint clean.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

RBAC: prompt resource-type now applies consistently across all after-request handlers. Searches return prompt rows for users with `prompt` grants, and prompt renames / deletes propagate to RBAC grants.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mlflow/codesmith/mlflow/pr/23426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->