### PR TITLE
Use `uv run --package flavors` in cross-version-tests matrix job

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -77,10 +77,6 @@ jobs:
       - uses: ./.github/actions/setup-python
         with:
           pin-micro-version: false
-      - name: Install dependencies
-        run: |
-          uv pip install --system -r dev/requirements.txt
-          uv pip install --system pytest pytest-cov
       - name: Check labels
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         id: check-labels
@@ -100,7 +96,7 @@ jobs:
             };
       - name: Test flavors CLI
         run: |
-          python -m pytest --noconftest dev/flavors/tests
+          uv run --package flavors pytest --noconftest dev/flavors/tests
       - id: set-matrix
         name: Set matrix
         env:
@@ -121,11 +117,11 @@ jobs:
             CHANGED_FILES=$(gh pr view "$PR_NUMBER" --json files --jq '.files[].path' | grep -v '^mlflow/server/js' || true)
             NO_DEV_FLAG=$([ "$ENABLE_DEV_TESTS" == "true" ] && echo "" || echo "--no-dev")
             ONLY_LATEST_FLAG=$([ "$ONLY_LATEST" == "true" ] && echo "--only-latest" || echo "")
-            flavors matrix --ref-versions-yaml "$REF_VERSIONS_YAML" --changed-files "$CHANGED_FILES" $NO_DEV_FLAG $ONLY_LATEST_FLAG
+            uv run --package flavors flavors matrix --ref-versions-yaml "$REF_VERSIONS_YAML" --changed-files "$CHANGED_FILES" $NO_DEV_FLAG $ONLY_LATEST_FLAG
           elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            flavors matrix --flavors "$FLAVORS" --versions "$VERSIONS"
+            uv run --package flavors flavors matrix --flavors "$FLAVORS" --versions "$VERSIONS"
           else
-            flavors matrix
+            uv run --package flavors flavors matrix
           fi
 
   test1:

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -77,6 +77,9 @@ jobs:
       - uses: ./.github/actions/setup-python
         with:
           pin-micro-version: false
+      - name: Install flavors
+        run: |
+          uv sync --package flavors
       - name: Check labels
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         id: check-labels
@@ -96,7 +99,7 @@ jobs:
             };
       - name: Test flavors CLI
         run: |
-          uv run --package flavors pytest --noconftest dev/flavors/tests
+          uv run --no-sync --package flavors pytest --noconftest dev/flavors/tests
       - id: set-matrix
         name: Set matrix
         env:
@@ -117,11 +120,11 @@ jobs:
             CHANGED_FILES=$(gh pr view "$PR_NUMBER" --json files --jq '.files[].path' | grep -v '^mlflow/server/js' || true)
             NO_DEV_FLAG=$([ "$ENABLE_DEV_TESTS" == "true" ] && echo "" || echo "--no-dev")
             ONLY_LATEST_FLAG=$([ "$ONLY_LATEST" == "true" ] && echo "--only-latest" || echo "")
-            uv run --package flavors flavors matrix --ref-versions-yaml "$REF_VERSIONS_YAML" --changed-files "$CHANGED_FILES" $NO_DEV_FLAG $ONLY_LATEST_FLAG
+            uv run --no-sync --package flavors flavors matrix --ref-versions-yaml "$REF_VERSIONS_YAML" --changed-files "$CHANGED_FILES" $NO_DEV_FLAG $ONLY_LATEST_FLAG
           elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            uv run --package flavors flavors matrix --flavors "$FLAVORS" --versions "$VERSIONS"
+            uv run --no-sync --package flavors flavors matrix --flavors "$FLAVORS" --versions "$VERSIONS"
           else
-            uv run --package flavors flavors matrix
+            uv run --no-sync --package flavors flavors matrix
           fi
 
   test1:

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -99,7 +99,7 @@ jobs:
             };
       - name: Test flavors CLI
         run: |
-          uv run --no-sync --package flavors pytest --noconftest dev/flavors/tests
+          uv run --no-sync pytest --noconftest dev/flavors/tests
       - id: set-matrix
         name: Set matrix
         env:
@@ -120,11 +120,11 @@ jobs:
             CHANGED_FILES=$(gh pr view "$PR_NUMBER" --json files --jq '.files[].path' | grep -v '^mlflow/server/js' || true)
             NO_DEV_FLAG=$([ "$ENABLE_DEV_TESTS" == "true" ] && echo "" || echo "--no-dev")
             ONLY_LATEST_FLAG=$([ "$ONLY_LATEST" == "true" ] && echo "--only-latest" || echo "")
-            uv run --no-sync --package flavors flavors matrix --ref-versions-yaml "$REF_VERSIONS_YAML" --changed-files "$CHANGED_FILES" $NO_DEV_FLAG $ONLY_LATEST_FLAG
+            uv run --no-sync flavors matrix --ref-versions-yaml "$REF_VERSIONS_YAML" --changed-files "$CHANGED_FILES" $NO_DEV_FLAG $ONLY_LATEST_FLAG
           elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            uv run --no-sync --package flavors flavors matrix --flavors "$FLAVORS" --versions "$VERSIONS"
+            uv run --no-sync flavors matrix --flavors "$FLAVORS" --versions "$VERSIONS"
           else
-            uv run --no-sync --package flavors flavors matrix
+            uv run --no-sync flavors matrix
           fi
 
   test1:

--- a/dev/flavors/pyproject.toml
+++ b/dev/flavors/pyproject.toml
@@ -9,5 +9,8 @@ dependencies = ["packaging", "pydantic>=2.0", "pypi", "pyyaml", "requests"]
 [project.scripts]
 flavors = "flavors._cli:main"
 
+[dependency-groups]
+dev = ["pytest"]
+
 [tool.uv.sources]
 pypi = { workspace = true }

--- a/dev/flavors/src/flavors/_matrix.py
+++ b/dev/flavors/src/flavors/_matrix.py
@@ -557,7 +557,7 @@ def apply_changed_files(changed_files: list[str], matrix: set[MatrixItem]) -> se
     changed_flavors = (
         # If matrix-generation code itself changed, re-run all tests.
         all_flavors
-        if any(f.startswith("dev/flavors/") for f in changed_files)
+        if any(f.startswith("dev/flavors/src/") for f in changed_files)
         else get_changed_flavors(changed_files, all_flavors)
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -1880,6 +1880,11 @@ dependencies = [
     { name = "requests" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "packaging" },
@@ -1888,6 +1893,9 @@ requires-dist = [
     { name = "pyyaml" },
     { name = "requests" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest" }]
 
 [[package]]
 name = "fonttools"


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Slim down the `set-matrix` job in the cross-version-tests workflow:

- `uv sync --package flavors` + `uv run --no-sync ...` instead of `uv pip install --system`, so only flavors' deps are installed and install vs. run timings are visible separately.
- Add a `dev` group with `pytest` to `dev/flavors/pyproject.toml` (drops unused `pytest-cov`).
- Scope the "matrix-gen code changed → full re-run" trigger in `apply_changed_files` to `dev/flavors/src/` so packaging-only edits don't blow up the matrix.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release