### PR TITLE
Skip Spark/Delta tests in `test_pandas_dataset.py` on Windows CI

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -442,5 +442,7 @@ jobs:
             --ignore=tests/data/test_spark_dataset.py \
             --ignore=tests/data/test_spark_dataset_source.py \
             --ignore=tests/data/test_delta_dataset_source.py \
+            --deselect=tests/data/test_pandas_dataset.py::test_from_pandas_spark_datasource \
+            --deselect=tests/data/test_pandas_dataset.py::test_from_pandas_delta_datasource \
             --ignore=tests/docker \
             --ignore=tests/demo


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23493

### What changes are proposed in this pull request?

`test_from_pandas_spark_datasource` and `test_from_pandas_delta_datasource` in `tests/data/test_pandas_dataset.py` fail on Windows CI with `NoClassDefFoundError: scala/collection/GenTraversableOnce` when the Spark session loads `delta-spark_2.12:3.0.0`. This is the same Scala-version mismatch that caused #23493 to skip `tests/data/test_delta_dataset_source.py`. Deselect just these two tests so the rest of `test_pandas_dataset.py` continues to run on Windows.

Example failure: https://github.com/mlflow/mlflow/actions/runs/26150900268/job/76917895798

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)