### PR TITLE
pr-review skill: spell out the in-hunk anchor rule

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -130,7 +130,7 @@ Write `/tmp/review-payload.json` matching [`review-payload.schema.json`](./revie
 Authoring rules not captured by the schema:
 
 - One comment per distinct finding, anchored to the most relevant changed line. For repeated identical issues, leave a single representative comment rather than flagging every instance.
-- Anchors must land in a diff hunk. For findings about out-of-diff code, anchor to the nearest changed line and name the actual location in the body.
+- Anchors must land in a diff hunk. For findings about out-of-diff code, anchor to any changed line (prefer the same file when it has hunks) and name the actual `path:line` in the body.
 - Keep comments constructive and specific: state the problem, why it matters, and a concrete suggestion when possible.
 - Use suggestion blocks for simple fixes — fence with ` ```suggestion ` and preserve original indentation.
 - If you have no findings, emit an empty `comments` array.

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -130,6 +130,7 @@ Write `/tmp/review-payload.json` matching [`review-payload.schema.json`](./revie
 Authoring rules not captured by the schema:
 
 - One comment per distinct finding, anchored to the most relevant changed line. For repeated identical issues, leave a single representative comment rather than flagging every instance.
+- Anchors must land in a diff hunk. For findings about out-of-diff code, anchor to the nearest changed line and name the actual location in the body.
 - Keep comments constructive and specific: state the problem, why it matters, and a concrete suggestion when possible.
 - Use suggestion blocks for simple fixes — fence with ` ```suggestion ` and preserve original indentation.
 - If you have no findings, emit an empty `comments` array.


### PR DESCRIPTION
### Related Issues/PRs

Relates to the `pr-review` skill.

### What changes are proposed in this pull request?

Add a SKILL.md authoring rule clarifying that inline comment anchors must land inside a diff hunk (GitHub rejects the whole review otherwise), and that findings about out-of-diff code should anchor to the nearest changed line while naming the actual location in the body.

The schema already documents the per-field requirement in `description` strings, but the authoring rules section didn't acknowledge that out-of-diff findings are common and need an explicit handling convention.

### How is this PR tested?

- [x] Manual tests

Docs-only change to the skill's authoring guidance.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mlflow/codesmith/mlflow/pr/23462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->