### PR TITLE
Add Codex symlinks for `AGENTS.md` and `.agents/skills`

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Codex reads project instructions from `AGENTS.md` and skills from `.agents/skills/`. This PR adds symlinks so Codex and Claude Code share the same configuration:

- `AGENTS.md` -> `CLAUDE.md`
- `.agents/skills` -> `../.claude/skills`

Same pattern as [turso](https://github.com/tursodatabase/turso), which symlinks `CLAUDE.md` -> `AGENTS.md`. No content duplication, no drift.

### How is this PR tested?

- [x] Manual tests

Verified Codex picks up the skills directory via the `.agents/skills` symlink.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)