### PR TITLE
Unpin uvicorn 0.47, bump server-readiness retry budgets in webhook + tracking tests

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -48,7 +48,7 @@ jobs:
   # The python skinny tests cover the subset of mlflow functionality
   # while also verifying certain dependencies are omitted.
   python-skinny:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
+    if: false # TEMP: scoped down for uvicorn unpin experiment
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -67,17 +67,11 @@ jobs:
           ./dev/run-python-skinny-tests.sh
 
   python:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
+    # TEMP: scoped down to webhook e2e tests for uvicorn unpin experiment
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 30
     permissions:
       contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        group: [1, 2, 3, 4]
-        include:
-          - splits: 4
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -95,34 +89,14 @@ jobs:
             -r requirements/test-requirements.txt \
             -r requirements/extra-ml-requirements.txt
       - uses: ./.github/actions/show-versions
-      - name: Import check
+      - name: Show uvicorn version
+        run: uv run --no-sync python -c "import uvicorn; print(uvicorn.__version__)"
+      - name: Run webhook e2e tests
         run: |
-          # `-I` is used to avoid importing modules from user-specific site-packages
-          # that might conflict with the built-in modules (e.g. `types`).
-          uv run --no-sync python -I tests/check_mlflow_lazily_imports_ml_packages.py
-      - name: Run tests
-        env:
-          SPLITS: ${{ matrix.splits }}
-          GROUP: ${{ matrix.group }}
-        run: |
-          source dev/setup-ssh.sh
-          uv run --no-sync pytest --splits=$SPLITS --group=$GROUP \
-            --quiet --requires-ssh --ignore-flavors \
-            --ignore=tests/examples \
-            --ignore=tests/evaluate \
-            --ignore=tests/genai \
-            --ignore=tests/docker \
-            tests
-
-      - name: Run databricks-connect related tests
-        run: |
-          # this needs to be run in a separate job because installing databricks-connect could break other
-          # tests that uses normal SparkSession instead of remote SparkSession
-          uv run --no-sync --with 'databricks-agents,databricks-connect' \
-            pytest tests/utils/test_requirements_utils.py::test_infer_pip_requirements_on_databricks_agents
+          uv run --no-sync pytest tests/webhooks/test_e2e.py -v
 
   database:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
+    if: false # TEMP: scoped down for uvicorn unpin experiment
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:
@@ -179,7 +153,7 @@ jobs:
           ./tests/db/compose.sh down --volumes --remove-orphans --rmi all
 
   java:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
+    if: false # TEMP: scoped down for uvicorn unpin experiment
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -203,7 +177,7 @@ jobs:
           uv run --no-dev mvn clean package -q
 
   flavors:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
+    if: false # TEMP: scoped down for uvicorn unpin experiment
     runs-on: ubuntu-latest
     timeout-minutes: 120
     permissions:
@@ -231,7 +205,7 @@ jobs:
             tests/autologging
 
   models:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
+    if: false # TEMP: scoped down for uvicorn unpin experiment
     runs-on: ubuntu-latest
     timeout-minutes: 120
     permissions:
@@ -266,7 +240,7 @@ jobs:
           uv run --no-sync pytest --splits=$SPLITS --group=$GROUP tests/models
 
   evaluate:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
+    if: false # TEMP: scoped down for uvicorn unpin experiment
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:
@@ -303,7 +277,7 @@ jobs:
           uv run --no-sync pytest tests/evaluate/test_default_evaluator_delta.py
 
   genai:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
+    if: false # TEMP: scoped down for uvicorn unpin experiment
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -345,7 +319,7 @@ jobs:
             --ignore tests/genai/scorers/guardrails
 
   pyfunc:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
+    if: false # TEMP: scoped down for uvicorn unpin experiment
     runs-on: ubuntu-latest
     timeout-minutes: 120
     permissions:
@@ -384,7 +358,7 @@ jobs:
           uv run --no-sync pytest tests/pyfunc/test_spark_connect.py
 
   windows:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
+    if: false # TEMP: scoped down for uvicorn unpin experiment
     runs-on: windows-latest
     timeout-minutes: 120
     permissions:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -48,7 +48,7 @@ jobs:
   # The python skinny tests cover the subset of mlflow functionality
   # while also verifying certain dependencies are omitted.
   python-skinny:
-    if: false # TEMP: scoped down for uvicorn unpin experiment
+    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -67,11 +67,17 @@ jobs:
           ./dev/run-python-skinny-tests.sh
 
   python:
