### PR TITLE
Adding wal components for claude code batch tracing (batch writer, clients, protocol, daemon supervisor)

### DIFF
--- a/libs/typescript/core/src/exporters/wal/batching_writer.ts
+++ b/libs/typescript/core/src/exporters/wal/batching_writer.ts
@@ -1,0 +1,98 @@
+/**
+ * Group-commit writer for IPC-submitted WAL records.
+ */
+
+import { open, FileHandle } from 'node:fs/promises';
+import { JSONBig } from '../../core/utils/json';
+import { getWalPath } from './paths';
+import { ensureParentDir, queueWriter } from './storage';
+import { WalLine, WalRecord } from './types';
+
+interface BatchItem {
+  line: WalLine;
+  resolve: () => void;
+  reject: (err: Error) => void;
+}
+
+export class BatchingWriter {
+  private pending: BatchItem[] = [];
+  private flushScheduled = false;
+
+  /**
+   * Enqueue `record` for the next batch flush. Resolves once the
+   * record (and its batch-mates) have been fsynced to `queue.log`.
+   */
+  submit(record: WalRecord): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      this.pending.push({ line: { type: 'append', record }, resolve, reject });
+      this.scheduleFlush();
+    });
+  }
+
+  private scheduleFlush(): void {
+    if (this.flushScheduled) {
+      return;
+    }
+    this.flushScheduled = true;
+    // setImmediate fires at the end of the current event-loop tick,
+    // so every `submit` call made within the same tick batches
+    // together.
+    setImmediate(() => {
+      this.flushScheduled = false;
+      if (this.pending.length === 0) {
+        return;
+      }
+      void queueWriter.run(() => this.drainAndFlush());
+    });
+  }
+
+  private async drainAndFlush(): Promise<void> {
+    const batch = this.pending;
+    this.pending = [];
+    if (batch.length === 0) {
+      return;
+    }
+
+    const path = getWalPath();
+    try {
+      await ensureParentDir(path);
+    } catch (err) {
+      const error = err as Error;
+      for (const item of batch) {
+        item.reject(error);
+      }
+      return;
+    }
+
+    let fh: FileHandle;
+    try {
+      fh = await open(path, 'a');
+    } catch (err) {
+      const error = err as Error;
+      for (const item of batch) {
+        item.reject(error);
+      }
+      return;
+    }
+
+    try {
+      for (const item of batch) {
+        const buf = Buffer.from(JSONBig.stringify(item.line) + '\n', 'utf8');
+        await fh.write(buf);
+      }
+      await fh.sync();
+    } catch (err) {
+      const error = err as Error;
+      for (const item of batch) {
+        item.reject(error);
+      }
+      await fh.close().catch(() => {});
+      return;
+    }
+
+    await fh.close().catch(() => {});
+    for (const item of batch) {
+      item.resolve();
+    }
+  }
+}

--- a/libs/typescript/core/src/exporters/wal/batching_writer.ts
+++ b/libs/typescript/core/src/exporters/wal/batching_writer.ts
@@ -1,5 +1,5 @@
 /**
- * Group-commit writer for IPC-submitted WAL records.
+ * Group-commit writer for WAL lines.
  */
 
 import { open, FileHandle } from 'node:fs/promises';
