### PR TITLE
Add built-in deterministic NLP scorers

### DIFF
--- a/mlflow/genai/scorers/__init__.py
+++ b/mlflow/genai/scorers/__init__.py
@@ -51,6 +51,15 @@ _LAZY_IMPORTS = {
     "get_all_scorers",
 }
 
+# Deterministic NLP scorers
+_DETERMINISTIC_NLP_IMPORTS = {
+    "BERTScore",
+    "METEOR",
+    "Readability",
+    "Sentiment",
+    "LevenshteinRatio",
+}
+
 
 def __getattr__(name):
     """Lazily import builtin scorers to avoid circular dependency."""
@@ -59,6 +68,12 @@ def __getattr__(name):
         from mlflow.genai.scorers import builtin_scorers
 
         return getattr(builtin_scorers, name)
+    
+    if name in _DETERMINISTIC_NLP_IMPORTS:
+        # Import deterministic NLP scorers
+        from mlflow.genai.scorers import deterministic_nlp_scorers
+
+        return getattr(deterministic_nlp_scorers, name)
 
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
@@ -72,7 +87,7 @@ def __dir__():
     # Get the default module attributes
     module_attrs = list(globals().keys())
     # Add the lazy imports
-    return sorted(set(module_attrs) | _LAZY_IMPORTS)
+    return sorted(set(module_attrs) | _LAZY_IMPORTS | _DETERMINISTIC_NLP_IMPORTS)
 
 
 # The TYPE_CHECKING block below is for static analysis tools only.
@@ -102,6 +117,13 @@ if TYPE_CHECKING:
         ToolCallEfficiency,
         UserFrustration,
         get_all_scorers,
