### PR TITLE
fix: guard against empty summary list in reasoning content streaming

### DIFF
--- a/mlflow/types/responses.py
+++ b/mlflow/types/responses.py
@@ -518,7 +518,9 @@ def _cc_stream_to_responses_stream(
                 for item in content:
                     if isinstance(item, dict):
                         if item.get("type") == "reasoning":
-                            reasoning_content += item.get("summary", [])[0].get("text", "")
+                            summary = item.get("summary", [])
+                            if summary:
+                                reasoning_content += summary[0].get("text", "")
                         if item.get("type") == "text" and item.get("text"):
                             llm_content += item["text"]
                             yield ResponsesAgentStreamEvent(


### PR DESCRIPTION
In `_cc_stream_to_responses_stream`, when a streaming chunk has a `reasoning` content item, the code accesses `item.get("summary", [])[0]` without checking if the list is empty first. If the server sends a reasoning item with an empty `summary` array, this raises `IndexError`.

```python
# before — crashes when summary is []
reasoning_content += item.get("summary", [])[0].get("text", "")

# after — safe
summary = item.get("summary", [])
if summary:
    reasoning_content += summary[0].get("text", "")
```

Repro:
```python
item = {"type": "reasoning", "summary": []}
item.get("summary", [])[0].get("text", "")  # IndexError: list index out of range
```