### PR TITLE
Add WAL foundational files for async batch trace export for TS claude code integration

### DIFF
--- a/libs/typescript/core/src/exporters/wal/constants.ts
+++ b/libs/typescript/core/src/exporters/wal/constants.ts
@@ -1,0 +1,48 @@
+/**
+ * Tunable defaults for the WAL exporter and uploader daemon.
+ *
+ * All values can be overridden by environment variables. Env vars are read
+ * at module load time, so changes take effect the next time the process
+ * that imports this module starts (e.g. the next Stop hook invocation, or
+ * the next daemon respawn after an idle exit).
+ */
+
+function readPositiveInt(envName: string, fallback: number): number {
+  const raw = process.env[envName];
+  if (raw === undefined || raw === '') {
+    return fallback;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    console.warn(
+      `[mlflow][wal] Ignoring invalid ${envName}=${JSON.stringify(raw)}; ` +
+        `expected a positive integer. Falling back to default ${fallback}.`,
+    );
+    return fallback;
+  }
+  return parsed;
+}
+
+/**
+ * Maximum number of upload attempts per record before the daemon moves the
+ * record to the dead-letter file (`failed.log`).
+ *
+ * Override via `MLFLOW_TRACE_MAX_RETRY_ATTEMPTS`.
+ */
+export const MAX_ATTEMPTS: number = readPositiveInt('MLFLOW_TRACE_MAX_RETRY_ATTEMPTS', 10);
+
+/**
+ * Interval between daemon batch loop iterations, in milliseconds.
+ *
+ * Override via `MLFLOW_TRACE_BATCH_INTERVAL_MS`.
+ */
+export const BATCH_INTERVAL_MS: number = readPositiveInt('MLFLOW_TRACE_BATCH_INTERVAL_MS', 15_000);
+
+/**
+ * Threshold for daemon idle shutdown, in milliseconds. After this much
+ * time with the WAL empty and no new records appended, the daemon flushes,
+ * releases its lock, and exits.
+ *
+ * Override via `MLFLOW_TRACE_DAEMON_IDLE_MS`.
+ */
+export const IDLE_MS: number = readPositiveInt('MLFLOW_TRACE_DAEMON_IDLE_MS', 120_000);

