### PR TITLE
Fix outdated pydantic-ai version requirement in autolog docs

### DIFF
--- a/docs/docs/genai/prompt-registry/optimize-prompts/pydantic-ai-optimization.mdx
+++ b/docs/docs/genai/prompt-registry/optimize-prompts/pydantic-ai-optimization.mdx
@@ -17,7 +17,7 @@ This guide demonstrates how to leverage <APILink fn="mlflow.genai.optimize_promp
 ## Prerequisites
 
 ```bash
-pip install -U pydantic-ai mlflow gepa nest_asyncio
+pip install -U "pydantic-ai>=1.63.0" mlflow gepa nest_asyncio
 ```
 
 Set your OpenAI API key:

--- a/docs/docs/genai/tracing/integrations/listing/pydantic_ai.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/pydantic_ai.mdx
@@ -48,6 +48,9 @@ import mlflow
 # Turn on auto tracing by calling mlflow.pydantic_ai.autolog()
 mlflow.pydantic_ai.autolog()
 
+:::note
+MLflow PydanticAI autologging requires `pydantic-ai>=1.63.0` for full support including streaming (`run_stream_sync`) and tool tracing.
+:::
 
 # Optional: Set a tracking URI and an experiment
 mlflow.set_tracking_uri("http://localhost:5000")


### PR DESCRIPTION
### What changes are being proposed?

Fix outdated PydanticAI version requirement in MLflow autolog documentation.

### Why are these changes needed?

MLflow PydanticAI autologging requires `pydantic-ai>=1.63.0` for proper streaming and tool tracing support. The previous documentation showed an outdated installation command and missing version requirement note.

### What component(s) does this PR affect?

- [x] Documentation
- [ ] Tracking
- [ ] Models
- [ ] Model Registry
- [ ] Projects
- [ ] UI
- [ ] API
- [ ] Examples
- [ ] Python client
- [ ] R client
- [ ] Java client

### How was this patch tested?

Checked documentation build locally / verified markdown rendering.

### Does this PR require documentation update?

Yes — this PR updates documentation only.

### Commit message / DCO

Signed-off-by: Gayathri Reddy <gayathrireddy18125@gmail.com>