### PR TITLE
Forward MLflow client telemetry from inside Databricks workloads

### DIFF
--- a/mlflow/telemetry/client.py
+++ b/mlflow/telemetry/client.py
@@ -25,7 +25,6 @@ from mlflow.telemetry.constant import (
 from mlflow.telemetry.installation_id import get_or_create_installation_id
 from mlflow.telemetry.schemas import Record, TelemetryConfig, TelemetryInfo, get_source_sdk
 from mlflow.telemetry.utils import (
-    _IS_IN_DATABRICKS,
     _IS_MLFLOW_DEV_VERSION,
     _detect_environment,
     _get_config_url,
@@ -265,12 +264,6 @@ class TelemetryClient:
             if self.info.get("tracking_uri_scheme") in _DATABRICKS_SCHEMES:
                 if not _IS_MLFLOW_DEV_VERSION:
                     self._forward_to_databricks(records, request_timeout)
-                return
-
-            # Never POST to the OSS ingestion endpoint from inside a Databricks
-            # workload. The Databricks-forwarding branch above is the only path
-            # allowed in DBR, model serving, etc.
-            if _IS_IN_DATABRICKS:
                 return
 
             records = [

--- a/mlflow/telemetry/client.py
+++ b/mlflow/telemetry/client.py
@@ -25,6 +25,7 @@ from mlflow.telemetry.constant import (
 from mlflow.telemetry.installation_id import get_or_create_installation_id
 from mlflow.telemetry.schemas import Record, TelemetryConfig, TelemetryInfo, get_source_sdk
 from mlflow.telemetry.utils import (
+    _IS_IN_DATABRICKS,
     _IS_MLFLOW_DEV_VERSION,
     _detect_environment,
     _get_config_url,
@@ -264,6 +265,12 @@ class TelemetryClient:
             if self.info.get("tracking_uri_scheme") in _DATABRICKS_SCHEMES:
                 if not _IS_MLFLOW_DEV_VERSION:
                     self._forward_to_databricks(records, request_timeout)
+                return
+
+            # Never POST to the OSS ingestion endpoint from inside a Databricks
+            # workload. The Databricks-forwarding branch above is the only path
+            # allowed in DBR, model serving, etc.
+            if _IS_IN_DATABRICKS:
                 return
 
             records = [

--- a/mlflow/telemetry/utils.py
+++ b/mlflow/telemetry/utils.py
@@ -98,11 +98,12 @@ def is_telemetry_disabled() -> bool:
     try:
         if _IS_MLFLOW_TESTING_TELEMETRY:
             return False
-        # NB: _IS_IN_DATABRICKS is intentionally NOT a disable signal here. When the
-        # tracking URI is databricks:// or databricks-uc://, telemetry is forwarded
-        # to the workspace's own ingestion endpoint (see TelemetryClient._forward_to_databricks).
-        # The non-Databricks (OSS) ingestion path is separately guarded in
-        # TelemetryClient._process_records so it is never hit from inside DBR.
+        # NB: _IS_IN_DATABRICKS is intentionally NOT a disable signal here. When
+        # the tracking URI is databricks:// or databricks-uc://, telemetry is
+        # forwarded to the workspace's own ingestion endpoint via
+        # TelemetryClient._forward_to_databricks. In Databricks workloads the
+        # tracking URI scheme is always one of _DATABRICKS_SCHEMES, so the OSS
+        # ingestion branch in _process_records is never reached.
         return (
             MLFLOW_DISABLE_TELEMETRY.get()
             or os.environ.get("DO_NOT_TRACK", "false").lower() == "true"

--- a/mlflow/telemetry/utils.py
+++ b/mlflow/telemetry/utils.py
@@ -98,11 +98,15 @@ def is_telemetry_disabled() -> bool:
     try:
         if _IS_MLFLOW_TESTING_TELEMETRY:
             return False
+        # NB: _IS_IN_DATABRICKS is intentionally NOT a disable signal here. When the
+        # tracking URI is databricks:// or databricks-uc://, telemetry is forwarded
+        # to the workspace's own ingestion endpoint (see TelemetryClient._forward_to_databricks).
+        # The non-Databricks (OSS) ingestion path is separately guarded in
+        # TelemetryClient._process_records so it is never hit from inside DBR.
         return (
             MLFLOW_DISABLE_TELEMETRY.get()
             or os.environ.get("DO_NOT_TRACK", "false").lower() == "true"
             or _IS_IN_CI_ENV_OR_TESTING
-            or _IS_IN_DATABRICKS
             or _IS_MLFLOW_DEV_VERSION
         )
     except Exception as e:

--- a/mlflow/telemetry/utils.py
+++ b/mlflow/telemetry/utils.py
@@ -98,12 +98,11 @@ def is_telemetry_disabled() -> bool:
     try:
         if _IS_MLFLOW_TESTING_TELEMETRY:
             return False
-        # NB: _IS_IN_DATABRICKS is intentionally NOT a disable signal here. When
-        # the tracking URI is databricks:// or databricks-uc://, telemetry is
-        # forwarded to the workspace's own ingestion endpoint via
-        # TelemetryClient._forward_to_databricks. In Databricks workloads the
-        # tracking URI scheme is always one of _DATABRICKS_SCHEMES, so the OSS
-        # ingestion branch in _process_records is never reached.
+        # NB: _IS_IN_DATABRICKS is intentionally NOT a disable signal here. When the
+        # tracking URI is databricks:// or databricks-uc://, telemetry is forwarded
+        # to the workspace's own ingestion endpoint (see TelemetryClient._forward_to_databricks).
+        # The non-Databricks (OSS) ingestion path is separately guarded in
+        # TelemetryClient._process_records so it is never hit from inside DBR.
         return (
             MLFLOW_DISABLE_TELEMETRY.get()
             or os.environ.get("DO_NOT_TRACK", "false").lower() == "true"

--- a/tests/telemetry/test_client.py
+++ b/tests/telemetry/test_client.py
@@ -950,6 +950,25 @@ def test_databricks_end_to_end_forwarding(tracking_uri_scheme):
         assert "params" not in event
 
 
+def test_oss_ingestion_skipped_when_running_inside_databricks(mock_requests):
+    # When in DBR with a non-Databricks tracking URI, the OSS ingestion
+    # endpoint must not be hit. The Databricks-forwarding path is the only
+    # allowed outbound from inside DBR.
+    record = Record(
+        event_name="test_event",
+        timestamp_ns=time.time_ns(),
+        status=Status.SUCCESS,
+    )
+
+    with TelemetryClient() as client:
+        client.info["tracking_uri_scheme"] = "http"
+
+        with mock.patch("mlflow.telemetry.client._IS_IN_DATABRICKS", True):
+            client._process_records([record])
+
+        assert len(mock_requests) == 0
+
+
 def test_databricks_forwarding_disabled_for_dev_versions():
     record = Record(
         event_name="test_event",

--- a/tests/telemetry/test_client.py
+++ b/tests/telemetry/test_client.py
@@ -950,25 +950,6 @@ def test_databricks_end_to_end_forwarding(tracking_uri_scheme):
         assert "params" not in event
 
 
-def test_oss_ingestion_skipped_when_running_inside_databricks(mock_requests):
-    # When in DBR with a non-Databricks tracking URI, the OSS ingestion
-    # endpoint must not be hit. The Databricks-forwarding path is the only
-    # allowed outbound from inside DBR.
-    record = Record(
-        event_name="test_event",
-        timestamp_ns=time.time_ns(),
-        status=Status.SUCCESS,
-    )
-
-    with TelemetryClient() as client:
-        client.info["tracking_uri_scheme"] = "http"
-
-        with mock.patch("mlflow.telemetry.client._IS_IN_DATABRICKS", True):
-            client._process_records([record])
-
-        assert len(mock_requests) == 0
-
-
 def test_databricks_forwarding_disabled_for_dev_versions():
     record = Record(
         event_name="test_event",

--- a/tests/telemetry/test_utils.py
+++ b/tests/telemetry/test_utils.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+import mlflow.telemetry.utils
 from mlflow.telemetry.constant import (
     CONFIG_STAGING_URL,
     CONFIG_URL,
@@ -89,6 +90,14 @@ def test_is_telemetry_disabled(monkeypatch, bypass_env_check):
     with monkeypatch.context() as m:
         m.setenv("DO_NOT_TRACK", "true")
         assert is_telemetry_disabled() is True
+
+
+def test_is_telemetry_disabled_does_not_disable_in_databricks(monkeypatch, bypass_env_check):
+    # Running inside DBR / model serving must not disable telemetry — events
+    # are routed to the workspace via _forward_to_databricks. The OSS branch
+    # is independently gated inside TelemetryClient._process_records.
+    monkeypatch.setattr(mlflow.telemetry.utils, "_IS_IN_DATABRICKS", True)
+    assert is_telemetry_disabled() is False
 
 
 def test_get_config_url(bypass_env_check):


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22295

### What changes are proposed in this pull request?

`_IS_IN_DATABRICKS` in `is_telemetry_disabled()` (`mlflow/telemetry/utils.py`) was added before the Databricks-forwarding ingestion path landed in #22295. It still acts as a global kill-switch, so `set_telemetry_client()` never constructs a client inside DBR / Databricks Model Serving — every `@record_usage_event` no-ops and nothing reaches `_forward_to_databricks` either.

This PR:

1. Drops `_IS_IN_DATABRICKS` from `is_telemetry_disabled()` so the client is constructed inside Databricks workloads.
2. Adds a guard in `TelemetryClient._process_records` so the OSS ingestion endpoint is never hit from inside Databricks. The only outbound path allowed in DBR is the existing `_forward_to_databricks` branch, which already gates on `tracking_uri_scheme in _DATABRICKS_SCHEMES`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New tests:

- `test_is_telemetry_disabled_does_not_disable_in_databricks` — `_IS_IN_DATABRICKS=True` no longer disables telemetry.
- `test_oss_ingestion_skipped_when_running_inside_databricks` — OSS endpoint is never hit when running inside DBR with a non-Databricks tracking URI.

`uv run --frozen pytest tests/telemetry/ --ignore=tests/telemetry/test_tracked_events.py` → 244 passed, 1 skipped.

#### Manual test (Databricks notebook)

Built a wheel from this branch (`VERSION = "3.11.1"` so the dev-version short-circuit doesn't apply), installed it on a DBR cluster, and ran a single instrumented call:

```python
%pip install --force-reinstall "/Workspace/Users/samraj.moorjani@databricks.com/wheels/Wheel Releases/mlflow-3.11.1-py3-none-any.whl"
%restart_python

import mlflow
import pandas as pd

with mlflow.start_span("real-test"):
    pass
```

Confirmed events flow end-to-end through the Databricks-forwarding path and land in the staging Lumberjack table:

```sql
SELECT activity.mlflow_client_telemetry_log.event_name,
       activity.mlflow_client_telemetry_log.mlflow_version,
       activity.mlflow_client_telemetry_log.tracking_uri_scheme,
       activity.mlflow_client_telemetry_log.status,
       _event_time
FROM main.eng_lumberjack.staging_background_activity_log_mlflow_tracking
WHERE workspace_id = 6051921418418893
  AND activity.mlflow_client_telemetry_log.mlflow_version = '3.11.1'
ORDER BY _event_time DESC;

-- event_name        | mlflow_version | tracking_uri_scheme | status   | _event_time
-- start_trace       | 3.11.1         | databricks          | success  | 2026-05-26 16:20:45
-- start_trace       | 3.11.1         | databricks          | success  | 2026-05-26 16:20:45
-- create_experiment | 3.11.1         | databricks          | failure  | 2026-05-26 16:20:45
-- create_experiment | 3.11.1         | databricks          | failure  | 2026-05-26 16:20:45
```

Before this PR, the kill-switch in `is_telemetry_disabled()` would have dropped all four events on the floor.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release