### PR TITLE
feat(db): add ORM models and Alembic migration for MCP server registry

### DIFF
--- a/mlflow/entities/mcp_server_version.py
+++ b/mlflow/entities/mcp_server_version.py
@@ -15,7 +15,6 @@ class MCPServerVersion:
     display_name: str | None = None
     status: MCPStatus = MCPStatus.DRAFT
     tools: list[MCPTool] | None = None
-    transport_types: list[str] | None = None
     aliases: list[str] = field(default_factory=list)
     tags: dict[str, str] = field(default_factory=dict)
     source: str | None = None

--- a/mlflow/store/db/workspace_move.py
+++ b/mlflow/store/db/workspace_move.py
@@ -20,6 +20,8 @@ from mlflow.store.tracking.dbmodels.models import (
     SqlExperiment,
     SqlExperimentTag,
     SqlJob,
+    SqlMCPServer,
+    SqlMCPServerTag,
 )
 from mlflow.store.workspace.sqlalchemy_store import _WORKSPACE_ROOT_MODELS
 
@@ -42,7 +44,7 @@ class _ResourceSpec:
     # Column used to join the tag table back to the resource table.
     # For experiments the tag table joins via experiment_id, not workspace+name.
     tag_join_column: str | None = None
-    child_tables: tuple[str, ...] = ()
+    child_tables: tuple[str | tuple[str, str], ...] = ()
     child_name_column: str = "name"
     has_unique_name: bool = True
 
@@ -91,6 +93,18 @@ _SPEC_BY_MODEL: dict[type, _ResourceSpec] = {
         model=SqlJob,
         name_column=SqlJob.job_name.key,
         has_unique_name=False,
+    ),
+    SqlMCPServer: _ResourceSpec(
+        model=SqlMCPServer,
+        name_column=SqlMCPServer.name.key,
+        tag_model=SqlMCPServerTag,
+        child_tables=(
+            "mcp_server_versions",
+            "mcp_server_tags",
+            "mcp_server_version_tags",
+            "mcp_server_aliases",
+            ("mcp_access_bindings", "server_name"),
+        ),
     ),
 }
 
