### PR TITLE
Fix pydantic-ai >= 1.78.0 ToolManager module rename (#23508)

### DIFF
--- a/mlflow/pydantic_ai/__init__.py
+++ b/mlflow/pydantic_ai/__init__.py
@@ -74,6 +74,20 @@ def _patch_method(cls, method_name):
         safe_patch(FLAVOR_NAME, cls, method_name, patched_class_call)
 
 
+def _get_tool_manager_module_path() -> str:
+    """Return the importable module path for ToolManager.
+
+    pydantic-ai >= 1.78.0 renamed _tool_manager to tool_manager (public).
+    Try the public path first; fall back to the private one for older versions.
+    """
+    try:
+        import pydantic_ai.tool_manager  # noqa: F401
+
+        return "pydantic_ai.tool_manager"
+    except ImportError:
+        return "pydantic_ai._tool_manager"
+
+
 def _tool_manager_uses_execute_tool_call() -> bool:
     """Return True if ToolManager has execute_tool_call (pydantic-ai >= 1.63.0).
 
@@ -81,10 +95,10 @@ def _tool_manager_uses_execute_tool_call() -> bool:
     tool_manager.execute_tool_call() directly rather than handle_call(), so we
     must patch execute_tool_call to capture the TOOL span.
     """
+    module_path = _get_tool_manager_module_path()
     try:
-        from pydantic_ai._tool_manager import ToolManager
-
-        return hasattr(ToolManager, "execute_tool_call")
+        module = __import__(module_path, fromlist=["ToolManager"])
+        return hasattr(module.ToolManager, "execute_tool_call")
     except ImportError:
         return False
 
@@ -111,6 +125,7 @@ def autolog(log_traces: bool = True, disable: bool = False, silent: bool = False
     except ImportError:
         pass
 
+    tool_manager_path = f"{_get_tool_manager_module_path()}.ToolManager"
     class_map = {
         "pydantic_ai.Agent": agent_methods,
         "pydantic_ai.models.instrumented.InstrumentedModel": [
@@ -120,7 +135,7 @@ def autolog(log_traces: bool = True, disable: bool = False, silent: bool = False
         # In pydantic-ai >= 1.63.0, _agent_graph calls execute_tool_call directly,
         # bypassing handle_call. Patch execute_tool_call when available; fall back to
         # handle_call for older versions where execute_tool_call doesn't exist.
-        "pydantic_ai._tool_manager.ToolManager": ["execute_tool_call"]
+        tool_manager_path: ["execute_tool_call"]
         if _tool_manager_uses_execute_tool_call()
         else ["handle_call"],
         "pydantic_ai.mcp.MCPServer": ["call_tool", "list_tools"],

--- a/mlflow/pydantic_ai/autolog.py
+++ b/mlflow/pydantic_ai/autolog.py
@@ -354,9 +354,10 @@ def _get_span_type(instance) -> str:
         return SpanType.TOOL
 
     try:
-        from pydantic_ai._tool_manager import ToolManager
+        from mlflow.pydantic_ai import _get_tool_manager_module_path
 
-        if isinstance(instance, ToolManager):
+        _tm_mod = __import__(_get_tool_manager_module_path(), fromlist=["ToolManager"])
+        if isinstance(instance, _tm_mod.ToolManager):
             return SpanType.TOOL
     except ImportError:
         pass

--- a/tests/pydantic_ai/test_pydanticai_fluent_tracing.py
+++ b/tests/pydantic_ai/test_pydanticai_fluent_tracing.py
@@ -28,9 +28,12 @@ HAS_RUN_STREAM_SYNC = hasattr(Agent, "run_stream_sync")
 HAS_STABLE_STREAMING_API = PYDANTIC_AI_VERSION >= Version("1.0.0")
 # In pydantic-ai >= 1.63.0, _agent_graph calls execute_tool_call directly instead of handle_call.
 # _tool_manager module doesn't exist in older versions (e.g. 0.2.x).
+# pydantic-ai >= 1.78.0 renamed it to the public tool_manager.
 try:
-    from pydantic_ai._tool_manager import ToolManager as _ToolManager
+    from mlflow.pydantic_ai import _get_tool_manager_module_path
 
+    _tm_mod = __import__(_get_tool_manager_module_path(), fromlist=["ToolManager"])
+    _ToolManager = _tm_mod.ToolManager
     TOOL_MANAGER_SPAN_NAME = (
         "ToolManager.execute_tool_call"
         if hasattr(_ToolManager, "execute_tool_call")

--- a/tests/pydantic_ai/test_pydanticai_tracing.py
+++ b/tests/pydantic_ai/test_pydanticai_tracing.py
@@ -10,6 +10,7 @@ from pydantic_ai.usage import Usage
 import mlflow
 import mlflow.pydantic_ai  # ensure the integration module is importable
 from mlflow.entities import SpanLogLevel, SpanType
+from mlflow.pydantic_ai import _get_tool_manager_module_path, _tool_manager_uses_execute_tool_call
 from mlflow.pydantic_ai.autolog import (
     _get_agent_attributes,
     _get_mcp_server_attributes,
@@ -462,3 +463,89 @@ def test_autolog_does_not_capture_client_references(simple_agent):
             assert "provider" not in key.lower()
             assert "_state" not in key.lower()
             assert "httpx" not in key.lower()
+
+
+# ---------------------------------------------------------------------------
+# Tests for _get_tool_manager_module_path and _tool_manager_uses_execute_tool_call
+# (covers both the public path introduced in pydantic-ai >= 1.78.0 and the
+#  legacy private path used by older versions)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("public_available", "expected_path"),
+    [
+        (True, "pydantic_ai.tool_manager"),
+        (False, "pydantic_ai._tool_manager"),
+    ],
+)
+def test_get_tool_manager_module_path(public_available, expected_path):
+    import sys
+    import types
+
+    if public_available:
+        fake_module = types.ModuleType("pydantic_ai.tool_manager")
+        modules_override = {"pydantic_ai.tool_manager": fake_module}
+    else:
+        # Setting to None causes import to raise ImportError
+        modules_override = {"pydantic_ai.tool_manager": None}
+
+    with patch.dict(sys.modules, modules_override):
+        result = _get_tool_manager_module_path()
+
+    assert result == expected_path
+
+
+@pytest.mark.parametrize(
+    ("public_available", "has_execute_tool_call", "expected"),
+    [
+        (True, True, True),
+        (True, False, False),
+        (False, True, True),
+        (False, False, False),
+    ],
+)
+def test_tool_manager_uses_execute_tool_call(public_available, has_execute_tool_call, expected):
+    import sys
+    import types
+
+    resolved_path = "pydantic_ai.tool_manager" if public_available else "pydantic_ai._tool_manager"
+
+    if has_execute_tool_call:
+
+        class FakeToolManager:
+            def execute_tool_call(self):
+                pass
+
+    else:
+
+        class FakeToolManager:
+            pass
+
+    fake_module = types.ModuleType(resolved_path)
+    fake_module.ToolManager = FakeToolManager
+
+    with patch("mlflow.pydantic_ai._get_tool_manager_module_path", return_value=resolved_path):
+        with patch.dict(sys.modules, {resolved_path: fake_module}):
+            result = _tool_manager_uses_execute_tool_call()
+
+    assert result is expected
+
+
+def test_autolog_uses_public_tool_manager_path_on_new_pydantic_ai():
+    with patch(
+        "mlflow.pydantic_ai._get_tool_manager_module_path",
+        return_value="pydantic_ai.tool_manager",
+    ):
+        with patch("mlflow.pydantic_ai._tool_manager_uses_execute_tool_call", return_value=True):
+            mlflow.pydantic_ai.autolog(log_traces=True)
+
+
+def test_autolog_uses_private_tool_manager_path_on_old_pydantic_ai():
+    """autolog() class_map key falls back to private path when public module is absent."""
+    with patch(
+        "mlflow.pydantic_ai._get_tool_manager_module_path",
+        return_value="pydantic_ai._tool_manager",
+    ):
+        with patch("mlflow.pydantic_ai._tool_manager_uses_execute_tool_call", return_value=True):
+            mlflow.pydantic_ai.autolog(log_traces=True)

--- a/tests/pydantic_ai/test_pydanticai_tracing.py
+++ b/tests/pydantic_ai/test_pydanticai_tracing.py
@@ -1,4 +1,6 @@
 import importlib.metadata
+import sys
+import types
 from unittest.mock import patch
 
 import pytest
@@ -480,9 +482,6 @@ def test_autolog_does_not_capture_client_references(simple_agent):
     ],
 )
 def test_get_tool_manager_module_path(public_available, expected_path):
-    import sys
-    import types
-
     if public_available:
         fake_module = types.ModuleType("pydantic_ai.tool_manager")
         modules_override = {"pydantic_ai.tool_manager": fake_module}
@@ -506,9 +505,6 @@ def test_get_tool_manager_module_path(public_available, expected_path):
     ],
 )
 def test_tool_manager_uses_execute_tool_call(public_available, has_execute_tool_call, expected):
-    import sys
-    import types
-
     resolved_path = "pydantic_ai.tool_manager" if public_available else "pydantic_ai._tool_manager"
 
     if has_execute_tool_call:
@@ -525,27 +521,32 @@ def test_tool_manager_uses_execute_tool_call(public_available, has_execute_tool_
     fake_module = types.ModuleType(resolved_path)
     fake_module.ToolManager = FakeToolManager
 
-    with patch("mlflow.pydantic_ai._get_tool_manager_module_path", return_value=resolved_path):
-        with patch.dict(sys.modules, {resolved_path: fake_module}):
-            result = _tool_manager_uses_execute_tool_call()
+    with (
+        patch("mlflow.pydantic_ai._get_tool_manager_module_path", return_value=resolved_path),
+        patch.dict(sys.modules, {resolved_path: fake_module}),
+    ):
+        result = _tool_manager_uses_execute_tool_call()
 
     assert result is expected
 
 
 def test_autolog_uses_public_tool_manager_path_on_new_pydantic_ai():
-    with patch(
-        "mlflow.pydantic_ai._get_tool_manager_module_path",
-        return_value="pydantic_ai.tool_manager",
+    with (
+        patch(
+            "mlflow.pydantic_ai._get_tool_manager_module_path",
+            return_value="pydantic_ai.tool_manager",
+        ),
+        patch("mlflow.pydantic_ai._tool_manager_uses_execute_tool_call", return_value=True),
     ):
-        with patch("mlflow.pydantic_ai._tool_manager_uses_execute_tool_call", return_value=True):
-            mlflow.pydantic_ai.autolog(log_traces=True)
+        mlflow.pydantic_ai.autolog(log_traces=True)
 
 
 def test_autolog_uses_private_tool_manager_path_on_old_pydantic_ai():
-    """autolog() class_map key falls back to private path when public module is absent."""
-    with patch(
-        "mlflow.pydantic_ai._get_tool_manager_module_path",
-        return_value="pydantic_ai._tool_manager",
+    with (
+        patch(
+            "mlflow.pydantic_ai._get_tool_manager_module_path",
+            return_value="pydantic_ai._tool_manager",
+        ),
+        patch("mlflow.pydantic_ai._tool_manager_uses_execute_tool_call", return_value=True),
     ):
-        with patch("mlflow.pydantic_ai._tool_manager_uses_execute_tool_call", return_value=True):
-            mlflow.pydantic_ai.autolog(log_traces=True)
+        mlflow.pydantic_ai.autolog(log_traces=True)


### PR DESCRIPTION
### Related Issues/PRs

Closes #23508

### What changes are proposed in this pull request?

Fixes `mlflow.pydantic_ai.autolog()` failing on pydantic-ai >= 1.78.0.

In pydantic-ai 1.78.0, the `_tool_manager` module was promoted to a public `tool_manager` module and the private one was removed. The autologging code referenced the private path in three places, producing this error on supported new Fixes `mlflow.pydantic_ai.autolog()` failing on pydantic-ai >= 1.78.0.

In pydantic-ai 1.78.0, the `_tool_manager` module was promoted to a public `tool_manager` module and the private one was removed. The autologging code referenced the private path in three places, producing this error on supported new versions:

ERROR mlflow.pydantic_ai: Error importing pydantic_ai._tool_manager.ToolManager:
No module named 'pydantic_ai._tool_manager'

The fix introduces a `_get_tool_manager_module_path()` helper that tries the public path first and falls back to the private one for older pydantic-ai releases. All three call sites now go through this helper, preserving backward compatibility with versions where only `_tool_manager` exists.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added 8 parametrized unit tests in `tests/pydantic_ai/test_pydanticai_tracing.py` covering both module-path resolutions and both `execute_tool_call` presence states, using `sys.modules` injection to exercise each branch without requiring a specific pydantic-ai version installed.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the MLflow Skills repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Restores `mlflow.pydantic_ai.autolog()` compatibility with pydantic-ai >= 1.78.0, which renamed the internal `_tool_manager` module to the public `tool_manager`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release