### PR TITLE
Add AI assistant tracing onboarding

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/traces/quickstart/TraceTableAiAssistantQuickstart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/traces/quickstart/TraceTableAiAssistantQuickstart.tsx
@@ -1,0 +1,119 @@
+import { Typography, type ThemeType } from '@databricks/design-system';
+import { FormattedMessage } from 'react-intl';
+
+import { AI_ASSISTANT_SKILLS_INSTALL_CODE, getAiAssistantPrompt } from './TraceTableQuickstart.utils';
+import { CodeBlock } from './components/CodeBlock';
+import { StepSection } from './components/StepSection';
+
+const SUPPORTED_AGENT_NAMES = ['Claude Code', 'Cursor', 'Codex CLI', 'Gemini CLI', 'OpenCode'];
+
+export const TraceTableAiAssistantQuickstart = ({
+  theme,
+  trackingUri,
+  experimentName,
+  workspace,
+}: {
+  theme: ThemeType;
+  trackingUri: string;
+  experimentName: string;
+  workspace?: string | null;
+}) => {
+  const prompt = getAiAssistantPrompt({ trackingUri, experimentName, workspace });
+
+  return (
+    <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.lg * 1.5 }}>
+      <div
+        css={{
+          display: 'flex',
+          alignItems: 'center',
+          flexWrap: 'wrap',
+          gap: theme.spacing.sm,
+        }}
+      >
+        <Typography.Text bold>
+          <FormattedMessage
+            defaultMessage="Works with"
+            description="Label introducing coding agents supported by the MLflow skills quickstart"
+          />
+        </Typography.Text>
+        {SUPPORTED_AGENT_NAMES.map((agentName) => (
+          <span
+            key={agentName}
+            css={{
+              border: `1px solid ${theme.colors.border}`,
+              borderRadius: theme.borders.borderRadiusMd,
+              padding: `${theme.spacing.xs}px ${theme.spacing.sm}px`,
+              backgroundColor: theme.colors.backgroundPrimary,
+              fontWeight: 600,
+            }}
+          >
+            {agentName}
+          </span>
+        ))}
+      </div>
+      <StepSection
+        theme={theme}
+        stepNumber={1}
+        title={
+          <FormattedMessage
+            defaultMessage="Install the MLflow skills"
+            description="Step 1 title for AI assistant traces onboarding"
+          />
+        }
+        description={
+          <FormattedMessage
+            defaultMessage="Add the MLflow skills once, then your coding assistant can use them to instrument tracing workflows."
+            description="Step 1 description for AI assistant traces onboarding"
+          />
+        }
+      >
+        <CodeBlock
+          theme={theme}
+          code={AI_ASSISTANT_SKILLS_INSTALL_CODE}
+          language="bash"
+          componentId="mlflow.traces.onboarding.ai_assistant.install.copy"
+        />
+      </StepSection>
+      <StepSection
+        theme={theme}
+        stepNumber={2}
+        title={
+          <FormattedMessage
+            defaultMessage="Ask your agent to add tracing"
+            description="Step 2 title for AI assistant traces onboarding"
+          />
+        }
+        description={
+          <FormattedMessage
+            defaultMessage="Paste this prompt into your coding agent. It includes this MLflow server and experiment so the generated traces land here."
+            description="Step 2 description for AI assistant traces onboarding"
+          />
+        }
+      >
+        <CodeBlock
+          theme={theme}
+          code={prompt}
+          language="text"
+          componentId="mlflow.traces.onboarding.ai_assistant.prompt.copy"
+        />
+      </StepSection>
+      <StepSection
+        theme={theme}
+        stepNumber={3}
+        title={
+          <FormattedMessage
+            defaultMessage="View your traces"
+            description="Step 3 title for AI assistant traces onboarding"
+          />
+        }
+        description={
+          <FormattedMessage
+            defaultMessage="After the agent finishes and runs the instrumented workflow, traces will appear here automatically."
+            description="Step 3 description for AI assistant traces onboarding"
+          />
+        }
+        isPending
+      />
+    </div>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/components/traces/quickstart/TraceTableQuickstart.utils.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/traces/quickstart/TraceTableQuickstart.utils.tsx
@@ -49,6 +49,24 @@ export const TS_INSTALL_CODE = 'npm install @mlflow/core';
 export const OTEL_INSTALL_CODE =
   'pip install opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp-proto-http';
 
