### PR TITLE
fix: return '<console>' as source name when sys.argv[0] is empty (REPL)

### DIFF
--- a/mlflow/spark/autologging.py
+++ b/mlflow/spark/autologging.py
@@ -179,7 +179,7 @@ def _get_repl_id():
     """
     if repl_id := get_databricks_repl_id():
         return repl_id
-    main_file = sys.argv[0] if len(sys.argv) > 0 else "<console>"
+    main_file = sys.argv[0] if sys.argv and sys.argv[0] else "<console>"
     return f"PythonSubscriber[{main_file}][{uuid.uuid4().hex}]"
 
 

--- a/mlflow/tracking/context/default_context.py
+++ b/mlflow/tracking/context/default_context.py
@@ -22,7 +22,7 @@ def _get_user():
 
 
 def _get_main_file():
-    if len(sys.argv) > 0:
+    if sys.argv and sys.argv[0]:
         return sys.argv[0]
     return None
 

--- a/tests/tracking/context/test_default_context.py
+++ b/tests/tracking/context/test_default_context.py
@@ -29,3 +29,12 @@ def test_default_run_context_tags(patch_script_name):
             MLFLOW_SOURCE_NAME: MOCK_SCRIPT_NAME,
             MLFLOW_SOURCE_TYPE: SourceType.to_string(SourceType.LOCAL),
         }
+
+
+@pytest.mark.parametrize("argv", [[], [""]])
+def test_default_run_context_tags_console(argv):
+    """Empty or missing sys.argv[0] (REPL) must report source as '<console>', not ''."""
+    mock_user = mock.Mock()
+    with mock.patch("sys.argv", argv), mock.patch("getpass.getuser", return_value=mock_user):
+        tags = DefaultRunContext().tags()
+        assert tags[MLFLOW_SOURCE_NAME] == "<console>"


### PR DESCRIPTION
## Summary

Fixes #23340.

`_get_main_file()` in `mlflow/tracking/context/default_context.py` checked `len(sys.argv) > 0`, but Python sets `sys.argv[0]` to `''` when running interactively (REPL). The empty string passes the `is not None` guard in `_get_source_name()`, so `''` was stored as the run's source name instead of `'<console>'`.

The same pattern existed in `_get_repl_id()` in `mlflow/spark/autologging.py`.

## Changes

- `default_context.py`: `len(sys.argv) > 0` → `sys.argv and sys.argv[0]`
- `spark/autologging.py`: same guard applied to the `main_file` assignment

## Tests

Added `test_default_run_context_tags_console` parametrized over `argv=[]` and `argv=[""]` — both must produce `MLFLOW_SOURCE_NAME == "<console>"`.

```
4 passed in 3.11s
```

*AI assistance: Written with Claude Code. All code reviewed, tested, and verified by the author.*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mlflow/codesmith/mlflow/pr/23436"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->