### PR TITLE
Drop `context: fork` from `analyze-ci` skill

### DIFF
--- a/.claude/skills/analyze-ci/SKILL.md
+++ b/.claude/skills/analyze-ci/SKILL.md
@@ -2,7 +2,6 @@
 name: analyze-ci
 description: Analyze failed GitHub Action jobs for a pull request.
 argument-hint: "url(s) of failed GitHub Action jobs, workflow runs, or PRs"
-model: haiku
 allowed-tools:
   - Bash(uv run --package skills skills fetch-logs:*)
   - Read

--- a/.claude/skills/analyze-ci/SKILL.md
+++ b/.claude/skills/analyze-ci/SKILL.md
@@ -2,7 +2,7 @@
 name: analyze-ci
 description: Analyze failed GitHub Action jobs for a pull request.
 argument-hint: "url(s) of failed GitHub Action jobs, workflow runs, or PRs"
-context: fork
+model: haiku
 allowed-tools:
   - Bash(uv run --package skills skills fetch-logs:*)
   - Read


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

`.claude/skills/analyze-ci/SKILL.md` set `context: fork`, which triggers a Claude Code bug ([anthropics/claude-code#48981](https://github.com/anthropics/claude-code/issues/48981)) where `$0` / `$ARGUMENTS` template variables substitute to empty strings in forked skill executions. As a result the URL the user passed never reached `skills fetch-logs`, and the skill responded by asking for a URL it had already been given.

Drop `context: fork` to run the skill inline so `$ARGUMENTS` substitutes correctly.

### How is this PR tested?

- [x] Manual tests

Invoked `/analyze-ci <workflow run URL>` locally and confirmed the URL is forwarded to `skills fetch-logs` end-to-end.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release