### PR TITLE
Drop the vestigial `directPermissions` parallel pass; hide synthetic `__user_<id>__` roles on Account/UserDetail

### DIFF
--- a/mlflow/server/js/src/account/AccountPage.tsx
+++ b/mlflow/server/js/src/account/AccountPage.tsx
@@ -23,13 +23,7 @@ import { useQueryClient } from '@mlflow/mlflow/src/common/utils/reactQueryHooks'
 import { useWorkspacesEnabled } from '../experiment-tracking/hooks/useServerInfo';
 import { useSearchParams } from '../common/utils/RoutingUtils';
 import { performLogout } from './auth-utils';
-import {
-  useCurrentUserQuery,
-  useIsBasicAuth,
-  useMyPermissionsQuery,
-  useUpdatePassword,
-  useUserRolesQuery,
-} from './hooks';
+import { useCurrentUserQuery, useIsBasicAuth, useUpdatePassword, useUserRolesQuery } from './hooks';
 import { PermissionsSection } from './PermissionsSection';
 import { DEFAULT_WORKSPACE_NAME, isSyntheticUserRole, isWorkspaceAdminRole } from './types';
 import type { Role } from './types';
@@ -91,31 +85,18 @@ const AccountPage = () => {
   };
 
   const { data: rolesData, isLoading: rolesLoading, error: rolesError } = useUserRolesQuery(username);
