### PR TITLE
Skip `transformers==5.0.0` in cross-version tests

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -455,6 +455,9 @@ transformers:
         # https://github.com/huggingface/transformers/issues/38269
         "== 4.52.1",
         "== 4.52.2",
+        # 5.0.0 broke the TAPAS table-QA and Whisper ASR pipelines; fixed in later 5.x patches.
+        # https://github.com/huggingface/transformers/issues/43792
+        "== 5.0.0",
       ]
     requirements:
       ">= 0.0.0": [


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/huggingface/transformers/issues/43792

### What changes are proposed in this pull request?

Add `==5.0.0` to the `unsupported` list for the `transformers / models` cross-version matrix. The `test_every_n_versions: 4` sampler started picking 5.0.0 on 2026-05-15, and the job has been red every day since. The TAPAS table-QA and Whisper ASR pipelines are both broken in this specific release; later 5.x patches (5.3.0, 5.7.0) pass.

Observed failures (both inside the upstream pipeline code, reproduced locally with `torch==2.11`):

- TAPAS: `KeyError: 'token_type_ids'` at `transformers/models/tapas/tokenization_tapas.py:1936`
- Whisper: `KeyError: 'num_frames'` at `transformers/pipelines/automatic_speech_recognition.py:486` — same traceback as huggingface/transformers#43792.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mlflow/codesmith/mlflow/pr/23427"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->