-    # TEMP: scoped down to webhook e2e tests for uvicorn unpin experiment
+    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 120
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [1, 2, 3, 4]
+        include:
+          - splits: 4
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -89,17 +95,34 @@ jobs:
             -r requirements/test-requirements.txt \
             -r requirements/extra-ml-requirements.txt
       - uses: ./.github/actions/show-versions
-      - name: Show uvicorn version
-        run: uv run --no-sync python -c "import uvicorn; print(uvicorn.__version__)"
-      - name: Run server-startup tests
+      - name: Import check
         run: |
-          uv run --no-sync pytest \
-            tests/webhooks/test_e2e.py \
-            tests/tracking/test_rest_tracking.py \
-            -v
+          # `-I` is used to avoid importing modules from user-specific site-packages
+          # that might conflict with the built-in modules (e.g. `types`).
+          uv run --no-sync python -I tests/check_mlflow_lazily_imports_ml_packages.py
+      - name: Run tests
+        env:
+          SPLITS: ${{ matrix.splits }}
+          GROUP: ${{ matrix.group }}
+        run: |
+          source dev/setup-ssh.sh
+          uv run --no-sync pytest --splits=$SPLITS --group=$GROUP \
+            --quiet --requires-ssh --ignore-flavors \
+            --ignore=tests/examples \
+            --ignore=tests/evaluate \
+            --ignore=tests/genai \
+            --ignore=tests/docker \
+            tests
+
+      - name: Run databricks-connect related tests
+        run: |
+          # this needs to be run in a separate job because installing databricks-connect could break other
+          # tests that uses normal SparkSession instead of remote SparkSession
+          uv run --no-sync --with 'databricks-agents,databricks-connect' \
+            pytest tests/utils/test_requirements_utils.py::test_infer_pip_requirements_on_databricks_agents
 
   database:
-    if: false # TEMP: scoped down for uvicorn unpin experiment
+    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:
@@ -156,7 +179,7 @@ jobs:
           ./tests/db/compose.sh down --volumes --remove-orphans --rmi all
 
   java:
-    if: false # TEMP: scoped down for uvicorn unpin experiment
+    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -180,7 +203,7 @@ jobs:
           uv run --no-dev mvn clean package -q
 
   flavors:
-    if: false # TEMP: scoped down for uvicorn unpin experiment
+    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
     runs-on: ubuntu-latest
     timeout-minutes: 120
     permissions:
@@ -208,7 +231,7 @@ jobs:
             tests/autologging
 
   models:
-    if: false # TEMP: scoped down for uvicorn unpin experiment
+    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
     runs-on: ubuntu-latest
     timeout-minutes: 120
     permissions:
@@ -243,7 +266,7 @@ jobs:
           uv run --no-sync pytest --splits=$SPLITS --group=$GROUP tests/models
 
   evaluate:
-    if: false # TEMP: scoped down for uvicorn unpin experiment
+    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:
@@ -280,7 +303,7 @@ jobs:
           uv run --no-sync pytest tests/evaluate/test_default_evaluator_delta.py
 
   genai:
-    if: false # TEMP: scoped down for uvicorn unpin experiment
+    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -322,7 +345,7 @@ jobs:
             --ignore tests/genai/scorers/guardrails
 
   pyfunc:
-    if: false # TEMP: scoped down for uvicorn unpin experiment
+    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
     runs-on: ubuntu-latest
     timeout-minutes: 120
     permissions:
@@ -361,7 +384,7 @@ jobs:
           uv run --no-sync pytest tests/pyfunc/test_spark_connect.py
 
   windows:
-    if: false # TEMP: scoped down for uvicorn unpin experiment
+    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
     runs-on: windows-latest
     timeout-minutes: 120
     permissions:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -91,9 +91,12 @@ jobs:
       - uses: ./.github/actions/show-versions
       - name: Show uvicorn version
         run: uv run --no-sync python -c "import uvicorn; print(uvicorn.__version__)"
-      - name: Run webhook e2e tests
+      - name: Run server-startup tests
         run: |
-          uv run --no-sync pytest tests/webhooks/test_e2e.py -v
+          uv run --no-sync pytest \
+            tests/webhooks/test_e2e.py \
+            tests/tracking/test_rest_tracking.py \
+            -v
 
   database:
     if: false # TEMP: scoped down for uvicorn unpin experiment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -250,8 +250,6 @@ constraint-dependencies = [
   # litellm 1.82.7 and 1.82.8 contain a malicious .pth file that steals credentials
   # https://github.com/BerriAI/litellm/issues/24512
   "litellm<=1.82.6",