-  const allRoles = useMemo(() => rolesData?.roles ?? [], [rolesData]);
-
-  const { data: directPermsData, isLoading: directPermsLoading, error: directPermsError } = useMyPermissionsQuery();
-  // ``GET /users/current/permissions`` returns every permission across every
-  // role; filter to the synthetic ``__user_<id>__`` role for direct grants.
-  // Role-derived rows are unioned in ``PermissionsSection`` via the ``roles``
-  // prop, so leaving them in would double-count.
-  const allDirectPermissions = useMemo(
-    () => (directPermsData?.permissions ?? []).filter((p) => isSyntheticUserRole(p.role_name)),
-    [directPermsData],
-  );
-
-  // Single-tenant mode hides the Workspace column, so stale non-default
-  // rows would look like duplicates. Filter them out.
-  const roles = useMemo(
-    () => (workspacesEnabled ? allRoles : allRoles.filter((r) => r.workspace === DEFAULT_WORKSPACE_NAME)),
-    [allRoles, workspacesEnabled],
-  );
-  const directPermissions = useMemo(
-    () =>
-      workspacesEnabled
-        ? allDirectPermissions
-        : allDirectPermissions.filter((p) => p.workspace === DEFAULT_WORKSPACE_NAME),
-    [allDirectPermissions, workspacesEnabled],
-  );
+  // Direct grants live on the synthetic ``__user_<id>__`` role surfaced via
+  // ``listUserRoles`` alongside regular roles. ``PermissionsSection`` splits
+  // them on display (synthetic → "Direct" label, regular → role name), so we
+  // pass the unfiltered list down. The Roles tab below filters synthetic out
+  // separately via ``displayRoles``.
+  // Single-tenant mode hides the Workspace column; drop non-default-workspace
+  // rows so they don't look like duplicates.
+  const roles = useMemo(() => {
+    const all = rolesData?.roles ?? [];
+    return workspacesEnabled ? all : all.filter((r) => r.workspace === DEFAULT_WORKSPACE_NAME);
+  }, [rolesData, workspacesEnabled]);
+  const displayRoles = useMemo(() => roles.filter((r) => !isSyntheticUserRole(r.name)), [roles]);
 
   const handleChangePassword = async () => {
     setError(null);
@@ -179,7 +160,7 @@ const AccountPage = () => {
   };
 
   const rolesEmptyState =
-    roles.length === 0 ? (
+    displayRoles.length === 0 ? (
       <Empty
         title={intl.formatMessage({
           defaultMessage: 'No roles',
@@ -431,7 +412,7 @@ const AccountPage = () => {
                       )}
                     </TableHeader>
                   </TableRow>
-                  {roles.map((role) => (
+                  {displayRoles.map((role) => (
                     <AccountRoleRow key={role.id} role={role} workspacesEnabled={workspacesEnabled} />
                   ))}
                 </Table>
@@ -448,10 +429,8 @@ const AccountPage = () => {
             >
               <PermissionsSection
                 roles={roles}
-                directPermissions={directPermissions}
-                isLoading={rolesLoading || directPermsLoading}
+                isLoading={rolesLoading}
                 rolesError={rolesError}
-                directPermsError={directPermsError}
                 componentId="account"
                 workspacesEnabled={workspacesEnabled}
               />

--- a/mlflow/server/js/src/account/PermissionsSection.test.tsx
+++ b/mlflow/server/js/src/account/PermissionsSection.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { renderWithDesignSystem, screen, within } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
 
 import { PermissionsSection } from './PermissionsSection';
-import type { Role, UserRolePermissionRow } from './types';
+import type { Role } from './types';
 
 const role = (overrides: Partial<Role>): Role => ({
   id: 1,
@@ -14,21 +14,19 @@ const role = (overrides: Partial<Role>): Role => ({
   ...overrides,
 });
 
-const direct = (overrides: Partial<UserRolePermissionRow>): UserRolePermissionRow => ({
-  role_id: 99,
-  role_name: '__user_1__',
-  resource_type: 'experiment',
-  resource_pattern: 'exp-1',
-  permission: 'READ',
-  workspace: 'default',
-  ...overrides,
-});
+// Convenience factory for a synthetic per-user role (renders as "Direct"
+// in the Source column).
+const syntheticRole = (overrides: Partial<Role>): Role =>
+  role({
+    id: 99,
+    name: '__user_1__',
+    permissions: [{ id: 1, role_id: 99, resource_type: 'experiment', resource_pattern: 'exp-1', permission: 'READ' }],
+    ...overrides,
+  });
 
 describe('PermissionsSection', () => {
-  it('renders an empty state when neither roles nor direct grants are present', () => {
-    renderWithDesignSystem(
-      <PermissionsSection roles={[]} directPermissions={[]} componentId="test" workspacesEnabled={false} />,
-    );
+  it('renders an empty state when no roles are present', () => {
+    renderWithDesignSystem(<PermissionsSection roles={[]} componentId="test" workspacesEnabled={false} />);
     expect(screen.getByText('No permissions')).toBeInTheDocument();
     expect(screen.getByText('No resource permissions to show.')).toBeInTheDocument();
   });
@@ -41,25 +39,29 @@ describe('PermissionsSection', () => {
         permissions: [{ id: 1, role_id: 1, resource_type: 'experiment', resource_pattern: '42', permission: 'READ' }],
       }),
     ];
-    renderWithDesignSystem(
-      <PermissionsSection roles={roles} directPermissions={[]} componentId="test" workspacesEnabled={false} />,
-    );
+    renderWithDesignSystem(<PermissionsSection roles={roles} componentId="test" workspacesEnabled={false} />);
     expect(screen.getByText(/experiment:42/)).toBeInTheDocument();
     expect(screen.getByText('READ')).toBeInTheDocument();
     expect(screen.getByText('team-readers')).toBeInTheDocument();
   });
 
-  it('renders direct grants with a localized "Direct" Source', () => {
+  it('renders synthetic __user_N__ rows with a localized "Direct" Source', () => {
     renderWithDesignSystem(
       <PermissionsSection
-        roles={[]}
-        directPermissions={[direct({ permission: 'EDIT' })]}
+        roles={[
+          syntheticRole({
+            permissions: [
+              { id: 1, role_id: 99, resource_type: 'experiment', resource_pattern: 'exp-1', permission: 'EDIT' },
+            ],
+          }),
+        ]}
         componentId="test"
         workspacesEnabled={false}
       />,
     );
     expect(screen.getByText('Direct')).toBeInTheDocument();
     expect(screen.getByText('EDIT')).toBeInTheDocument();
+    expect(screen.queryByText('__user_1__')).not.toBeInTheDocument();
   });
 
   it('dedupes a triple granted via two roles into one row, listing both sources', () => {
@@ -77,12 +79,28 @@ describe('PermissionsSection', () => {
         permissions: [{ id: 2, role_id: 2, resource_type: 'experiment', resource_pattern: '42', permission: 'READ' }],
       }),
     ];
-    renderWithDesignSystem(
-      <PermissionsSection roles={roles} directPermissions={[]} componentId="test" workspacesEnabled={false} />,
-    );
+    renderWithDesignSystem(<PermissionsSection roles={roles} componentId="test" workspacesEnabled={false} />);
     // Sources are sorted alphabetically and joined with ', '.
     expect(screen.getByText('role-a, role-b')).toBeInTheDocument();
     // Only one resource cell - no duplicate row.
+    expect(screen.getAllByText(/experiment:42/)).toHaveLength(1);
+  });
+
+  it('dedupes a role-derived and direct grant on the same triple, joining both labels', () => {
+    // Synthetic and regular role granting the same (ws, type, pattern, perm)
+    // collapse into one row whose Source lists both the role name and "Direct".
+    const roles = [
+      role({
+        id: 1,
+        name: 'team-readers',
+        permissions: [{ id: 1, role_id: 1, resource_type: 'experiment', resource_pattern: '42', permission: 'READ' }],
+      }),
+      syntheticRole({
+        permissions: [{ id: 2, role_id: 99, resource_type: 'experiment', resource_pattern: '42', permission: 'READ' }],
+      }),
+    ];
+    renderWithDesignSystem(<PermissionsSection roles={roles} componentId="test" workspacesEnabled={false} />);
+    expect(screen.getByText('Direct, team-readers')).toBeInTheDocument();
     expect(screen.getAllByText(/experiment:42/)).toHaveLength(1);
   });
 
@@ -103,9 +121,7 @@ describe('PermissionsSection', () => {
         permissions: [{ id: 2, role_id: 2, resource_type: 'experiment', resource_pattern: '42', permission: 'READ' }],
       }),
     ];
-    renderWithDesignSystem(
-      <PermissionsSection roles={roles} directPermissions={[]} componentId="test" workspacesEnabled />,
-    );
+    renderWithDesignSystem(<PermissionsSection roles={roles} componentId="test" workspacesEnabled />);
     expect(screen.getAllByText(/experiment:42/)).toHaveLength(2);
     expect(screen.getByText('ws-a')).toBeInTheDocument();
     expect(screen.getByText('ws-b')).toBeInTheDocument();
@@ -113,61 +129,33 @@ describe('PermissionsSection', () => {
 
   it('hides the Workspace column when workspacesEnabled is false', () => {
     renderWithDesignSystem(
-      <PermissionsSection roles={[]} directPermissions={[direct({})]} componentId="test" workspacesEnabled={false} />,
+      <PermissionsSection roles={[syntheticRole({})]} componentId="test" workspacesEnabled={false} />,
     );
     expect(screen.queryByText('Workspace')).not.toBeInTheDocument();
   });
 
   it('shows the Workspace column when workspacesEnabled is true', () => {
-    renderWithDesignSystem(
-      <PermissionsSection roles={[]} directPermissions={[direct({})]} componentId="test" workspacesEnabled />,
-    );
+    renderWithDesignSystem(<PermissionsSection roles={[syntheticRole({})]} componentId="test" workspacesEnabled />);
     expect(screen.getByText('Workspace')).toBeInTheDocument();
   });
 
   it('surfaces rolesError as a warning Alert above the table', () => {
     renderWithDesignSystem(
       <PermissionsSection
-        roles={[]}
-        directPermissions={[direct({})]}
+        roles={[syntheticRole({})]}
         rolesError={new Error('roles backend exploded')}
         componentId="test"
         workspacesEnabled={false}
       />,
     );
-    expect(screen.getByText('Failed to load role-derived permissions')).toBeInTheDocument();
+    expect(screen.getByText('Failed to load permissions')).toBeInTheDocument();
     expect(screen.getByText('roles backend exploded')).toBeInTheDocument();
-    // Direct grants still render below the alert.
+    // Any rows we managed to receive still render below the alert.
     expect(screen.getByText('Direct')).toBeInTheDocument();
   });
 
-  it('surfaces directPermsError as a warning Alert above the table', () => {
-    const roles = [
-      role({
-        id: 1,
-        name: 'team-readers',
-        permissions: [{ id: 1, role_id: 1, resource_type: 'experiment', resource_pattern: '42', permission: 'READ' }],
-      }),
-    ];
-    renderWithDesignSystem(
-      <PermissionsSection
-        roles={roles}
-        directPermissions={[]}
-        directPermsError={new Error('direct backend exploded')}
-        componentId="test"
-        workspacesEnabled={false}
-      />,
-    );
-    expect(screen.getByText('Failed to load direct permissions')).toBeInTheDocument();
-    expect(screen.getByText('direct backend exploded')).toBeInTheDocument();
-    // Role-derived rows still render.
-    expect(screen.getByText('team-readers')).toBeInTheDocument();
-  });
-
   it('shows a Spinner instead of the table when isLoading', () => {
-    renderWithDesignSystem(
-      <PermissionsSection roles={[]} directPermissions={[]} isLoading componentId="test" workspacesEnabled={false} />,
-    );
+    renderWithDesignSystem(<PermissionsSection roles={[]} isLoading componentId="test" workspacesEnabled={false} />);
     // No table rendered (no header text); the spinner takes the place.
     expect(screen.queryByText('Resource')).not.toBeInTheDocument();
     expect(screen.queryByText('No permissions')).not.toBeInTheDocument();
@@ -197,7 +185,7 @@ describe('PermissionsSection', () => {
       }),
     ];
     const { container } = renderWithDesignSystem(
-      <PermissionsSection roles={roles} directPermissions={[]} componentId="test" workspacesEnabled />,
+      <PermissionsSection roles={roles} componentId="test" workspacesEnabled />,
     );
 
     // Find the resource cells in document order; first-row resource should be

--- a/mlflow/server/js/src/account/PermissionsSection.tsx
+++ b/mlflow/server/js/src/account/PermissionsSection.tsx
@@ -11,23 +11,20 @@ import {
   useDesignSystemTheme,
 } from '@databricks/design-system';
 import { FormattedMessage, useIntl } from 'react-intl';
-import type { Role, UserRolePermissionRow } from './types';
-import { formatResourcePattern } from './types';
+import type { Role } from './types';
+import { formatResourcePattern, isSyntheticUserRole } from './types';
 
 interface Props {
-  roles: Role[];
   /**
-   * Direct grants only — rows on the user's synthetic ``__user_<id>__``
-   * role. The caller is responsible for filtering ``GET /users/permissions/list``
-   * to that role (e.g. via ``isSyntheticUserRole``) before passing here, so
-   * role-derived rows aren't double-counted alongside the ``roles`` prop.
+   * Every role the user holds — including the synthetic ``__user_<id>__``
+   * role(s) that back direct grants. The component splits them on display:
+   * synthetic rows render with the localized ``Direct`` label; everything
+   * else renders with the role name as Source.
    */
-  directPermissions: UserRolePermissionRow[];
+  roles: Role[];
   isLoading?: boolean;
-  /** Non-fatal - surfaces inline so direct grants still render. */
+  /** Non-fatal - surfaces inline so any rows we have still render. */
   rolesError?: unknown;
-  /** Non-fatal - surfaces inline so role-derived rows still render. */
-  directPermsError?: unknown;
   /** Scopes the component IDs emitted by this section. */
   componentId: string;
   /** When false, the Workspace column is hidden. Defaults to true. */
@@ -51,15 +48,7 @@ const rowKey = (workspace: string | null, resource_type: string, resource_patter
  * ``(type, pattern, permission)`` granted in two workspaces stays as
  * two rows.
  */
-export const PermissionsSection = ({
-  roles,
-  directPermissions,
-  isLoading,
-  rolesError,
-  directPermsError,
-  componentId,
-  workspacesEnabled = true,
-}: Props) => {
+export const PermissionsSection = ({ roles, isLoading, rolesError, componentId, workspacesEnabled = true }: Props) => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
 
@@ -80,17 +69,18 @@ export const PermissionsSection = ({
         byKey.set(key, { workspace, resource_type, resource_pattern, permission, sources: new Set([source]) });
       }
     };
-    for (const role of roles) {
-      for (const p of role.permissions ?? []) {
-        upsert(role.workspace, p.resource_type, p.resource_pattern, p.permission, role.name);
-      }
-    }
     const directLabel = intl.formatMessage({
       defaultMessage: 'Direct',
       description: 'Source label for a per-resource permission granted directly to the user (not via a role)',
     });
-    for (const p of directPermissions) {
-      upsert(p.workspace, p.resource_type, p.resource_pattern, p.permission, directLabel);
+    for (const role of roles) {
+      // Synthetic ``__user_N__`` roles back per-user direct grants; render
+      // them under the localized ``Direct`` label rather than the synthetic
+      // role name.
+      const source = isSyntheticUserRole(role.name) ? directLabel : role.name;
+      for (const p of role.permissions ?? []) {
+        upsert(role.workspace, p.resource_type, p.resource_pattern, p.permission, source);
+      }
     }
     return Array.from(byKey.values()).sort((a, b) => {
       const aw = a.workspace ?? '';
@@ -100,7 +90,7 @@ export const PermissionsSection = ({
       if (a.resource_pattern !== b.resource_pattern) return a.resource_pattern.localeCompare(b.resource_pattern);
       return a.permission.localeCompare(b.permission);
     });
-  }, [roles, directPermissions, intl]);
+  }, [roles, intl]);
 
   return (
     <>
@@ -109,33 +99,14 @@ export const PermissionsSection = ({
           componentId={`${componentId}.roles_error`}
           type="warning"
           message={intl.formatMessage({
-            defaultMessage: 'Failed to load role-derived permissions',
+            defaultMessage: 'Failed to load permissions',
             description: 'Alert title shown when the roles query fails on the permissions section',
           })}
           description={
             (rolesError as Error)?.message ||
             intl.formatMessage({
-              defaultMessage: 'Showing direct grants only - role-derived permissions are unavailable.',
-              description:
-                'Alert description shown when only direct grants are available because role-derived permissions failed to load',
-            })
-          }
-        />
-      ) : null}
-      {directPermsError ? (
-        <Alert
-          componentId={`${componentId}.direct_permissions_error`}
-          type="warning"
-          message={intl.formatMessage({
-            defaultMessage: 'Failed to load direct permissions',
-            description: 'Alert title shown when the direct-permissions query fails',
-          })}
-          description={
-            (directPermsError as Error)?.message ||
-            intl.formatMessage({
-              defaultMessage: 'Showing role-derived permissions only - direct grants are unavailable.',
-              description:
-                'Alert description shown when only role-derived permissions are available because direct grants failed to load',
+              defaultMessage: 'Permissions for this user are temporarily unavailable.',
+              description: 'Alert description shown when role-derived permissions failed to load',
             })
           }
         />

--- a/mlflow/server/js/src/admin/pages/UserDetailPage.tsx
+++ b/mlflow/server/js/src/admin/pages/UserDetailPage.tsx
@@ -17,13 +17,7 @@ import {
 import { ScrollablePageWrapper } from '@mlflow/mlflow/src/common/components/ScrollablePageWrapper';
 import { Link, useParams, useSearchParams } from '../../common/utils/RoutingUtils';
 import { useActiveWorkspace } from '../../workspaces/utils/WorkspaceUtils';
-import {
-  useCurrentUserIsAdmin,
-  useUserPermissionsQuery,
-  useUserRolesQuery,
-  useUsersQuery,
-  useWithSettingsReturnTo,
-} from '../hooks';
+import { useCurrentUserIsAdmin, useUserRolesQuery, useUsersQuery, useWithSettingsReturnTo } from '../hooks';
 import { useWorkspacesEnabled } from '../../experiment-tracking/hooks/useServerInfo';
 import AdminRoutes from '../routes';
 import { EditAccessModal } from '../components/EditAccessModal';
@@ -42,7 +36,6 @@ const UserDetailPage = () => {
   const activeTab = tabFromUrl === 'permissions' ? 'permissions' : 'roles';
 
   const { data: rolesData, isLoading: rolesLoading, error: rolesErrorRaw } = useUserRolesQuery(username);
-  const { data: directPermsData, isLoading: directPermsLoading } = useUserPermissionsQuery(username);
   // ``useUsersQuery`` is admin-only; we use it just to surface the
   // ``is_admin`` flag for this user. Failing this should not block the
   // permissions view, so the error is not fatal here.
@@ -64,24 +57,20 @@ const UserDetailPage = () => {
   const [editAccessOpen, setEditAccessOpen] = useState(false);
 
   const user = useMemo(() => usersData?.users?.find((u) => u.username === username), [usersData, username]);
-  // Strip synthetic ``__user_N__`` roles — they back per-user direct
-  // grants and are rendered separately by the Permissions section.
-  const allRoles = useMemo(() => (rolesData?.roles ?? []).filter((r) => !isSyntheticUserRole(r.name)), [rolesData]);
-  const roles = isAdmin || !activeWorkspace ? allRoles : allRoles.filter((r) => r.workspace === activeWorkspace);
-  // ``GET /users/permissions/list`` returns every permission across every
-  // role the user holds; filter to the synthetic ``__user_<id>__`` role to
-  // get just the direct grants. Role-derived permissions are handled
-  // separately via the ``roles`` union in ``PermissionsSection``.
-  const allDirectPermissions = (directPermsData?.permissions ?? []).filter((p) => isSyntheticUserRole(p.role_name));
-  // Direct permissions also carry ``workspace`` — same scope rule as roles:
-  // workspace managers only see grants in the active workspace.
-  const directPermissions =
-    isAdmin || !activeWorkspace
-      ? allDirectPermissions
-      : allDirectPermissions.filter((p) => p.workspace === activeWorkspace);
+  // Direct grants live on the synthetic ``__user_<id>__`` role surfaced via
+  // ``listUserRoles`` alongside regular roles. ``PermissionsSection`` splits
+  // them on display (synthetic → "Direct" label, regular → role name), so we
+  // pass the unfiltered list down. The Roles tab below filters synthetic out
+  // separately via ``displayRoles``.
+  // Workspace managers see only roles in the active workspace; admins see all.
+  const roles = useMemo(() => {
+    const all = rolesData?.roles ?? [];
+    return isAdmin || !activeWorkspace ? all : all.filter((r) => r.workspace === activeWorkspace);
+  }, [rolesData, isAdmin, activeWorkspace]);
+  const displayRoles = useMemo(() => roles.filter((r) => !isSyntheticUserRole(r.name)), [roles]);
 
   const rolesEmptyState =
-    roles.length === 0 ? (
+    displayRoles.length === 0 ? (
       <Empty
         title="No roles"
         description={
@@ -206,7 +195,7 @@ const UserDetailPage = () => {
                     {workspacesEnabled ? 'Workspace Manager' : 'Admin'}
                   </TableHeader>
                 </TableRow>
-                {roles.map((role) => (
+                {displayRoles.map((role) => (
                   <TableRow key={role.id}>
                     <TableCell css={{ flex: 2 }}>
                       <Link componentId="admin.user_detail.role_link" to={AdminRoutes.getRoleDetailRoute(role.id)}>
@@ -235,18 +224,10 @@ const UserDetailPage = () => {
               gap: theme.spacing.md,
             }}
           >
-            {/*
-             * ``directPermsError`` is intentionally not surfaced: a missing
-             * or empty direct-permissions response degrades silently to
-             * "role-derived rows only", because the fetch isn't load-bearing
-             * for this view (the Roles tab and the Permissions union are
-             * still useful without the direct-grant rows).
-             */}
             <PermissionsSection
               componentId="admin.user_detail.permissions"
               roles={roles}
-              directPermissions={directPermissions}
-              isLoading={rolesLoading || directPermsLoading}
+              isLoading={rolesLoading}
               rolesError={rolesError}
               workspacesEnabled={workspacesEnabled}
             />

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -4279,6 +4279,10 @@
     "defaultMessage": "Registered at",
     "description": "Column title text for created at timestamp in model version table"
   },
+  "NmWSTV": {
+    "defaultMessage": "Failed to load permissions",
+    "description": "Alert title shown when the roles query fails on the permissions section"
+  },
   "NnO0Lz": {
     "defaultMessage": "MLflow allows you to evaluate your GenAI applications using scorers. Scorers compute quality metrics like relevance, correctness, and custom assessments. Copy the code snippet below to run an evaluation, or visit the documentation for a more in-depth example.",
     "description": "Empty state description for the quality tab in overview page"
@@ -4374,10 +4378,6 @@
   "OH7hV5": {
     "defaultMessage": "Value",
     "description": "Tag filter input for value field in the tags filter popover for experiments page search by tags"
-  },
-  "OJBFVt": {
-    "defaultMessage": "Showing role-derived permissions only - direct grants are unavailable.",
-    "description": "Alert description shown when only role-derived permissions are available because direct grants failed to load"
   },
   "OLZyxe": {
     "defaultMessage": "{errorCount, plural, one {# error} other {# errors}}",
@@ -5190,10 +5190,6 @@
   "TCAbKZ": {
     "defaultMessage": "Save",
     "description": "Save webhook button"
-  },
-  "TI/9fP": {
-    "defaultMessage": "Showing direct grants only - role-derived permissions are unavailable.",
-    "description": "Alert description shown when only direct grants are available because role-derived permissions failed to load"
   },
   "TKtJIK": {
     "defaultMessage": "Page not found",
@@ -7354,6 +7350,10 @@
   "fdfi96": {
     "defaultMessage": "Create judge",
     "description": "Button to create a new judge"
+  },
+  "ffHGW/": {
+    "defaultMessage": "Permissions for this user are temporarily unavailable.",
+    "description": "Alert description shown when role-derived permissions failed to load"
   },
   "ffIouW": {
     "defaultMessage": "Retrieval sufficiency assessment is missing. This is likely because your agent is not returning retrieved_context.",
@@ -9611,10 +9611,6 @@
     "defaultMessage": "You are exceeding a limit of {limit} aliases assigned to the single model version",
     "description": "Alias editor > Warning about exceeding aliases limit"
   },
-  "s+Flkm": {
-    "defaultMessage": "Failed to load direct permissions",
-    "description": "Alert title shown when the direct-permissions query fails"
-  },
   "s29iQg": {
     "defaultMessage": "Session",
     "description": "Usage overview > metrics filter > session column option label"
@@ -9666,10 +9662,6 @@
   "sD3+jL": {
     "defaultMessage": "Failed to save webhook",
     "description": "Generic error message informing the user that webhook saving failed"
-  },
-  "sDAqfh": {
-    "defaultMessage": "Failed to load role-derived permissions",
-    "description": "Alert title shown when the roles query fails on the permissions section"
   },
   "sDqD2S": {
     "defaultMessage": "The dataset is an array. To see a preview of the dataset, view the dataset in the training notebook.",


### PR DESCRIPTION
### Related Issues/PRs

RBAC bugbash paper-cut. Pat noticed synthetic role names leaking into the self-view Account page; the underlying cause is a vestigial data-flow pattern.

### What changes are proposed in this pull request?

Synthetic per-user roles (\`__user_<id>__\`) back the direct-grant API and are an implementation detail of the auth store. They appeared in the UI on the self-view Account page in two places:

1. **Roles tab** listed \`__user_1__\` as if it were a regular assigned role.
2. **Permissions tab** Source column showed both \`__user_1__\` and \`Direct\` for the same row (the synthetic role's permissions get unioned by \`(workspace, type, pattern, permission)\` with the direct-grant pass; both labels ended up in the \`sources\` set).

**Root cause**: \`PermissionsSection\` accepted both a \`roles\` prop AND a parallel \`directPermissions\` prop, even though the synthetic role(s) in \`useUserRolesQuery\`'s response already carry the same data. The parallel pass was a vestige from the pre-unification era (separate per-resource endpoint family, removed in #23337) when role-derived and direct-derived grants truly came from different sources.

**Refactor**: \`PermissionsSection\` now takes only \`roles\` and splits synthetic vs. regular on display. The dedup loop labels synthetic roles with the localized \`Direct\` string; regular roles keep their role name as Source. Both callers (\`AccountPage\`, \`UserDetailPage\`) stop firing the parallel \`useMyPermissionsQuery\` / \`useUserPermissionsQuery\` for display — one fewer query per page open, and the synthetic-role display behavior is now self-contained (impossible to leak by construction).

\`EditAccessModal\` still uses \`useUserPermissionsQuery\` (workspace-scoped) for its editable-state pre-fill, which has different semantics from the display path. That hook stays in the codebase.

### How is this PR tested?

- [x] \`yarn test --testPathPattern='account/PermissionsSection'\` — 11/11. Updated fixtures to use synthetic role objects; new case pins the merged \`Direct, role-name\` Source.
- [x] \`yarn test --testPathPattern='(account/|admin/)'\` — 4332/4333 (1 pre-existing skip).
- [x] \`yarn type-check && yarn lint && yarn prettier:check\` — clean.
- [x] Manual: log in as a user with at least one direct grant; visit \`/account\`. Roles tab no longer lists \`__user_<id>__\`; Permissions tab Source column shows only \`Direct\` for direct grants. Same behavior on \`/admin/users/<username>\`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] \`area/uiux\`

<a name=\"release-note-category\"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] \`rn/bug-fix\`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release


This pull request and its description were written by Isaac.