### PR TITLE
Default weights_only=True for safe torch.load sites

### DIFF
--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -1045,6 +1045,7 @@ def load_state_dict(state_dict_uri, **kwargs):
     _load_by_pickle_check(True)
     local_path = _download_artifact_from_uri(artifact_uri=state_dict_uri)
     state_dict_path = os.path.join(local_path, _TORCH_STATE_DICT_FILE_NAME)
+    kwargs.setdefault("weights_only", True)
     return torch.load(state_dict_path, **kwargs)
 
 

--- a/mlflow/pytorch/_lightning_autolog.py
+++ b/mlflow/pytorch/_lightning_autolog.py
@@ -654,7 +654,9 @@ def patched_fit(original, self, *args, **kwargs):
             model_signature = None
             input_output_tensors_file = os.path.join(tempdir, _INPUT_OUTPUT_TENSORS_FILENAME)
             if os.path.exists(input_output_tensors_file):
-                input_tensor, output_tensor = torch.load(input_output_tensors_file)
+                input_tensor, output_tensor = torch.load(
+                    input_output_tensors_file, weights_only=True
+                )
                 try:
                     input_example = input_tensor.cpu().numpy()
                     with torch.no_grad():


### PR DESCRIPTION
## What

Apply `kwargs.setdefault(\"weights_only\", True)` (or explicit `weights_only=True`) to two `torch.load` call sites where the loaded payload is plain tensors / state-dicts:

- `mlflow/pytorch/__init__.py:1048` — `load_state_dict()` — uses `setdefault` so callers can still pass `weights_only=False` for unusual state dicts.
- `mlflow/pytorch/_lightning_autolog.py:657` — input/output tensor file produced by MLflow itself; the payload is a `(input_tensor, output_tensor)` tuple.

## What is intentionally NOT changed

The full-model load paths in `_load_model` at `mlflow/pytorch/__init__.py:722,727` are not touched. Those sites require pickle by design — the existing `_load_by_pickle_check` gate plus the operator setting `MLFLOW_ALLOW_PICKLE_DESERIALIZATION=true` already document that the operator is opting into pickle. Adding `weights_only=True` there would surprise opt-in users on PyTorch < 2.6.

If maintainers prefer to harden the full-model paths too (e.g., with an explicit `weights_only=False` to keep PyTorch 2.6+ from changing behavior, plus a docstring note), I'm happy to extend the PR in a follow-up.

## Why

PyTorch 2.6 made `weights_only=True` the default for `torch.load`. This change aligns the MLflow trusted-tensor call sites with that default ahead of broader ecosystem migration, providing a small defense-in-depth benefit for users on older PyTorch where `weights_only=False` is still the default.

## How to test

- `load_state_dict` callers passing standard PyTorch tensor state dicts will continue to work unchanged.
- Callers passing a state dict containing non-tensor / custom-class objects can pass `weights_only=False` explicitly to restore the old behavior.
- The lightning autolog tuple file is written by MLflow itself and contains only tensors, so the explicit `weights_only=True` is unconditionally safe.

## Provenance

Found via an OSS security review block focused on defense-relevant ML infra. AI-assisted code review; human verification + sign-off (DCO included).