### PR TITLE
Reserve the entire `__user_` role-name prefix from admin authoring

### DIFF
--- a/mlflow/server/auth/sqlalchemy_store.py
+++ b/mlflow/server/auth/sqlalchemy_store.py
@@ -268,12 +268,18 @@ class SqlAlchemyStore:
 
     @classmethod
     def _reject_synthetic_role_name(cls, name: str) -> None:
-        """Guard user-facing role CRUD against the reserved synthetic pattern."""
-        if cls._is_synthetic_role_name(name):
+        """Guard user-facing role CRUD against the reserved synthetic namespace.
+
+        Reject any name starting with ``__user_`` (not just the strict
+        ``__user_<digits>__`` synthetic pattern): the whole prefix is reserved
+        so a future change to the synthetic naming scheme can't be hijacked by
+        an admin-created role that lined up with the older format.
+        """
+        if name.startswith(cls._SYNTHETIC_ROLE_PREFIX):
             raise MlflowException.invalid_parameter_value(
-                f"Role name {name!r} matches the reserved synthetic pattern "
-                "'__user_<id>__' used by the per-user permission representation. "
-                "Choose a different name."
+                f"Role name {name!r} uses the reserved '__user_' prefix, which "
+                "is held for the per-user permission representation. Choose a "
+                "different name."
             )
 
     def _get_or_create_synthetic_user_role(self, session, user_id: int, workspace: str) -> SqlRole:

--- a/tests/server/auth/test_sqlalchemy_store_rbac.py
+++ b/tests/server/auth/test_sqlalchemy_store_rbac.py
@@ -57,30 +57,40 @@ def test_create_role_same_name_different_workspace(store):
     assert r1.id != r2.id
 
 
-# Sample names matching the reserved ``__user_<id>__`` pattern. Shared by
-# the create-time and update-time guards so a future pattern addition
-# (e.g. another reserved prefix) lands in both tests automatically.
-_SYNTHETIC_USER_ROLE_NAMES = ["__user_1__", "__user_42__", "__user_999999__"]
+# Sample names matching the reserved ``__user_`` prefix. Includes both the
+# strict synthetic pattern (``__user_<digits>__``) and looser variants
+# (admin-author-able lookalikes) so the broader prefix guard is exercised.
+_RESERVED_USER_PREFIX_NAMES = [
+    "__user_1__",
+    "__user_42__",
+    "__user_999999__",
+    "__user_admin",
+    "__user_alice",
+    "__user_foo_bar",
+    "__user_",
+]
 
 
-@pytest.mark.parametrize("name", _SYNTHETIC_USER_ROLE_NAMES)
-def test_create_role_rejects_synthetic_user_name_pattern(store, name):
-    # The ``__user_<id>__`` pattern is reserved for synthetic per-user roles
-    # created internally by ``grant_user_permission``. Allowing an operator
-    # to author a role with that name would let them collide with a real
+@pytest.mark.parametrize("name", _RESERVED_USER_PREFIX_NAMES)
+def test_create_role_rejects_reserved_user_prefix(store, name):
+    # The ``__user_`` prefix is reserved for synthetic per-user roles created
+    # internally by ``grant_user_permission``. Allowing an operator to author
+    # a role with that prefix lets them collide with (or shadow) a real
     # user's synthetic role and silently attach grants to that user — a
-    # privilege-escalation footgun.
-    with pytest.raises(MlflowException, match="reserved synthetic pattern"):
+    # privilege-escalation footgun. The guard covers the whole prefix, not
+    # just the strict ``__user_<digits>__`` pattern, so future changes to the
+    # synthetic naming scheme can't be hijacked by an existing collision.
+    with pytest.raises(MlflowException, match="reserved '__user_' prefix"):
         store.create_role(name=name, workspace="ws1")
 
 
-@pytest.mark.parametrize("name", _SYNTHETIC_USER_ROLE_NAMES)
-def test_update_role_rejects_synthetic_user_name_pattern(store, name):
+@pytest.mark.parametrize("name", _RESERVED_USER_PREFIX_NAMES)
+def test_update_role_rejects_reserved_user_prefix(store, name):
     # The same reservation must apply when *renaming* an existing role —
     # otherwise the create-time guard could be bypassed by creating with a
-    # normal name and then renaming into the reserved pattern.
+    # normal name and then renaming into the reserved prefix.
     role = store.create_role(name="viewer", workspace="ws1")
-    with pytest.raises(MlflowException, match="reserved synthetic pattern"):
+    with pytest.raises(MlflowException, match="reserved '__user_' prefix"):
         store.update_role(role.id, name=name)
 
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/23496/files) to review incremental changes.
- [**stack/rbac-reserve-user-prefix**](https://github.com/mlflow/mlflow/pull/23496) [[Files changed](https://github.com/mlflow/mlflow/pull/23496/files)]

---------
### Related Issues/PRs

Last item from the [RBAC bugbash](https://docs.google.com/document/d/17BWoF5n_a8Y1bafsQp1NDmSONe6uC9MDMPsCXn85aXg/edit). Reported by Kris Concepcion: *"We should disallow role creation with the prefix `__user_` instead of an explicit pattern match for `__user_digit__`."* Stacks on #23420.

### What changes are proposed in this pull request?

`_reject_synthetic_role_name` was only blocking the strict `__user_<digits>__` synthetic pattern, leaving admins free to create roles named `__user_admin`, `__user_alice`, `__user_foo_bar`, or even `__user_` itself.

Any collision in that namespace is dangerous:

- A role named exactly like a real user's synthetic role would silently attach role grants to that user's direct-grant bookkeeping (privilege escalation).
- Pinning the guard to the strict regex commits us to the current synthetic naming scheme forever — any future change to use, e.g., usernames or hashes (`__user_alice__`, `__user_a1b2`) would be hijackable by pre-existing admin-authored roles.

Tighten `_reject_synthetic_role_name` to reject any name starting with `_SYNTHETIC_ROLE_PREFIX` (`"__user_"`). The guard is applied on both `create_role` and `update_role`, so renames can't bypass the create-time check.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests — `test_create_role_rejects_reserved_user_prefix` and `test_update_role_rejects_reserved_user_prefix` in `tests/server/auth/test_sqlalchemy_store_rbac.py`, parametrised across the strict pattern (`__user_1__`, `__user_42__`, `__user_999999__`) and loose variants the previous guard let through (`__user_admin`, `__user_alice`, `__user_foo_bar`, `__user_`).
- [x] Manual: locally created roles confirmed rejection on all variants.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release