--- a/libs/typescript/core/src/exporters/wal/constants.ts
+++ b/libs/typescript/core/src/exporters/wal/constants.ts
@@ -12,8 +12,11 @@ function readPositiveInt(envName: string, fallback: number): number {
   if (raw === undefined || raw === '') {
     return fallback;
   }
-  const parsed = Number.parseInt(raw, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
+  // `Number` (vs `Number.parseInt`) refuses trailing garbage and unit
+  // suffixes — e.g. "15000abc", "15s", and "10.9" all become NaN or a
+  // non-integer, so the `isInteger` check below rejects them cleanly.
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
     console.warn(
       `[mlflow][wal] Ignoring invalid ${envName}=${JSON.stringify(raw)}; ` +
         `expected a positive integer. Falling back to default ${fallback}.`,

--- a/libs/typescript/core/src/exporters/wal/paths.ts
+++ b/libs/typescript/core/src/exporters/wal/paths.ts
@@ -1,26 +1,52 @@
 /**
- * Filesystem paths for the per-user MLflow trace WAL (Write-Ahead Log) spool.
+ * Filesystem paths for the MLflow trace WAL (Write-Ahead Log) spool.
  *
- * The spool is shared across all Claude Code sessions (and other MLflow TS
- * integrations) for a single OS user. All paths derive from the spool root,
- * which can be overridden by setting `MLFLOW_WAL_DIR`.
+ * A spool is shared across all Claude Code sessions (and other MLflow TS
+ * integrations) that resolve to the same `MLFLOW_WAL_DIR` for a single OS
+ * user. The WAL data files (`queue.log`, `failed.log`, `daemon.log`)
+ * always live inside the resolved spool root.
+ *
+ * The daemon's singleton lock is scoped per `(user, spool root)` on both
+ * platforms; its exact location depends on the platform and the resolved
+ * spool root's length:
+ * - POSIX, common case: `<spool>/daemon.sock` next to `queue.log`.
+ * - POSIX, long-path fallback: `<tmpdir>/mlflow-<scoped_id>.sock` when the
+ *   natural path would exceed `sun_path`.
+ * - Windows: a Named Pipe whose name embeds a hash of the spool root.
+ *
+ * See {@link getLockSocketPath} for the full rationale.
  */
 
-import { homedir, platform, userInfo } from 'node:os';
-import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { homedir, platform, tmpdir, userInfo } from 'node:os';
+import { join, resolve } from 'node:path';
+
+/**
+ * Maximum allowed length, in bytes, for a UNIX domain socket path.
+ *
+ * `sun_path` is fixed-size in `struct sockaddr_un`: 108 bytes on Linux,
+ * 104 on macOS/BSD. Each is one byte of NUL terminator, so the actual
+ * string max is 107 / 103 respectively. We use the tighter macOS/BSD
+ * limit (103) for the check so the same code works on both kernels
+ * without per-platform branching.
+ */
+const POSIX_SOCKET_PATH_MAX_BYTES = 103;
 
 /**
  * Root directory of the per-user spool. Defaults to `~/.mlflow/wal/`.
+ *
+ * The result is always an absolute, resolved path so that callers comparing
+ * or hashing the WAL dir cannot accidentally treat `/tmp/foo` and
+ * `/tmp/foo/` as two different roots.
  *
  * Empty-string values for `MLFLOW_WAL_DIR` (e.g. `export MLFLOW_WAL_DIR=""`)
  * are treated the same as unset to avoid silently producing relative paths.
  */
 export function getWalDir(): string {
   const override = process.env.MLFLOW_WAL_DIR;
-  if (override !== undefined && override !== '') {
-    return override;
-  }
-  return join(homedir(), '.mlflow', 'wal');
+  const raw =
+    override !== undefined && override !== '' ? override : join(homedir(), '.mlflow', 'wal');
+  return resolve(raw);
 }
 
 /**
@@ -47,24 +73,67 @@ export function getDaemonLogPath(): string {
 }
 
 /**
+ * Stable per-`(user, wal_dir)` identifier used to scope the daemon lock when
+ * the lock cannot simply live inside the WAL dir (Windows pipe namespace,
+ * POSIX `tmpdir` fallback). 12 hex chars (~48 bits) of SHA-256 is plenty
+ * for the handful of distinct WAL dirs a single user would realistically
+ * use, and the sanitized username keeps multi-user hosts isolated.
+ */
+function getScopedLockId(): string {
+  const sanitizedUser = userInfo().username.replace(/[^a-zA-Z0-9_-]/g, '_');
+  const walDirHash = createHash('sha256').update(getWalDir()).digest('hex').slice(0, 12);
+  return `${sanitizedUser}-${walDirHash}`;
+}
+
+/**
  * Path used as the daemon's singleton liveness lock.
  *
- * - POSIX: a UNIX domain socket file at `<wal_dir>/daemon.sock`. The daemon
- *   binds it with `net.createServer().listen()` for its whole lifetime;
- *   the kernel's exclusive-bind semantic on that path is what gives us the
- *   at-most-one-daemon guarantee.
- * - Windows: a Named Pipe at `\\?\pipe\mlflow-trace-daemon-<user>`. Same
- *   `net.createServer().listen()` API, different kernel object. Named pipes
- *   are kernel-refcounted and disappear automatically on process exit, so
- *   no stale-cleanup logic is needed there.
+ * The lock is scoped per `(user, wal_dir)` on both platforms so that a user
+ * with two terminals overriding `MLFLOW_WAL_DIR` to different values gets
+ * one independent daemon per WAL dir (each daemon only reads its own
+ * `queue.log`). A single shared lock identifier would otherwise let one
+ * daemon claim the lock and leave the other WAL stranded.
  *
- * The username is sanitized into the pipe name to keep it a valid Windows
- * path component and to scope the pipe per OS user.
+ * - **POSIX, common case**: a UNIX domain socket file at
+ *   `<wal_dir>/daemon.sock`. The daemon binds it with
+ *   `net.createServer().listen()` for its whole lifetime; the kernel's
+ *   exclusive-bind semantic on that path is what gives us the
+ *   at-most-one-daemon guarantee. Scoping falls out naturally from the
+ *   socket file living inside the WAL dir.
+ * - **POSIX, long-path fallback**: `<wal_dir>/daemon.sock` can exceed the
+ *   fixed `sun_path` size (104 bytes on macOS/BSD, 108 on Linux), e.g.
+ *   if `MLFLOW_WAL_DIR` resolves to a sandboxed container dir or a deep
+ *   user folder. When the natural path would exceed
+ *   {@link POSIX_SOCKET_PATH_MAX_BYTES}, the socket falls back to
+ *   `<tmpdir>/mlflow-<scoped_id>.sock`. A `console.warn` makes the
+ *   deviation discoverable. Per-(user, wal_dir) scoping is preserved by
+ *   the `<scoped_id>` suffix.
+ * - **Windows**: a Named Pipe at `\\?\pipe\mlflow-trace-daemon-<scoped_id>`.
+ *   Named pipes share a single flat namespace per machine, so the pipe
+ *   name has to encode both the user (to keep multi-user hosts isolated)
+ *   and a hash of the resolved WAL dir (to match POSIX's per-WAL-dir
+ *   scoping). Named pipes are kernel-refcounted and disappear
+ *   automatically on process exit, so no stale-cleanup logic is needed.
  */
 export function getLockSocketPath(): string {
+  const scopedId = getScopedLockId();
+
   if (platform() === 'win32') {
-    const sanitizedUser = userInfo().username.replace(/[^a-zA-Z0-9_-]/g, '_');
-    return `\\\\?\\pipe\\mlflow-trace-daemon-${sanitizedUser}`;
+    return `\\\\?\\pipe\\mlflow-trace-daemon-${scopedId}`;
   }
-  return join(getWalDir(), 'daemon.sock');
+
+  const naturalPath = join(getWalDir(), 'daemon.sock');
+  if (Buffer.byteLength(naturalPath, 'utf8') <= POSIX_SOCKET_PATH_MAX_BYTES) {
+    return naturalPath;
+  }
+
+  // Short basename so the fallback itself stays under sun_path even on
+  // macOS, whose tmpdir is already ~49 chars (`/var/folders/<2>/<30>/T/`).
+  const fallback = join(tmpdir(), `mlflow-${scopedId}.sock`);
+  console.warn(
+    `[mlflow][wal] WAL dir produces a socket path longer than ` +
+      `${POSIX_SOCKET_PATH_MAX_BYTES} bytes (${Buffer.byteLength(naturalPath, 'utf8')}); ` +
+      `using ${fallback} for the daemon lock instead.`,
+  );
+  return fallback;
 }

--- a/libs/typescript/core/src/exporters/wal/paths.ts
+++ b/libs/typescript/core/src/exporters/wal/paths.ts
@@ -1,0 +1,70 @@
+/**
+ * Filesystem paths for the per-user MLflow trace WAL (Write-Ahead Log) spool.
+ *
+ * The spool is shared across all Claude Code sessions (and other MLflow TS
+ * integrations) for a single OS user. All paths derive from the spool root,
+ * which can be overridden by setting `MLFLOW_WAL_DIR`.
+ */
+
+import { homedir, platform, userInfo } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Root directory of the per-user spool. Defaults to `~/.mlflow/wal/`.
+ *
+ * Empty-string values for `MLFLOW_WAL_DIR` (e.g. `export MLFLOW_WAL_DIR=""`)
+ * are treated the same as unset to avoid silently producing relative paths.
+ */
+export function getWalDir(): string {
+  const override = process.env.MLFLOW_WAL_DIR;
+  if (override !== undefined && override !== '') {
+    return override;
+  }
+  return join(homedir(), '.mlflow', 'wal');
+}
+
+/**
+ * Append-only Write-Ahead Log of pending trace uploads.
+ */
+export function getWalPath(): string {
+  return join(getWalDir(), 'queue.log');
+}
+
+/**
+ * Append-only dead-letter file containing records that have exhausted
+ * `MLFLOW_TRACE_MAX_RETRY_ATTEMPTS` attempts. Records here are durable and
+ * inspectable / replayable by operators; the daemon never re-reads this file.
+ */
+export function getDeadLetterPath(): string {
+  return join(getWalDir(), 'failed.log');
+}
+
+/**
+ * Daemon log file with diagnostic lines (retries, DLQ entries, fatal errors).
+ */
+export function getDaemonLogPath(): string {
+  return join(getWalDir(), 'daemon.log');
+}
+
+/**
+ * Path used as the daemon's singleton liveness lock.
+ *
+ * - POSIX: a UNIX domain socket file at `<wal_dir>/daemon.sock`. The daemon
+ *   binds it with `net.createServer().listen()` for its whole lifetime;
+ *   the kernel's exclusive-bind semantic on that path is what gives us the
+ *   at-most-one-daemon guarantee.
+ * - Windows: a Named Pipe at `\\?\pipe\mlflow-trace-daemon-<user>`. Same
+ *   `net.createServer().listen()` API, different kernel object. Named pipes
+ *   are kernel-refcounted and disappear automatically on process exit, so
+ *   no stale-cleanup logic is needed there.
+ *
+ * The username is sanitized into the pipe name to keep it a valid Windows
+ * path component and to scope the pipe per OS user.
+ */
+export function getLockSocketPath(): string {
+  if (platform() === 'win32') {
+    const sanitizedUser = userInfo().username.replace(/[^a-zA-Z0-9_-]/g, '_');
+    return `\\\\?\\pipe\\mlflow-trace-daemon-${sanitizedUser}`;
+  }
+  return join(getWalDir(), 'daemon.sock');
+}

--- a/libs/typescript/core/src/exporters/wal/types.ts
+++ b/libs/typescript/core/src/exporters/wal/types.ts
@@ -44,6 +44,4 @@ export interface WalRecord {
  * `Map<id, WalRecord>`, applying tombstones as deletions. The "current"
  * set of pending records is whatever survives the replay.
  */
-export type WalLine =
-  | { type: 'append'; record: WalRecord }
-  | { type: 'tombstone'; id: string };
+export type WalLine = { type: 'append'; record: WalRecord } | { type: 'tombstone'; id: string };

--- a/libs/typescript/core/src/exporters/wal/types.ts
+++ b/libs/typescript/core/src/exporters/wal/types.ts
@@ -1,0 +1,49 @@
+/**
+ * Type definitions for the per-user trace upload WAL.
+ *
+ * The WAL is an append-only JSONL file. Each line is one of the variants of
+ * {@link WalLine}: either an append (a complete trace record) or a tombstone
+ * (a marker that shadows a previously-appended record by id).
+ */
+
+/**
+ * One queued trace upload, serialized to a single JSONL line.
+ *
+ * Field semantics:
+ * - `id`: a fresh uuid v4 per WAL row (not the MLflow trace id). Retries
+ *   tombstone the old row and re-append a new row with a fresh `id`, so
+ *   per-attempt rows are independently tombstone-addressable. The MLflow
+ *   trace id lives inside `traceInfo`.
+ * - `trackingUri`: routing key. The daemon groups records by this field
+ *   and uses one memoized `MlflowClient` per distinct value.
+ * - `experimentId`: captured at hook time so the daemon does not need to
+ *   re-resolve experiments at upload time.
+ * - `traceInfo` / `traceData`: results of `TraceInfo.toJson()` and
+ *   `TraceData.toJson()`. Deserialized via the corresponding `fromJson`
+ *   factories inside the daemon's batch loop.
+ * - `attempts`, `nextAttemptAt`: retry state. `nextAttemptAt` is the unix
+ *   ms epoch before which the daemon skips this record on a batch tick.
+ * - `createdAt`: when the record first entered the WAL (unix ms). Used
+ *   for diagnostics / ordering only; not part of retry semantics.
+ */
+export interface WalRecord {
+  id: string;
+  trackingUri: string;
+  experimentId: string;
+  traceInfo: Record<string, unknown>;
+  traceData: unknown;
+  attempts: number;
+  nextAttemptAt: number;
+  createdAt: number;
+}
+
+/**
+ * Discriminated union for a single line of the WAL file.
+ *
+ * Readers (`storage.readPending`) replay the file linewise into a
+ * `Map<id, WalRecord>`, applying tombstones as deletions. The "current"
+ * set of pending records is whatever survives the replay.
+ */
+export type WalLine =
+  | { type: 'append'; record: WalRecord }
+  | { type: 'tombstone'; id: string };

--- a/libs/typescript/core/tests/exporters/wal/paths.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/paths.test.ts
@@ -1,0 +1,120 @@
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+import { getLockSocketPath, getWalDir, getWalPath } from '../../../src/exporters/wal/paths';
+
+describe('wal/paths', () => {
+  const originalEnv = process.env.MLFLOW_WAL_DIR;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.MLFLOW_WAL_DIR;
+    } else {
+      process.env.MLFLOW_WAL_DIR = originalEnv;
+    }
+  });
+
+  describe('getWalDir', () => {
+    it('honors MLFLOW_WAL_DIR and returns an absolute, resolved path', () => {
+      process.env.MLFLOW_WAL_DIR = '/tmp/foo/';
+      expect(getWalDir()).toBe(resolve('/tmp/foo'));
+    });
+
+    it('treats empty MLFLOW_WAL_DIR as unset', () => {
+      process.env.MLFLOW_WAL_DIR = '';
+      expect(getWalDir()).toMatch(/[/\\]\.mlflow[/\\]wal$/);
+    });
+
+    it('produces the same value for /tmp/foo and /tmp/foo/', () => {
+      process.env.MLFLOW_WAL_DIR = '/tmp/foo';
+      const a = getWalDir();
+      process.env.MLFLOW_WAL_DIR = '/tmp/foo/';
+      const b = getWalDir();
+      expect(a).toBe(b);
+    });
+  });
+
+  describe('getLockSocketPath', () => {
+    let scratchDir: string;
+
+    beforeEach(async () => {
+      scratchDir = await mkdtemp(join(tmpdir(), 'mlflow-paths-'));
+      process.env.MLFLOW_WAL_DIR = scratchDir;
+    });
+
+    afterEach(async () => {
+      await rm(scratchDir, { recursive: true, force: true });
+    });
+
+    const isWindows = process.platform === 'win32';
+
+    (isWindows ? it.skip : it)('POSIX: returns <wal_dir>/daemon.sock for short WAL dirs', () => {
+      const lock = getLockSocketPath();
+      expect(lock).toBe(join(scratchDir, 'daemon.sock'));
+    });
+
+    (isWindows ? it.skip : it)(
+      'POSIX: falls back to tmpdir-based path when wal_dir would exceed sun_path',
+      () => {
+        // Construct a long WAL dir that pushes <wal_dir>/daemon.sock past 103
+        // bytes. We do not need this directory to exist; getLockSocketPath
+        // only inspects path lengths.
+        const longWalDir = '/tmp/' + 'x'.repeat(150);
+        process.env.MLFLOW_WAL_DIR = longWalDir;
+
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+          const lock = getLockSocketPath();
+          expect(lock.startsWith(tmpdir())).toBe(true);
+          expect(lock).toMatch(/[/\\]mlflow-[A-Za-z0-9._-]+-[0-9a-f]{12}\.sock$/);
+          expect(Buffer.byteLength(lock, 'utf8')).toBeLessThanOrEqual(103);
+          expect(warnSpy).toHaveBeenCalledTimes(1);
+          expect(warnSpy.mock.calls[0]?.[0]).toContain('longer than 103 bytes');
+        } finally {
+          warnSpy.mockRestore();
+        }
+      },
+    );
+
+    (isWindows ? it.skip : it)(
+      'POSIX: fallback identifier is stable for the same wal_dir and differs for distinct wal_dirs',
+      () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+          process.env.MLFLOW_WAL_DIR = '/tmp/' + 'a'.repeat(150);
+          const lockA1 = getLockSocketPath();
+          const lockA2 = getLockSocketPath();
+          process.env.MLFLOW_WAL_DIR = '/tmp/' + 'b'.repeat(150);
+          const lockB = getLockSocketPath();
+          expect(lockA1).toBe(lockA2);
+          expect(lockA1).not.toBe(lockB);
+        } finally {
+          warnSpy.mockRestore();
+        }
+      },
+    );
+
+    (isWindows ? it : it.skip)(
+      'Windows: returns a Named Pipe path scoped by user + wal_dir hash',
+      () => {
+        const lock = getLockSocketPath();
+        expect(lock).toMatch(/^\\\\\?\\pipe\\mlflow-trace-daemon-[A-Za-z0-9._-]+-[0-9a-f]{12}$/);
+      },
+    );
+
+    (isWindows ? it : it.skip)('Windows: pipe name differs for distinct wal_dirs', () => {
+      process.env.MLFLOW_WAL_DIR = 'C:\\tmp\\walA';
+      const lockA = getLockSocketPath();
+      process.env.MLFLOW_WAL_DIR = 'C:\\tmp\\walB';
+      const lockB = getLockSocketPath();
+      expect(lockA).not.toBe(lockB);
+    });
+  });
+
+  describe('getWalPath', () => {
+    it('lives inside the resolved WAL dir', () => {
+      process.env.MLFLOW_WAL_DIR = '/tmp/foo';
+      expect(getWalPath()).toBe(join(resolve('/tmp/foo'), 'queue.log'));
+    });
+  });
+});


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

This is part of a series of changes to support async batch tracing for TS Claude Code / Coding Agent LLM MLflow tracing 

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

### What changes are proposed in this pull request?
- paths.ts: per-user spool paths (queue.log, failed.log, daemon.log, daemon.sock/Named Pipe on Windows); MLFLOW_WAL_DIR override.
- types.ts: WalRecord interface and WalLine append/tombstone union.
- constants.ts: env-var-backed MAX_ATTEMPTS, BATCH_INTERVAL_MS, IDLE_MS with validation and a positive-int parser.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
