### PR TITLE
fixes #20575: replace `ThreadPoolExecutor` with daemon-thread pool in async logging

### DIFF
--- a/mlflow/utils/async_logging/async_artifacts_logging_queue.py
+++ b/mlflow/utils/async_logging/async_artifacts_logging_queue.py
@@ -6,10 +6,10 @@ queue based approach.
 import atexit
 import logging
 import threading
-from concurrent.futures import ThreadPoolExecutor
 from queue import Empty, Queue
 from typing import TYPE_CHECKING, Callable, Union
 
+from mlflow.utils.async_logging.daemon_thread_pool import DaemonThreadPool
 from mlflow.utils.async_logging.run_artifact import RunArtifact
 from mlflow.utils.async_logging.run_operations import RunOperations
 
@@ -17,6 +17,12 @@ if TYPE_CHECKING:
     import PIL.Image
 
 _logger = logging.getLogger(__name__)
+
+# Maximum seconds to spend in `_at_exit_callback`. Workers are daemon threads,
+# so any work still in flight after this window is abandoned with the
+# interpreter; this bound keeps the atexit hook from blocking exit if a queue
+# was never drained explicitly.
+_AT_EXIT_TIMEOUT_SECONDS = 30
 
 
 class AsyncArtifactsLoggingQueue:
@@ -44,16 +50,19 @@ class AsyncArtifactsLoggingQueue:
     def _at_exit_callback(self) -> None:
         """Callback function to be executed when the program is exiting.
 
-        Stops the data processing thread and waits for the queue to be drained. Finally, shuts down
-        the thread pools used for data logging and artifact processing status check.
+        Stops the data processing thread and waits for the queue to be drained, bounded by
+        `_AT_EXIT_TIMEOUT_SECONDS`. Worker threads are daemons, so any work still in flight
+        after the bound is abandoned with the interpreter rather than blocking exit.
         """
         try:
-            # Stop the data processing thread
             self._stop_data_logging_thread_event.set()
-            # Waits till logging queue is drained.
-            self._artifact_logging_thread.join()
-            self._artifact_logging_worker_threadpool.shutdown(wait=True)
-            self._artifact_status_check_threadpool.shutdown(wait=True)
+            self._artifact_logging_thread.join(timeout=_AT_EXIT_TIMEOUT_SECONDS)
+            self._artifact_logging_worker_threadpool.shutdown(
+                wait=True, timeout=_AT_EXIT_TIMEOUT_SECONDS
+            )
+            self._artifact_status_check_threadpool.shutdown(
+                wait=True, timeout=_AT_EXIT_TIMEOUT_SECONDS
+            )
         except Exception as e:
             _logger.error(f"Encountered error while trying to finish logging: {e}")
 
@@ -227,12 +236,12 @@ class AsyncArtifactsLoggingQueue:
                 name="MLflowAsyncArtifactsLoggingLoop",
                 daemon=True,
             )
