### PR TITLE
Factor `pr-review` severity prefixes into `$defs`

### DIFF
--- a/.claude/skills/pr-review/review-payload.schema.json
+++ b/.claude/skills/pr-review/review-payload.schema.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/mlflow/mlflow/.claude/skills/pr-review/review-payload.schema.json",
   "title": "PR Review Payload",
   "description": "Payload emitted by the pr-review skill and posted via POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews.",
   "type": "object",
@@ -41,7 +40,7 @@
             "items": {
               "properties": {
                 "body": {
-                  "not": { "pattern": "^🔴 \\*\\*CRITICAL:" }
+                  "not": { "$ref": "#/$defs/criticalPrefix" }
                 }
               }
             }
@@ -55,6 +54,18 @@
       "type": "string",
       "enum": ["LEFT", "RIGHT"]
     },
+    "criticalPrefix": {
+      "type": "string",
+      "pattern": "^🔴 \\*\\*CRITICAL:\\*\\* "
+    },
+    "moderatePrefix": {
+      "type": "string",
+      "pattern": "^🟡 \\*\\*MODERATE:\\*\\* "
+    },
+    "nitPrefix": {
+      "type": "string",
+      "pattern": "^🟢 \\*\\*NIT:\\*\\* "
+    },
     "comment": {
       "type": "object",
       "additionalProperties": false,
@@ -67,8 +78,11 @@
         },
         "body": {
           "description": "Comment body. Must start with '🔴 **CRITICAL:** ', '🟡 **MODERATE:** ', or '🟢 **NIT:** '.",
-          "type": "string",
-          "pattern": "^(🔴 \\*\\*CRITICAL:\\*\\*|🟡 \\*\\*MODERATE:\\*\\*|🟢 \\*\\*NIT:\\*\\*) "
+          "anyOf": [
+            { "$ref": "#/$defs/criticalPrefix" },
+            { "$ref": "#/$defs/moderatePrefix" },
+            { "$ref": "#/$defs/nitPrefix" }
+          ]
         },
         "line": {
           "description": "Anchor line. Must be inside a diff hunk on the chosen side (added/context on RIGHT, deleted/context on LEFT). For multi-line comments, this is the last line of the range.",


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Small cleanup to `.claude/skills/pr-review/review-payload.schema.json`:

- Promote each severity prefix (`🔴 **CRITICAL:** `, `🟡 **MODERATE:** `, `🟢 **NIT:** `) into its own `$defs` entry, and have both `comment.body` (via `anyOf`) and the APPROVE-conditional (via `not: { $ref }`) reference them. Previously the two sites duplicated the prefix patterns and had drifted slightly (the APPROVE check was matching `^🔴 \*\*CRITICAL:` while the body rule expected `^🔴 \*\*CRITICAL:\*\*` followed by a space). One source of truth now.
- Drop the `$id` field. It pointed at a non-resolvable `github.com/...schema.json` URL and the schema is purely self-contained (only intra-document `#/$defs/...` refs), so it served no purpose.

No behavior change for any payload that was already valid; the APPROVE gate is now strictly tighter (rejects exactly the full critical prefix instead of a loose substring), which is what the body rule already required.

### How is this PR tested?

- [x] Manual tests

Spot-checked against representative payloads using `uv run --frozen --package skills skills validate-review`: clean APPROVE, APPROVE with a CRITICAL comment (correctly rejected via the new `$ref`), and a COMMENT payload all behave as expected.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release