### PR TITLE
Adding storage layer changes for Claude Code tracing WAL batch processing

### DIFF
--- a/libs/typescript/core/src/core/utils/env.ts
+++ b/libs/typescript/core/src/core/utils/env.ts
@@ -1,0 +1,37 @@
+/**
+ * Read an env var and require a strictly positive integer.
+ */
+export const readPositiveInt = (envName: string, fallback: number): number => {
+  const raw = process.env[envName];
+  if (raw === undefined || raw === '') {
+    return fallback;
+  }
+  // `Number` (vs `Number.parseInt`) refuses trailing garbage and unit
+  // suffixes — e.g. "15000abc", "15s", and "10.9" all become NaN or a
+  // non-integer, so the `isInteger` check below rejects them cleanly.
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    console.warn(
+      `[mlflow] Ignoring invalid ${envName}=${JSON.stringify(raw)}; ` +
+        `expected a positive integer. Falling back to default ${fallback}.`,
+    );
+    return fallback;
+  }
+  return parsed;
+};
+
+export const readNonNegativeInt = (envName: string, fallback: number): number => {
+  const raw = process.env[envName];
+  if (raw === undefined || raw === '') {
+    return fallback;
+  }
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    console.warn(
+      `[mlflow] Ignoring invalid ${envName}=${JSON.stringify(raw)}; ` +
+        `expected a non-negative integer. Falling back to default ${fallback}.`,
+    );
+    return fallback;
+  }
+  return parsed;
+};

--- a/libs/typescript/core/src/exporters/wal/constants.ts
+++ b/libs/typescript/core/src/exporters/wal/constants.ts
@@ -27,19 +27,68 @@ function readPositiveInt(envName: string, fallback: number): number {
 }
 
 /**
- * Maximum number of upload attempts per record before the daemon moves the
- * record to the dead-letter file (`failed.log`).
- *
- * Override via `MLFLOW_TRACE_MAX_RETRY_ATTEMPTS`.
+ * Like {@link readPositiveInt} but accepts `0` as a valid value. Used for
+ * knobs where `0` carries the semantic of "disabled" (e.g. retention sweep
+ * off) rather than "invalid".
  */
-export const MAX_ATTEMPTS: number = readPositiveInt('MLFLOW_TRACE_MAX_RETRY_ATTEMPTS', 10);
+function readNonNegativeInt(envName: string, fallback: number): number {
+  const raw = process.env[envName];
+  if (raw === undefined || raw === '') {
+    return fallback;
+  }
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    console.warn(
+      `[mlflow][wal] Ignoring invalid ${envName}=${JSON.stringify(raw)}; ` +
+        `expected a non-negative integer. Falling back to default ${fallback}.`,
+    );
+    return fallback;
+  }
+  return parsed;
+}
+
+/**
+ * Wall-clock budget for retrying a single record before the daemon moves it
+ * to the dead-letter file (`failed.log`), in milliseconds.
+ *
+ * Reuses Python's `MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT` (seconds, default
+ * 500) and multiplies by 1000 to keep the daemon math in ms alongside
+ * {@link backoff}. The anchor for "elapsed" is the daemon's first attempt
+ * on the record (`WalRecord.firstAttemptAt`), not the record's creation
+ * time, so a record that sat in the WAL while the daemon was idle still
+ * gets a fresh budget once a daemon picks it up.
+ *
+ * On every failure the daemon checks `elapsed + next_backoff_delay`; if
+ * that would exceed the budget, the record is dead-lettered instead of
+ * re-appended. This mirrors Python's
+ * `_retry_databricks_sdk_call_with_exponential_backoff`.
+ */
+export const RETRY_TIMEOUT_MS: number =
+  readPositiveInt('MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT', 500) * 1_000;
 
 /**
  * Interval between daemon batch loop iterations, in milliseconds.
  *
- * Override via `MLFLOW_TRACE_BATCH_INTERVAL_MS`.
+ * Reuses `MLFLOW_ASYNC_TRACE_LOGGING_MAX_INTERVAL_MILLIS` — the same env var
+ * the Python `BatchSpanProcessor` and `SpanBatcher` consult — so an operator
+ * sets one knob to control "max latency between a trace landing and being
+ * shipped to the backend" across both runtimes.
+ *
+ * Note that the cost shape is different in the two layers: Python's variable
+ * gates an in-process span buffer flush (effectively free per tick), while
+ * the TS variable gates an out-of-process daemon poll that reads the on-disk
+ * WAL each tick. Setting this very aggressively (e.g. <1000 ms) saves only
+ * a few seconds of trace-export lag and pays the disk-scan cost continuously
+ * — usually not worth it.
+ *
+ * The default is intentionally higher than the Python side's 5000 ms because
+ * the disk-scan cost makes the trade-off lean toward fewer ticks. Operators
+ * who want the runtimes to behave identically can simply set this env var.
  */
-export const BATCH_INTERVAL_MS: number = readPositiveInt('MLFLOW_TRACE_BATCH_INTERVAL_MS', 15_000);
+export const BATCH_INTERVAL_MS: number = readPositiveInt(
+  'MLFLOW_ASYNC_TRACE_LOGGING_MAX_INTERVAL_MILLIS',
+  15_000,
+);
 
 /**
  * Threshold for daemon idle shutdown, in milliseconds. After this much
@@ -49,3 +98,18 @@ export const BATCH_INTERVAL_MS: number = readPositiveInt('MLFLOW_TRACE_BATCH_INT
  * Override via `MLFLOW_TRACE_DAEMON_IDLE_MS`.
  */
 export const IDLE_MS: number = readPositiveInt('MLFLOW_TRACE_DAEMON_IDLE_MS', 120_000);
+
+/**
+ * Retention window (in UTC days) for the daily-rotated `failed.log.<date>`
+ * and `daemon.log.<date>` files under the WAL directory. Files older than
+ * `today_utc − LOG_RETENTION_DAYS` are unlinked once per daemon startup;
+ * a value of `0` disables the sweep entirely.
+ *
+ * This is the only resource the daemon owns whose disk footprint grows
+ * monotonically — `queue.log` is bounded by compaction, and the lock
+ * socket is managed by the lock lifecycle. `MLFLOW_TRACE_LOG_RETENTION_DAYS`
+ * is the operator knob; the default of 14 days is enough to cover a
+ * multi-day backend outage's dead-letter trail while still being a
+ * meaningful upper bound.
+ */
+export const LOG_RETENTION_DAYS: number = readNonNegativeInt('MLFLOW_TRACE_LOG_RETENTION_DAYS', 14);

--- a/libs/typescript/core/src/exporters/wal/constants.ts
+++ b/libs/typescript/core/src/exporters/wal/constants.ts
@@ -1,92 +1,18 @@
 /**
  * Tunable defaults for the WAL exporter and uploader daemon.
- *
- * All values can be overridden by environment variables. Env vars are read
- * at module load time, so changes take effect the next time the process
- * that imports this module starts (e.g. the next Stop hook invocation, or
- * the next daemon respawn after an idle exit).
  */
 
