### PR TITLE
Enable mypy on `dev/flavors`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,7 +67,6 @@ repos:
             dev/gen_rest_api\.py|
             dev/proto_plugin\.py|
             dev/update_ml_package_versions\.py|
-            dev/flavors/.*\.py|
             dev/proto_to_graphql/.*\.py|
             dev/benchmarks/gateway/fake_server\.py|
             dev/benchmarks/gateway/benchmark\.py|

--- a/dev/flavors/src/flavors/_loader.py
+++ b/dev/flavors/src/flavors/_loader.py
@@ -26,5 +26,9 @@ def load_or_default(path: str | Path, default: Any) -> Any:
 
 def load_raw(path: str | Path) -> dict[str, Any]:
     with open(path) as f:
-        data: dict[str, Any] = yaml.safe_load(f)
+        data = yaml.safe_load(f)
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"Expected a YAML mapping at top level of {path}, got {type(data).__name__}"
+        )
     return data

--- a/dev/flavors/src/flavors/_loader.py
+++ b/dev/flavors/src/flavors/_loader.py
@@ -26,4 +26,5 @@ def load_or_default(path: str | Path, default: Any) -> Any:
 
 def load_raw(path: str | Path) -> dict[str, Any]:
     with open(path) as f:
-        return yaml.safe_load(f)
+        data: dict[str, Any] = yaml.safe_load(f)
+    return data

--- a/dev/flavors/src/flavors/_matrix.py
+++ b/dev/flavors/src/flavors/_matrix.py
@@ -67,15 +67,15 @@ class MatrixItem(BaseModel):
     pre_test: str | None = None
     model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(frozenset(dict(self)))
 
 
-def get_latest_micro_versions(versions):
+def get_latest_micro_versions(versions: list[Version]) -> list[Version]:
     """
     Returns the latest micro version in each minor version.
     """
-    by_minor = {}
+    by_minor: dict[tuple[int, ...], Version] = {}
     for ver in sorted(versions, reverse=True):
         by_minor.setdefault(ver.release[:2], ver)
     return list(by_minor.values())
@@ -88,7 +88,7 @@ def filter_versions(
     max_ver: Version,
     unsupported: list[SpecifierSet],
     allow_unreleased_max_version: bool = False,
-):
+) -> list[Version]:
     """
     Returns the versions that satisfy the following conditions:
     1. Newer than or equal to `min_ver`.
@@ -96,7 +96,7 @@ def filter_versions(
     3. Not in `unsupported`.
     """
 
-    def _is_supported(v):
+    def _is_supported(v: Version) -> bool:
         for specified_set in unsupported:
             if v in specified_set:
                 return False
@@ -107,7 +107,9 @@ def filter_versions(
             # Exclude versions uploaded very recently to avoid testing unstable or potentially
             # buggy releases. Newly released versions may have unresolved issues
             # (see: https://github.com/huggingface/transformers/issues/34370).
-            v.major <= max_ver.major and v.days_since_release and v.days_since_release >= 1
+            v.major <= max_ver.major
+            and v.days_since_release is not None
+            and v.days_since_release >= 1
         )
 
     def _check_min(v: Version) -> bool:
