### PR TITLE
pr-review skill: clarify hunk-anchor rules in payload schema

### DIFF
--- a/.claude/skills/pr-review/review-payload.schema.json
+++ b/.claude/skills/pr-review/review-payload.schema.json
@@ -61,7 +61,7 @@
       "required": ["path", "body", "line", "side"],
       "properties": {
         "path": {
-          "description": "File path relative to the repo root. Must match a path present in the PR diff.",
+          "description": "File path relative to the repo root. Must be a file with at least one hunk in the PR diff.",
           "type": "string",
           "minLength": 1
         },
@@ -71,21 +71,21 @@
           "pattern": "^(🔴 \\*\\*CRITICAL:\\*\\*|🟡 \\*\\*MODERATE:\\*\\*|🟢 \\*\\*NIT:\\*\\*) "
         },
         "line": {
-          "description": "Line number to anchor to. For multi-line comments, this is the last line of the range.",
+          "description": "Anchor line. Must be inside a diff hunk on the chosen side (added/context on RIGHT, deleted/context on LEFT). For multi-line comments, this is the last line of the range.",
           "type": "integer",
           "minimum": 1
         },
         "side": {
-          "description": "RIGHT for added/modified lines, LEFT for deleted lines.",
+          "description": "RIGHT for the post-merge file (added/context lines), LEFT for the pre-change file (deleted/context lines). RIGHT is the common case.",
           "$ref": "#/$defs/side"
         },
         "start_line": {
-          "description": "First line of a multi-line comment range. Required together with start_side.",
+          "description": "First line of a multi-line range. Same hunk requirement as `line`, and must be < line. Must be set together with start_side.",
           "type": "integer",
           "minimum": 1
         },
         "start_side": {
-          "description": "Side for start_line. Required together with start_line.",
+          "description": "Side for start_line. Must be set together with start_line.",
           "$ref": "#/$defs/side"
         }
       },


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23450

### What changes are proposed in this pull request?

Clarify the inline-comment fields in `.claude/skills/pr-review/review-payload.schema.json` so the model picks anchor positions GitHub can resolve.

Motivation: a recent `/review` run failed with `HTTP 422 "Line could not be resolved"` because the inline comment was anchored to a line outside any diff hunk. The schema descriptions for `line`/`side`/`start_line`/`start_side` didn't say the anchor must lie inside a hunk on the chosen side, so the model had no way to know that from the schema alone.

Only descriptions change. No validation behavior changes; runtime enforcement against the diff would need to live in `validate-review` and is left as a follow-up.

### How is this PR tested?

- [x] Manual tests

JSON re-parsed cleanly after the edit.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mlflow/codesmith/mlflow/pr/23454"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->