### PR TITLE
Count `nailaopus[bot]` approvals toward core-maintainer gate

### DIFF
--- a/.github/workflows/approval.js
+++ b/.github/workflows/approval.js
@@ -75,11 +75,12 @@ module.exports = async ({ github, context, core }) => {
     repo: context.repo.repo,
     pull_number: context.issue.number,
   });
+  const APPROVED_BOTS = new Set(["mlflow-app[bot]", "nailaopus[bot]"]);
   const maintainerApproved = reviews.some(
     ({ state, user }) =>
       state === "APPROVED" &&
       (maintainers.includes(user.login) ||
-        (user.type.toLowerCase() === "bot" && user.login === "mlflow-app[bot]"))
+        (user.type.toLowerCase() === "bot" && APPROVED_BOTS.has(user.login)))
   );
 
   const files = await github.paginate(github.rest.pulls.listFiles, {

--- a/.github/workflows/approval.js
+++ b/.github/workflows/approval.js
@@ -79,6 +79,9 @@ module.exports = async ({ github, context, core }) => {
   const maintainerApproved = reviews.some(
     ({ state, user }) =>
       state === "APPROVED" &&
+      // GitHub returns `user: null` on reviews from accounts that have since
+      // been deleted; skip them rather than crashing on `user.login`.
+      user &&
       (maintainers.includes(user.login) ||
         (user.type.toLowerCase() === "bot" && APPROVED_BOTS.has(user.login)))
   );


### PR DESCRIPTION
### Related Issues/PRs

Regression surfaced on #23440 (B-Step62's `transformers<5` pin) — `nailaopus[bot]` stamped the PR with `event: APPROVE`, but the `check` workflow's "Fail without core maintainer approval" step still failed because the bot wasn't in `approval.js`'s whitelist of recognized bots. PR was BLOCKED despite the stamp.

### What changes are proposed in this pull request?

`approval.js`'s `maintainerApproved` predicate accepted bot APPROVE reviews only when `user.login === "mlflow-app[bot]"`. Extend it to also count `nailaopus[bot]`, which now stamps eligible PRs (XS/S/M with no unresolved bot concerns and no human `CHANGES_REQUESTED`).

Extracted the whitelist into a `Set` so future bot additions don't ripple through the inline predicate logic.

```js
const APPROVED_BOTS = new Set(["mlflow-app[bot]", "nailaopus[bot]"]);
const maintainerApproved = reviews.some(
  ({ state, user }) =>
    state === "APPROVED" &&
    (maintainers.includes(user.login) ||
      (user.type.toLowerCase() === "bot" && APPROVED_BOTS.has(user.login)))
);
```

### How is this PR tested?

- [x] Existing unit/integration tests (JS workflow script, no test harness in-repo)
- [ ] New unit/integration tests
- [x] Manual tests

Manual validation plan: once this lands, the `check` workflow on #23440 (and any other currently-blocked PR where nailaopus stamped) will recognize the bot's approval and the maintainer-approval gate will pass.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

Internal CI plumbing; not user-facing.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mlflow/codesmith/mlflow/pr/23447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->