@@ -304,7 +318,15 @@ def move_resources(
 
             # Explicitly update child tables because not all backends honour
             # ON UPDATE CASCADE (e.g. SQLite without the foreign_keys pragma).
-            for child_table_name in spec.child_tables:
+            # Each entry is either a table name str (uses spec.child_name_column)
+            # or a (table_name, column_name) tuple for non-standard FK columns.
+            for entry in spec.child_tables:
+                if isinstance(entry, tuple):
+                    child_table_name = entry[0]
+                    col_name = entry[1]
+                else:
+                    child_table_name = entry
+                    col_name = spec.child_name_column
                 child = get_workspace_table(conn, child_table_name)
                 conn.execute(
                     _filtered(
@@ -312,7 +334,7 @@ def move_resources(
                         .update()
                         .where(child.c.workspace == source_workspace)
                         .values(workspace=target_workspace),
-                        child.c[spec.child_name_column],
+                        child.c[col_name],
                     )
                 )
 

--- a/mlflow/store/db/workspace_utils.py
+++ b/mlflow/store/db/workspace_utils.py
@@ -22,6 +22,11 @@ MODEL_CHILD_TABLES = [
 # They must also be migrated explicitly during workspace operations.
 OTHER_WORKSPACE_CHILD_TABLES = [
     "guardrail_configs",
+    "mcp_server_versions",
+    "mcp_server_tags",
+    "mcp_server_version_tags",
+    "mcp_server_aliases",
+    "mcp_access_bindings",
 ]
 
 

--- a/mlflow/store/db_migrations/versions/a8b9c0d1e2f3_add_mcp_server_registry_tables.py
+++ b/mlflow/store/db_migrations/versions/a8b9c0d1e2f3_add_mcp_server_registry_tables.py
@@ -1,0 +1,222 @@
+"""add MCP server registry tables
+
+Create Date: 2026-05-11
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import mssql
+
+revision = "a8b9c0d1e2f3"
+down_revision = "7d34483879f0"
+branch_labels = None
+depends_on = None
+
+
+def _get_json_type():
+    dialect_name = op.get_bind().dialect.name
+    if dialect_name == "mssql":
+        return mssql.JSON
+    else:
+        return sa.JSON
+
+
+def upgrade():
+    json_type = _get_json_type()
+
+    op.create_table(
+        "mcp_servers",
+        sa.Column(
+            "workspace",
+            sa.String(length=63),
+            nullable=False,
+            server_default=sa.text("'default'"),
+        ),
+        sa.Column("name", sa.String(length=256), nullable=False),
+        sa.Column("display_name", sa.String(length=256), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("icons", json_type, nullable=True),
+        sa.Column("latest_version", sa.String(length=128), nullable=True),
+        sa.Column("created_by", sa.String(length=256), nullable=True),
+        sa.Column("last_updated_by", sa.String(length=256), nullable=True),
+        sa.Column("created_at", sa.BigInteger(), nullable=False),
+        sa.Column("last_updated_at", sa.BigInteger(), nullable=False),
+        sa.PrimaryKeyConstraint("workspace", "name", name="mcp_servers_pk"),
+    )
+
+    op.create_table(
+        "mcp_server_versions",
+        sa.Column(
+            "workspace",
+            sa.String(length=63),
+            nullable=False,
+            server_default=sa.text("'default'"),
+        ),
+        sa.Column("name", sa.String(length=256), nullable=False),
+        sa.Column("version", sa.String(length=128), nullable=False),
+        sa.Column("server_json", json_type, nullable=False),
+        sa.Column("display_name", sa.String(length=256), nullable=True),
+        sa.Column(
+            "status",
+            sa.String(length=20),
+            nullable=False,
+            server_default=sa.text("'draft'"),
+        ),
+        sa.Column("tools", json_type, nullable=True),
+        sa.Column("source", sa.String(length=512), nullable=True),
+        sa.Column("created_by", sa.String(length=256), nullable=True),
+        sa.Column("last_updated_by", sa.String(length=256), nullable=True),
+        sa.Column("created_at", sa.BigInteger(), nullable=False),
+        sa.Column("last_updated_at", sa.BigInteger(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["workspace", "name"],
+            ["mcp_servers.workspace", "mcp_servers.name"],
+            ondelete="CASCADE",
+            onupdate="CASCADE",
+            name="mcp_server_versions_server_fkey",
+        ),
+        sa.PrimaryKeyConstraint("workspace", "name", "version", name="mcp_server_versions_pk"),
+    )
+
+    op.create_table(
+        "mcp_server_tags",
+        sa.Column(
+            "workspace",
+            sa.String(length=63),
+            nullable=False,
+            server_default=sa.text("'default'"),
+        ),
+        sa.Column("name", sa.String(length=256), nullable=False),
+        sa.Column("key", sa.String(length=250), nullable=False),
+        sa.Column("value", sa.String(length=5000), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["workspace", "name"],
+            ["mcp_servers.workspace", "mcp_servers.name"],
+            ondelete="CASCADE",
+            onupdate="CASCADE",
+            name="mcp_server_tags_server_fkey",
+        ),
+        sa.PrimaryKeyConstraint("workspace", "name", "key", name="mcp_server_tags_pk"),
+    )
+
+    op.create_table(
+        "mcp_server_version_tags",
+        sa.Column(
+            "workspace",
+            sa.String(length=63),
+            nullable=False,
+            server_default=sa.text("'default'"),
+        ),
+        sa.Column("name", sa.String(length=256), nullable=False),
+        sa.Column("version", sa.String(length=128), nullable=False),
+        sa.Column("key", sa.String(length=250), nullable=False),
+        sa.Column("value", sa.String(length=5000), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["workspace", "name", "version"],
+            [
+                "mcp_server_versions.workspace",
+                "mcp_server_versions.name",
+                "mcp_server_versions.version",
+            ],
+            ondelete="CASCADE",
+            onupdate="CASCADE",
+            name="mcp_server_version_tags_version_fkey",
+        ),
+        sa.PrimaryKeyConstraint(
+            "workspace",
+            "name",
+            "version",
+            "key",
+            name="mcp_server_version_tags_pk",
+        ),
+    )
+
+    op.create_table(
+        "mcp_server_aliases",
+        sa.Column(
+            "workspace",
+            sa.String(length=63),
+            nullable=False,
+            server_default=sa.text("'default'"),
+        ),
+        sa.Column("name", sa.String(length=256), nullable=False),
+        sa.Column("alias", sa.String(length=256), nullable=False),
+        sa.Column("version", sa.String(length=128), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["workspace", "name"],
+            ["mcp_servers.workspace", "mcp_servers.name"],
+            ondelete="CASCADE",
+            onupdate="CASCADE",
+            name="mcp_server_aliases_server_fkey",
+        ),
+        sa.PrimaryKeyConstraint("workspace", "name", "alias", name="mcp_server_aliases_pk"),
+    )
+
+    op.create_table(
+        "mcp_access_bindings",
+        sa.Column("binding_id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column(
+            "workspace",
+            sa.String(length=63),
+            nullable=False,
+            server_default=sa.text("'default'"),
+        ),
+        sa.Column("server_name", sa.String(length=256), nullable=False),
+        sa.Column("server_version", sa.String(length=128), nullable=True),
+        sa.Column("server_alias", sa.String(length=256), nullable=True),
+        sa.Column("endpoint_url", sa.String(length=2048), nullable=False),
+        sa.Column(
+            "transport_type",
+            sa.String(length=32),
+            nullable=False,
+            server_default=sa.text("'streamable-http'"),
+        ),
+        sa.Column("created_by", sa.String(length=256), nullable=True),
+        sa.Column("last_updated_by", sa.String(length=256), nullable=True),
+        sa.Column("created_at", sa.BigInteger(), nullable=False),
+        sa.Column("last_updated_at", sa.BigInteger(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["workspace", "server_name"],
+            ["mcp_servers.workspace", "mcp_servers.name"],
+            ondelete="CASCADE",
+            onupdate="CASCADE",
+            name="mcp_access_bindings_server_fkey",
+        ),
+        sa.PrimaryKeyConstraint("binding_id", name="mcp_access_bindings_pk"),
+    )
+
+    op.create_index(
+        "idx_mcp_server_versions_latest",
+        "mcp_server_versions",
+        ["workspace", "name", "status", sa.text("created_at DESC"), sa.text("version DESC")],
+    )
+
+    op.create_index(
+        "ix_mcp_access_bindings_server_name",
+        "mcp_access_bindings",
+        ["workspace", "server_name"],
+    )
+    op.create_index(
+        "ix_mcp_access_bindings_version",
+        "mcp_access_bindings",
+        ["workspace", "server_name", "server_version"],
+    )
+    op.create_index(
+        "ix_mcp_access_bindings_alias",
+        "mcp_access_bindings",
+        ["workspace", "server_name", "server_alias"],
+    )
+
+
+def downgrade():
+    op.drop_index("ix_mcp_access_bindings_alias", table_name="mcp_access_bindings")
+    op.drop_index("ix_mcp_access_bindings_version", table_name="mcp_access_bindings")
+    op.drop_index("ix_mcp_access_bindings_server_name", table_name="mcp_access_bindings")
+    op.drop_index("idx_mcp_server_versions_latest", table_name="mcp_server_versions")
+    op.drop_table("mcp_access_bindings")
+    op.drop_table("mcp_server_aliases")
+    op.drop_table("mcp_server_version_tags")
+    op.drop_table("mcp_server_tags")
+    op.drop_table("mcp_server_versions")
+    op.drop_table("mcp_servers")

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -24,7 +24,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.inspection import inspect
-from sqlalchemy.orm import backref, relationship
+from sqlalchemy.orm import aliased, backref, query_expression, relationship, with_expression
 
 from mlflow.entities import (
     Assessment,
@@ -52,6 +52,14 @@ from mlflow.entities import (
     IssueReference,
     IssueSeverity,
     IssueStatus,
+    MCPAccessBinding,
+    MCPRemoteTransportType,
+    MCPServer,
+    MCPServerAlias,
+    MCPServerTag,
+    MCPServerVersion,
+    MCPStatus,
+    MCPTool,
     Metric,
     Param,
     RoutingStrategy,
@@ -3209,4 +3217,387 @@ class SqlGatewayGuardrailConfig(Base):
             guardrail=self.guardrail.to_mlflow_entity() if self.guardrail else None,
             created_by=self.created_by,
             workspace=self.workspace,
+        )
+
+
+class SqlMCPServer(Base):
+    __tablename__ = "mcp_servers"
+
+    workspace = Column(
+        String(63),
+        nullable=False,
+        default=DEFAULT_WORKSPACE_NAME,
+        server_default=sa.text(f"'{DEFAULT_WORKSPACE_NAME}'"),
+    )
+    name = Column(String(256), nullable=False)
+    display_name = Column(String(256), nullable=True)
+    description = Column(Text, nullable=True)
+    icons = Column(JSON, nullable=True)
+    # Not a FK to mcp_server_versions to avoid a circular dependency;
+    # stale pins are handled by with_resolved_latest() resolving to NULL.
+    latest_version = Column(String(128), nullable=True)
+    resolved_latest_version = query_expression()
+    resolved_status = query_expression()
+    created_by = Column(String(256), nullable=True)
+    last_updated_by = Column(String(256), nullable=True)
+    created_at = Column(BigInteger, default=get_current_time_millis, nullable=False)
+    last_updated_at = Column(BigInteger, default=get_current_time_millis, nullable=False)
+
+    __table_args__ = (PrimaryKeyConstraint("workspace", "name", name="mcp_servers_pk"),)
+
+    def __repr__(self):
+        return f"<SqlMCPServer ({self.name}, {self.workspace})>"
+
+    @classmethod
+    def with_resolved_latest(cls, query):
+        pinned_version = aliased(SqlMCPServerVersion, name="pinned_mcp_server_version")
+        latest_candidates = (
+            sa
+            .select(
+                SqlMCPServerVersion.workspace.label("workspace"),
+                SqlMCPServerVersion.name.label("name"),
+                SqlMCPServerVersion.version.label("version"),
+                SqlMCPServerVersion.status.label("status"),
+                sa.func
+                .row_number()
+                .over(
+                    partition_by=(SqlMCPServerVersion.workspace, SqlMCPServerVersion.name),
+                    order_by=(
+                        SqlMCPServerVersion.created_at.desc(),
+                        SqlMCPServerVersion.version.desc(),
+                    ),
+                )
+                .label("row_num"),
+            )
+            .where(
+                SqlMCPServerVersion.status.notin_([MCPStatus.DRAFT.value, MCPStatus.DELETED.value])
+            )
+            .subquery("mcp_latest_candidates")
+        )
+
+        # CASE (not COALESCE) is intentional: a stale pin should resolve
+        # to NULL rather than silently falling back to the latest candidate.
+        def _pinned_or_fallback(pinned_col, fallback_col):
+            return sa.case(
+                (cls.latest_version.is_not(None), pinned_col),
+                else_=fallback_col,
+            )
+
+        return (
+            query
+            .outerjoin(
+                pinned_version,
+                sa.and_(
+                    pinned_version.workspace == cls.workspace,
+                    pinned_version.name == cls.name,
+                    pinned_version.version == cls.latest_version,
+                ),
+            )
+            .outerjoin(
+                latest_candidates,
+                sa.and_(
+                    latest_candidates.c.workspace == cls.workspace,
+                    latest_candidates.c.name == cls.name,
+                    latest_candidates.c.row_num == 1,
+                ),
+            )
+            .options(
+                with_expression(
+                    cls.resolved_latest_version,
+                    _pinned_or_fallback(pinned_version.version, latest_candidates.c.version),
+                ),
+                with_expression(
+                    cls.resolved_status,
+                    _pinned_or_fallback(pinned_version.status, latest_candidates.c.status),
+                ),
+            )
+        )
+
+    def to_mlflow_entity(self):
+        tags = {t.key: t.value for t in self.tags}
+        aliases = {a.alias: a.version for a in self.server_aliases}
+        binding_entities = [b.to_mlflow_entity() for b in self.access_bindings]
+
+        status = MCPStatus(self.resolved_status) if self.resolved_status is not None else None
+
+        return MCPServer(
+            name=self.name,
+            display_name=self.display_name,
+            description=self.description,
+            icons=self.icons,
+            workspace=self.workspace,
+            status=status,
+            tags=tags,
+            aliases=aliases,
+            access_bindings=binding_entities,
+            latest_version=self.latest_version,
+            created_by=self.created_by,
+            last_updated_by=self.last_updated_by,
+            creation_timestamp=self.created_at,
+            last_updated_timestamp=self.last_updated_at,
+        )
+
+
+class SqlMCPServerVersion(Base):
+    __tablename__ = "mcp_server_versions"
+
+    workspace = Column(
+        String(63),
+        nullable=False,
+        default=DEFAULT_WORKSPACE_NAME,
+        server_default=sa.text(f"'{DEFAULT_WORKSPACE_NAME}'"),
+    )
+    name = Column(String(256), nullable=False)
+    version = Column(String(128), nullable=False)
+    server_json = Column(JSON, nullable=False)
+    display_name = Column(String(256), nullable=True)
+    status = Column(
+        String(20),
+        nullable=False,
+        default=MCPStatus.DRAFT.value,
+        server_default=sa.text(f"'{MCPStatus.DRAFT.value}'"),
+    )
+    tools = Column(JSON, nullable=True)
+    source = Column(String(512), nullable=True)
+    created_by = Column(String(256), nullable=True)
+    last_updated_by = Column(String(256), nullable=True)
+    created_at = Column(BigInteger, default=get_current_time_millis, nullable=False)
+    last_updated_at = Column(BigInteger, default=get_current_time_millis, nullable=False)
+
+    server = relationship(
+        "SqlMCPServer",
+        backref=backref("server_versions", cascade="all, delete-orphan"),
+        foreign_keys=[workspace, name],
+    )
+
+    __table_args__ = (
+        PrimaryKeyConstraint("workspace", "name", "version", name="mcp_server_versions_pk"),
+        ForeignKeyConstraint(
+            ["workspace", "name"],
+            ["mcp_servers.workspace", "mcp_servers.name"],
+            ondelete="CASCADE",
+            onupdate="CASCADE",
+            name="mcp_server_versions_server_fkey",
+        ),
+        Index(
+            "idx_mcp_server_versions_latest",
+            "workspace",
+            "name",
+            "status",
+            sa.text("created_at DESC"),
+            sa.text("version DESC"),
+        ),
+    )
+
+    def __repr__(self):
+        return f"<SqlMCPServerVersion ({self.name}, {self.version}, {self.status})>"
+
+    def to_mlflow_entity(self, alias_names=None):
+        tags = {t.key: t.value for t in self.version_tags}
+        if alias_names is None:
+            alias_names = [a.alias for a in self.server.server_aliases if a.version == self.version]
+        tools = None
+        if self.tools is not None:
+            raw = self.tools if isinstance(self.tools, list) else json.loads(self.tools)
+            tools = [MCPTool.from_dict(t) for t in raw]
+        server_json = (
+            self.server_json if isinstance(self.server_json, dict) else json.loads(self.server_json)
+        )
+        return MCPServerVersion(
+            name=self.name,
+            version=self.version,
+            server_json=server_json,
+            display_name=self.display_name,
+            status=MCPStatus(self.status),
+            tools=tools,
+            aliases=alias_names,
+            tags=tags,
+            source=self.source,
+            workspace=self.workspace,
+            created_by=self.created_by,
+            last_updated_by=self.last_updated_by,
+            creation_timestamp=self.created_at,
+            last_updated_timestamp=self.last_updated_at,
+        )
+
+
+class SqlMCPServerTag(Base):
+    __tablename__ = "mcp_server_tags"
+
+    workspace = Column(
+        String(63),
+        nullable=False,
+        default=DEFAULT_WORKSPACE_NAME,
+        server_default=sa.text(f"'{DEFAULT_WORKSPACE_NAME}'"),
+    )
+    name = Column(String(256), nullable=False)
+    key = Column(String(250), nullable=False)
+    value = Column(String(5000), nullable=True)
+
+    server = relationship(
+        "SqlMCPServer",
+        backref=backref("tags", cascade="all, delete-orphan"),
+        foreign_keys=[workspace, name],
+    )
+
+    __table_args__ = (
+        PrimaryKeyConstraint("workspace", "name", "key", name="mcp_server_tags_pk"),
+        ForeignKeyConstraint(
+            ["workspace", "name"],
+            ["mcp_servers.workspace", "mcp_servers.name"],
+            ondelete="CASCADE",
+            onupdate="CASCADE",
+            name="mcp_server_tags_server_fkey",
+        ),
+    )
+
+    def __repr__(self):
+        return f"<SqlMCPServerTag ({self.name}, {self.key}={self.value})>"
+
+    def to_mlflow_entity(self):
+        return MCPServerTag(key=self.key, value=self.value)
+
+
+class SqlMCPServerVersionTag(Base):
+    __tablename__ = "mcp_server_version_tags"
+
+    workspace = Column(
+        String(63),
+        nullable=False,
+        default=DEFAULT_WORKSPACE_NAME,
+        server_default=sa.text(f"'{DEFAULT_WORKSPACE_NAME}'"),
+    )
+    name = Column(String(256), nullable=False)
+    version = Column(String(128), nullable=False)
+    key = Column(String(250), nullable=False)
+    value = Column(String(5000), nullable=True)
+
+    server_version = relationship(
+        "SqlMCPServerVersion",
+        backref=backref("version_tags", cascade="all, delete-orphan"),
+        foreign_keys=[workspace, name, version],
+    )
+
+    __table_args__ = (
+        PrimaryKeyConstraint(
+            "workspace", "name", "version", "key", name="mcp_server_version_tags_pk"
+        ),
+        ForeignKeyConstraint(
+            ["workspace", "name", "version"],
+            [
+                "mcp_server_versions.workspace",
+                "mcp_server_versions.name",
+                "mcp_server_versions.version",
+            ],
+            ondelete="CASCADE",
+            onupdate="CASCADE",
+            name="mcp_server_version_tags_version_fkey",
+        ),
+    )
+
+    def __repr__(self):
+        return f"<SqlMCPServerVersionTag ({self.name}, {self.version}, {self.key}={self.value})>"
+
+    def to_mlflow_entity(self):
+        return MCPServerTag(key=self.key, value=self.value)
+
+
+class SqlMCPServerAlias(Base):
+    __tablename__ = "mcp_server_aliases"
+
+    workspace = Column(
+        String(63),
+        nullable=False,
+        default=DEFAULT_WORKSPACE_NAME,
+        server_default=sa.text(f"'{DEFAULT_WORKSPACE_NAME}'"),
+    )
+    name = Column(String(256), nullable=False)
+    alias = Column(String(256), nullable=False)
+    version = Column(String(128), nullable=False)
+
+    server = relationship(
+        "SqlMCPServer",
+        backref=backref("server_aliases", cascade="all, delete-orphan"),
+        foreign_keys=[workspace, name],
+    )
+
+    __table_args__ = (
+        PrimaryKeyConstraint("workspace", "name", "alias", name="mcp_server_aliases_pk"),
+        ForeignKeyConstraint(
+            ["workspace", "name"],
+            ["mcp_servers.workspace", "mcp_servers.name"],
+            ondelete="CASCADE",
+            onupdate="CASCADE",
+            name="mcp_server_aliases_server_fkey",
+        ),
+    )
+
+    def __repr__(self):
+        return f"<SqlMCPServerAlias ({self.name}, {self.alias} -> {self.version})>"
+
+    def to_mlflow_entity(self):
+        return MCPServerAlias(name=self.name, alias=self.alias, version=self.version)
+
+
+class SqlMCPAccessBinding(Base):
+    __tablename__ = "mcp_access_bindings"
+
+    binding_id = Column(Integer, autoincrement=True)
+    workspace = Column(
+        String(63),
+        nullable=False,
+        default=DEFAULT_WORKSPACE_NAME,
+        server_default=sa.text(f"'{DEFAULT_WORKSPACE_NAME}'"),
+    )
+    server_name = Column(String(256), nullable=False)
+    server_version = Column(String(128), nullable=True)
+    server_alias = Column(String(256), nullable=True)
+    endpoint_url = Column(String(2048), nullable=False)
+    transport_type = Column(
+        String(32),
+        nullable=False,
+        default=MCPRemoteTransportType.STREAMABLE_HTTP.value,
+        server_default=sa.text(f"'{MCPRemoteTransportType.STREAMABLE_HTTP.value}'"),
+    )
+    created_by = Column(String(256), nullable=True)
+    last_updated_by = Column(String(256), nullable=True)
+    created_at = Column(BigInteger, default=get_current_time_millis, nullable=False)
+    last_updated_at = Column(BigInteger, default=get_current_time_millis, nullable=False)
+
+    server = relationship(
+        "SqlMCPServer",
+        backref=backref("access_bindings", cascade="all, delete-orphan"),
+        foreign_keys=[workspace, server_name],
+    )
+
+    __table_args__ = (
+        PrimaryKeyConstraint("binding_id", name="mcp_access_bindings_pk"),
+        ForeignKeyConstraint(
+            ["workspace", "server_name"],
+            ["mcp_servers.workspace", "mcp_servers.name"],
+            ondelete="CASCADE",
+            onupdate="CASCADE",
+            name="mcp_access_bindings_server_fkey",
+        ),
+        Index("ix_mcp_access_bindings_server_name", "workspace", "server_name"),
+        Index("ix_mcp_access_bindings_version", "workspace", "server_name", "server_version"),
+        Index("ix_mcp_access_bindings_alias", "workspace", "server_name", "server_alias"),
+    )
+
+    def __repr__(self):
+        return f"<SqlMCPAccessBinding ({self.binding_id}, {self.server_name})>"
+
+    def to_mlflow_entity(self):
+        return MCPAccessBinding(
+            binding_id=self.binding_id,
+            server_name=self.server_name,
+            endpoint_url=self.endpoint_url,
+            transport_type=MCPRemoteTransportType(self.transport_type),
+            server_version=self.server_version,
+            server_alias=self.server_alias,
+            workspace=self.workspace,
+            created_by=self.created_by,
+            last_updated_by=self.last_updated_by,
+            creation_timestamp=self.created_at,
+            last_updated_timestamp=self.last_updated_at,
         )

--- a/mlflow/store/tracking/sqlalchemy_workspace_store.py
+++ b/mlflow/store/tracking/sqlalchemy_workspace_store.py
@@ -32,6 +32,12 @@ from mlflow.store.tracking.dbmodels.models import (
     SqlGatewaySecret,
     SqlIssue,
     SqlLoggedModel,
+    SqlMCPAccessBinding,
+    SqlMCPServer,
+    SqlMCPServerAlias,
+    SqlMCPServerTag,
+    SqlMCPServerVersion,
+    SqlMCPServerVersionTag,
     SqlOnlineScoringConfig,
     SqlRun,
     SqlScorer,
@@ -124,6 +130,16 @@ class WorkspaceAwareSqlAlchemyStore(WorkspaceAwareMixin, SqlAlchemyStore):
 
         if model is SqlGatewayEndpointModelMapping:
             return query.join(SqlGatewayEndpoint).filter(SqlGatewayEndpoint.workspace == workspace)
+
+        if model in (
+            SqlMCPServer,
+            SqlMCPServerVersion,
+            SqlMCPServerTag,
+            SqlMCPServerVersionTag,
+            SqlMCPServerAlias,
+            SqlMCPAccessBinding,
+        ):
+            return query.filter(model.workspace == workspace)
 
         return query
 

--- a/mlflow/store/workspace/sqlalchemy_store.py
+++ b/mlflow/store/workspace/sqlalchemy_store.py
@@ -29,6 +29,7 @@ from mlflow.store.tracking.dbmodels.models import (
     SqlGatewayModelDefinition,
     SqlGatewaySecret,
     SqlJob,
+    SqlMCPServer,
 )
 from mlflow.store.workspace.abstract_store import AbstractStore, WorkspaceNameValidator
 from mlflow.store.workspace.dbmodels import SqlWorkspace
@@ -54,6 +55,7 @@ _WORKSPACE_ROOT_MODELS = [
     SqlGatewayBudgetPolicy,
     SqlGatewayGuardrail,
     SqlJob,
+    SqlMCPServer,
 ]
 
 

--- a/tests/db/schemas/sqlite.sql
+++ b/tests/db/schemas/sqlite.sql
@@ -97,6 +97,21 @@ CREATE TABLE jobs (
 )
 
 
+CREATE TABLE mcp_servers (
+	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
+	name VARCHAR(256) NOT NULL,
+	display_name VARCHAR(256),
+	description TEXT,
+	icons JSON,
+	latest_version VARCHAR(128),
+	created_by VARCHAR(256),
+	last_updated_by VARCHAR(256),
+	created_at BIGINT NOT NULL,
+	last_updated_at BIGINT NOT NULL,
+	CONSTRAINT mcp_servers_pk PRIMARY KEY (workspace, name)
+)
+
+
 CREATE TABLE registered_models (
 	name VARCHAR(256) NOT NULL,
 	creation_time BIGINT,
@@ -236,6 +251,61 @@ CREATE TABLE logged_models (
 	CONSTRAINT logged_models_pk PRIMARY KEY (model_id),
 	CONSTRAINT fk_logged_models_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE,
 	CONSTRAINT logged_models_lifecycle_stage_check CHECK (lifecycle_stage IN ('active', 'deleted'))
+)
+
+
+CREATE TABLE mcp_access_bindings (
+	binding_id INTEGER NOT NULL,
+	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
+	server_name VARCHAR(256) NOT NULL,
+	server_version VARCHAR(128),
+	server_alias VARCHAR(256),
+	endpoint_url VARCHAR(2048) NOT NULL,
+	transport_type VARCHAR(32) DEFAULT 'streamable-http' NOT NULL,
+	created_by VARCHAR(256),
+	last_updated_by VARCHAR(256),
+	created_at BIGINT NOT NULL,
+	last_updated_at BIGINT NOT NULL,
+	CONSTRAINT mcp_access_bindings_pk PRIMARY KEY (binding_id),
+	CONSTRAINT mcp_access_bindings_server_fkey FOREIGN KEY(workspace, server_name) REFERENCES mcp_servers (workspace, name) ON DELETE CASCADE ON UPDATE CASCADE
+)
+
+
+CREATE TABLE mcp_server_aliases (
+	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
+	name VARCHAR(256) NOT NULL,
+	alias VARCHAR(256) NOT NULL,
+	version VARCHAR(128) NOT NULL,
+	CONSTRAINT mcp_server_aliases_pk PRIMARY KEY (workspace, name, alias),
+	CONSTRAINT mcp_server_aliases_server_fkey FOREIGN KEY(workspace, name) REFERENCES mcp_servers (workspace, name) ON DELETE CASCADE ON UPDATE CASCADE
+)
+
+
+CREATE TABLE mcp_server_tags (
+	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
+	name VARCHAR(256) NOT NULL,
+	key VARCHAR(250) NOT NULL,
+	value VARCHAR(5000),
+	CONSTRAINT mcp_server_tags_pk PRIMARY KEY (workspace, name, key),
+	CONSTRAINT mcp_server_tags_server_fkey FOREIGN KEY(workspace, name) REFERENCES mcp_servers (workspace, name) ON DELETE CASCADE ON UPDATE CASCADE
+)
+
+
+CREATE TABLE mcp_server_versions (
+	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
+	name VARCHAR(256) NOT NULL,
+	version VARCHAR(128) NOT NULL,
+	server_json JSON NOT NULL,
+	display_name VARCHAR(256),
+	status VARCHAR(20) DEFAULT 'draft' NOT NULL,
+	tools JSON,
+	source VARCHAR(512),
+	created_by VARCHAR(256),
+	last_updated_by VARCHAR(256),
+	created_at BIGINT NOT NULL,
+	last_updated_at BIGINT NOT NULL,
+	CONSTRAINT mcp_server_versions_pk PRIMARY KEY (workspace, name, version),
+	CONSTRAINT mcp_server_versions_server_fkey FOREIGN KEY(workspace, name) REFERENCES mcp_servers (workspace, name) ON DELETE CASCADE ON UPDATE CASCADE
 )
 
 
@@ -483,6 +553,17 @@ CREATE TABLE logged_model_tags (
 )
 
 
+CREATE TABLE mcp_server_version_tags (
+	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
+	name VARCHAR(256) NOT NULL,
+	version VARCHAR(128) NOT NULL,
+	key VARCHAR(250) NOT NULL,
+	value VARCHAR(5000),
+	CONSTRAINT mcp_server_version_tags_pk PRIMARY KEY (workspace, name, version, key),
+	CONSTRAINT mcp_server_version_tags_version_fkey FOREIGN KEY(workspace, name, version) REFERENCES mcp_server_versions (workspace, name, version) ON DELETE CASCADE ON UPDATE CASCADE
+)
+
+
 CREATE TABLE metrics (
 	key VARCHAR(250) NOT NULL,
 	value FLOAT NOT NULL,
@@ -633,4 +714,3 @@ CREATE TABLE guardrail_configs (
 	CONSTRAINT fk_guardrail_configs_endpoint_id FOREIGN KEY(endpoint_id) REFERENCES endpoints (endpoint_id) ON DELETE CASCADE,
 	CONSTRAINT fk_guardrail_configs_guardrail_id FOREIGN KEY(guardrail_id) REFERENCES guardrails (guardrail_id) ON DELETE CASCADE
 )
-

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -97,6 +97,21 @@ CREATE TABLE jobs (
 )
 
 
+CREATE TABLE mcp_servers (
+	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
+	name VARCHAR(256) NOT NULL,
+	display_name VARCHAR(256),
+	description TEXT,
+	icons JSON,
+	latest_version VARCHAR(128),
+	created_by VARCHAR(256),
+	last_updated_by VARCHAR(256),
+	created_at BIGINT NOT NULL,
+	last_updated_at BIGINT NOT NULL,
+	CONSTRAINT mcp_servers_pk PRIMARY KEY (workspace, name)
+)
+
+
 CREATE TABLE registered_models (
 	name VARCHAR(256) NOT NULL,
 	creation_time BIGINT,
@@ -236,6 +251,61 @@ CREATE TABLE logged_models (
 	CONSTRAINT logged_models_pk PRIMARY KEY (model_id),
 	CONSTRAINT fk_logged_models_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE,
 	CONSTRAINT logged_models_lifecycle_stage_check CHECK (lifecycle_stage IN ('active', 'deleted'))
+)
+
+
+CREATE TABLE mcp_access_bindings (
+	binding_id INTEGER NOT NULL,
+	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
+	server_name VARCHAR(256) NOT NULL,
+	server_version VARCHAR(128),
+	server_alias VARCHAR(256),
+	endpoint_url VARCHAR(2048) NOT NULL,
+	transport_type VARCHAR(32) DEFAULT 'streamable-http' NOT NULL,
+	created_by VARCHAR(256),
+	last_updated_by VARCHAR(256),
+	created_at BIGINT NOT NULL,
+	last_updated_at BIGINT NOT NULL,
+	CONSTRAINT mcp_access_bindings_pk PRIMARY KEY (binding_id),
+	CONSTRAINT mcp_access_bindings_server_fkey FOREIGN KEY(workspace, server_name) REFERENCES mcp_servers (workspace, name) ON DELETE CASCADE ON UPDATE CASCADE
+)
+
+
+CREATE TABLE mcp_server_aliases (
+	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
+	name VARCHAR(256) NOT NULL,
+	alias VARCHAR(256) NOT NULL,
+	version VARCHAR(128) NOT NULL,
+	CONSTRAINT mcp_server_aliases_pk PRIMARY KEY (workspace, name, alias),
+	CONSTRAINT mcp_server_aliases_server_fkey FOREIGN KEY(workspace, name) REFERENCES mcp_servers (workspace, name) ON DELETE CASCADE ON UPDATE CASCADE
+)
+
+
+CREATE TABLE mcp_server_tags (
+	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
+	name VARCHAR(256) NOT NULL,
+	key VARCHAR(250) NOT NULL,
+	value VARCHAR(5000),
+	CONSTRAINT mcp_server_tags_pk PRIMARY KEY (workspace, name, key),
+	CONSTRAINT mcp_server_tags_server_fkey FOREIGN KEY(workspace, name) REFERENCES mcp_servers (workspace, name) ON DELETE CASCADE ON UPDATE CASCADE
+)
+
+
+CREATE TABLE mcp_server_versions (
+	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
+	name VARCHAR(256) NOT NULL,
+	version VARCHAR(128) NOT NULL,
+	server_json JSON NOT NULL,
+	display_name VARCHAR(256),
+	status VARCHAR(20) DEFAULT 'draft' NOT NULL,
+	tools JSON,
+	source VARCHAR(512),
+	created_by VARCHAR(256),
+	last_updated_by VARCHAR(256),
+	created_at BIGINT NOT NULL,
+	last_updated_at BIGINT NOT NULL,
+	CONSTRAINT mcp_server_versions_pk PRIMARY KEY (workspace, name, version),
+	CONSTRAINT mcp_server_versions_server_fkey FOREIGN KEY(workspace, name) REFERENCES mcp_servers (workspace, name) ON DELETE CASCADE ON UPDATE CASCADE
 )
 
 
@@ -480,6 +550,17 @@ CREATE TABLE logged_model_tags (
 	CONSTRAINT logged_model_tags_pk PRIMARY KEY (model_id, tag_key),
 	CONSTRAINT fk_logged_model_tags_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
 	CONSTRAINT fk_logged_model_tags_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE
+)
+
+
+CREATE TABLE mcp_server_version_tags (
+	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
+	name VARCHAR(256) NOT NULL,
+	version VARCHAR(128) NOT NULL,
+	key VARCHAR(250) NOT NULL,
+	value VARCHAR(5000),
+	CONSTRAINT mcp_server_version_tags_pk PRIMARY KEY (workspace, name, version, key),
+	CONSTRAINT mcp_server_version_tags_version_fkey FOREIGN KEY(workspace, name, version) REFERENCES mcp_server_versions (workspace, name, version) ON DELETE CASCADE ON UPDATE CASCADE
 )
 
 

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_schema.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_schema.py
@@ -386,6 +386,49 @@ def _insert_row(conn, table_name, workspace, overrides=None, seed=1):
             "retry_count": 0,
             "last_update_time": seed,
         },
+        "mcp_servers": {
+            "workspace": workspace,
+            "name": f"mcp_server_{seed}",
+            "created_at": seed,
+            "last_updated_at": seed,
+        },
+        "mcp_server_versions": {
+            "workspace": workspace,
+            "name": f"mcp_server_{seed}",
+            "version": f"v{seed}",
+            "server_json": "{}",
+            "status": "draft",
+            "created_at": seed,
+            "last_updated_at": seed,
+        },
+        "mcp_server_tags": {
+            "workspace": workspace,
+            "name": f"mcp_server_{seed}",
+            "key": f"tag_{seed}",
+            "value": f"value_{seed}",
+        },
+        "mcp_server_version_tags": {
+            "workspace": workspace,
+            "name": f"mcp_server_{seed}",
+            "version": f"v{seed}",
+            "key": f"vtag_{seed}",
+            "value": f"value_{seed}",
+        },
+        "mcp_server_aliases": {
+            "workspace": workspace,
+            "name": f"mcp_server_{seed}",
+            "alias": f"alias_{seed}",
+            "version": f"v{seed}",
+        },
+        "mcp_access_bindings": {
+            "binding_id": seed,
+            "workspace": workspace,
+            "server_name": f"mcp_server_{seed}",
+            "endpoint_url": f"http://localhost/{seed}",
+            "transport_type": "streamable-http",
+            "created_at": seed,
+            "last_updated_at": seed,
+        },
     }
     if table_name not in base_values:
         raise AssertionError(f"Unexpected table: {table_name}")


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

This PR add ORM models and the Alembic migration for mcp registry.  Most of this PR is just our entities being converted to different forms - database models, alembic migration,  and raw sql. I think the changes that deserve the most scrutiny is in `mlflow/store/db/workspace_move.py`.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mlflow/codesmith/mlflow/pr/23444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->