### PR TITLE
fix: return `<console>` as source name when `sys.argv[0]` is empty string (REPL)

### DIFF
--- a/mlflow/spark/autologging.py
+++ b/mlflow/spark/autologging.py
@@ -179,7 +179,7 @@ def _get_repl_id():
     """
     if repl_id := get_databricks_repl_id():
         return repl_id
-    main_file = sys.argv[0] if len(sys.argv) > 0 else "<console>"
+    main_file = sys.argv[0] if sys.argv and sys.argv[0] else "<console>"
     return f"PythonSubscriber[{main_file}][{uuid.uuid4().hex}]"
 
 

--- a/mlflow/tracking/context/default_context.py
+++ b/mlflow/tracking/context/default_context.py
@@ -22,7 +22,7 @@ def _get_user():
 
 
 def _get_main_file():
-    if len(sys.argv) > 0:
+    if sys.argv and sys.argv[0]:
         return sys.argv[0]
     return None
 

--- a/tests/tracking/context/test_default_context.py
+++ b/tests/tracking/context/test_default_context.py
@@ -29,3 +29,12 @@ def test_default_run_context_tags(patch_script_name):
             MLFLOW_SOURCE_NAME: MOCK_SCRIPT_NAME,
             MLFLOW_SOURCE_TYPE: SourceType.to_string(SourceType.LOCAL),
         }
+
+
+@pytest.mark.parametrize("argv", [[], [""]])
+def test_default_run_context_tags_console(argv):
+    """Empty or missing sys.argv[0] (REPL) must report source as '<console>', not ''."""
+    mock_user = mock.Mock()
+    with mock.patch("sys.argv", argv), mock.patch("getpass.getuser", return_value=mock_user):
+        tags = DefaultRunContext().tags()
+        assert tags[MLFLOW_SOURCE_NAME] == "<console>"


### PR DESCRIPTION
### Related Issues/PRs

Closes #23340

### What changes are proposed in this pull request?

`_get_main_file()` in `mlflow/tracking/context/default_context.py` checked `len(sys.argv) > 0`, but Python sets `sys.argv[0]` to `''` when running interactively (REPL/console). The empty string passes the `is not None` guard in `_get_source_name()`, so `''` was stored as the run's `mlflow.source.name` tag instead of `'<console>'`.

The same false-positive existed in `_get_repl_id()` in `mlflow/spark/autologging.py`.

**Fix:** guard with `sys.argv and sys.argv[0]` so an empty `argv[0]` is treated the same as a missing `argv`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added `test_default_run_context_tags_console` parametrized over `argv=[]` and `argv=[""]` — both must produce `MLFLOW_SOURCE_NAME == "<console>"`.

```
4 passed in 3.11s  (tests/tracking/context/test_default_context.py)
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Runs started from a Python REPL or interactive console now correctly report `mlflow.source.name` as `<console>` instead of an empty string.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

*AI assistance: Written with Claude Code. All code reviewed, tested, and verified by the author.*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mlflow/codesmith/mlflow/pr/23437"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->