### PR TITLE
Support mapping gen_ai.conversation.id to MLflow trace session

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -185,6 +185,7 @@ from mlflow.telemetry.track import record_usage_event
 from mlflow.tracing.analysis import TraceFilterCorrelationResult
 from mlflow.tracing.constant import (
     AssessmentMetadataKey,
+    GenAiSemconvKey,
     SpanAttributeKey,
     SpansLocation,
     TokenUsageKey,
@@ -4896,7 +4897,10 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                     # Session ID from OTel semantic conventions:
                     # https://opentelemetry.io/docs/specs/semconv/registry/attributes/session/#session-id
                     if session_id is None and (
-                        span_session_id := span_attributes.get("session.id")
+                        span_session_id := (
+                            span_attributes.get(SpanAttributeKey.SESSION_ID)
+                            or span_attributes.get(GenAiSemconvKey.CONVERSATION_ID)
+                        )
                     ):
                         session_id = span_session_id
                     # user id used by OTel semantic conventions: https://opentelemetry.io/docs/specs/semconv/registry/attributes/user/#user-id

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -375,6 +375,7 @@ class AssessmentMetricSearchKey:
 # OpenTelemetry GenAI Semantic Convention attribute keys.
 # https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/
 class GenAiSemconvKey:
+    CONVERSATION_ID = "gen_ai.conversation.id"
     OPERATION_NAME = "gen_ai.operation.name"
     REQUEST_MODEL = "gen_ai.request.model"
     RESPONSE_MODEL = "gen_ai.response.model"

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
@@ -5179,6 +5179,19 @@ def test_log_spans_session_id_handling(store: SqlAlchemyStore) -> None:
     trace_info1 = store.get_trace_info(trace_id1)
     assert trace_info1.trace_metadata.get(TraceMetadataKey.TRACE_SESSION) == "session-123"
 
+    # Session ID gets stored from gen_ai.conversation.id attribute
+    trace_id1_gen_ai = f"tr-{uuid.uuid4().hex}"
+    otel_span1_gen_ai = create_test_otel_span(trace_id=trace_id1_gen_ai)
+    otel_span1_gen_ai._attributes = {
+        "mlflow.traceRequestId": json.dumps(trace_id1_gen_ai, cls=TraceJSONEncoder),
+        "gen_ai.conversation.id": "conv-123",
+    }
+    span1_gen_ai = create_mlflow_span(otel_span1_gen_ai, trace_id1_gen_ai, "LLM")
+    store.log_spans(experiment_id, [span1_gen_ai])
+
+    trace_info1_gen_ai = store.get_trace_info(trace_id1_gen_ai)
+    assert trace_info1_gen_ai.trace_metadata.get(TraceMetadataKey.TRACE_SESSION) == "conv-123"
+
     # Existing session ID is preserved
     trace_id2 = f"tr-{uuid.uuid4().hex}"
     trace_with_session = TraceInfo(

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
@@ -5203,7 +5203,9 @@ def test_log_spans_session_id_handling(store: SqlAlchemyStore) -> None:
     store.log_spans(experiment_id, [span1_precedence])
 
     trace_info1_precedence = store.get_trace_info(trace_id1_precedence)
-    assert trace_info1_precedence.trace_metadata.get(TraceMetadataKey.TRACE_SESSION) == "session-456"
+    assert (
+        trace_info1_precedence.trace_metadata.get(TraceMetadataKey.TRACE_SESSION) == "session-456"
+    )
 
     # Existing session ID is preserved
     trace_id2 = f"tr-{uuid.uuid4().hex}"

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
@@ -5192,6 +5192,19 @@ def test_log_spans_session_id_handling(store: SqlAlchemyStore) -> None:
     trace_info1_gen_ai = store.get_trace_info(trace_id1_gen_ai)
     assert trace_info1_gen_ai.trace_metadata.get(TraceMetadataKey.TRACE_SESSION) == "conv-123"
 
+    trace_id1_precedence = f"tr-{uuid.uuid4().hex}"
+    otel_span1_precedence = create_test_otel_span(trace_id=trace_id1_precedence)
+    otel_span1_precedence._attributes = {
+        "mlflow.traceRequestId": json.dumps(trace_id1_precedence, cls=TraceJSONEncoder),
+        "session.id": "session-456",
+        "gen_ai.conversation.id": "conv-456",
+    }
+    span1_precedence = create_mlflow_span(otel_span1_precedence, trace_id1_precedence, "LLM")
+    store.log_spans(experiment_id, [span1_precedence])
+
+    trace_info1_precedence = store.get_trace_info(trace_id1_precedence)
+    assert trace_info1_precedence.trace_metadata.get(TraceMetadataKey.TRACE_SESSION) == "session-456"
+
     # Existing session ID is preserved
     trace_id2 = f"tr-{uuid.uuid4().hex}"
     trace_with_session = TraceInfo(


### PR DESCRIPTION
### Related Issues/PRs

Closes #23524

### What changes are proposed in this pull request?

MLflow currently maps the OTel span attribute `session.id` to the trace-level metadata key `mlflow.trace.session` when ingesting OpenTelemetry traces.

This PR extends that mapping to also recognize `gen_ai.conversation.id` as a fallback when `session.id` is not present, since open source LLM orchestration libraries like OpenInference or Traceloop emit this attribute.

Changes made:
- Added `CONVERSATION_ID = "gen_ai.conversation.id"` in the `GenAiSemconvKey` class in `mlflow/tracing/constant.py`.
- Updated `log_spans` in `mlflow/store/tracking/sqlalchemy_store.py` to use `GenAiSemconvKey.CONVERSATION_ID` as a fallback.
- Added a test case `test_log_spans_session_id_handling` to `tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py` to verify this behavior.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:

### Does this PR require updating the MLflow Skills repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added support for mapping the OpenTelemetry `gen_ai.conversation.id` attribute to `mlflow.trace.session` during trace ingestion.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release