### PR TITLE
Raise default `/review` effort from medium to high

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -175,7 +175,7 @@ jobs:
 
           parser = argparse.ArgumentParser(add_help=False)
           parser.add_argument("-m", "--model", choices=MODEL_CHOICES, default=default_model)
-          parser.add_argument("-e", "--effort", choices=EFFORT_CHOICES, default="medium")
+          parser.add_argument("-e", "--effort", choices=EFFORT_CHOICES, default="high")
           args, leftover = parser.parse_known_args(head.split())
 
           prompt = (" ".join(leftover) + sep + tail).strip()


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Bumps the default `--effort` for the `/review` workflow from `medium` to `high`. Reviewers can still override via the comment (e.g. `/review -e medium`); this just changes the default applied when no flag is supplied.

### How is this PR tested?

- [x] Manual tests

The smoke run on this PR exercises the `/pr-review` skill end-to-end (Post is gated off on `pull_request`), so any default-effort regression would surface here.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release