### PR TITLE
Fix compare run artifact image scaling

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactImageView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactImageView.tsx
@@ -91,7 +91,7 @@ const classNames = {
     background: 'white',
     minHeight: '100%',
   },
-  imageWrapper: { display: 'inline-block' },
+  imageWrapper: { display: 'inline-block', maxWidth: '100%' },
   image: {
     maxWidth: '100%',
     height: 'auto',


### PR DESCRIPTION
### Related Issues/PRs

Closes #20703

### What changes are proposed in this pull request?

- Constrain compare-run artifact images to the column width so they scale instead of overflowing.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

Tests run:
- 
ode .\\yarn\\releases\\yarn-4.12.0.cjs lint
- 
ode .\\yarn\\releases\\yarn-4.12.0.cjs test *(fails locally: existing timeouts in multiple suites)*
- 
ode .\\yarn\\releases\\yarn-4.12.0.cjs build

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Compare-run artifact images now scale to the column width to avoid horizontal scrolling.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] rea/tracking: Tracking Service, tracking client APIs, autologging
- [ ] rea/models: MLmodel format, model serialization/deserialization, flavors
- [ ] rea/model-registry: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] rea/scoring: MLflow Model server, model deployment tools, Spark UDFs
- [ ] rea/evaluation: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] rea/gateway: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] rea/prompts: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] rea/tracing: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] rea/projects: MLproject format, project running backends
- [ ] rea/uiux: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] rea/build: Build and test infrastructure for MLflow
- [ ] rea/docs: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] n/none - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] n/breaking-change - The PR will be mentioned in the "Breaking Changes" section
- [ ] n/feature - A new user-facing feature worth mentioning in the release notes
- [x] n/bug-fix - A user-facing bug fix worth mentioning in the release notes
- [ ] n/documentation - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release