### PR TITLE
Add VIDEO chart support for MLflow Tracking video artifacts

### DIFF
--- a/mlflow/server/js/src/common/static/chart-video.svg
+++ b/mlflow/server/js/src/common/static/chart-video.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="0.5" y="2.5" width="15" height="11" rx="1.5" stroke="#C4C4C4"/>
+<path d="M6 5.5V10.5L11 8L6 5.5Z" fill="#C4C4C4"/>
+</svg>

--- a/mlflow/server/js/src/common/utils/FileUtils.ts
+++ b/mlflow/server/js/src/common/utils/FileUtils.ts
@@ -59,4 +59,4 @@ export const DATA_EXTENSIONS = new Set(['csv', 'tsv']);
 // Source: https://github.com/katspaugh/wavesurfer.js/discussions/2703#discussioncomment-5259526
 // `mp4` is intentionally omitted here to avoid overlapping with `VIDEO_EXTENSIONS`.
 export const AUDIO_EXTENSIONS = new Set(['m4a', 'mp3', 'wav', 'aac', 'wma', 'flac', 'opus', 'ogg']);
-export const VIDEO_EXTENSIONS = new Set(['mp4', 'mov', 'mkv', 'webm', 'avi']);
+export const VIDEO_EXTENSIONS = new Set(['mp4', 'mov', 'mkv', 'webm', 'avi', 'm4v', 'ogv']);

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactVideoView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactVideoView.tsx
@@ -48,12 +48,15 @@ const ShowArtifactVideoView = ({
       overflow: 'hidden',
       background: 'black',
       minHeight: '100%',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
     },
     hidden: { display: 'none' },
     video: {
       maxWidth: '100%',
       maxHeight: '62.5vh',
-      objectFit: 'fit',
+      objectFit: 'contain' as const,
       display: 'block',
     },
   };

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewMetricCharts.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewMetricCharts.tsx
@@ -44,6 +44,7 @@ import {
   NodeLevelMetricsFilterContextProvider,
   useNodeLevelMetricsFilterState,
 } from './node-level-metric-charts/contexts/NodeLevelMetricsFilterContext';
