### PR TITLE
Don't cancel in-progress reviews on unrelated PR comments

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -10,7 +10,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 defaults:
   run:


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23462 (where this was observed)

### What changes are proposed in this pull request?

`review.yml` uses `cancel-in-progress: true` on a concurrency group keyed by PR/issue number. Concurrency is evaluated before any job `if:`, so **any** new `issue_comment` event on the PR cancels an in-progress review -- including bot comments (e.g., `nailaopus[bot]` posting an inline review) that the gate would have rejected anyway.

Change `cancel-in-progress` to only apply on `pull_request` events. For `issue_comment`, queued runs go Pending until the in-progress one finishes, then skip in seconds at the gate. They never consume runner minutes (a Pending run isn't running).

Example of the bug: https://github.com/mlflow/mlflow/actions/runs/26085102170?pr=23462 -- a real `/review` got cancelled by a follow-up bot comment.

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)