### PR TITLE
Switch NaiLaOpus auto-trigger to `pull_request_target` (fixes fork-PR auto-trigger)

### DIFF
--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -9,7 +9,24 @@ on:
   # back. `synchronize` is intentionally excluded so subsequent author
   # pushes don't re-trigger; maintainers can use `/review-v2` for re-runs,
   # and the orchestrator's head-SHA cache short-circuits same-SHA runs.
-  pull_request:
+  #
+  # `pull_request_target` (not `pull_request`) is required so the workflow
+  # runs in the base repo's context with access to base-repo secrets/vars
+  # (`secrets.NAILAOPUS_APP_KEY`, `vars.NAILAOPUS_APP_CLIENT_ID`,
+  # `secrets.EXPERIMENTAL_ANTHROPIC_API_KEY`). For `pull_request` events
+  # from forks GitHub does not pass base-repo secrets/vars, so the App
+  # token step fails with "client-id input must be set". Most maintainer
+  # PRs are from personal forks, so `pull_request_target` is needed to
+  # make the auto-trigger work in the common case.
+  #
+  # Safety: `pull_request_target` reads the workflow file from the base
+  # branch (not the PR head), so a PR cannot self-modify what runs. The
+  # workflow checks out PR head into `mlflow/` only to be *read* by the
+  # spotter/reviewer agents; the orchestrator code itself comes from a
+  # pinned `mlflow/internal` SHA, and we never `pip install` the PR's
+  # `pyproject.toml`. PR content is data, not code, from the runner's
+  # perspective.
+  pull_request_target:
     types: [opened, ready_for_review, reopened]
 
 concurrency:
@@ -19,7 +36,7 @@ concurrency:
   # auto-trigger immediately followed by /review-v2 on the same SHA
   # short-circuits in the second run. The number coalesce handles both
   # event payloads: issue_comment uses github.event.issue.number,
-  # pull_request uses github.event.pull_request.number.
+  # pull_request_target uses github.event.pull_request.number.
   group: nailaopus-${{ github.event.issue.number || github.event.pull_request.number }}
   cancel-in-progress: false
 
@@ -43,11 +60,11 @@ jobs:
     #   2. PR author must be a maintainer (prevents review of community-
     #      authored PRs whose diff content could contain prompt-injection
     #      attempts against the LLM).
-    # `pull_request` event gets an additional `!draft` guard: `opened`
-    # fires for PRs opened directly in draft state too, so without this
-    # the bot would review drafts. `ready_for_review` handles the
-    # draft -> ready transition separately, so only non-draft `opened`
-    # events should pass through.
+    # `pull_request_target` event gets an additional `!draft` guard:
+    # `opened` fires for PRs opened directly in draft state too, so
+    # without this the bot would review drafts. `ready_for_review`
+    # handles the draft -> ready transition separately, so only non-draft
+    # `opened` events should pass through.
     # The same trust model applies to PRs from forks as to PRs from
     # branches on `mlflow/mlflow`: maintainers commonly push to personal
     # forks, and `/review-v2` already trusts `author_association` without
@@ -58,7 +75,7 @@ jobs:
        startsWith(github.event.comment.body, '/review-v2') &&
        contains(fromJSON('["MEMBER", "COLLABORATOR", "OWNER"]'), github.event.comment.author_association) &&
        contains(fromJSON('["MEMBER", "COLLABORATOR", "OWNER"]'), github.event.issue.author_association)) ||
