### PR TITLE
Skip flaky `test_search_traces_yields_expected_dataframe_contents` on Windows

### DIFF
--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -1064,6 +1064,7 @@ def test_search_traces_warns_on_uc_location_without_time_range(
 
 
 @skip_when_testing_trace_sdk
+@pytest.mark.skipif(os.name == "nt", reason="Flaky on Windows")
 def test_search_traces_yields_expected_dataframe_contents(monkeypatch):
     model = DefaultTestModel()
     expected_traces = []


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

`tests/tracing/test_fluent.py::test_search_traces_yields_expected_dataframe_contents` has been flaky on Windows runners. Skip it on Windows to unblock CI while the underlying issue is investigated.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)