### PR TITLE
Document linking evaluations to training runs

### DIFF
--- a/docs/docs/genai/eval-monitor/running-evaluation/eval-examples.mdx
+++ b/docs/docs/genai/eval-monitor/running-evaluation/eval-examples.mdx
@@ -230,10 +230,11 @@ By default, `mlflow.genai.evaluate` logs results to the active MLflow run, or cr
 
 ```python
 import mlflow
-from mlflow.genai.scorers import Correctness
+from mlflow.genai.scorers import Safety
 
 # Fine-tuning or training run
 with mlflow.start_run() as training_run:
+    mlflow.set_tag("mlflow.runType", "training")
     mlflow.log_params({"base_model": "gpt-4o-mini", "learning_rate": 1e-5})
     training_run_id = training_run.info.run_id
 
@@ -242,8 +243,8 @@ with mlflow.start_run(run_id=training_run_id):
     results = mlflow.genai.evaluate(
         data=eval_dataset,
         predict_fn=evaluate_model,
-        scorers=[Correctness()],
+        scorers=[Safety()],
     )
 ```
 
-Use this pattern when you want the run page to contain both the training metadata and the evaluation artifacts, metrics, and trace assessments for the resulting model.
+Use this pattern when you want the run page to contain both the training metadata and the evaluation artifacts, metrics, and trace assessments for the resulting model. Set the run type before evaluation if the run should remain classified as a training run.

--- a/docs/docs/genai/eval-monitor/running-evaluation/eval-examples.mdx
+++ b/docs/docs/genai/eval-monitor/running-evaluation/eval-examples.mdx
@@ -223,3 +223,27 @@ results = mlflow.genai.evaluate(
     scorers=[Safety()],
 )
 ```
+
+### Log evaluation results to an existing training run
+
+By default, `mlflow.genai.evaluate` logs results to the active MLflow run, or creates a new run if none is active. To keep evaluation results with a fine-tuning or training run, resume that run before calling `mlflow.genai.evaluate`.
+
+```python
+import mlflow
+from mlflow.genai.scorers import Correctness
+
+# Fine-tuning or training run
+with mlflow.start_run() as training_run:
+    mlflow.log_params({"base_model": "gpt-4o-mini", "learning_rate": 1e-5})
+    training_run_id = training_run.info.run_id
+
+# Later, evaluate the fine-tuned model and log results to the same run
+with mlflow.start_run(run_id=training_run_id):
+    results = mlflow.genai.evaluate(
+        data=eval_dataset,
+        predict_fn=evaluate_model,
+        scorers=[Correctness()],
+    )
+```
+
+Use this pattern when you want the run page to contain both the training metadata and the evaluation artifacts, metrics, and trace assessments for the resulting model.


### PR DESCRIPTION
### Related Issues/PRs

Relates to #18917

### What changes are proposed in this pull request?

This PR updates the GenAI evaluation examples with a fine-tuning workflow that logs evaluation results to an existing training run.

The new example shows how to:

- capture a training run ID
- resume that run with `mlflow.start_run(run_id=...)`
- call `mlflow.genai.evaluate` so evaluation artifacts, metrics, and trace assessments are logged to the same run

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Checks run:

```bash
npm --prefix docs run prettier -- --check docs/genai/eval-monitor/running-evaluation/eval-examples.mdx
npm --prefix docs run eslint
git diff --check
```

Also attempted:

```bash
DOCS_BASE_URL=/docs/latest npm --prefix docs run build
```

The full docs build was blocked before reaching this page because generated notebook docs are missing from the local checkout. Per `docs/README.md`, I attempted `npm --prefix docs run convert-notebooks`, but that was blocked by the local `uv` version (`0.11.2`) being below the repository requirement (`>=0.11.14`).

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added documentation showing how to log `mlflow.genai.evaluate` results to an existing training or fine-tuning run by resuming the run with `mlflow.start_run(run_id=...)`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
