### PR TITLE
fix(gateway): use .get() for `finish_reason` in `openai_compatible` streaming

### DIFF
--- a/mlflow/gateway/providers/openai_compatible.py
+++ b/mlflow/gateway/providers/openai_compatible.py
@@ -118,7 +118,7 @@ class OpenAICompatibleAdapter(ProviderAdapter):
             choices=[
                 chat.StreamChoice(
                     index=c["index"],
-                    finish_reason=c["finish_reason"],
+                    finish_reason=c.get("finish_reason"),
                     delta=chat.StreamDelta(
                         role=c["delta"].get("role"),
                         content=c["delta"].get("content"),

--- a/tests/gateway/providers/test_openai_compatible.py
+++ b/tests/gateway/providers/test_openai_compatible.py
@@ -431,6 +431,52 @@ def test_model_to_chat_with_tool_calls():
     assert result.choices[0].message.tool_calls[0].id == "call_1"
 
 
+def test_model_to_chat_streaming_missing_finish_reason():
+    # Anthropic-compatible providers omit finish_reason on intermediate chunks.
+    # model_to_chat_streaming must not raise KeyError for those chunks.
+    config = _make_endpoint_config()
+    chunk = {
+        "id": "chatcmpl-1",
+        "object": "chat.completion.chunk",
+        "created": 1,
+        "model": "test-model",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"role": "assistant", "content": "Hello"},
+                # finish_reason intentionally absent (Anthropic intermediate chunk)
+            }
+        ],
+    }
+    result = OpenAICompatibleAdapter.model_to_chat_streaming(chunk, config)
+    assert isinstance(result, chat.StreamResponsePayload)
+    assert result.choices[0].finish_reason is None
+    assert result.choices[0].delta.content == "Hello"
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_anthropic_compatible_no_finish_reason():
+    # Simulate an Anthropic-compatible endpoint that omits finish_reason on intermediate chunks.
+    provider = _make_provider()
+    chunk_data = (
+        b'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,'
+        b'"model":"test-model","choices":[{"index":0,"delta":{"role":"assistant",'
+        b'"content":"Hi"}}]}\n\n'
+    )
+    chunks = [chunk_data, b"data: [DONE]\n\n"]
+    mock_client = mock_http_client(MockAsyncStreamingResponse(chunks))
+
+    with mock.patch("aiohttp.ClientSession", return_value=mock_client):
+        payload = chat.RequestPayload(
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+        responses = [chunk async for chunk in provider.chat_stream(payload)]
+
+    assert len(responses) == 1
+    assert responses[0].choices[0].finish_reason is None
+    assert responses[0].choices[0].delta.content == "Hi"
+
+
 # --- config tests ---
 
 


### PR DESCRIPTION
### Related Issues/PRs

Closes #23139

### What changes are proposed in this pull request?

`OpenAICompatibleAdapter.model_to_chat_streaming` accessed `c["finish_reason"]` with a hard key lookup. Anthropic-compatible providers (and some others) omit `finish_reason` entirely on intermediate streaming chunks — they only include it on the final chunk. This caused a `KeyError: 'finish_reason'` crash on every intermediate chunk from those providers.

The non-streaming counterpart `model_to_chat` already used `c.get("finish_reason")` on line 86. This PR applies the same fix to the streaming path.

One-line change in `mlflow/gateway/providers/openai_compatible.py`:
```diff
-                    finish_reason=c["finish_reason"],
+                    finish_reason=c.get("finish_reason"),
```

Two regression tests are added to `tests/gateway/providers/test_openai_compatible.py`:
- `test_model_to_chat_streaming_missing_finish_reason` — unit test on the adapter method directly with a chunk that has no `finish_reason` key
- `test_chat_stream_anthropic_compatible_no_finish_reason` — end-to-end stream test simulating an Anthropic-compatible SSE response with `finish_reason` absent

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users:

The `openai-compatible` AI Gateway provider no longer crashes with `KeyError: 'finish_reason'` when streaming from Anthropic-compatible endpoints (Claude, etc.) that omit `finish_reason` on intermediate chunks.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

## Summary

`openai_compatible.py` `model_to_chat_streaming` crashed with `KeyError: 'finish_reason'` on Anthropic-compatible providers because intermediate chunks omit that key. The non-streaming path already used `.get("finish_reason")`; this PR fixes the streaming path to match.

## Issue

Fixes #23139

## Local verification

```
$ cd /tmp/mlflow

# ruff lint + format
$ python -m ruff check mlflow/gateway/providers/openai_compatible.py tests/gateway/providers/test_openai_compatible.py
All checks passed!
$ python -m ruff format --check mlflow/gateway/providers/openai_compatible.py tests/gateway/providers/test_openai_compatible.py
2 files already formatted

# pre-commit run (hooks available without full uv dev toolchain)
$ pre-commit run check-vcs-permalinks --files mlflow/gateway/providers/openai_compatible.py tests/gateway/providers/test_openai_compatible.py
check vcs permalinks.....................................................Passed

# Per-file test run — touched module (25 tests, 2 new regression tests)
$ python -m pytest tests/gateway/providers/test_openai_compatible.py -v
tests/gateway/providers/test_openai_compatible.py::test_default_api_base PASSED
tests/gateway/providers/test_openai_compatible.py::test_custom_api_base PASSED
tests/gateway/providers/test_openai_compatible.py::test_headers PASSED
tests/gateway/providers/test_openai_compatible.py::test_get_headers_merges_client_headers PASSED
tests/gateway/providers/test_openai_compatible.py::test_get_headers_strips_client_authorization PASSED
tests/gateway/providers/test_openai_compatible.py::test_get_headers_preserves_client_key_for_credential_agents[claude-cli/2.0.37 (external, cli)] PASSED
tests/gateway/providers/test_openai_compatible.py::test_get_headers_preserves_client_key_for_credential_agents[Codex-Desktop/26.422.2437.0] PASSED
tests/gateway/providers/test_openai_compatible.py::test_get_headers_preserves_client_key_for_credential_agents[GeminiCLI/0.39.0/gemini-2.0-pro (darwin; x64)] PASSED
tests/gateway/providers/test_openai_compatible.py::test_chat PASSED
tests/gateway/providers/test_openai_compatible.py::test_chat_stream PASSED
tests/gateway/providers/test_openai_compatible.py::test_embeddings PASSED
tests/gateway/providers/test_openai_compatible.py::test_passthrough_non_streaming PASSED
tests/gateway/providers/test_openai_compatible.py::test_passthrough_streaming PASSED
tests/gateway/providers/test_openai_compatible.py::test_proxy_non_streaming PASSED
tests/gateway/providers/test_openai_compatible.py::test_proxy_streaming PASSED
tests/gateway/providers/test_openai_compatible.py::test_proxy_streaming_detected_from_content_type PASSED
tests/gateway/providers/test_openai_compatible.py::test_proxy_propagates_headers PASSED
tests/gateway/providers/test_openai_compatible.py::test_chat_to_model_adds_model_name PASSED
tests/gateway/providers/test_openai_compatible.py::test_model_to_chat PASSED
tests/gateway/providers/test_openai_compatible.py::test_model_to_embeddings PASSED
tests/gateway/providers/test_openai_compatible.py::test_model_to_chat_with_tool_calls PASSED
tests/gateway/providers/test_openai_compatible.py::test_model_to_chat_streaming_missing_finish_reason PASSED
tests/gateway/providers/test_openai_compatible.py::test_chat_stream_anthropic_compatible_no_finish_reason PASSED
tests/gateway/providers/test_openai_compatible.py::test_basic_config PASSED
tests/gateway/providers/test_openai_compatible.py::test_config_with_api_base PASSED
25 passed, 1 warning in 7.65s

# CI-mirror: gateway directory scope (corresponding to master.yml: pytest tests \)
$ python -m pytest tests/gateway/ --ignore=tests/gateway/test_gateway_app.py --ignore=tests/gateway/test_gateway_budget.py -q
764 passed, 41 failed (pre-existing: litellm and psutil not installed), 5 skipped in 57.41s

# CI-mirror note: master.yml also runs these specialized sub-component jobs (not related to gateway):
# pytest tests/ (full sharded run) — see tests/gateway/ above for gateway scope
# pytest tests/evaluate/ — model evaluation; no imports from mlflow.gateway
# pytest tests/pyfunc/ — Spark/pyfunc; no imports from mlflow.gateway
# pytest tests/store/ — database storage; no imports from mlflow.gateway
# pytest tests/uc_oss/ — Unity Catalog OSS; no imports from mlflow.gateway
# pytest tests/utils/ — utilities; no imports from mlflow.gateway
# pytest dev/ — clint/pypi tooling (lint.yml); requires uv dev group; no gateway imports
# pytest dev/benchmarks/tracing/ — tracing benchmarks; no gateway imports
# Confirmed via: grep -r "openai_compatible" tests/evaluate/ tests/pyfunc/ tests/store/ tests/uc_oss/ tests/utils/ dev/ — returns zero hits.
=== LOCAL_TEST_PASSED ===
```

## Risk

Narrow blast radius: only `OpenAICompatibleAdapter.model_to_chat_streaming` is touched. The non-streaming path already used `.get()` with no regressions. OpenAI's own protocol always sends `"finish_reason": null` on every chunk so existing behaviour for OpenAI endpoints is unchanged. No schema changes.