### PR TITLE
Skip Helm chart `appVersion` update during pre-release

### DIFF
--- a/dev/update_mlflow_versions.py
+++ b/dev/update_mlflow_versions.py
@@ -175,10 +175,10 @@ def update_versions(new_py_version: str, helm_app_version: str | None = None) ->
       - a RC version (e.g. "2.1.0rc0")
       - a dev version (e.g. "2.1.0.dev0")
 
-    `helm_app_version` overrides the version written to the Helm chart's
-    `appVersion`. The Helm chart's `appVersion` is used as the default Docker
-    image tag, so it must point to a published release. When omitted, falls
-    back to `new_py_version` (with any dev/rc suffix stripped).
+    `helm_app_version` is the version written to the Helm chart's `appVersion`.
+    The Helm chart's `appVersion` is used as the default Docker image tag, so it
+    must point to a published release. When omitted, the Helm chart is left
+    untouched.
     """
     old_py_version = get_current_py_version()
 
@@ -188,7 +188,8 @@ def update_versions(new_py_version: str, helm_app_version: str | None = None) ->
     replace_java(old_py_version, new_py_version, _JAVA_VERSION_FILES)
     replace_java_pom_xml(old_py_version, new_py_version, _JAVA_POM_XML_FILES)
     replace_r(old_py_version, new_py_version, _R_VERSION_FILES)
-    replace_helm_chart(helm_app_version or new_py_version, _HELM_CHART_FILES)
+    if helm_app_version is not None:
+        replace_helm_chart(helm_app_version, _HELM_CHART_FILES)
 
 
 def validate_new_version(value: str) -> str:


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23495 (issue surfaced while reviewing that PR).

### What changes are proposed in this pull request?

`pre_release` no longer touches `charts/Chart.yaml`. The chart's `appVersion` is used as the default Docker image tag, so it must point to a published release. Pre-release runs before the new version exists as a Docker image, so writing `appVersion: "3.13.0"` (or worse, the suffix-stripped `"3.13.0"` for `3.13.0rc0`) would point the chart at a tag that hasn't been pushed yet. `post_release` is unchanged and remains the only path that bumps `appVersion`, to the version that was actually released.

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)