### PR TITLE
Add RBAC regression guards: removed surfaces + synthetic role pattern

### DIFF
--- a/tests/server/auth/test_auth_workspace.py
+++ b/tests/server/auth/test_auth_workspace.py
@@ -523,6 +523,58 @@ def test_filter_list_workspaces_filters_to_allowed(monkeypatch):
     assert [ws["name"] for ws in payload["workspaces"]] == ["team-a"]
 
 
+def test_list_workspaces_hides_workspace_with_only_synthetic_resource_grant(tmp_path, monkeypatch):
+    # Pins the docs scenario: a user with only a per-resource grant (e.g.
+    # ``(experiment, exp-456, EDIT)``) inside team-a does NOT see team-a in
+    # ``mlflow.list_workspaces()`` — workspace visibility requires a
+    # workspace-scoped role assignment, not a synthetic per-resource grant.
+    #
+    # The grant lives on Carol's synthetic ``__user_<id>__`` role with a
+    # single ``(experiment, exp-456, EDIT)`` row — no ``(workspace, *)``
+    # grant. ``list_accessible_workspace_names`` should treat this as "no
+    # workspace-level access" and filter team-a out.
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+    monkeypatch.setattr(auth_module, "sender_is_admin", lambda: False)
+    monkeypatch.setattr(
+        auth_module,
+        "auth_config",
+        auth_module.auth_config._replace(grant_default_workspace_access=False),
+        raising=False,
+    )
+
+    db_uri = f"sqlite:///{tmp_path / 'auth-store.db'}"
+    auth_store = SqlAlchemyStore()
+    auth_store.init_db(db_uri)
+    monkeypatch.setattr(auth_module, "store", auth_store, raising=False)
+
+    auth_store.create_user("carol", "supersecurepassword", is_admin=False)
+    # Direct per-resource grant via ``grant_user_permission`` — writes to
+    # Carol's synthetic ``__user_<id>__`` role in team-a. This is exactly the
+    # surface the admin UI's "Direct permissions" section sits on top of.
+    with workspace_context.WorkspaceContext("team-a"):
+        auth_store.grant_user_permission("carol", "experiment", "exp-456", "EDIT")
+
+    monkeypatch.setattr(
+        auth_module, "authenticate_request", lambda: SimpleNamespace(username="carol")
+    )
+
+    response = Response(
+        json.dumps({"workspaces": [{"name": "team-a"}, {"name": "team-b"}]}),
+        mimetype="application/json",
+    )
+    auth_module.filter_list_workspaces(response)
+    payload = json.loads(response.get_data(as_text=True))
+    # protobuf-to-JSON omits empty repeated fields, so an empty list of
+    # workspaces serializes as ``{}``. Both forms mean "Carol sees no
+    # workspaces", which is what the docs claim.
+    assert [ws["name"] for ws in payload.get("workspaces", [])] == [], (
+        "A direct-permission-only user must not see team-a in list_workspaces; "
+        "only workspace-scoped role assignments confer visibility."
+    )
+
+    auth_store.engine.dispose()
+
+
 def test_list_workspaces_filters_to_role_assigned_workspaces(tmp_path, monkeypatch):
     # End-to-end guard for the list_accessible_workspace_names fix: alice has NO
     # legacy workspace_permissions rows — her only workspace membership is via a

--- a/tests/server/auth/test_client.py
+++ b/tests/server/auth/test_client.py
@@ -546,3 +546,49 @@ def test_unified_permission_endpoints_reachable_at_both_path_prefixes(
         auth=(ADMIN_USERNAME, ADMIN_PASSWORD),
     )
     assert resp.status_code != 404, f"{method} /{api_prefix}{endpoint} unexpectedly returned 404"
