### PR TITLE
Mcp registry abstract mixin

### DIFF
--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -45,6 +45,7 @@ from mlflow.store.tracking import (
     SEARCH_TRACES_DEFAULT_MAX_RESULTS,
 )
 from mlflow.store.tracking.gateway import GatewayStoreMixin
+from mlflow.store.tracking.mcp_server_registry import MCPServerRegistryMixin
 from mlflow.tracing.analysis import TraceFilterCorrelationResult
 from mlflow.utils import mlflow_tags
 from mlflow.utils.annotations import developer_stable, requires_sql_backend
@@ -53,7 +54,7 @@ from mlflow.utils.async_logging.run_operations import RunOperations
 
 
 @developer_stable
-class AbstractStore(GatewayStoreMixin):
+class AbstractStore(MCPServerRegistryMixin, GatewayStoreMixin):
     """
     Abstract class for Backend Storage.
     This class defines the API interface for front ends to connect with various types of backends.

--- a/mlflow/store/tracking/mcp_server_registry/__init__.py
+++ b/mlflow/store/tracking/mcp_server_registry/__init__.py
@@ -1,0 +1,3 @@
+from mlflow.store.tracking.mcp_server_registry.abstract_mixin import MCPServerRegistryMixin
+
+__all__ = ["MCPServerRegistryMixin"]

--- a/mlflow/store/tracking/mcp_server_registry/abstract_mixin.py
+++ b/mlflow/store/tracking/mcp_server_registry/abstract_mixin.py
@@ -1,0 +1,380 @@
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+from typing_extensions import NotRequired
+
+from mlflow.entities.mcp_access_binding import MCPAccessBinding
+from mlflow.entities.mcp_server import MCPRemoteTransportType, MCPServer, MCPStatus, MCPTool
+from mlflow.entities.mcp_server_version import MCPServerVersion
+from mlflow.store.entities.paged_list import PagedList
+from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
+
+
+class MCPIcon(TypedDict):
+    """Icon following the upstream MCP server.json icon schema."""
+
+    src: str
+    sizes: NotRequired[list[str]]
+    mimeType: NotRequired[str]
+    theme: NotRequired[str]
+
+
+class MCPServerRegistryMixin:
+    """Mixin class providing MCP Server Registry interface for tracking stores.
+
+    This mixin adds MCP server management to tracking stores, enabling
+    registration, versioning, aliasing, tagging, and access binding
+    management for MCP servers.
+
+    All methods raise NotImplementedError rather than using @abstractmethod,
+    following the GatewayStoreMixin pattern. This allows stores that don't
+    support MCP servers (e.g., FileStore) to work without stubbing every method.
+    """
+
+    # --- MCPServer operations ---
+
+    def create_mcp_server(
+        self,
+        name: str,
+        description: str | None = None,
+        icons: list[MCPIcon] | None = None,
+    ) -> MCPServer:
+        """Create a new MCP server entry.
+
+        Args:
+            name: Unique server name (e.g., "io.github.org/server").
+            description: Human-readable description.
+            icons: Sized icon variants (src, sizes, mimeType, theme).
+
+        Returns:
+            The created MCPServer entity.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def get_mcp_server(self, name: str) -> MCPServer:
+        """Retrieve an MCP server by name.
+
+        Args:
+            name: Server name.
+
+        Returns:
+            The MCPServer entity with tags, aliases, and bindings populated.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def search_mcp_servers(
+        self,
+        filter_string: str | None = None,
+        max_results: int = SEARCH_MAX_RESULTS_DEFAULT,
+        order_by: list[str] | None = None,
+        page_token: str | None = None,
+    ) -> PagedList[MCPServer]:
+        """Search MCP servers with optional filtering and pagination.
+
+        Args:
+            filter_string: SQL-like filter (e.g., "status = 'active'").
+            max_results: Maximum number of results to return.
+            order_by: List of columns to order by.
+            page_token: Token for pagination.
+
+        Returns:
+            A PagedList of MCPServer entities.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def update_mcp_server(
+        self,
+        name: str,
+        description: str | None = None,
+        display_name: str | None = None,
+        icons: list[MCPIcon] | None = None,
+        latest_version: str | None = None,
+    ) -> MCPServer:
+        """Update an existing MCP server's metadata.
+
+        Args:
+            name: Server name.
+            description: New description (if not None).
+            display_name: New display name (if not None).
+            icons: New icon variants (if not None).
+            latest_version: Pin the latest version pointer (if not None).
+
+        Returns:
+            The updated MCPServer entity.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def delete_mcp_server(self, name: str) -> None:
+        """Delete an MCP server and all its child entities.
+
+        Args:
+            name: Server name.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    # --- MCPServerVersion operations ---
+
+    def create_mcp_server_version(
+        self,
+        server_json: dict[str, Any],
+        display_name: str | None = None,
+        source: str | None = None,
+        status: MCPStatus | None = None,
+        tools: list[MCPTool] | None = None,
+    ) -> MCPServerVersion:
+        """Create a new version of an MCP server.
+
+        The parent MCPServer is auto-created from server_json["name"] if it
+        does not already exist.
+
+        Args:
+            server_json: The server.json payload (must contain "name" and "version").
+            display_name: Human-readable display name.
+            source: Origin URL or identifier for this version.
+            status: Initial status (defaults to DRAFT).
+            tools: List of MCPTool definitions.
+
+        Returns:
+            The created MCPServerVersion entity.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def get_mcp_server_version(self, name: str, version: str) -> MCPServerVersion:
+        """Retrieve a specific version of an MCP server.
+
+        Args:
+            name: Server name.
+            version: Version string.
+
+        Returns:
+            The MCPServerVersion entity.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def get_mcp_server_version_by_alias(self, name: str, alias: str) -> MCPServerVersion:
+        """Retrieve a version by its alias. "latest" delegates to get_latest.
+
+        Args:
+            name: Server name.
+            alias: Alias name.
+
+        Returns:
+            The MCPServerVersion entity pointed to by the alias.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def get_latest_mcp_server_version(self, name: str) -> MCPServerVersion:
+        """Retrieve the latest version of an MCP server.
+
+        Uses the pinned latest_version if set, otherwise falls back to the
+        most recently created non-draft version.
+
+        Args:
+            name: Server name.
+
+        Returns:
+            The latest MCPServerVersion entity.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def search_mcp_server_versions(
+        self,
+        name: str,
+        filter_string: str | None = None,
+        max_results: int = SEARCH_MAX_RESULTS_DEFAULT,
+        order_by: list[str] | None = None,
+        page_token: str | None = None,
+    ) -> PagedList[MCPServerVersion]:
+        """Search versions of a specific MCP server.
+
+        Args:
+            name: Server name.
+            filter_string: SQL-like filter (e.g., "status = 'active'").
+            max_results: Maximum number of results to return.
+            order_by: List of columns to order by.
+            page_token: Token for pagination.
+
+        Returns:
+            A PagedList of MCPServerVersion entities.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def update_mcp_server_version(
+        self,
+        name: str,
+        version: str,
+        display_name: str | None = None,
+        status: MCPStatus | None = None,
+        tools: list[MCPTool] | None = None,
+    ) -> MCPServerVersion:
+        """Update a version's metadata or status.
+
+        Args:
+            name: Server name.
+            version: Version string.
+            display_name: New display name (if not None).
+            status: New status (if not None); validated against transition rules.
+            tools: New tool definitions (if not None).
+
+        Returns:
+            The updated MCPServerVersion entity.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def delete_mcp_server_version(self, name: str, version: str) -> None:
+        """Delete a specific version of an MCP server.
+
+        Args:
+            name: Server name.
+            version: Version string.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    # --- MCPAccessBinding operations ---
+
+    def create_mcp_access_binding(
+        self,
+        server_name: str,
+        endpoint_url: str,
+        transport_type: MCPRemoteTransportType = MCPRemoteTransportType.STREAMABLE_HTTP,
+        server_version: str | None = None,
+        server_alias: str | None = None,
+    ) -> MCPAccessBinding:
+        """Create a direct-access binding for an MCP server.
+
+        Exactly one of server_version or server_alias must be set.
+
+        Args:
+            server_name: Server name.
+            endpoint_url: URL of the remote MCP endpoint.
+            transport_type: Transport protocol.
+            server_version: Pin to a specific version.
+            server_alias: Pin to an alias.
+
+        Returns:
+            The created MCPAccessBinding entity.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def get_mcp_access_binding(self, server_name: str, binding_id: int) -> MCPAccessBinding:
+        """Retrieve a specific access binding.
+
+        Args:
+            server_name: Server name.
+            binding_id: Binding ID.
+
+        Returns:
+            The MCPAccessBinding entity.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def search_mcp_access_bindings(
+        self,
+        server_name: str | None = None,
+        server_version: str | None = None,
+        server_alias: str | None = None,
+        filter_string: str | None = None,
+        max_results: int = SEARCH_MAX_RESULTS_DEFAULT,
+        order_by: list[str] | None = None,
+        page_token: str | None = None,
+    ) -> PagedList[MCPAccessBinding]:
+        """Search access bindings, optionally scoped to a server.
+
+        Args:
+            server_name: If set, only return bindings for this server.
+            server_version: If set, only return bindings targeting this version.
+            server_alias: If set, only return bindings targeting this alias.
+            filter_string: SQL-like filter.
+            max_results: Maximum number of results to return.
+            order_by: List of columns to order by.
+            page_token: Token for pagination.
+
+        Returns:
+            A PagedList of MCPAccessBinding entities.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def update_mcp_access_binding(
+        self,
+        server_name: str,
+        binding_id: int,
+        server_version: str | None = None,
+        server_alias: str | None = None,
+        endpoint_url: str | None = None,
+        transport_type: MCPRemoteTransportType | None = None,
+    ) -> MCPAccessBinding:
+        """Update an existing access binding.
+
+        Args:
+            server_name: Server name.
+            binding_id: Binding ID.
+            server_version: New version target (if not None).
+            server_alias: New alias target (if not None).
+            endpoint_url: New endpoint URL (if not None).
+            transport_type: New transport type (if not None).
+
+        Returns:
+            The updated MCPAccessBinding entity.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def delete_mcp_access_binding(self, server_name: str, binding_id: int) -> None:
+        """Delete an access binding.
+
+        Args:
+            server_name: Server name.
+            binding_id: Binding ID.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    # --- Tag operations ---
+
+    def set_mcp_server_tag(self, name: str, key: str, value: str) -> None:
+        """Set a tag on an MCP server (upsert)."""
+        raise NotImplementedError(self.__class__.__name__)
+
+    def delete_mcp_server_tag(self, name: str, key: str) -> None:
+        """Delete a tag from an MCP server."""
+        raise NotImplementedError(self.__class__.__name__)
+
+    def set_mcp_server_version_tag(self, name: str, version: str, key: str, value: str) -> None:
+        """Set a tag on an MCP server version (upsert)."""
+        raise NotImplementedError(self.__class__.__name__)
+
+    def delete_mcp_server_version_tag(self, name: str, version: str, key: str) -> None:
+        """Delete a tag from an MCP server version."""
+        raise NotImplementedError(self.__class__.__name__)
+
+    # --- Alias operations ---
+
+    def set_mcp_server_alias(self, name: str, alias: str, version: str) -> None:
+        """Set an alias on an MCP server pointing to a version (upsert).
+
+        The alias name ``"latest"`` is reserved for automatic resolution and
+        must not be used here.  Implementations should raise
+        ``MlflowException`` with ``INVALID_PARAMETER_VALUE`` if the caller
+        passes ``alias="latest"``.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def delete_mcp_server_alias(self, name: str, alias: str) -> None:
+        """Delete an alias from an MCP server."""
+        raise NotImplementedError(self.__class__.__name__)
+
+    # --- Trace linking ---
+
+    def link_mcp_server_versions_to_trace(
+        self,
+        trace_id: str,
+        mcp_servers: list[MCPServerVersion],
+    ) -> None:
+        """Link MCP server versions to a trace via entity associations."""
+        raise NotImplementedError(self.__class__.__name__)
+
+    def get_mcp_server_versions_for_trace(
+        self,
+        trace_id: str,
+    ) -> list[MCPServerVersion]:
+        """Retrieve MCP server versions linked to a trace."""
+        raise NotImplementedError(self.__class__.__name__)


### PR DESCRIPTION
Adds MCPServerRegistryMixin with ~24 methods (all raising NotImplementedError, following GatewayStoreMixin pattern) and wires AbstractStore to inherit from it via multiple inheritance.

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
