### PR TITLE
Revert `uv pip install` in `install-skinny.sh` back to `pip install`

### DIFF
--- a/dev/install-skinny.sh
+++ b/dev/install-skinny.sh
@@ -18,6 +18,6 @@ git sparse-checkout set --no-cone /mlflow /libs/skinny /pyproject.toml '!/mlflow
 git fetch origin "$REF"
 git config advice.detachedHead false
 git checkout FETCH_HEAD
-OPTIONS=$(if uv pip freeze --system | grep -q "mlflow-skinny @"; then echo "--force-reinstall --no-deps"; fi)
-uv pip install --system $OPTIONS ./libs/skinny
+OPTIONS=$(if pip freeze | grep -q "mlflow-skinny @"; then echo "--force-reinstall --no-deps"; fi)
+pip install $OPTIONS ./libs/skinny
 rm -rf $TEMP_DIR


### PR DESCRIPTION
### Related Issues/PRs

Reverts #21985

### What changes are proposed in this pull request?

Revert `dev/install-skinny.sh` to use `pip install` instead of `uv pip install --system`. The script is consumed on Databricks runtimes, which don't ship `uv`, so the curl-piped install fails out of the box.

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mlflow/codesmith/mlflow/pr/23449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->