-function readPositiveInt(envName: string, fallback: number): number {
-  const raw = process.env[envName];
-  if (raw === undefined || raw === '') {
-    return fallback;
-  }
-  // `Number` (vs `Number.parseInt`) refuses trailing garbage and unit
-  // suffixes — e.g. "15000abc", "15s", and "10.9" all become NaN or a
-  // non-integer, so the `isInteger` check below rejects them cleanly.
-  const parsed = Number(raw);
-  if (!Number.isInteger(parsed) || parsed <= 0) {
-    console.warn(
-      `[mlflow][wal] Ignoring invalid ${envName}=${JSON.stringify(raw)}; ` +
-        `expected a positive integer. Falling back to default ${fallback}.`,
-    );
-    return fallback;
-  }
-  return parsed;
-}
-
-/**
- * Like {@link readPositiveInt} but accepts `0` as a valid value. Used for
- * knobs where `0` carries the semantic of "disabled" (e.g. retention sweep
- * off) rather than "invalid".
- */
-function readNonNegativeInt(envName: string, fallback: number): number {
-  const raw = process.env[envName];
-  if (raw === undefined || raw === '') {
-    return fallback;
-  }
-  const parsed = Number(raw);
-  if (!Number.isInteger(parsed) || parsed < 0) {
-    console.warn(
-      `[mlflow][wal] Ignoring invalid ${envName}=${JSON.stringify(raw)}; ` +
-        `expected a non-negative integer. Falling back to default ${fallback}.`,
-    );
-    return fallback;
-  }
-  return parsed;
-}
+import { readNonNegativeInt, readPositiveInt } from '../../core/utils/env';
 
 /**
  * Wall-clock budget for retrying a single record before the daemon moves it
  * to the dead-letter file (`failed.log`), in milliseconds.
- *
- * Reuses Python's `MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT` (seconds, default
- * 500) and multiplies by 1000 to keep the daemon math in ms alongside
- * {@link backoff}. The anchor for "elapsed" is the daemon's first attempt
- * on the record (`WalRecord.firstAttemptAt`), not the record's creation
- * time, so a record that sat in the WAL while the daemon was idle still
- * gets a fresh budget once a daemon picks it up.
- *
- * On every failure the daemon checks `elapsed + next_backoff_delay`; if
- * that would exceed the budget, the record is dead-lettered instead of
- * re-appended. This mirrors Python's
- * `_retry_databricks_sdk_call_with_exponential_backoff`.
- *
- * `0` is a legitimate value, not "invalid → fall back to default": it
- * means "dead-letter on the first failure" and matches Python exactly.
  */
 export const RETRY_TIMEOUT_MS: number =
   readNonNegativeInt('MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT', 500) * 1_000;
 
 /**
  * Interval between daemon batch loop iterations, in milliseconds.
- *
- * Reuses `MLFLOW_ASYNC_TRACE_LOGGING_MAX_INTERVAL_MILLIS` — the same env var
- * the Python `BatchSpanProcessor` and `SpanBatcher` consult — so an operator
- * sets one knob to control "max latency between a trace landing and being
- * shipped to the backend" across both runtimes.
- *
- * Note that the cost shape is different in the two layers: Python's variable
- * gates an in-process span buffer flush (effectively free per tick), while
- * the TS variable gates an out-of-process daemon poll that reads the on-disk
- * WAL each tick. Setting this very aggressively (e.g. <1000 ms) saves only
- * a few seconds of trace-export lag and pays the disk-scan cost continuously
- * — usually not worth it.
- *
- * The default is intentionally higher than the Python side's 5000 ms because
- * the disk-scan cost makes the trade-off lean toward fewer ticks. Operators
- * who want the runtimes to behave identically can simply set this env var.
  */
 export const BATCH_INTERVAL_MS: number = readPositiveInt(
   'MLFLOW_ASYNC_TRACE_LOGGING_MAX_INTERVAL_MILLIS',
@@ -97,8 +23,6 @@ export const BATCH_INTERVAL_MS: number = readPositiveInt(
  * Threshold for daemon idle shutdown, in milliseconds. After this much
  * time with the WAL empty and no new records appended, the daemon flushes,
  * releases its lock, and exits.
- *
- * Override via `MLFLOW_TRACE_DAEMON_IDLE_MS`.
  */
 export const IDLE_MS: number = readPositiveInt('MLFLOW_TRACE_DAEMON_IDLE_MS', 120_000);
 
@@ -107,12 +31,5 @@ export const IDLE_MS: number = readPositiveInt('MLFLOW_TRACE_DAEMON_IDLE_MS', 12
  * and `daemon.log.<date>` files under the WAL directory. Files older than
  * `today_utc − LOG_RETENTION_DAYS` are unlinked once per daemon startup;
  * a value of `0` disables the sweep entirely.
- *
- * This is the only resource the daemon owns whose disk footprint grows
- * monotonically — `queue.log` is bounded by compaction, and the lock
- * socket is managed by the lock lifecycle. `MLFLOW_TRACE_LOG_RETENTION_DAYS`
- * is the operator knob; the default of 14 days is enough to cover a
- * multi-day backend outage's dead-letter trail while still being a
- * meaningful upper bound.
  */
 export const LOG_RETENTION_DAYS: number = readNonNegativeInt('MLFLOW_TRACE_LOG_RETENTION_DAYS', 14);

--- a/libs/typescript/core/src/exporters/wal/constants.ts
+++ b/libs/typescript/core/src/exporters/wal/constants.ts
@@ -62,9 +62,12 @@ function readNonNegativeInt(envName: string, fallback: number): number {
  * that would exceed the budget, the record is dead-lettered instead of
  * re-appended. This mirrors Python's
  * `_retry_databricks_sdk_call_with_exponential_backoff`.
+ *
+ * `0` is a legitimate value, not "invalid → fall back to default": it
+ * means "dead-letter on the first failure" and matches Python exactly.
  */
 export const RETRY_TIMEOUT_MS: number =
-  readPositiveInt('MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT', 500) * 1_000;
+  readNonNegativeInt('MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT', 500) * 1_000;
 
 /**
  * Interval between daemon batch loop iterations, in milliseconds.

--- a/libs/typescript/core/src/exporters/wal/paths.ts
+++ b/libs/typescript/core/src/exporters/wal/paths.ts
@@ -3,8 +3,19 @@
  *
  * A spool is shared across all Claude Code sessions (and other MLflow TS
  * integrations) that resolve to the same `MLFLOW_WAL_DIR` for a single OS
- * user. The WAL data files (`queue.log`, `failed.log`, `daemon.log`)
- * always live inside the resolved spool root.
+ * user. The WAL files always live inside the resolved spool root:
+ *
+ * - `queue.log` — single file, compacted on the fly. The hot work queue.
+ * - `failed.log.<YYYY-MM-DD>` — daily-rotated dead-letter file. Append-only
+ *   forever; never compacted. The suffix comes from the *UTC* date so the
+ *   day boundary is stable across timezones and matches the `…Z` ISO
+ *   timestamps written inside `daemon.log`.
+ * - `daemon.log.<YYYY-MM-DD>` — daily-rotated diagnostic stream. Same UTC
+ *   convention as `failed.log`.
+ *
+ * "Rotation" is stateless: every write resolves its path from the current
+ * date, so a writer that crosses midnight UTC lands subsequent lines in
+ * the next-day file with no rename, no detection, no coordination.
  *
  * The daemon's singleton lock is scoped per `(user, spool root)` on both
  * platforms; its exact location depends on the platform and the resolved
@@ -57,19 +68,44 @@ export function getWalPath(): string {
 }
 
 /**
- * Append-only dead-letter file containing records that have exhausted
- * `MLFLOW_TRACE_MAX_RETRY_ATTEMPTS` attempts. Records here are durable and
- * inspectable / replayable by operators; the daemon never re-reads this file.
+ * `YYYY-MM-DD` in UTC. Used as the suffix on `failed.log` and `daemon.log`
+ * so the two files rotate daily without any explicit rename. UTC keeps the
+ * boundary stable across the timezones a multi-region rollout will hit and
+ * matches the `…Z` ISO timestamps the daemon writes inside the files.
+ *
+ * Exposed as an optional argument purely so tests can pin the date.
  */
-export function getDeadLetterPath(): string {
-  return join(getWalDir(), 'failed.log');
+function dateSuffix(d: Date = new Date()): string {
+  const yyyy = d.getUTCFullYear().toString().padStart(4, '0');
+  const mm = (d.getUTCMonth() + 1).toString().padStart(2, '0');
+  const dd = d.getUTCDate().toString().padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+/**
+ * Append-only dead-letter file containing records whose retry-budget window
+ * (`MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT`) has elapsed. Records here are
+ * durable and inspectable / replayable by operators; the daemon never
+ * re-reads this file.
+ *
+ * Rotated daily by the UTC date in the filename suffix. Day boundaries that
+ * occur mid-write naturally split lines into the next-day file because the
+ * path is resolved from the clock at every `appendDeadLetter` call.
+ */
+export function getDeadLetterPath(now: Date = new Date()): string {
+  return join(getWalDir(), `failed.log.${dateSuffix(now)}`);
 }
 
 /**
  * Daemon log file with diagnostic lines (retries, DLQ entries, fatal errors).
+ *
+ * Same daily-by-UTC rotation as {@link getDeadLetterPath}: the daemon's
+ * `log()` helper resolves this on every line, so a daemon that spans
+ * midnight writes earlier lines to the `…<today>` file and later lines to
+ * the `…<tomorrow>` file with no explicit handoff.
  */
-export function getDaemonLogPath(): string {
-  return join(getWalDir(), 'daemon.log');
+export function getDaemonLogPath(now: Date = new Date()): string {
+  return join(getWalDir(), `daemon.log.${dateSuffix(now)}`);
 }
 
 /**

--- a/libs/typescript/core/src/exporters/wal/paths.ts
+++ b/libs/typescript/core/src/exporters/wal/paths.ts
@@ -62,7 +62,7 @@ export function getDaemonLogPath(now: Date = new Date()): string {
 }
 
 /**
- * Stable per (user, wal_dir)` identifier used to scope the daemon lock
+ * Stable per (user, wal_dir) identifier used to scope the daemon lock
  */
 function getScopedLockId(): string {
   const sanitizedUser = userInfo().username.replace(/[^a-zA-Z0-9_-]/g, '_');

--- a/libs/typescript/core/src/exporters/wal/paths.ts
+++ b/libs/typescript/core/src/exporters/wal/paths.ts
@@ -1,21 +1,7 @@
 /**
  * Filesystem paths for the MLflow trace WAL (Write-Ahead Log) spool.
  *
- * A spool is shared across all Claude Code sessions (and other MLflow TS
- * integrations) that resolve to the same `MLFLOW_WAL_DIR` for a single OS
- * user. The WAL files always live inside the resolved spool root:
- *
- * - `queue.log` — single file, compacted on the fly. The hot work queue.
- * - `failed.log.<YYYY-MM-DD>` — daily-rotated dead-letter file. Append-only
- *   forever; never compacted. The suffix comes from the *UTC* date so the
- *   day boundary is stable across timezones and matches the `…Z` ISO
- *   timestamps written inside `daemon.log`.
- * - `daemon.log.<YYYY-MM-DD>` — daily-rotated diagnostic stream. Same UTC
- *   convention as `failed.log`.
- *
- * "Rotation" is stateless: every write resolves its path from the current
- * date, so a writer that crosses midnight UTC lands subsequent lines in
- * the next-day file with no rename, no detection, no coordination.
+ * A spool is shared across all Claude Code sessions
  *
  * The daemon's singleton lock is scoped per `(user, spool root)` on both
  * platforms; its exact location depends on the platform and the resolved
@@ -24,8 +10,6 @@
  * - POSIX, long-path fallback: `<tmpdir>/mlflow-<scoped_id>.sock` when the
  *   natural path would exceed `sun_path`.
  * - Windows: a Named Pipe whose name embeds a hash of the spool root.
- *
- * See {@link getLockSocketPath} for the full rationale.
  */
 
 import { createHash } from 'node:crypto';
@@ -34,24 +18,11 @@ import { join, resolve } from 'node:path';
 
 /**
  * Maximum allowed length, in bytes, for a UNIX domain socket path.
- *
- * `sun_path` is fixed-size in `struct sockaddr_un`: 108 bytes on Linux,
- * 104 on macOS/BSD. Each is one byte of NUL terminator, so the actual
- * string max is 107 / 103 respectively. We use the tighter macOS/BSD
- * limit (103) for the check so the same code works on both kernels
- * without per-platform branching.
  */
 const POSIX_SOCKET_PATH_MAX_BYTES = 103;
 
 /**
  * Root directory of the per-user spool. Defaults to `~/.mlflow/wal/`.
- *
- * The result is always an absolute, resolved path so that callers comparing
- * or hashing the WAL dir cannot accidentally treat `/tmp/foo` and
- * `/tmp/foo/` as two different roots.
- *
- * Empty-string values for `MLFLOW_WAL_DIR` (e.g. `export MLFLOW_WAL_DIR=""`)
- * are treated the same as unset to avoid silently producing relative paths.
  */
 export function getWalDir(): string {
   const override = process.env.MLFLOW_WAL_DIR;
@@ -67,14 +38,6 @@ export function getWalPath(): string {
   return join(getWalDir(), 'queue.log');
 }
 
-/**
- * `YYYY-MM-DD` in UTC. Used as the suffix on `failed.log` and `daemon.log`
- * so the two files rotate daily without any explicit rename. UTC keeps the
- * boundary stable across the timezones a multi-region rollout will hit and
- * matches the `…Z` ISO timestamps the daemon writes inside the files.
- *
- * Exposed as an optional argument purely so tests can pin the date.
- */
 function dateSuffix(d: Date = new Date()): string {
   const yyyy = d.getUTCFullYear().toString().padStart(4, '0');
   const mm = (d.getUTCMonth() + 1).toString().padStart(2, '0');
@@ -85,12 +48,7 @@ function dateSuffix(d: Date = new Date()): string {
 /**
  * Append-only dead-letter file containing records whose retry-budget window
  * (`MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT`) has elapsed. Records here are
- * durable and inspectable / replayable by operators; the daemon never
- * re-reads this file.
- *
- * Rotated daily by the UTC date in the filename suffix. Day boundaries that
- * occur mid-write naturally split lines into the next-day file because the
- * path is resolved from the clock at every `appendDeadLetter` call.
+ * durable and inspectable / replayable by operators.
  */
 export function getDeadLetterPath(now: Date = new Date()): string {
   return join(getWalDir(), `failed.log.${dateSuffix(now)}`);
@@ -98,22 +56,13 @@ export function getDeadLetterPath(now: Date = new Date()): string {
 
 /**
  * Daemon log file with diagnostic lines (retries, DLQ entries, fatal errors).
- *
- * Same daily-by-UTC rotation as {@link getDeadLetterPath}: the daemon's
- * `log()` helper resolves this on every line, so a daemon that spans
- * midnight writes earlier lines to the `…<today>` file and later lines to
- * the `…<tomorrow>` file with no explicit handoff.
  */
 export function getDaemonLogPath(now: Date = new Date()): string {
   return join(getWalDir(), `daemon.log.${dateSuffix(now)}`);
 }
 
 /**
- * Stable per-`(user, wal_dir)` identifier used to scope the daemon lock when
- * the lock cannot simply live inside the WAL dir (Windows pipe namespace,
- * POSIX `tmpdir` fallback). 12 hex chars (~48 bits) of SHA-256 is plenty
- * for the handful of distinct WAL dirs a single user would realistically
- * use, and the sanitized username keeps multi-user hosts isolated.
+ * Stable per (user, wal_dir)` identifier used to scope the daemon lock
  */
 function getScopedLockId(): string {
   const sanitizedUser = userInfo().username.replace(/[^a-zA-Z0-9_-]/g, '_');
@@ -123,33 +72,6 @@ function getScopedLockId(): string {
 
 /**
  * Path used as the daemon's singleton liveness lock.
- *
- * The lock is scoped per `(user, wal_dir)` on both platforms so that a user
- * with two terminals overriding `MLFLOW_WAL_DIR` to different values gets
- * one independent daemon per WAL dir (each daemon only reads its own
- * `queue.log`). A single shared lock identifier would otherwise let one
- * daemon claim the lock and leave the other WAL stranded.
- *
- * - **POSIX, common case**: a UNIX domain socket file at
- *   `<wal_dir>/daemon.sock`. The daemon binds it with
- *   `net.createServer().listen()` for its whole lifetime; the kernel's
- *   exclusive-bind semantic on that path is what gives us the
- *   at-most-one-daemon guarantee. Scoping falls out naturally from the
- *   socket file living inside the WAL dir.
- * - **POSIX, long-path fallback**: `<wal_dir>/daemon.sock` can exceed the
- *   fixed `sun_path` size (104 bytes on macOS/BSD, 108 on Linux), e.g.
- *   if `MLFLOW_WAL_DIR` resolves to a sandboxed container dir or a deep
- *   user folder. When the natural path would exceed
- *   {@link POSIX_SOCKET_PATH_MAX_BYTES}, the socket falls back to
- *   `<tmpdir>/mlflow-<scoped_id>.sock`. A `console.warn` makes the
- *   deviation discoverable. Per-(user, wal_dir) scoping is preserved by
- *   the `<scoped_id>` suffix.
- * - **Windows**: a Named Pipe at `\\?\pipe\mlflow-trace-daemon-<scoped_id>`.
- *   Named pipes share a single flat namespace per machine, so the pipe
- *   name has to encode both the user (to keep multi-user hosts isolated)
- *   and a hash of the resolved WAL dir (to match POSIX's per-WAL-dir
- *   scoping). Named pipes are kernel-refcounted and disappear
- *   automatically on process exit, so no stale-cleanup logic is needed.
  */
 export function getLockSocketPath(): string {
   const scopedId = getScopedLockId();

--- a/libs/typescript/core/src/exporters/wal/storage.ts
+++ b/libs/typescript/core/src/exporters/wal/storage.ts
@@ -26,10 +26,11 @@ class SerialQueue {
   }
 }
 
-const queueWriter = new SerialQueue();
+export const queueWriter = new SerialQueue();
+
 const deadLetterWriter = new SerialQueue();
 
-async function ensureParentDir(filePath: string): Promise<void> {
+export async function ensureParentDir(filePath: string): Promise<void> {
   await mkdir(dirname(filePath), { recursive: true });
 }
 
@@ -54,9 +55,6 @@ async function appendJsonLine(path: string, line: WalLine): Promise<void> {
 
 /**
  * Append a pending trace upload to the WAL.
- *
- * Returns when the line is durable on disk (post-fsync). Callers may safely
- * exit immediately after this resolves.
  */
 export function appendRecord(record: WalRecord): Promise<void> {
   return queueWriter.run(() => appendJsonLine(getWalPath(), { type: 'append', record }));
@@ -82,22 +80,14 @@ export function appendDeadLetter(record: WalRecord): Promise<void> {
 /**
  * Replay `queue.log` and return the set of records still considered pending.
  */
-export async function readPending(opts: { byteLimit?: number } = {}): Promise<WalRecord[]> {
+export async function readPending(): Promise<WalRecord[]> {
   const path = getWalPath();
   if (!existsSync(path)) {
     return [];
   }
-  // Empty snapshot: don't open the stream at all
-  if (opts.byteLimit !== undefined && opts.byteLimit <= 0) {
-    return [];
-  }
 
   const alive = new Map<string, WalRecord>();
-  const streamOpts: Parameters<typeof createReadStream>[1] =
-    opts.byteLimit !== undefined
-      ? { encoding: 'utf8', start: 0, end: opts.byteLimit - 1 }
-      : { encoding: 'utf8' };
-  const stream = createReadStream(path, streamOpts);
+  const stream = createReadStream(path, { encoding: 'utf8' });
   const rl = createInterface({ input: stream, crlfDelay: Infinity });
 
   for await (const line of rl) {
@@ -141,8 +131,7 @@ export function compact(): Promise<void> {
       return;
     }
 
-    const startSize = (await stat(path)).size;
-    const liveRecords = await readPending({ byteLimit: startSize });
+    const liveRecords = await readPending();
 
     const tmpPath = `${path}.tmp.${process.pid}`;
     const tmpFh = await open(tmpPath, 'w');
@@ -154,20 +143,6 @@ export function compact(): Promise<void> {
         );
         await tmpFh.write(buf);
       }
-
-      const currentSize = (await stat(path)).size;
-      if (currentSize > startSize) {
-        const tailLength = currentSize - startSize;
-        const tail = Buffer.alloc(tailLength);
-        const srcFh = await open(path, 'r');
-        try {
-          await srcFh.read(tail, 0, tailLength, startSize);
-        } finally {
-          await srcFh.close();
-        }
-        await tmpFh.write(tail);
-      }
-
       await tmpFh.sync();
       await tmpFh.close();
       await rename(tmpPath, path);

--- a/libs/typescript/core/src/exporters/wal/storage.ts
+++ b/libs/typescript/core/src/exporters/wal/storage.ts
@@ -1,0 +1,253 @@
+/**
+ * Append-only JSONL store backing the trace upload Write-Ahead Log.
+ *
+ * Two files live here, both under `getWalDir()`:
+ *
+ * - `queue.log` — pending uploads. Two line types: `{type:"append",record}`
+ *   and `{type:"tombstone",id}`. Readers replay the file into a
+ *   `Map<id, WalRecord>` and `tombstone` lines act as `Map.delete(id)`.
+ *   Periodically compacted (read live records, rewrite, atomic rename) so
+ *   the file does not grow without bound.
+ * - `failed.log.<YYYY-MM-DD>` — dead-letter file, rotated daily by UTC date.
+ *   Records whose retry-budget window (`RETRY_TIMEOUT_MS`) expired. Only ever appended
+ *   to; never tombstoned, never compacted. Inspectable by operators; the
+ *   daemon never re-reads it. Rotation is stateless: every
+ *   {@link appendDeadLetter} call resolves the path from the current date,
+ *   so a record dead-lettered at 23:59:59 UTC and another at 00:00:00 UTC
+ *   land in two adjacent dated files automatically.
+ *
+ * Concurrency model:
+ *
+ * - In-process: every write to a given file goes through a {@link SerialQueue}
+ *   so that open/write/fsync/close phases never interleave. Two separate
+ *   queues (one per file) allow append-to-queue.log and append-to-failed.log
+ *   to make progress in parallel.
+ * - Cross-process: hooks open queue.log with `flag: 'a'` and write a single
+ *   line buffer per record, which is atomic on common filesystems for the
+ *   sizes we write. The daemon is the only compactor; `compact` snapshots
+ *   the file size up-front, writes the compacted output to a tmp file, then
+ *   re-reads any tail bytes that arrived during the rewrite and appends them
+ *   before the final atomic `rename`. A tiny race window remains between the
+ *   tail-read and the rename; any record appended in that ~ms window would
+ *   be overwritten. We accept this for v1 because compaction is
+ *   daemon-driven (rare) and the only racers are Stop hooks (low rate).
+ */
+
+import { createReadStream, existsSync } from 'node:fs';
+import { mkdir, open, rename, stat, unlink } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { createInterface } from 'node:readline';
+import { JSONBig } from '../../core/utils/json';
+import { getDeadLetterPath, getWalPath } from './paths';
+import { WalLine, WalRecord } from './types';
+
+/**
+ * Promise-chained queue that serializes async tasks one at a time.
+ *
+ * Errors thrown by an enqueued task surface to that task's caller (the
+ * `Promise` returned by `run`), but they do not break the chain — subsequent
+ * tasks still run. This matters because a transient `EIO` on one append must
+ * not poison every later append in the same process.
+ */
+class SerialQueue {
+  private tail: Promise<void> = Promise.resolve();
+
+  run<T>(fn: () => Promise<T>): Promise<T> {
+    const result = this.tail.then(fn, fn);
+    this.tail = result.then(
+      () => {},
+      () => {},
+    );
+    return result;
+  }
+}
+
+const queueWriter = new SerialQueue();
+const deadLetterWriter = new SerialQueue();
+
+async function ensureParentDir(filePath: string): Promise<void> {
+  await mkdir(dirname(filePath), { recursive: true });
+}
+
+/**
+ * Append a single JSONL line + `\n` to `path`, fsync, and close.
+ *
+ * Encodes the line into a single `Buffer` so that the write hits the file in
+ * one syscall. On the filesystems we target (ext4, APFS, NTFS) writes up to
+ * `PIPE_BUF` (~4 KiB) are atomic; line-sized records are well below that,
+ * and even multi-KB records are atomic in practice for `flag: 'a'` opens.
+ * If a write is ever torn (e.g. host crash mid-write), {@link readPending}
+ * tolerates the bad line by parsing-and-skipping.
+ *
+ * Uses {@link JSONBig} so `SerializedSpan.start_time_unix_nano` (and other
+ * `bigint` fields on the trace data) round-trip cleanly. Native
+ * `JSON.stringify` throws `TypeError: Do not know how to serialize a BigInt`
+ * on those fields, matching the codec the rest of the codebase already uses
+ * for outbound trace payloads (`clients/utils.ts`, `clients/artifacts/*`).
+ */
+async function appendJsonLine(path: string, line: WalLine): Promise<void> {
+  await ensureParentDir(path);
+  const buf = Buffer.from(JSONBig.stringify(line) + '\n', 'utf8');
+  const fh = await open(path, 'a');
+  try {
+    await fh.write(buf);
+    await fh.sync();
+  } finally {
+    await fh.close();
+  }
+}
+
+/**
+ * Append a pending trace upload to the WAL.
+ *
+ * Returns when the line is durable on disk (post-fsync). Callers may safely
+ * exit immediately after this resolves.
+ */
+export function appendRecord(record: WalRecord): Promise<void> {
+  return queueWriter.run(() => appendJsonLine(getWalPath(), { type: 'append', record }));
+}
+
+/**
+ * Append a tombstone for `id` to the WAL. Logically shadows any earlier
+ * `{type:"append"}` line for the same id.
+ */
+export function appendTombstone(id: string): Promise<void> {
+  return queueWriter.run(() => appendJsonLine(getWalPath(), { type: 'tombstone', id }));
+}
+
+/**
+ * Append `record` to the dead-letter file (`failed.log`).
+ *
+ * Dead-lettering does not tombstone the live queue on its own; callers
+ * (the daemon) should pair this with {@link appendTombstone} so that the
+ * next batch tick does not retry the same poison record.
+ */
+export function appendDeadLetter(record: WalRecord): Promise<void> {
+  return deadLetterWriter.run(() =>
+    appendJsonLine(getDeadLetterPath(), { type: 'append', record }),
+  );
+}
+
+/**
+ * Replay `queue.log` and return the set of records still considered pending.
+ *
+ * Unknown line types and malformed lines (failed `JSON.parse`) are silently
+ * skipped with a `console.debug` so a single torn write cannot block the
+ * whole batch. Returns an empty array if the WAL file does not exist yet.
+ */
+export async function readPending(): Promise<WalRecord[]> {
+  const path = getWalPath();
+  if (!existsSync(path)) {
+    return [];
+  }
+
+  const alive = new Map<string, WalRecord>();
+  const stream = createReadStream(path, { encoding: 'utf8' });
+  const rl = createInterface({ input: stream, crlfDelay: Infinity });
+
+  for await (const line of rl) {
+    if (line === '') {
+      continue;
+    }
+    let parsed: unknown;
+    try {
+      // JSONBig.parse so bigint fields written by `appendJsonLine` are
+      // restored as `bigint` (and not as the lossy `number` JSON.parse
+      // would coerce them to once stringified back through `JSONBig`).
+      parsed = JSONBig.parse(line);
+    } catch {
+      console.debug(`[mlflow][wal] Skipping malformed WAL line: ${line.slice(0, 120)}`);
+      continue;
+    }
+    if (!parsed || typeof parsed !== 'object') {
+      continue;
+    }
+    const obj = parsed as { type?: unknown; record?: unknown; id?: unknown };
+    if (obj.type === 'append') {
+      const record = obj.record as WalRecord | undefined;
+      if (record && typeof record.id === 'string') {
+        alive.set(record.id, record);
+      }
+    } else if (obj.type === 'tombstone' && typeof obj.id === 'string') {
+      alive.delete(obj.id);
+    }
+  }
+
+  return [...alive.values()];
+}
+
+/**
+ * Rewrite `queue.log` to contain only currently-live records.
+ *
+ * Procedure:
+ *   1. Stat the WAL to snapshot `startSize`.
+ *   2. Read pending records.
+ *   3. Write each record as a fresh `{type:"append"}` line to
+ *      `queue.log.tmp.<pid>`.
+ *   4. Stat the WAL again; if it grew since step 1, copy the tail bytes
+ *      `[startSize, currentSize)` (representing concurrent appends from
+ *      other processes) into the tmp file. These bytes are guaranteed to
+ *      consist of full lines because writers fsync after each line.
+ *   5. fsync the tmp file and atomically rename it onto `queue.log`.
+ *
+ * The whole thing runs inside the in-process queue writer so it cannot
+ * interleave with in-process appends. Cross-process appends that land
+ * between step 4 and step 5 will be lost — see the file header comment.
+ */
+export function compact(): Promise<void> {
+  return queueWriter.run(async () => {
+    const path = getWalPath();
+    if (!existsSync(path)) {
+      return;
+    }
+
+    const startSize = (await stat(path)).size;
+    const liveRecords = await readPending();
+
+    const tmpPath = `${path}.tmp.${process.pid}`;
+    const tmpFh = await open(tmpPath, 'w');
+    try {
+      for (const record of liveRecords) {
+        const buf = Buffer.from(
+          JSONBig.stringify({ type: 'append', record } as WalLine) + '\n',
+          'utf8',
+        );
+        await tmpFh.write(buf);
+      }
+
+      const currentSize = (await stat(path)).size;
+      if (currentSize > startSize) {
+        const tailLength = currentSize - startSize;
+        const tail = Buffer.alloc(tailLength);
+        const srcFh = await open(path, 'r');
+        try {
+          await srcFh.read(tail, 0, tailLength, startSize);
+        } finally {
+          await srcFh.close();
+        }
+        await tmpFh.write(tail);
+      }
+
+      await tmpFh.sync();
+    } catch (err) {
+      await tmpFh.close().catch(() => {});
+      await unlink(tmpPath).catch(() => {});
+      throw err;
+    }
+    await tmpFh.close();
+
+    await rename(tmpPath, path);
+  });
+}
+
+/**
+ * Size of `queue.log` in bytes, or 0 if the file does not exist.
+ * Used by the daemon's idle-shutdown heuristic.
+ */
+export async function walSize(): Promise<number> {
+  const path = getWalPath();
+  if (!existsSync(path)) {
+    return 0;
+  }
+  return (await stat(path)).size;
+}

--- a/libs/typescript/core/src/exporters/wal/storage.ts
+++ b/libs/typescript/core/src/exporters/wal/storage.ts
@@ -125,7 +125,12 @@ export function appendTombstone(id: string): Promise<void> {
 }
 
 /**
- * Append `record` to the dead-letter file (`failed.log`).
+ * Append `record` to the dead-letter file (`failed.log.<YYYY-MM-DD>`).
+ *
+ * The path is resolved per call via {@link getDeadLetterPath}, so the
+ * concrete file name reflects the current UTC date — a record written at
+ * 23:59:59 UTC and another at 00:00:00 UTC land in two adjacent dated
+ * files automatically, with no in-process rotation state to maintain.
  *
  * Dead-lettering does not tombstone the live queue on its own; callers
  * (the daemon) should pair this with {@link appendTombstone} so that the

--- a/libs/typescript/core/src/exporters/wal/storage.ts
+++ b/libs/typescript/core/src/exporters/wal/storage.ts
@@ -1,36 +1,5 @@
 /**
- * Append-only JSONL store backing the trace upload Write-Ahead Log.
- *
- * Two files live here, both under `getWalDir()`:
- *
- * - `queue.log` — pending uploads. Two line types: `{type:"append",record}`
- *   and `{type:"tombstone",id}`. Readers replay the file into a
- *   `Map<id, WalRecord>` and `tombstone` lines act as `Map.delete(id)`.
- *   Periodically compacted (read live records, rewrite, atomic rename) so
- *   the file does not grow without bound.
- * - `failed.log.<YYYY-MM-DD>` — dead-letter file, rotated daily by UTC date.
- *   Records whose retry-budget window (`RETRY_TIMEOUT_MS`) expired. Only ever appended
- *   to; never tombstoned, never compacted. Inspectable by operators; the
- *   daemon never re-reads it. Rotation is stateless: every
- *   {@link appendDeadLetter} call resolves the path from the current date,
- *   so a record dead-lettered at 23:59:59 UTC and another at 00:00:00 UTC
- *   land in two adjacent dated files automatically.
- *
- * Concurrency model:
- *
- * - In-process: every write to a given file goes through a {@link SerialQueue}
- *   so that open/write/fsync/close phases never interleave. Two separate
- *   queues (one per file) allow append-to-queue.log and append-to-failed.log
- *   to make progress in parallel.
- * - Cross-process: hooks open queue.log with `flag: 'a'` and write a single
- *   line buffer per record, which is atomic on common filesystems for the
- *   sizes we write. The daemon is the only compactor; `compact` snapshots
- *   the file size up-front, writes the compacted output to a tmp file, then
- *   re-reads any tail bytes that arrived during the rewrite and appends them
- *   before the final atomic `rename`. A tiny race window remains between the
- *   tail-read and the rename; any record appended in that ~ms window would
- *   be overwritten. We accept this for v1 because compaction is
- *   daemon-driven (rare) and the only racers are Stop hooks (low rate).
+ * Append-only JSONL store backing the trace upload WAL.
  */
 
 import { createReadStream, existsSync } from 'node:fs';
@@ -43,20 +12,6 @@ import { WalLine, WalRecord } from './types';
 
 /**
  * Promise-chained queue that serializes async tasks one at a time.
- *
- * Errors thrown by an enqueued task surface to that task's caller (the
- * `Promise` returned by `run`), but they do not break the chain — subsequent
- * tasks still run. This matters because a transient `EIO` on one append must
- * not poison every later append in the same process.
- *
- * The `tail` invariant: it is always a fulfilled `Promise<void>`. The
- * `result.then(() => {}, () => {})` rebind below swallows both outcomes,
- * so by induction every later `run` reads a fulfilled `this.tail`. The
- * `.catch(() => {})` before `.then(fn)` is therefore strictly defensive
- * — it costs one extra microtask per enqueue (negligible next to the
- * `fsync` we're already gated on) and keeps the next-task scheduling
- * correct even if a future refactor accidentally lets `this.tail`
- * reject (e.g. by inlining the chain or removing the rebind).
  */
 class SerialQueue {
   private tail: Promise<void> = Promise.resolve();
@@ -79,20 +34,11 @@ async function ensureParentDir(filePath: string): Promise<void> {
 }
 
 /**
- * Append a single JSONL line + `\n` to `path`, fsync, and close.
+ * Append one JSONL line to `path`, fsync, and close.
  *
- * Encodes the line into a single `Buffer` so that the write hits the file in
- * one syscall. On the filesystems we target (ext4, APFS, NTFS) writes up to
- * `PIPE_BUF` (~4 KiB) are atomic; line-sized records are well below that,
- * and even multi-KB records are atomic in practice for `flag: 'a'` opens.
- * If a write is ever torn (e.g. host crash mid-write), {@link readPending}
- * tolerates the bad line by parsing-and-skipping.
- *
- * Uses {@link JSONBig} so `SerializedSpan.start_time_unix_nano` (and other
- * `bigint` fields on the trace data) round-trip cleanly. Native
- * `JSON.stringify` throws `TypeError: Do not know how to serialize a BigInt`
- * on those fields, matching the codec the rest of the codebase already uses
- * for outbound trace payloads (`clients/utils.ts`, `clients/artifacts/*`).
+ * Encoded as a single `Buffer` so the write goes out in one `O_APPEND`
+ * syscall — line-sized records sit well under `PIPE_BUF`, so concurrent
+ * appenders never interleave their bytes.
  */
 async function appendJsonLine(path: string, line: WalLine): Promise<void> {
   await ensureParentDir(path);
@@ -126,15 +72,6 @@ export function appendTombstone(id: string): Promise<void> {
 
 /**
  * Append `record` to the dead-letter file (`failed.log.<YYYY-MM-DD>`).
- *
- * The path is resolved per call via {@link getDeadLetterPath}, so the
- * concrete file name reflects the current UTC date — a record written at
- * 23:59:59 UTC and another at 00:00:00 UTC land in two adjacent dated
- * files automatically, with no in-process rotation state to maintain.
- *
- * Dead-lettering does not tombstone the live queue on its own; callers
- * (the daemon) should pair this with {@link appendTombstone} so that the
- * next batch tick does not retry the same poison record.
  */
 export function appendDeadLetter(record: WalRecord): Promise<void> {
   return deadLetterWriter.run(() =>
@@ -144,25 +81,13 @@ export function appendDeadLetter(record: WalRecord): Promise<void> {
 
 /**
  * Replay `queue.log` and return the set of records still considered pending.
- *
- * Unknown line types and malformed lines (failed `JSON.parse`) are silently
- * skipped with a `console.debug` so a single torn write cannot block the
- * whole batch. Returns an empty array if the WAL file does not exist yet.
- *
- * The optional `byteLimit` bounds the read to `[0, byteLimit)`. {@link compact}
- * uses this to snapshot the WAL at the same byte offset it captures with
- * `stat`, so cross-process appends that land mid-read do not end up in
- * `liveRecords` AND in the tail-byte copy (which would double-write them).
- * Every other caller (e.g. the daemon's batch loop) omits the option and
- * reads to EOF as before.
  */
 export async function readPending(opts: { byteLimit?: number } = {}): Promise<WalRecord[]> {
   const path = getWalPath();
   if (!existsSync(path)) {
     return [];
   }
-  // Empty snapshot: don't open the stream at all (createReadStream would
-  // reject `end: -1`).
+  // Empty snapshot: don't open the stream at all
   if (opts.byteLimit !== undefined && opts.byteLimit <= 0) {
     return [];
   }
@@ -208,26 +133,6 @@ export async function readPending(opts: { byteLimit?: number } = {}): Promise<Wa
 
 /**
  * Rewrite `queue.log` to contain only currently-live records.
- *
- * Procedure:
- *   1. Stat the WAL to snapshot `startSize`.
- *   2. Read pending records.
- *   3. Write each record as a fresh `{type:"append"}` line to
- *      `queue.log.tmp.<pid>`.
- *   4. Stat the WAL again; if it grew since step 1, copy the tail bytes
- *      `[startSize, currentSize)` (representing concurrent appends from
- *      other processes) into the tmp file. These bytes are guaranteed to
- *      consist of full lines because writers fsync after each line.
- *   5. fsync, close, and atomically rename the tmp file onto `queue.log`.
- *
- * Steps 3–5 all live inside the same try / catch so that a failure in
- * close or rename — not just in the write/sync block — still triggers
- * the tmp-file cleanup. Otherwise a flaky FS could orphan one
- * `queue.log.tmp.<pid>` per daemon lifetime.
- *
- * The whole thing runs inside the in-process queue writer so it cannot
- * interleave with in-process appends. Cross-process appends that land
- * between step 4 and step 5 will be lost — see the file header comment.
  */
 export function compact(): Promise<void> {
   return queueWriter.run(async () => {

--- a/libs/typescript/core/src/exporters/wal/storage.ts
+++ b/libs/typescript/core/src/exporters/wal/storage.ts
@@ -48,12 +48,21 @@ import { WalLine, WalRecord } from './types';
  * `Promise` returned by `run`), but they do not break the chain — subsequent
  * tasks still run. This matters because a transient `EIO` on one append must
  * not poison every later append in the same process.
+ *
+ * The `tail` invariant: it is always a fulfilled `Promise<void>`. The
+ * `result.then(() => {}, () => {})` rebind below swallows both outcomes,
+ * so by induction every later `run` reads a fulfilled `this.tail`. The
+ * `.catch(() => {})` before `.then(fn)` is therefore strictly defensive
+ * — it costs one extra microtask per enqueue (negligible next to the
+ * `fsync` we're already gated on) and keeps the next-task scheduling
+ * correct even if a future refactor accidentally lets `this.tail`
+ * reject (e.g. by inlining the chain or removing the rebind).
  */
 class SerialQueue {
   private tail: Promise<void> = Promise.resolve();
 
   run<T>(fn: () => Promise<T>): Promise<T> {
-    const result = this.tail.then(fn, fn);
+    const result = this.tail.catch(() => {}).then(fn);
     this.tail = result.then(
       () => {},
       () => {},
@@ -134,15 +143,31 @@ export function appendDeadLetter(record: WalRecord): Promise<void> {
  * Unknown line types and malformed lines (failed `JSON.parse`) are silently
  * skipped with a `console.debug` so a single torn write cannot block the
  * whole batch. Returns an empty array if the WAL file does not exist yet.
+ *
+ * The optional `byteLimit` bounds the read to `[0, byteLimit)`. {@link compact}
+ * uses this to snapshot the WAL at the same byte offset it captures with
+ * `stat`, so cross-process appends that land mid-read do not end up in
+ * `liveRecords` AND in the tail-byte copy (which would double-write them).
+ * Every other caller (e.g. the daemon's batch loop) omits the option and
+ * reads to EOF as before.
  */
-export async function readPending(): Promise<WalRecord[]> {
+export async function readPending(opts: { byteLimit?: number } = {}): Promise<WalRecord[]> {
   const path = getWalPath();
   if (!existsSync(path)) {
     return [];
   }
+  // Empty snapshot: don't open the stream at all (createReadStream would
+  // reject `end: -1`).
+  if (opts.byteLimit !== undefined && opts.byteLimit <= 0) {
+    return [];
+  }
 
   const alive = new Map<string, WalRecord>();
-  const stream = createReadStream(path, { encoding: 'utf8' });
+  const streamOpts: Parameters<typeof createReadStream>[1] =
+    opts.byteLimit !== undefined
+      ? { encoding: 'utf8', start: 0, end: opts.byteLimit - 1 }
+      : { encoding: 'utf8' };
+  const stream = createReadStream(path, streamOpts);
   const rl = createInterface({ input: stream, crlfDelay: Infinity });
 
   for await (const line of rl) {
@@ -188,7 +213,12 @@ export async function readPending(): Promise<WalRecord[]> {
  *      `[startSize, currentSize)` (representing concurrent appends from
  *      other processes) into the tmp file. These bytes are guaranteed to
  *      consist of full lines because writers fsync after each line.
- *   5. fsync the tmp file and atomically rename it onto `queue.log`.
+ *   5. fsync, close, and atomically rename the tmp file onto `queue.log`.
+ *
+ * Steps 3–5 all live inside the same try / catch so that a failure in
+ * close or rename — not just in the write/sync block — still triggers
+ * the tmp-file cleanup. Otherwise a flaky FS could orphan one
+ * `queue.log.tmp.<pid>` per daemon lifetime.
  *
  * The whole thing runs inside the in-process queue writer so it cannot
  * interleave with in-process appends. Cross-process appends that land
@@ -202,7 +232,7 @@ export function compact(): Promise<void> {
     }
 
     const startSize = (await stat(path)).size;
-    const liveRecords = await readPending();
+    const liveRecords = await readPending({ byteLimit: startSize });
 
     const tmpPath = `${path}.tmp.${process.pid}`;
     const tmpFh = await open(tmpPath, 'w');
@@ -229,14 +259,13 @@ export function compact(): Promise<void> {
       }
 
       await tmpFh.sync();
+      await tmpFh.close();
+      await rename(tmpPath, path);
     } catch (err) {
       await tmpFh.close().catch(() => {});
       await unlink(tmpPath).catch(() => {});
       throw err;
     }
-    await tmpFh.close();
-
-    await rename(tmpPath, path);
   });
 }
 

--- a/libs/typescript/core/src/exporters/wal/types.ts
+++ b/libs/typescript/core/src/exporters/wal/types.ts
@@ -8,40 +8,6 @@
 
 /**
  * One queued trace upload, serialized to a single JSONL line.
- *
- * Field semantics:
- * - `id`: a fresh uuid v4 per WAL row (not the MLflow trace id). Retries
- *   tombstone the old row and re-append a new row with a fresh `id`, so
- *   per-attempt rows are independently tombstone-addressable. The MLflow
- *   trace id lives inside `traceInfo`.
- * - `trackingUri`: routing key. The daemon groups records by this field
- *   and uses one memoized `MlflowClient` per distinct value.
- * - `experimentId`: captured at hook time so the daemon does not need to
- *   re-resolve experiments at upload time.
- * - `traceInfo` / `traceData`: results of `TraceInfo.toJson()` and
- *   `TraceData.toJson()`. Deserialized via the corresponding `fromJson`
- *   factories inside the daemon's batch loop.
- * - `attempts`, `nextAttemptAt`: retry state. `nextAttemptAt` is the unix
- *   ms epoch before which the daemon skips this record on a batch tick.
- *   `attempts` is incremented per failure and indexes into the exponential
- *   `backoff(attempt)` schedule, *separate from* the wall-clock dead-letter
- *   gate (which is governed by `firstAttemptAt` vs
- *   `MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT`). The two governors are
- *   orthogonal: `attempts` controls *how long to wait between retries*,
- *   the wall-clock budget controls *whether to keep retrying*. Mirrors
- *   Python's `_retry_databricks_sdk_call_with_exponential_backoff`, which
- *   keeps both `attempt`-indexed backoff and `retry_timeout_seconds`.
- * - `firstAttemptAt`: unix ms epoch of the daemon's first upload attempt
- *   on this record. Anchored once and preserved across retries (the
- *   retry copy keeps the original anchor). Used as the start of the
- *   retry-budget window measured against
- *   `MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT`. `undefined` until the
- *   first attempt — daemons fall back to `createdAt` when the field is
- *   missing so records written by older daemon versions still upgrade
- *   cleanly.
- * - `createdAt`: when the record first entered the WAL (unix ms). Used
- *   for diagnostics / ordering and as a fallback anchor when
- *   `firstAttemptAt` is absent.
  */
 export interface WalRecord {
   id: string;
@@ -55,11 +21,4 @@ export interface WalRecord {
   firstAttemptAt?: number;
 }
 
-/**
- * Discriminated union for a single line of the WAL file.
- *
- * Readers (`storage.readPending`) replay the file linewise into a
- * `Map<id, WalRecord>`, applying tombstones as deletions. The "current"
- * set of pending records is whatever survives the replay.
- */
 export type WalLine = { type: 'append'; record: WalRecord } | { type: 'tombstone'; id: string };

--- a/libs/typescript/core/src/exporters/wal/types.ts
+++ b/libs/typescript/core/src/exporters/wal/types.ts
@@ -23,8 +23,14 @@
  *   factories inside the daemon's batch loop.
  * - `attempts`, `nextAttemptAt`: retry state. `nextAttemptAt` is the unix
  *   ms epoch before which the daemon skips this record on a batch tick.
- *   `attempts` is incremented per failure and kept for diagnostics only;
- *   the dead-letter gate is wall-clock based via `firstAttemptAt`.
+ *   `attempts` is incremented per failure and indexes into the exponential
+ *   `backoff(attempt)` schedule, *separate from* the wall-clock dead-letter
+ *   gate (which is governed by `firstAttemptAt` vs
+ *   `MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT`). The two governors are
+ *   orthogonal: `attempts` controls *how long to wait between retries*,
+ *   the wall-clock budget controls *whether to keep retrying*. Mirrors
+ *   Python's `_retry_databricks_sdk_call_with_exponential_backoff`, which
+ *   keeps both `attempt`-indexed backoff and `retry_timeout_seconds`.
  * - `firstAttemptAt`: unix ms epoch of the daemon's first upload attempt
  *   on this record. Anchored once and preserved across retries (the
  *   retry copy keeps the original anchor). Used as the start of the

--- a/libs/typescript/core/src/exporters/wal/types.ts
+++ b/libs/typescript/core/src/exporters/wal/types.ts
@@ -23,8 +23,19 @@
  *   factories inside the daemon's batch loop.
  * - `attempts`, `nextAttemptAt`: retry state. `nextAttemptAt` is the unix
  *   ms epoch before which the daemon skips this record on a batch tick.
+ *   `attempts` is incremented per failure and kept for diagnostics only;
+ *   the dead-letter gate is wall-clock based via `firstAttemptAt`.
+ * - `firstAttemptAt`: unix ms epoch of the daemon's first upload attempt
+ *   on this record. Anchored once and preserved across retries (the
+ *   retry copy keeps the original anchor). Used as the start of the
+ *   retry-budget window measured against
+ *   `MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT`. `undefined` until the
+ *   first attempt — daemons fall back to `createdAt` when the field is
+ *   missing so records written by older daemon versions still upgrade
+ *   cleanly.
  * - `createdAt`: when the record first entered the WAL (unix ms). Used
- *   for diagnostics / ordering only; not part of retry semantics.
+ *   for diagnostics / ordering and as a fallback anchor when
+ *   `firstAttemptAt` is absent.
  */
 export interface WalRecord {
   id: string;
@@ -35,6 +46,7 @@ export interface WalRecord {
   attempts: number;
   nextAttemptAt: number;
   createdAt: number;
+  firstAttemptAt?: number;
 }
 
 /**

--- a/libs/typescript/core/tests/exporters/wal/paths.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/paths.test.ts
@@ -1,7 +1,13 @@
 import { mkdtemp, rm } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join, resolve } from 'path';
-import { getLockSocketPath, getWalDir, getWalPath } from '../../../src/exporters/wal/paths';
+import {
+  getDaemonLogPath,
+  getDeadLetterPath,
+  getLockSocketPath,
+  getWalDir,
+  getWalPath,
+} from '../../../src/exporters/wal/paths';
 
 describe('wal/paths', () => {
   const originalEnv = process.env.MLFLOW_WAL_DIR;
@@ -115,6 +121,56 @@ describe('wal/paths', () => {
     it('lives inside the resolved WAL dir', () => {
       process.env.MLFLOW_WAL_DIR = '/tmp/foo';
       expect(getWalPath()).toBe(join(resolve('/tmp/foo'), 'queue.log'));
+    });
+  });
+
+  describe('daily rotation of failed.log / daemon.log', () => {
+    beforeEach(() => {
+      process.env.MLFLOW_WAL_DIR = '/tmp/wal-rotation';
+    });
+
+    it('suffixes failed.log with the UTC date of the supplied Date', () => {
+      const d = new Date('2026-05-20T12:34:56.000Z');
+      expect(getDeadLetterPath(d)).toBe(
+        join(resolve('/tmp/wal-rotation'), 'failed.log.2026-05-20'),
+      );
+    });
+
+    it('suffixes daemon.log with the UTC date of the supplied Date', () => {
+      const d = new Date('2026-05-20T12:34:56.000Z');
+      expect(getDaemonLogPath(d)).toBe(join(resolve('/tmp/wal-rotation'), 'daemon.log.2026-05-20'));
+    });
+
+    it('rolls failed.log to the next day across midnight UTC', () => {
+      const lastSecondOfDay = new Date('2026-05-20T23:59:59.999Z');
+      const firstInstantOfNextDay = new Date('2026-05-21T00:00:00.000Z');
+      expect(getDeadLetterPath(lastSecondOfDay)).toMatch(/failed\.log\.2026-05-20$/);
+      expect(getDeadLetterPath(firstInstantOfNextDay)).toMatch(/failed\.log\.2026-05-21$/);
+    });
+
+    it('rolls daemon.log to the next day across midnight UTC', () => {
+      const lastSecondOfDay = new Date('2026-05-20T23:59:59.999Z');
+      const firstInstantOfNextDay = new Date('2026-05-21T00:00:00.000Z');
+      expect(getDaemonLogPath(lastSecondOfDay)).toMatch(/daemon\.log\.2026-05-20$/);
+      expect(getDaemonLogPath(firstInstantOfNextDay)).toMatch(/daemon\.log\.2026-05-21$/);
+    });
+
+    it('uses UTC date, not local date, regardless of the process timezone', () => {
+      // 2026-05-20T18:00:00 UTC = 2026-05-21T02:00:00 in UTC+8 (e.g. Singapore).
+      // The suffix must reflect UTC, not the host TZ.
+      const d = new Date('2026-05-20T18:00:00.000Z');
+      expect(getDaemonLogPath(d)).toMatch(/daemon\.log\.2026-05-20$/);
+      expect(getDeadLetterPath(d)).toMatch(/failed\.log\.2026-05-20$/);
+    });
+
+    it('zero-pads month and day', () => {
+      const earlyDay = new Date('2026-01-03T12:00:00.000Z');
+      expect(getDaemonLogPath(earlyDay)).toMatch(/daemon\.log\.2026-01-03$/);
+    });
+
+    it('defaults to "now" when called without an argument', () => {
+      expect(getDaemonLogPath()).toMatch(/daemon\.log\.\d{4}-\d{2}-\d{2}$/);
+      expect(getDeadLetterPath()).toMatch(/failed\.log\.\d{4}-\d{2}-\d{2}$/);
     });
   });
 });

--- a/libs/typescript/core/tests/exporters/wal/storage.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/storage.test.ts
@@ -203,7 +203,6 @@ describe('wal/storage', () => {
   });
 
   it('does not double-write records appended between the startSize stat and readPending', async () => {
-
     await appendRecord(makeRecord('a'));
     const walPath = getWalPath();
 

--- a/libs/typescript/core/tests/exporters/wal/storage.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/storage.test.ts
@@ -3,10 +3,7 @@
 // dozens of real fs operations the rest of the suite needs. Hoisted by
 // ts-jest above the storage.ts import so storage's
 // `import { ... } from 'node:fs/promises'` resolves to the mocked bindings.
-//
-// Test-file fs imports below (e.g. `from 'fs/promises'`) intentionally use
-// the un-prefixed specifier so they stay backed by the real module — the
-// mock only intercepts the storage module's view of `node:fs/promises`.
+
 jest.mock('node:fs/promises', () => {
   const actual = jest.requireActual<typeof import('node:fs/promises')>('node:fs/promises');
   return {
@@ -51,10 +48,7 @@ function makeRecord(idSuffix: string, overrides: Partial<WalRecord> = {}): WalRe
 
 describe('wal/storage', () => {
   let walDir: string;
-  // Capture the developer's pre-test value so we restore (not just unset)
-  // in afterEach. Without this, running `MLFLOW_WAL_DIR=/some/dir jest`
-  // would lose the override for every later test in the same worker.
-  // Mirrors the pattern in paths.test.ts.
+
   const originalWalDir = process.env.MLFLOW_WAL_DIR;
 
   beforeEach(async () => {
@@ -87,13 +81,6 @@ describe('wal/storage', () => {
   });
 
   it('round-trips bigint fields (regression for SerializedSpan timestamps)', async () => {
-    // `SerializedSpan.start_time_unix_nano` is a `bigint`; native
-    // `JSON.stringify` throws on those. The storage layer uses JSONBig
-    // so spans coming out of `Span.toJson()` survive a WAL round-trip
-    // unchanged. The value here is intentionally above
-    // `Number.MAX_SAFE_INTEGER` to catch a regression to plain
-    // `JSON.parse(JSON.stringify(...))` (which would silently lose
-    // precision rather than throw).
     const startNs = 1_750_000_000_123_456_789n;
     const record = makeRecord('bigint', {
       traceData: {
@@ -216,22 +203,10 @@ describe('wal/storage', () => {
   });
 
   it('does not double-write records appended between the startSize stat and readPending', async () => {
-    // Regression: an earlier shape called `readPending()` unbounded, so
-    // a cross-process append landing between compact's first `stat`
-    // (capturing `startSize`) and the end of the stream would be
-    // included BOTH in `liveRecords` AND in the tail-byte copy that
-    // covers `[startSize, currentSize)` — producing a duplicate
-    // `{type:"append"}` line in the compacted file. The fix bounds
-    // `readPending` to `[0, startSize)` so the two sources cannot
-    // overlap.
+
     await appendRecord(makeRecord('a'));
     const walPath = getWalPath();
 
-    // Real stat used to compute the pre-injection size; we delegate the
-    // first mocked call to it, then inject one extra append line to
-    // mimic another process writing between compact's first stat and
-    // readPending. Returning the pre-injection stats keeps `startSize`
-    // honest.
     const realStat = jest.requireActual<typeof import('node:fs/promises')>('node:fs/promises').stat;
     let injected = false;
     statMock.mockImplementationOnce(async (path) => {
@@ -248,8 +223,7 @@ describe('wal/storage', () => {
     expect(injected).toBe(true);
 
     // After compaction the WAL must contain exactly two append lines,
-    // one per record, with no duplicate of `wal-b`. Without the
-    // bounding fix this assertion fails (three lines, `wal-b` repeated).
+    // one per record, with no duplicate of `wal-b`.
     const lines = (await readFile(walPath, 'utf8')).split('\n').filter((l) => l.length > 0);
     expect(lines).toHaveLength(2);
     const ids = lines.map((l) => (JSON.parse(l) as { record: WalRecord }).record.id).sort();

--- a/libs/typescript/core/tests/exporters/wal/storage.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/storage.test.ts
@@ -1,6 +1,26 @@
-import { mkdtemp, readFile, rm, stat, writeFile } from 'fs/promises';
+// Mock node:fs/promises with a passthrough so individual tests can flip a
+// single method (e.g. `rename`, `stat`) to fail/inject without breaking the
+// dozens of real fs operations the rest of the suite needs. Hoisted by
+// ts-jest above the storage.ts import so storage's
+// `import { ... } from 'node:fs/promises'` resolves to the mocked bindings.
+//
+// Test-file fs imports below (e.g. `from 'fs/promises'`) intentionally use
+// the un-prefixed specifier so they stay backed by the real module — the
+// mock only intercepts the storage module's view of `node:fs/promises`.
+jest.mock('node:fs/promises', () => {
+  const actual = jest.requireActual<typeof import('node:fs/promises')>('node:fs/promises');
+  return {
+    ...actual,
+    rename: jest.fn(actual.rename),
+    stat: jest.fn(actual.stat),
+  };
+});
+
+import { appendFileSync } from 'fs';
+import { mkdtemp, readdir, readFile, rm, stat, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import * as fsPromises from 'node:fs/promises';
 import {
   appendDeadLetter,
   appendRecord,
@@ -11,6 +31,9 @@ import {
 } from '../../../src/exporters/wal/storage';
 import { getDeadLetterPath, getWalPath } from '../../../src/exporters/wal/paths';
 import type { WalRecord } from '../../../src/exporters/wal/types';
+
+const renameMock = fsPromises.rename as jest.MockedFunction<typeof fsPromises.rename>;
+const statMock = fsPromises.stat as jest.MockedFunction<typeof fsPromises.stat>;
 
 function makeRecord(idSuffix: string, overrides: Partial<WalRecord> = {}): WalRecord {
   return {
@@ -28,6 +51,11 @@ function makeRecord(idSuffix: string, overrides: Partial<WalRecord> = {}): WalRe
 
 describe('wal/storage', () => {
   let walDir: string;
+  // Capture the developer's pre-test value so we restore (not just unset)
+  // in afterEach. Without this, running `MLFLOW_WAL_DIR=/some/dir jest`
+  // would lose the override for every later test in the same worker.
+  // Mirrors the pattern in paths.test.ts.
+  const originalWalDir = process.env.MLFLOW_WAL_DIR;
 
   beforeEach(async () => {
     walDir = await mkdtemp(join(tmpdir(), 'mlflow-wal-'));
@@ -35,7 +63,11 @@ describe('wal/storage', () => {
   });
 
   afterEach(async () => {
-    delete process.env.MLFLOW_WAL_DIR;
+    if (originalWalDir === undefined) {
+      delete process.env.MLFLOW_WAL_DIR;
+    } else {
+      process.env.MLFLOW_WAL_DIR = originalWalDir;
+    }
     await rm(walDir, { recursive: true, force: true });
   });
 
@@ -159,6 +191,72 @@ describe('wal/storage', () => {
   it('is a no-op when compacting a non-existent WAL', async () => {
     await expect(compact()).resolves.toBeUndefined();
     await expect(stat(getWalPath())).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('cleans up the tmp file when rename throws after a successful write', async () => {
+    // Regression: an earlier shape had `close()` and `rename()` outside
+    // the try/catch, so a flaky FS at the rename step would orphan one
+    // `queue.log.tmp.<pid>` per failed compaction. The fix moved both
+    // into the try so the catch's `unlink(tmpPath)` always runs on
+    // failure regardless of which step blew up.
+    await appendRecord(makeRecord('a'));
+
+    renameMock.mockRejectedValueOnce(
+      Object.assign(new Error('EBUSY: simulated rename failure'), { code: 'EBUSY' }),
+    );
+
+    await expect(compact()).rejects.toThrow(/simulated rename failure/);
+
+    // After the failed compaction, the WAL itself is unchanged and no
+    // `.tmp.<pid>` orphan remains in the spool dir.
+    const entries = await readdir(walDir);
+    expect(entries.some((e) => /\.tmp\.\d+$/.test(e))).toBe(false);
+    const pending = await readPending();
+    expect(pending.map((r) => r.id)).toEqual(['wal-a']);
+  });
+
+  it('does not double-write records appended between the startSize stat and readPending', async () => {
+    // Regression: an earlier shape called `readPending()` unbounded, so
+    // a cross-process append landing between compact's first `stat`
+    // (capturing `startSize`) and the end of the stream would be
+    // included BOTH in `liveRecords` AND in the tail-byte copy that
+    // covers `[startSize, currentSize)` — producing a duplicate
+    // `{type:"append"}` line in the compacted file. The fix bounds
+    // `readPending` to `[0, startSize)` so the two sources cannot
+    // overlap.
+    await appendRecord(makeRecord('a'));
+    const walPath = getWalPath();
+
+    // Real stat used to compute the pre-injection size; we delegate the
+    // first mocked call to it, then inject one extra append line to
+    // mimic another process writing between compact's first stat and
+    // readPending. Returning the pre-injection stats keeps `startSize`
+    // honest.
+    const realStat = jest.requireActual<typeof import('node:fs/promises')>('node:fs/promises').stat;
+    let injected = false;
+    statMock.mockImplementationOnce(async (path) => {
+      const stats = await realStat(path);
+      if (!injected) {
+        const otherRecord = makeRecord('b');
+        appendFileSync(walPath, JSON.stringify({ type: 'append', record: otherRecord }) + '\n');
+        injected = true;
+      }
+      return stats;
+    });
+
+    await compact();
+    expect(injected).toBe(true);
+
+    // After compaction the WAL must contain exactly two append lines,
+    // one per record, with no duplicate of `wal-b`. Without the
+    // bounding fix this assertion fails (three lines, `wal-b` repeated).
+    const lines = (await readFile(walPath, 'utf8')).split('\n').filter((l) => l.length > 0);
+    expect(lines).toHaveLength(2);
+    const ids = lines.map((l) => (JSON.parse(l) as { record: WalRecord }).record.id).sort();
+    expect(ids).toEqual(['wal-a', 'wal-b']);
+
+    const pending = await readPending();
+    expect(pending.map((r) => r.id).sort()).toEqual(['wal-a', 'wal-b']);
   });
 
   it('skips malformed lines but keeps surrounding records', async () => {

--- a/libs/typescript/core/tests/exporters/wal/storage.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/storage.test.ts
@@ -1,5 +1,5 @@
 // Mock node:fs/promises with a passthrough so individual tests can flip a
-// single method (e.g. `rename`, `stat`) to fail/inject without breaking the
+// single method (e.g. `rename`) to fail/inject without breaking the
 // dozens of real fs operations the rest of the suite needs. Hoisted by
 // ts-jest above the storage.ts import so storage's
 // `import { ... } from 'node:fs/promises'` resolves to the mocked bindings.
@@ -9,11 +9,9 @@ jest.mock('node:fs/promises', () => {
   return {
     ...actual,
     rename: jest.fn(actual.rename),
-    stat: jest.fn(actual.stat),
   };
 });
 
-import { appendFileSync } from 'fs';
 import { mkdtemp, readdir, readFile, rm, stat, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -30,7 +28,6 @@ import { getDeadLetterPath, getWalPath } from '../../../src/exporters/wal/paths'
 import type { WalRecord } from '../../../src/exporters/wal/types';
 
 const renameMock = fsPromises.rename as jest.MockedFunction<typeof fsPromises.rename>;
-const statMock = fsPromises.stat as jest.MockedFunction<typeof fsPromises.stat>;
 
 function makeRecord(idSuffix: string, overrides: Partial<WalRecord> = {}): WalRecord {
   return {
@@ -200,36 +197,6 @@ describe('wal/storage', () => {
     expect(entries.some((e) => /\.tmp\.\d+$/.test(e))).toBe(false);
     const pending = await readPending();
     expect(pending.map((r) => r.id)).toEqual(['wal-a']);
-  });
-
-  it('does not double-write records appended between the startSize stat and readPending', async () => {
-    await appendRecord(makeRecord('a'));
-    const walPath = getWalPath();
-
-    const realStat = jest.requireActual<typeof import('node:fs/promises')>('node:fs/promises').stat;
-    let injected = false;
-    statMock.mockImplementationOnce(async (path) => {
-      const stats = await realStat(path);
-      if (!injected) {
-        const otherRecord = makeRecord('b');
-        appendFileSync(walPath, JSON.stringify({ type: 'append', record: otherRecord }) + '\n');
-        injected = true;
-      }
-      return stats;
-    });
-
-    await compact();
-    expect(injected).toBe(true);
-
-    // After compaction the WAL must contain exactly two append lines,
-    // one per record, with no duplicate of `wal-b`.
-    const lines = (await readFile(walPath, 'utf8')).split('\n').filter((l) => l.length > 0);
-    expect(lines).toHaveLength(2);
-    const ids = lines.map((l) => (JSON.parse(l) as { record: WalRecord }).record.id).sort();
-    expect(ids).toEqual(['wal-a', 'wal-b']);
-
-    const pending = await readPending();
-    expect(pending.map((r) => r.id).sort()).toEqual(['wal-a', 'wal-b']);
   });
 
   it('skips malformed lines but keeps surrounding records', async () => {

--- a/libs/typescript/core/tests/exporters/wal/storage.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/storage.test.ts
@@ -1,0 +1,211 @@
+import { mkdtemp, readFile, rm, stat, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  appendDeadLetter,
+  appendRecord,
+  appendTombstone,
+  compact,
+  readPending,
+  walSize,
+} from '../../../src/exporters/wal/storage';
+import { getDeadLetterPath, getWalPath } from '../../../src/exporters/wal/paths';
+import type { WalRecord } from '../../../src/exporters/wal/types';
+
+function makeRecord(idSuffix: string, overrides: Partial<WalRecord> = {}): WalRecord {
+  return {
+    id: `wal-${idSuffix}`,
+    trackingUri: 'http://localhost:5000',
+    experimentId: '0',
+    traceInfo: { trace_id: `t-${idSuffix}` },
+    traceData: { spans: [] },
+    attempts: 0,
+    nextAttemptAt: 0,
+    createdAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('wal/storage', () => {
+  let walDir: string;
+
+  beforeEach(async () => {
+    walDir = await mkdtemp(join(tmpdir(), 'mlflow-wal-'));
+    process.env.MLFLOW_WAL_DIR = walDir;
+  });
+
+  afterEach(async () => {
+    delete process.env.MLFLOW_WAL_DIR;
+    await rm(walDir, { recursive: true, force: true });
+  });
+
+  it('returns an empty array when no WAL file exists yet', async () => {
+    expect(await readPending()).toEqual([]);
+    expect(await walSize()).toBe(0);
+  });
+
+  it('appends a record and reads it back', async () => {
+    const record = makeRecord('a');
+    await appendRecord(record);
+
+    const pending = await readPending();
+    expect(pending).toHaveLength(1);
+    expect(pending[0]).toEqual(record);
+    expect(await walSize()).toBeGreaterThan(0);
+  });
+
+  it('round-trips bigint fields (regression for SerializedSpan timestamps)', async () => {
+    // `SerializedSpan.start_time_unix_nano` is a `bigint`; native
+    // `JSON.stringify` throws on those. The storage layer uses JSONBig
+    // so spans coming out of `Span.toJson()` survive a WAL round-trip
+    // unchanged. The value here is intentionally above
+    // `Number.MAX_SAFE_INTEGER` to catch a regression to plain
+    // `JSON.parse(JSON.stringify(...))` (which would silently lose
+    // precision rather than throw).
+    const startNs = 1_750_000_000_123_456_789n;
+    const record = makeRecord('bigint', {
+      traceData: {
+        spans: [
+          {
+            trace_id: 't-bigint',
+            start_time_unix_nano: startNs,
+            end_time_unix_nano: startNs + 5_000_000n,
+          },
+        ],
+      },
+    });
+
+    await appendRecord(record);
+    const pending = await readPending();
+    expect(pending).toHaveLength(1);
+    const restored = (pending[0].traceData as { spans: Array<Record<string, unknown>> }).spans[0];
+    expect(restored.start_time_unix_nano).toBe(startNs);
+    expect(restored.end_time_unix_nano).toBe(startNs + 5_000_000n);
+  });
+
+  it('hides a record once it has been tombstoned', async () => {
+    const r1 = makeRecord('a');
+    const r2 = makeRecord('b');
+    await appendRecord(r1);
+    await appendRecord(r2);
+    await appendTombstone(r1.id);
+
+    const pending = await readPending();
+    expect(pending.map((r) => r.id)).toEqual(['wal-b']);
+  });
+
+  it('treats a tombstone before its corresponding append as a no-op', async () => {
+    // Records use fresh ids per attempt, so a tombstone never legitimately
+    // precedes its append; if it does (e.g. corrupt log), the later append
+    // must still win.
+    const r = makeRecord('a');
+    await appendTombstone(r.id);
+    await appendRecord(r);
+
+    const pending = await readPending();
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.id).toBe(r.id);
+  });
+
+  it('accumulates entries in the dead-letter file without touching queue.log', async () => {
+    const live = makeRecord('live');
+    await appendRecord(live);
+
+    const dead1 = makeRecord('dead-1', { attempts: 10 });
+    const dead2 = makeRecord('dead-2', { attempts: 10 });
+    await appendDeadLetter(dead1);
+    await appendDeadLetter(dead2);
+
+    const dlqPath = getDeadLetterPath();
+    // failed.log is daily-rotated; the resolved path must include a
+    // YYYY-MM-DD suffix so a regression to a single unbounded file is
+    // caught in CI.
+    expect(dlqPath).toMatch(/[/\\]failed\.log\.\d{4}-\d{2}-\d{2}$/);
+    const dlqContents = await readFile(dlqPath, 'utf8');
+    const dlqLines = dlqContents.split('\n').filter((l) => l.length > 0);
+    expect(dlqLines).toHaveLength(2);
+    expect(JSON.parse(dlqLines[0])).toEqual({ type: 'append', record: dead1 });
+    expect(JSON.parse(dlqLines[1])).toEqual({ type: 'append', record: dead2 });
+
+    const pending = await readPending();
+    expect(pending).toEqual([live]);
+  });
+
+  it('preserves live records and shrinks the file when compacting', async () => {
+    const r1 = makeRecord('a');
+    const r2 = makeRecord('b');
+    const r3 = makeRecord('c');
+    await appendRecord(r1);
+    await appendRecord(r2);
+    await appendRecord(r3);
+    await appendTombstone(r2.id);
+
+    const sizeBefore = await walSize();
+    await compact();
+    const sizeAfter = await walSize();
+
+    expect(sizeAfter).toBeLessThan(sizeBefore);
+
+    const pending = await readPending();
+    expect(pending.map((r) => r.id).sort()).toEqual(['wal-a', 'wal-c']);
+
+    const lines = (await readFile(getWalPath(), 'utf8')).split('\n').filter((l) => l.length > 0);
+    expect(lines).toHaveLength(2);
+    for (const line of lines) {
+      expect(JSON.parse(line).type).toBe('append');
+    }
+  });
+
+  it('is a no-op when compacting a non-existent WAL', async () => {
+    await expect(compact()).resolves.toBeUndefined();
+    await expect(stat(getWalPath())).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('skips malformed lines but keeps surrounding records', async () => {
+    const r1 = makeRecord('a');
+    const r2 = makeRecord('b');
+    await appendRecord(r1);
+    await writeFile(getWalPath(), '{not valid json}\n', { flag: 'a' });
+    await appendRecord(r2);
+
+    const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
+    try {
+      const pending = await readPending();
+      expect(pending.map((r) => r.id).sort()).toEqual(['wal-a', 'wal-b']);
+      expect(debugSpy).toHaveBeenCalled();
+    } finally {
+      debugSpy.mockRestore();
+    }
+  });
+
+  it('survives 50 concurrent appends with no torn or lost lines', async () => {
+    const records = Array.from({ length: 50 }, (_, i) => makeRecord(i.toString().padStart(2, '0')));
+    await Promise.all(records.map((r) => appendRecord(r)));
+
+    const contents = await readFile(getWalPath(), 'utf8');
+    const lines = contents.split('\n').filter((l) => l.length > 0);
+    expect(lines).toHaveLength(50);
+    for (const line of lines) {
+      expect(() => {
+        JSON.parse(line);
+      }).not.toThrow();
+    }
+
+    const pending = await readPending();
+    expect(pending).toHaveLength(50);
+    const ids = new Set(pending.map((r) => r.id));
+    for (const r of records) {
+      expect(ids.has(r.id)).toBe(true);
+    }
+  });
+
+  it('records nonzero walSize after an append', async () => {
+    expect(await walSize()).toBe(0);
+    await appendRecord(makeRecord('a'));
+    const size = await walSize();
+    expect(size).toBeGreaterThan(0);
+
+    const fsSize = (await stat(getWalPath())).size;
+    expect(size).toBe(fsSize);
+  });
+});


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Relates to https://github.com/mlflow/mlflow/pull/23464

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

This is part of a series of changes to support async batch tracing for TS Claude Code / Coding Agent LLM MLflow tracing using WAL + daemon. This is a new feature, so these changes are safe as the integration layer has not been implemented yet.

Updated constants based on new design considerations for retry and clean up strategy:
- replaced MAX_ATTEMPTS with RETRY_TIMEOUT_MS - as internally discussed, we will retry based on timeout
- added LOG_RETENTION_DAYS for log deletion policy to clean up stale log resources (i.e. failed.log & daemon.log) that will be left behind by the daemon

New changes:
- added storage layer changes that will be used by the daemon for appending/tombstoning/compacting WAL spool records

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
