### PR TITLE
Release `_post_import_hooks_lock` before firing hooks

### DIFF
--- a/mlflow/utils/import_hooks/__init__.py
+++ b/mlflow/utils/import_hooks/__init__.py
@@ -202,23 +202,29 @@ def discover_post_import_hooks(group):
 # the import of the target module to fail.
 
 
-@synchronized(_post_import_hooks_lock)
 def notify_module_loaded(module):
+    # Snapshot hooks under the lock, then release it before firing them. Hooks
+    # may trigger imports that re-enter the import machinery on another thread
+    # and try to acquire this lock, which would deadlock against per-module
+    # import locks held by that thread.
     name = getattr(module, "__name__", None)
-    if hooks := _post_import_hooks.get(name):
-        _post_import_hooks[name] = []
+    with _post_import_hooks_lock:
+        hooks = _post_import_hooks.get(name) or []
+        if hooks:
+            _post_import_hooks[name] = []
 
-        for hook in hooks:
-            hook(module)
+    for hook in hooks:
+        hook(module)
 
 
-@synchronized(_import_error_hooks_lock)
 def notify_module_import_error(module_name):
-    if hooks := _import_error_hooks.get(module_name):
+    with _import_error_hooks_lock:
         # Error hooks differ from post import hooks, in that we don't clear the
         # hook as soon as it fires.
-        for hook in hooks:
-            hook(module_name)
+        hooks = list(_import_error_hooks.get(module_name) or [])
+
+    for hook in hooks:
+        hook(module_name)
 
 
 # A custom module import finder. This intercepts attempts to import


### PR DESCRIPTION
### Related Issues/PRs

Relates to reports of `import statsmodels.formula.api` hanging indefinitely when MLflow autologging is enabled (same root cause as #22953, smaller fix).

### What changes are proposed in this pull request?

`notify_module_loaded` and `notify_module_import_error` previously held the hook-registry lock across hook execution. Since hooks can trigger imports that re-enter the import machinery on another thread, the lock collides with Python's per-module import locks in an AB-BA pattern.

```
Thread A: import statsmodels.formula.api          Thread B: import <anything>
  ┌──────────────────────────────────────┐          ┌──────────────────────────────────┐
  │ holds per-module lock("statsmodels") │          │ holds per-module lock(<other>)   │
  │ in notify_module_loaded(statsmodels) │          │ in ImportHookFinder.find_spec()  │
  │                                      │          │                                  │
  │ HOLDS _post_import_hooks_lock        │◄──wants──┤                                  │
  │                                      │          │                                  │
  │ hook → autolog() → import            │          │                                  │
  │ statsmodels.api → cascade of         │          │                                  │
  │ submodule imports                    │──wants──►│                                  │
  │                                      │          │                                  │
  │   wants per-module lock(<other>) ────┼──────────┤                                  │
  └──────────────────────────────────────┘          └──────────────────────────────────┘
                                       D E A D L O C K
```

The fix is to snapshot the hook list under the lock and fire it after release. Two functions, ~14 net lines.

```python
def notify_module_loaded(module):
    name = getattr(module, "__name__", None)
    with _post_import_hooks_lock:
        hooks = _post_import_hooks.get(name) or []
        if hooks:
            _post_import_hooks[name] = []
    for hook in hooks:
        hook(module)
```

This is the minimum viable fix. The broader refactor in #22953 also rewrites `ImportHookFinder` and `register_*_hook`, but the actual user-visible hang is caused only by the two `notify_*` paths above.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fix a deadlock that caused `import statsmodels` (and potentially other libraries) to hang indefinitely when MLflow autologging was enabled in multi-threaded environments.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)