### PR TITLE
Bump R `mlflow.connect.wait` in tests to reduce flakes

### DIFF
--- a/mlflow/R/mlflow/tests/testthat/helpers.R
+++ b/mlflow/R/mlflow/tests/testthat/helpers.R
@@ -1,3 +1,7 @@
+# CI runners can be slow to boot a local tracking server; the package default
+# of 10s for mlflow_validate_server times out intermittently.
+options(mlflow.connect.wait = 30)
+
 mlflow_clear_test_dir <- function(path) {
   purrr::safely(mlflow_end_run)()
   mlflow:::mlflow_set_active_experiment_id(NULL)


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

The R test suite spawns a local tracking server and then validates it by polling `mlflow_validate_server` -> `wait_for(...)` with a default timeout of `getOption("mlflow.connect.wait", 10)`. On the GitHub Actions runner this 10s window is intermittently too tight to cover gunicorn boot + SQLAlchemy init + first request, producing failures like:

```
Error ('test-keras-model.R:33:3'): mlflow can save keras model
Error in `wait_for(function() mlflow_rest("experiments", "search", ...), 10, 1)`:
  Operation failed after waiting for 10 seconds
```

Five recent `r.yml` runs all hit the same timeout (including a master push), so this is structural rather than a random flake.

This PR sets `options(mlflow.connect.wait = 30)` in `mlflow/R/mlflow/tests/testthat/helpers.R` so the test setup tolerates a slower-than-usual server boot. The package default (10s) is unchanged.

### How is this PR tested?

- [x] Existing unit/integration tests

The `r` CI job exercises the path that was timing out.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release