+export const AI_ASSISTANT_SKILLS_INSTALL_CODE = 'npx skills add mlflow/skills';
+
+export const getAiAssistantPrompt = ({
+  trackingUri,
+  experimentName,
+  workspace,
+}: {
+  trackingUri: string;
+  experimentName: string;
+  workspace?: string | null;
+}) => {
+  const workspaceInstruction = workspace ? ` Use workspace "${workspace}".` : '';
+  const trackingUriInstruction = trackingUri.includes('<port>')
+    ? `Use tracking URI "${trackingUri}" after replacing "<port>" with the backend port.`
+    : `Use tracking URI "${trackingUri}".`;
+  return `Add MLflow tracing to my app using the installed MLflow skills. ${trackingUriInstruction} Log traces to experiment "${experimentName}".${workspaceInstruction} Run a small smoke test and confirm a trace appears in MLflow.`;
+};
+
 export const getOtelEnvCode = (trackingUri: string, experimentId: string) =>
   `export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=${trackingUri}/v1/traces
 export OTEL_EXPORTER_OTLP_TRACES_HEADERS=x-mlflow-experiment-id=${experimentId}`;

--- a/mlflow/server/js/src/experiment-tracking/components/traces/quickstart/TracesViewTableNoTracesQuickstart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/traces/quickstart/TracesViewTableNoTracesQuickstart.tsx
@@ -23,6 +23,7 @@ import {
 import { CodeBlock } from './components/CodeBlock';
 import { StepSection } from './components/StepSection';
 import { LanguageTab, type Language } from './components/LanguageTab';
+import { TraceTableAiAssistantQuickstart } from './TraceTableAiAssistantQuickstart';
 
 const TRACING_VIDEO_START_SEC = 24;
 const TRACING_VIDEO_URL = `https://mlflow.org/docs/latest/images/llms/tracing/tracing-top.mp4#t=${TRACING_VIDEO_START_SEC}`;
@@ -38,7 +39,7 @@ export const TracesViewTableNoTracesQuickstart = ({
   experimentId?: string;
 }) => {
   const { theme } = useDesignSystemTheme();
-  const [language, setLanguage] = useState<Language>('python');
+  const [language, setLanguage] = useState<Language>('ai-assistant');
   const [selectedPythonFramework, setSelectedPythonFramework] = useState<QUICKSTART_FLAVOR>('openai');
   const [selectedTsFramework, setSelectedTsFramework] = useState<string>('openai');
   const [videoFailed, setVideoFailed] = useState(false);
@@ -134,24 +135,34 @@ export const TracesViewTableNoTracesQuickstart = ({
       </div>
 
       {/* Steps */}
-      <div css={{ width: '100%', display: 'flex', flexDirection: 'column', gap: theme.spacing.lg * 1.5 }}>
-        <ConnectStep
-          theme={theme}
-          language={language}
-          pythonConnectCode={pythonConnectCode}
-          tsConnectCode={tsConnectCode}
-          otelEnvCode={otelEnvCode}
-        />
-        <InstrumentStep
-          theme={theme}
-          language={language}
-          frameworkOptions={frameworkOptions}
-          selectedFramework={selectedFramework}
-          onSelectFramework={handleFrameworkSelect}
-          pythonCode={pythonCode}
-          tsFramework={tsFramework}
-        />
-        <VerifyStep theme={theme} />
+      <div css={{ width: '100%' }}>
+        {language === 'ai-assistant' ? (
+          <TraceTableAiAssistantQuickstart
+            theme={theme}
+            trackingUri={trackingUri}
+            experimentName={experimentName || 'my-experiment'}
+          />
+        ) : (
+          <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.lg * 1.5 }}>
+            <ConnectStep
+              theme={theme}
+              language={language}
+              pythonConnectCode={pythonConnectCode}
+              tsConnectCode={tsConnectCode}
+              otelEnvCode={otelEnvCode}
+            />
+            <InstrumentStep
+              theme={theme}
+              language={language}
+              frameworkOptions={frameworkOptions}
+              selectedFramework={selectedFramework}
+              onSelectFramework={handleFrameworkSelect}
+              pythonCode={pythonCode}
+              tsFramework={tsFramework}
+            />
+            <VerifyStep theme={theme} />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/mlflow/server/js/src/experiment-tracking/components/traces/quickstart/components/CodeBlock.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/traces/quickstart/components/CodeBlock.tsx
@@ -31,7 +31,9 @@ export const CodeBlock = ({
       />
       <CodeSnippet
         showLineNumbers
-        language={language === 'bash' ? 'text' : language === 'typescript' ? 'javascript' : 'python'}
+        language={
+          language === 'bash' || language === 'text' ? 'text' : language === 'typescript' ? 'javascript' : 'python'
+        }
         theme={theme.isDarkMode ? 'duotoneDark' : 'light'}
         style={{
           fontSize: 12,

--- a/mlflow/server/js/src/experiment-tracking/components/traces/quickstart/components/LanguageTab.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/traces/quickstart/components/LanguageTab.tsx
@@ -1,6 +1,6 @@
 import { SegmentedControlButton, SegmentedControlGroup } from '@databricks/design-system';
 
-export type Language = 'python' | 'typescript' | 'opentelemetry';
+export type Language = 'ai-assistant' | 'python' | 'typescript' | 'opentelemetry';
 
 export const LanguageTab = ({
   language,
@@ -10,6 +10,7 @@ export const LanguageTab = ({
   setLanguage: (lang: Language) => void;
 }) => {
   const tabs: { key: Language; label: string }[] = [
+    { key: 'ai-assistant', label: 'AI assistants' },
     { key: 'python', label: 'Python' },
     { key: 'typescript', label: 'TypeScript' },
     { key: 'opentelemetry', label: 'OpenTelemetry' },

--- a/mlflow/server/js/src/home/components/LogTracesDrawer.test.tsx
+++ b/mlflow/server/js/src/home/components/LogTracesDrawer.test.tsx
@@ -12,6 +12,28 @@ jest.mock('@mlflow/mlflow/src/experiment-tracking/components/traces/quickstart/T
   ),
 }));
 
+jest.mock(
+  '@mlflow/mlflow/src/experiment-tracking/components/traces/quickstart/TraceTableAiAssistantQuickstart',
+  () => ({
+    TraceTableAiAssistantQuickstart: ({
+      trackingUri,
+      experimentName,
+      workspace,
+    }: {
+      trackingUri: string;
+      experimentName: string;
+      workspace?: string | null;
+    }) => (
+      <div
+        data-testid="ai-assistant-quickstart"
+        data-tracking-uri={trackingUri}
+        data-experiment-name={experimentName}
+        data-workspace={workspace || ''}
+      />
+    ),
+  }),
+);
+
 const OpenOnMount = () => {
   const { openLogTracesDrawer } = useHomePageViewState();
   React.useEffect(() => {
@@ -21,7 +43,7 @@ const OpenOnMount = () => {
 };
 
 describe('LogTracesDrawer', () => {
-  it('renders the drawer with default framework selected', () => {
+  it('renders the drawer with AI assistant quickstart selected by default', () => {
     renderWithDesignSystem(
       <MemoryRouter>
         <OpenOnMount />
@@ -35,12 +57,12 @@ describe('LogTracesDrawer', () => {
       }),
     ).toBeInTheDocument();
 
-    const openAiButton = screen.getByRole('button', { name: 'OpenAI' });
-    expect(openAiButton).toHaveAttribute('aria-pressed', 'true');
+    const aiAssistantsButton = screen.getByRole('button', { name: 'AI assistants' });
+    expect(aiAssistantsButton).toHaveAttribute('aria-pressed', 'true');
 
-    const quickstart = screen.getByTestId('quickstart');
-    expect(quickstart).toHaveAttribute('data-flavor', 'openai');
-    expect(quickstart).toHaveAttribute('data-base', 'mlflow.home.log_traces.drawer.openai');
+    const quickstart = screen.getByTestId('ai-assistant-quickstart');
+    expect(quickstart).toHaveAttribute('data-tracking-uri', 'http://<tracking-server-host>:<port>');
+    expect(quickstart).toHaveAttribute('data-experiment-name', 'traces-quickstart');
   });
 
   it('updates quickstart content when selecting a different framework', async () => {
@@ -55,10 +77,29 @@ describe('LogTracesDrawer', () => {
     await userEvent.click(langChainButton);
 
     expect(langChainButton).toHaveAttribute('aria-pressed', 'true');
-    expect(screen.getByRole('button', { name: 'OpenAI' })).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByRole('button', { name: 'AI assistants' })).toHaveAttribute('aria-pressed', 'false');
 
     const quickstart = screen.getByTestId('quickstart');
     expect(quickstart).toHaveAttribute('data-flavor', 'langchain');
     expect(quickstart).toHaveAttribute('data-base', 'mlflow.home.log_traces.drawer.langchain');
+  });
+
+  it('renders the OpenAI quickstart after switching away from AI assistants', async () => {
+    renderWithDesignSystem(
+      <MemoryRouter>
+        <OpenOnMount />
+        <LogTracesDrawer />
+      </MemoryRouter>,
+    );
+
+    const openAiButton = screen.getByRole('button', { name: 'OpenAI' });
+    await userEvent.click(openAiButton);
+
+    expect(openAiButton).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'AI assistants' })).toHaveAttribute('aria-pressed', 'false');
+
+    const quickstart = screen.getByTestId('quickstart');
+    expect(quickstart).toHaveAttribute('data-flavor', 'openai');
+    expect(quickstart).toHaveAttribute('data-base', 'mlflow.home.log_traces.drawer.openai');
   });
 });

--- a/mlflow/server/js/src/home/components/LogTracesDrawer.tsx
+++ b/mlflow/server/js/src/home/components/LogTracesDrawer.tsx
@@ -9,9 +9,9 @@ import {
   WorkflowsIcon,
 } from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
-import { QUICKSTART_CONTENT } from '@mlflow/mlflow/src/experiment-tracking/components/traces/quickstart/TraceTableQuickstart.utils';
 import { TraceTableGenericQuickstart } from '@mlflow/mlflow/src/experiment-tracking/components/traces/quickstart/TraceTableGenericQuickstart';
 import type { QUICKSTART_FLAVOR } from '@mlflow/mlflow/src/experiment-tracking/components/traces/quickstart/TraceTableQuickstart.utils';
+import { TraceTableAiAssistantQuickstart } from '@mlflow/mlflow/src/experiment-tracking/components/traces/quickstart/TraceTableAiAssistantQuickstart';
 import { CopyButton } from '@mlflow/mlflow/src/shared/building_blocks/CopyButton';
 import { CodeSnippet } from '@databricks/web-shared/snippet';
 import { Link, useSearchParams } from '../../common/utils/RoutingUtils';
@@ -33,7 +33,8 @@ import AutoGenLogo from '../../common/static/logos/autogen.png';
 import CrewAILogo from '../../common/static/logos/crewai.png';
 import { useHomePageViewState } from '../HomePageViewStateContext';
 
-type SupportedQuickstartFlavor = QUICKSTART_FLAVOR;
+type AgentQuickstartFlavor = 'ai-assistant';
+type SupportedQuickstartFlavor = QUICKSTART_FLAVOR | AgentQuickstartFlavor;
 
 type FrameworkDefinition = {
   id: SupportedQuickstartFlavor;
@@ -43,6 +44,10 @@ type FrameworkDefinition = {
 };
 
 const frameworks: FrameworkDefinition[] = [
+  {
+    id: 'ai-assistant',
+    message: 'AI assistants',
+  },
   {
     id: 'openai',
     message: 'OpenAI',
@@ -106,20 +111,22 @@ const frameworks: FrameworkDefinition[] = [
 const MORE_INTEGRATIONS_URL = 'https://mlflow.org/docs/latest/genai/tracing/#one-line-auto-tracing-integrations';
 
 const TRACING_DOCS_URL = 'https://mlflow.org/docs/latest/genai/tracing/';
+const TRACE_QUICKSTART_EXPERIMENT_NAME = 'traces-quickstart';
+const TRACE_QUICKSTART_TRACKING_URI = 'http://<tracking-server-host>:<port>';
 
 const getConfigureExperimentSnippet = (workspace?: string | null) => {
   const workspaceLine = workspace ? `mlflow.set_workspace("${workspace}")\n` : '';
   return `import mlflow
 
 # Specify the tracking server URI, e.g. http://localhost:5000
-mlflow.set_tracking_uri("http://<tracking-server-host>:<port>")
-${workspaceLine}# If the experiment with the name "traces-quickstart" doesn't exist, MLflow will create it
-mlflow.set_experiment("traces-quickstart")`;
+mlflow.set_tracking_uri("${TRACE_QUICKSTART_TRACKING_URI}")
+${workspaceLine}# If the experiment with the name "${TRACE_QUICKSTART_EXPERIMENT_NAME}" doesn't exist, MLflow will create it
+mlflow.set_experiment("${TRACE_QUICKSTART_EXPERIMENT_NAME}")`;
 };
 
 export const LogTracesDrawer = () => {
   const { theme } = useDesignSystemTheme();
-  const [selectedFramework, setSelectedFramework] = useState<SupportedQuickstartFlavor>('openai');
+  const [selectedFramework, setSelectedFramework] = useState<SupportedQuickstartFlavor>('ai-assistant');
   const { isLogTracesDrawerOpen, closeLogTracesDrawer } = useHomePageViewState();
   const [searchParams] = useSearchParams();
   const activeWorkspace = extractWorkspaceFromSearchParams(searchParams);
@@ -127,7 +134,7 @@ export const LogTracesDrawer = () => {
 
   const handleOpenChange = (open: boolean) => {
     if (!open) {
-      setSelectedFramework('openai');
+      setSelectedFramework('ai-assistant');
       closeLogTracesDrawer();
     }
   };
@@ -314,10 +321,19 @@ export const LogTracesDrawer = () => {
                   description="Section title introducing the tracing quickstart example"
                 />
               </Typography.Title>
-              <TraceTableGenericQuickstart
-                flavorName={selectedFramework}
-                baseComponentId={`mlflow.home.log_traces.drawer.${selectedFramework}`}
-              />
+              {selectedFramework === 'ai-assistant' ? (
+                <TraceTableAiAssistantQuickstart
+                  theme={theme}
+                  trackingUri={TRACE_QUICKSTART_TRACKING_URI}
+                  experimentName={TRACE_QUICKSTART_EXPERIMENT_NAME}
+                  workspace={activeWorkspace}
+                />
+              ) : (
+                <TraceTableGenericQuickstart
+                  flavorName={selectedFramework}
+                  baseComponentId={`mlflow.home.log_traces.drawer.${selectedFramework}`}
+                />
+              )}
             </section>
 
             <section


### PR DESCRIPTION
### Related Issues/PRs

Relates to MLflow Skills onboarding improvements

### What changes are proposed in this pull request?

This PR adds an AI assistant quickstart flow to MLflow tracing onboarding.

The new flow:

- Adds an `AI assistants` onboarding option to the traces empty state.
- Adds an `AI assistants` option to the Home page `Log traces` drawer.
- Shows the MLflow Skills installation command: `npx skills add mlflow/skills`
- Provides a copyable prompt based on the MLflow Skills README example, with the current tracking URI, experiment name, and workspace context when available.
- Reuses the existing tracing onboarding step and code block UI patterns.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Tested with:

```bash
yarn test src/home/components/LogTracesDrawer.test.tsx --runInBand
yarn eslint src/experiment-tracking/components/traces/quickstart/TraceTableAiAssistantQuickstart.tsx src/experiment-tracking/components/traces/quickstart/TraceTableQuickstart.utils.tsx src/experiment-tracking/components/traces/quickstart/TracesViewTableNoTracesQuickstart.tsx src/experiment-tracking/components/traces/quickstart/components/LanguageTab.tsx src/experiment-tracking/components/traces/quickstart/components/CodeBlock.tsx src/home/components/LogTracesDrawer.tsx src/home/components/LogTracesDrawer.test.tsx
yarn type-check
```

Also manually verified the onboarding flow in the local MLflow UI.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

This PR references the existing MLflow Skills install command and example prompt from the Skills README. No Skills repository changes are required.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Adds an AI assistant quickstart flow to MLflow tracing onboarding, making it easier to install MLflow Skills and ask coding agents to add tracing to an app.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mlflow/codesmith/mlflow/pr/23453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->