### PR TITLE
Document workflow-context rule in GitHub Actions guidelines

### DIFF
--- a/.claude/rules/github-actions.md
+++ b/.claude/rules/github-actions.md
@@ -20,14 +20,14 @@ runs-on: ubuntu-slim
 
 ## Use Workflow Context Instead of Fetching
 
-If the trigger event already carries the data, read it from the `github` context instead of calling `gh` or `actions/github-script`. Extra API calls burn rate-limit budget and add a flaky network hop for nothing.
+If the trigger event already carries the data, read it from the `github` context instead of calling `gh` or `actions/github-script`. Extra API calls burn rate-limit budget and add a flaky network hop for nothing. Passing context values through `env:` (rather than inlining `${{ }}` inside `run:`) also avoids the [script-injection foot-gun](https://docs.github.com/en/actions/reference/security/secure-use#good-practices-for-mitigating-script-injection-attacks) when the field could ever be user-controlled (e.g., `title`, `body`, `head.ref`).
 
 ```yaml
 # Bad
 - env:
     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   run: |
-    PR_NUMBER=$(gh pr view ${{ github.event.pull_request.html_url }} --json number -q .number)
+    PR_NUMBER=$(gh pr view --json number -q .number)
 
 # Good
 - env:

--- a/.claude/rules/github-actions.md
+++ b/.claude/rules/github-actions.md
@@ -20,7 +20,7 @@ runs-on: ubuntu-slim
 
 ## Use Workflow Context Instead of Fetching
 
-If the trigger event already carries the data, read it from the `github` context instead of calling `gh` or `actions/github-script`. Extra API calls burn rate-limit budget and add a flaky network hop for nothing. Passing context values through `env:` (rather than inlining `${{ }}` inside `run:`) also avoids the [script-injection foot-gun](https://docs.github.com/en/actions/reference/security/secure-use#good-practices-for-mitigating-script-injection-attacks) when the field could ever be user-controlled (e.g., `title`, `body`, `head.ref`).
+If the trigger event already carries the data, read it from the `github` context instead of calling `gh` or `actions/github-script`. Extra API calls burn rate-limit budget and add a flaky network hop for nothing.
 
 ```yaml
 # Bad

--- a/.claude/rules/github-actions.md
+++ b/.claude/rules/github-actions.md
@@ -18,6 +18,25 @@ runs-on: ubuntu-latest
 runs-on: ubuntu-slim
 ```
 
+## Use Workflow Context Instead of Fetching
+
+If the trigger event already carries the data, read it from the `github` context instead of calling `gh` or `actions/github-script`. Extra API calls burn rate-limit budget and add a flaky network hop for nothing.
+
+```yaml
+# Bad
+- env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  run: |
+    PR_NUMBER=$(gh pr view ${{ github.event.pull_request.html_url }} --json number -q .number)
+
+# Good
+- env:
+    PR_NUMBER: ${{ github.event.pull_request.number }}
+  run: echo "PR #$PR_NUMBER"
+```
+
+Only fetch when the data isn't in the payload (e.g., check runs, review threads, changed files on `issue_comment`).
+
 ## Prefer `gh` CLI over `actions/github-script`
 
 For simple GitHub API operations (commenting, labeling, cancelling runs, etc.),

--- a/.claude/rules/github-actions.md
+++ b/.claude/rules/github-actions.md
@@ -26,14 +26,14 @@ If the trigger event already carries the data, read it from the `github` context
 # Bad
 - env:
     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    PR_URL: ${{ github.event.pull_request.html_url }}
+    PR_NUMBER: ${{ github.event.pull_request.number }}
   run: |
-    PR_NUMBER=$(gh pr view "$PR_URL" --json number -q .number)
+    HEAD_SHA=$(gh pr view "$PR_NUMBER" --json headRefOid -q .headRefOid)
 
 # Good
 - env:
-    PR_NUMBER: ${{ github.event.pull_request.number }}
-  run: echo "PR #$PR_NUMBER"
+    HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+  run: echo "$HEAD_SHA"
 ```
 
 Only fetch when the data isn't in the payload (e.g., check runs, review threads, changed files on `issue_comment`).

--- a/.claude/rules/github-actions.md
+++ b/.claude/rules/github-actions.md
@@ -26,8 +26,9 @@ If the trigger event already carries the data, read it from the `github` context
 # Bad
 - env:
     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    PR_URL: ${{ github.event.pull_request.html_url }}
   run: |
-    PR_NUMBER=$(gh pr view --json number -q .number)
+    PR_NUMBER=$(gh pr view "$PR_URL" --json number -q .number)
 
 # Good
 - env:


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Add a rule to `.claude/rules/github-actions.md` instructing workflows to read data from the `github` event payload instead of calling `gh` or `actions/github-script` when the trigger already carries it. Extra API calls burn rate-limit budget and add a flaky network hop for nothing.

### How is this PR tested?

- [x] N/A (documentation only)

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release