+
+
+# Workspace permission methods that the RBAC migration removed from
+# ``AuthServiceClient``. Their replacement is the unified
+# ``grant_user_permission`` / ``revoke_user_permission`` surface. This list
+# guards against accidental re-addition during refactors or merges.
+_REMOVED_WORKSPACE_PERMISSION_METHODS = [
+    "set_workspace_permission",
+    "list_workspace_permissions",
+    "delete_workspace_permission",
+    "list_user_workspace_permissions",
+]
+
+
+@pytest.mark.parametrize("method_name", _REMOVED_WORKSPACE_PERMISSION_METHODS)
+def test_removed_workspace_permission_methods_absent(method_name):
+    fake_client = AuthServiceClient("http://127.0.0.1:1")
+    assert not hasattr(fake_client, method_name), (
+        f"{method_name} was removed in the RBAC migration but is still defined on AuthServiceClient"
+    )
+
+
+# Wire endpoints that the RBAC migration removed. Hitting these paths should
+# not match any registered handler; Flask returns 404 for unregistered paths.
+# Guards against accidental re-registration in ``create_app``.
+@pytest.mark.parametrize(
+    ("path", "method"),
+    [
+        ("/api/2.0/mlflow/workspaces/team-a/permissions/get", "GET"),
+        ("/api/2.0/mlflow/workspaces/team-a/permissions/create", "POST"),
+        ("/api/2.0/mlflow/workspaces/team-a/permissions/update", "PATCH"),
+        ("/api/2.0/mlflow/workspaces/team-a/permissions/delete", "DELETE"),
+        ("/api/3.0/mlflow/workspaces/team-a/permissions/get", "GET"),
+        ("/api/3.0/mlflow/workspaces/team-a/permissions/create", "POST"),
+        ("/api/3.0/mlflow/workspaces/team-a/permissions/update", "PATCH"),
+        ("/api/3.0/mlflow/workspaces/team-a/permissions/delete", "DELETE"),
+    ],
+)
+def test_removed_workspace_permission_endpoints_return_404(client, path, method):
+    resp = requests.request(
+        method, client.tracking_uri + path, auth=(ADMIN_USERNAME, ADMIN_PASSWORD)
+    )
+    assert resp.status_code == 404, (
+        f"{method} {path} was removed in the RBAC migration but returned "
+        f"{resp.status_code} (expected 404)"
+    )

--- a/tests/server/auth/test_sqlalchemy_store_rbac.py
+++ b/tests/server/auth/test_sqlalchemy_store_rbac.py
@@ -57,6 +57,27 @@ def test_create_role_same_name_different_workspace(store):
     assert r1.id != r2.id
 
 
+@pytest.mark.parametrize("name", ["__user_1__", "__user_42__", "__user_999999__"])
+def test_create_role_rejects_synthetic_user_name_pattern(store, name):
+    # The ``__user_<id>__`` pattern is reserved for synthetic per-user roles
+    # created internally by ``grant_user_permission``. Allowing an operator
+    # to author a role with that name would let them collide with a real
+    # user's synthetic role and silently attach grants to that user — a
+    # privilege-escalation footgun.
+    with pytest.raises(MlflowException, match="reserved synthetic pattern"):
+        store.create_role(name=name, workspace="ws1")
+
+
+@pytest.mark.parametrize("name", ["__user_1__", "__user_42__"])
+def test_update_role_rejects_synthetic_user_name_pattern(store, name):
+    # The same reservation must apply when *renaming* an existing role —
+    # otherwise the create-time guard could be bypassed by creating with a
+    # normal name and then renaming into the reserved pattern.
+    role = store.create_role(name="viewer", workspace="ws1")
+    with pytest.raises(MlflowException, match="reserved synthetic pattern"):
+        store.update_role(role.id, name=name)
+
+
 def test_get_role(store):
     created = store.create_role(name="editor", workspace="ws1")
     fetched = store.get_role(created.id)

--- a/tests/server/auth/test_sqlalchemy_store_rbac.py
+++ b/tests/server/auth/test_sqlalchemy_store_rbac.py
@@ -57,7 +57,13 @@ def test_create_role_same_name_different_workspace(store):
     assert r1.id != r2.id
 
 
