### PR TITLE
Default `/review` to Opus 4.7 for large PRs

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -160,7 +160,7 @@ jobs:
               "opus",
               "sonnet",
               "haiku",
-              "claude-opus-4-6",
+              "claude-opus-4-7",
               "claude-sonnet-4-6",
               "claude-haiku-4-5",
           ]
@@ -168,7 +168,7 @@ jobs:
 
           labels = {l["name"] for l in json.loads(os.environ["LABELS_JSON"])}
           big = bool(labels & {"size/M", "size/L", "size/XL"})
-          default_model = "claude-opus-4-6" if big else "claude-sonnet-4-6"
+          default_model = "claude-opus-4-7" if big else "claude-sonnet-4-6"
 
           body = sys.stdin.read().removeprefix("/review")
           head, sep, tail = body.partition("\n")


### PR DESCRIPTION
### Related Issues/PRs

Relates to #review-workflow

### What changes are proposed in this pull request?

Update the `review` workflow to use `claude-opus-4-7` in place of `claude-opus-4-6`:

- Add `claude-opus-4-7` to `MODEL_CHOICES` (and drop `claude-opus-4-6`).
- Make `claude-opus-4-7` the default model for `size/M`, `size/L`, and `size/XL` PRs.

Opus 4.7 is the newer Opus generation with stronger reasoning/coding performance; pricing per token is unchanged from 4.6.

### How is this PR tested?

- [x] Manual tests

The workflow's `pull_request` trigger runs an end-to-end smoke against this PR (Post is gated off, so no review is submitted).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mlflow/codesmith/mlflow/pr/23457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->