### PR TITLE
Drop NaiLaOpus auto-trigger + bump internal SHA pin

### DIFF
--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -159,7 +159,7 @@ jobs:
           # open a new PR that updates this SHA to the latest mlflow/internal
           # main after reviewing the diff. We'll migrate to release tags once
           # the bump cadence is stable; see mlflow/internal for the policy.
-          ref: 564858ace69e52162b4f07c02626d9f3ced2f4f6
+          ref: c24ef6de064d48cb4b244492dcd4bb70cefb1685
           sparse-checkout: |
             nailaopus
           path: internal

--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -1,26 +1,22 @@
 name: NaiLaOpus
 
 on:
+  # `/review-v2` is the only trigger. We previously also auto-ran on
+  # `pull_request` (opened/ready_for_review/reopened) but pulled it back:
+  # fork PRs (the common case for maintainer PRs) don't get base-repo
+  # secrets on `pull_request` events, and the `pull_request_target`
+  # alternative trips clint's pwn-requests anti-pattern check on
+  # actions/checkout of PR head. Living with the convenience cost of
+  # one typed `/review-v2` comment is cleaner than maintaining a lint
+  # exception or splitting the workflow into LLM-runner + poster jobs.
   issue_comment:
     types: [created]
-  # Auto-run on the first time a maintainer's PR is ready for review.
-  # `opened` fires for non-draft opens; `ready_for_review` fires for the
-  # draft -> ready transition; `reopened` fires when a closed PR is brought
-  # back. `synchronize` is intentionally excluded so subsequent author
-  # pushes don't re-trigger; maintainers can use `/review-v2` for re-runs,
-  # and the orchestrator's head-SHA cache short-circuits same-SHA runs.
-  pull_request:
-    types: [opened, ready_for_review, reopened]
 
 concurrency:
-  # Single group per PR. cancel-in-progress is false so each invocation
-  # finishes; subsequent invocations on the same PR queue behind it. The
-  # orchestrator's head_sha cache dedupes against same-SHA runs, so an
-  # auto-trigger immediately followed by /review-v2 on the same SHA
-  # short-circuits in the second run. The number coalesce handles both
-  # event payloads: issue_comment uses github.event.issue.number,
-  # pull_request uses github.event.pull_request.number.
-  group: nailaopus-${{ github.event.issue.number || github.event.pull_request.number }}
+  # Single group per PR. cancel-in-progress is false so each /review-v2
+  # invocation finishes; subsequent invocations on the same PR queue
+  # behind it. The orchestrator's head_sha cache dedupes same-SHA runs.
+  group: nailaopus-${{ github.event.issue.number }}
   cancel-in-progress: false
 
 defaults:
@@ -38,25 +34,19 @@ jobs:
     # Two layers of gating, both at the job level so that non-maintainer PRs
     # never load the App-token secret or run any step at all (no observable
     # side effects, no review burden on each step before a runtime gate):
-    #   1. Trigger author must be a maintainer (the commenter on
-    #      `/review-v2`, or the PR author on auto-trigger).
+    #   1. Comment author must be a maintainer (prevents random users from
+    #      triggering the bot via `/review-v2`).
     #   2. PR author must be a maintainer (prevents review of community-
     #      authored PRs whose diff content could contain prompt-injection
     #      attempts against the LLM).
-    # For the `pull_request` auto-trigger we additionally require the head
-    # ref to live on `mlflow/mlflow` (no fork PRs). `author_association`
-    # alone doesn't prevent a community fork from a maintainer; combining
-    # both ensures the diff cannot come from an untrusted source.
+    # `issue_comment` payloads expose both associations directly, so we
+    # can do this check without an extra `gh api` step.
     if: |
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request != null &&
-       startsWith(github.event.comment.body, '/review-v2') &&
-       contains(fromJSON('["MEMBER", "COLLABORATOR", "OWNER"]'), github.event.comment.author_association) &&
-       contains(fromJSON('["MEMBER", "COLLABORATOR", "OWNER"]'), github.event.issue.author_association)) ||
-      (github.event_name == 'pull_request' &&
-       !github.event.pull_request.draft &&
-       github.event.pull_request.head.repo.full_name == github.repository &&
-       contains(fromJSON('["MEMBER", "COLLABORATOR", "OWNER"]'), github.event.pull_request.author_association))
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request != null &&
+      startsWith(github.event.comment.body, '/review-v2') &&
+      contains(fromJSON('["MEMBER", "COLLABORATOR", "OWNER"]'), github.event.comment.author_association) &&
+      contains(fromJSON('["MEMBER", "COLLABORATOR", "OWNER"]'), github.event.issue.author_association)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -50,20 +50,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - name: Resolve PR number and trigger source
+      - name: Resolve PR number
         id: ctx
         env:
-          EVENT_NAME: ${{ github.event_name }}
           ISSUE_PR: ${{ github.event.issue.number }}
