### PR TITLE
Fix outdated pydantic-ai version requirement in autolog docs

### DIFF
--- a/docs/docs/genai/prompt-registry/optimize-prompts/pydantic-ai-optimization.mdx
+++ b/docs/docs/genai/prompt-registry/optimize-prompts/pydantic-ai-optimization.mdx
@@ -17,7 +17,7 @@ This guide demonstrates how to leverage <APILink fn="mlflow.genai.optimize_promp
 ## Prerequisites
 
 ```bash
-pip install -U pydantic-ai mlflow gepa nest_asyncio
+pip install -U "pydantic-ai>=1.63.0" mlflow gepa nest_asyncio
 ```
 
 Set your OpenAI API key:

--- a/docs/docs/genai/tracing/integrations/listing/pydantic_ai.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/pydantic_ai.mdx
@@ -48,6 +48,9 @@ import mlflow
 # Turn on auto tracing by calling mlflow.pydantic_ai.autolog()
 mlflow.pydantic_ai.autolog()
 
+:::note
+MLflow PydanticAI autologging requires `pydantic-ai>=1.63.0` for full support including streaming (`run_stream_sync`) and tool tracing.
+:::
 
 # Optional: Set a tracking URI and an experiment
 mlflow.set_tracking_uri("http://localhost:5000")

--- a/docs/docs/genai/tracing/integrations/listing/pydantic_ai.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/pydantic_ai.mdx
@@ -46,7 +46,9 @@ First, enable auto-tracing for PydanticAI, and optionally create an MLflow exper
 import mlflow
 
 # Turn on auto tracing by calling mlflow.pydantic_ai.autolog()
+```python
 mlflow.pydantic_ai.autolog()
+```
 
 :::note
 MLflow PydanticAI autologging requires `pydantic-ai>=1.63.0` for full support including streaming (`run_stream_sync`) and tool tracing.


### PR DESCRIPTION
### Related Issues/PRs

Closes #23550

### What changes are proposed in this pull request?

Fix outdated PydanticAI version requirement in MLflow autolog documentation.

### How is this PR tested?

- [x] Manual tests

No code changes affecting runtime behavior, only documentation updates.

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Examples
  - [x] Instructions

### Does this PR require updating the MLflow Skills repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Documentation updated to reflect minimum supported `pydantic-ai>=1.63.0`.

#### Components

- [x] `area/docs`

#### How should the PR be classified in the release notes?

- [x] `rn/documentation`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release
- [x] This PR can wait for the next minor release