@@ -119,11 +121,11 @@ def filter_versions(
 FLAVOR_FILE_PATTERN = re.compile(r"^(mlflow|tests)/(.+?)(_autolog(ging)?)?(\.py|/)")
 
 
-def get_changed_flavors(changed_files, flavors):
+def get_changed_flavors(changed_files: list[str], flavors: set[str]) -> set[str]:
     """
     Detects changed flavors from a list of changed files.
     """
-    changed_flavors = set()
+    changed_flavors: set[str] = set()
     for f in changed_files:
         match = FLAVOR_FILE_PATTERN.match(f)
         if match and match.group(2) in flavors:
@@ -147,12 +149,12 @@ def _find_matches(spec: dict[str, T], version: str) -> Iterator[T]:
             yield val
 
 
-def get_matched_requirements(requirements, version=None):
+def get_matched_requirements(requirements: dict[str, list[str]], version: str) -> list[str]:
     if not isinstance(requirements, dict):
         raise TypeError(
             f"Invalid object type for `requirements`: '{type(requirements)}'. Must be dict."
         )
-    reqs = set()
+    reqs: set[str] = set()
     for packages in _find_matches(requirements, version):
         reqs.update(packages)
     return sorted(reqs)
@@ -181,7 +183,7 @@ def _requires_python_from_repo(repo_url: str) -> str | None:
         resp = requests.get(raw_url, timeout=10)
         resp.raise_for_status()
     except requests.HTTPError as e:
-        if e.response.status_code == 404:
+        if e.response is not None and e.response.status_code == 404:
             print(f"  pyproject.toml not found at {raw_url}", file=sys.stderr)
             return None
         raise
@@ -233,20 +235,20 @@ def get_runs_on(runs_on: dict[str, str] | None, version: str) -> str:
     return _get_spec_value(runs_on, version, "ubuntu-latest")
 
 
-def remove_comments(s):
+def remove_comments(s: str) -> str:
     return "\n".join(l for l in s.strip().split("\n") if not l.strip().startswith("#"))
 
 
-def make_pip_install_command(packages):
+def make_pip_install_command(packages: list[str]) -> str:
     return "uv pip install --system " + " ".join(f"'{x}'" for x in packages)
 
 
-def divider(title, length=None):
+def divider(title: str, length: int | None = None) -> str:
     length = length or shutil.get_terminal_size(fallback=(80, 24))[0]
     return "\n" + f" {title} ".center(length, "=") + "\n"
 
 
-def split_by_comma(x):
+def split_by_comma(x: str) -> list[str]:
     return [s for item in x.split(",") if (s := item.strip())]
 
 
@@ -312,17 +314,17 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def parse_args(args):
+def parse_args(args: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Set a test matrix for the cross version tests")
     add_arguments(parser)
     return parser.parse_args(args)
 
 
-def get_flavor(name):
+def get_flavor(name: str) -> str:
     return {"pytorch-lightning": "pytorch"}.get(name, name)
 
 
-def validate_test_coverage(flavor: str, config: FlavorConfig):
+def validate_test_coverage(flavor: str, config: FlavorConfig) -> None:
     """
     Validate that all test files for the flavor are executed in the cross-version tests.
 
@@ -372,14 +374,14 @@ def _get_test_files(test_dir_or_path: str) -> set[Path]:
     return set()
 
 
-def _get_test_files_from_pytest_command(cmd, test_dir):
+def _get_test_files_from_pytest_command(cmd: str, test_dir: str) -> set[Path]:
     parser = argparse.ArgumentParser()
     parser.add_argument("--ignore", action="append")
     parser.add_argument("paths", nargs="*")
     args = parser.parse_known_args(shlex.split(cmd))[0]
 
-    executed_files = set()
-    ignore_files = set()
+    executed_files: set[Path] = set()
+    ignore_files: set[Path] = set()
     for path in args.paths:
         if path.startswith(test_dir):
             executed_files |= _get_test_files(path)
@@ -426,8 +428,10 @@ def validate_requirements(
             )
 
 
-async def expand_config(config: dict[str, Any], *, is_ref: bool = False) -> set[MatrixItem]:
-    matrix = set()
+async def expand_config(
+    config: dict[str, FlavorConfig], *, is_ref: bool = False
+) -> set[MatrixItem]:
+    matrix: set[MatrixItem] = set()
     pip_releases = list({fc.package_info.pip_release for fc in config.values()})
     packages = dict(zip(pip_releases, await get_packages(pip_releases)))
     for name, flavor_config in config.items():
@@ -469,7 +473,7 @@ async def expand_config(config: dict[str, Any], *, is_ref: bool = False) -> set[
                 install = make_pip_install_command(requirements)
                 run = remove_comments(cfg.run)
                 python = get_python_version(cfg.python, package, str(ver), package_info.repo)
-                runs_on = get_runs_on(cfg.runs_on, ver)
+                runs_on = get_runs_on(cfg.runs_on, str(ver))
                 java = get_java_version(cfg.java, str(ver))
 
                 matrix.add(
@@ -549,7 +553,7 @@ async def expand_config(config: dict[str, Any], *, is_ref: bool = False) -> set[
     return matrix
 
 
-def apply_changed_files(changed_files, matrix):
+def apply_changed_files(changed_files: list[str], matrix: set[MatrixItem]) -> set[MatrixItem]:
     all_flavors = {x.flavor for x in matrix}
     changed_flavors = (
         # If matrix-generation code itself changed, re-run all tests.
@@ -583,21 +587,23 @@ async def _generate(args: argparse.Namespace) -> set[MatrixItem]:
 
     # Apply the filtering arguments
     if args.no_dev:
-        matrix = filter(lambda x: x.version != Version.create_dev(), matrix)
+        dev_ver = Version.create_dev()
+        matrix = {x for x in matrix if x.version != dev_ver}
 
     if args.flavors:
-        matrix = filter(lambda x: x.flavor in args.flavors, matrix)
+        matrix = {x for x in matrix if x.flavor in args.flavors}
 
     if args.versions:
-        matrix = filter(lambda x: x.version in map(Version, args.versions), matrix)
+        target_versions = list(map(Version, args.versions))
+        matrix = {x for x in matrix if x.version in target_versions}
 
     if args.only_latest:
-        groups = defaultdict(list)
+        groups: dict[tuple[str, str], list[MatrixItem]] = defaultdict(list)
         for item in matrix:
             groups[(item.name, item.category)].append(item)
         matrix = {max(group, key=lambda x: x.version) for group in groups.values()}
 
-    return set(matrix)
+    return matrix
 
 
 async def generate_matrix(args: list[str]) -> set[MatrixItem]:
@@ -605,7 +611,7 @@ async def generate_matrix(args: list[str]) -> set[MatrixItem]:
 
 
 class CustomEncoder(json.JSONEncoder):
-    def default(self, o):
+    def default(self, o: Any) -> Any:
         if isinstance(o, MatrixItem):
             return o.model_dump(exclude_none=True)
         elif isinstance(o, Version):
@@ -613,18 +619,18 @@ class CustomEncoder(json.JSONEncoder):
         return super().default(o)
 
 
-def set_action_output(name, value):
-    with open(os.environ.get("GITHUB_OUTPUT"), "a") as f:
+def set_action_output(name: str, value: str) -> None:
+    with open(os.environ["GITHUB_OUTPUT"], "a") as f:
         f.write(f"{name}={value}\n")
 
 
-def split(matrix, n):
-    grouped_by_name = defaultdict(list)
+def split(matrix: list[MatrixItem], n: int) -> Iterator[list[MatrixItem]]:
+    grouped_by_name: dict[str, list[MatrixItem]] = defaultdict(list)
     for item in matrix:
         grouped_by_name[item.name].append(item)
 
     num = len(matrix) // n
-    chunk = []
+    chunk: list[MatrixItem] = []
     for group in grouped_by_name.values():
         chunk.extend(group)
         if len(chunk) >= num:
@@ -643,13 +649,12 @@ async def run(args: argparse.Namespace) -> None:
 
     print(divider("Parameters"))
     print(json.dumps(vars(args), indent=2, default=str))
-    matrix = await _generate(args)
-    matrix = sorted(matrix, key=lambda x: (x.name, x.category, x.version))
+    matrix = sorted(await _generate(args), key=lambda x: (x.name, x.category, x.version))
     assert len(matrix) <= MAX_ITEMS * 2, f"Too many jobs: {len(matrix)} > {MAX_ITEMS * NUM_JOBS}"
     for idx, mat in enumerate(split(matrix, NUM_JOBS), start=1):
-        mat = {"include": mat, "job_name": [x.job_name for x in mat]}
+        payload = {"include": mat, "job_name": [x.job_name for x in mat]}
         print(divider(f"Matrix {idx}"))
-        print(json.dumps(mat, indent=2, cls=CustomEncoder))
+        print(json.dumps(payload, indent=2, cls=CustomEncoder))
         if "GITHUB_ACTIONS" in os.environ:
-            set_action_output(f"matrix{idx}", json.dumps(mat, cls=CustomEncoder))
-            set_action_output(f"is_matrix{idx}_empty", "true" if len(mat) == 0 else "false")
+            set_action_output(f"matrix{idx}", json.dumps(payload, cls=CustomEncoder))
+            set_action_output(f"is_matrix{idx}_empty", "true" if len(payload) == 0 else "false")

--- a/dev/flavors/src/flavors/_matrix.py
+++ b/dev/flavors/src/flavors/_matrix.py
@@ -320,8 +320,7 @@ def parse_args(args: list[str]) -> argparse.Namespace:
     return parser.parse_args(args)
 
 
-def get_flavor(name: str) -> str:
-    return {"pytorch-lightning": "pytorch"}.get(name, name)
+FLAVOR_NAME_ALIASES = {"pytorch-lightning": "pytorch"}
 
 
 def validate_test_coverage(flavor: str, config: FlavorConfig) -> None:
@@ -435,7 +434,7 @@ async def expand_config(
     pip_releases = list({fc.package_info.pip_release for fc in config.values()})
     packages = dict(zip(pip_releases, await get_packages(pip_releases)))
     for name, flavor_config in config.items():
-        flavor = get_flavor(name)
+        flavor = FLAVOR_NAME_ALIASES.get(name, name)
         package_info = flavor_config.package_info
         package = packages[package_info.pip_release]
         all_versions = get_released_versions(package)
@@ -657,4 +656,4 @@ async def run(args: argparse.Namespace) -> None:
         print(json.dumps(payload, indent=2, cls=CustomEncoder))
         if "GITHUB_ACTIONS" in os.environ:
             set_action_output(f"matrix{idx}", json.dumps(payload, cls=CustomEncoder))
-            set_action_output(f"is_matrix{idx}_empty", "true" if len(payload) == 0 else "false")
+            set_action_output(f"is_matrix{idx}_empty", "true" if len(mat) == 0 else "false")

--- a/dev/flavors/src/flavors/_schema.py
+++ b/dev/flavors/src/flavors/_schema.py
@@ -13,16 +13,16 @@ DEV_NUMERIC = "9999.9999.9999"
 
 
 class Version(OriginalVersion):
-    def __init__(self, version: str, release_date: datetime | None = None):
+    def __init__(self, version: str, release_date: datetime | None = None) -> None:
         self._is_dev = version == DEV_VERSION
         self._release_date = release_date
         super().__init__(DEV_NUMERIC if self._is_dev else version)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return DEV_VERSION if self._is_dev else super().__str__()
 
     @classmethod
-    def create_dev(cls):
+    def create_dev(cls) -> Version:
         return cls(DEV_VERSION, datetime.now(timezone.utc))
 
     @property
@@ -64,22 +64,22 @@ class TestConfig(BaseModel):
 
     @field_validator("minimum", mode="before")
     @classmethod
-    def validate_minimum(cls, v):
+    def validate_minimum(cls, v: str) -> Version:
         return Version(v)
 
     @field_validator("maximum", mode="before")
     @classmethod
-    def validate_maximum(cls, v):
+    def validate_maximum(cls, v: str) -> Version:
         return Version(v)
 
     @field_validator("unsupported", mode="before")
     @classmethod
-    def validate_unsupported(cls, v):
+    def validate_unsupported(cls, v: list[str] | None) -> list[SpecifierSet] | None:
         return [SpecifierSet(x) for x in v] if v else None
 
     @field_validator("python", mode="before")
     @classmethod
-    def validate_python_requirements(cls, v):
+    def validate_python_requirements(cls, v: dict[str, str] | None) -> dict[str, str] | None:
         if v is None:
             return v
 
@@ -104,7 +104,7 @@ class FlavorConfig(BaseModel):
 
     @property
     def categories(self) -> list[tuple[str, TestConfig]]:
-        cs = []
+        cs: list[tuple[str, TestConfig]] = []
         if self.models:
             cs.append(("models", self.models))
         if self.autologging:

--- a/dev/flavors/src/flavors/_update.py
+++ b/dev/flavors/src/flavors/_update.py
@@ -61,10 +61,6 @@ def get_package_version_infos(package: Package) -> list[VersionInfo]:
     ]
 
 
-def get_latest_version(candidates: set[str]) -> str:
-    return max(candidates, key=PkgVersion)
-
-
 def update_version(src: str, key: str, new_version: str, category: str, update_max: bool) -> str:
     """
     Examples
@@ -289,7 +285,7 @@ def update(skip_yml: bool = False) -> None:
                 unsupported = config[category].get("unsupported", [])
                 # exclude unsupported versions
                 supported_versions = set(version_strs).difference(unsupported)
-                latest_version = get_latest_version(supported_versions)
+                latest_version = max(supported_versions, key=PkgVersion)
 
                 if PkgVersion(latest_version) <= PkgVersion(max_ver):
                     continue

--- a/dev/flavors/src/flavors/_update.py
+++ b/dev/flavors/src/flavors/_update.py
@@ -21,6 +21,7 @@ import urllib.request
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import Any
 
 import yaml
 from packaging.version import Version as PkgVersion
@@ -29,16 +30,6 @@ from pypi import Package, get_packages
 from flavors._releases import RELEASE_CUTOFF_DAYS
 
 PYPI_URL = os.environ.get("PYPI_URL", "https://pypi.org").rstrip("/")
-
-
-def read_file(path):
-    with open(path) as f:
-        return f.read()
-
-
-def save_file(src, path):
-    with open(path, "w") as f:
-        f.write(src)
 
 
 def check_pypi_accessibility() -> None:
@@ -70,11 +61,11 @@ def get_package_version_infos(package: Package) -> list[VersionInfo]:
     ]
 
 
-def get_latest_version(candidates):
+def get_latest_version(candidates: set[str]) -> str:
     return max(candidates, key=PkgVersion)
 
 
-def update_version(src, key, new_version, category, update_max):
+def update_version(src: str, key: str, new_version: str, category: str, update_max: bool) -> str:
     """
     Examples
     ========
@@ -118,7 +109,7 @@ def update_version(src, key, new_version, category, update_max):
     return re.sub(pattern, rf'\g<1>"{new_version}"', src, flags=re.DOTALL)
 
 
-def extract_field(d, keys):
+def extract_field(d: Any, keys: tuple[str, ...]) -> Any:
     for key in keys:
         if key in d:
             d = d[key]
@@ -127,25 +118,25 @@ def extract_field(d, keys):
     return d
 
 
-def _get_autolog_flavor_module_map(config):
+def _get_autolog_flavor_module_map(config: dict[str, dict[str, Any]]) -> dict[str, str]:
     """
     Parse _ML_PACKAGE_VERSIONS to get the mapping of flavor name to
     the module name to be imported for autologging.
     """
-    autolog_flavor_module_map = {}
-    for flavor, config in config.items():
-        if "autologging" not in config:
+    autolog_flavor_module_map: dict[str, str] = {}
+    for flavor, cfg in config.items():
+        if "autologging" not in cfg:
             continue
-        module_name = config["package_info"].get("module_name", flavor)
+        module_name = cfg["package_info"].get("module_name", flavor)
         autolog_flavor_module_map[flavor] = module_name
 
     return autolog_flavor_module_map
 
 
-def update_ml_package_versions_py(config_path):
+def update_ml_package_versions_py(config_path: Path) -> None:
     with open(config_path) as f:
-        genai_config = {}
-        non_genai_config = {}
+        genai_config: dict[str, dict[str, Any]] = {}
+        non_genai_config: dict[str, dict[str, Any]] = {}
 
         for name, cfg in yaml.load(f, Loader=yaml.SafeLoader).items():
             # Extract required fields
@@ -249,13 +240,13 @@ def get_min_supported_version(versions_infos: list[VersionInfo], genai: bool = F
     return min(recent_versions, key=lambda v: v.upload_time).version
 
 
-def update(skip_yml=False):
+def update(skip_yml: bool = False) -> None:
     if not skip_yml:
         check_pypi_accessibility()
-    yml_path = "mlflow/ml-package-versions.yml"
+    yml_path = Path("mlflow/ml-package-versions.yml")
 
     if not skip_yml:
-        old_src = read_file(yml_path)
+        old_src = yml_path.read_text()
         new_src = old_src
         config_dict = yaml.load(old_src, Loader=yaml.SafeLoader)
         # We currently don't have bandwidth to support newer versions of these flavors.
@@ -294,10 +285,11 @@ def update(skip_yml=False):
                     continue
 
                 max_ver = config[category]["maximum"]
-                versions = [v.version for v in versions_and_upload_times]
+                version_strs = [v.version for v in versions_and_upload_times]
                 unsupported = config[category].get("unsupported", [])
-                versions = set(versions).difference(unsupported)  # exclude unsupported versions
-                latest_version = get_latest_version(versions)
+                # exclude unsupported versions
+                supported_versions = set(version_strs).difference(unsupported)
+                latest_version = get_latest_version(supported_versions)
 
                 if PkgVersion(latest_version) <= PkgVersion(max_ver):
                     continue
@@ -306,7 +298,7 @@ def update(skip_yml=False):
                     new_src, flavor_key, latest_version, category, update_max=True
                 )
 
-        save_file(new_src, yml_path)
+        yml_path.write_text(new_src)
 
     update_ml_package_versions_py(yml_path)
 

--- a/dev/flavors/tests/test_cli.py
+++ b/dev/flavors/tests/test_cli.py
@@ -6,7 +6,7 @@ import pytest
 from flavors import _cli
 
 
-def _run(*args: str) -> subprocess.CompletedProcess:
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [sys.executable, "-m", "flavors._cli", *args],
         capture_output=True,

--- a/dev/flavors/tests/test_matrix.py
+++ b/dev/flavors/tests/test_matrix.py
@@ -1,8 +1,11 @@
+import asyncio
 import functools
 import re
 import tempfile
+from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
+from typing import Any, Callable, ParamSpec, TypeVar
 from unittest import mock
 
 import pytest
@@ -13,19 +16,22 @@ pytestmark = pytest.mark.skip(
 
 from flavors._matrix import generate_matrix
 
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
 
 class MockResponse:
-    def __init__(self, data):
+    def __init__(self, data: dict[str, Any]) -> None:
         self.data = data
 
-    def json(self):
+    def json(self) -> dict[str, Any]:
         return self.data
 
-    def raise_for_status(self):
+    def raise_for_status(self) -> None:
         pass
 
     @classmethod
-    def from_versions(cls, versions):
+    def from_versions(cls, versions: list[str]) -> "MockResponse":
         return cls({
             "releases": {
                 v: [
@@ -39,14 +45,17 @@ class MockResponse:
         })
 
 
-def mock_pypi_api(mock_responses):
-    def requests_get_patch(url, *args, **kwargs):
-        package_name = re.search(r"https://pypi\.org/pypi/(.+)/json", url).group(1)
-        return mock_responses[package_name]
+def mock_pypi_api(
+    mock_responses: dict[str, MockResponse],
+) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:
+    def requests_get_patch(url: str, *args: Any, **kwargs: Any) -> MockResponse:
+        match = re.search(r"https://pypi\.org/pypi/(.+)/json", url)
+        assert match is not None
+        return mock_responses[match.group(1)]
 
-    def decorator(test_func):
+    def decorator(test_func: Callable[_P, _R]) -> Callable[_P, _R]:
         @functools.wraps(test_func)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
             with mock.patch("requests.get", new=requests_get_patch):
                 return test_func(*args, **kwargs)
 
@@ -56,7 +65,7 @@ def mock_pypi_api(mock_responses):
 
 
 @contextmanager
-def mock_ml_package_versions_yml(src_base, src_ref):
+def mock_ml_package_versions_yml(src_base: str, src_ref: str) -> Iterator[list[str]]:
     with tempfile.TemporaryDirectory() as tmp_dir:
         yml_base = Path(tmp_dir).joinpath("base.yml")
         yml_ref = Path(tmp_dir).joinpath("ref.yml")
@@ -104,12 +113,12 @@ MOCK_PYPI_API_RESPONSES = {
     ],
 )
 @mock_pypi_api(MOCK_PYPI_API_RESPONSES)
-def test_flavors(flavors, expected):
+def test_flavors(flavors: str | None, expected: set[str]) -> None:
     with mock_ml_package_versions_yml(MOCK_YAML_SOURCE, "{}") as path_args:
         flavors_args = [] if flavors is None else ["--flavors", flavors]
-        matrix = generate_matrix([*path_args, *flavors_args])
-        flavors = {x.flavor for x in matrix}
-        assert flavors == expected
+        matrix = asyncio.run(generate_matrix([*path_args, *flavors_args]))
+        flavor_names = {x.flavor for x in matrix}
+        assert flavor_names == expected
 
 
 @pytest.mark.parametrize(
@@ -123,39 +132,43 @@ def test_flavors(flavors, expected):
     ],
 )
 @mock_pypi_api(MOCK_PYPI_API_RESPONSES)
-def test_versions(versions, expected):
+def test_versions(versions: str | None, expected: set[str]) -> None:
     with mock_ml_package_versions_yml(MOCK_YAML_SOURCE, "{}") as path_args:
         versions_args = [] if versions is None else ["--versions", versions]
-        matrix = generate_matrix([*path_args, *versions_args])
-        versions = {str(x.version) for x in matrix}
-        assert versions == expected
+        matrix = asyncio.run(generate_matrix([*path_args, *versions_args]))
+        version_strs = {str(x.version) for x in matrix}
+        assert version_strs == expected
 
 
 @mock_pypi_api(MOCK_PYPI_API_RESPONSES)
-def test_flavors_and_versions():
+def test_flavors_and_versions() -> None:
     with mock_ml_package_versions_yml(MOCK_YAML_SOURCE, "{}") as path_args:
-        matrix = generate_matrix([*path_args, "--flavors", "foo,bar", "--versions", "dev"])
+        matrix = asyncio.run(
+            generate_matrix([*path_args, "--flavors", "foo,bar", "--versions", "dev"])
+        )
         flavors = {x.flavor for x in matrix}
         versions = {str(x.version) for x in matrix}
-        assert set(flavors) == {"foo", "bar"}
-        assert set(versions) == {"dev"}
+        assert flavors == {"foo", "bar"}
+        assert versions == {"dev"}
 
 
 @mock_pypi_api(MOCK_PYPI_API_RESPONSES)
-def test_no_dev():
+def test_no_dev() -> None:
     with mock_ml_package_versions_yml(MOCK_YAML_SOURCE, "{}") as path_args:
-        matrix = generate_matrix([*path_args, "--no-dev"])
+        matrix = asyncio.run(generate_matrix([*path_args, "--no-dev"]))
         flavors = {x.flavor for x in matrix}
         versions = {str(x.version) for x in matrix}
-        assert set(flavors) == {"foo", "bar"}
-        assert set(versions) == {"1.0.0", "1.1.1", "1.2.0", "1.3", "1.4"}
+        assert flavors == {"foo", "bar"}
+        assert versions == {"1.0.0", "1.1.1", "1.2.0", "1.3", "1.4"}
 
 
 @mock_pypi_api(MOCK_PYPI_API_RESPONSES)
-def test_changed_files():
+def test_changed_files() -> None:
     with mock_ml_package_versions_yml(MOCK_YAML_SOURCE, MOCK_YAML_SOURCE) as path_args:
-        matrix = generate_matrix([*path_args, "--changed-files", "mlflow/foo/__init__.py"])
+        matrix = asyncio.run(
+            generate_matrix([*path_args, "--changed-files", "mlflow/foo/__init__.py"])
+        )
         flavors = {x.flavor for x in matrix}
         versions = {str(x.version) for x in matrix}
-        assert set(flavors) == {"foo"}
-        assert set(versions) == {"1.0.0", "1.1.1", "1.2.0", "dev"}
+        assert flavors == {"foo"}
+        assert versions == {"1.0.0", "1.1.1", "1.2.0", "dev"}

--- a/dev/flavors/tests/test_update.py
+++ b/dev/flavors/tests/test_update.py
@@ -32,7 +32,7 @@ def package_from_versions(versions: list[str]) -> Package:
 
 
 @pytest.fixture(autouse=True)
-def change_working_directory(tmp_path, monkeypatch):
+def change_working_directory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """
     Changes the current working directory to a temporary directory to avoid modifying files in the
     repository.
@@ -40,8 +40,8 @@ def change_working_directory(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
 
-def run_test(src, src_expected, mock_packages):
-    async def fake_get_packages(names):
+def run_test(src: str, src_expected: str, mock_packages: dict[str, Package]) -> None:
+    async def fake_get_packages(names: list[str]) -> list[Package]:
         return [mock_packages[n] for n in names]
 
     versions_yaml = Path("mlflow/ml-package-versions.yml")
@@ -58,7 +58,7 @@ def run_test(src, src_expected, mock_packages):
     assert versions_yaml.read_text() == src_expected
 
 
-def test_multiple_flavors_are_correctly_updated():
+def test_multiple_flavors_are_correctly_updated() -> None:
     src = """
 sklearn:
   package_info:
@@ -90,7 +90,7 @@ xgboost:
     run_test(src, src_expected, mock_packages)
 
 
-def test_both_models_and_autologging_are_updated():
+def test_both_models_and_autologging_are_updated() -> None:
     src = """
 sklearn:
   package_info:
@@ -115,7 +115,7 @@ sklearn:
     run_test(src, src_expected, mock_packages)
 
 
-def test_pre_and_dev_versions_are_ignored():
+def test_pre_and_dev_versions_are_ignored() -> None:
     src = """
 sklearn:
   package_info:
@@ -142,7 +142,7 @@ sklearn:
     run_test(src, src_expected, mock_packages)
 
 
-def test_unsupported_versions_are_ignored():
+def test_unsupported_versions_are_ignored() -> None:
     src = """
 sklearn:
   package_info:
@@ -163,7 +163,7 @@ sklearn:
     run_test(src, src_expected, mock_packages)
 
 
-def test_freeze_field_prevents_updating_maximum_version():
+def test_freeze_field_prevents_updating_maximum_version() -> None:
     src = """
 sklearn:
   package_info:
@@ -184,7 +184,7 @@ sklearn:
     run_test(src, src_expected, mock_packages)
 
 
-def test_update_min_supported_version():
+def test_update_min_supported_version() -> None:
     src = """
 sklearn:
   package_info:
@@ -211,7 +211,7 @@ sklearn:
     run_test(src, src_expected, mock_packages)
 
 
-def test_update_min_supported_version_for_dead_package():
+def test_update_min_supported_version_for_dead_package() -> None:
     src = """
 sklearn:
   package_info:


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Drop `dev/flavors` from the pre-commit `mypy` exclude and annotate the package so it passes under `strict = true`. Also fixes a few latent issues mypy surfaced (e.g. `HTTPError.response` not None-guarded, `_generate` filters that returned `filter` objects instead of `set`s, async tests calling `generate_matrix` without `await`).

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/build`

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release