-  # uvicorn 0.47.0 appears to delay multi-worker readiness on CI, causing server health checks to time out
-  "uvicorn<0.47",
 ]
 # Prevent third-party libraries from installing uv to avoid conflicts with uv installed
 # by the standalone installer

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -5,5 +5,3 @@ xgboost<3.1.0
 # litellm 1.82.7 and 1.82.8 contain a malicious .pth file that steals credentials
 # https://github.com/BerriAI/litellm/issues/24512
 litellm<=1.82.6
-# uvicorn 0.47.0 appears to delay multi-worker readiness on CI, causing server health checks to time out
-uvicorn<0.47

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -1909,7 +1909,7 @@ def test_create_model_version_with_validation_regex(db_uri: str):
     ) as proc:
         try:
             # Wait for the server to start
-            for _ in range(10):
+            for _ in range(30):
                 try:
                     if requests.get(f"http://localhost:{port}/health").ok:
                         break

--- a/tests/webhooks/test_e2e.py
+++ b/tests/webhooks/test_e2e.py
@@ -29,7 +29,7 @@ class WebhookLogEntry:
     attempt: int | None = None
 
 
-def wait_until_ready(health_endpoint: str, max_attempts: int = 10) -> None:
+def wait_until_ready(health_endpoint: str, max_attempts: int = 30) -> None:
     for _ in range(max_attempts):
         try:
             resp = requests.get(health_endpoint, timeout=2)

--- a/uv.lock
+++ b/uv.lock
@@ -30,7 +30,6 @@ constraints = [
     { name = "litellm", specifier = "<=1.82.6" },
     { name = "pyspark", specifier = "<4.1.0" },
     { name = "setuptools", specifier = "<82" },
-    { name = "uvicorn", specifier = "<0.47" },
     { name = "xgboost", specifier = "<3.1.0" },
 ]
 excludes = ["uv"]
@@ -8343,16 +8342,16 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.46.0"
+version = "0.47.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/b1/8e7077a8641086aea449e1b5752a570f1b5906c64e0a33cd6d93b63a066b/uvicorn-0.47.0.tar.gz", hash = "sha256:7c9a0ea1a9414106bbab7324609c162d8fa0cdcdcb703060987269d77c7bb533", size = 90582, upload-time = "2026-05-14T18:16:54.455Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
+    { url = "https://files.pythonhosted.org/packages/15/41/ac2dfdbc1f60c7af4f994c7a335cfa7040c01642b605d65f611cecc2a1e4/uvicorn-0.47.0-py3-none-any.whl", hash = "sha256:2c5715bc12d1892d84752049f400cd1c3cb018514967fdfeb97640443a6a9432", size = 71301, upload-time = "2026-05-14T18:16:51.762Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23577 (the lockfile update where uvicorn was pinned to `<0.47`)

### What changes are proposed in this pull request?

uvicorn 0.47.0 was pinned in #23577 with the note that it delays multi-worker readiness on CI and times out server health checks. The actual upstream change is encode/uvicorn#2919, which makes `uvicorn.run()` eagerly call `config.load_app()` (i.e. import the ASGI app synchronously in the parent process) before constructing the supervisor or forking workers. For MLflow that means `mlflow.server.fastapi_app` (which pulls in `mlflow.server.handlers` (~7,300 lines) and the rest of the tracking/gateway/job/otel surface) is now imported serially in the parent before any worker is forked, lengthening the cold-start critical path.

Two test helpers used a 10-attempt × 1s retry to wait for `mlflow server` (default 4 uvicorn workers) to answer `/health`. With 0.47 that budget is no longer wide enough on CI runners.

This PR:

- Removes the `uvicorn<0.47` constraint from `pyproject.toml` and `requirements/constraints.txt`, refreshes `uv.lock` (0.46.0 → 0.47.0).
- Raises the retry budget from 10 to 30 attempts in two places:
  - `tests/webhooks/test_e2e.py::wait_until_ready` — used by the `mlflow_server` fixture.
  - `tests/tracking/test_rest_tracking.py::test_create_model_version_with_validation_regex` — inline copy of the same pattern.

Reproduction + fix were validated on a scoped-down master.yml against this branch (run 26429894819 reproduced `RuntimeError: Failed to start server at .../health` with uvicorn 0.47; run after the bumps was green).

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release