### PR TITLE
Pin `wrapt<2` for agno autologging cross-version tests

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -910,7 +910,9 @@ agno:
     requirements:
       ">= 0.0.0": ["anthropic", "yfinance"]
       ">= 2.0.0": ["opentelemetry-exporter-otlp", "openinference-instrumentation-agno"]
-      "<= 2.4.8": ["openinference-instrumentation-agno==0.1.20"]
+      # openinference-instrumentation-agno <= 0.1.30 calls wrap_function_wrapper(module=...),
+      # but wrapt 2.0 renamed the kwarg to `target`. Pin wrapt<2 until we can move off 0.1.20.
+      "<= 2.4.8": ["openinference-instrumentation-agno==0.1.20", "wrapt<2"]
     run: pytest tests/agno
     test_tracing_sdk: true
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/Arize-ai/openinference/issues/2996

### What changes are proposed in this pull request?

`openinference-instrumentation-agno==0.1.20` calls `wrap_function_wrapper(module=..., name=..., wrapper=...)`, but `wrapt 2.0` (released 2025-10-19) renamed the first kwarg from `module` to `target`. As a result, OTel instrumentation setup raises `TypeError` and `mlflow.agno.autolog_v2` silently disables itself, leaving the cross-version tests with zero spans:

```
WARNING mlflow.agno.autolog_v2: Failed to set up OpenTelemetry instrumentation for Agno V2:
  wrap_function_wrapper() got an unexpected keyword argument 'module'
```

The upstream fix landed in `openinference-instrumentation-agno 0.1.31` (positional args), but our matrix pins `0.1.20` for `agno <= 2.4.8`. Pin `wrapt<2` for that bracket so the resolver picks a compatible runtime.

### How is this PR tested?

- [x] Existing unit/integration tests

Re-ran the previously failing tests locally with the pin applied:

```
pytest tests/agno/test_agno_tracing.py::test_v2_creates_otel_spans tests/agno/test_agno_tracing.py::test_v2_failure_creates_spans
# 3 passed
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release