### PR TITLE
Drop unused user-supplied prompt from `/review` workflow

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -153,7 +153,6 @@ jobs:
           import argparse
           import json
           import os
-          import secrets
           import sys
 
           MODEL_CHOICES = [
@@ -171,19 +170,14 @@ jobs:
           default_model = "claude-opus-4-7" if big else "claude-sonnet-4-6"
 
           body = sys.stdin.read().removeprefix("/review")
-          head, sep, tail = body.partition("\n")
+          head, _, _ = body.partition("\n")
 
           parser = argparse.ArgumentParser(add_help=False)
           parser.add_argument("-m", "--model", choices=MODEL_CHOICES, default=default_model)
           parser.add_argument("-e", "--effort", choices=EFFORT_CHOICES, default="high")
-          args, leftover = parser.parse_known_args(head.split())
+          args, _ = parser.parse_known_args(head.split())
 
-          prompt = (" ".join(leftover) + sep + tail).strip()
-          # Random delimiter so user input can't terminate the heredoc.
-          delim = f"PROMPT_EOF_{secrets.token_hex(8)}"
-          sys.stdout.write(
-              f"prompt<<{delim}\n{prompt}\n{delim}\nmodel={args.model}\neffort={args.effort}\n"
-          )
+          sys.stdout.write(f"model={args.model}\neffort={args.effort}\n")
           EOF
 
           echo "$COMMENT_BODY" | python /tmp/parse_args.py >> "$GITHUB_OUTPUT"
@@ -196,23 +190,14 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
-          PROMPT: ${{ steps.prompt.outputs.prompt }}
           MODEL: ${{ steps.prompt.outputs.model }}
           EFFORT: ${{ steps.prompt.outputs.effort }}
-          EVENT_NAME: ${{ github.event_name }}
         run: |
           OUTPUT_FILE="/tmp/output.jsonl"
 
-          # Safe construction using arrays - PROMPT is passed as separate argument to prevent shell injection.
           # Both event paths run /pr-review end-to-end against the PR; on
           # pull_request (smoke), Post is gated off so no review is submitted.
-          ARGS=("/pr-review" "$REPO" "$PR_NUMBER")
-          if [ "$EVENT_NAME" = "issue_comment" ] && [ -n "$PROMPT" ]; then
-            ARGS+=("$PROMPT")
-          fi
-
           EXIT_CODE=0
-          # Note: ARGS[*] is intentional - claude CLI expects a single prompt string
           timeout 20m claude \
             --model "$MODEL" \
             --effort "$EFFORT" \
@@ -220,7 +205,7 @@ jobs:
             --print \
             --verbose \
             --output-format stream-json \
-            "${ARGS[*]}" \
+            "/pr-review $REPO $PR_NUMBER" \
             | .claude/scripts/stream.sh "$OUTPUT_FILE" || EXIT_CODE=$?
           if [ "${EXIT_CODE:-0}" -eq 124 ]; then
             echo "Warning: Claude command timed out after 20 minutes"

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -175,7 +175,7 @@ jobs:
           parser = argparse.ArgumentParser(add_help=False)
           parser.add_argument("-m", "--model", choices=MODEL_CHOICES, default=default_model)
           parser.add_argument("-e", "--effort", choices=EFFORT_CHOICES, default="high")
-          args, _ = parser.parse_known_args(head.split())
+          args = parser.parse_args(head.split())
 
           sys.stdout.write(f"model={args.model}\neffort={args.effort}\n")
           EOF

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -170,12 +170,11 @@ jobs:
           default_model = "claude-opus-4-7" if big else "claude-sonnet-4-6"
 
           body = sys.stdin.read().removeprefix("/review")
-          head, _, _ = body.partition("\n")
 
           parser = argparse.ArgumentParser(add_help=False)
           parser.add_argument("-m", "--model", choices=MODEL_CHOICES, default=default_model)
           parser.add_argument("-e", "--effort", choices=EFFORT_CHOICES, default="high")
-          args = parser.parse_args(head.split())
+          args = parser.parse_args(body.split())
 
           sys.stdout.write(f"model={args.model}\neffort={args.effort}\n")
           EOF


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Removes the freeform user-supplied prompt plumbing from `.github/workflows/review.yml`. In practice users just type `/review` with no trailing text, so the `prompt` output from `parse_args.py`, the `PROMPT` env var, and the `ARGS` array were unused. The `-m` / `-e` flags still work.

### How is this PR tested?

- [x] Manual tests

The `pull_request` smoke path on this workflow will exercise the `/pr-review` invocation end-to-end (without posting).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release