### PR TITLE
Drop parallel-lookup guidance from `pr-review` skill

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -91,8 +91,6 @@ The working tree holds the PR merged into the base (`refs/pull/<pr>/merge`), so 
 
 The merge ref's base parent is also reachable as `HEAD^1`. When the diff doesn't show enough (verifying a refactor preserved behavior, reading the full content of a deleted file, or seeing the pre-change version of a heavily modified file), use `git show HEAD^1:<path>` rather than re-fetching via the GitHub API.
 
-Batch independent lookups into a single turn. If you need to read several changed files, grep for a few symbols, or spawn multiple `Explore` agents, issue them as parallel tool calls. Only serialize when a later call depends on an earlier result.
-
 #### Don't comment on
 
 - Pre-existing code. You may read unchanged/context lines to understand the change, but only file findings against the changed lines (added, modified, or deleted), even if surrounding code looks suboptimal.


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Remove the "Batch independent lookups into a single turn..." paragraph from `.claude/skills/pr-review/SKILL.md`. The advice tells the reviewer to issue parallel tool calls, which doesn't apply in headless mode where parallel execution behaves differently.

### How is this PR tested?

- [x] N/A (skill prose only)

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release