@@ -19,12 +19,24 @@ export class BatchingWriter {
   private flushScheduled = false;
 
   /**
-   * Enqueue `record` for the next batch flush. Resolves once the
-   * record (and its batch-mates) have been fsynced to `queue.log`.
+   * Enqueue an append for `record`. Resolves once the record (and its
+   * batch-mates) have been fsynced to `queue.log`.
    */
   submit(record: WalRecord): Promise<void> {
+    return this.enqueue({ type: 'append', record });
+  }
+
+  /**
+   * Enqueue a tombstone for `id`. Resolves once the tombstone (and its
+   * batch-mates) have been fsynced to `queue.log`.
+   */
+  submitTombstone(id: string): Promise<void> {
+    return this.enqueue({ type: 'tombstone', id });
+  }
+
+  private enqueue(line: WalLine): Promise<void> {
     return new Promise<void>((resolve, reject) => {
-      this.pending.push({ line: { type: 'append', record }, resolve, reject });
+      this.pending.push({ line, resolve, reject });
       this.scheduleFlush();
     });
   }

--- a/libs/typescript/core/src/exporters/wal/batching_writer.ts
+++ b/libs/typescript/core/src/exporters/wal/batching_writer.ts
@@ -88,10 +88,8 @@ export class BatchingWriter {
     }
 
     try {
-      for (const item of batch) {
-        const buf = Buffer.from(JSONBig.stringify(item.line) + '\n', 'utf8');
-        await fh.write(buf);
-      }
+      const buffers = batch.map((item) => Buffer.from(JSONBig.stringify(item.line) + '\n', 'utf8'));
+      await fh.writev(buffers);
       await fh.sync();
     } catch (err) {
       const error = err as Error;

--- a/libs/typescript/core/src/exporters/wal/clients.ts
+++ b/libs/typescript/core/src/exporters/wal/clients.ts
@@ -1,0 +1,28 @@
+/**
+ * Daemon-side `MlflowClient` cache.
+ */
+
+import { createAuthProvider } from '../../auth';
+import { MlflowClient } from '../../clients/client';
+
+const cache = new Map<string, MlflowClient>();
+
+/**
+ * Return the cached `MlflowClient` for `trackingUri`, constructing it
+ * lazily on first access. Subsequent calls with the same URI return the
+ * same instance.
+ */
+export function clientForUri(trackingUri: string): MlflowClient {
+  const cached = cache.get(trackingUri);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const authProvider = createAuthProvider({ trackingUri });
+  const client = new MlflowClient({ trackingUri, authProvider });
+  cache.set(trackingUri, client);
+  return client;
+}
+
+export function clearClientCache(): void {
+  cache.clear();
+}

--- a/libs/typescript/core/src/exporters/wal/clients.ts
+++ b/libs/typescript/core/src/exporters/wal/clients.ts
@@ -10,7 +10,8 @@ const cache = new Map<string, MlflowClient>();
 /**
  * Return the cached `MlflowClient` for `trackingUri`, constructing it
  * lazily on first access. Subsequent calls with the same URI return the
- * same instance.
+ * same instance unless an explicit {@link clearClientForUri} happened
+ * in between (typically driven by the upload loop's auth-error retry).
  */
 export function clientForUri(trackingUri: string): MlflowClient {
   const cached = cache.get(trackingUri);
@@ -23,6 +24,20 @@ export function clientForUri(trackingUri: string): MlflowClient {
   return client;
 }
 
+/**
+ * Drop the cached client for `trackingUri` only, leaving other URIs'
+ * entries intact. Called by the upload loop on 401 / 403 so the next
+ * `clientForUri(uri)` call rebuilds the client with freshly-resolved
+ * credentials. No-op if no entry exists for `trackingUri`.
+ */
+export function clearClientForUri(trackingUri: string): void {
+  cache.delete(trackingUri);
+}
+
+/**
+ * Drop all cached clients. Intended for daemon shutdown paths and
+ * tests; not part of the steady-state batch loop.
+ */
 export function clearClientCache(): void {
   cache.clear();
 }

--- a/libs/typescript/core/src/exporters/wal/protocol.ts
+++ b/libs/typescript/core/src/exporters/wal/protocol.ts
@@ -1,0 +1,27 @@
+/**
+ * Wire protocol for the daemon's IPC socket.
+ *
+ * op: 'append' resolves only after the record is durable in
+ * queue.log (the daemon's batching writer fsyncs the batch before
+ * acknowledging).
+ */
+
+import { WalRecord } from './types';
+
+export interface AppendRequest {
+  op: 'append';
+  record: WalRecord;
+}
+
+export type IpcRequest = AppendRequest;
+
+export interface OkResponse {
+  ok: true;
+}
+
+export interface ErrResponse {
+  ok: false;
+  error: string;
+}
+
+export type IpcResponse = OkResponse | ErrResponse;

--- a/libs/typescript/core/src/exporters/wal/supervisor.ts
+++ b/libs/typescript/core/src/exporters/wal/supervisor.ts
@@ -61,6 +61,30 @@ export function resolveDaemonEntry(): string {
   if (override !== undefined && override !== '') {
     return override;
   }
+  // DO NOT collapse this into a plain string literal. The concatenation
+  // hides the specifier from esbuild's static scanner (which walks every
+  // literal passed to `require.resolve(...)`) so the lookup stays
+  // runtime-only. The design requires the daemon to run in its own
+  // long-lived process - separate from any individual hook invocation -
+  // so the hook can exit immediately after appending to the WAL while
+  // the daemon handles uploads, retries, and group-commit batching
+  // across many concurrent hooks.
+  //
+  // If a literal specifier appeared here, a consumer re-bundling
+  // @mlflow/core into their own hook (e.g. claude-code's
+  // `bundle/stop.cjs`) would suffer two bundler-induced regressions:
+  //   (a) esbuild inlines @mlflow/core's package.json contents into the
+  //       consumer bundle, so `dirname(pkgJsonPath)` resolves to the
+  //       *consumer's* bundle dir instead of @mlflow/core's install
+  //       dir, and `join(..., 'bundle', 'daemon.cjs')` points at a
+  //       file that does not exist.
+  //   (b) esbuild follows the path forward and inlines the entire
+  //       `bundle/daemon.cjs` source into the hook bundle - bloating
+  //       it by many MB (OTel SDKs, Databricks SDK, HTTP stack, retry
+  //       logic) and making it tempting to `require()` the daemon
+  //       in-process, which would re-couple hook latency to backend
+  //       latency and break the "one daemon per host, N hooks" model.
+  // Both outcomes are bad; the string-concat prevents both.
   const pkgJsonModule = '@mlflow' + '/core' + '/package.json';
   const requireFromHere = createRequire(__filename);
   const pkgJsonPath = requireFromHere.resolve(pkgJsonModule);

--- a/libs/typescript/core/src/exporters/wal/supervisor.ts
+++ b/libs/typescript/core/src/exporters/wal/supervisor.ts
@@ -1,0 +1,96 @@
+/**
+ * Daemon supervisor - handles the "is the uploader daemon alive? if not,
+ * spawn one" check invoked by `WalSpanExporter` on each WAL append.
+ */
+
+import { spawn } from 'node:child_process';
+import { createConnection } from 'node:net';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { getLockSocketPath } from './paths';
+
+const PROBE_TIMEOUT_MS = 1000;
+
+/**
+ * Probe the daemon's liveness lock with a short timeout.
+ *
+ * Returns:
+ * - `true` if the socket/pipe at `getLockSocketPath()` is currently
+ *   accepting connections (i.e. a daemon has bound it).
+ * - `false` on any error (ENOENT — no socket file; ECONNREFUSED — a
+ *   stale socket file with no listener) or on probe timeout.
+ */
+export function isDaemonAlive(): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socketPath = getLockSocketPath();
+    const socket = createConnection(socketPath);
+
+    let settled = false;
+    const finish = (alive: boolean): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      socket.destroy();
+      resolve(alive);
+    };
+
+    const timer = setTimeout(() => finish(false), PROBE_TIMEOUT_MS);
+
+    socket.once('connect', () => {
+      clearTimeout(timer);
+      finish(true);
+    });
+    socket.once('error', () => {
+      clearTimeout(timer);
+      finish(false);
+    });
+  });
+}
+
+/**
+ * Resolve the absolute path of the daemon entry point.
+ *
+ * Precedence:
+ *   1. `MLFLOW_TRACE_DAEMON_EXECUTABLE` env var — used by tests and
+ *      advanced operators who want to override the bundled daemon.
+ *   2. The bundled daemon at `<@mlflow/core install dir>/bundle/daemon.cjs`.
+ */
+export function resolveDaemonEntry(): string {
+  const override = process.env.MLFLOW_TRACE_DAEMON_EXECUTABLE;
+  if (override !== undefined && override !== '') {
+    return override;
+  }
+  const pkgJsonModule = '@mlflow' + '/core' + '/package.json';
+  const requireFromHere = createRequire(__filename);
+  const pkgJsonPath = requireFromHere.resolve(pkgJsonModule);
+  return join(dirname(pkgJsonPath), 'bundle', 'daemon.cjs');
+}
+
+/**
+ * Fork a detached daemon process. Assumes no daemon is currently bound —
+ * the caller is responsible for guarding with {@link isDaemonAlive}.
+ */
+export function spawnDaemon(): void {
+  const entry = resolveDaemonEntry();
+  const child = spawn(process.execPath, [entry], {
+    detached: true,
+    stdio: 'ignore',
+    env: process.env,
+  });
+  child.unref();
+}
+
+/**
+ * Ensure a daemon is alive; spawn one if not.
+ */
+export async function ensureDaemon(): Promise<void> {
+  try {
+    if (await isDaemonAlive()) {
+      return;
+    }
+    spawnDaemon();
+  } catch (err) {
+    console.error('[mlflow][wal] ensureDaemon failed:', err);
+  }
+}

--- a/libs/typescript/core/src/exporters/wal/supervisor.ts
+++ b/libs/typescript/core/src/exporters/wal/supervisor.ts
@@ -78,19 +78,41 @@ export function spawnDaemon(): void {
     stdio: 'ignore',
     env: process.env,
   });
+
+  child.once('error', (err) => {
+    console.error(`[mlflow][wal] daemon spawn failed (entry=${entry}):`, err);
+  });
+
+  child.once('exit', (code, signal) => {
+    if (code != null && code !== 0) {
+      console.error(
+        `[mlflow][wal] daemon exited unexpectedly: entry=${entry} code=${code} signal=${signal ?? 'none'}`,
+      );
+    }
+  });
   child.unref();
 }