-@pytest.mark.parametrize("name", ["__user_1__", "__user_42__", "__user_999999__"])
+# Sample names matching the reserved ``__user_<id>__`` pattern. Shared by
+# the create-time and update-time guards so a future pattern addition
+# (e.g. another reserved prefix) lands in both tests automatically.
+_SYNTHETIC_USER_ROLE_NAMES = ["__user_1__", "__user_42__", "__user_999999__"]
+
+
+@pytest.mark.parametrize("name", _SYNTHETIC_USER_ROLE_NAMES)
 def test_create_role_rejects_synthetic_user_name_pattern(store, name):
     # The ``__user_<id>__`` pattern is reserved for synthetic per-user roles
     # created internally by ``grant_user_permission``. Allowing an operator
@@ -68,7 +74,7 @@ def test_create_role_rejects_synthetic_user_name_pattern(store, name):
         store.create_role(name=name, workspace="ws1")
 
 
-@pytest.mark.parametrize("name", ["__user_1__", "__user_42__"])
+@pytest.mark.parametrize("name", _SYNTHETIC_USER_ROLE_NAMES)
 def test_update_role_rejects_synthetic_user_name_pattern(store, name):
     # The same reservation must apply when *renaming* an existing role —
     # otherwise the create-time guard could be bypassed by creating with a


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23337, #23379, #23426. Replaces #23219 (closed; see [explanation](https://github.com/mlflow/mlflow/pull/23219#issuecomment) below).

### What changes are proposed in this pull request?

Three test-only regression guards for behaviors already in place on master but not directly pinned. No production code changes.

| Test | What it pins |
|---|---|
| `test_removed_workspace_permission_methods_absent` (4-way parametrize) | The 4 workspace-permission methods removed from `AuthServiceClient` in the RBAC migration (`set_workspace_permission`, `list_workspace_permissions`, `delete_workspace_permission`, `list_user_workspace_permissions`) stay removed. |
| `test_removed_workspace_permission_endpoints_return_404` (8-way parametrize) | The 8 `/workspaces/<name>/permissions/*` REST endpoints stay unregistered. Master already pins the per-resource `permissions/*` endpoints via `test_legacy_permission_endpoints_return_404` (added in #23337); this fills the workspace-permission gap. |
| `test_create_role_rejects_synthetic_user_name_pattern` + `test_update_role_rejects_synthetic_user_name_pattern` | The `__user_<id>__` role name pattern is reserved on both `create_role` and `update_role`. Without the rename guard, an operator could bypass the create-time guard by creating with a normal name and renaming into the reserved pattern — silently colliding with a real user's synthetic role (privilege-escalation footgun). |
| `test_list_workspaces_hides_workspace_with_only_synthetic_resource_grant` | A user holding only `(experiment, exp-456, EDIT)` on team-a does NOT see team-a in `mlflow.list_workspaces()` — workspace visibility requires a workspace-scoped role assignment, not a synthetic per-resource grant. |

### Why a new PR instead of unblocking #23219

#23219 had 7 tests; #23337 / #23379 / #23426 landed in the interim and rendered:

- The 24-way `test_every_legacy_permission_method_emits_deprecation_warning` test stale — the methods themselves were deleted, so there's nothing to emit a deprecation warning.
- The `test_per_resource_manage_allows_deprecated_endpoint_but_not_role_api` test stale — it relied on the now-removed `/experiments/permissions/create` endpoint.

This PR salvages the 4 still-useful tests (3 verbatim + 1 ported from the deleted `create_experiment_permission` API to the unified `grant_user_permission` API).

### How is this PR tested?

- [x] New unit/integration tests
- [ ] Manual tests

Locally, 18 tests pass (5 new + the existing parametrized cases on `test_legacy_permission_endpoints_return_404`). Ruff / ruff-format / clint clean.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mlflow/codesmith/mlflow/pr/23452"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->