### PR TITLE
Forbid posting review/comments in `pr-review` skill

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -140,4 +140,4 @@ Validate before finishing — fix any errors and re-emit until this passes:
 uv run --package skills skills validate-review /tmp/review-payload.json
 ```
 
-Do not post the review or comments by running `gh pr review`, calling GitHub review/comment APIs, or using any other skills that publish feedback to the PR. Stop after writing and validating the local review payload.
+Do not post the review or comments by running `gh pr review`, calling GitHub review/comment APIs, or using any other skills. Stop after writing and validating the local review payload.

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -125,7 +125,7 @@ Determine the review `event`:
 
 ### 4. Emit Local Review Payload
 
-The payload is the only deliverable. Do not post. Write `/tmp/review-payload.json` matching [`review-payload.schema.json`](./review-payload.schema.json), then validate it.
+Write `/tmp/review-payload.json` matching [`review-payload.schema.json`](./review-payload.schema.json), then validate it.
 
 Authoring rules not captured by the schema:
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-review
-description: Review a GitHub pull request and emit a single review payload (comments + approval decision) for the workflow to validate and post
+description: Review a GitHub pull request and emit a validated local review payload (comments + approval decision)
 disable-model-invocation: true
 allowed-tools:
   - Read
@@ -123,9 +123,9 @@ Determine the review `event`:
 - **No CRITICAL findings** -> `event: "APPROVE"`
 - **Any CRITICAL finding** -> `event: "COMMENT"`
 
-### 4. Emit Review Payload
+### 4. Emit Local Review Payload
 
-Write `/tmp/review-payload.json` matching [`review-payload.schema.json`](./review-payload.schema.json). Do not post the review yourself.
+The payload is the only deliverable. Do not post. Write `/tmp/review-payload.json` matching [`review-payload.schema.json`](./review-payload.schema.json), then validate it.
 
 Authoring rules not captured by the schema:
 
@@ -139,3 +139,5 @@ Validate before finishing — fix any errors and re-emit until this passes:
 ```bash
 uv run --package skills skills validate-review /tmp/review-payload.json
 ```
+
+Do not post the review or comments by running `gh pr review`, calling GitHub review/comment APIs, or using any other skills that publish feedback to the PR. Stop after writing and validating the local review payload.


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Relates to #23449

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Tighten the `pr-review` skill so it cannot post reviews or comments to the PR.

Motivation: in [this run](https://github.com/mlflow/mlflow/actions/runs/26069848716?pr=23449), Sonnet validated the local payload, then ignored the prior `Do not post the review yourself` line and attempted to post via the `add-review-comment` skill and `gh api .../reviews`. Both attempts 403'd at the workflow's read-only app token, but the model didn't know that and burned budget. The new wording explicitly names both bypass paths and hoists the prohibition to the top of step 4.

### How is this PR tested?

- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

Re-ran `/review` on this PR with both Sonnet and Opus; both stopped at validation with no posting attempts.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)