### PR TITLE
Cap review workflow spend at $5 via `--max-budget-usd`

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -216,6 +216,7 @@ jobs:
           timeout 20m claude \
             --model "$MODEL" \
             --effort "$EFFORT" \
+            --max-budget-usd 5 \
             --print \
             --verbose \
             --output-format stream-json \


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Pass `--max-budget-usd 5` to the `claude` CLI in the `review` workflow so a single review run can't exceed $5 in API spend. The flag only takes effect with `--print`, which the workflow already uses.

### How is this PR tested?

- [x] Manual tests

Ran `claude -p --max-budget-usd 5 "say hi"` locally to confirm the flag is accepted.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release