+
+let spawnInFlight: Promise<void> | null = null;
 
 /**
  * Ensure a daemon is alive; spawn one if not.
  */
-export async function ensureDaemon(): Promise<void> {
-  try {
-    if (await isDaemonAlive()) {
-      return;
-    }
-    spawnDaemon();
-  } catch (err) {
-    console.error('[mlflow][wal] ensureDaemon failed:', err);
+export function ensureDaemon(): Promise<void> {
+  if (spawnInFlight != null) {
+    return spawnInFlight;
   }
+  spawnInFlight = (async () => {
+    try {
+      if (await isDaemonAlive()) {
+        return;
+      }
+      spawnDaemon();
+    } catch (err) {
+      console.error('[mlflow][wal] ensureDaemon failed:', err);
+    } finally {
+      spawnInFlight = null;
+    }
+  })();
+  return spawnInFlight;
 }

--- a/libs/typescript/core/src/exporters/wal/supervisor.ts
+++ b/libs/typescript/core/src/exporters/wal/supervisor.ts
@@ -61,30 +61,18 @@ export function resolveDaemonEntry(): string {
   if (override !== undefined && override !== '') {
     return override;
   }
-  // DO NOT collapse this into a plain string literal. The concatenation
-  // hides the specifier from esbuild's static scanner (which walks every
-  // literal passed to `require.resolve(...)`) so the lookup stays
-  // runtime-only. The design requires the daemon to run in its own
-  // long-lived process - separate from any individual hook invocation -
-  // so the hook can exit immediately after appending to the WAL while
-  // the daemon handles uploads, retries, and group-commit batching
-  // across many concurrent hooks.
+  // DO NOT collapse this into a plain string literal. esbuild
+  // evaluates `require.resolve(literal)` at build time and bakes the
+  // resolved (developer-machine) path directly into the shipped
+  // bundle. On end users' machines that path does not exist, so
+  // `spawn` fails with ENOENT and traces silently stop uploading
+  // while the WAL grows unbounded. The string-concat hides the
+  // specifier from esbuild's AST scanner so the lookup runs at
+  // runtime against the user's own node_modules.
   //
-  // If a literal specifier appeared here, a consumer re-bundling
-  // @mlflow/core into their own hook (e.g. claude-code's
-  // `bundle/stop.cjs`) would suffer two bundler-induced regressions:
-  //   (a) esbuild inlines @mlflow/core's package.json contents into the
-  //       consumer bundle, so `dirname(pkgJsonPath)` resolves to the
-  //       *consumer's* bundle dir instead of @mlflow/core's install
-  //       dir, and `join(..., 'bundle', 'daemon.cjs')` points at a
-  //       file that does not exist.
-  //   (b) esbuild follows the path forward and inlines the entire
-  //       `bundle/daemon.cjs` source into the hook bundle - bloating
-  //       it by many MB (OTel SDKs, Databricks SDK, HTTP stack, retry
-  //       logic) and making it tempting to `require()` the daemon
-  //       in-process, which would re-couple hook latency to backend
-  //       latency and break the "one daemon per host, N hooks" model.
-  // Both outcomes are bad; the string-concat prevents both.
+  // This defense lives in the supervisor (not in consumers' esbuild
+  // configs) because every plugin-marketplace consumer must bundle
+  // @mlflow/core into their hook to ship as a self-contained file.
   const pkgJsonModule = '@mlflow' + '/core' + '/package.json';
   const requireFromHere = createRequire(__filename);
   const pkgJsonPath = requireFromHere.resolve(pkgJsonModule);

--- a/libs/typescript/core/src/exporters/wal/supervisor.ts
+++ b/libs/typescript/core/src/exporters/wal/supervisor.ts
@@ -102,7 +102,7 @@ export function ensureDaemon(): Promise<void> {
   if (spawnInFlight != null) {
     return spawnInFlight;
   }
-  spawnInFlight = (async () => {
+  const inFlight = (async () => {
     try {
       if (await isDaemonAlive()) {
         return;
@@ -114,5 +114,6 @@ export function ensureDaemon(): Promise<void> {
       spawnInFlight = null;
     }
   })();
-  return spawnInFlight;
+  spawnInFlight = inFlight;
+  return inFlight;
 }

--- a/libs/typescript/core/tests/exporters/wal/batching_writer.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/batching_writer.test.ts
@@ -1,0 +1,146 @@
+import * as fsPromises from 'node:fs/promises';
+import { mkdtemp, readFile, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { BatchingWriter } from '../../../src/exporters/wal/batching_writer';
+import { getWalPath } from '../../../src/exporters/wal/paths';
+import { appendTombstone, readPending } from '../../../src/exporters/wal/storage';
+import type { WalRecord } from '../../../src/exporters/wal/types';
+
+function makeRecord(idSuffix: string, overrides: Partial<WalRecord> = {}): WalRecord {
+  return {
+    id: `wal-${idSuffix}`,
+    trackingUri: 'http://localhost:5000',
+    experimentId: '0',
+    traceInfo: { trace_id: `t-${idSuffix}` },
+    traceData: { spans: [] },
+    attempts: 0,
+    nextAttemptAt: 0,
+    createdAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('wal/batching_writer', () => {
+  let walDir: string;
+  // Capture the developer's pre-test value so we restore (not just unset)
+  // in afterEach. Mirrors the pattern in paths.test.ts so running
+  // `MLFLOW_WAL_DIR=/some/dir jest` doesn't lose the override for later
+  // tests in the same worker.
+  const originalWalDir = process.env.MLFLOW_WAL_DIR;
+
+  beforeEach(async () => {
+    walDir = await mkdtemp(join(tmpdir(), 'mlflow-wal-batch-'));
+    process.env.MLFLOW_WAL_DIR = walDir;
+  });
+
+  afterEach(async () => {
+    if (originalWalDir === undefined) {
+      delete process.env.MLFLOW_WAL_DIR;
+    } else {
+      process.env.MLFLOW_WAL_DIR = originalWalDir;
+    }
+    await rm(walDir, { recursive: true, force: true });
+  });
+
+  it('persists a single submitted record after the ack', async () => {
+    const writer = new BatchingWriter();
+    const record = makeRecord('s1');
+    await writer.submit(record);
+
+    const lines = (await readFile(getWalPath(), 'utf8')).split('\n').filter((l) => l.length > 0);
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0])).toEqual({ type: 'append', record });
+  });
+
+  it('coalesces concurrent submits into a single fsync (group commit)', async () => {
+    // Spy on FileHandle.sync via the prototype so we count every fsync
+    // the writer issues regardless of which fd it opens. With group
+    // commit, N submissions made in the same tick must collapse into a
+    // single fsync. The probe fd is closed immediately after we grab
+    // the prototype so Node's "FileHandle closed by GC" guard never
+    // trips.
+    const probeFh = await fsPromises.open(join(walDir, '.probe'), 'w');
+    const fdProto = Object.getPrototypeOf(probeFh) as { sync: () => Promise<void> };
+    await probeFh.close();
+    const syncSpy = jest.spyOn(fdProto, 'sync');
+    try {
+      const writer = new BatchingWriter();
+      const records = Array.from({ length: 25 }, (_, i) =>
+        makeRecord(i.toString().padStart(2, '0')),
+      );
+
+      const syncsBefore = syncSpy.mock.calls.length;
+      // Fire all submits in the same tick before awaiting any of them.
+      await Promise.all(records.map((r) => writer.submit(r)));
+      const syncsAfter = syncSpy.mock.calls.length;
+
+      // Allow at most one extra fsync above the one we expect, in case
+      // a stray tick splits the batch in two; the regression we care
+      // about is the "N fsyncs for N submits" shape.
+      expect(syncsAfter - syncsBefore).toBeLessThanOrEqual(2);
+      expect(syncsAfter - syncsBefore).toBeGreaterThanOrEqual(1);
+
+      const lines = (await readFile(getWalPath(), 'utf8')).split('\n').filter((l) => l.length > 0);
+      expect(lines).toHaveLength(records.length);
+      const ids = lines.map((l) => (JSON.parse(l) as { record: WalRecord }).record.id).sort();
+      expect(ids).toEqual(records.map((r) => r.id).sort());
+    } finally {
+      syncSpy.mockRestore();
+    }
+  });
+
+  it('resolves submit() only after the byte is durable', async () => {
+    // The post-submit file read must observe the record — i.e. the
+    // ack-after-fsync invariant. If submit resolved before write+sync
+    // completed this read would race and occasionally come up empty.
+    const writer = new BatchingWriter();
+    const record = makeRecord('durable');
+    await writer.submit(record);
+
+    const contents = await readFile(getWalPath(), 'utf8');
+    expect(contents).toContain(`"id":"${record.id}"`);
+  });
+
+  it('produces well-formed lines when batched submits interleave with direct writers', async () => {
+    // BatchingWriter.submit defers the actual file write to a
+    // setImmediate so it can coalesce same-tick submissions; a
+    // tombstone or direct appendRecord called inline therefore lands
+    // on queue.log before the deferred batch. We can't pin a specific
+    // ordering here, but two invariants must hold regardless of the
+    // interleaving: (1) every line in queue.log is valid JSON (no
+    // torn writes thanks to the shared SerialQueue), and (2) the
+    // visible record after the tombstone shadows the submitted
+    // record. We pick a tombstone for an id that the writer also
+    // submits and confirm that id is *not* in `readPending` —
+    // whichever wrote first, the tombstone always wins because
+    // `appendRecord(r1)` followed by `appendTombstone(r1.id)` and
+    // `appendTombstone(r1.id)` followed by `appendRecord(r1)` both
+    // collapse to "r1 hidden" under {@link readPending}'s replay
+    // semantics (tombstone shadows earlier appends; an append after a
+    // tombstone wins, but our writer never re-submits the same id).
+    const writer = new BatchingWriter();
+    const r1 = makeRecord('mixed-1');
+    const r2 = makeRecord('mixed-2');
+
+    const submitR1 = writer.submit(r1);
+    const tombstone = appendTombstone(r1.id);
+    const submitR2 = writer.submit(r2);
+    await Promise.all([submitR1, tombstone, submitR2]);
+
+    const lines = (await readFile(getWalPath(), 'utf8')).split('\n').filter((l) => l.length > 0);
+    // Two appends + one tombstone, none truncated, all valid JSON.
+    expect(lines).toHaveLength(3);
+    for (const line of lines) {
+      expect(() => {
+        JSON.parse(line);
+      }).not.toThrow();
+    }
+
+    // Either ordering of tombstone vs. r1's append leaves r2 visible;
+    // r1's pending state depends on the interleaving and is not part
+    // of the contract under test.
+    const pending = await readPending();
+    expect(pending.map((r) => r.id)).toContain(r2.id);
+  });
+});

--- a/libs/typescript/core/tests/exporters/wal/batching_writer.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/batching_writer.test.ts
@@ -21,6 +21,33 @@ function makeRecord(idSuffix: string, overrides: Partial<WalRecord> = {}): WalRe
   };
 }
 
+/**
+ * Install a `jest.spyOn` on `FileHandle.prototype.sync` so the
+ * group-commit tests below can count fsync invocations issued by the
+ * production code. We discover the prototype by opening a throwaway
+ * handle and walking one step up its prototype chain — that's where
+ * `sync` is defined today, and where every FileHandle instance
+ * (including the ones `BatchingWriter` opens internally) inherits it
+ * from.
+ *
+ * The precondition assertion guards against a future Node release
+ * moving `sync` off this prototype (or inlining it into a C++ binding
+ * that bypasses the JS surface): without it, a missing method would
+ * either make `jest.spyOn` throw a generic
+ * "Cannot spy the sync property because it is not a function" error,
+ * or — if the spy installed but never fired — make the test fail with
+ * the equally confusing "expected 0 to be greater than or equal to 1".
+ * The precondition gives operators a one-line breadcrumb pointing at
+ * the actual cause.
+ */
+async function spyOnFileHandleSync(walDir: string): Promise<jest.SpyInstance> {
+  const probeFh = await fsPromises.open(join(walDir, '.probe'), 'w');
+  const fdProto = Object.getPrototypeOf(probeFh) as { sync?: () => Promise<void> };
+  await probeFh.close();
+  expect(typeof fdProto.sync).toBe('function');
+  return jest.spyOn(fdProto as { sync: () => Promise<void> }, 'sync');
+}
+
 describe('wal/batching_writer', () => {
   let walDir: string;
   const originalWalDir = process.env.MLFLOW_WAL_DIR;
@@ -50,10 +77,7 @@ describe('wal/batching_writer', () => {
   });
 
   it('coalesces concurrent submits into a single fsync (group commit)', async () => {
-    const probeFh = await fsPromises.open(join(walDir, '.probe'), 'w');
-    const fdProto = Object.getPrototypeOf(probeFh) as { sync: () => Promise<void> };
-    await probeFh.close();
-    const syncSpy = jest.spyOn(fdProto, 'sync');
+    const syncSpy = await spyOnFileHandleSync(walDir);
     try {
       const writer = new BatchingWriter();
       const records = Array.from({ length: 25 }, (_, i) =>
@@ -113,5 +137,69 @@ describe('wal/batching_writer', () => {
 
     const pending = await readPending();
     expect(pending.map((r) => r.id)).toContain(r2.id);
+  });
+
+  it('persists a single submitted tombstone after the ack', async () => {
+    const writer = new BatchingWriter();
+    const record = makeRecord('t-single');
+    await writer.submit(record);
+    await writer.submitTombstone(record.id);
+
+    const lines = (await readFile(getWalPath(), 'utf8')).split('\n').filter((l) => l.length > 0);
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[1])).toEqual({ type: 'tombstone', id: record.id });
+
+    // Tombstone has shadowed the append: nothing should remain pending.
+    const pending = await readPending();
+    expect(pending.find((r) => r.id === record.id)).toBeUndefined();
+  });
+
+  it('resolves submitTombstone() only after the byte is durable', async () => {
+    // Symmetric to the submit() ack-after-fsync test: the post-ack file
+    // read must observe the tombstone, otherwise tombstones could be
+    // ack'd before being durable and a daemon crash mid-batch would
+    // resurrect already-uploaded records on the next pass.
+    const writer = new BatchingWriter();
+    const id = 'wal-t-durable';
+    await writer.submitTombstone(id);
+
+    const contents = await readFile(getWalPath(), 'utf8');
+    expect(contents).toContain(`"id":"${id}"`);
+    expect(contents).toContain('"type":"tombstone"');
+  });
+
+  it('coalesces appends and tombstones into a single fsync when submitted in the same tick', async () => {
+    // The whole point of routing tombstones through the BatchingWriter:
+    // a tombstone storm from the upload loop should batch with concurrent
+    // hook submits instead of paying its own fsync per call.
+    const syncSpy = await spyOnFileHandleSync(walDir);
+    try {
+      const writer = new BatchingWriter();
+      const records = Array.from({ length: 10 }, (_, i) => makeRecord(`mix-a-${i}`));
+      const tombstoneIds = Array.from({ length: 10 }, (_, i) => `mix-t-${i}`);
+
+      const syncsBefore = syncSpy.mock.calls.length;
+      await Promise.all([
+        ...records.map((r) => writer.submit(r)),
+        ...tombstoneIds.map((id) => writer.submitTombstone(id)),
+      ]);
+      const syncsAfter = syncSpy.mock.calls.length;
+
+      // Same shape guarantee as the append-only group-commit test: a
+      // stray tick may split the batch into two, but never N fsyncs for
+      // N submits.
+      expect(syncsAfter - syncsBefore).toBeLessThanOrEqual(2);
+      expect(syncsAfter - syncsBefore).toBeGreaterThanOrEqual(1);
+
+      const lines = (await readFile(getWalPath(), 'utf8')).split('\n').filter((l) => l.length > 0);
+      expect(lines).toHaveLength(records.length + tombstoneIds.length);
+
+      const tombstoneLines = lines.filter((l) => l.includes('"type":"tombstone"'));
+      const appendLines = lines.filter((l) => l.includes('"type":"append"'));
+      expect(tombstoneLines).toHaveLength(tombstoneIds.length);
+      expect(appendLines).toHaveLength(records.length);
+    } finally {
+      syncSpy.mockRestore();
+    }
   });
 });

--- a/libs/typescript/core/tests/exporters/wal/batching_writer.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/batching_writer.test.ts
@@ -21,31 +21,22 @@ function makeRecord(idSuffix: string, overrides: Partial<WalRecord> = {}): WalRe
   };
 }
 
-/**
- * Install a `jest.spyOn` on `FileHandle.prototype.sync` so the
- * group-commit tests below can count fsync invocations issued by the
- * production code. We discover the prototype by opening a throwaway
- * handle and walking one step up its prototype chain — that's where
- * `sync` is defined today, and where every FileHandle instance
- * (including the ones `BatchingWriter` opens internally) inherits it
- * from.
- *
- * The precondition assertion guards against a future Node release
- * moving `sync` off this prototype (or inlining it into a C++ binding
- * that bypasses the JS surface): without it, a missing method would
- * either make `jest.spyOn` throw a generic
- * "Cannot spy the sync property because it is not a function" error,
- * or — if the spy installed but never fired — make the test fail with
- * the equally confusing "expected 0 to be greater than or equal to 1".
- * The precondition gives operators a one-line breadcrumb pointing at
- * the actual cause.
- */
 async function spyOnFileHandleSync(walDir: string): Promise<jest.SpyInstance> {
-  const probeFh = await fsPromises.open(join(walDir, '.probe'), 'w');
-  const fdProto = Object.getPrototypeOf(probeFh) as { sync?: () => Promise<void> };
-  await probeFh.close();
-  expect(typeof fdProto.sync).toBe('function');
-  return jest.spyOn(fdProto as { sync: () => Promise<void> }, 'sync');
+  let spy: jest.SpyInstance | undefined;
+  try {
+    const probeFh = await fsPromises.open(join(walDir, '.probe'), 'w');
+    const fdProto = Object.getPrototypeOf(probeFh) as { sync?: () => Promise<void> };
+    await probeFh.close();
+    expect(typeof fdProto.sync).toBe('function');
+    spy = jest.spyOn(fdProto as { sync: () => Promise<void> }, 'sync');
+    return spy;
+  } catch (err) {
+    // `spy` is undefined for any throw before the install, so the
+    // optional chain is a no-op; if the install succeeded and a later
+    // line throws, this restores the prototype before propagating.
+    spy?.mockRestore();
+    throw err;
+  }
 }
 
 describe('wal/batching_writer', () => {

--- a/libs/typescript/core/tests/exporters/wal/batching_writer.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/batching_writer.test.ts
@@ -23,10 +23,6 @@ function makeRecord(idSuffix: string, overrides: Partial<WalRecord> = {}): WalRe
 
 describe('wal/batching_writer', () => {
   let walDir: string;
-  // Capture the developer's pre-test value so we restore (not just unset)
-  // in afterEach. Mirrors the pattern in paths.test.ts so running
-  // `MLFLOW_WAL_DIR=/some/dir jest` doesn't lose the override for later
-  // tests in the same worker.
   const originalWalDir = process.env.MLFLOW_WAL_DIR;
 
   beforeEach(async () => {
@@ -54,12 +50,6 @@ describe('wal/batching_writer', () => {
   });
 
   it('coalesces concurrent submits into a single fsync (group commit)', async () => {
-    // Spy on FileHandle.sync via the prototype so we count every fsync
-    // the writer issues regardless of which fd it opens. With group
-    // commit, N submissions made in the same tick must collapse into a
-    // single fsync. The probe fd is closed immediately after we grab
-    // the prototype so Node's "FileHandle closed by GC" guard never
-    // trips.
     const probeFh = await fsPromises.open(join(walDir, '.probe'), 'w');
     const fdProto = Object.getPrototypeOf(probeFh) as { sync: () => Promise<void> };
     await probeFh.close();
@@ -103,22 +93,6 @@ describe('wal/batching_writer', () => {
   });
 
   it('produces well-formed lines when batched submits interleave with direct writers', async () => {
-    // BatchingWriter.submit defers the actual file write to a
-    // setImmediate so it can coalesce same-tick submissions; a
-    // tombstone or direct appendRecord called inline therefore lands
-    // on queue.log before the deferred batch. We can't pin a specific
-    // ordering here, but two invariants must hold regardless of the
-    // interleaving: (1) every line in queue.log is valid JSON (no
-    // torn writes thanks to the shared SerialQueue), and (2) the
-    // visible record after the tombstone shadows the submitted
-    // record. We pick a tombstone for an id that the writer also
-    // submits and confirm that id is *not* in `readPending` —
-    // whichever wrote first, the tombstone always wins because
-    // `appendRecord(r1)` followed by `appendTombstone(r1.id)` and
-    // `appendTombstone(r1.id)` followed by `appendRecord(r1)` both
-    // collapse to "r1 hidden" under {@link readPending}'s replay
-    // semantics (tombstone shadows earlier appends; an append after a
-    // tombstone wins, but our writer never re-submits the same id).
     const writer = new BatchingWriter();
     const r1 = makeRecord('mixed-1');
     const r2 = makeRecord('mixed-2');
@@ -137,9 +111,6 @@ describe('wal/batching_writer', () => {
       }).not.toThrow();
     }
 
-    // Either ordering of tombstone vs. r1's append leaves r2 visible;
-    // r1's pending state depends on the interleaving and is not part
-    // of the contract under test.
     const pending = await readPending();
     expect(pending.map((r) => r.id)).toContain(r2.id);
   });

--- a/libs/typescript/core/tests/exporters/wal/clients.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/clients.test.ts
@@ -1,4 +1,8 @@
-import { clearClientCache, clientForUri } from '../../../src/exporters/wal/clients';
+import {
+  clearClientCache,
+  clearClientForUri,
+  clientForUri,
+} from '../../../src/exporters/wal/clients';
 import { MlflowClient } from '../../../src/clients/client';
 
 describe('wal/clients', () => {
@@ -38,5 +42,31 @@ describe('wal/clients', () => {
     expect(a2).not.toBe(a1);
     expect(b2).not.toBe(b1);
     expect(a2).not.toBe(b2);
+  });
+
+  describe('clearClientForUri', () => {
+    it('evicts only the targeted URI and rebuilds it on next access', () => {
+      // Targeted eviction is the upload loop's auth-error retry path:
+      // we want the *specific* stale client gone, not every other URI's
+      // working cache entry blown away as collateral damage.
+      const a = clientForUri('http://a:5000');
+      const b = clientForUri('http://b:5000');
+
+      clearClientForUri('http://a:5000');
+
+      const aAfter = clientForUri('http://a:5000');
+      const bAfter = clientForUri('http://b:5000');
+
+      expect(aAfter).not.toBe(a);
+      expect(bAfter).toBe(b);
+    });
+
+    it('is a silent no-op for a URI that was never cached', () => {
+      // The upload loop calls clearClientForUri unconditionally before
+      // re-resolving via the factory; it must not throw if the cache
+      // entry was already evicted (e.g. by a prior auth-retry in a
+      // sibling group, or by clearClientCache() during shutdown).
+      expect(() => clearClientForUri('http://never-cached:5000')).not.toThrow();
+    });
   });
 });

--- a/libs/typescript/core/tests/exporters/wal/clients.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/clients.test.ts
@@ -1,0 +1,42 @@
+import { clearClientCache, clientForUri } from '../../../src/exporters/wal/clients';
+import { MlflowClient } from '../../../src/clients/client';
+
+describe('wal/clients', () => {
+  beforeEach(() => {
+    clearClientCache();
+  });
+
+  it('returns the same MlflowClient instance for repeat calls with the same URI', () => {
+    const a = clientForUri('http://localhost:5000');
+    const b = clientForUri('http://localhost:5000');
+    expect(a).toBeInstanceOf(MlflowClient);
+    expect(b).toBe(a);
+  });
+
+  it('returns distinct MlflowClient instances for different URIs', () => {
+    const local = clientForUri('http://localhost:5000');
+    const remote = clientForUri('http://other-host:5000');
+    expect(local).not.toBe(remote);
+    expect(local.getHost()).toBe('http://localhost:5000');
+    expect(remote.getHost()).toBe('http://other-host:5000');
+  });
+
+  it('rebuilds the client after the cache is cleared', () => {
+    const before = clientForUri('http://localhost:5000');
+    clearClientCache();
+    const after = clientForUri('http://localhost:5000');
+    expect(after).not.toBe(before);
+    expect(after).toBeInstanceOf(MlflowClient);
+  });
+
+  it('isolates state for different tracking URIs after a clear', () => {
+    const a1 = clientForUri('http://a:5000');
+    const b1 = clientForUri('http://b:5000');
+    clearClientCache();
+    const a2 = clientForUri('http://a:5000');
+    const b2 = clientForUri('http://b:5000');
+    expect(a2).not.toBe(a1);
+    expect(b2).not.toBe(b1);
+    expect(a2).not.toBe(b2);
+  });
+});

--- a/libs/typescript/core/tests/exporters/wal/supervisor.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/supervisor.test.ts
@@ -1,3 +1,4 @@
+import * as childProcess from 'node:child_process';
 import { existsSync } from 'fs';
 import { mkdtemp, readFile, rm, writeFile } from 'fs/promises';
 import { createServer, Server } from 'net';
@@ -9,6 +10,14 @@ import {
   resolveDaemonEntry,
 } from '../../../src/exporters/wal/supervisor';
 import { getLockSocketPath } from '../../../src/exporters/wal/paths';
+
+jest.mock('node:child_process', () => {
+  const actual = jest.requireActual<typeof import('node:child_process')>('node:child_process');
+  return {
+    ...actual,
+    spawn: jest.fn((...args: Parameters<typeof actual.spawn>) => actual.spawn(...args)),
+  };
+});
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -152,16 +161,108 @@ describe('wal/supervisor', () => {
       expect(await readFile(counterFile, 'utf8')).toBe('+');
     });
 
-    it('logs and swallows errors instead of throwing', async () => {
-      // Point the resolver at a nonexistent file so spawn fails (the
-      // child can't load it). ensureDaemon must still resolve cleanly.
-      process.env.MLFLOW_TRACE_DAEMON_EXECUTABLE = join(walDir, 'does-not-exist.js');
+    it('swallows broken-entry failures and surfaces a diagnostic to stderr', async () => {
+      // Broken-install failures surface asynchronously, *after*
+      // `ensureDaemon` has already resolved (the spawn itself is
+      // fire-and-forget by design). The listener in `spawnDaemon` must:
+      //   1. let `ensureDaemon` resolve cleanly (no upstream crash);
+      //   2. log a breadcrumb mentioning the broken entry so a broken
+      //      install (missing `bundle/daemon.cjs`, bad
+      //      `MLFLOW_TRACE_DAEMON_EXECUTABLE`) doesn't degrade into
+      //      ~3.85 s of opaque ECONNREFUSED retries in the WAL exporter
+      //      with zero indication of cause.
+      //
+      // Two child events can carry the diagnostic and the listener
+      // hooks both: `'error'` fires when libuv can't start the binary
+      // at all (we can't easily trigger this here because `spawnDaemon`
+      // runs `spawn(process.execPath, [entry], ...)` and the node
+      // binary always exists), and `'exit'` fires with a non-zero code
+      // when the binary starts but the entry script fails to load —
+      // which is what pointing `MLFLOW_TRACE_DAEMON_EXECUTABLE` at a
+      // nonexistent `.js` file actually triggers. The test accepts
+      // either: both equally serve the reviewer-visible "broken
+      // install" purpose.
+      const missing = join(walDir, 'does-not-exist.js');
+      process.env.MLFLOW_TRACE_DAEMON_EXECUTABLE = missing;
       const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
       try {
         await expect(ensureDaemon()).resolves.toBeUndefined();
+        // Generous timeout: node cold-start + script-resolution failure
+        // + exit can comfortably exceed 1 s on a busy CI box.
+        await waitFor(
+          () =>
+            errSpy.mock.calls.some(
+              ([msg]) =>
+                typeof msg === 'string' &&
+                msg.includes(missing) &&
+                /daemon (spawn failed|exited unexpectedly)/.test(msg),
+            ),
+          5000,
+        );
+        const match = errSpy.mock.calls.find(
+          ([msg]) =>
+            typeof msg === 'string' &&
+            msg.includes(missing) &&
+            /daemon (spawn failed|exited unexpectedly)/.test(msg),
+        );
+        expect(match).toBeDefined();
+        expect(match![0]).toContain(missing);
       } finally {
         errSpy.mockRestore();
       }
+    });
+
+    it('catches synchronous spawn failures via the outer ensureDaemon catch', async () => {
+      // The per-child `'error'` / `'exit'` listeners installed by
+      // `spawnDaemon` only fire for *async* failures (the binary started
+      // but the entry script blew up). Synchronous failures from
+      // `spawn()` itself — libuv refusing the args, or
+      // `resolveDaemonEntry()` throwing on a broken package-resolution
+      // path — rely on the outer try/catch in `ensureDaemon`'s IIFE.
+      // Without that catch, `spawnInFlight` would settle as a rejected
+      // promise and hooks would crash on cold spawn failures the
+      // per-child listener can't help with.
+      //
+      // The top-of-file `jest.mock('node:child_process', ...)` installs
+      // a passthrough mock; here we override the next `spawn` call
+      // (and only that one) with a synchronous throw. The override
+      // is scoped to this test via `mockImplementationOnce`, so the
+      // adjacent coalescing test below sees real spawn behavior again.
+      const spawnMock = childProcess.spawn as jest.MockedFunction<typeof childProcess.spawn>;
+      spawnMock.mockImplementationOnce(() => {
+        throw new Error('synthetic synchronous spawn failure');
+      });
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      try {
+        // The outer catch must convert the synchronous throw into a
+        // clean resolution + a diagnostic log line. Anything else
+        // (rejection, unhandled crash, no log) is a regression in the
+        // defense-in-depth path.
+        await expect(ensureDaemon()).resolves.toBeUndefined();
+        expect(spawnMock).toHaveBeenCalled();
+        expect(
+          errSpy.mock.calls.some(
+            ([msg]) => typeof msg === 'string' && msg.includes('ensureDaemon failed'),
+          ),
+        ).toBe(true);
+      } finally {
+        errSpy.mockRestore();
+      }
+    });
+
+    it('coalesces concurrent calls into a single spawn', async () => {
+      // The realistic trigger is multiple `submitRecord` calls in one
+      // hook all hitting ECONNREFUSED during a daemon cold-start. Each
+      // would otherwise spawn its own child; the in-flight latch should
+      // dedupe them down to a single `spawn()` invocation.
+      const concurrent = 5;
+      await Promise.all(Array.from({ length: concurrent }, () => ensureDaemon()));
+      await waitFor(() => existsSync(counterFile));
+      // Give any (errant) extra spawns time to write to the counter.
+      await sleep(200);
+
+      const counterContents = await readFile(counterFile, 'utf8');
+      expect(counterContents).toBe('+');
     });
   });
 });

--- a/libs/typescript/core/tests/exporters/wal/supervisor.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/supervisor.test.ts
@@ -1,0 +1,167 @@
+import { existsSync } from 'fs';
+import { mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import { createServer, Server } from 'net';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  ensureDaemon,
+  isDaemonAlive,
+  resolveDaemonEntry,
+} from '../../../src/exporters/wal/supervisor';
+import { getLockSocketPath } from '../../../src/exporters/wal/paths';
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor(
+  predicate: () => boolean | Promise<boolean>,
+  timeoutMs = 2000,
+): Promise<void> {
+  const start = Date.now();
+  for (;;) {
+    if (await predicate()) {
+      return;
+    }
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`waitFor: predicate did not become true within ${timeoutMs}ms`);
+    }
+    await sleep(20);
+  }
+}
+
+describe('wal/supervisor', () => {
+  let walDir: string;
+  
+  const originalWalDir = process.env.MLFLOW_WAL_DIR;
+  const originalDaemonExecutable = process.env.MLFLOW_TRACE_DAEMON_EXECUTABLE;
+
+  beforeEach(async () => {
+    walDir = await mkdtemp(join(tmpdir(), 'mlflow-supervisor-'));
+    process.env.MLFLOW_WAL_DIR = walDir;
+  });
+
+  afterEach(async () => {
+    if (originalWalDir === undefined) {
+      delete process.env.MLFLOW_WAL_DIR;
+    } else {
+      process.env.MLFLOW_WAL_DIR = originalWalDir;
+    }
+    if (originalDaemonExecutable === undefined) {
+      delete process.env.MLFLOW_TRACE_DAEMON_EXECUTABLE;
+    } else {
+      process.env.MLFLOW_TRACE_DAEMON_EXECUTABLE = originalDaemonExecutable;
+    }
+    await rm(walDir, { recursive: true, force: true });
+  });
+
+  describe('isDaemonAlive', () => {
+    it('returns false when no socket is bound', async () => {
+      expect(await isDaemonAlive()).toBe(false);
+    });
+
+    it('returns true when a server is bound to the lock socket', async () => {
+      const server: Server = createServer((s) => s.end());
+      await new Promise<void>((resolve) => server.listen(getLockSocketPath(), resolve));
+      try {
+        expect(await isDaemonAlive()).toBe(true);
+      } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+    });
+  });
+
+  describe('resolveDaemonEntry', () => {
+    it('returns the value of MLFLOW_TRACE_DAEMON_EXECUTABLE when set', () => {
+      process.env.MLFLOW_TRACE_DAEMON_EXECUTABLE = '/custom/path/to/daemon.cjs';
+      expect(resolveDaemonEntry()).toBe('/custom/path/to/daemon.cjs');
+    });
+
+    it('treats an empty MLFLOW_TRACE_DAEMON_EXECUTABLE as unset', () => {
+      process.env.MLFLOW_TRACE_DAEMON_EXECUTABLE = '';
+      // With the env var empty, the resolver falls through to package
+      // resolution. We can't predict the absolute path, but it must end
+      // in `bundle/daemon.cjs` per the documented contract.
+      const resolved = resolveDaemonEntry();
+      expect(resolved.endsWith(join('bundle', 'daemon.cjs'))).toBe(true);
+    });
+  });
+
+  describe('ensureDaemon', () => {
+    let stubScript: string;
+    let counterFile: string;
+    let pidFile: string;
+
+    beforeEach(async () => {
+      stubScript = join(walDir, 'stub-daemon.js');
+      counterFile = join(walDir, 'spawns.log');
+      pidFile = join(walDir, 'pids.log');
+
+      // Minimal CJS script: record that we spawned, bind the lock
+      // socket, and self-terminate after a short window so a failing
+      // test cannot leak indefinitely. fs writes happen *before* the
+      // listen() call so the counter / pid record is durable even if
+      // the parent has already moved on by the time we bind.
+      const lockPath = getLockSocketPath();
+      const stubSource = [
+        "const net = require('net');",
+        "const fs = require('fs');",
+        `fs.appendFileSync(${JSON.stringify(counterFile)}, '+');`,
+        `fs.appendFileSync(${JSON.stringify(pidFile)}, process.pid + '\\n');`,
+        'const server = net.createServer((s) => s.end());',
+        `server.listen(${JSON.stringify(lockPath)}, () => {`,
+        '  setTimeout(() => process.exit(0), 3000);',
+        '});',
+      ].join('\n');
+      await writeFile(stubScript, stubSource);
+      process.env.MLFLOW_TRACE_DAEMON_EXECUTABLE = stubScript;
+    });
+
+    afterEach(async () => {
+      // Kill any stub daemons that haven't self-destructed yet so
+      // subsequent tests don't see stale processes / sockets.
+      if (existsSync(pidFile)) {
+        const pids = (await readFile(pidFile, 'utf8')).split('\n').filter((l) => l.length > 0);
+        for (const pid of pids) {
+          try {
+            process.kill(Number.parseInt(pid, 10), 'SIGKILL');
+          } catch {
+            // Already exited.
+          }
+        }
+      }
+    });
+
+    it('spawns a daemon when none is alive', async () => {
+      await ensureDaemon();
+      await waitFor(() => existsSync(counterFile));
+      expect(await readFile(counterFile, 'utf8')).toBe('+');
+    });
+
+    it('does not spawn a second daemon when one is already alive', async () => {
+      await ensureDaemon();
+      await waitFor(() => existsSync(counterFile));
+      // Wait until the first stub has actually bound the socket; only
+      // after that will the second probe see "alive".
+      await waitFor(() => isDaemonAlive(), 3000);
+
+      await ensureDaemon();
+      // Give any (errant) second spawn time to write to the counter.
+      await sleep(200);
+
+      expect(await readFile(counterFile, 'utf8')).toBe('+');
+    });
+
+    it('logs and swallows errors instead of throwing', async () => {
+      // Point the resolver at a nonexistent file so spawn fails (the
+      // child can't load it). ensureDaemon must still resolve cleanly.
+      process.env.MLFLOW_TRACE_DAEMON_EXECUTABLE = join(walDir, 'does-not-exist.js');
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      try {
+        await expect(ensureDaemon()).resolves.toBeUndefined();
+      } finally {
+        errSpy.mockRestore();
+      }
+    });
+  });
+});

--- a/libs/typescript/core/tests/exporters/wal/supervisor.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/supervisor.test.ts
@@ -32,7 +32,7 @@ async function waitFor(
 
 describe('wal/supervisor', () => {
   let walDir: string;
-  
+
   const originalWalDir = process.env.MLFLOW_WAL_DIR;
   const originalDaemonExecutable = process.env.MLFLOW_TRACE_DAEMON_EXECUTABLE;
 

--- a/libs/typescript/core/tests/exporters/wal/supervisor.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/supervisor.test.ts
@@ -1,6 +1,6 @@
 import * as childProcess from 'node:child_process';
 import { existsSync } from 'fs';
-import { mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import { mkdtemp, readFile, rm, unlink, writeFile } from 'fs/promises';
 import { createServer, Server } from 'net';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -139,6 +139,15 @@ describe('wal/supervisor', () => {
           }
         }
       }
+      if (process.platform !== 'win32') {
+        try {
+          await unlink(getLockSocketPath());
+        } catch {
+          // ENOENT (no stale file from this test) or any other error —
+          // best-effort cleanup; the next test's beforeEach reseeds
+          // everything regardless.
+        }
+      }
     });
 
     it('spawns a daemon when none is alive', async () => {
@@ -213,21 +222,6 @@ describe('wal/supervisor', () => {
     });
 
     it('catches synchronous spawn failures via the outer ensureDaemon catch', async () => {
-      // The per-child `'error'` / `'exit'` listeners installed by
-      // `spawnDaemon` only fire for *async* failures (the binary started
-      // but the entry script blew up). Synchronous failures from
-      // `spawn()` itself — libuv refusing the args, or
-      // `resolveDaemonEntry()` throwing on a broken package-resolution
-      // path — rely on the outer try/catch in `ensureDaemon`'s IIFE.
-      // Without that catch, `spawnInFlight` would settle as a rejected
-      // promise and hooks would crash on cold spawn failures the
-      // per-child listener can't help with.
-      //
-      // The top-of-file `jest.mock('node:child_process', ...)` installs
-      // a passthrough mock; here we override the next `spawn` call
-      // (and only that one) with a synchronous throw. The override
-      // is scoped to this test via `mockImplementationOnce`, so the
-      // adjacent coalescing test below sees real spawn behavior again.
       const spawnMock = childProcess.spawn as jest.MockedFunction<typeof childProcess.spawn>;
       spawnMock.mockImplementationOnce(() => {
         throw new Error('synthetic synchronous spawn failure');


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/23545/files) to review incremental changes.
- [**stack/async-batch-cc**](https://github.com/mlflow/mlflow/pull/23545) [[Files changed](https://github.com/mlflow/mlflow/pull/23545/files)]

---------
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Relates to previously merged PRs:
- https://github.com/mlflow/mlflow/pull/23511
- https://github.com/mlflow/mlflow/pull/23464

This is part of a series of changes to support async batch tracing for TS Claude Code / Coding Agent LLM MLflow tracing

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

This PR introduces four small, dependency-free building blocks under libs/typescript/core/src/exporters/wal/ that the upcoming daemon-proxy WAL pipeline relies on. None of them are wired into the tracing flow yet, so changes are safe.

- protocol.ts — wire types for the hook ↔ daemon IPC channel (AppendRequest, IpcRequest, OkResponse, ErrResponse, IpcResponse).
- batching_writer.ts — BatchingWriter class providing group-commit (one open / N writes / one fsync / close) over the daemon's WAL append path, with ack-after-fsync semantics for callers.
- clients.ts — process-local MlflowClient cache (clientForUri, clearClientCache) keyed by trackingUri
- supervisor.ts — isDaemonAlive, resolveDaemonEntry, spawnDaemon, ensureDaemon; everything needed for a hook process to probe-and-spawn a long-lived daemon on demand.

PR summary generated by Claude, reviewed by author

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