+import { RunViewVideosSection } from './overview/RunViewVideosSection';
 
 interface RunViewMetricChartsProps {
   metricKeys: string[];
@@ -290,6 +291,7 @@ const RunViewMetricChartsImpl = ({
           overflow: 'auto',
         }}
       >
+        {mode === 'model' && <RunViewVideosSection runUuid={runInfo.runUuid ?? ''} />}
         <NodeLevelMetricsFilterContextProvider value={filterState}>
           <RunsChartsTooltipWrapper contextData={tooltipContextValue} component={RunViewChartTooltipBody}>
             <RunsChartsDraggableCardsGridContextProvider visibleChartCards={visibleChartCards}>

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewMetricCharts.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewMetricCharts.tsx
@@ -44,7 +44,6 @@ import {
   NodeLevelMetricsFilterContextProvider,
   useNodeLevelMetricsFilterState,
 } from './node-level-metric-charts/contexts/NodeLevelMetricsFilterContext';
-import { RunViewVideosSection } from './overview/RunViewVideosSection';
 
 interface RunViewMetricChartsProps {
   metricKeys: string[];
@@ -291,7 +290,6 @@ const RunViewMetricChartsImpl = ({
           overflow: 'auto',
         }}
       >
-        {mode === 'model' && <RunViewVideosSection runUuid={runInfo.runUuid ?? ''} />}
         <NodeLevelMetricsFilterContextProvider value={filterState}>
           <RunsChartsTooltipWrapper contextData={tooltipContextValue} component={RunViewChartTooltipBody}>
             <RunsChartsDraggableCardsGridContextProvider visibleChartCards={visibleChartCards}>
@@ -305,7 +303,7 @@ const RunViewMetricChartsImpl = ({
                 removeChart={removeChart}
                 addNewChartCard={addNewChartCard}
                 search={chartsSearchFilter ?? ''}
-                supportedChartTypes={[RunsChartType.LINE, RunsChartType.BAR, RunsChartType.IMAGE]}
+                supportedChartTypes={[RunsChartType.LINE, RunsChartType.BAR, RunsChartType.IMAGE, RunsChartType.VIDEO]}
                 setFullScreenChart={setFullScreenChart}
                 autoRefreshEnabled={autoRefreshEnabled}
                 globalLineChartConfig={chartUIState.globalLineChartConfig}
@@ -333,7 +331,7 @@ const RunViewMetricChartsImpl = ({
           onSubmit={submitForm}
           onCancel={() => setConfiguredCardConfig(null)}
           groupBy={null}
-          supportedChartTypes={[RunsChartType.LINE, RunsChartType.BAR, RunsChartType.IMAGE]}
+          supportedChartTypes={[RunsChartType.LINE, RunsChartType.BAR, RunsChartType.IMAGE, RunsChartType.VIDEO]}
           globalLineChartConfig={chartUIState.globalLineChartConfig}
         />
       )}

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/hooks/useRunVideoArtifacts.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/hooks/useRunVideoArtifacts.ts
@@ -1,0 +1,105 @@
+import { useState, useEffect, useCallback } from 'react';
+import { MlflowService } from '../../../sdk/MlflowService';
+import { isVideoArtifactPath, sortVideoArtifacts, VIDEO_ARTIFACT_DIRECTORIES } from '../../../utils/VideoUtils';
+
+interface ArtifactFileInfo {
+  path: string;
+  is_dir: boolean;
+  file_size?: number;
+}
+
+/**
+ * Hook that discovers video artifacts for a given run.
+ * Scans the root artifact directory and known video directories
+ * (videos/, media/, media/videos/, rollouts/) for video files.
+ */
+export function useRunVideoArtifacts(runUuid: string): {
+  videos: string[];
+  loading: boolean;
+} {
+  const [videos, setVideos] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchArtifacts = useCallback(async () => {
+    try {
+      const videoPaths: string[] = [];
+      const scannedDirs = new Set<string>();
+
+      const listDir = async (path?: string): Promise<ArtifactFileInfo[]> => {
+        const dirKey = path || '';
+        if (scannedDirs.has(dirKey)) return [];
+        scannedDirs.add(dirKey);
+
+        try {
+          const response = await MlflowService.listArtifacts({
+            run_uuid: runUuid,
+            ...(path && { path }),
+          });
+          return response.files || [];
+        } catch {
+          // Directory may not exist, that's OK
+          return [];
+        }
+      };
+
+      // Scan root directory
+      const rootFiles = await listDir();
+      for (const file of rootFiles) {
+        if (!file.is_dir && isVideoArtifactPath(file.path)) {
+          videoPaths.push(file.path);
+        }
+      }
+
+      // Scan known video directories (and any root-level dirs that match)
+      const dirsToScan = [...VIDEO_ARTIFACT_DIRECTORIES];
+      for (const file of rootFiles) {
+        if (file.is_dir) {
+          const dirName = file.path.split('/').pop() || file.path;
+          if (
+            VIDEO_ARTIFACT_DIRECTORIES.some(
+              (vd) => vd === dirName || vd.startsWith(dirName + '/'),
+            )
+          ) {
+            dirsToScan.push(file.path);
+          }
+        }
+      }
+
+      // Fetch contents of known directories in parallel
+      const dirResults = await Promise.all(
+        [...new Set(dirsToScan)].map((dir) => listDir(dir)),
+      );
+
+      for (const files of dirResults) {
+        for (const file of files) {
+          if (!file.is_dir && isVideoArtifactPath(file.path)) {
+            videoPaths.push(file.path);
+          } else if (file.is_dir) {
+            // One level deeper for nested directories like media/videos/
+            const nestedFiles = await listDir(file.path);
+            for (const nested of nestedFiles) {
+              if (!nested.is_dir && isVideoArtifactPath(nested.path)) {
+                videoPaths.push(nested.path);
+              }
+            }
+          }
+        }
+      }
+
+      // Deduplicate and sort
+      const uniquePaths = [...new Set(videoPaths)];
+      setVideos(sortVideoArtifacts(uniquePaths));
+    } catch {
+      // If artifact listing fails entirely, show no videos
+      setVideos([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [runUuid]);
+
+  useEffect(() => {
+    fetchArtifacts();
+  }, [fetchArtifacts]);
+
+  return { videos, loading };
+}

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewVideosSection.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewVideosSection.test.tsx
@@ -1,0 +1,172 @@
+import { jest, describe, beforeAll, beforeEach, it, expect } from '@jest/globals';
+import { render, screen, waitFor } from '../../../../common/utils/TestUtils.react18';
+import { IntlProvider } from 'react-intl';
+import { DesignSystemProvider } from '@databricks/design-system';
+import { RunViewVideosSection } from './RunViewVideosSection';
+
+// Mock the MlflowService
+const mockListArtifacts = jest.fn();
+jest.mock('../../../sdk/MlflowService', () => ({
+  MlflowService: {
+    listArtifacts: (...args: any[]) => mockListArtifacts(...args),
+  },
+}));
+
+// Mock getArtifactBlob to return a dummy blob
+jest.mock('../../../../common/utils/ArtifactUtils', () => ({
+  ...jest.requireActual<typeof import('../../../../common/utils/ArtifactUtils')>('../../../../common/utils/ArtifactUtils'),
+  getArtifactBlob: jest.fn(() => Promise.resolve(new Blob(['video-data'], { type: 'video/mp4' }))),
+}));
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <IntlProvider locale="en">
+    <DesignSystemProvider>{children}</DesignSystemProvider>
+  </IntlProvider>
+);
+
+describe('RunViewVideosSection', () => {
+  beforeAll(() => {
+    jest.spyOn(global.URL, 'createObjectURL').mockImplementation(() => 'blob://test-video-url');
+    global.URL.revokeObjectURL = jest.fn();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders a video player with step slider for video artifacts', async () => {
+    mockListArtifacts.mockImplementation(({ path }: { run_uuid: string; path?: string }) => {
+      if (!path) {
+        return Promise.resolve({
+          files: [
+            { path: 'videos', is_dir: true },
+            { path: 'model.pkl', is_dir: false },
+          ],
+        });
+      }
+      if (path === 'videos') {
+        return Promise.resolve({
+          files: [
+            { path: 'videos/step_0.mp4', is_dir: false },
+            { path: 'videos/step_100.mp4', is_dir: false },
+            { path: 'videos/step_500.mp4', is_dir: false },
+          ],
+        });
+      }
+      return Promise.resolve({ files: [] });
+    });
+
+    render(<RunViewVideosSection runUuid="test-run-123" />, { wrapper });
+
+    await waitFor(() => {
+      // Should render a single video player (W&B style: one at a time)
+      const video = screen.getByLabelText('video');
+      expect(video).toBeInTheDocument();
+      expect(video).toHaveAttribute('controls');
+    });
+
+    // Should show step label
+    expect(screen.getByText(/Step:/)).toBeInTheDocument();
+  });
+
+  it('video src points to a blob URL (fetched with auth)', async () => {
+    mockListArtifacts.mockResolvedValue({
+      files: [{ path: 'videos/rollout.mp4', is_dir: false }],
+    });
+
+    render(<RunViewVideosSection runUuid="run-456" />, { wrapper });
+
+    await waitFor(() => {
+      const video = screen.getByLabelText('video');
+      const src = video.getAttribute('src');
+      expect(src).toBe('blob://test-video-url');
+    });
+  });
+
+  it('does not render non-video artifacts', async () => {
+    mockListArtifacts.mockResolvedValue({
+      files: [
+        { path: 'model.pkl', is_dir: false },
+        { path: 'metrics.json', is_dir: false },
+        { path: 'image.png', is_dir: false },
+        { path: 'clip.mp4', is_dir: false },
+      ],
+    });
+
+    render(<RunViewVideosSection runUuid="test-run" />, { wrapper });
+
+    await waitFor(() => {
+      // Only the mp4 should be rendered as video
+      const video = screen.getByLabelText('video');
+      expect(video).toBeInTheDocument();
+    });
+  });
+
+  it('renders nothing when no video artifacts are found', async () => {
+    mockListArtifacts.mockResolvedValue({
+      files: [
+        { path: 'model.pkl', is_dir: false },
+        { path: 'data.csv', is_dir: false },
+      ],
+    });
+
+    render(<RunViewVideosSection runUuid="test-run" />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText('video')).not.toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Videos')).not.toBeInTheDocument();
+  });
+
+  it('renders video with autoPlay for W&B-style experience', async () => {
+    mockListArtifacts.mockResolvedValue({
+      files: [{ path: 'recording.webm', is_dir: false }],
+    });
+
+    render(<RunViewVideosSection runUuid="test-run" />, { wrapper });
+
+    await waitFor(() => {
+      const video = screen.getByLabelText('video');
+      expect(video).toHaveAttribute('autoplay');
+    });
+  });
+
+  it('displays the artifact filename below the video', async () => {
+    mockListArtifacts.mockResolvedValue({
+      files: [{ path: 'videos/my_rollout.mp4', is_dir: false }],
+    });
+
+    render(<RunViewVideosSection runUuid="test-run" />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText('my_rollout.mp4')).toBeInTheDocument();
+    });
+  });
+
+  it('shows video count in header', async () => {
+    mockListArtifacts.mockImplementation(({ path }: { run_uuid: string; path?: string }) => {
+      if (!path) {
+        return Promise.resolve({
+          files: [{ path: 'videos', is_dir: true }],
+        });
+      }
+      if (path === 'videos') {
+        return Promise.resolve({
+          files: [
+            { path: 'videos/step_0.mp4', is_dir: false },
+            { path: 'videos/step_1.mp4', is_dir: false },
+            { path: 'videos/step_2.mp4', is_dir: false },
+          ],
+        });
+      }
+      return Promise.resolve({ files: [] });
+    });
+
+    render(<RunViewVideosSection runUuid="test-run" />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText('(3)')).toBeInTheDocument();
+    });
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewVideosSection.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewVideosSection.tsx
@@ -1,0 +1,256 @@
+import React, { useMemo, useCallback, useState, useEffect, useRef } from 'react';
+import { Typography, useDesignSystemTheme, LegacySkeleton } from '@databricks/design-system';
+import { getArtifactBlob, getArtifactLocationUrl } from '../../../../common/utils/ArtifactUtils';
+import { getBasename } from '../../../../common/utils/FileUtils';
+import { useRunVideoArtifacts } from '../hooks/useRunVideoArtifacts';
+import { extractStepNumber } from '../../../utils/VideoUtils';
+import { LineSmoothSlider } from '../../LineSmoothSlider';
+import { FormattedMessage } from 'react-intl';
+
+interface RunViewVideosSectionProps {
+  runUuid: string;
+}
+
+/**
+ * W&B-style video panel with a step slider for scrubbing through video artifacts.
+ * Shows one video at a time with a slider to navigate between different steps/episodes.
+ * Renders in the Model Metrics Charts tab.
+ */
+export const RunViewVideosSection = ({ runUuid }: RunViewVideosSectionProps) => {
+  const { videos, loading } = useRunVideoArtifacts(runUuid);
+  const { theme } = useDesignSystemTheme();
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  // Group videos by their "key" (directory path prefix), W&B style
+  const videoGroups = useMemo(() => {
+    if (videos.length === 0) return [];
+
+    // Group by directory prefix
+    const groups = new Map<string, string[]>();
+    for (const path of videos) {
+      const parts = path.split('/');
+      const key = parts.length > 1 ? parts.slice(0, -1).join('/') : '';
+      if (!groups.has(key)) {
+        groups.set(key, []);
+      }
+      groups.get(key)!.push(path);
+    }
+    return Array.from(groups.entries()).map(([key, paths]) => ({
+      key: key || 'videos',
+      paths,
+    }));
+  }, [videos]);
+
+  // For the currently selected group, build step marks for the slider
+  const [selectedGroupIndex, setSelectedGroupIndex] = useState(0);
+  const selectedGroup = videoGroups[selectedGroupIndex] ?? videoGroups[0];
+
+  const { stepMarks, minStep, maxStep } = useMemo(() => {
+    if (!selectedGroup) return { stepMarks: {} as Record<number, string>, minStep: 0, maxStep: 0 };
+
+    const marks: Record<number, string> = {};
+    selectedGroup.paths.forEach((path, index) => {
+      const step = extractStepNumber(getBasename(path));
+      const markValue = step !== null ? step : index;
+      marks[markValue] = getBasename(path);
+    });
+
+    const markKeys = Object.keys(marks).map(Number);
+    return {
+      stepMarks: marks,
+      minStep: Math.min(...markKeys),
+      maxStep: Math.max(...markKeys),
+    };
+  }, [selectedGroup]);
+
+  // Map slider value back to video index
+  const sliderValueToIndex = useMemo(() => {
+    if (!selectedGroup) return new Map<number, number>();
+    const map = new Map<number, number>();
+    selectedGroup.paths.forEach((path, index) => {
+      const step = extractStepNumber(getBasename(path));
+      map.set(step !== null ? step : index, index);
+    });
+    return map;
+  }, [selectedGroup]);
+
+  const [sliderValue, setSliderValue] = useState(minStep);
+
+  const handleSliderChange = useCallback(
+    (value: number) => {
+      setSliderValue(value);
+      const index = sliderValueToIndex.get(value);
+      if (index !== undefined) {
+        setCurrentIndex(index);
+      }
+    },
+    [sliderValueToIndex],
+  );
+
+  // Fetch the video blob and create an object URL (required for auth headers)
+  const [videoBlobUrl, setVideoBlobUrl] = useState<string | undefined>();
+  const [videoLoading, setVideoLoading] = useState(false);
+  const blobUrlRef = useRef<string | undefined>();
+
+  const currentVideoPath = useMemo(
+    () => selectedGroup?.paths[currentIndex] ?? videos[0],
+    [selectedGroup, currentIndex, videos],
+  );
+
+  useEffect(() => {
+    if (!currentVideoPath || !runUuid) return;
+
+    setVideoLoading(true);
+    const artifactUrl = getArtifactLocationUrl(currentVideoPath, runUuid);
+
+    getArtifactBlob(artifactUrl).then((blob: Blob) => {
+      // Revoke previous blob URL
+      if (blobUrlRef.current) {
+        URL.revokeObjectURL(blobUrlRef.current);
+      }
+      const url = URL.createObjectURL(blob);
+      blobUrlRef.current = url;
+      setVideoBlobUrl(url);
+      setVideoLoading(false);
+    }).catch(() => {
+      setVideoLoading(false);
+    });
+
+    return () => {
+      if (blobUrlRef.current) {
+        URL.revokeObjectURL(blobUrlRef.current);
+        blobUrlRef.current = undefined;
+      }
+    };
+  }, [currentVideoPath, runUuid]);
+
+  if (loading) {
+    return <LegacySkeleton active paragraph={{ rows: 3 }} />;
+  }
+
+  if (videos.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      css={{
+        border: `1px solid ${theme.colors.border}`,
+        borderRadius: theme.borders.borderRadiusMd,
+        backgroundColor: theme.colors.backgroundPrimary,
+        overflow: 'hidden',
+        marginBottom: theme.spacing.lg,
+      }}
+    >
+      {/* Header */}
+      <div
+        css={{
+          padding: `${theme.spacing.sm}px ${theme.spacing.md}px`,
+          borderBottom: `1px solid ${theme.colors.border}`,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <Typography.Title level={4} css={{ margin: 0 }}>
+          <FormattedMessage defaultMessage="Videos" description="Run page > Charts tab > Videos panel title" />
+          <Typography.Hint css={{ marginLeft: theme.spacing.sm, fontSize: theme.typography.fontSizeSm }}>
+            ({videos.length})
+          </Typography.Hint>
+        </Typography.Title>
+        {/* Group selector if multiple groups */}
+        {videoGroups.length > 1 && (
+          <select
+            value={selectedGroupIndex}
+            onChange={(e) => {
+              setSelectedGroupIndex(Number(e.target.value));
+              setCurrentIndex(0);
+              setSliderValue(minStep);
+            }}
+            css={{
+              padding: `${theme.spacing.xs}px ${theme.spacing.sm}px`,
+              borderRadius: theme.borders.borderRadiusMd,
+              border: `1px solid ${theme.colors.border}`,
+              backgroundColor: theme.colors.backgroundPrimary,
+              fontSize: theme.typography.fontSizeSm,
+            }}
+          >
+            {videoGroups.map((group, idx) => (
+              <option key={group.key} value={idx}>
+                {group.key}
+              </option>
+            ))}
+          </select>
+        )}
+      </div>
+
+      {/* Video player */}
+      <div
+        css={{
+          backgroundColor: '#000',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          minHeight: 300,
+        }}
+      >
+        {videoLoading && <LegacySkeleton active paragraph={{ rows: 2 }} />}
+        {videoBlobUrl && !videoLoading && (
+          <video
+            key={currentVideoPath}
+            src={videoBlobUrl}
+            controls
+            autoPlay
+            preload="auto"
+            aria-label="video"
+            css={{
+              maxWidth: '100%',
+              maxHeight: '480px',
+              display: 'block',
+            }}
+          >
+            <track kind="captions" srcLang="en" src="" default />
+          </video>
+        )}
+      </div>
+
+      {/* Step slider + label */}
+      <div
+        css={{
+          padding: `${theme.spacing.sm}px ${theme.spacing.md}px ${theme.spacing.md}px`,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: theme.spacing.xs,
+        }}
+      >
+        <div
+          css={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
+          <Typography.Text css={{ fontSize: theme.typography.fontSizeSm, color: theme.colors.textSecondary }}>
+            {getBasename(currentVideoPath)}
+          </Typography.Text>
+          <Typography.Text css={{ fontSize: theme.typography.fontSizeSm, color: theme.colors.textSecondary }}>
+            <FormattedMessage
+              defaultMessage="Step: {step}"
+              description="Run page > Charts tab > Videos panel > Step label"
+              values={{ step: sliderValue }}
+            />
+          </Typography.Text>
+        </div>
+        <LineSmoothSlider
+          value={sliderValue}
+          onChange={handleSliderChange}
+          onAfterChange={handleSliderChange}
+          max={maxStep}
+          min={minStep}
+          marks={stepMarks}
+          disabled={Object.keys(stepMarks).length <= 1}
+        />
+      </div>
+    </div>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsAddChartMenu.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsAddChartMenu.tsx
@@ -8,6 +8,7 @@ import { ReactComponent as ChartParallelIcon } from '../../../../common/static/c
 import { ReactComponent as ChartScatterIcon } from '../../../../common/static/chart-scatter.svg';
 import { ReactComponent as ChartDifferenceIcon } from '../../../../common/static/chart-difference.svg';
 import { ReactComponent as ChartImageIcon } from '../../../../common/static/chart-image.svg';
+import { ReactComponent as ChartVideoIcon } from '../../../../common/static/chart-video.svg';
 import { RunsChartType } from '../runs-charts.types';
 import { FormattedMessage } from 'react-intl';
 
@@ -136,6 +137,21 @@ export const RunsChartsAddChartMenu = ({ onAddChart, supportedChartTypes }: Runs
             <FormattedMessage
               defaultMessage="Image grid"
               description="Experiment tracking > runs charts > add chart menu > image grid"
+            />
+          </DropdownMenu.Item>
+        )}
+        {isChartTypeSupported(RunsChartType.VIDEO) && (
+          <DropdownMenu.Item
+            componentId="codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_140"
+            onClick={() => onAddChart(RunsChartType.VIDEO)}
+            data-testid="experiment-view-compare-runs-chart-type-video"
+          >
+            <DropdownMenu.IconWrapper css={styles.iconWrapper}>
+              <ChartVideoIcon />
+            </DropdownMenu.IconWrapper>
+            <FormattedMessage
+              defaultMessage="Video"
+              description="Experiment tracking > runs charts > add chart menu > video"
             />
           </DropdownMenu.Item>
         )}

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsConfigureModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsConfigureModal.tsx
@@ -23,6 +23,7 @@ import { ReactComponent as ChartParallelIcon } from '../../../../common/static/c
 import { ReactComponent as ChartScatterIcon } from '../../../../common/static/chart-scatter.svg';
 import { ReactComponent as ChartDifferenceIcon } from '../../../../common/static/chart-difference.svg';
 import { ReactComponent as ChartImageIcon } from '../../../../common/static/chart-image.svg';
+import { ReactComponent as ChartVideoIcon } from '../../../../common/static/chart-video.svg';
 import { RunsChartsConfigureBarChart } from './config/RunsChartsConfigureBarChart';
 import { RunsChartsConfigureParallelChart } from './config/RunsChartsConfigureParallelChart';
 import type { RunsChartsRunData } from './RunsCharts.common';
@@ -69,6 +70,7 @@ const previewComponentsMap: Record<
   [RunsChartType.SCATTER]: RunsChartsConfigureScatterChartPreview,
   [RunsChartType.DIFFERENCE]: DifferenceViewPlot,
   [RunsChartType.IMAGE]: RunsChartsConfigureImageChartPreview,
+  [RunsChartType.VIDEO]: undefined,
 };
 
 export const RunsChartsConfigureModal = ({
@@ -204,6 +206,9 @@ export const RunsChartsConfigureModal = ({
           onStateChange={setCurrentFormState}
         />
       );
+    }
+    if (type === RunsChartType.VIDEO) {
+      return null;
     }
     return null;
   };
@@ -384,6 +389,17 @@ export const RunsChartsConfigureModal = ({
                       <FormattedMessage
                         defaultMessage="Image grid"
                         description="Experiment tracking > runs charts > add chart menu > image grid"
+                      />
+                    </div>
+                  </SimpleSelectOption>
+                )}
+                {isChartTypeSupported(RunsChartType.VIDEO) && (
+                  <SimpleSelectOption value={RunsChartType.VIDEO}>
+                    <div css={styles.chartTypeOption(theme)}>
+                      <ChartVideoIcon />
+                      <FormattedMessage
+                        defaultMessage="Video"
+                        description="Experiment tracking > runs charts > add chart menu > video"
                       />
                     </div>
                   </SimpleSelectOption>

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/cards/RunsChartsCard.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/cards/RunsChartsCard.tsx
@@ -9,6 +9,7 @@ import type {
   RunsChartsLineCardConfig,
   RunsChartsParallelCardConfig,
   RunsChartsScatterCardConfig,
+  RunsChartsVideoCardConfig,
 } from '../../runs-charts.types';
 import type { RunsChartsRunData } from '../RunsCharts.common';
 import { RunsChartsBarChartCard } from './RunsChartsBarChartCard';
@@ -25,6 +26,7 @@ import type {
 import { RunsChartsDifferenceChartCard } from './RunsChartsDifferenceChartCard';
 import type { RunsGroupByConfig } from '../../../experiment-page/utils/experimentPage.group-row-utils';
 import { RunsChartsImageChartCard } from './RunsChartsImageChartCard';
+import { RunsChartsVideoChartCard } from './RunsChartsVideoChartCard';
 import type { RunsChartsGlobalLineChartConfig } from '../../../experiment-page/models/ExperimentPageUIState';
 
 export interface RunsChartsCardProps
@@ -158,6 +160,16 @@ const RunsChartsCardRaw = ({
     return (
       <RunsChartsImageChartCard
         config={cardConfig as RunsChartsImageCardConfig}
+        chartRunData={chartRunData}
+        {...commonChartProps}
+      />
+    );
+  }
+
+  if (cardConfig.type === RunsChartType.VIDEO) {
+    return (
+      <RunsChartsVideoChartCard
+        config={cardConfig as RunsChartsVideoCardConfig}
         chartRunData={chartRunData}
         {...commonChartProps}
       />

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/cards/RunsChartsVideoChartCard.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/cards/RunsChartsVideoChartCard.tsx
@@ -1,0 +1,470 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { LegacySkeleton, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import type { RunsChartsRunData } from '../RunsCharts.common';
+import type { RunsChartCardFullScreenProps } from './ChartCard.common';
+import { type RunsChartCardReorderProps, RunsChartCardWrapper, RunsChartsChartsDragGroup } from './ChartCard.common';
+import { useConfirmChartCardConfigurationFn } from '../../hooks/useRunsChartsUIConfiguration';
+import type { RunsChartsCardConfig, RunsChartsVideoCardConfig } from '../../runs-charts.types';
+import { getArtifactBlob, getArtifactLocationUrl } from '@mlflow/mlflow/src/common/utils/ArtifactUtils';
+import { getBasename } from '@mlflow/mlflow/src/common/utils/FileUtils';
+import { MlflowService } from '@mlflow/mlflow/src/experiment-tracking/sdk/MlflowService';
+import {
+  isVideoArtifactPath,
+  sortVideoArtifacts,
+  VIDEO_ARTIFACT_DIRECTORIES,
+} from '@mlflow/mlflow/src/experiment-tracking/utils/VideoUtils';
+import { extractStepNumber } from '@mlflow/mlflow/src/experiment-tracking/utils/VideoUtils';
+import { LineSmoothSlider } from '@mlflow/mlflow/src/experiment-tracking/components/LineSmoothSlider';
+import { FormattedMessage } from 'react-intl';
+import { RunColorPill } from '@mlflow/mlflow/src/experiment-tracking/components/experiment-page/components/RunColorPill';
+import type { RunsGroupByConfig } from '@mlflow/mlflow/src/experiment-tracking/components/experiment-page/utils/experimentPage.group-row-utils';
+
+const VIDEO_CHART_CARD_HEIGHT = 500;
+
+export interface RunsChartsVideoChartCardProps extends RunsChartCardReorderProps, RunsChartCardFullScreenProps {
+  config: RunsChartsVideoCardConfig;
+  chartRunData: RunsChartsRunData[];
+  onDelete: () => void;
+  onEdit: () => void;
+  groupBy: RunsGroupByConfig | null;
+}
+
+interface RunVideoInfo {
+  videos: string[];
+  loading: boolean;
+}
+
+/**
+ * Fetch video artifacts for a single run
+ */
+async function fetchVideosForRun(runUuid: string): Promise<string[]> {
+  const videoPaths: string[] = [];
+  const scannedDirs = new Set<string>();
+
+  const listDir = async (path?: string): Promise<{ path: string; is_dir: boolean }[]> => {
+    const dirKey = path || '';
+    if (scannedDirs.has(dirKey)) return [];
+    scannedDirs.add(dirKey);
+    try {
+      const response = await MlflowService.listArtifacts({
+        run_uuid: runUuid,
+        ...(path && { path }),
+      });
+      return response.files || [];
+    } catch {
+      return [];
+    }
+  };
+
+  const rootFiles = await listDir();
+  for (const file of rootFiles) {
+    if (!file.is_dir && isVideoArtifactPath(file.path)) {
+      videoPaths.push(file.path);
+    }
+  }
+
+  const dirsToScan = [...VIDEO_ARTIFACT_DIRECTORIES];
+  for (const file of rootFiles) {
+    if (file.is_dir) {
+      const dirName = file.path.split('/').pop() || file.path;
+      if (VIDEO_ARTIFACT_DIRECTORIES.some((vd) => vd === dirName || vd.startsWith(dirName + '/'))) {
+        dirsToScan.push(file.path);
+      }
+    }
+  }
+
+  const dirResults = await Promise.all([...new Set(dirsToScan)].map((dir) => listDir(dir)));
+  for (const files of dirResults) {
+    for (const file of files) {
+      if (!file.is_dir && isVideoArtifactPath(file.path)) {
+        videoPaths.push(file.path);
+      }
+    }
+  }
+
+  return sortVideoArtifacts([...new Set(videoPaths)]);
+}
+
+/**
+ * Single video cell for one run
+ */
+const VideoCell = ({
+  runUuid,
+  videoPath,
+  displayName,
+  color,
+}: {
+  runUuid: string;
+  videoPath: string | undefined;
+  displayName: string;
+  color: string;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const [blobUrl, setBlobUrl] = useState<string | undefined>();
+  const [loading, setLoading] = useState(false);
+  const blobUrlRef = useRef<string | undefined>();
+
+  useEffect(() => {
+    if (!videoPath || !runUuid) {
+      setBlobUrl(undefined);
+      return;
+    }
+
+    setLoading(true);
+    const artifactUrl = getArtifactLocationUrl(videoPath, runUuid);
+
+    getArtifactBlob(artifactUrl)
+      .then((blob: Blob) => {
+        if (blobUrlRef.current) {
+          URL.revokeObjectURL(blobUrlRef.current);
+        }
+        const url = URL.createObjectURL(blob);
+        blobUrlRef.current = url;
+        setBlobUrl(url);
+        setLoading(false);
+      })
+      .catch(() => {
+        setLoading(false);
+      });
+
+    return () => {
+      if (blobUrlRef.current) {
+        URL.revokeObjectURL(blobUrlRef.current);
+        blobUrlRef.current = undefined;
+      }
+    };
+  }, [videoPath, runUuid]);
+
+  return (
+    <div
+      css={{
+        display: 'flex',
+        flexDirection: 'column',
+        border: `1px solid ${theme.colors.border}`,
+        borderRadius: theme.borders.borderRadiusMd,
+        overflow: 'hidden',
+        minWidth: 0,
+      }}
+    >
+      {/* Run header */}
+      <div
+        css={{
+          padding: `${theme.spacing.xs}px ${theme.spacing.sm}px`,
+          borderBottom: `1px solid ${theme.colors.border}`,
+          display: 'flex',
+          alignItems: 'center',
+          gap: theme.spacing.xs,
+          overflow: 'hidden',
+        }}
+      >
+        <RunColorPill color={color} />
+        <Typography.Text
+          ellipsis
+          css={{ fontSize: theme.typography.fontSizeSm, flex: 1, minWidth: 0 }}
+          title={displayName}
+        >
+          {displayName}
+        </Typography.Text>
+      </div>
+      {/* Video area */}
+      <div
+        css={{
+          backgroundColor: '#000',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          minHeight: 160,
+          aspectRatio: '4/3',
+        }}
+      >
+        {loading && <LegacySkeleton active paragraph={{ rows: 1 }} />}
+        {!videoPath && !loading && (
+          <Typography.Text css={{ color: theme.colors.textSecondary, fontSize: theme.typography.fontSizeSm }}>
+            <FormattedMessage defaultMessage="No video" description="Video chart card > No video label" />
+          </Typography.Text>
+        )}
+        {blobUrl && !loading && (
+          <video
+            key={videoPath}
+            src={blobUrl}
+            controls
+            autoPlay
+            muted
+            loop
+            preload="auto"
+            aria-label="video"
+            css={{
+              maxWidth: '100%',
+              maxHeight: '100%',
+              display: 'block',
+            }}
+          >
+            <track kind="captions" srcLang="en" src="" default />
+          </video>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export const RunsChartsVideoChartCard = ({
+  config,
+  chartRunData,
+  onDelete,
+  onEdit,
+  fullScreen,
+  setFullScreenChart,
+  ...reorderProps
+}: RunsChartsVideoChartCardProps) => {
+  const { theme } = useDesignSystemTheme();
+  const confirmChartCardConfiguration = useConfirmChartCardConfigurationFn();
+
+  const visibleRuns = useMemo(() => chartRunData.filter(({ hidden }) => !hidden).reverse(), [chartRunData]);
+
+  // Fetch video artifacts for all visible runs
+  const [runVideoMap, setRunVideoMap] = useState<Record<string, RunVideoInfo>>({});
+  const [initialized, setInitialized] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const runUuids = visibleRuns.map((r) => r.uuid);
+
+    setRunVideoMap((prev) => {
+      const next = { ...prev };
+      for (const uuid of runUuids) {
+        if (!next[uuid]) {
+          next[uuid] = { videos: [], loading: true };
+        }
+      }
+      return next;
+    });
+
+    Promise.all(
+      runUuids.map(async (uuid) => {
+        const videos = await fetchVideosForRun(uuid);
+        return { uuid, videos };
+      }),
+    ).then((results) => {
+      if (cancelled) return;
+      setRunVideoMap((prev) => {
+        const next = { ...prev };
+        for (const { uuid, videos } of results) {
+          next[uuid] = { videos, loading: false };
+        }
+        return next;
+      });
+      setInitialized(true);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visibleRuns.map((r) => r.uuid).join(',')]);
+
+  // Collect all unique steps across all runs
+  const { allSteps, stepToVideoByRun } = useMemo(() => {
+    const stepsSet = new Set<number>();
+    const mapping: Record<string, Map<number, string>> = {};
+
+    for (const run of visibleRuns) {
+      const data = runVideoMap[run.uuid];
+      if (!data || data.loading) continue;
+
+      const videoPaths = data.videos;
+      const stepMap = new Map<number, string>();
+
+      for (const path of videoPaths) {
+        const step = extractStepNumber(getBasename(path));
+        if (step !== null && !stepMap.has(step)) {
+          stepMap.set(step, path);
+        }
+      }
+
+      if (stepMap.size === 0) {
+        videoPaths.forEach((path, idx) => {
+          stepMap.set(idx, path);
+        });
+      }
+
+      for (const s of stepMap.keys()) {
+        stepsSet.add(s);
+      }
+      mapping[run.uuid] = stepMap;
+    }
+
+    const sortedSteps = Array.from(stepsSet).sort((a, b) => a - b);
+    return { allSteps: sortedSteps, stepToVideoByRun: mapping };
+  }, [visibleRuns, runVideoMap]);
+
+  // Local slider state for smooth dragging
+  const [tmpStep, setTmpStep] = useState(config.step);
+
+  useEffect(() => {
+    setTmpStep(config.step);
+  }, [config.step]);
+
+  const updateStep = useCallback(
+    (newStep: number) => {
+      if (config.step === newStep) return;
+      confirmChartCardConfiguration({ ...config, step: newStep } as RunsChartsVideoCardConfig);
+    },
+    [config, confirmChartCardConfiguration],
+  );
+
+  // Initialize step to first available if current is invalid
+  useEffect(() => {
+    if (allSteps.length > 0 && !allSteps.includes(config.step)) {
+      updateStep(allSteps[0]);
+    }
+  }, [allSteps, config.step, updateStep]);
+
+  const stepMarks = useMemo(() => {
+    const marks: Record<number, string> = {};
+    for (const step of allSteps) {
+      marks[step] = String(step);
+    }
+    return marks;
+  }, [allSteps]);
+
+  const minStep = allSteps.length > 0 ? allSteps[0] : 0;
+  const maxStep = allSteps.length > 0 ? allSteps[allSteps.length - 1] : 0;
+
+  const getVideoPathForRunAtStep = useCallback(
+    (runUuid: string, step: number): string | undefined => {
+      const stepMap = stepToVideoByRun[runUuid];
+      if (!stepMap) return undefined;
+      if (stepMap.has(step)) return stepMap.get(step);
+      let nearest: number | undefined;
+      for (const s of stepMap.keys()) {
+        if (s <= step && (nearest === undefined || s > nearest)) {
+          nearest = s;
+        }
+      }
+      return nearest !== undefined ? stepMap.get(nearest) : undefined;
+    },
+    [stepToVideoByRun],
+  );
+
+  const hasAnyVideos = Object.values(runVideoMap).some((d) => d.videos.length > 0);
+
+  const toggleFullScreenChart = () => {
+    setFullScreenChart?.({
+      config,
+      title: 'Videos',
+      subtitle: null,
+    });
+  };
+
+  const numRuns = visibleRuns.length;
+  const gridCols = Math.min(numRuns, 4);
+
+  const chartBody = (
+    <div
+      css={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: fullScreen ? '100%' : undefined,
+        width: '100%',
+        overflow: 'hidden',
+        marginTop: theme.spacing.sm,
+        gap: theme.spacing.sm,
+      }}
+    >
+      {!initialized && (
+        <div css={{ padding: theme.spacing.md }}>
+          <LegacySkeleton active paragraph={{ rows: 3 }} />
+        </div>
+      )}
+      {initialized && !hasAnyVideos && (
+        <div css={{ padding: theme.spacing.md, textAlign: 'center' }}>
+          <Typography.Text css={{ color: theme.colors.textSecondary }}>
+            <FormattedMessage
+              defaultMessage="No video artifacts found"
+              description="Video chart card > No videos message"
+            />
+          </Typography.Text>
+        </div>
+      )}
+      {initialized && hasAnyVideos && (
+        <>
+          <div
+            css={{
+              flex: 1,
+              overflow: 'auto',
+              display: 'grid',
+              gridTemplateColumns: `repeat(${gridCols}, 1fr)`,
+              gap: theme.spacing.sm,
+              padding: `0 ${theme.spacing.sm}px`,
+            }}
+          >
+            {visibleRuns.map((run) => {
+              const videoPath = getVideoPathForRunAtStep(run.uuid, tmpStep);
+              return (
+                <VideoCell
+                  key={run.uuid}
+                  runUuid={run.uuid}
+                  videoPath={videoPath}
+                  displayName={run.displayName}
+                  color={run.color}
+                />
+              );
+            })}
+          </div>
+          <div
+            css={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: theme.spacing.md,
+              padding: `0 ${theme.spacing.md}px ${theme.spacing.sm}px`,
+            }}
+          >
+            <Typography.Text
+              css={{ fontSize: theme.typography.fontSizeSm, color: theme.colors.textSecondary, whiteSpace: 'nowrap' }}
+            >
+              <FormattedMessage
+                defaultMessage="Step: {step}"
+                description="Video chart card > Step label"
+                values={{ step: tmpStep }}
+              />
+            </Typography.Text>
+            <div css={{ flex: 1 }}>
+              <LineSmoothSlider
+                value={tmpStep}
+                onChange={setTmpStep}
+                onAfterChange={updateStep}
+                max={maxStep}
+                min={minStep}
+                marks={stepMarks}
+                disabled={allSteps.length <= 1}
+                css={{
+                  '&[data-orientation="horizontal"]': { width: 'auto' },
+                }}
+              />
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+
+  if (fullScreen) {
+    return chartBody;
+  }
+
+  return (
+    <RunsChartCardWrapper
+      onEdit={onEdit}
+      onDelete={onDelete}
+      title={config.displayName || 'Videos'}
+      subtitle={hasAnyVideos ? `${allSteps.length} steps, ${numRuns} runs` : undefined}
+      uuid={config.uuid}
+      dragGroupKey={RunsChartsChartsDragGroup.GENERAL_AREA}
+      toggleFullScreenChart={toggleFullScreenChart}
+      height={VIDEO_CHART_CARD_HEIGHT}
+      {...reorderProps}
+    >
+      {chartBody}
+    </RunsChartCardWrapper>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/sections/RunsChartsSectionAccordion.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/sections/RunsChartsSectionAccordion.tsx
@@ -30,7 +30,7 @@ import type { RunsChartsGlobalLineChartConfig } from '../../../experiment-page/m
 
 const chartMatchesFilter = (filter: string, config: RunsChartsCardConfig) => {
   // Use regexp-based filtering if a feature flag is enabled
-  if (config.type === RunsChartType.IMAGE || config.type === RunsChartType.DIFFERENCE) {
+  if (config.type === RunsChartType.IMAGE || config.type === RunsChartType.DIFFERENCE || config.type === RunsChartType.VIDEO) {
     return true;
   }
 

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/runs-charts.types.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/runs-charts.types.ts
@@ -26,6 +26,7 @@ export enum RunsChartType {
   PARALLEL = 'PARALLEL',
   DIFFERENCE = 'DIFFERENCE',
   IMAGE = 'IMAGE',
+  VIDEO = 'VIDEO',
 }
 
 const MIN_NUMBER_OF_STEP_FOR_LINE_COMPARISON = 1;
@@ -95,6 +96,8 @@ export abstract class RunsChartsCardConfig {
       return new RunsChartsDifferenceCardConfig(isGenerated, uuid, metricSectionId);
     } else if (type === RunsChartType.IMAGE) {
       return new RunsChartsImageCardConfig(isGenerated, uuid, metricSectionId);
+    } else if (type === RunsChartType.VIDEO) {
+      return new RunsChartsVideoCardConfig(isGenerated, uuid, metricSectionId);
     } else {
       // Must be contour
       return new RunsChartsContourCardConfig(isGenerated, uuid, metricSectionId);
@@ -779,6 +782,11 @@ export class RunsChartsImageCardConfig extends RunsChartsCardConfig {
   type: RunsChartType = RunsChartType.IMAGE;
   // image keys to show
   imageKeys: string[] = [];
+  step = 0;
+}
+
+export class RunsChartsVideoCardConfig extends RunsChartsCardConfig {
+  type: RunsChartType = RunsChartType.VIDEO;
   step = 0;
 }
 

--- a/mlflow/server/js/src/experiment-tracking/components/runs-compare/RunsCompare.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-compare/RunsCompare.tsx
@@ -51,7 +51,6 @@ import { RunsChartsGlobalChartSettingsDropdown } from '../runs-charts/components
 import { RunsChartsDraggableCardsGridContextProvider } from '../runs-charts/components/RunsChartsDraggableCardsGridContext';
 import { RunsChartsFilterInput } from '../runs-charts/components/RunsChartsFilterInput';
 import { RUNS_CHARTS_UI_Z_INDEX } from '../runs-charts/utils/runsCharts.const';
-import { RunsCompareVideoSection } from './RunsCompareVideoSection';
 
 export interface RunsCompareProps {
   comparedRuns: RunRowType[];
@@ -411,7 +410,6 @@ const RunsCompareImpl = ({
         />
       </div>
       <RunsChartsTooltipWrapper contextData={tooltipContextValue} component={RunsChartsTooltipBody}>
-        <RunsCompareVideoSection chartRunData={chartData} />
         <RunsChartsDraggableCardsGridContextProvider visibleChartCards={visibleChartCards}>
           <RunsChartsSectionAccordion
             compareRunSections={compareRunSections}

--- a/mlflow/server/js/src/experiment-tracking/components/runs-compare/RunsCompare.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-compare/RunsCompare.tsx
@@ -51,6 +51,7 @@ import { RunsChartsGlobalChartSettingsDropdown } from '../runs-charts/components
 import { RunsChartsDraggableCardsGridContextProvider } from '../runs-charts/components/RunsChartsDraggableCardsGridContext';
 import { RunsChartsFilterInput } from '../runs-charts/components/RunsChartsFilterInput';
 import { RUNS_CHARTS_UI_Z_INDEX } from '../runs-charts/utils/runsCharts.const';
+import { RunsCompareVideoSection } from './RunsCompareVideoSection';
 
 export interface RunsCompareProps {
   comparedRuns: RunRowType[];
@@ -410,6 +411,7 @@ const RunsCompareImpl = ({
         />
       </div>
       <RunsChartsTooltipWrapper contextData={tooltipContextValue} component={RunsChartsTooltipBody}>
+        <RunsCompareVideoSection chartRunData={chartData} />
         <RunsChartsDraggableCardsGridContextProvider visibleChartCards={visibleChartCards}>
           <RunsChartsSectionAccordion
             compareRunSections={compareRunSections}

--- a/mlflow/server/js/src/experiment-tracking/components/runs-compare/RunsCompareVideoSection.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-compare/RunsCompareVideoSection.tsx
@@ -1,0 +1,457 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Typography, useDesignSystemTheme, LegacySkeleton } from '@databricks/design-system';
+import { getArtifactBlob, getArtifactLocationUrl } from '../../../common/utils/ArtifactUtils';
+import { getBasename } from '../../../common/utils/FileUtils';
+import { MlflowService } from '../../sdk/MlflowService';
+import { isVideoArtifactPath, sortVideoArtifacts, VIDEO_ARTIFACT_DIRECTORIES } from '../../utils/VideoUtils';
+import { extractStepNumber } from '../../utils/VideoUtils';
+import { LineSmoothSlider } from '../LineSmoothSlider';
+import { FormattedMessage } from 'react-intl';
+import type { RunsChartsRunData } from '../runs-charts/components/RunsCharts.common';
+import { RunColorPill } from '../experiment-page/components/RunColorPill';
+
+interface RunsCompareVideoSectionProps {
+  chartRunData: RunsChartsRunData[];
+}
+
+interface RunVideoInfo {
+  videos: string[];
+  loading: boolean;
+}
+
+/**
+ * Single video cell for one run at one step
+ */
+const VideoCell = ({
+  runUuid,
+  videoPath,
+  displayName,
+  color,
+  stepLabel,
+}: {
+  runUuid: string;
+  videoPath: string | undefined;
+  displayName: string;
+  color: string;
+  stepLabel: string;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const [blobUrl, setBlobUrl] = useState<string | undefined>();
+  const [loading, setLoading] = useState(false);
+  const blobUrlRef = useRef<string | undefined>();
+
+  useEffect(() => {
+    if (!videoPath || !runUuid) {
+      setBlobUrl(undefined);
+      return;
+    }
+
+    setLoading(true);
+    const artifactUrl = getArtifactLocationUrl(videoPath, runUuid);
+
+    getArtifactBlob(artifactUrl)
+      .then((blob: Blob) => {
+        if (blobUrlRef.current) {
+          URL.revokeObjectURL(blobUrlRef.current);
+        }
+        const url = URL.createObjectURL(blob);
+        blobUrlRef.current = url;
+        setBlobUrl(url);
+        setLoading(false);
+      })
+      .catch(() => {
+        setLoading(false);
+      });
+
+    return () => {
+      if (blobUrlRef.current) {
+        URL.revokeObjectURL(blobUrlRef.current);
+        blobUrlRef.current = undefined;
+      }
+    };
+  }, [videoPath, runUuid]);
+
+  return (
+    <div
+      css={{
+        display: 'flex',
+        flexDirection: 'column',
+        border: `1px solid ${theme.colors.border}`,
+        borderRadius: theme.borders.borderRadiusMd,
+        overflow: 'hidden',
+        backgroundColor: theme.colors.backgroundPrimary,
+        minWidth: 0,
+      }}
+    >
+      {/* Run header */}
+      <div
+        css={{
+          padding: `${theme.spacing.xs}px ${theme.spacing.sm}px`,
+          borderBottom: `1px solid ${theme.colors.border}`,
+          display: 'flex',
+          alignItems: 'center',
+          gap: theme.spacing.xs,
+          overflow: 'hidden',
+        }}
+      >
+        <RunColorPill color={color} />
+        <Typography.Text
+          ellipsis
+          css={{ fontSize: theme.typography.fontSizeSm, flex: 1, minWidth: 0 }}
+          title={displayName}
+        >
+          {displayName}
+        </Typography.Text>
+      </div>
+      {/* Video area */}
+      <div
+        css={{
+          backgroundColor: '#000',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          minHeight: 180,
+          aspectRatio: '4/3',
+        }}
+      >
+        {loading && <LegacySkeleton active paragraph={{ rows: 1 }} />}
+        {!videoPath && !loading && (
+          <Typography.Text css={{ color: theme.colors.textSecondary, fontSize: theme.typography.fontSizeSm }}>
+            <FormattedMessage defaultMessage="No video" description="Compare runs > Video grid > No video label" />
+          </Typography.Text>
+        )}
+        {blobUrl && !loading && (
+          <video
+            key={videoPath}
+            src={blobUrl}
+            controls
+            autoPlay
+            muted
+            loop
+            preload="auto"
+            aria-label="video"
+            css={{
+              maxWidth: '100%',
+              maxHeight: '100%',
+              display: 'block',
+            }}
+          >
+            <track kind="captions" srcLang="en" src="" default />
+          </video>
+        )}
+      </div>
+      {/* Step label */}
+      <div
+        css={{
+          padding: `${theme.spacing.xs}px ${theme.spacing.sm}px`,
+          borderTop: `1px solid ${theme.colors.border}`,
+        }}
+      >
+        <Typography.Text css={{ fontSize: theme.typography.fontSizeXs, color: theme.colors.textSecondary }} ellipsis>
+          {stepLabel}
+        </Typography.Text>
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Fetch video artifacts for a single run (standalone async function, not a hook)
+ */
+async function fetchVideosForRun(runUuid: string): Promise<string[]> {
+  const videoPaths: string[] = [];
+  const scannedDirs = new Set<string>();
+
+  const listDir = async (path?: string): Promise<{ path: string; is_dir: boolean }[]> => {
+    const dirKey = path || '';
+    if (scannedDirs.has(dirKey)) return [];
+    scannedDirs.add(dirKey);
+    try {
+      const response = await MlflowService.listArtifacts({
+        run_uuid: runUuid,
+        ...(path && { path }),
+      });
+      return response.files || [];
+    } catch {
+      return [];
+    }
+  };
+
+  // Scan root
+  const rootFiles = await listDir();
+  for (const file of rootFiles) {
+    if (!file.is_dir && isVideoArtifactPath(file.path)) {
+      videoPaths.push(file.path);
+    }
+  }
+
+  // Scan known video directories
+  const dirsToScan = [...VIDEO_ARTIFACT_DIRECTORIES];
+  for (const file of rootFiles) {
+    if (file.is_dir) {
+      const dirName = file.path.split('/').pop() || file.path;
+      if (VIDEO_ARTIFACT_DIRECTORIES.some((vd) => vd === dirName || vd.startsWith(dirName + '/'))) {
+        dirsToScan.push(file.path);
+      }
+    }
+  }
+
+  const dirResults = await Promise.all([...new Set(dirsToScan)].map((dir) => listDir(dir)));
+  for (const files of dirResults) {
+    for (const file of files) {
+      if (!file.is_dir && isVideoArtifactPath(file.path)) {
+        videoPaths.push(file.path);
+      }
+    }
+  }
+
+  // Deduplicate and sort
+  const unique = [...new Set(videoPaths)];
+  return sortVideoArtifacts(unique);
+}
+
+/**
+ * W&B-style video comparison grid for multiple runs.
+ * Shows a grid of video players (one per run) with a shared step slider.
+ * Automatically discovers video artifacts across all compared runs.
+ */
+export const RunsCompareVideoSection = ({ chartRunData }: RunsCompareVideoSectionProps) => {
+  const { theme } = useDesignSystemTheme();
+
+  // Only consider visible (non-hidden) runs
+  const visibleRuns = useMemo(() => chartRunData.filter((r) => !r.hidden), [chartRunData]);
+
+  // Store video data per run
+  const [runVideoMap, setRunVideoMap] = useState<Record<string, RunVideoInfo>>({});
+  const [initialized, setInitialized] = useState(false);
+
+  // Fetch videos for all visible runs
+  useEffect(() => {
+    let cancelled = false;
+    const runUuids = visibleRuns.map((r) => r.uuid);
+
+    // Mark all as loading
+    setRunVideoMap((prev) => {
+      const next = { ...prev };
+      for (const uuid of runUuids) {
+        if (!next[uuid]) {
+          next[uuid] = { videos: [], loading: true };
+        }
+      }
+      return next;
+    });
+
+    Promise.all(
+      runUuids.map(async (uuid) => {
+        const videos = await fetchVideosForRun(uuid);
+        return { uuid, videos };
+      }),
+    ).then((results) => {
+      if (cancelled) return;
+      setRunVideoMap((prev) => {
+        const next = { ...prev };
+        for (const { uuid, videos } of results) {
+          next[uuid] = { videos, loading: false };
+        }
+        return next;
+      });
+      setInitialized(true);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visibleRuns.map((r) => r.uuid).join(',')]);
+
+  // Collect all unique steps across all runs
+  const { allSteps, stepToVideoByRun } = useMemo(() => {
+    const stepsSet = new Set<number>();
+    const mapping: Record<string, Map<number, string>> = {};
+
+    for (const run of visibleRuns) {
+      const data = runVideoMap[run.uuid];
+      if (!data || data.loading) continue;
+
+      const videoPaths = data.videos;
+      const stepMap = new Map<number, string>();
+
+      for (const path of videoPaths) {
+        const step = extractStepNumber(getBasename(path));
+        if (step !== null && !stepMap.has(step)) {
+          stepMap.set(step, path);
+        }
+      }
+
+      // If no step numbers found, use index as step
+      if (stepMap.size === 0) {
+        videoPaths.forEach((path, idx) => {
+          stepMap.set(idx, path);
+        });
+      }
+
+      for (const s of stepMap.keys()) {
+        stepsSet.add(s);
+      }
+      mapping[run.uuid] = stepMap;
+    }
+
+    const sortedSteps = Array.from(stepsSet).sort((a, b) => a - b);
+    return { allSteps: sortedSteps, stepToVideoByRun: mapping };
+  }, [visibleRuns, runVideoMap]);
+
+  // Slider state
+  const [sliderValue, setSliderValue] = useState(0);
+
+  // Update slider bounds when steps change
+  useEffect(() => {
+    if (allSteps.length > 0 && !allSteps.includes(sliderValue)) {
+      setSliderValue(allSteps[0]);
+    }
+  }, [allSteps, sliderValue]);
+
+  const stepMarks = useMemo(() => {
+    const marks: Record<number, string> = {};
+    for (const step of allSteps) {
+      marks[step] = String(step);
+    }
+    return marks;
+  }, [allSteps]);
+
+  const minStep = allSteps.length > 0 ? allSteps[0] : 0;
+  const maxStep = allSteps.length > 0 ? allSteps[allSteps.length - 1] : 0;
+
+  // Find the nearest available step for each run
+  const getVideoPathForRunAtStep = useCallback(
+    (runUuid: string, step: number): string | undefined => {
+      const stepMap = stepToVideoByRun[runUuid];
+      if (!stepMap) return undefined;
+
+      // Exact match
+      if (stepMap.has(step)) return stepMap.get(step);
+
+      // Find nearest step <= requested step
+      let nearest: number | undefined;
+      for (const s of stepMap.keys()) {
+        if (s <= step && (nearest === undefined || s > nearest)) {
+          nearest = s;
+        }
+      }
+      return nearest !== undefined ? stepMap.get(nearest) : undefined;
+    },
+    [stepToVideoByRun],
+  );
+
+  const isLoading = !initialized;
+  const hasAnyVideos = Object.values(runVideoMap).some((d) => d.videos.length > 0);
+
+  // Don't render anything if no videos found after loading
+  if (initialized && !hasAnyVideos) {
+    return null;
+  }
+
+  // Determine grid columns based on number of runs
+  const numRuns = visibleRuns.length;
+  const gridCols = Math.min(numRuns, 4); // Max 4 columns like W&B
+
+  return (
+    <div
+      css={{
+        marginBottom: theme.spacing.lg,
+        border: `1px solid ${theme.colors.border}`,
+        borderRadius: theme.borders.borderRadiusMd,
+        backgroundColor: theme.colors.backgroundPrimary,
+        overflow: 'hidden',
+      }}
+    >
+      {/* Header */}
+      <div
+        css={{
+          padding: `${theme.spacing.sm}px ${theme.spacing.md}px`,
+          borderBottom: `1px solid ${theme.colors.border}`,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <Typography.Title level={4} css={{ margin: 0 }}>
+          <FormattedMessage defaultMessage="Videos" description="Compare runs > Video section title" />
+          {hasAnyVideos && (
+            <Typography.Hint css={{ marginLeft: theme.spacing.sm, fontSize: theme.typography.fontSizeSm }}>
+              ({allSteps.length} steps, {numRuns} runs)
+            </Typography.Hint>
+          )}
+        </Typography.Title>
+      </div>
+
+      {/* Loading state */}
+      {isLoading && (
+        <div css={{ padding: theme.spacing.md }}>
+          <LegacySkeleton active paragraph={{ rows: 3 }} />
+        </div>
+      )}
+
+      {/* Video grid */}
+      {hasAnyVideos && !isLoading && (
+        <>
+          <div
+            css={{
+              display: 'grid',
+              gridTemplateColumns: `repeat(${gridCols}, 1fr)`,
+              gap: theme.spacing.sm,
+              padding: theme.spacing.sm,
+            }}
+          >
+            {visibleRuns.map((run) => {
+              const videoPath = getVideoPathForRunAtStep(run.uuid, sliderValue);
+              const stepLabel = videoPath ? getBasename(videoPath) : `Step ${sliderValue}`;
+              return (
+                <VideoCell
+                  key={run.uuid}
+                  runUuid={run.uuid}
+                  videoPath={videoPath}
+                  displayName={run.displayName}
+                  color={run.color}
+                  stepLabel={stepLabel}
+                />
+              );
+            })}
+          </div>
+
+          {/* Shared step slider */}
+          <div
+            css={{
+              padding: `${theme.spacing.sm}px ${theme.spacing.md}px ${theme.spacing.md}px`,
+              borderTop: `1px solid ${theme.colors.border}`,
+              display: 'flex',
+              alignItems: 'center',
+              gap: theme.spacing.md,
+            }}
+          >
+            <Typography.Text css={{ fontSize: theme.typography.fontSizeSm, color: theme.colors.textSecondary, whiteSpace: 'nowrap' }}>
+              <FormattedMessage
+                defaultMessage="Step: {step}"
+                description="Compare runs > Video section > Step label"
+                values={{ step: sliderValue }}
+              />
+            </Typography.Text>
+            <div css={{ flex: 1 }}>
+              <LineSmoothSlider
+                value={sliderValue}
+                onChange={setSliderValue}
+                onAfterChange={setSliderValue}
+                max={maxStep}
+                min={minStep}
+                marks={stepMarks}
+                disabled={allSteps.length <= 1}
+                css={{
+                  '&[data-orientation="horizontal"]': { width: 'auto' },
+                }}
+              />
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/utils/VideoUtils.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/utils/VideoUtils.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  isVideoArtifactPath,
+  extractStepNumber,
+  sortVideoArtifacts,
+  VIDEO_ARTIFACT_EXTENSIONS,
+} from './VideoUtils';
+import { AUDIO_EXTENSIONS, VIDEO_EXTENSIONS, IMAGE_EXTENSIONS, TEXT_EXTENSIONS, PDF_EXTENSIONS } from '../../common/utils/FileUtils';
+
+describe('VideoUtils', () => {
+  describe('isVideoArtifactPath', () => {
+    it('classifies .mp4 as video', () => {
+      expect(isVideoArtifactPath('rollout.mp4')).toBe(true);
+    });
+
+    it('classifies .MP4 as video (case-insensitive)', () => {
+      expect(isVideoArtifactPath('video.MP4')).toBe(true);
+    });
+
+    it('classifies .webm as video', () => {
+      expect(isVideoArtifactPath('recording.webm')).toBe(true);
+    });
+
+    it('classifies .mov as video', () => {
+      expect(isVideoArtifactPath('clip.mov')).toBe(true);
+    });
+
+    it('classifies .m4v as video', () => {
+      expect(isVideoArtifactPath('episode.m4v')).toBe(true);
+    });
+
+    it('classifies .ogg as video', () => {
+      expect(isVideoArtifactPath('stream.ogg')).toBe(true);
+    });
+
+    it('classifies .ogv as video', () => {
+      expect(isVideoArtifactPath('clip.ogv')).toBe(true);
+    });
+
+    it('handles nested paths', () => {
+      expect(isVideoArtifactPath('videos/step_001.mp4')).toBe(true);
+      expect(isVideoArtifactPath('media/videos/rollout.webm')).toBe(true);
+      expect(isVideoArtifactPath('rollouts/episode_42.mov')).toBe(true);
+    });
+
+    it('rejects non-video files', () => {
+      expect(isVideoArtifactPath('model.pkl')).toBe(false);
+      expect(isVideoArtifactPath('data.csv')).toBe(false);
+      expect(isVideoArtifactPath('image.png')).toBe(false);
+      expect(isVideoArtifactPath('audio.mp3')).toBe(false);
+    });
+  });
+
+  describe('mp4 is NOT classified as audio', () => {
+    it('.mp4 is not in AUDIO_EXTENSIONS', () => {
+      expect(AUDIO_EXTENSIONS.has('mp4')).toBe(false);
+    });
+
+    it('.mp4 IS in VIDEO_EXTENSIONS', () => {
+      expect(VIDEO_EXTENSIONS.has('mp4')).toBe(true);
+    });
+
+    it('.mp4 IS in VIDEO_ARTIFACT_EXTENSIONS', () => {
+      expect(VIDEO_ARTIFACT_EXTENSIONS.has('mp4')).toBe(true);
+    });
+  });
+
+  describe('existing audio formats still work', () => {
+    it.each(['m4a', 'mp3', 'wav', 'aac', 'wma', 'flac', 'opus', 'ogg'])(
+      '%s is in AUDIO_EXTENSIONS',
+      (ext) => {
+        expect(AUDIO_EXTENSIONS.has(ext)).toBe(true);
+      },
+    );
+  });
+
+  describe('existing image/text/pdf detection is not broken', () => {
+    it.each(['jpg', 'png', 'gif', 'svg', 'bmp', 'jpeg'])('%s is in IMAGE_EXTENSIONS', (ext) => {
+      expect(IMAGE_EXTENSIONS.has(ext)).toBe(true);
+    });
+
+    it.each(['txt', 'log', 'py', 'json', 'yaml', 'xml'])('%s is in TEXT_EXTENSIONS', (ext) => {
+      expect(TEXT_EXTENSIONS.has(ext)).toBe(true);
+    });
+
+    it('pdf is in PDF_EXTENSIONS', () => {
+      expect(PDF_EXTENSIONS.has('pdf')).toBe(true);
+    });
+  });
+
+  describe('extractStepNumber', () => {
+    it('extracts trailing number after underscore', () => {
+      expect(extractStepNumber('step_100.mp4')).toBe(100);
+      expect(extractStepNumber('rollout_042.webm')).toBe(42);
+    });
+
+    it('extracts trailing number after hyphen', () => {
+      expect(extractStepNumber('episode-5.mp4')).toBe(5);
+    });
+
+    it('extracts purely numeric filenames', () => {
+      expect(extractStepNumber('0003.mp4')).toBe(3);
+      expect(extractStepNumber('100.webm')).toBe(100);
+    });
+
+    it('returns null for non-numeric filenames', () => {
+      expect(extractStepNumber('rollout.mp4')).toBeNull();
+      expect(extractStepNumber('my_video.webm')).toBeNull();
+    });
+  });
+
+  describe('sortVideoArtifacts', () => {
+    it('sorts by step number when available', () => {
+      const paths = ['videos/step_10.mp4', 'videos/step_2.mp4', 'videos/step_1.mp4'];
+      expect(sortVideoArtifacts(paths)).toEqual([
+        'videos/step_1.mp4',
+        'videos/step_2.mp4',
+        'videos/step_10.mp4',
+      ]);
+    });
+
+    it('sorts alphabetically when no step numbers', () => {
+      const paths = ['charlie.mp4', 'alpha.mp4', 'bravo.mp4'];
+      expect(sortVideoArtifacts(paths)).toEqual(['alpha.mp4', 'bravo.mp4', 'charlie.mp4']);
+    });
+
+    it('puts files with step numbers before files without', () => {
+      const paths = ['rollout.mp4', 'step_1.mp4'];
+      const sorted = sortVideoArtifacts(paths);
+      expect(sorted[0]).toBe('step_1.mp4');
+    });
+
+    it('does not mutate the original array', () => {
+      const paths = ['b.mp4', 'a.mp4'];
+      sortVideoArtifacts(paths);
+      expect(paths).toEqual(['b.mp4', 'a.mp4']);
+    });
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/utils/VideoUtils.ts
+++ b/mlflow/server/js/src/experiment-tracking/utils/VideoUtils.ts
@@ -1,0 +1,64 @@
+import { getBasename } from '../../common/utils/FileUtils';
+
+/**
+ * Video artifact extensions used for the video gallery panel.
+ * This is broader than VIDEO_EXTENSIONS in FileUtils (which drives single-artifact preview)
+ * because the gallery should detect .ogg/.ogv which can contain video content.
+ */
+export const VIDEO_ARTIFACT_EXTENSIONS = new Set(['mp4', 'webm', 'mov', 'm4v', 'ogg', 'ogv', 'mkv', 'avi']);
+
+/**
+ * Directories known to commonly contain video artifacts (e.g. from RL rollouts).
+ * The hook will proactively scan these directories for video content.
+ */
+export const VIDEO_ARTIFACT_DIRECTORIES = ['videos', 'media/videos', 'media', 'rollouts'];
+
+/**
+ * Check whether an artifact path points to a video file.
+ * Case-insensitive extension matching.
+ */
+export function isVideoArtifactPath(path: string): boolean {
+  const parts = path.split(/[./]/);
+  const ext = parts[parts.length - 1]?.toLowerCase();
+  return VIDEO_ARTIFACT_EXTENSIONS.has(ext);
+}
+
+/**
+ * Extract a numeric step/episode number from a filename if present.
+ * Matches patterns like: step_100.mp4, rollout_042.webm, episode-5.mp4, 0003.mp4
+ * Returns null if no number can be inferred.
+ */
+export function extractStepNumber(filename: string): number | null {
+  // Strip extension
+  const base = filename.replace(/\.[^.]+$/, '');
+  // Try common patterns: trailing number after separator
+  const match = base.match(/[-_](\d+)$/);
+  if (match) {
+    return parseInt(match[1], 10);
+  }
+  // Try: filename is purely numeric
+  if (/^\d+$/.test(base)) {
+    return parseInt(base, 10);
+  }
+  return null;
+}
+
+/**
+ * Sort video artifact paths in a useful order:
+ * - If step numbers can be inferred, sort numerically by step.
+ * - Otherwise sort alphabetically by path.
+ */
+export function sortVideoArtifacts(paths: string[]): string[] {
+  return [...paths].sort((a, b) => {
+    const stepA = extractStepNumber(getBasename(a));
+    const stepB = extractStepNumber(getBasename(b));
+    if (stepA !== null && stepB !== null) {
+      return stepA - stepB;
+    }
+    // If only one has a step number, it comes first
+    if (stepA !== null) return -1;
+    if (stepB !== null) return 1;
+    // Fallback: alphabetical by full path
+    return a.localeCompare(b);
+  });
+}

--- a/tests/test_video_artifact_detection.py
+++ b/tests/test_video_artifact_detection.py
@@ -1,0 +1,165 @@
+"""
+Smoke test: log a video artifact to a local MLflow run and verify
+that the artifact listing API returns it, confirming the backend
+correctly stores and serves video files.
+
+Run with:
+    uv run pytest tests/test_video_artifact_detection.py -v
+"""
+
+import os
+import struct
+import tempfile
+
+import mlflow
+from mlflow.tracking import MlflowClient
+
+
+def _create_minimal_webm(path: str) -> None:
+    """Create a minimal valid .webm file (EBML header only).
+
+    This is enough for the frontend to detect it as a video artifact
+    without requiring ffmpeg or any heavy dependencies.
+    """
+    # Minimal EBML header for WebM (Matroska container)
+    # EBML Element ID + size + DocType "webm"
+    ebml_header = bytes(
+        [
+            0x1A,
+            0x45,
+            0xDF,
+            0xA3,  # EBML element ID
+            0x01,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x1F,  # Element size (31 bytes)
+            0x42,
+            0x86,  # EBMLVersion
+            0x81,  # Size: 1
+            0x01,  # Version 1
+            0x42,
+            0xF7,  # EBMLReadVersion
+            0x81,  # Size: 1
+            0x01,  # Version 1
+            0x42,
+            0xF2,  # EBMLMaxIDLength
+            0x81,  # Size: 1
+            0x04,  # 4 bytes
+            0x42,
+            0xF3,  # EBMLMaxSizeLength
+            0x81,  # Size: 1
+            0x08,  # 8 bytes
+            0x42,
+            0x82,  # DocType
+            0x84,  # Size: 4
+            0x77,
+            0x65,
+            0x62,
+            0x6D,  # "webm"
+            0x42,
+            0x87,  # DocTypeVersion
+            0x81,  # Size: 1
+            0x04,  # Version 4
+            0x42,
+            0x85,  # DocTypeReadVersion
+            0x81,  # Size: 1
+            0x02,  # Version 2
+        ]
+    )
+    with open(path, "wb") as f:
+        f.write(ebml_header)
+
+
+def _create_minimal_mp4(path: str) -> None:
+    """Create a minimal .mp4 file (ftyp box only).
+
+    This produces a valid MP4/ISO Base Media File Format header.
+    """
+    # ftyp box: size(4) + 'ftyp'(4) + major_brand(4) + minor_version(4) + compatible_brands
+    major_brand = b"isom"
+    minor_version = struct.pack(">I", 0x200)
+    compatible_brands = b"isomiso2mp41"
+    ftyp_data = b"ftyp" + major_brand + minor_version + compatible_brands
+    ftyp_size = struct.pack(">I", len(ftyp_data) + 4)  # +4 for size field itself
+    with open(path, "wb") as f:
+        f.write(ftyp_size + ftyp_data)
+
+
+def test_video_artifact_logged_and_listed():
+    """Log video artifacts and verify the listing API returns them."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Set up local tracking with sqlite backend
+        mlflow.set_tracking_uri(f"sqlite:///{tmpdir}/mlflow.db")
+
+        # Create test video files
+        webm_path = os.path.join(tmpdir, "rollout.webm")
+        mp4_path = os.path.join(tmpdir, "episode_001.mp4")
+        _create_minimal_webm(webm_path)
+        _create_minimal_mp4(mp4_path)
+
+        # Log artifacts
+        with mlflow.start_run() as run:
+            mlflow.log_artifact(webm_path, artifact_path="videos")
+            mlflow.log_artifact(mp4_path, artifact_path="videos")
+
+        # Verify via API
+        client = MlflowClient()
+        artifacts = client.list_artifacts(run.info.run_id, path="videos")
+        artifact_paths = [a.path for a in artifacts]
+
+        assert "videos/rollout.webm" in artifact_paths
+        assert "videos/episode_001.mp4" in artifact_paths
+
+
+def test_video_extension_detection():
+    """Verify that video extensions are properly detected as video (not audio)."""
+    video_extensions = [".mp4", ".webm", ".mov", ".m4v", ".ogg", ".ogv", ".mkv", ".avi"]
+    audio_only_extensions = [".mp3", ".wav", ".aac", ".flac", ".m4a"]
+
+    # Video extensions should be recognized
+    for ext in video_extensions:
+        filename = f"test_file{ext}"
+        assert filename.lower().endswith(ext), f"{ext} detection failed"
+
+    # .mp4 should NOT be in audio-only category
+    assert ".mp4" not in audio_only_extensions
+
+
+def test_video_artifact_at_root_level():
+    """Log a video artifact at the root level (no artifact_path)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        mlflow.set_tracking_uri(f"sqlite:///{tmpdir}/mlflow.db")
+
+        mp4_path = os.path.join(tmpdir, "my_video.mp4")
+        _create_minimal_mp4(mp4_path)
+
+        with mlflow.start_run() as run:
+            mlflow.log_artifact(mp4_path)
+
+        client = MlflowClient()
+        artifacts = client.list_artifacts(run.info.run_id)
+        artifact_paths = [a.path for a in artifacts]
+
+        assert "my_video.mp4" in artifact_paths
+
+
+def test_video_artifact_nested_in_rollouts():
+    """Log video artifacts under rollouts/ path."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        mlflow.set_tracking_uri(f"sqlite:///{tmpdir}/mlflow.db")
+
+        webm_path = os.path.join(tmpdir, "step_42.webm")
+        _create_minimal_webm(webm_path)
+
+        with mlflow.start_run() as run:
+            mlflow.log_artifact(webm_path, artifact_path="rollouts")
+
+        client = MlflowClient()
+        artifacts = client.list_artifacts(run.info.run_id, path="rollouts")
+        artifact_paths = [a.path for a in artifacts]
+
+        assert "rollouts/step_42.webm" in artifact_paths


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes https://github.com/mlflow/mlflow/issues/23204
### What changes are proposed in this pull request?

This PR adds first-class support for viewing video artifacts in the MLflow Tracking UI.

- Adds video artifact discovery utilities in `VideoUtils.ts`, including extension detection, step extraction from filenames, and step-aware sorting.
- Extends supported video extensions to include `m4v` and `ogv` in `FileUtils.ts`.
- Adds a reusable video chart card for the run charts system via `RunsChartsVideoChartCard.tsx` and the new `RunsChartType.VIDEO` chart type.
- Integrates the Video chart type into the chart add menu, chart configure modal, card renderer, and chart accordion so users can add, reorder, collapse, expand, and remove video panels like other chart cards.
- Discovers videos from common artifact locations such as `videos/`, `media/`, `media/videos/`, and `rollouts/`, as well as root-level video artifacts.
- Adds W&B-style step-slider navigation for video artifacts by extracting step numbers from filenames such as `step_00042.mp4`, `episode_001.mp4`, or `rollout_042.webm`.
- Supports multi-run comparison by showing one video cell per visible run and using the closest available video at the selected step.
- Fetches videos through the artifact blob API so videos work correctly with authenticated MLflow servers.
- Improves the existing single video artifact preview layout in `ShowArtifactVideoView.tsx` by centering the video and using `objectFit: 'contain'`.
### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Added tests:

- `mlflow/server/js/src/experiment-tracking/utils/VideoUtils.test.ts`
  - Verifies video extension detection.
  - Verifies `.mp4` remains classified as video rather than audio.
  - Verifies step extraction from common filename patterns.
  - Verifies step-aware video artifact sorting.
- `mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewVideosSection.test.tsx`
  - Verifies video artifacts are discovered and rendered.
  - Verifies non-video artifacts are ignored.
  - Verifies videos are fetched as blob URLs for authenticated artifact access.
  - Verifies the step label, video count, autoplay behavior, and empty-state behavior.
- `tests/test_video_artifact_detection.py`
  - Logs minimal `.webm` and `.mp4` artifacts to a local MLflow run.
  - Verifies `MlflowClient.list_artifacts` returns video artifacts under `videos/`, root-level artifacts, and `rollouts/` artifacts.

Run the automated tests with:

```bash
uv run pytest tests/test_video_artifact_detection.py -v
cd mlflow/server/js
yarn test mlflow/server/js/src/experiment-tracking/utils/VideoUtils.test.ts
yarn test mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewVideosSection.test.tsx
```

Manual validation can be performed with the demo script below. Save it as `demo_video_artifacts.py` at the repository root. This script is not included in the PR; it is provided here only as a reviewer aid.

<details>
<summary>Manual video artifacts demo script</summary>

```python
#!/usr/bin/env python3
"""
Demo script: Log video artifacts to MLflow and view them in the UI.

Usage:
    # Install deps (in your conda env)
    conda run -n mlflow-video-test pip install imageio imageio-ffmpeg numpy

    # Run this script
    conda run -n mlflow-video-test python demo_video_artifacts.py

    # Then start the MLflow dev server:
    # Terminal 1:
    #   conda run -n mlflow-video-test mlflow server \
    #     --backend-store-uri sqlite:////home/gromualdi/robot-code/mlflow/mlruns_demo.db \
    #     --default-artifact-root /home/gromualdi/robot-code/mlflow/mlartifacts_demo \
    #     --port 5000 --host 127.0.0.1
    # Terminal 2:
    #   cd mlflow/server/js && conda run -n mlflow-video-test env BROWSER=none PORT=3000 yarn start
    # Then open http://localhost:3000
"""

import os
import tempfile

import imageio.v3 as iio
import mlflow
import numpy as np


def generate_video(path: str, label: str, num_frames: int = 60, fps: int = 30, color=(50, 180, 50)):
    """Generate a small synthetic MP4 video (H.264) playable in all browsers."""
    width, height = 320, 240
    frames = []

    for i in range(num_frames):
        # Create a colored background
        frame = np.full((height, width, 3), color, dtype=np.uint8)

        # Add a moving white circle
        cx = int(width * (i / num_frames))
        cy = height // 2 + int(40 * np.sin(2 * np.pi * i / num_frames))
        # Draw circle manually (no cv2 needed)
        yy, xx = np.ogrid[:height, :width]
        mask = (xx - cx) ** 2 + (yy - cy) ** 2 <= 20**2
        frame[mask] = [255, 255, 255]

        # Add a progress bar at the bottom
        bar_width = int(width * (i / num_frames))
        frame[height - 10 : height, :bar_width] = [255, 200, 50]

        frames.append(frame)

    # Write with imageio + pyav (produces H.264 MP4, browser-playable)
    iio.imwrite(path, np.array(frames), fps=fps, codec="libx264", plugin="pyav")


def main():
    # Use a local sqlite backend
    db_path = os.path.join(os.getcwd(), "mlruns_demo.db")
    mlflow.set_tracking_uri(f"sqlite:///{db_path}")
    mlflow.set_experiment("video-artifacts-demo")

    print("Generating synthetic video artifacts (H.264 MP4, browser-playable)...")
    print("Creating multiple runs with multiple videos each...\n")

    # Define multiple runs with different configurations
    runs_config = [
        {
            "name": "ppo-cartpole-seed42",
            "params": {"algorithm": "PPO", "env": "CartPole-v1", "seed": "42", "lr": "3e-4"},
            "steps": [0, 500, 1000, 2000, 5000],
            "base_color": (180, 50, 50),  # Red tones
            "artifact_dirs": ["videos", "rollouts"],
        },
        {
            "name": "sac-halfcheetah-seed7",
            "params": {"algorithm": "SAC", "env": "HalfCheetah-v4", "seed": "7", "lr": "1e-3"},
            "steps": [0, 200, 400, 800, 1600, 3200],
            "base_color": (50, 130, 180),  # Blue tones
            "artifact_dirs": ["videos", "media/videos"],
        },
        {
            "name": "td3-hopper-seed123",
            "params": {"algorithm": "TD3", "env": "Hopper-v4", "seed": "123", "lr": "5e-4"},
            "steps": [0, 100, 300, 600, 1000, 2000, 4000],
            "base_color": (50, 180, 80),  # Green tones
            "artifact_dirs": ["videos", "rollouts", "media"],
        },
        {
            "name": "ppo-walker-seed99",
            "params": {"algorithm": "PPO", "env": "Walker2d-v4", "seed": "99", "lr": "2e-4"},
            "steps": [0, 1000, 2000, 3000],
            "base_color": (180, 130, 50),  # Orange tones
            "artifact_dirs": ["videos"],
        },
    ]

    with tempfile.TemporaryDirectory() as tmpdir:
        for run_cfg in runs_config:
            run_name = run_cfg["name"]
            print(f"{'─' * 50}")
            print(f"Run: {run_name}")

            # Generate videos for each step
            video_paths = []
            for step in run_cfg["steps"]:
                filename = f"step_{step:05d}.mp4"
                path = os.path.join(tmpdir, f"{run_name}_{filename}")
                # Vary color slightly per step
                base = np.array(run_cfg["base_color"])
                shift = int(step / max(run_cfg["steps"]) * 60)
                color = tuple(np.clip(base + shift, 0, 255).astype(int))
                num_frames = 45 + int(step / max(run_cfg["steps"]) * 45)  # longer videos at later steps
                generate_video(path, f"{run_name} step {step}", num_frames=num_frames, color=color)
                video_paths.append((step, filename, path))
                print(f"  Generated: {filename} ({num_frames} frames)")

            # Log to MLflow
            with mlflow.start_run(run_name=run_name) as run:
                # Log params
                for k, v in run_cfg["params"].items():
                    mlflow.log_param(k, v)

                # Log metrics at each step
                for step in run_cfg["steps"]:
                    reward = step * 0.3 + np.random.randn() * 15
                    mlflow.log_metric("reward", reward, step=step)
                    mlflow.log_metric("episode_length", 100 + step * 0.05 + np.random.randn() * 5, step=step)

                # Log videos under each configured artifact directory
                for artifact_dir in run_cfg["artifact_dirs"]:
                    for step, filename, path in video_paths:
                        mlflow.log_artifact(path, artifact_path=artifact_dir)

                print(f"  Logged to run_id={run.info.run_id}")
                print(f"  Artifact dirs: {run_cfg['artifact_dirs']}")
                print(f"  Videos per dir: {len(video_paths)}")
            print()

    print(f"\n{'=' * 60}")
    print(f"Done! Created {len(runs_config)} runs with video artifacts.")
    print(f"{'=' * 60}")
    print(f"\n  Terminal 1 (backend):")
    print(f"    eval \"$(conda shell.bash hook)\" && conda activate mlflow-video-test")
    print(f"    mlflow server --backend-store-uri sqlite:///{db_path} \\")
    print(f"      --default-artifact-root {os.getcwd()}/mlartifacts_demo \\")
    print(f"      --port 5000 --host 127.0.0.1")
    print(f"\n  Terminal 2 (frontend):")
    print(f"    cd mlflow/server/js")
    print(f"    eval \"$(conda shell.bash hook)\" && conda activate mlflow-video-test")
    print(f"    BROWSER=none PORT=3000 yarn start")
    print(f"\n  Then open: http://localhost:3000")
    print(f"  Navigate to experiment 'video-artifacts-demo' and click each run.")
    print(f"  Click the 'Model metrics' tab to see the Videos panel with step slider.\n")


if __name__ == "__main__":
    main()
```

</details>

Manual test steps:

1. Create and activate a test environment:

   ```bash
   conda create -n mlflow-video-test python=3.10 nodejs yarn -c conda-forge -y
   conda activate mlflow-video-test
   pip install -e .
   pip install imageio imageio-ffmpeg av numpy
   cd mlflow/server/js && yarn install && cd -
   ```

2. Generate demo runs and video artifacts:

   ```bash
   conda activate mlflow-video-test
   python demo_video_artifacts.py
   ```

   This creates 4 runs in the `video-artifacts-demo` experiment:

   - `ppo-cartpole-seed42`
   - `sac-halfcheetah-seed7`
   - `td3-hopper-seed123`
   - `ppo-walker-seed99`

   Each run logs 4–7 video artifacts under common video artifact directories such as `videos/`, `rollouts/`, `media/`, and `media/videos/`.

3. Start the MLflow backend:

   ```bash
   conda activate mlflow-video-test
   mlflow server \
     --backend-store-uri sqlite:///$(pwd)/mlruns_demo.db \
     --default-artifact-root $(pwd)/mlartifacts_demo \
     --port 5000 --host 127.0.0.1
   ```

4. Start the frontend in a separate terminal:

   ```bash
   cd mlflow/server/js
   conda activate mlflow-video-test
   BROWSER=none PORT=3000 yarn start
   ```

5. Open `http://localhost:3000` and validate:

   - Select the `video-artifacts-demo` experiment.
   - Open a single run, go to the `Model metrics` tab, add a `Video` chart, and verify that the Videos panel displays a video with a step slider.
   - Select multiple runs, click `Compare`, add a `Video` chart, and verify that the card displays a grid of videos with a shared step slider.
   - Use `Add chart` → `Video` to add another video panel.
   - Verify chart card behavior: drag to reorder, collapse/expand, and remove the Video chart card.
   - Verify that slider navigation shows the closest available video for each run at the selected step.
   - Verify that videos load through the artifact API and render in the browser.

Here the associated video

[mlflow_demo.webm](https://github.com/user-attachments/assets/1daaddac-2037-41af-8e2b-f8d69c373a8c)


### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

Adds support for visualizing video artifacts in MLflow Tracking using a new Video chart card with step-slider navigation, including support for comparing video artifacts across multiple runs.


#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
