### PR TITLE
docs: add mlflow-falsify as a community plugin (Run Context & Provenance)

### DIFF
--- a/docs/docs/classic-ml/plugins/index.mdx
+++ b/docs/docs/classic-ml/plugins/index.mdx
@@ -623,6 +623,38 @@ pip install trubrics-sdk
 ```
 
   </TabItem>
+  <TabItem value="run-context-plugin" label="Run Context &amp; Provenance">
+
+#### **mlflow-falsify**
+
+Bind every MLflow run to a [PRML](https://spec.falsify.dev/v0.1) manifest (Pre-Registered ML Manifest) via a tamper-evident SHA-256 hash, so reviewers can verify after the fact that a reported metric matches a pre-registered claim:
+
+```bash
+pip install mlflow-falsify
+```
+
+```python
+import mlflow
+
+# Drop a .prml.yaml in your repo (or any ancestor directory).
+# Every run is auto-tagged — no workflow change.
+with mlflow.start_run():
+    mlflow.log_metric("accuracy", 0.873)
+```
+
+**Tags applied automatically:**
+
+- `prml.manifest_hash` — SHA-256 of the canonical manifest bytes
+- `prml.manifest_path`, `prml.version`
+- `prml.metric`, `prml.comparator`, `prml.threshold`
+- `prml.dataset_id`
+
+For HPO sweeps, descriptive tags can be lifted to experiment scope via `MLFLOW_FALSIFY_TAG_SCOPE=experiment`. The provider never raises into your run.
+
+Implements the documented `mlflow.run_context_provider` entry point (above). MIT-licensed. Spec is CC BY 4.0.
+
+  </TabItem>
+
   <TabItem value="execution" label="Execution Backends">
 
 | Plugin          | Platform     | Use Case                     |


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23369 (Discussion: mlflow-falsify community plugin)

### What changes are proposed in this pull request?

Adds `mlflow-falsify` to the "Popular Community Plugins" section of the plugins documentation, under a new **Run Context & Provenance** tab.

[`mlflow-falsify`](https://pypi.org/project/mlflow-falsify/) is an MLflow Run Context Provider that auto-tags every `mlflow.start_run()` with the SHA-256 hash of a [PRML](https://spec.falsify.dev/v0.1) manifest discovered in the working directory. It implements the documented `mlflow.run_context_provider` entry point, which is described earlier on this same page.

No existing community plugin in the section covers run-context / provenance, so this adds a new tab rather than crowding an existing one.

- PyPI: https://pypi.org/project/mlflow-falsify/ (v0.2.0)
- Source (MIT): https://github.com/studio-11-co/mlflow-falsify
- Spec (CC BY 4.0): https://spec.falsify.dev/v0.1

Single doc file edit: `docs/docs/classic-ml/plugins/index.mdx`. 32 lines added, 0 removed. No code, dependency, sidebar, or nav changes. Happy to adjust placement, copy, or tab label.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Manual: rendered the MDX section locally via the docs build and verified the new `<TabItem>` renders correctly between the existing "Model Evaluation" and "Execution Backends" tabs.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`
- [ ] `area/models`
- [ ] `area/model-registry`
- [ ] `area/scoring`
- [ ] `area/evaluation`
- [ ] `area/gateway`
- [ ] `area/prompts`
- [ ] `area/tracing`
- [ ] `area/projects`
- [ ] `area/uiux`
- [ ] `area/build`
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none`
- [ ] `rn/breaking-change`
- [ ] `rn/feature`
- [ ] `rn/bug-fix`
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
