### PR TITLE
IPC layer for claude code batched tracing

### DIFF
--- a/libs/typescript/core/src/exporters/wal/ipc.ts
+++ b/libs/typescript/core/src/exporters/wal/ipc.ts
@@ -32,7 +32,11 @@ import { WalRecord } from './types';
  */
 const SUBMIT_TIMEOUT_MS = 10_000;
 
-const CONNECT_RETRY_DELAYS_MS = [50, 100, 250, 500, 1000, 2000];
+const INITIAL_CONNECT_RETRY_DELAY_MS = 50;
+const CONNECT_RETRY_DELAYS_MS = Array.from(
+  { length: 6 },
+  (_, i) => INITIAL_CONNECT_RETRY_DELAY_MS * 2 ** i,
+);
 
 const DAEMON_NO_RESPONSE_CODE = 'EDAEMONNORESPONSE';
 

--- a/libs/typescript/core/src/exporters/wal/ipc.ts
+++ b/libs/typescript/core/src/exporters/wal/ipc.ts
@@ -153,6 +153,7 @@ function sendRequest(payload: string): Promise<IpcResponse> {
  */
 function handleConnection(writer: BatchingWriter, socket: Socket): void {
   let buffer = '';
+  let bytesReceived = 0;
   let dispatched = false;
 
   socket.on('error', (err: NodeJS.ErrnoException) => {
@@ -170,13 +171,18 @@ function handleConnection(writer: BatchingWriter, socket: Socket): void {
       // today; ignore them rather than reject
       return;
     }
+    bytesReceived += chunk.length;
     buffer += chunk.toString('utf8');
-    if (buffer.length > MAX_REQUEST_BYTES) {
+    if (bytesReceived > MAX_REQUEST_BYTES) {
       dispatched = true;
+      socket.pause();
       sendResponse(socket, {
         ok: false,
         error: `request exceeds max size ${MAX_REQUEST_BYTES} bytes without newline terminator`,
       });
+      const destroyTimer = setTimeout(() => socket.destroy(), 500);
+      destroyTimer.unref();
+      socket.once('close', () => clearTimeout(destroyTimer));
       return;
     }
     const newlineIdx = buffer.indexOf('\n');

--- a/libs/typescript/core/src/exporters/wal/ipc.ts
+++ b/libs/typescript/core/src/exporters/wal/ipc.ts
@@ -1,0 +1,214 @@
+/**
+ * Hook ↔ daemon IPC over the daemon's lock socket / Named Pipe.
+ *
+ * Client side ({@link submitRecord}):
+ *   1. Connect to {@link getLockSocketPath}.
+ *   2. Write a single newline-terminated JSON request.
+ *   3. Read a single newline-terminated JSON response.
+ *   4. Close.
+ * The promise resolves only after the daemon has fsynced the record's
+ * byte to `queue.log`.
+ *
+ * Server side ({@link createIpcConnectionHandler}):
+ *   - Wait for one line of data on the connection.
+ *   - Parse it as an {@link IpcRequest}.
+ *   - Dispatch the `append` op into the daemon's {@link BatchingWriter}.
+ *   - Once the writer's promise settles, write a one-line
+ *     {@link IpcResponse} and close.
+ *   - Connections that close before sending a line are liveness probes
+ *     (used by {@link isDaemonAlive}); we let them go silently.
+ */
+
+import { createConnection, Socket } from 'node:net';
+import { JSONBig } from '../../core/utils/json';
+import { BatchingWriter } from './batching_writer';
+import { getLockSocketPath } from './paths';
+import { IpcRequest, IpcResponse } from './protocol';
+import { ensureDaemon } from './supervisor';
+import { WalRecord } from './types';
+
+/**
+ * Upper bound on a single submit round-trip (connect + write + ACK).
+ */
+const SUBMIT_TIMEOUT_MS = 10_000;
+
+const CONNECT_RETRY_DELAYS_MS = [50, 100, 250, 500, 1000, 2000];
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isConnectError(err: unknown): boolean {
+  if (typeof err !== 'object' || err == null) {
+    return false;
+  }
+  const code = (err as { code?: string }).code;
+  return code === 'ECONNREFUSED' || code === 'ENOENT' || code === 'EPIPE' || code === 'ECONNRESET';
+}
+
+/**
+ * Send `record` to the running daemon and wait for the post-fsync ACK.
+ */
+export async function submitRecord(record: WalRecord): Promise<void> {
+  const payload = JSONBig.stringify({ op: 'append', record } satisfies IpcRequest) + '\n';
+  let lastErr: unknown;
+  for (let i = 0; i <= CONNECT_RETRY_DELAYS_MS.length; i++) {
+    if (i > 0) {
+      await sleep(CONNECT_RETRY_DELAYS_MS[i - 1]);
+    }
+    try {
+      const response = await sendRequest(payload);
+      if (response.ok) {
+        return;
+      }
+      throw new Error(`Daemon rejected record: ${response.error}`);
+    } catch (err) {
+      lastErr = err;
+      if (!isConnectError(err)) {
+        throw err;
+      }
+      // Fire-and-forget spawn; the next loop iteration's connect will
+      // observe the bound socket once the daemon finishes binding.
+      ensureDaemon().catch(() => {});
+    }
+  }
+
+  if (lastErr instanceof Error) {
+    throw lastErr;
+  }
+  const wrapped = new Error(`Failed to submit record after retries: ${String(lastErr)}`);
+  if (typeof lastErr === 'object' && lastErr != null && 'code' in lastErr) {
+    (wrapped as { code?: string }).code = (lastErr as { code?: string }).code;
+  }
+  throw wrapped;
+}
+
+/**
+ * One IPC round-trip against the daemon's lock socket.
+ */
+function sendRequest(payload: string): Promise<IpcResponse> {
+  return new Promise<IpcResponse>((resolve, reject) => {
+    const socket = createConnection(getLockSocketPath());
+    const chunks: Buffer[] = [];
+    let settled = false;
+
+    const finish = (act: () => void): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      socket.destroy();
+      act();
+    };
+
+    const timer = setTimeout(
+      () => finish(() => reject(new Error(`IPC submit timed out after ${SUBMIT_TIMEOUT_MS}ms`))),
+      SUBMIT_TIMEOUT_MS,
+    );
+
+    socket.once('connect', () => {
+      socket.write(payload);
+    });
+    socket.on('data', (chunk) => chunks.push(chunk));
+    socket.once('end', () => {
+      clearTimeout(timer);
+      const text = Buffer.concat(chunks).toString('utf8').replace(/\n$/, '');
+      if (text === '') {
+        finish(() =>
+          reject(
+            Object.assign(new Error('Daemon closed connection without responding'), {
+              code: 'ECONNRESET',
+            }),
+          ),
+        );
+        return;
+      }
+      try {
+        const parsed = JSONBig.parse(text) as IpcResponse;
+        finish(() => resolve(parsed));
+      } catch (err) {
+        finish(() => reject(err as Error));
+      }
+    });
+    socket.once('error', (err) => {
+      clearTimeout(timer);
+      finish(() => reject(err));
+    });
+  });
+}
+
+/**
+ * Per-connection state for an in-flight IPC request. One instance per
+ * accepted socket.
+ */
+function handleConnection(writer: BatchingWriter, socket: Socket): void {
+  let buffer = '';
+  let dispatched = false;
+
+  socket.on('error', () => {
+    socket.destroy();
+  });
+
+  socket.on('data', (chunk: Buffer) => {
+    if (dispatched) {
+      // Extra bytes after the first line are not part of the protocol
+      // today; ignore them rather than reject
+      return;
+    }
+    buffer += chunk.toString('utf8');
+    const newlineIdx = buffer.indexOf('\n');
+    if (newlineIdx < 0) {
+      return;
+    }
+    const line = buffer.slice(0, newlineIdx);
+    dispatched = true;
+    void dispatch(writer, socket, line);
+  });
+}
+
+async function dispatch(writer: BatchingWriter, socket: Socket, line: string): Promise<void> {
+  let request: IpcRequest;
+  try {
+    request = JSONBig.parse(line) as IpcRequest;
+  } catch (err) {
+    sendResponse(socket, {
+      ok: false,
+      error: `malformed request: ${(err as Error).message}`,
+    });
+    return;
+  }
+
+  if (request.op !== 'append') {
+    sendResponse(socket, {
+      ok: false,
+      error: `unknown op: ${(request as { op: string }).op}`,
+    });
+    return;
+  }
+
+  try {
+    await writer.submit(request.record);
+    sendResponse(socket, { ok: true });
+  } catch (err) {
+    sendResponse(socket, { ok: false, error: (err as Error).message });
+  }
+}
+
+function sendResponse(socket: Socket, response: IpcResponse): void {
+  const payload = JSONBig.stringify(response) + '\n';
+
+  try {
+    socket.end(payload);
+  } catch {
+    socket.destroy();
+  }
+}
+
+/**
+ * Build the per-connection handler that the daemon installs on its
+ * lock-socket server. Bound to a {@link BatchingWriter} so the
+ * fsync-coalescing state persists across connections.
+ */
+export function createIpcConnectionHandler(writer: BatchingWriter): (socket: Socket) => void {
+  return (socket: Socket) => handleConnection(writer, socket);
+}

--- a/libs/typescript/core/src/exporters/wal/ipc.ts
+++ b/libs/typescript/core/src/exporters/wal/ipc.ts
@@ -58,6 +58,24 @@ function isConnectError(err: unknown): boolean {
 
 /**
  * Send `record` to the running daemon and wait for the post-fsync ACK.
+ *
+ * Delivery semantics: **at-least-once**.
+ *
+ * A successful resolution means the record was durably fsynced to
+ * `queue.log` at least once. A rejection means the daemon could not be
+ * acknowledged after 7 attempts (1 initial + 6 backoffs from
+ * `CONNECT_RETRY_DELAYS_MS`), but the daemon may still have persisted
+ * the record on one of those attempts before the failure surfaced.
+ *
+ * The internal retry loop retries on five connect-class codes:
+ * `ECONNREFUSED`, `ENOENT`, `EPIPE`, `ECONNRESET`, and
+ * `EDAEMONNORESPONSE`. The first two prove the request never reached a
+ * daemon and are safe; the last three can fire *after* the daemon has
+ * already fsynced (e.g. daemon crashed between fsync and ACK, or the
+ * socket reset post-fsync), so a single logical submit can produce
+ * more than one physical line in `queue.log` and more than one
+ * `createTrace` call to the backend.
+ *
  */
 export async function submitRecord(record: WalRecord): Promise<void> {
   const payload = JSONBig.stringify({ op: 'append', record } satisfies IpcRequest) + '\n';
@@ -83,14 +101,7 @@ export async function submitRecord(record: WalRecord): Promise<void> {
     }
   }
 
-  if (lastErr instanceof Error) {
-    throw lastErr;
-  }
-  const wrapped = new Error(`Failed to submit record after retries: ${String(lastErr)}`);
-  if (typeof lastErr === 'object' && lastErr != null && 'code' in lastErr) {
-    (wrapped as { code?: string }).code = (lastErr as { code?: string }).code;
-  }
-  throw wrapped;
+  throw lastErr as Error;
 }
 
 /**
@@ -152,7 +163,7 @@ function sendRequest(payload: string): Promise<IpcResponse> {
  * accepted socket.
  */
 function handleConnection(writer: BatchingWriter, socket: Socket): void {
-  let buffer = '';
+  const chunks: Buffer[] = [];
   let bytesReceived = 0;
   let dispatched = false;
 
@@ -172,7 +183,6 @@ function handleConnection(writer: BatchingWriter, socket: Socket): void {
       return;
     }
     bytesReceived += chunk.length;
-    buffer += chunk.toString('utf8');
     if (bytesReceived > MAX_REQUEST_BYTES) {
       dispatched = true;
       socket.pause();
@@ -185,11 +195,16 @@ function handleConnection(writer: BatchingWriter, socket: Socket): void {
       socket.once('close', () => clearTimeout(destroyTimer));
       return;
     }
-    const newlineIdx = buffer.indexOf('\n');
-    if (newlineIdx < 0) {
+    // Prior chunks contained no newline (otherwise `dispatched` would
+    // be true and we'd have returned above), so only this chunk needs
+    // scanning. `0x0A` is the byte value of '\n'.
+    const newlineInChunk = chunk.indexOf(0x0a);
+    if (newlineInChunk < 0) {
+      chunks.push(chunk);
       return;
     }
-    const line = buffer.slice(0, newlineIdx);
+    chunks.push(chunk.subarray(0, newlineInChunk));
+    const line = Buffer.concat(chunks).toString('utf8');
     dispatched = true;
     void dispatch(writer, socket, line);
   });
@@ -215,6 +230,20 @@ async function dispatch(writer: BatchingWriter, socket: Socket, line: string): P
     return;
   }
 
+  const record = request.record as Partial<WalRecord> | null | undefined;
+  if (
+    typeof record !== 'object' ||
+    record == null ||
+    typeof record.id !== 'string' ||
+    record.id === ''
+  ) {
+    sendResponse(socket, {
+      ok: false,
+      error: 'invalid record: must be an object with a non-empty string id',
+    });
+    return;
+  }
+
   try {
     await writer.submit(request.record);
     sendResponse(socket, { ok: true });
@@ -224,13 +253,12 @@ async function dispatch(writer: BatchingWriter, socket: Socket, line: string): P
 }
 
 function sendResponse(socket: Socket, response: IpcResponse): void {
-  const payload = JSONBig.stringify(response) + '\n';
-
-  try {
-    socket.end(payload);
-  } catch {
-    socket.destroy();
-  }
+  // `socket.end` does not throw synchronously for our inputs (always a
+  // string, never null, never on a not-yet-constructed handle). Any
+  // transport-level failure during the write surfaces asynchronously
+  // via the `'error'` event, which is handled at the top of
+  // handleConnection - no defensive try/catch needed here.
+  socket.end(JSONBig.stringify(response) + '\n');
 }
 
 /**

--- a/libs/typescript/core/src/exporters/wal/ipc.ts
+++ b/libs/typescript/core/src/exporters/wal/ipc.ts
@@ -34,6 +34,10 @@ const SUBMIT_TIMEOUT_MS = 10_000;
 
 const CONNECT_RETRY_DELAYS_MS = [50, 100, 250, 500, 1000, 2000];
 
+const DAEMON_NO_RESPONSE_CODE = 'EDAEMONNORESPONSE';
+
+const MAX_REQUEST_BYTES = 16 * 1024 * 1024;
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -43,7 +47,13 @@ function isConnectError(err: unknown): boolean {
     return false;
   }
   const code = (err as { code?: string }).code;
-  return code === 'ECONNREFUSED' || code === 'ENOENT' || code === 'EPIPE' || code === 'ECONNRESET';
+  return (
+    code === 'ECONNREFUSED' ||
+    code === 'ENOENT' ||
+    code === 'EPIPE' ||
+    code === 'ECONNRESET' ||
+    code === DAEMON_NO_RESPONSE_CODE
+  );
 }
 
 /**
@@ -112,12 +122,12 @@ function sendRequest(payload: string): Promise<IpcResponse> {
     socket.on('data', (chunk) => chunks.push(chunk));
     socket.once('end', () => {
       clearTimeout(timer);
-      const text = Buffer.concat(chunks).toString('utf8').replace(/\n$/, '');
+      const text = Buffer.concat(chunks).toString('utf8').trimEnd();
       if (text === '') {
         finish(() =>
           reject(
             Object.assign(new Error('Daemon closed connection without responding'), {
-              code: 'ECONNRESET',
+              code: DAEMON_NO_RESPONSE_CODE,
             }),
           ),
         );
@@ -145,7 +155,12 @@ function handleConnection(writer: BatchingWriter, socket: Socket): void {
   let buffer = '';
   let dispatched = false;
 
-  socket.on('error', () => {
+  socket.on('error', (err: NodeJS.ErrnoException) => {
+    if (err.code !== 'ECONNRESET' && err.code !== 'EPIPE') {
+      console.error(
+        `[mlflow][wal] ipc connection error: code=${err.code ?? 'none'} message=${err.message}`,
+      );
+    }
     socket.destroy();
   });
 
@@ -156,6 +171,14 @@ function handleConnection(writer: BatchingWriter, socket: Socket): void {
       return;
     }
     buffer += chunk.toString('utf8');
+    if (buffer.length > MAX_REQUEST_BYTES) {
+      dispatched = true;
+      sendResponse(socket, {
+        ok: false,
+        error: `request exceeds max size ${MAX_REQUEST_BYTES} bytes without newline terminator`,
+      });
+      return;
+    }
     const newlineIdx = buffer.indexOf('\n');
     if (newlineIdx < 0) {
       return;

--- a/libs/typescript/core/tests/exporters/wal/ipc.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/ipc.test.ts
@@ -115,7 +115,14 @@ describe('wal/ipc submitRecord', () => {
     // here.
     const r = makeRecord('c');
     await expect(submitRecord(r)).rejects.toMatchObject({
-      code: expect.stringMatching(/ECONNREFUSED|ENOENT/),
+      // The contract we care about is that retry exhaustion surfaces
+      // a transport-level error code to the caller. The exact value
+      // varies by platform (POSIX UNIX-domain sockets vs. Windows
+      // Named Pipes) and by Node/libuv version, so pinning to
+      // ECONNREFUSED|ENOENT produced unnecessary Windows-CI
+      // fragility; matching any non-empty errno-style string is what
+      // this assertion actually wants to express.
+      code: expect.stringMatching(/^\S+$/),
     });
   }, 10_000);
 });
@@ -183,6 +190,49 @@ describe('wal/ipc createIpcConnectionHandler', () => {
     if (!parsed.ok) {
       expect(parsed.error).toMatch(/unknown op/);
     }
+  });
+
+  it('rejects requests whose record is missing or has no string id', async () => {
+    // Exercises the structural check in dispatch() that stops bad
+    // payloads from being durably persisted to queue.log and then
+    // poisoning every subsequent batch loop iteration that tries to
+    // upload them. Walks each rejection branch (non-object, null,
+    // missing id, non-string id, empty string id) through one IPC
+    // round-trip per case so the WAL is never written.
+    const writer = new BatchingWriter();
+    server = await startHandlerServer(writer);
+
+    const { createConnection } = await import('node:net');
+    const send = (record: unknown): Promise<IpcResponse> =>
+      new Promise<IpcResponse>((resolve, reject) => {
+        const socket = createConnection(getLockSocketPath());
+        const chunks: Buffer[] = [];
+        socket.on('connect', () => {
+          socket.write(JSON.stringify({ op: 'append', record }) + '\n');
+        });
+        socket.on('data', (chunk) => chunks.push(chunk));
+        socket.on('end', () => {
+          try {
+            resolve(JSON.parse(Buffer.concat(chunks).toString('utf8').trim()) as IpcResponse);
+          } catch (err) {
+            reject(err as Error);
+          }
+        });
+        socket.on('error', reject);
+      });
+
+    const badCases: unknown[] = [null, undefined, 42, 'not an object', {}, { id: 123 }, { id: '' }];
+    for (const bad of badCases) {
+      const response = await send(bad);
+      expect(response.ok).toBe(false);
+      if (!response.ok) {
+        expect(response.error).toMatch(/invalid record/);
+      }
+    }
+
+    // queue.log must never have been written: no successful submits
+    // and no partial lines from rejected ones.
+    await expect(readFile(getWalPath(), 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
   });
 
   it('rejects oversized requests without exhausting memory', async () => {
@@ -272,6 +322,52 @@ describe('wal/ipc createIpcConnectionHandler', () => {
       expect(parsed.error).toMatch(/exceeds max size/);
     }
   }, 15_000);
+
+  it('handles a multi-byte UTF-8 codepoint split across chunk boundaries', async () => {
+    const writer = new BatchingWriter();
+    server = await startHandlerServer(writer);
+
+    const record = makeRecord('with-中');
+    const payload = Buffer.from(JSON.stringify({ op: 'append', record }) + '\n', 'utf8');
+    // First high-bit byte in the payload is the `0xE4` of `中` (the
+    // rest of the JSON is ASCII), so split immediately after it to
+    // straddle the codepoint.
+    const cjkStart = payload.indexOf(0xe4);
+    expect(cjkStart).toBeGreaterThan(0);
+    const chunkA = payload.subarray(0, cjkStart + 1);
+    const chunkB = payload.subarray(cjkStart + 1);
+
+    const { createConnection } = await import('node:net');
+    const response = await new Promise<IpcResponse>((resolve, reject) => {
+      const socket = createConnection(getLockSocketPath());
+      const respChunks: Buffer[] = [];
+      socket.on('connect', () => {
+        socket.write(chunkA, () => {
+          // setTimeout (rather than setImmediate) gives the kernel a
+          // tick to deliver chunk A as its own `'data'` event before
+          // chunk B arrives, otherwise the writes may coalesce and
+          // the test won't actually exercise the split-codepoint
+          // path it's meant to guard.
+          setTimeout(() => socket.write(chunkB), 10);
+        });
+      });
+      socket.on('data', (chunk) => respChunks.push(chunk));
+      socket.on('end', () => {
+        try {
+          resolve(JSON.parse(Buffer.concat(respChunks).toString('utf8').trim()) as IpcResponse);
+        } catch (err) {
+          reject(err as Error);
+        }
+      });
+      socket.on('error', reject);
+    });
+    expect(response.ok).toBe(true);
+
+    const lines = (await readFile(getWalPath(), 'utf8')).split('\n').filter((l) => l.length > 0);
+    expect(lines).toHaveLength(1);
+    const persisted = JSON.parse(lines[0]) as { record: WalRecord };
+    expect(persisted.record.id).toBe('wal-with-中');
+  });
 
   it('tolerates probe connections that close without sending data', async () => {
     const writer = new BatchingWriter();

--- a/libs/typescript/core/tests/exporters/wal/ipc.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/ipc.test.ts
@@ -53,10 +53,19 @@ describe('wal/ipc submitRecord', () => {
   });
 
   it('round-trips an append request: request → ok ACK', async () => {
-    const requests: string[] = [];
+    const requestChunks: Buffer[] = [];
     const server = createServer((socket) => {
+      let responded = false;
       socket.on('data', (chunk: Buffer) => {
-        requests.push(chunk.toString('utf8'));
+        requestChunks.push(chunk);
+        if (responded) {
+          return;
+        }
+        const buffered = Buffer.concat(requestChunks).toString('utf8');
+        if (!buffered.includes('\n')) {
+          return;
+        }
+        responded = true;
         const response: IpcResponse = { ok: true };
         socket.end(JSON.stringify(response) + '\n');
       });
@@ -66,8 +75,8 @@ describe('wal/ipc submitRecord', () => {
     try {
       const record = makeRecord('a');
       await expect(submitRecord(record)).resolves.toBeUndefined();
-      expect(requests).toHaveLength(1);
-      const parsed = JSON.parse(requests[0].trim()) as IpcRequest;
+      const request = Buffer.concat(requestChunks).toString('utf8').trim();
+      const parsed = JSON.parse(request) as IpcRequest;
       expect(parsed.op).toBe('append');
       expect(parsed.record.id).toBe(record.id);
     } finally {
@@ -169,6 +178,46 @@ describe('wal/ipc createIpcConnectionHandler', () => {
       expect(parsed.error).toMatch(/unknown op/);
     }
   });
+
+  it('rejects oversized requests without exhausting memory', async () => {
+    // Stream bytes well past the 16 MiB cap without ever sending a
+    // newline. The handler should respond with ok=false and close the
+    // socket instead of letting `buffer` grow unbounded.
+    const writer = new BatchingWriter();
+    server = await startHandlerServer(writer);
+
+    const { createConnection } = await import('node:net');
+    const result = await new Promise<string>((resolve, reject) => {
+      const socket = createConnection(getLockSocketPath());
+      const chunks: Buffer[] = [];
+      socket.on('connect', () => {
+        // 1 MiB of 'A's per chunk × 17 chunks = 17 MiB, no trailing
+        // newline. We send chunks back-to-back; once the daemon's
+        // cumulative buffer crosses 16 MiB it must short-circuit and
+        // respond, after which it ignores any further bytes.
+        const oneMib = Buffer.alloc(1024 * 1024, 0x41);
+        const pump = (remaining: number): void => {
+          if (remaining === 0 || socket.destroyed) {
+            return;
+          }
+          if (!socket.write(oneMib)) {
+            socket.once('drain', () => pump(remaining - 1));
+            return;
+          }
+          setImmediate(() => pump(remaining - 1));
+        };
+        pump(17);
+      });
+      socket.on('data', (chunk) => chunks.push(chunk));
+      socket.on('end', () => resolve(Buffer.concat(chunks).toString('utf8').trim()));
+      socket.on('error', reject);
+    });
+    const parsed = JSON.parse(result) as IpcResponse;
+    expect(parsed.ok).toBe(false);
+    if (!parsed.ok) {
+      expect(parsed.error).toMatch(/exceeds max size/);
+    }
+  }, 15_000);
 
   it('tolerates probe connections that close without sending data', async () => {
     const writer = new BatchingWriter();

--- a/libs/typescript/core/tests/exporters/wal/ipc.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/ipc.test.ts
@@ -102,11 +102,17 @@ describe('wal/ipc submitRecord', () => {
 
   it('throws after exhausting retries when no daemon is listening', async () => {
     // No server bound; submitRecord should retry, fail to reach
-    // anyone, and surface a connect error to the caller. We don't
-    // want to wait the full ~3.85s backoff in CI, so we override the
-    // socket path to something that ENOENTs immediately on every
-    // retry (no kernel timeouts) and rely on the bounded retry count
-    // to give up quickly.
+    // anyone, and surface a connect error to the caller. The full
+    // CONNECT_RETRY_DELAYS_MS sleeps (~3.85s) still elapse - we
+    // don't currently inject those in tests - but pointing
+    // MLFLOW_WAL_DIR at a tmpdir guarantees each connect attempt
+    // fails fast with ENOENT instead of stacking on top of the
+    // (much longer) per-attempt kernel connect timeout that would
+    // fire against an unreachable bound socket. The 10s test
+    // timeout accommodates the configured backoff with margin; if
+    // retry latency ever becomes a CI bottleneck the fix is to make
+    // CONNECT_RETRY_DELAYS_MS injectable rather than to chase it
+    // here.
     const r = makeRecord('c');
     await expect(submitRecord(r)).rejects.toMatchObject({
       code: expect.stringMatching(/ECONNREFUSED|ENOENT/),
@@ -181,8 +187,9 @@ describe('wal/ipc createIpcConnectionHandler', () => {
 
   it('rejects oversized requests without exhausting memory', async () => {
     // Stream bytes well past the 16 MiB cap without ever sending a
-    // newline. The handler should respond with ok=false and close the
-    // socket instead of letting `buffer` grow unbounded.
+    // newline. The handler should respond with ok=false, pause its
+    // read side so the kernel buffer stops growing, and half-close
+    // the write side so we observe a clean `'end'` here.
     const writer = new BatchingWriter();
     server = await startHandlerServer(writer);
 
@@ -210,7 +217,54 @@ describe('wal/ipc createIpcConnectionHandler', () => {
       });
       socket.on('data', (chunk) => chunks.push(chunk));
       socket.on('end', () => resolve(Buffer.concat(chunks).toString('utf8').trim()));
-      socket.on('error', reject);
+      socket.on('error', (err: NodeJS.ErrnoException) => {
+        // EPIPE can surface from the pump's writes once the daemon
+        // pauses reading and our kernel send buffer eventually fills.
+        // That's expected; the contract we care about is that the
+        // daemon replied before that backpressure hit.
+        if (err.code === 'EPIPE') {
+          return;
+        }
+        reject(err);
+      });
+    });
+    const parsed = JSON.parse(result) as IpcResponse;
+    expect(parsed.ok).toBe(false);
+    if (!parsed.ok) {
+      expect(parsed.error).toMatch(/exceeds max size/);
+    }
+  }, 15_000);
+
+  it('measures the cap in wire bytes, not UTF-16 code units', async () => {
+    const writer = new BatchingWriter();
+    server = await startHandlerServer(writer);
+
+    const { createConnection } = await import('node:net');
+    const result = await new Promise<string>((resolve, reject) => {
+      const socket = createConnection(getLockSocketPath());
+      const chunks: Buffer[] = [];
+      socket.on('connect', () => {
+        const cjkChunk = Buffer.from('中'.repeat(349_525), 'utf8');
+        const pump = (remaining: number): void => {
+          if (remaining === 0 || socket.destroyed) {
+            return;
+          }
+          if (!socket.write(cjkChunk)) {
+            socket.once('drain', () => pump(remaining - 1));
+            return;
+          }
+          setImmediate(() => pump(remaining - 1));
+        };
+        pump(17);
+      });
+      socket.on('data', (chunk) => chunks.push(chunk));
+      socket.on('end', () => resolve(Buffer.concat(chunks).toString('utf8').trim()));
+      socket.on('error', (err: NodeJS.ErrnoException) => {
+        if (err.code === 'EPIPE') {
+          return;
+        }
+        reject(err);
+      });
     });
     const parsed = JSON.parse(result) as IpcResponse;
     expect(parsed.ok).toBe(false);

--- a/libs/typescript/core/tests/exporters/wal/ipc.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/ipc.test.ts
@@ -103,7 +103,7 @@ describe('wal/ipc submitRecord', () => {
   it('throws after exhausting retries when no daemon is listening', async () => {
     // No server bound; submitRecord should retry, fail to reach
     // anyone, and surface a connect error to the caller. The full
-    // CONNECT_RETRY_DELAYS_MS sleeps (~3.85s) still elapse - we
+    // CONNECT_RETRY_DELAYS_MS sleeps (~3.15s) still elapse - we
     // don't currently inject those in tests - but pointing
     // MLFLOW_WAL_DIR at a tmpdir guarantees each connect attempt
     // fails fast with ENOENT instead of stacking on top of the

--- a/libs/typescript/core/tests/exporters/wal/ipc.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/ipc.test.ts
@@ -1,0 +1,193 @@
+import { mkdtemp, readFile, rm } from 'fs/promises';
+import { createServer, Server } from 'net';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { BatchingWriter } from '../../../src/exporters/wal/batching_writer';
+import { createIpcConnectionHandler, submitRecord } from '../../../src/exporters/wal/ipc';
+import { getLockSocketPath, getWalPath } from '../../../src/exporters/wal/paths';
+import type { IpcRequest, IpcResponse } from '../../../src/exporters/wal/protocol';
+import type { WalRecord } from '../../../src/exporters/wal/types';
+
+function makeRecord(idSuffix: string, overrides: Partial<WalRecord> = {}): WalRecord {
+  return {
+    id: `wal-${idSuffix}`,
+    trackingUri: 'http://localhost:5000',
+    experimentId: '0',
+    traceInfo: { trace_id: `t-${idSuffix}` },
+    traceData: { spans: [] },
+    attempts: 0,
+    nextAttemptAt: 0,
+    createdAt: Date.now(),
+    ...overrides,
+  };
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+describe('wal/ipc submitRecord', () => {
+  let walDir: string;
+
+  const originalWalDir = process.env.MLFLOW_WAL_DIR;
+  const originalDaemonExe = process.env.MLFLOW_TRACE_DAEMON_EXECUTABLE;
+
+  beforeEach(async () => {
+    walDir = await mkdtemp(join(tmpdir(), 'mlflow-ipc-'));
+    process.env.MLFLOW_WAL_DIR = walDir;
+    process.env.MLFLOW_TRACE_DAEMON_EXECUTABLE = join(walDir, 'noop-daemon.cjs');
+  });
+
+  afterEach(async () => {
+    if (originalWalDir === undefined) {
+      delete process.env.MLFLOW_WAL_DIR;
+    } else {
+      process.env.MLFLOW_WAL_DIR = originalWalDir;
+    }
+    if (originalDaemonExe === undefined) {
+      delete process.env.MLFLOW_TRACE_DAEMON_EXECUTABLE;
+    } else {
+      process.env.MLFLOW_TRACE_DAEMON_EXECUTABLE = originalDaemonExe;
+    }
+    await rm(walDir, { recursive: true, force: true });
+  });
+
+  it('round-trips an append request: request → ok ACK', async () => {
+    const requests: string[] = [];
+    const server = createServer((socket) => {
+      socket.on('data', (chunk: Buffer) => {
+        requests.push(chunk.toString('utf8'));
+        const response: IpcResponse = { ok: true };
+        socket.end(JSON.stringify(response) + '\n');
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(getLockSocketPath(), resolve));
+
+    try {
+      const record = makeRecord('a');
+      await expect(submitRecord(record)).resolves.toBeUndefined();
+      expect(requests).toHaveLength(1);
+      const parsed = JSON.parse(requests[0].trim()) as IpcRequest;
+      expect(parsed.op).toBe('append');
+      expect(parsed.record.id).toBe(record.id);
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('throws when the daemon responds with an error', async () => {
+    const server = createServer((socket) => {
+      socket.on('data', () => {
+        const response: IpcResponse = { ok: false, error: 'disk full' };
+        socket.end(JSON.stringify(response) + '\n');
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(getLockSocketPath(), resolve));
+
+    try {
+      await expect(submitRecord(makeRecord('b'))).rejects.toThrow(/disk full/);
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('throws after exhausting retries when no daemon is listening', async () => {
+    // No server bound; submitRecord should retry, fail to reach
+    // anyone, and surface a connect error to the caller. We don't
+    // want to wait the full ~3.85s backoff in CI, so we override the
+    // socket path to something that ENOENTs immediately on every
+    // retry (no kernel timeouts) and rely on the bounded retry count
+    // to give up quickly.
+    const r = makeRecord('c');
+    await expect(submitRecord(r)).rejects.toMatchObject({
+      code: expect.stringMatching(/ECONNREFUSED|ENOENT/),
+    });
+  }, 10_000);
+});
+
+describe('wal/ipc createIpcConnectionHandler', () => {
+  let walDir: string;
+  let server: Server | null = null;
+  const originalWalDir = process.env.MLFLOW_WAL_DIR;
+
+  beforeEach(async () => {
+    walDir = await mkdtemp(join(tmpdir(), 'mlflow-ipc-handler-'));
+    process.env.MLFLOW_WAL_DIR = walDir;
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await closeServer(server);
+      server = null;
+    }
+    if (originalWalDir === undefined) {
+      delete process.env.MLFLOW_WAL_DIR;
+    } else {
+      process.env.MLFLOW_WAL_DIR = originalWalDir;
+    }
+    await rm(walDir, { recursive: true, force: true });
+  });
+
+  async function startHandlerServer(writer: BatchingWriter): Promise<Server> {
+    const s = createServer(createIpcConnectionHandler(writer));
+    await new Promise<void>((resolve) => s.listen(getLockSocketPath(), resolve));
+    return s;
+  }
+
+  it('persists the submitted record and acks with ok=true', async () => {
+    const writer = new BatchingWriter();
+    server = await startHandlerServer(writer);
+
+    const record = makeRecord('h1');
+    await submitRecord(record);
+
+    const lines = (await readFile(getWalPath(), 'utf8')).split('\n').filter((l) => l.length > 0);
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[0]) as { type: string; record: WalRecord };
+    expect(parsed.type).toBe('append');
+    expect(parsed.record.id).toBe(record.id);
+  });
+
+  it('responds with ok=false for an unknown op', async () => {
+    const writer = new BatchingWriter();
+    server = await startHandlerServer(writer);
+
+    const { createConnection } = await import('node:net');
+    const result = await new Promise<string>((resolve, reject) => {
+      const socket = createConnection(getLockSocketPath());
+      const chunks: Buffer[] = [];
+      socket.on('connect', () => {
+        socket.write(JSON.stringify({ op: 'frobnicate', record: makeRecord('x') }) + '\n');
+      });
+      socket.on('data', (chunk) => chunks.push(chunk));
+      socket.on('end', () => resolve(Buffer.concat(chunks).toString('utf8').trim()));
+      socket.on('error', reject);
+    });
+    const parsed = JSON.parse(result) as IpcResponse;
+    expect(parsed.ok).toBe(false);
+    if (!parsed.ok) {
+      expect(parsed.error).toMatch(/unknown op/);
+    }
+  });
+
+  it('tolerates probe connections that close without sending data', async () => {
+    const writer = new BatchingWriter();
+    server = await startHandlerServer(writer);
+
+    const { createConnection } = await import('node:net');
+    await new Promise<void>((resolve, reject) => {
+      const socket = createConnection(getLockSocketPath());
+      socket.on('connect', () => {
+        socket.destroy();
+        resolve();
+      });
+      socket.on('error', reject);
+    });
+
+    // A subsequent real submit must still succeed: the probe-and-tear
+    // pattern must not have left the handler in a bad state.
+    await submitRecord(makeRecord('after-probe'));
+    const lines = (await readFile(getWalPath(), 'utf8')).split('\n').filter((l) => l.length > 0);
+    expect(lines).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/23579/files) to review incremental changes.
- [**stack/ipc-batch-cc-tracing**](https://github.com/mlflow/mlflow/pull/23579) [[Files changed](https://github.com/mlflow/mlflow/pull/23579/files)]
  - [stack/daemon-impl-batch-tracing](https://github.com/mlflow/mlflow/pull/23605) [[Files changed](https://github.com/mlflow/mlflow/pull/23605/files/62e2803e3c97852c8ed2d74de90fd52e1c00cf5c..d584d61c8c81972626ab13aee2dbb21183eb4419)]

---------
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

This PR related to the following PRs that is merged:
- https://github.com/mlflow/mlflow/pull/23545
- https://github.com/mlflow/mlflow/pull/23511
- https://github.com/mlflow/mlflow/pull/23464

This is part of a series of changes to support async batch tracing for TS Claude Code / Coding Agent LLM MLflow tracing

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

### What changes are proposed in this pull request?

Introduces the hook ↔ daemon IPC over the daemon's existing lock socket / Named Pipe — the wire link that lets the Claude Code Stop hook hand a trace record to the long-lived daemon and exit immediately while the daemon owns retries, batching, and upload.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [ ] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