-          PR_NUM: ${{ github.event.pull_request.number }}
-        run: |
-          if [ "$EVENT_NAME" = "issue_comment" ]; then
-            echo "pr=$ISSUE_PR" >> "$GITHUB_OUTPUT"
-            echo "trigger=comment" >> "$GITHUB_OUTPUT"
-          else
-            echo "pr=$PR_NUM" >> "$GITHUB_OUTPUT"
-            echo "trigger=auto" >> "$GITHUB_OUTPUT"
-          fi
+        run: echo "pr=$ISSUE_PR" >> "$GITHUB_OUTPUT"
 
       - name: Generate App installation token (multi-repo)
         id: app_token
@@ -80,7 +71,6 @@ jobs:
           permission-issues: write
 
       - name: Annotate trigger comment with run URL
-        if: steps.ctx.outputs.trigger == 'comment'
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           REPO: ${{ github.repository }}
@@ -161,9 +151,8 @@ jobs:
         with:
           enable-cache: false
 
-      - name: Parse review flags (comment-triggered only)
+      - name: Parse review flags
         id: flags
-        if: steps.ctx.outputs.trigger == 'comment'
         env:
           BODY: ${{ github.event.comment.body }}
         run: |
@@ -183,9 +172,6 @@ jobs:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           PR: ${{ steps.ctx.outputs.pr }}
           REPO: ${{ github.repository }}
-          # FLAGS is empty on auto-triggered runs by design: the flags step
-          # only runs for /review-v2 comments, and there is no comment body to
-          # parse on a pull_request event.
           FLAGS: ${{ steps.flags.outputs.flags }}
         # Inputs flow through env vars rather than ${{ }} interpolation
         # directly into the shell, so an unexpected character in any value
@@ -198,8 +184,8 @@ jobs:
         run: |
           uv run --directory internal/nailaopus nailaopus "$PR" --repo "$REPO" --mlflow-tree "$GITHUB_WORKSPACE/mlflow" --no-dry-run $FLAGS
 
-      - name: React +1 on success (comment-triggered only)
-        if: success() && steps.ctx.outputs.trigger == 'comment'
+      - name: React +1 on success
+        if: success()
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -149,7 +149,7 @@ jobs:
           # open a new PR that updates this SHA to the latest mlflow/internal
           # main after reviewing the diff. We'll migrate to release tags once
           # the bump cadence is stable; see mlflow/internal for the policy.
-          ref: c24ef6de064d48cb4b244492dcd4bb70cefb1685
+          ref: ee5492f55a011e67dfe9643f74b3f8fb3ae52d27
           sparse-checkout: |
             nailaopus
           path: internal


### PR DESCRIPTION
### Related Issues/PRs

Supersedes #23431 (closed). Picks up two `mlflow/internal` PRs in the SHA bump:

- mlflow/internal#48 — Catch Anthropic billing errors (HTTP 402) and post a maintainer-facing comment instead of crashing the workflow step.
- mlflow/internal#50 — Stamp gate treats `OUT_OF_HUNK_LOW_SEVERITY` skips as non-blocking. Fixes the regression observed on #23447 where an XS PR with one bot-suppressed out-of-hunk finding wasn't stamped.

### What changes are proposed in this pull request?

Two changes to `.github/workflows/nailaopus.yml`:

**1. Drop the `pull_request` auto-trigger.** `/review-v2` comments become the only path to invoke the bot.

The auto-trigger added in #23422 doesn't work in the common case (maintainer PRs from forks) because `pull_request` events from forks don't receive base-repo secrets, so the App-token mint step fails. The `pull_request_target` alternative (#23431) trips clint's pwn-requests check on `actions/checkout` of PR head — the workflow is safe in practice (orchestrator runs from a pinned `mlflow/internal` SHA, PR files are data-only via the agents' Read/Grep tools) but the lint check is structural and can't see that. Living with one typed `/review-v2` comment per maintainer PR is cleaner than either maintaining a lint exception or splitting the workflow into LLM-runner + poster jobs.

Removes:
- `pull_request:` from `on:`
- the `pull_request` branch from the job-level `if:`
- the now-dead `||` from the concurrency `group:` expression

**2. Bump the `mlflow/internal` SHA pin from `564858a` to `c24ef6d`.** Picks up #48 and #50 (described above).

### How is this PR tested?

- [x] Existing unit/integration tests (workflow change has no Python code; mlflow/internal tests at 280/280 cover both behaviors)
- [ ] New unit/integration tests
- [x] Manual tests

Manual validation plan once merged:
- `/review-v2` on any maintainer PR (fork or origin) still works.
- A PR with a bot-suppressed out-of-hunk drive-by skip gets stamped (regression coverage for #23447).
- If the Anthropic key hits 402 mid-run, the bot posts a billing-specific comment and the workflow step exits success.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

Internal bot infrastructure; not user-facing.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release