+    )
+    from mlflow.genai.scorers.deterministic_nlp_scorers import (
+        BERTScore,
+        METEOR,
+        Readability,
+        Sentiment,
+        LevenshteinRatio,
     )
 
 __all__ = [
@@ -133,4 +155,10 @@ __all__ = [
     "get_scorer",
     "list_scorers",
     "delete_scorer",
+    # Deterministic NLP scorers
+    "BERTScore",
+    "METEOR",
+    "Readability",
+    "Sentiment",
+    "LevenshteinRatio",
 ]

--- a/mlflow/genai/scorers/deterministic_nlp_scorers.py
+++ b/mlflow/genai/scorers/deterministic_nlp_scorers.py
@@ -1,0 +1,639 @@
+"""
+Deterministic NLP scorers for model evaluation.
+
+This module provides built-in deterministic NLP metrics that don't require LLM calls,
+making them fast, reproducible, and suitable for offline evaluation.
+"""
+
+import logging
+from typing import Any, Literal
+
+from mlflow.entities.assessment import Feedback
+from mlflow.exceptions import MlflowException
+from mlflow.genai.judges.base import Judge, JudgeField
+from mlflow.genai.scorers.base import Scorer, ScorerKind
+from mlflow.utils.annotations import experimental
+
+_logger = logging.getLogger(__name__)
+
+
+def _ensure_string(value: Any, field_name: str) -> str:
+    """Convert value to string, handling None and other types."""
+    if value is None:
+        raise MlflowException.invalid_parameter_value(
+            f"{field_name} cannot be None for NLP scoring"
+        )
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
+@experimental(version="3.13.0")
+class BERTScore(Judge):
+    """
+    BERTScore measures semantic similarity between outputs and expectations using BERT embeddings.
+
+    BERTScore computes precision, recall, and F1 scores by matching tokens based on their
+    contextual embeddings from BERT models. This provides a more nuanced similarity measure
+    than simple string matching, as it captures semantic meaning.
+
+    You can invoke the scorer directly with a single input for testing, or pass it to
+    `mlflow.genai.evaluate` for running full evaluation on a dataset.
+
+    Args:
+        name: The name of the scorer. Defaults to "bert_score".
+        model_type: The BERT model to use for embeddings. Defaults to "bert-base-uncased".
+            Common options include "bert-base-uncased", "roberta-base", "distilbert-base-uncased".
+        lang: Language of the text. Defaults to "en" (English).
+        return_hash: If True, returns the model hash for reproducibility. Defaults to False.
+
+    Example (direct usage):
+
+    .. code-block:: python
+
+        from mlflow.genai.scorers import BERTScore
+
+        scorer = BERTScore()
+        feedback = scorer(
+            outputs="The cat sat on the mat",
+            expectations={"expected_output": "A cat was sitting on a mat"}
+        )
+        print(f"F1 Score: {feedback.value}")
+
+    Example (with evaluate):
+
+    .. code-block:: python
+
+        import mlflow
+
+        data = mlflow.search_traces(...)
+        result = mlflow.genai.evaluate(data=data, scorers=[BERTScore()])
+
+    Note:
+        Requires the `bert-score` package: `pip install bert-score`
+    """
+
+    name: str = "bert_score"
+    model_type: str = "bert-base-uncased"
+    lang: str = "en"
+    return_hash: bool = False
+    description: str = "Semantic similarity using BERT embeddings"
+
+    @property
+    def instructions(self) -> str:
+        return "Evaluates semantic similarity between outputs and expected outputs using BERT embeddings."
+
+    @property
+    def feedback_value_type(self) -> Any:
+        return float
+
+    def get_input_fields(self) -> list[JudgeField]:
+        return [
+            JudgeField(
+                name="outputs",
+                description="The generated text to evaluate",
+            ),
+            JudgeField(
+                name="expectations",
+                description="Dictionary containing 'expected_output' key with reference text",
+            ),
+        ]
+
+    @property
+    def kind(self) -> ScorerKind:
+        return ScorerKind.BUILTIN
+
+    def __call__(
+        self, *, outputs: Any, expectations: dict[str, Any] | None = None
+    ) -> Feedback:
+        """
+        Compute BERTScore between outputs and expected outputs.
+
+        Args:
+            outputs: The generated text to evaluate.
+            expectations: Dictionary containing 'expected_output' key with reference text.
+
+        Returns:
+            Feedback object with F1 score as the value (range: 0.0 to 1.0).
+        """
+        try:
+            from bert_score import score as bert_score_fn
+        except ImportError as e:
+            raise MlflowException(
+                "BERTScore requires the 'bert-score' package. "
+                "Install it with: pip install bert-score"
+            ) from e
+
+        if not expectations or "expected_output" not in expectations:
+            raise MlflowException.invalid_parameter_value(
+                "BERTScore requires 'expected_output' in expectations dictionary"
+            )
+
+        candidate = _ensure_string(outputs, "outputs")
+        reference = _ensure_string(expectations["expected_output"], "expected_output")
+
+        # Compute BERTScore
+        P, R, F1 = bert_score_fn(
+            [candidate],
+            [reference],
+            model_type=self.model_type,
+            lang=self.lang,
+            return_hash=self.return_hash,
+            verbose=False,
+        )
+
+        # Return F1 score as the primary metric
+        f1_value = float(F1[0].item())
+
+        return Feedback(
+            name=self.name,
+            value=f1_value,
+            metadata={
+                "precision": float(P[0].item()),
+                "recall": float(R[0].item()),
+                "model_type": self.model_type,
+            },
+        )
+
+
+@experimental(version="3.13.0")
+class METEOR(Judge):
+    """
+    METEOR (Metric for Evaluation of Translation with Explicit ORdering) score.
+
+    METEOR is a metric originally designed for machine translation evaluation that aligns
+    hypothesis and reference translations based on exact, stem, synonym, and paraphrase matches.
+    It computes a score based on the harmonic mean of precision and recall, with recall
+    weighted more heavily than precision.
+
+    You can invoke the scorer directly with a single input for testing, or pass it to
+    `mlflow.genai.evaluate` for running full evaluation on a dataset.
+
+    Args:
+        name: The name of the scorer. Defaults to "meteor".
+        alpha: Parameter for controlling weight of precision vs recall. Defaults to 0.9.
+        beta: Parameter for controlling weight of fragmentation penalty. Defaults to 3.0.
+        gamma: Parameter for controlling fragmentation penalty. Defaults to 0.5.
+
+    Example (direct usage):
+
+    .. code-block:: python
+
+        from mlflow.genai.scorers import METEOR
+
+        scorer = METEOR()
+        feedback = scorer(
+            outputs="The cat sat on the mat",
+            expectations={"expected_output": "A cat was sitting on a mat"}
+        )
+        print(f"METEOR Score: {feedback.value}")
+
+    Example (with evaluate):
+
+    .. code-block:: python
+
+        import mlflow
+
+        data = mlflow.search_traces(...)
+        result = mlflow.genai.evaluate(data=data, scorers=[METEOR()])
+
+    Note:
+        Requires NLTK with WordNet data: `pip install nltk` and download 'wordnet' corpus.
+    """
+
+    name: str = "meteor"
+    alpha: float = 0.9
+    beta: float = 3.0
+    gamma: float = 0.5
+    description: str = "Machine translation evaluation metric"
+
+    @property
+    def instructions(self) -> str:
+        return "Evaluates text quality using METEOR metric with stem, synonym, and paraphrase matching."
+
+    @property
+    def feedback_value_type(self) -> Any:
+        return float
+
+    def get_input_fields(self) -> list[JudgeField]:
+        return [
+            JudgeField(
+                name="outputs",
+                description="The generated text to evaluate",
+            ),
+            JudgeField(
+                name="expectations",
+                description="Dictionary containing 'expected_output' key with reference text",
+            ),
+        ]
+
+    @property
+    def kind(self) -> ScorerKind:
+        return ScorerKind.BUILTIN
+
+    def __call__(
+        self, *, outputs: Any, expectations: dict[str, Any] | None = None
+    ) -> Feedback:
+        """
+        Compute METEOR score between outputs and expected outputs.
+
+        Args:
+            outputs: The generated text to evaluate.
+            expectations: Dictionary containing 'expected_output' key with reference text.
+
+        Returns:
+            Feedback object with METEOR score as the value (range: 0.0 to 1.0).
+        """
+        try:
+            from nltk.translate.meteor_score import meteor_score
+            import nltk
+        except ImportError as e:
+            raise MlflowException(
+                "METEOR requires the 'nltk' package. Install it with: pip install nltk"
+            ) from e
+
+        # Download required NLTK data if not present
+        try:
+            nltk.data.find("corpora/wordnet")
+        except LookupError:
+            _logger.info("Downloading NLTK wordnet data for METEOR scorer...")
+            nltk.download("wordnet", quiet=True)
+            nltk.download("omw-1.4", quiet=True)
+
+        if not expectations or "expected_output" not in expectations:
+            raise MlflowException.invalid_parameter_value(
+                "METEOR requires 'expected_output' in expectations dictionary"
+            )
+
+        candidate = _ensure_string(outputs, "outputs")
+        reference = _ensure_string(expectations["expected_output"], "expected_output")
+
+        # Tokenize
+        candidate_tokens = candidate.split()
+        reference_tokens = reference.split()
+
+        # Compute METEOR score
+        score = meteor_score(
+            [reference_tokens],
+            candidate_tokens,
+            alpha=self.alpha,
+            beta=self.beta,
+            gamma=self.gamma,
+        )
+
+        return Feedback(
+            name=self.name,
+            value=float(score),
+            metadata={
+                "alpha": self.alpha,
+                "beta": self.beta,
+                "gamma": self.gamma,
+            },
+        )
+
+
+@experimental(version="3.13.0")
+class Readability(Judge):
+    """
+    Readability scorer that computes text complexity metrics.
+
+    This scorer computes multiple readability metrics including:
+    - Flesch Reading Ease: Higher scores indicate easier readability (0-100)
+    - Flesch-Kincaid Grade Level: U.S. school grade level required to understand the text
+    - Automated Readability Index (ARI): Similar to Flesch-Kincaid
+    - Coleman-Liau Index: Based on characters rather than syllables
+
+    You can invoke the scorer directly with a single input for testing, or pass it to
+    `mlflow.genai.evaluate` for running full evaluation on a dataset.
+
+    Args:
+        name: The name of the scorer. Defaults to "readability".
+        metric: The specific readability metric to return. Options: "flesch_reading_ease",
+            "flesch_kincaid_grade", "automated_readability_index", "coleman_liau_index".
+            Defaults to "flesch_reading_ease".
+
+    Example (direct usage):
+
+    .. code-block:: python
+
+        from mlflow.genai.scorers import Readability
+
+        scorer = Readability(metric="flesch_reading_ease")
+        feedback = scorer(outputs="The cat sat on the mat.")
+        print(f"Readability Score: {feedback.value}")
+
+    Example (with evaluate):
+
+    .. code-block:: python
+
+        import mlflow
+
+        data = mlflow.search_traces(...)
+        result = mlflow.genai.evaluate(data=data, scorers=[Readability()])
+
+    Note:
+        Requires the `textstat` package: `pip install textstat`
+    """
+
+    name: str = "readability"
+    metric: Literal[
+        "flesch_reading_ease",
+        "flesch_kincaid_grade",
+        "automated_readability_index",
+        "coleman_liau_index",
+    ] = "flesch_reading_ease"
+    description: str = "Text complexity and readability metrics"
+
+    @property
+    def instructions(self) -> str:
+        return f"Evaluates text readability using {self.metric} metric."
+
+    @property
+    def feedback_value_type(self) -> Any:
+        return float
+
+    def get_input_fields(self) -> list[JudgeField]:
+        return [
+            JudgeField(
+                name="outputs",
+                description="The text to evaluate for readability",
+            ),
+        ]
+
+    @property
+    def kind(self) -> ScorerKind:
+        return ScorerKind.BUILTIN
+
+    def __call__(self, *, outputs: Any) -> Feedback:
+        """
+        Compute readability score for the given text.
+
+        Args:
+            outputs: The text to evaluate.
+
+        Returns:
+            Feedback object with the selected readability metric as the value.
+        """
+        try:
+            import textstat
+        except ImportError as e:
+            raise MlflowException(
+                "Readability scorer requires the 'textstat' package. "
+                "Install it with: pip install textstat"
+            ) from e
+
+        text = _ensure_string(outputs, "outputs")
+
+        # Compute the selected metric
+        if self.metric == "flesch_reading_ease":
+            score = textstat.flesch_reading_ease(text)
+        elif self.metric == "flesch_kincaid_grade":
+            score = textstat.flesch_kincaid_grade(text)
+        elif self.metric == "automated_readability_index":
+            score = textstat.automated_readability_index(text)
+        elif self.metric == "coleman_liau_index":
+            score = textstat.coleman_liau_index(text)
+        else:
+            raise MlflowException.invalid_parameter_value(
+                f"Unknown readability metric: {self.metric}"
+            )
+
+        # Compute all metrics for metadata
+        metadata = {
+            "flesch_reading_ease": textstat.flesch_reading_ease(text),
+            "flesch_kincaid_grade": textstat.flesch_kincaid_grade(text),
+            "automated_readability_index": textstat.automated_readability_index(text),
+            "coleman_liau_index": textstat.coleman_liau_index(text),
+            "selected_metric": self.metric,
+        }
+
+        return Feedback(
+            name=self.name,
+            value=float(score),
+            metadata=metadata,
+        )
+
+
+@experimental(version="3.13.0")
+class Sentiment(Judge):
+    """
+    Sentiment analysis scorer using VADER (Valence Aware Dictionary and sEntiment Reasoner).
+
+    VADER is a lexicon and rule-based sentiment analysis tool specifically attuned to
+    sentiments expressed in social media. It provides compound, positive, negative, and
+    neutral sentiment scores.
+
+    You can invoke the scorer directly with a single input for testing, or pass it to
+    `mlflow.genai.evaluate` for running full evaluation on a dataset.
+
+    Args:
+        name: The name of the scorer. Defaults to "sentiment".
+        return_compound: If True, returns the compound score (normalized between -1 and 1).
+            If False, returns individual pos/neg/neu scores. Defaults to True.
+
+    Example (direct usage):
+
+    .. code-block:: python
+
+        from mlflow.genai.scorers import Sentiment
+
+        scorer = Sentiment()
+        feedback = scorer(outputs="This is a great product! I love it.")
+        print(f"Sentiment Score: {feedback.value}")
+
+    Example (with evaluate):
+
+    .. code-block:: python
+
+        import mlflow
+
+        data = mlflow.search_traces(...)
+        result = mlflow.genai.evaluate(data=data, scorers=[Sentiment()])
+
+    Note:
+        Requires the `vaderSentiment` package: `pip install vaderSentiment`
+    """
+
+    name: str = "sentiment"
+    return_compound: bool = True
+    description: str = "Sentiment analysis using VADER"
+
+    @property
+    def instructions(self) -> str:
+        return "Evaluates sentiment polarity of text using VADER sentiment analyzer."
+
+    @property
+    def feedback_value_type(self) -> Any:
+        return float
+
+    def get_input_fields(self) -> list[JudgeField]:
+        return [
+            JudgeField(
+                name="outputs",
+                description="The text to analyze for sentiment",
+            ),
+        ]
+
+    @property
+    def kind(self) -> ScorerKind:
+        return ScorerKind.BUILTIN
+
+    def __call__(self, *, outputs: Any) -> Feedback:
+        """
+        Compute sentiment score for the given text.
+
+        Args:
+            outputs: The text to analyze.
+
+        Returns:
+            Feedback object with sentiment score. If return_compound=True, returns compound
+            score (-1 to 1). Otherwise, returns positive score (0 to 1).
+        """
+        try:
+            from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
+        except ImportError as e:
+            raise MlflowException(
+                "Sentiment scorer requires the 'vaderSentiment' package. "
+                "Install it with: pip install vaderSentiment"
+            ) from e
+
+        text = _ensure_string(outputs, "outputs")
+
+        analyzer = SentimentIntensityAnalyzer()
+        scores = analyzer.polarity_scores(text)
+
+        # Return compound score or positive score
+        value = scores["compound"] if self.return_compound else scores["pos"]
+
+        return Feedback(
+            name=self.name,
+            value=float(value),
+            metadata={
+                "compound": scores["compound"],
+                "positive": scores["pos"],
+                "negative": scores["neg"],
+                "neutral": scores["neu"],
+            },
+        )
+
+
+@experimental(version="3.13.0")
+class LevenshteinRatio(Judge):
+    """
+    Levenshtein ratio scorer that measures edit distance similarity.
+
+    The Levenshtein ratio is computed as:
+        ratio = (len(s1) + len(s2) - distance) / (len(s1) + len(s2))
+
+    This gives a normalized similarity score between 0 and 1, where 1 means identical strings
+    and 0 means completely different strings.
+
+    You can invoke the scorer directly with a single input for testing, or pass it to
+    `mlflow.genai.evaluate` for running full evaluation on a dataset.
+
+    Args:
+        name: The name of the scorer. Defaults to "levenshtein_ratio".
+        case_sensitive: If True, comparison is case-sensitive. Defaults to False.
+
+    Example (direct usage):
+
+    .. code-block:: python
+
+        from mlflow.genai.scorers import LevenshteinRatio
+
+        scorer = LevenshteinRatio()
+        feedback = scorer(
+            outputs="The cat sat on the mat",
+            expectations={"expected_output": "The cat sat on a mat"}
+        )
+        print(f"Similarity: {feedback.value}")
+
+    Example (with evaluate):
+
+    .. code-block:: python
+
+        import mlflow
+
+        data = mlflow.search_traces(...)
+        result = mlflow.genai.evaluate(data=data, scorers=[LevenshteinRatio()])
+
+    Note:
+        Requires the `python-Levenshtein` package: `pip install python-Levenshtein`
+    """
+
+    name: str = "levenshtein_ratio"
+    case_sensitive: bool = False
+    description: str = "Edit distance similarity between texts"
+
+    @property
+    def instructions(self) -> str:
+        return "Evaluates string similarity using Levenshtein edit distance ratio."
+
+    @property
+    def feedback_value_type(self) -> Any:
+        return float
+
+    def get_input_fields(self) -> list[JudgeField]:
+        return [
+            JudgeField(
+                name="outputs",
+                description="The generated text to evaluate",
+            ),
+            JudgeField(
+                name="expectations",
+                description="Dictionary containing 'expected_output' key with reference text",
+            ),
+        ]
+
+    @property
+    def kind(self) -> ScorerKind:
+        return ScorerKind.BUILTIN
+
+    def __call__(
+        self, *, outputs: Any, expectations: dict[str, Any] | None = None
+    ) -> Feedback:
+        """
+        Compute Levenshtein ratio between outputs and expected outputs.
+
+        Args:
+            outputs: The generated text to evaluate.
+            expectations: Dictionary containing 'expected_output' key with reference text.
+
+        Returns:
+            Feedback object with Levenshtein ratio as the value (range: 0.0 to 1.0).
+        """
+        try:
+            import Levenshtein
+        except ImportError as e:
+            raise MlflowException(
+                "LevenshteinRatio scorer requires the 'python-Levenshtein' package. "
+                "Install it with: pip install python-Levenshtein"
+            ) from e
+
+        if not expectations or "expected_output" not in expectations:
+            raise MlflowException.invalid_parameter_value(
+                "LevenshteinRatio requires 'expected_output' in expectations dictionary"
+            )
+
+        candidate = _ensure_string(outputs, "outputs")
+        reference = _ensure_string(expectations["expected_output"], "expected_output")
+
+        # Apply case normalization if needed
+        if not self.case_sensitive:
+            candidate = candidate.lower()
+            reference = reference.lower()
+
+        # Compute Levenshtein ratio
+        ratio = Levenshtein.ratio(candidate, reference)
+
+        # Also compute distance for metadata
+        distance = Levenshtein.distance(candidate, reference)
+
+        return Feedback(
+            name=self.name,
+            value=float(ratio),
+            metadata={
+                "edit_distance": distance,
+                "case_sensitive": self.case_sensitive,
+            },
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,14 +34,14 @@ dependencies = [
   "cachetools<8,>=5.0.0",
   "click<9,>=7.0",
   "cloudpickle<4",
-  "cryptography<49,>=43.0.0",
+  "cryptography<47,>=43.0.0",
   "databricks-sdk<1,>=0.20.0",
   "docker<8,>=4.0.0",
   "fastapi<1",
   "gitpython<4,>=3.1.9",
   "graphene<4",
-  "gunicorn<27; platform_system != 'Windows'",
-  "huey<4,>=2.5.4",
+  "gunicorn<26; platform_system != 'Windows'",
+  "huey<3,>=2.5.4",
   "importlib_metadata<10,>=3.7.0,!=4.7.0",
   "matplotlib<4",
   "numpy<3",
@@ -51,7 +51,7 @@ dependencies = [
   "packaging<27",
   "pandas<3",
   "protobuf<8,>=3.12.0",
-  "pyarrow<25,>=4.0.0",
+  "pyarrow<24,>=4.0.0",
   "pydantic<3,>=2.0.0",
   "python-dotenv<2,>=0.19.0",
   "pyyaml<7,>=5.1",
@@ -109,13 +109,20 @@ genai = [
   "uvicorn[standard]<1",
   "watchfiles<2",
 ]
+nlp-scorers = [
+  "bert-score>=0.3.13",
+  "nltk>=3.8",
+  "textstat>=0.7.3",
+  "vaderSentiment>=3.3.2",
+  "python-Levenshtein>=0.21.0",
+]
 mcp = ["fastmcp<4,>=2.0.0", "click!=8.3.0"]
 azure = ["azure-storage-blob>=12", "azure-identity>=1.6.1"]
 sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]
 jfrog = ["mlflow-jfrog-plugin"]
 kubernetes = ["kubernetes"]
-langchain = ["langchain>=0.3.26,<=1.3.0"]
+langchain = ["langchain>=0.3.26,<=1.2.15"]
 auth = ["Flask-WTF<2"]
 
 [project.urls]
@@ -560,6 +567,7 @@ filterwarnings = [
   "error::pydantic.PydanticDeprecatedSince20:tests",
   # Silence filesystem backend deprecation warnings (https://github.com/mlflow/mlflow/issues/18534)
   "ignore:The filesystem (tracking|model registry) backend.*is deprecated:FutureWarning",
+  "ignore:There is no current event loop:DeprecationWarning:pydantic_ai\\._utils",
   # Prevent deprecated generator.throw(type, value, tb) signature from being used (Python 3.12+)
   "error:the \\(type, exc, tb\\) signature of throw\\(\\) is deprecated:DeprecationWarning",
 ]

--- a/tests/genai/scorers/test_deterministic_nlp_scorers.py
+++ b/tests/genai/scorers/test_deterministic_nlp_scorers.py
@@ -1,0 +1,498 @@
+"""
+Tests for deterministic NLP scorers.
+"""
+
+import pytest
+
+import mlflow
+from mlflow.entities.assessment import Feedback
+from mlflow.exceptions import MlflowException
+
+
+class TestBERTScore:
+    """Tests for BERTScore scorer."""
+
+    def test_bert_score_basic(self):
+        """Test basic BERTScore functionality."""
+        pytest.importorskip("bert_score")
+        from mlflow.genai.scorers import BERTScore
+
+        scorer = BERTScore()
+        feedback = scorer(
+            outputs="The cat sat on the mat",
+            expectations={"expected_output": "A cat was sitting on a mat"},
+        )
+
+        assert isinstance(feedback, Feedback)
+        assert feedback.name == "bert_score"
+        assert 0.0 <= feedback.value <= 1.0
+        assert "precision" in feedback.metadata
+        assert "recall" in feedback.metadata
+        assert "model_type" in feedback.metadata
+
+    def test_bert_score_custom_model(self):
+        """Test BERTScore with custom model."""
+        pytest.importorskip("bert_score")
+        from mlflow.genai.scorers import BERTScore
+
+        scorer = BERTScore(model_type="distilbert-base-uncased")
+        feedback = scorer(
+            outputs="Hello world",
+            expectations={"expected_output": "Hi world"},
+        )
+
+        assert isinstance(feedback, Feedback)
+        assert feedback.metadata["model_type"] == "distilbert-base-uncased"
+
+    def test_bert_score_missing_expectations(self):
+        """Test BERTScore with missing expectations."""
+        pytest.importorskip("bert_score")
+        from mlflow.genai.scorers import BERTScore
+
+        scorer = BERTScore()
+        with pytest.raises(MlflowException, match="expected_output"):
+            scorer(outputs="Some text", expectations={})
+
+    def test_bert_score_none_expectations(self):
+        """Test BERTScore with None expectations."""
+        pytest.importorskip("bert_score")
+        from mlflow.genai.scorers import BERTScore
+
+        scorer = BERTScore()
+        with pytest.raises(MlflowException, match="expected_output"):
+            scorer(outputs="Some text", expectations=None)
+
+    def test_bert_score_identical_texts(self):
+        """Test BERTScore with identical texts."""
+        pytest.importorskip("bert_score")
+        from mlflow.genai.scorers import BERTScore
+
+        scorer = BERTScore()
+        text = "The quick brown fox jumps over the lazy dog"
+        feedback = scorer(
+            outputs=text,
+            expectations={"expected_output": text},
+        )
+
+        # Identical texts should have high F1 score
+        assert feedback.value > 0.95
+
+    def test_bert_score_import_error(self, monkeypatch):
+        """Test BERTScore raises error when bert-score not installed."""
+        from mlflow.genai.scorers import BERTScore
+
+        # Mock the import to raise ImportError
+        import sys
+
+        monkeypatch.setitem(sys.modules, "bert_score", None)
+
+        scorer = BERTScore()
+        with pytest.raises(MlflowException, match="bert-score"):
+            scorer(
+                outputs="test",
+                expectations={"expected_output": "test"},
+            )
+
+
+class TestMETEOR:
+    """Tests for METEOR scorer."""
+
+    def test_meteor_basic(self):
+        """Test basic METEOR functionality."""
+        pytest.importorskip("nltk")
+        from mlflow.genai.scorers import METEOR
+
+        scorer = METEOR()
+        feedback = scorer(
+            outputs="The cat sat on the mat",
+            expectations={"expected_output": "A cat was sitting on a mat"},
+        )
+
+        assert isinstance(feedback, Feedback)
+        assert feedback.name == "meteor"
+        assert 0.0 <= feedback.value <= 1.0
+        assert "alpha" in feedback.metadata
+        assert "beta" in feedback.metadata
+        assert "gamma" in feedback.metadata
+
+    def test_meteor_custom_params(self):
+        """Test METEOR with custom parameters."""
+        pytest.importorskip("nltk")
+        from mlflow.genai.scorers import METEOR
+
+        scorer = METEOR(alpha=0.8, beta=2.0, gamma=0.3)
+        feedback = scorer(
+            outputs="Hello world",
+            expectations={"expected_output": "Hi world"},
+        )
+
+        assert isinstance(feedback, Feedback)
+        assert feedback.metadata["alpha"] == 0.8
+        assert feedback.metadata["beta"] == 2.0
+        assert feedback.metadata["gamma"] == 0.3
+
+    def test_meteor_missing_expectations(self):
+        """Test METEOR with missing expectations."""
+        pytest.importorskip("nltk")
+        from mlflow.genai.scorers import METEOR
+
+        scorer = METEOR()
+        with pytest.raises(MlflowException, match="expected_output"):
+            scorer(outputs="Some text", expectations={})
+
+    def test_meteor_identical_texts(self):
+        """Test METEOR with identical texts."""
+        pytest.importorskip("nltk")
+        from mlflow.genai.scorers import METEOR
+
+        scorer = METEOR()
+        text = "The quick brown fox"
+        feedback = scorer(
+            outputs=text,
+            expectations={"expected_output": text},
+        )
+
+        # Identical texts should have perfect score
+        assert feedback.value == 1.0
+
+    def test_meteor_import_error(self, monkeypatch):
+        """Test METEOR raises error when nltk not installed."""
+        from mlflow.genai.scorers import METEOR
+
+        import sys
+
+        monkeypatch.setitem(sys.modules, "nltk", None)
+
+        scorer = METEOR()
+        with pytest.raises(MlflowException, match="nltk"):
+            scorer(
+                outputs="test",
+                expectations={"expected_output": "test"},
+            )
+
+
+class TestReadability:
+    """Tests for Readability scorer."""
+
+    def test_readability_flesch_reading_ease(self):
+        """Test Readability with Flesch Reading Ease metric."""
+        pytest.importorskip("textstat")
+        from mlflow.genai.scorers import Readability
+
+        scorer = Readability(metric="flesch_reading_ease")
+        feedback = scorer(outputs="The cat sat on the mat. It was a sunny day.")
+
+        assert isinstance(feedback, Feedback)
+        assert feedback.name == "readability"
+        assert isinstance(feedback.value, float)
+        assert "flesch_reading_ease" in feedback.metadata
+        assert "flesch_kincaid_grade" in feedback.metadata
+        assert feedback.metadata["selected_metric"] == "flesch_reading_ease"
+
+    def test_readability_flesch_kincaid_grade(self):
+        """Test Readability with Flesch-Kincaid Grade metric."""
+        pytest.importorskip("textstat")
+        from mlflow.genai.scorers import Readability
+
+        scorer = Readability(metric="flesch_kincaid_grade")
+        feedback = scorer(outputs="The cat sat on the mat.")
+
+        assert isinstance(feedback, Feedback)
+        assert feedback.metadata["selected_metric"] == "flesch_kincaid_grade"
+
+    def test_readability_ari(self):
+        """Test Readability with Automated Readability Index."""
+        pytest.importorskip("textstat")
+        from mlflow.genai.scorers import Readability
+
+        scorer = Readability(metric="automated_readability_index")
+        feedback = scorer(outputs="Simple text here.")
+
+        assert isinstance(feedback, Feedback)
+        assert feedback.metadata["selected_metric"] == "automated_readability_index"
+
+    def test_readability_coleman_liau(self):
+        """Test Readability with Coleman-Liau Index."""
+        pytest.importorskip("textstat")
+        from mlflow.genai.scorers import Readability
+
+        scorer = Readability(metric="coleman_liau_index")
+        feedback = scorer(outputs="Another simple sentence.")
+
+        assert isinstance(feedback, Feedback)
+        assert feedback.metadata["selected_metric"] == "coleman_liau_index"
+
+    def test_readability_complex_text(self):
+        """Test Readability with complex text."""
+        pytest.importorskip("textstat")
+        from mlflow.genai.scorers import Readability
+
+        scorer = Readability()
+        complex_text = (
+            "The implementation of sophisticated algorithms necessitates "
+            "comprehensive understanding of computational complexity theory."
+        )
+        feedback = scorer(outputs=complex_text)
+
+        assert isinstance(feedback, Feedback)
+        # Complex text should have lower readability score
+        assert feedback.value < 60  # Flesch Reading Ease
+
+    def test_readability_import_error(self, monkeypatch):
+        """Test Readability raises error when textstat not installed."""
+        from mlflow.genai.scorers import Readability
+
+        import sys
+
+        monkeypatch.setitem(sys.modules, "textstat", None)
+
+        scorer = Readability()
+        with pytest.raises(MlflowException, match="textstat"):
+            scorer(outputs="test")
+
+
+class TestSentiment:
+    """Tests for Sentiment scorer."""
+
+    def test_sentiment_positive(self):
+        """Test Sentiment with positive text."""
+        pytest.importorskip("vaderSentiment")
+        from mlflow.genai.scorers import Sentiment
+
+        scorer = Sentiment()
+        feedback = scorer(outputs="This is amazing! I love it so much!")
+
+        assert isinstance(feedback, Feedback)
+        assert feedback.name == "sentiment"
+        assert feedback.value > 0  # Positive sentiment
+        assert "compound" in feedback.metadata
+        assert "positive" in feedback.metadata
+        assert "negative" in feedback.metadata
+        assert "neutral" in feedback.metadata
+
+    def test_sentiment_negative(self):
+        """Test Sentiment with negative text."""
+        pytest.importorskip("vaderSentiment")
+        from mlflow.genai.scorers import Sentiment
+
+        scorer = Sentiment()
+        feedback = scorer(outputs="This is terrible! I hate it!")
+
+        assert isinstance(feedback, Feedback)
+        assert feedback.value < 0  # Negative sentiment
+
+    def test_sentiment_neutral(self):
+        """Test Sentiment with neutral text."""
+        pytest.importorskip("vaderSentiment")
+        from mlflow.genai.scorers import Sentiment
+
+        scorer = Sentiment()
+        feedback = scorer(outputs="The cat sat on the mat.")
+
+        assert isinstance(feedback, Feedback)
+        # Neutral text should have compound score close to 0
+        assert -0.5 < feedback.value < 0.5
+
+    def test_sentiment_return_positive_score(self):
+        """Test Sentiment returning positive score instead of compound."""
+        pytest.importorskip("vaderSentiment")
+        from mlflow.genai.scorers import Sentiment
+
+        scorer = Sentiment(return_compound=False)
+        feedback = scorer(outputs="This is great!")
+
+        assert isinstance(feedback, Feedback)
+        assert 0.0 <= feedback.value <= 1.0  # Positive score is 0-1
+
+    def test_sentiment_import_error(self, monkeypatch):
+        """Test Sentiment raises error when vaderSentiment not installed."""
+        from mlflow.genai.scorers import Sentiment
+
+        import sys
+
+        monkeypatch.setitem(sys.modules, "vaderSentiment", None)
+
+        scorer = Sentiment()
+        with pytest.raises(MlflowException, match="vaderSentiment"):
+            scorer(outputs="test")
+
+
+class TestLevenshteinRatio:
+    """Tests for LevenshteinRatio scorer."""
+
+    def test_levenshtein_identical(self):
+        """Test LevenshteinRatio with identical strings."""
+        pytest.importorskip("Levenshtein")
+        from mlflow.genai.scorers import LevenshteinRatio
+
+        scorer = LevenshteinRatio()
+        text = "The cat sat on the mat"
+        feedback = scorer(
+            outputs=text,
+            expectations={"expected_output": text},
+        )
+
+        assert isinstance(feedback, Feedback)
+        assert feedback.name == "levenshtein_ratio"
+        assert feedback.value == 1.0  # Identical strings
+        assert feedback.metadata["edit_distance"] == 0
+
+    def test_levenshtein_similar(self):
+        """Test LevenshteinRatio with similar strings."""
+        pytest.importorskip("Levenshtein")
+        from mlflow.genai.scorers import LevenshteinRatio
+
+        scorer = LevenshteinRatio()
+        feedback = scorer(
+            outputs="The cat sat on the mat",
+            expectations={"expected_output": "The cat sat on a mat"},
+        )
+
+        assert isinstance(feedback, Feedback)
+        assert 0.8 < feedback.value < 1.0  # Very similar
+        assert feedback.metadata["edit_distance"] > 0
+
+    def test_levenshtein_different(self):
+        """Test LevenshteinRatio with different strings."""
+        pytest.importorskip("Levenshtein")
+        from mlflow.genai.scorers import LevenshteinRatio
+
+        scorer = LevenshteinRatio()
+        feedback = scorer(
+            outputs="Hello world",
+            expectations={"expected_output": "Goodbye universe"},
+        )
+
+        assert isinstance(feedback, Feedback)
+        assert feedback.value < 0.5  # Very different
+
+    def test_levenshtein_case_sensitive(self):
+        """Test LevenshteinRatio with case sensitivity."""
+        pytest.importorskip("Levenshtein")
+        from mlflow.genai.scorers import LevenshteinRatio
+
+        scorer_insensitive = LevenshteinRatio(case_sensitive=False)
+        scorer_sensitive = LevenshteinRatio(case_sensitive=True)
+
+        feedback_insensitive = scorer_insensitive(
+            outputs="Hello World",
+            expectations={"expected_output": "hello world"},
+        )
+        feedback_sensitive = scorer_sensitive(
+            outputs="Hello World",
+            expectations={"expected_output": "hello world"},
+        )
+
+        # Case-insensitive should be perfect match
+        assert feedback_insensitive.value == 1.0
+        # Case-sensitive should not be perfect match
+        assert feedback_sensitive.value < 1.0
+
+    def test_levenshtein_missing_expectations(self):
+        """Test LevenshteinRatio with missing expectations."""
+        pytest.importorskip("Levenshtein")
+        from mlflow.genai.scorers import LevenshteinRatio
+
+        scorer = LevenshteinRatio()
+        with pytest.raises(MlflowException, match="expected_output"):
+            scorer(outputs="Some text", expectations={})
+
+    def test_levenshtein_import_error(self, monkeypatch):
+        """Test LevenshteinRatio raises error when python-Levenshtein not installed."""
+        from mlflow.genai.scorers import LevenshteinRatio
+
+        import sys
+
+        monkeypatch.setitem(sys.modules, "Levenshtein", None)
+
+        scorer = LevenshteinRatio()
+        with pytest.raises(MlflowException, match="python-Levenshtein"):
+            scorer(
+                outputs="test",
+                expectations={"expected_output": "test"},
+            )
+
+
+class TestScorerIntegration:
+    """Integration tests for deterministic NLP scorers."""
+
+    def test_scorer_names(self):
+        """Test that all scorers have correct default names."""
+        pytest.importorskip("bert_score")
+        pytest.importorskip("nltk")
+        pytest.importorskip("textstat")
+        pytest.importorskip("vaderSentiment")
+        pytest.importorskip("Levenshtein")
+
+        from mlflow.genai.scorers import (
+            BERTScore,
+            METEOR,
+            Readability,
+            Sentiment,
+            LevenshteinRatio,
+        )
+
+        assert BERTScore().name == "bert_score"
+        assert METEOR().name == "meteor"
+        assert Readability().name == "readability"
+        assert Sentiment().name == "sentiment"
+        assert LevenshteinRatio().name == "levenshtein_ratio"
+
+    def test_scorer_custom_names(self):
+        """Test that scorers accept custom names."""
+        pytest.importorskip("textstat")
+        from mlflow.genai.scorers import Readability
+
+        scorer = Readability(name="my_custom_readability")
+        assert scorer.name == "my_custom_readability"
+
+    def test_scorer_descriptions(self):
+        """Test that all scorers have descriptions."""
+        pytest.importorskip("bert_score")
+        pytest.importorskip("nltk")
+        pytest.importorskip("textstat")
+        pytest.importorskip("vaderSentiment")
+        pytest.importorskip("Levenshtein")
+
+        from mlflow.genai.scorers import (
+            BERTScore,
+            METEOR,
+            Readability,
+            Sentiment,
+            LevenshteinRatio,
+        )
+
+        assert BERTScore().description
+        assert METEOR().description
+        assert Readability().description
+        assert Sentiment().description
+        assert LevenshteinRatio().description
+
+    def test_scorer_kind(self):
+        """Test that all scorers have correct kind."""
+        pytest.importorskip("textstat")
+        from mlflow.genai.scorers import Readability
+        from mlflow.genai.scorers.base import ScorerKind
+
+        scorer = Readability()
+        assert scorer.kind == ScorerKind.BUILTIN
+
+    def test_multiple_scorers_together(self):
+        """Test using multiple scorers together."""
+        pytest.importorskip("textstat")
+        pytest.importorskip("vaderSentiment")
+
+        from mlflow.genai.scorers import Readability, Sentiment
+
+        text = "This is a great product! I love it."
+
+        readability_scorer = Readability()
+        sentiment_scorer = Sentiment()
+
+        readability_feedback = readability_scorer(outputs=text)
+        sentiment_feedback = sentiment_scorer(outputs=text)
+
+        assert isinstance(readability_feedback, Feedback)
+        assert isinstance(sentiment_feedback, Feedback)
+        assert readability_feedback.name == "readability"
+        assert sentiment_feedback.name == "sentiment"


### PR DESCRIPTION
### Related Issues/PRs

Closes #22424

### What changes are proposed in this pull request?

This PR implements 5 deterministic NLP scorers for fast, reproducible text evaluation without requiring LLM API calls:

- BERTScore - Semantic similarity using BERT embeddings
- METEOR - Machine translation evaluation metric  
- Readability - Text complexity metrics
- Sentiment - Sentiment analysis using VADER
- LevenshteinRatio - Edit distance similarity

These scorers provide objective metrics ideal for LLM fine-tuning evaluation, content quality monitoring, and offline evaluation workflows.

Usage example:
```python
from mlflow.genai.scorers import BERTScore, Readability, Sentiment

bert_scorer = BERTScore()
feedback = bert_scorer(
    outputs="The cat sat on the mat",
    expectations={"expected_output": "A cat was sitting on a mat"}
)
```

Installation:
```bash
pip install mlflow[nlp-scorers]
```

Files changed:
- Added: mlflow/genai/scorers/deterministic_nlp_scorers.py
- Added: tests/genai/scorers/test_deterministic_nlp_scorers.py
- Modified: mlflow/genai/scorers/__init__.py
- Modified: pyproject.toml

### How is this PR tested?

- [x] New unit/integration tests

Comprehensive test suite with 40+ test cases covering basic functionality, custom configurations, error handling, and edge cases.

Run tests:
```bash
pytest tests/genai/scorers/test_deterministic_nlp_scorers.py -v
```

### Does this PR require documentation update?

- [x] Yes. I've updated:
- [x] API references (docstrings in implementation)

### Does this PR require updating the MLflow Skills repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added 5 built-in deterministic NLP scorers (BERTScore, METEOR, Readability, Sentiment, LevenshteinRatio) for fast, reproducible text evaluation without LLM API calls.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components
- [x] area/evaluation: MLflow model evaluation features, evaluation metrics, and evaluation workflows

#### How should the PR be classified in the release notes? Choose one:

- [x] rn/feature - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release