-      (github.event_name == 'pull_request' &&
+      (github.event_name == 'pull_request_target' &&
        !github.event.pull_request.draft &&
        contains(fromJSON('["MEMBER", "COLLABORATOR", "OWNER"]'), github.event.pull_request.author_association))
     runs-on: ubuntu-latest
@@ -199,7 +216,7 @@ jobs:
           REPO: ${{ github.repository }}
           # FLAGS is empty on auto-triggered runs by design: the flags step
           # only runs for /review-v2 comments, and there is no comment body to
-          # parse on a pull_request event.
+          # parse on a pull_request_target event.
           FLAGS: ${{ steps.flags.outputs.flags }}
         # Inputs flow through env vars rather than ${{ }} interpolation
         # directly into the shell, so an unexpected character in any value

--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -43,10 +43,15 @@ jobs:
     #   2. PR author must be a maintainer (prevents review of community-
     #      authored PRs whose diff content could contain prompt-injection
     #      attempts against the LLM).
-    # For the `pull_request` auto-trigger we additionally require the head
-    # ref to live on `mlflow/mlflow` (no fork PRs). `author_association`
-    # alone doesn't prevent a community fork from a maintainer; combining
-    # both ensures the diff cannot come from an untrusted source.
+    # `pull_request` event gets an additional `!draft` guard: `opened`
+    # fires for PRs opened directly in draft state too, so without this
+    # the bot would review drafts. `ready_for_review` handles the
+    # draft -> ready transition separately, so only non-draft `opened`
+    # events should pass through.
+    # The same trust model applies to PRs from forks as to PRs from
+    # branches on `mlflow/mlflow`: maintainers commonly push to personal
+    # forks, and `/review-v2` already trusts `author_association` without
+    # a head-repo check.
     if: |
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request != null &&
@@ -55,7 +60,6 @@ jobs:
        contains(fromJSON('["MEMBER", "COLLABORATOR", "OWNER"]'), github.event.issue.author_association)) ||
       (github.event_name == 'pull_request' &&
        !github.event.pull_request.draft &&
-       github.event.pull_request.head.repo.full_name == github.repository &&
        contains(fromJSON('["MEMBER", "COLLABORATOR", "OWNER"]'), github.event.pull_request.author_association))
     runs-on: ubuntu-latest
     timeout-minutes: 15


### PR DESCRIPTION
### Related Issues/PRs

Follow-up to #23422 (NaiLaOpus auto-trigger + SHA bump). Fixes the failing run on this branch ([run #26036611539](https://github.com/mlflow/mlflow/actions/runs/26036611539)).

### What changes are proposed in this pull request?

Two changes to the `pull_request` branch of the NaiLaOpus job-level gate:

1. **Switch the event from `pull_request` to `pull_request_target`.** GitHub does not pass base-repo secrets or vars to workflows triggered by `pull_request` events from forks. The App-token step fails with `client-id input must be set` because `vars.NAILAOPUS_APP_CLIENT_ID` resolves to empty — verified on the failing run on this branch. Most maintainer PRs come from personal forks (kriscon-db, B-Step62, etc.), so the auto-trigger could not work on the common case.

   `pull_request_target` runs in the base repo's context, so `secrets.NAILAOPUS_APP_KEY`, `vars.NAILAOPUS_APP_CLIENT_ID`, and `secrets.EXPERIMENTAL_ANTHROPIC_API_KEY` are all available regardless of where the PR head lives.

2. **Drop `github.event.pull_request.head.repo.full_name == github.repository`.** With `pull_request_target`, the head_repo check is no longer needed for security (the workflow file is read from the base branch, so a PR cannot self-modify what runs). Same maintainer-association gate as `/review-v2`.

### Safety model

`pull_request_target` is GitHub's recommended event for workflows that need base-repo secrets while operating on PR content. The bot's existing pattern fits cleanly:

- Workflow file is read from the **base branch**, not PR head. PRs cannot modify what runs.
- The job explicitly checks out PR head into `mlflow/` for the orchestrator's spotter/reviewer agents to *read* (`Read`/`Grep` only).
- The orchestrator code itself comes from a **pinned `mlflow/internal` SHA**, not from the PR. We never `pip install` the PR's `pyproject.toml`.
- PR content is data, not code, from the runner's perspective.

### How is this PR tested?

- [x] Existing unit/integration tests (workflow change has no Python code)
- [ ] New unit/integration tests
- [x] Manual tests

Manual validation plan once merged:
- Open a maintainer PR from a personal fork (e.g., `kriscon-db/mlflow`): confirm bot fires on `opened` AND the App-token step succeeds
- Open a maintainer PR from a branch on `mlflow/mlflow`: confirm bot still fires
- Open a community-authored PR (from fork): confirm bot does NOT fire (gated out by `author_association`)
- Open a draft maintainer PR: confirm bot does NOT fire; then mark ready, confirm bot fires on `ready_for_review`
- `/review-v2` on any maintainer PR: confirm comment-triggered path still works (unchanged)

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

Internal bot infrastructure; not user-facing.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release