### PR TITLE
Drop `EditAccessModal`'s redundant `/users/permissions/list` fetch

### DIFF
--- a/.github/actions/check-component-ids/componentId-registry.js
+++ b/.github/actions/check-component-ids/componentId-registry.js
@@ -665,6 +665,7 @@ module.exports = {
   "admin.edit_access_modal.error": "",
   "admin.edit_access_modal.is_admin": "",
   "admin.edit_access_modal.review": "",
+  "admin.edit_access_modal.roles_error": "",
   "admin.edit_role_modal": "",
   "admin.edit_role_modal.back": "",
   "admin.edit_role_modal.cancel": "",

--- a/mlflow/server/js/src/admin/api.ts
+++ b/mlflow/server/js/src/admin/api.ts
@@ -13,7 +13,7 @@ import type {
   UpdateAdminRequest,
   UpdateRoleRequest,
 } from './types';
-import type { ListMyPermissionsResponse, UpdatePasswordRequest, UserResponse } from '../account/types';
+import type { UpdatePasswordRequest, UserResponse } from '../account/types';
 
 const defaultErrorHandler = async ({
   reject,
@@ -146,17 +146,6 @@ export const AdminApi = {
       relativeUrl,
       error: defaultErrorHandler,
     }) as Promise<ListAssignmentsResponse>;
-  },
-
-  // Direct permissions for an arbitrary user (admin / self / WP-admin-of-target).
-  // The response shape mirrors ``/users/current/permissions``.
-  listUserPermissions: (username: string) => {
-    const params = new URLSearchParams();
-    params.append('username', username);
-    return fetchEndpoint({
-      relativeUrl: `ajax-api/3.0/mlflow/users/permissions/list?${params.toString()}`,
-      error: defaultErrorHandler,
-    }) as Promise<ListMyPermissionsResponse>;
   },
 
   // User CRUD (admin-only)

--- a/mlflow/server/js/src/admin/components/EditAccessModal.test.tsx
+++ b/mlflow/server/js/src/admin/components/EditAccessModal.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import React from 'react';
+import { renderWithDesignSystem, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
+
+import { EditAccessModal } from './EditAccessModal';
+
+// Per-test override for ``useUserRolesQuery`` so each case can pick its own
+// success / error shape. ``mockReset`` in ``beforeEach`` keeps cross-test
+// state from leaking.
+const mockUseUserRolesQuery = jest.fn();
+
+jest.mock('../hooks', () => ({
+  AdminQueryKeys: {
+    users: ['admin_users'],
+    roles: ['admin_roles'],
+    roleUsers: (roleId: number) => ['admin_role_users', roleId],
+    resourceOptions: (resourceType: string) => ['admin_resource_options', resourceType],
+  },
+  useCurrentUserIsAdmin: () => false,
+  useGrantUserPermission: () => ({ mutateAsync: jest.fn() }),
+  useRevokeUserPermission: () => ({ mutateAsync: jest.fn() }),
+  useRolesQuery: () => ({ data: { roles: [] }, isLoading: false, error: null }),
+  useUserRolesQuery: (username: string) => mockUseUserRolesQuery(username),
+  useUsersQuery: () => ({
+    data: { users: [{ id: 1, username: 'alice', is_admin: false, roles: [] }] },
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+jest.mock('../../workspaces/utils/WorkspaceUtils', () => ({
+  useActiveWorkspace: () => null,
+}));
+
+jest.mock('@mlflow/mlflow/src/common/utils/reactQueryHooks', () => ({
+  useQueryClient: () => ({ invalidateQueries: jest.fn() }),
+}));
+
+describe('EditAccessModal — rolesError handling', () => {
+  beforeEach(() => {
+    mockUseUserRolesQuery.mockReset();
+  });
+
+  it('renders an error Alert when useUserRolesQuery fails', () => {
+    mockUseUserRolesQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('boom'),
+    });
+    renderWithDesignSystem(<EditAccessModal open onClose={jest.fn()} username="alice" />);
+    expect(screen.getByText('Failed to load access state')).toBeInTheDocument();
+    expect(screen.getByText('boom')).toBeInTheDocument();
+    // Form sections must be suppressed so the admin can't edit against a
+    // phantom empty state — see the ``rolesError`` branch in the modal.
+    expect(screen.queryByText('Role assignments')).not.toBeInTheDocument();
+    expect(screen.queryByText('Direct permissions')).not.toBeInTheDocument();
+  });
+
+  it('disables the Review changes button when useUserRolesQuery fails', () => {
+    mockUseUserRolesQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('boom'),
+    });
+    renderWithDesignSystem(<EditAccessModal open onClose={jest.fn()} username="alice" />);
+    expect(screen.getByRole('button', { name: /Review changes/ })).toBeDisabled();
+  });
+});

--- a/mlflow/server/js/src/admin/components/EditAccessModal.tsx
+++ b/mlflow/server/js/src/admin/components/EditAccessModal.tsx
@@ -67,7 +67,7 @@ export const EditAccessModal = ({ open, onClose, username }: EditAccessModalProp
   const isCurrentUserAdmin = useCurrentUserIsAdmin();
 
   // --- Current state from backend (used to pre-fill + compute diff) ---
-  const { data: rolesData, isLoading: rolesLoading } = useUserRolesQuery(username);
+  const { data: rolesData, isLoading: rolesLoading, error: rolesError } = useUserRolesQuery(username);
   const { data: usersData, isLoading: usersLoading } = useUsersQuery();
   // Roles list for the Review step's name lookup (the form uses the
   // dropdown's own label, but the Review step renders by id). Platform
@@ -133,19 +133,21 @@ export const EditAccessModal = ({ open, onClose, username }: EditAccessModalProp
   }, [open]);
 
   // Pre-fill editable fields once per open, after backing queries resolve.
+  // Skip on ``rolesError`` so a 403 / network failure doesn't silently
+  // overwrite the user's actual access with an empty staged state.
   useEffect(() => {
     if (!open) {
       prefilledRef.current = false;
       return;
     }
-    if (prefilledRef.current || !stateLoaded) {
+    if (prefilledRef.current || !stateLoaded || rolesError) {
       return;
     }
     setRoleValue({ roleIds: [...currentRoleIds] });
     setDirectPermissions([...currentDirectPerms]);
     setIsAdmin(currentIsAdmin);
     prefilledRef.current = true;
-  }, [open, stateLoaded, currentRoleIds, currentDirectPerms, currentIsAdmin]);
+  }, [open, stateLoaded, rolesError, currentRoleIds, currentDirectPerms, currentIsAdmin]);
 
   // --- Diff computation ---
   const diff = useMemo<AccessDiff>(() => {
@@ -305,7 +307,7 @@ export const EditAccessModal = ({ open, onClose, username }: EditAccessModalProp
                 setError(null);
                 setStep('review');
               }}
-              disabled={!hasAnyChange || !stateLoaded}
+              disabled={!hasAnyChange || !stateLoaded || Boolean(rolesError)}
             >
               Review changes
             </Button>
@@ -367,6 +369,18 @@ export const EditAccessModal = ({ open, onClose, username }: EditAccessModalProp
             >
               <Spinner size="small" />
             </div>
+          ) : rolesError ? (
+            // Block the form on a failed roles fetch so the empty pre-fill
+            // doesn't masquerade as the user's actual access.
+            <Alert
+              componentId="admin.edit_access_modal.roles_error"
+              type="error"
+              message="Failed to load access state"
+              description={
+                (rolesError as Error)?.message ||
+                `An error occurred while fetching the current access for ${username}. Close the modal and try again.`
+              }
+            />
           ) : (
             <>
               <LongFormSection title="Role assignments">

--- a/mlflow/server/js/src/admin/components/EditAccessModal.tsx
+++ b/mlflow/server/js/src/admin/components/EditAccessModal.tsx
@@ -19,7 +19,6 @@ import {
   useGrantUserPermission,
   useRevokeUserPermission,
   useRolesQuery,
-  useUserPermissionsQuery,
   useUserRolesQuery,
   useUsersQuery,
 } from '../hooks';
@@ -69,7 +68,6 @@ export const EditAccessModal = ({ open, onClose, username }: EditAccessModalProp
 
   // --- Current state from backend (used to pre-fill + compute diff) ---
   const { data: rolesData, isLoading: rolesLoading } = useUserRolesQuery(username);
-  const { data: directPermsData, isLoading: directPermsLoading } = useUserPermissionsQuery(username);
   const { data: usersData, isLoading: usersLoading } = useUsersQuery();
   // Roles list for the Review step's name lookup (the form uses the
   // dropdown's own label, but the Review step renders by id). Platform
@@ -87,21 +85,21 @@ export const EditAccessModal = ({ open, onClose, username }: EditAccessModalProp
     () => (rolesData?.roles ?? []).filter((r) => !isSyntheticUserRole(r.name)).map((r) => r.id),
     [rolesData],
   );
+  // Direct grants live on the synthetic ``__user_<id>__`` role surfaced by
+  // ``useUserRolesQuery``; flatten its nested ``permissions`` to recover the
+  // editable list (custom roles are shown in the Roles tab).
   const currentDirectPerms = useMemo<StagedDirectPermission[]>(
     () =>
-      (directPermsData?.permissions ?? [])
-        // The unified ``/users/permissions/list`` response returns every
-        // permission across every role the user holds. Direct grants live on
-        // the synthetic ``__user_<id>__`` role; filter to just those for the
-        // "Direct permissions" view (custom roles are shown in the Roles tab).
-        .filter((p) => isSyntheticUserRole(p.role_name))
+      (rolesData?.roles ?? [])
+        .filter((r) => isSyntheticUserRole(r.name))
+        .flatMap((r) => r.permissions ?? [])
         .filter((p) => isDirectGrantResourceType(p.resource_type))
         .map((p) => ({
           resourceType: p.resource_type as DirectGrantResourceType,
           resourceId: p.resource_pattern,
           permission: p.permission,
         })),
-    [directPermsData],
+    [rolesData],
   );
   const currentIsAdmin = useMemo(
     () => Boolean(usersData?.users?.find((u) => u.username === username)?.is_admin),
@@ -116,7 +114,7 @@ export const EditAccessModal = ({ open, onClose, username }: EditAccessModalProp
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const stateLoaded = !rolesLoading && !directPermsLoading && !usersLoading;
+  const stateLoaded = !rolesLoading && !usersLoading;
 
   // ``prefilledRef`` gates the data-fill effect against background
   // refetches that would clobber in-progress edits.

--- a/mlflow/server/js/src/admin/components/EditAccessModal.tsx
+++ b/mlflow/server/js/src/admin/components/EditAccessModal.tsx
@@ -377,7 +377,7 @@ export const EditAccessModal = ({ open, onClose, username }: EditAccessModalProp
               type="error"
               message="Failed to load access state"
               description={
-                (rolesError as Error)?.message ||
+                (rolesError instanceof Error ? rolesError.message : null) ||
                 `An error occurred while fetching the current access for ${username}. Close the modal and try again.`
               }
             />

--- a/mlflow/server/js/src/admin/hooks.ts
+++ b/mlflow/server/js/src/admin/hooks.ts
@@ -54,18 +54,6 @@ export const AdminQueryKeys = {
   roleDetail: (roleId: number) => ['admin_role', roleId] as const,
   roleUsers: (roleId: number) => ['admin_role_users', roleId] as const,
   resourceOptions: (resourceType: string) => ['admin_resource_options', resourceType] as const,
-  userPermissions: (username: string) => ['admin_user_permissions', username] as const,
-};
-
-/** Direct (non-role-derived) grants for an arbitrary user. Admin / self / WP-admin-of-target. */
-export const useUserPermissionsQuery = (username: string) => {
-  return useQuery({
-    queryKey: AdminQueryKeys.userPermissions(username),
-    queryFn: () => AdminApi.listUserPermissions(username),
-    enabled: Boolean(username),
-    retry: false,
-    refetchOnWindowFocus: false,
-  });
 };
 
 // User queries and mutations
@@ -246,10 +234,10 @@ export const useGrantUserPermission = () => {
     mutationFn: (request: { resource_type: string; resource_id: string; username: string; permission: string }) =>
       AdminApi.grantUserPermission(request.resource_type, request.resource_id, request.username, request.permission),
     onSuccess: (_data, variables) => {
-      // Refresh the per-user roles cell (Admin Users tab + Account page)
-      // and the per-user direct-permissions list (UserDetailPage).
+      // Direct grants flow through the synthetic ``__user_<id>__`` role
+      // surfaced by ``listUserRoles``, so a single ``userRoles`` invalidation
+      // refreshes both the Roles tab and the Direct Permissions view.
       queryClient.invalidateQueries({ queryKey: AccountQueryKeys.userRoles(variables.username) });
-      queryClient.invalidateQueries({ queryKey: AdminQueryKeys.userPermissions(variables.username) });
     },
   });
 };
@@ -262,7 +250,6 @@ export const useRevokeUserPermission = () => {
       AdminApi.revokeUserPermission(request.resource_type, request.resource_id, request.username),
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: AccountQueryKeys.userRoles(variables.username) });
-      queryClient.invalidateQueries({ queryKey: AdminQueryKeys.userPermissions(variables.username) });
     },
   });
 };


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23578

### What changes are proposed in this pull request?

`EditAccessModal` was reading `currentDirectPerms` from `useUserPermissionsQuery` (the flat `GET /users/permissions/list` endpoint) while `AccountPage` and `UserDetailPage` derive the same data from the synthetic `__user_<id>__` role surfaced by `useUserRolesQuery` (after #23578). Both endpoints return the same direct-grant rows in different shapes, so the second fetch was redundant.

This PR migrates the modal to flatten the synthetic role's nested `permissions` from `rolesData`, restoring a single source of truth across the display and edit paths. It also removes the now-unused:

- `useUserPermissionsQuery` hook (the only caller was this modal)
- `AdminQueryKeys.userPermissions` query-key factory
- `AdminApi.listUserPermissions` API method
- Parallel `AdminQueryKeys.userPermissions` invalidations in `useGrantUserPermission` / `useRevokeUserPermission` — refreshing `AccountQueryKeys.userRoles` now covers both the Roles tab and the Direct Permissions view, since direct grants live on the synthetic role

The `GET /users/permissions/list` endpoint itself stays as a public REST surface for non-UI callers; only the UI's dependency on it goes away. Same semantics, one fewer HTTP request per modal open, one cache key to invalidate after writes.

Net diff: 3 files, +12 / −38.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

`yarn type-check`, `yarn lint`, `yarn prettier:check`, and the full `admin/` + `account/` jest suites (80 tests, 10 suites) pass clean. No tests had to change — the modal isn't directly tested, and `hooks.test.tsx` didn't cover the removed hook.

Manual testing plan: open `EditAccessModal` for a user with at least one direct grant; confirm the Direct Permissions section pre-fills with the same rows as before, that removing a row revokes it on apply, and that the modal's data refreshes after grant/revoke (single `userRoles` invalidation).

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
