### PR TITLE
Fix console source names for empty sys.argv[0]

### DIFF
--- a/mlflow/spark/autologging.py
+++ b/mlflow/spark/autologging.py
@@ -179,7 +179,7 @@ def _get_repl_id():
     """
     if repl_id := get_databricks_repl_id():
         return repl_id
-    main_file = sys.argv[0] if len(sys.argv) > 0 else "<console>"
+    main_file = sys.argv[0] if len(sys.argv) > 0 and sys.argv[0] else "<console>"
     return f"PythonSubscriber[{main_file}][{uuid.uuid4().hex}]"
 
 

--- a/mlflow/tracking/context/default_context.py
+++ b/mlflow/tracking/context/default_context.py
@@ -22,7 +22,7 @@ def _get_user():
 
 
 def _get_main_file():
-    if len(sys.argv) > 0:
+    if len(sys.argv) > 0 and sys.argv[0]:
         return sys.argv[0]
     return None
 

--- a/tests/spark/autologging/datasource/test_spark_datasource_autologging_unit.py
+++ b/tests/spark/autologging/datasource/test_spark_datasource_autologging_unit.py
@@ -4,7 +4,7 @@ import pytest
 
 import mlflow.spark
 from mlflow.exceptions import MlflowException
-from mlflow.spark.autologging import PythonSubscriber, _get_current_listener
+from mlflow.spark.autologging import PythonSubscriber, _get_current_listener, _get_repl_id
 
 
 @pytest.fixture
@@ -31,6 +31,17 @@ def test_subscriber_methods():
     # Assert repl ID is stable & different between subscribers
     assert subscriber.replId() == subscriber.replId()
     assert PythonSubscriber().replId() != subscriber.replId()
+
+
+@pytest.mark.parametrize("argv", [[], [""]])
+def test_get_repl_id_uses_console_when_no_main_file(argv):
+    mock_uuid = mock.Mock(hex="mock-uuid")
+    with (
+        mock.patch("sys.argv", argv),
+        mock.patch("mlflow.spark.autologging.get_databricks_repl_id", return_value=None),
+        mock.patch("mlflow.spark.autologging.uuid.uuid4", return_value=mock_uuid),
+    ):
+        assert _get_repl_id() == "PythonSubscriber[<console>][mock-uuid]"
 
 
 def test_enabling_autologging_throws_for_wrong_spark_version(

--- a/tests/tracking/context/test_default_context.py
+++ b/tests/tracking/context/test_default_context.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 
 from mlflow.entities import SourceType
-from mlflow.tracking.context.default_context import DefaultRunContext
+from mlflow.tracking.context.default_context import DefaultRunContext, _get_source_name
 from mlflow.utils.mlflow_tags import MLFLOW_SOURCE_NAME, MLFLOW_SOURCE_TYPE, MLFLOW_USER
 
 MOCK_SCRIPT_NAME = "/path/to/script.py"
@@ -29,3 +29,9 @@ def test_default_run_context_tags(patch_script_name):
             MLFLOW_SOURCE_NAME: MOCK_SCRIPT_NAME,
             MLFLOW_SOURCE_TYPE: SourceType.to_string(SourceType.LOCAL),
         }
+
+
+@pytest.mark.parametrize("argv", [[], [""]])
+def test_get_source_name_returns_console_when_no_main_file(argv):
+    with mock.patch("sys.argv", argv):
+        assert _get_source_name() == "<console>"


### PR DESCRIPTION
### Related Issues/PRs

Closes #23340

### What changes are proposed in this pull request?

This PR treats an empty `sys.argv[0]` the same as a missing main file when MLflow derives source names for console/REPL execution.

It updates both `DefaultRunContext` source name detection and Spark autologging REPL IDs so console sessions use `<console>` instead of an empty string.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Targeted regression tests:

```shell
UV_CACHE_DIR=.uv-cache UV_PYTHON_INSTALL_DIR=.uv-python uv run --group pytest python - <<'PY'
import sys

sys.modules["psutil"] = None
import pytest

raise SystemExit(
    pytest.main(
        [
            "tests/tracking/context/test_default_context.py",
            "tests/spark/autologging/datasource/test_spark_datasource_autologging_unit.py",
            "-k",
            "test_get_source_name_returns_console_when_no_main_file or test_get_repl_id_uses_console_when_no_main_file",
        ]
    )
)
PY
```

Result: 4 passed, 6 deselected.

Also ran:

```shell
UV_CACHE_DIR=.uv-cache UV_PYTHON_INSTALL_DIR=.uv-python uv run ruff check mlflow/tracking/context/default_context.py mlflow/spark/autologging.py tests/tracking/context/test_default_context.py tests/spark/autologging/datasource/test_spark_datasource_autologging_unit.py
```

Result: All checks passed.

Note: The full Spark datasource unit file requires a locally built MLflow Spark jar (`mlflow/java/spark_2.13/target`), which is not present in this checkout. The new non-Spark-session regression cases were run directly.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Console/REPL runs now record `<console>` for `mlflow.source.name` instead of an empty string.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mlflow/codesmith/mlflow/pr/23438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->