### PR TITLE
Skip `update-release-labels` job for release candidates

### DIFF
--- a/.github/workflows/update-release-labels.yml
+++ b/.github/workflows/update-release-labels.yml
@@ -16,6 +16,9 @@ defaults:
 
 jobs:
   update-labels:
+    if: >-
+      (github.event_name == 'release' && !github.event.release.prerelease) ||
+      (github.event_name == 'workflow_dispatch' && !contains(github.event.inputs.release_version, 'rc'))
     runs-on: ubuntu-slim
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

`update-release-labels.js` only accepts strict `X.Y.Z` versions, so RC tags like `v3.13.0rc0` fall through the regex and the job errors out with `Invalid version format` after running checkout and listing commits. Gate the job with an `if:` so it never starts for RCs:

- `release` event: require `!github.event.release.prerelease` (RC tags are marked as prereleases on GitHub).
- `workflow_dispatch`: reject `release_version` inputs containing `rc`.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release