### PR TITLE
fix: guard against empty `summary` list in reasoning content streaming

### DIFF
--- a/mlflow/types/responses.py
+++ b/mlflow/types/responses.py
@@ -518,7 +518,9 @@ def _cc_stream_to_responses_stream(
                 for item in content:
                     if isinstance(item, dict):
                         if item.get("type") == "reasoning":
-                            reasoning_content += item.get("summary", [])[0].get("text", "")
+                            summary = item.get("summary", [])
+                            if summary:
+                                reasoning_content += summary[0].get("text", "")
                         if item.get("type") == "text" and item.get("text"):
                             llm_content += item["text"]
                             yield ResponsesAgentStreamEvent(


### PR DESCRIPTION
### Related Issues/PRs

Relates to N/A

### What changes are proposed in this pull request?

In `_cc_stream_to_responses_stream`, when a streaming chunk has a `reasoning` content item, the code accesses `item.get("summary", [])[0]` without checking if the list is empty. If the server sends a reasoning item with an empty `summary` array, this raises `IndexError`.

```python
# before — crashes when summary is []
reasoning_content += item.get("summary", [])[0].get("text", "")

# after — safe
summary = item.get("summary", [])
if summary:
    reasoning_content += summary[0].get("text", "")
```

Repro:
```python
item = {"type": "reasoning", "summary": []}
item.get("summary", [])[0].get("text", "")  # IndexError: list index out of range
```

### How is this PR tested?

- [x] Manual tests

Verified the fix avoids the crash with an empty `summary` array.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fixes an `IndexError` crash in the chat-completions to responses streaming converter when a server emits a reasoning content item with an empty `summary` array.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release