### PR TITLE
Link `status.claude.com` from review workflow when Claude API hits 529

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -332,6 +332,9 @@ jobs:
               const summary = resultEvent.is_error ? 'Error' : 'Result';
               const formatted = JSON.stringify(resultEvent, null, 2);
               resultLine += `\n<details><summary>${summary}</summary>\n\n\`\`\`json\n${formatted}\n\`\`\`\n\n</details>`;
+              if (resultEvent.is_error && /529|Overloaded/i.test(resultEvent.result || '')) {
+                resultLine += `\n\nThe Claude API is overloaded. Check [status.claude.com](https://status.claude.com/) and retry.`;
+              }
             } else if (failed) {
               resultLine += `\n\nSee [workflow logs](${workflowUrl}) for details.`;
             }


### PR DESCRIPTION
### Related Issues/PRs

Relates to #_n/a_

### What changes are proposed in this pull request?

When the `review` workflow's Claude step exits with a 529 / `Overloaded` API error, the resulting PR comment now appends a link to https://status.claude.com/ so reviewers can quickly check API status before retrying.

Example trigger: run [26268689317](https://github.com/mlflow/mlflow/actions/runs/26268689317) failed with `Repeated 529 Overloaded errors. The API is at capacity` and the comment didn't surface where to look.

### How is this PR tested?

- [x] Manual tests

`/review` invocation in this PR triggers the workflow. The 529 path is gated behind `is_error && /529|Overloaded/i.test(resultEvent.result)`; the success path is unaffected.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release