-            self._artifact_logging_worker_threadpool = ThreadPoolExecutor(
+            self._artifact_logging_worker_threadpool = DaemonThreadPool(
                 max_workers=5,
                 thread_name_prefix="MLflowArtifactsLoggingWorkerPool",
             )
 
-            self._artifact_status_check_threadpool = ThreadPoolExecutor(
+            self._artifact_status_check_threadpool = DaemonThreadPool(
                 max_workers=5,
                 thread_name_prefix="MLflowAsyncArtifactsLoggingStatusCheck",
             )

--- a/mlflow/utils/async_logging/async_logging_queue.py
+++ b/mlflow/utils/async_logging/async_logging_queue.py
@@ -7,7 +7,6 @@ import atexit
 import enum
 import logging
 import threading
-from concurrent.futures import ThreadPoolExecutor
 from queue import Empty, Queue
 from typing import Callable
 
@@ -18,6 +17,7 @@ from mlflow.environment_variables import (
     MLFLOW_ASYNC_LOGGING_BUFFERING_SECONDS,
     MLFLOW_ASYNC_LOGGING_THREADPOOL_SIZE,
 )
+from mlflow.utils.async_logging.daemon_thread_pool import DaemonThreadPool
 from mlflow.utils.async_logging.run_batch import RunBatch
 from mlflow.utils.async_logging.run_operations import RunOperations
 
@@ -26,6 +26,11 @@ _logger = logging.getLogger(__name__)
 
 ASYNC_LOGGING_WORKER_THREAD_PREFIX = "MLflowBatchLoggingWorkerPool"
 ASYNC_LOGGING_STATUS_CHECK_THREAD_PREFIX = "MLflowAsyncLoggingStatusCheck"
+# Maximum seconds to spend in `_at_exit_callback`. Workers are daemon threads,
+# so any work still in flight after this window is abandoned with the
+# interpreter; this bound keeps the atexit hook from blocking exit if a queue
+# was never drained explicitly.
+_AT_EXIT_TIMEOUT_SECONDS = 30
 
 
 class QueueStatus(enum.Enum):
@@ -70,16 +75,19 @@ class AsyncLoggingQueue:
     def _at_exit_callback(self) -> None:
         """Callback function to be executed when the program is exiting.
 
-        Stops the data processing thread and waits for the queue to be drained. Finally, shuts down
-        the thread pools used for data logging and batch processing status check.
+        Stops the data processing thread and waits for the queue to be drained, bounded by
+        `_AT_EXIT_TIMEOUT_SECONDS`. Worker threads are daemons, so any work still in flight
+        after the bound is abandoned with the interpreter rather than blocking exit.
         """
         try:
-            # Stop the data processing thread
             self._stop_data_logging_thread_event.set()
-            # Waits till logging queue is drained.
-            self._batch_logging_thread.join()
-            self._batch_logging_worker_threadpool.shutdown(wait=True)
-            self._batch_status_check_threadpool.shutdown(wait=True)
+            self._batch_logging_thread.join(timeout=_AT_EXIT_TIMEOUT_SECONDS)
+            self._batch_logging_worker_threadpool.shutdown(
+                wait=True, timeout=_AT_EXIT_TIMEOUT_SECONDS
+            )
+            self._batch_status_check_threadpool.shutdown(
+                wait=True, timeout=_AT_EXIT_TIMEOUT_SECONDS
+            )
         except Exception as e:
             _logger.error(f"Encountered error while trying to finish logging: {e}")
 
@@ -334,12 +342,12 @@ class AsyncLoggingQueue:
                 name="MLflowAsyncLoggingLoop",
                 daemon=True,
             )
-            self._batch_logging_worker_threadpool = ThreadPoolExecutor(
+            self._batch_logging_worker_threadpool = DaemonThreadPool(
                 max_workers=MLFLOW_ASYNC_LOGGING_THREADPOOL_SIZE.get() or 10,
                 thread_name_prefix=ASYNC_LOGGING_WORKER_THREAD_PREFIX,
             )
 
-            self._batch_status_check_threadpool = ThreadPoolExecutor(
+            self._batch_status_check_threadpool = DaemonThreadPool(
                 max_workers=MLFLOW_ASYNC_LOGGING_THREADPOOL_SIZE.get() or 10,
                 thread_name_prefix=ASYNC_LOGGING_STATUS_CHECK_THREAD_PREFIX,
             )

--- a/mlflow/utils/async_logging/daemon_thread_pool.py
+++ b/mlflow/utils/async_logging/daemon_thread_pool.py
@@ -1,0 +1,83 @@
+"""
+Daemon-thread-backed worker pool used by the async logging queues.
+
+`concurrent.futures.ThreadPoolExecutor` registers its worker threads with
+`concurrent.futures.thread._threads_queues` and installs `_python_exit` via
+`threading._register_atexit`. During interpreter shutdown `_python_exit` joins
+every tracked worker with no timeout, executing *before* any
+`atexit.register` hook. When a worker is blocked on network I/O the process
+hangs indefinitely and `_at_exit_callback` never runs (the symptom in #20575).
+
+`DaemonThreadPool` is API-compatible with the small subset of
+`ThreadPoolExecutor` used by the async logging queues -- `submit(fn, *args)`
+returning a `concurrent.futures.Future`, and `shutdown(wait=, timeout=)`. Its
+workers are plain daemon `threading.Thread`s, so they are not joined by
+`_python_exit` and the interpreter can finalize even when a worker is stuck.
+"""
+
+import logging
+import queue
+import threading
+import time
+from concurrent.futures import Future
+from typing import Any, Callable
+
+_logger = logging.getLogger(__name__)
+
+_SHUTDOWN_SENTINEL = object()
+
+
+class DaemonThreadPool:
+    def __init__(self, max_workers: int, thread_name_prefix: str = "DaemonThreadPool") -> None:
+        if max_workers <= 0:
+            raise ValueError("max_workers must be positive")
+        self._queue: queue.Queue = queue.Queue()
+        self._workers: list[threading.Thread] = []
+        self._shutdown = False
+        self._shutdown_lock = threading.Lock()
+        self._thread_name_prefix = thread_name_prefix
+        for i in range(max_workers):
+            t = threading.Thread(
+                target=self._worker_loop,
+                name=f"{thread_name_prefix}_{i}",
+                daemon=True,
+            )
+            t.start()
+            self._workers.append(t)
+
+    def _worker_loop(self) -> None:
+        while True:
+            item = self._queue.get()
+            if item is _SHUTDOWN_SENTINEL:
+                return
+            fn, args, kwargs, fut = item
+            if not fut.set_running_or_notify_cancel():
+                continue
+            try:
+                result = fn(*args, **kwargs)
+            except BaseException as exc:
+                fut.set_exception(exc)
+            else:
+                fut.set_result(result)
+
+    def submit(self, fn: Callable[..., Any], *args, **kwargs) -> Future:
+        with self._shutdown_lock:
+            if self._shutdown:
+                raise RuntimeError("cannot schedule new futures after shutdown")
+            fut: Future = Future()
+            self._queue.put((fn, args, kwargs, fut))
+            return fut
+
+    def shutdown(self, wait: bool = True, timeout: float | None = None) -> None:
+        with self._shutdown_lock:
+            if self._shutdown:
+                return
+            self._shutdown = True
+            for _ in self._workers:
+                self._queue.put(_SHUTDOWN_SENTINEL)
+        if not wait:
+            return
+        deadline = None if timeout is None else time.monotonic() + timeout
+        for t in self._workers:
+            remaining = None if deadline is None else max(0.0, deadline - time.monotonic())
+            t.join(timeout=remaining)

--- a/tests/utils/test_async_artifacts_logging_queue.py
+++ b/tests/utils/test_async_artifacts_logging_queue.py
@@ -7,6 +7,7 @@ import time
 import pytest
 from PIL import Image
 
+import mlflow.utils.async_logging.async_artifacts_logging_queue
 from mlflow import MlflowException
 from mlflow.utils.async_logging.async_artifacts_logging_queue import AsyncArtifactsLoggingQueue
 
@@ -278,3 +279,28 @@ def test_async_logging_queue_pickle():
         run_operation.wait()
 
     assert len(deserialized_consumer.filenames) == 10
+
+
+def test_at_exit_callback_returns_within_timeout_when_worker_blocked(monkeypatch):
+    monkeypatch.setattr(
+        mlflow.utils.async_logging.async_artifacts_logging_queue,
+        "_AT_EXIT_TIMEOUT_SECONDS",
+        0.5,
+    )
+    worker_blocking = threading.Event()
+
+    def blocking_artifact_logging_func(filename, artifact_path, artifact):
+        worker_blocking.set()
+        time.sleep(120)
+
+    queue = AsyncArtifactsLoggingQueue(artifact_logging_func=blocking_artifact_logging_func)
+    queue.activate()
+    queue.log_artifacts_async(
+        filename="x.png", artifact_path="p", artifact=Image.new("RGB", (10, 10))
+    )
+    assert worker_blocking.wait(timeout=5)
+
+    start = time.monotonic()
+    queue._at_exit_callback()
+    elapsed = time.monotonic() - start
+    assert elapsed < 5.0, f"_at_exit_callback took {elapsed:.2f}s, expected < 5.0s"

--- a/tests/utils/test_async_logging_queue.py
+++ b/tests/utils/test_async_logging_queue.py
@@ -437,3 +437,47 @@ def test_batch_split(monkeypatch):
         async_logging_queue.flush()
 
         assert run_data.batch_count == 2
+
+
+def test_at_exit_callback_returns_within_timeout_when_worker_blocked(monkeypatch):
+    monkeypatch.setattr(
+        mlflow.utils.async_logging.async_logging_queue, "_AT_EXIT_TIMEOUT_SECONDS", 0.5
+    )
+    worker_blocking = threading.Event()
+
+    def blocking_logging_func(run_id, metrics, params, tags):
+        worker_blocking.set()
+        time.sleep(120)
+
+    queue = AsyncLoggingQueue(logging_func=blocking_logging_func)
+    queue.activate()
+    queue.log_batch_async(
+        run_id="r",
+        metrics=[Metric(key="m", value=1.0, timestamp=int(time.time() * 1000), step=0)],
+        params=[],
+        tags=[],
+    )
+    assert worker_blocking.wait(timeout=5)
+
+    start = time.monotonic()
+    queue._at_exit_callback()
+    elapsed = time.monotonic() - start
+    # 3 bounded waits of 0.5s each; allow generous headroom for CI jitter.
+    assert elapsed < 5.0, f"_at_exit_callback took {elapsed:.2f}s, expected < 5.0s"
+
+
+def test_at_exit_callback_succeeds_on_happy_path(monkeypatch):
+    monkeypatch.setattr(
+        mlflow.utils.async_logging.async_logging_queue, "_AT_EXIT_TIMEOUT_SECONDS", 5
+    )
+    run_data = RunData()
+    queue = AsyncLoggingQueue(logging_func=run_data.consume_queue_data)
+    queue.activate()
+    queue.log_batch_async(
+        run_id="r",
+        metrics=[Metric(key="m", value=1.0, timestamp=int(time.time() * 1000), step=0)],
+        params=[],
+        tags=[],
+    )
+    queue._at_exit_callback()
+    assert run_data.received_run_id == "r"

--- a/tests/utils/test_async_logging_shutdown_regression.py
+++ b/tests/utils/test_async_logging_shutdown_regression.py
@@ -1,0 +1,71 @@
+"""
+Process-level regression test for mlflow/mlflow#20575.
+
+Async-logging worker pools used to be `concurrent.futures.ThreadPoolExecutor`s,
+whose workers are non-daemon and tracked in
+`concurrent.futures.thread._threads_queues`. Python's `_python_exit` joins those
+workers with no timeout *before* any `atexit.register` hook runs, so a worker
+blocked on network I/O made the interpreter hang and never reach
+`_at_exit_callback`. The fix replaces the worker pools with daemon threads via
+`mlflow.utils.async_logging.daemon_thread_pool.DaemonThreadPool`.
+
+This test launches a subprocess that submits a job that sleeps for 120s and
+then exits. With the fix, the process exits cleanly within a few seconds.
+Without the fix, it hangs and the subprocess timeout fires.
+"""
+
+import subprocess
+import sys
+import textwrap
+import time
+
+_HANG_WORKER_SCRIPT = textwrap.dedent(
+    """
+    import threading
+    import time
+
+    import mlflow.utils.async_logging.async_logging_queue as alq
+    alq._AT_EXIT_TIMEOUT_SECONDS = 1.0
+
+    from mlflow.utils.async_logging.async_logging_queue import AsyncLoggingQueue
+    from mlflow.entities.metric import Metric
+
+    started = threading.Event()
+
+
+    def blocking(run_id, metrics, params, tags):
+        started.set()
+        time.sleep(120)
+
+
+    q = AsyncLoggingQueue(logging_func=blocking)
+    q.activate()
+    q.log_batch_async(
+        run_id="r",
+        metrics=[Metric(key="m", value=1.0, timestamp=int(time.time() * 1000), step=0)],
+        params=[],
+        tags=[],
+    )
+    assert started.wait(timeout=5)
+    print("READY", flush=True)
+    """
+)
+
+
+def test_subprocess_exits_when_async_worker_blocked():
+    start = time.monotonic()
+    result = subprocess.run(
+        [sys.executable, "-c", _HANG_WORKER_SCRIPT],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    elapsed = time.monotonic() - start
+
+    assert result.returncode == 0, (
+        f"subprocess exited with code {result.returncode}\n"
+        f"stdout: {result.stdout!r}\n"
+        f"stderr: {result.stderr!r}"
+    )
+    assert "READY" in result.stdout
+    assert elapsed < 15, f"subprocess took {elapsed:.2f}s, expected < 15s"

--- a/tests/utils/test_daemon_thread_pool.py
+++ b/tests/utils/test_daemon_thread_pool.py
@@ -1,0 +1,79 @@
+import threading
+import time
+
+import pytest
+
+from mlflow.utils.async_logging.daemon_thread_pool import DaemonThreadPool
+
+
+def test_submit_returns_future_with_result():
+    pool = DaemonThreadPool(max_workers=2, thread_name_prefix="TestSubmit")
+    try:
+        fut = pool.submit(lambda x: x + 1, 41)
+        assert fut.result(timeout=5) == 42
+    finally:
+        pool.shutdown(wait=True, timeout=1)
+
+
+def test_submit_propagates_exception():
+    pool = DaemonThreadPool(max_workers=1, thread_name_prefix="TestRaise")
+    try:
+        fut = pool.submit(lambda: 1 / 0)
+        with pytest.raises(ZeroDivisionError, match="division by zero"):
+            fut.result(timeout=5)
+    finally:
+        pool.shutdown(wait=True, timeout=1)
+
+
+def test_workers_are_daemons():
+    pool = DaemonThreadPool(max_workers=3, thread_name_prefix="TestDaemon")
+    try:
+        assert all(t.daemon for t in pool._workers)
+    finally:
+        pool.shutdown(wait=True, timeout=1)
+
+
+def test_submit_after_shutdown_raises():
+    pool = DaemonThreadPool(max_workers=1, thread_name_prefix="TestPostShutdown")
+    pool.shutdown(wait=True, timeout=1)
+    with pytest.raises(RuntimeError, match="cannot schedule new futures after shutdown"):
+        pool.submit(lambda: None)
+
+
+def test_shutdown_timeout_bounded_when_worker_blocked():
+    pool = DaemonThreadPool(max_workers=1, thread_name_prefix="TestBlocked")
+    started = threading.Event()
+
+    def blocking():
+        started.set()
+        time.sleep(120)
+
+    pool.submit(blocking)
+    assert started.wait(timeout=5)
+    t0 = time.monotonic()
+    pool.shutdown(wait=True, timeout=0.5)
+    elapsed = time.monotonic() - t0
+    # `t.join(timeout=0.5)` returns after at most 0.5s even if the worker is stuck.
+    assert elapsed < 2.0, f"shutdown took {elapsed:.2f}s, expected < 2.0s"
+
+
+@pytest.mark.parametrize("max_workers", [0, -1])
+def test_invalid_max_workers(max_workers):
+    with pytest.raises(ValueError, match="max_workers must be positive"):
+        DaemonThreadPool(max_workers=max_workers)
+
+
+def test_shutdown_is_idempotent():
+    pool = DaemonThreadPool(max_workers=2, thread_name_prefix="TestIdempotent")
+    pool.shutdown(wait=True, timeout=1)
+    pool.shutdown(wait=True, timeout=1)
+
+
+def test_multiple_submits_in_flight():
+    pool = DaemonThreadPool(max_workers=3, thread_name_prefix="TestParallel")
+    try:
+        futs = [pool.submit(lambda i=i: i * 2) for i in range(20)]
+        results = sorted(f.result(timeout=5) for f in futs)
+        assert results == [i * 2 for i in range(20)]
+    finally:
+        pool.shutdown(wait=True, timeout=2)


### PR DESCRIPTION
### Related Issues/PRs

Closes #20575 - Async artifact logging hangs on exit

Relates to:
- #20577 - prior fix attempt; this PR explores a different fix shape
- #12402 - same root cause in metrics/params logging (closed as "not planned")
- #21681, #21706 - earlier fix attempts (closed)
- #8386 - Client hangs in list_artifacts
- #16467 - download_artifacts hangs forever

### What changes are proposed in this pull request?

This PR replaces `concurrent.futures.ThreadPoolExecutor` with a daemon-thread pool in MLflow's async logging worker pools to prevent indefinite hangs during program exit. It fixes both async artifact logging and async metrics/params logging.

#### Problem

MLflow's async logging uses `ThreadPoolExecutor` workers that can block indefinitely on network I/O. When a Python process exits, these workers prevent the interpreter from finalizing because of how `concurrent.futures` interacts with interpreter shutdown.

**Root Cause:**

`ThreadPoolExecutor` registers its workers in `concurrent.futures.thread._threads_queues` and installs `_python_exit` via `threading._register_atexit`. During interpreter shutdown, `_python_exit` joins every tracked worker with `t.join()` -- no timeout -- and it runs *before* any `atexit.register` hook. If a worker is blocked, the process hangs in `_python_exit` and the queues' `_at_exit_callback` never executes.

The two affected files are:

1. **`mlflow/utils/async_logging/async_logging_queue.py`** -- used by `mlflow.log_metric()`, `mlflow.log_param()` (related to #12402)
2. **`mlflow/utils/async_logging/async_artifacts_logging_queue.py`** -- used by `mlflow.log_artifact()`, `mlflow.log_text()` (primary fix for #20575)

Adding a timeout to `_at_exit_callback()` cannot fix this on its own, because that callback is unreachable in the failure mode.

**Impact:**

This makes MLflow unreliable in:
- CI/CD pipelines (jobs timeout)
- Batch processing scripts (processes accumulate)
- Container environments (pods stuck terminating)
- Development workflows (must force-kill scripts)

#### Solution

Stop tracking worker threads through `_threads_queues`. Replace `ThreadPoolExecutor` in both queues with `DaemonThreadPool`, a small pool of daemon `threading.Thread`s consuming a `queue.Queue`. Daemon threads are not tracked in `_threads_queues`, so `_python_exit` is a no-op for them, and the interpreter can finalize cleanly. `_at_exit_callback` is also bounded by `_AT_EXIT_TIMEOUT_SECONDS = 30` as defense-in-depth for the case where the hook does run.

#### Changes

**New file:**

1. **`mlflow/utils/async_logging/daemon_thread_pool.py`** -- `DaemonThreadPool` exposes the subset of `ThreadPoolExecutor` used by the async logging queues (`submit(fn, *args) -> concurrent.futures.Future`, `shutdown(wait=, timeout=)`).

**Modified files:**

2. **`mlflow/utils/async_logging/async_logging_queue.py`** -- replace `ThreadPoolExecutor` with `DaemonThreadPool` in `_set_up_logging_thread()`; bound `_at_exit_callback()` with `_AT_EXIT_TIMEOUT_SECONDS = 30`.

3. **`mlflow/utils/async_logging/async_artifacts_logging_queue.py`** -- same changes as above.

4. **`tests/utils/test_daemon_thread_pool.py`** (NEW) -- 9 unit tests for the new helper.

5. **`tests/utils/test_async_logging_shutdown_regression.py`** (NEW) -- subprocess regression test that reproduces #20575.

6. **`tests/utils/test_async_logging_queue.py`**, **`test_async_artifacts_logging_queue.py`** -- new tests asserting `_at_exit_callback` returns within bound when a worker is blocked.

**Code Example:**

Before (hangs indefinitely):
```python
self._batch_logging_worker_threadpool = ThreadPoolExecutor(
    max_workers=10, thread_name_prefix="MLflowBatchLoggingWorkerPool"
)

def _at_exit_callback(self):
    self._stop_data_logging_thread_event.set()
    self._batch_logging_thread.join()  # NO TIMEOUT
    self._batch_logging_worker_threadpool.shutdown(wait=True)  # NO TIMEOUT
```

After (daemon-thread pool, bounded cleanup):
```python
self._batch_logging_worker_threadpool = DaemonThreadPool(
    max_workers=10, thread_name_prefix="MLflowBatchLoggingWorkerPool"
)

def _at_exit_callback(self):
    self._stop_data_logging_thread_event.set()
    self._batch_logging_thread.join(timeout=_AT_EXIT_TIMEOUT_SECONDS)
    self._batch_logging_worker_threadpool.shutdown(
        wait=True, timeout=_AT_EXIT_TIMEOUT_SECONDS
    )
    self._batch_status_check_threadpool.shutdown(
        wait=True, timeout=_AT_EXIT_TIMEOUT_SECONDS
    )
```

#### Backward Compatibility

Fully backward compatible. No new environment variables, no API changes for callers:

- `submit()` still returns a `concurrent.futures.Future`; `RunOperations` uses only `.result()` which is unchanged.
- Happy-path behavior (workers drain in time) is unchanged.
- Only blocked-worker exit behavior changes: previously hangs indefinitely, now exits within `_AT_EXIT_TIMEOUT_SECONDS` (30s) and abandons the blocked work via the workers' `daemon=True` flag.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

**New tests:**

```bash
pytest tests/utils/test_daemon_thread_pool.py
pytest tests/utils/test_async_logging_queue.py
pytest tests/utils/test_async_artifacts_logging_queue.py
pytest tests/utils/test_async_logging_shutdown_regression.py
```

**Test Scenarios:**

- DaemonThreadPool submit/result, exception propagation, daemon-ness
- DaemonThreadPool bounded shutdown when worker blocked
- `_at_exit_callback` returns within timeout when worker is blocked (both queues)
- `_at_exit_callback` happy-path still drains the queue
- Subprocess regression: process exits in < 15s when async worker blocked 120s (pre-fix the subprocess timeout fires; post-fix it exits cleanly)

**Manual Testing:**

```python
import os
os.environ["MLFLOW_LOGGING_LEVEL"] = "DEBUG"
import time, threading
from mlflow.utils.async_logging.async_logging_queue import AsyncLoggingQueue
from mlflow.entities.metric import Metric

blocking = threading.Event()
def hang(run_id, metrics, params, tags):
    blocking.set()
    time.sleep(120)

q = AsyncLoggingQueue(logging_func=hang)
q.activate()
q.log_batch_async(
    run_id="r",
    metrics=[Metric("m", 1.0, int(time.time() * 1000), 0)],
    params=[], tags=[],
)
blocking.wait(5)
# Let script exit. Process exits within ~30s post-fix; hangs forever pre-fix.
```

**Before fix**: Process hangs indefinitely (20+ minutes), requires `kill -9`

**After fix**: Process exits within 30 seconds with clean shutdown

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a bug where MLflow processes could hang indefinitely during exit when async logging workers were blocked on network I/O (e.g. remote artifact backends, unreachable tracking servers). Async logging now uses daemon worker threads, so the interpreter can finalize cleanly even when uploads are stalled.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mlflow/codesmith/mlflow/pr/23432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->