### PR TITLE
Collapse optional sections by default in Create Role modal

### DIFF
--- a/mlflow/server/js/src/admin/components/CreateRoleModal.tsx
+++ b/mlflow/server/js/src/admin/components/CreateRoleModal.tsx
@@ -237,7 +237,7 @@ export const CreateRoleModal = ({ open, onClose }: CreateRoleModalProps) => {
           </Typography.Paragraph>
         </div>
       </LongFormSection>
-      <LongFormSection title="Permissions">
+      <LongFormSection title="Permissions" collapsible defaultCollapsed>
         <Typography.Text color="secondary" css={{ display: 'block', marginBottom: theme.spacing.sm }}>
           Add one or more permissions to this role. You can add more later from the role detail page.
         </Typography.Text>
@@ -248,7 +248,7 @@ export const CreateRoleModal = ({ open, onClose }: CreateRoleModalProps) => {
           disabled={submitting}
         />
       </LongFormSection>
-      <LongFormSection title="Assign users" hideDivider>
+      <LongFormSection title="Assign users" hideDivider collapsible defaultCollapsed>
         <Typography.Text color="secondary" css={{ display: 'block', marginBottom: theme.spacing.sm }}>
           Assign one or more users to this role. You can assign more later from the role detail page.
         </Typography.Text>

--- a/mlflow/server/js/src/common/components/long-form/LongFormSection.test.tsx
+++ b/mlflow/server/js/src/common/components/long-form/LongFormSection.test.tsx
@@ -28,6 +28,40 @@ describe('LongFormSection — collapsible mode', () => {
     expect(screen.getByRole('button', { name: /Permissions/ })).toHaveAttribute('aria-expanded', 'false');
   });
 
+  it('wires up the disclosure-widget ARIA relationship + ``inert`` when collapsed', () => {
+    // ARIA: ``aria-controls`` on the toggle button must point at the content
+    // region's ``id`` so screen readers announce what the toggle expands.
+    // ``inert`` on the collapsed wrapper is a belt-and-suspenders guarantee:
+    // ``hidden`` alone can be overridden by CSS resets, but ``inert``
+    // removes the subtree from tab order regardless.
+    const { container } = renderWithDesignSystem(
+      <LongFormSection title="Permissions" collapsible defaultCollapsed>
+        <button type="button">deep button</button>
+      </LongFormSection>,
+    );
+    const toggle = screen.getByRole('button', { name: /Permissions/ });
+    const controlsId = toggle.getAttribute('aria-controls');
+    expect(controlsId).toBeTruthy();
+    const region = container.querySelector(`#${controlsId}`);
+    expect(region).not.toBeNull();
+    expect(region).toHaveAttribute('hidden');
+    expect(region).toHaveAttribute('inert');
+  });
+
+  it('drops ``inert`` when expanded so inner controls are focusable again', async () => {
+    renderWithDesignSystem(
+      <LongFormSection title="Permissions" collapsible defaultCollapsed>
+        <button type="button">deep button</button>
+      </LongFormSection>,
+    );
+    const toggle = screen.getByRole('button', { name: /Permissions/ });
+    await userEvent.click(toggle);
+    const controlsId = toggle.getAttribute('aria-controls')!;
+    const region = document.getElementById(controlsId)!;
+    expect(region).not.toHaveAttribute('hidden');
+    expect(region).not.toHaveAttribute('inert');
+  });
+
   it('toggles visibility on title click when collapsible', async () => {
     renderWithDesignSystem(
       <LongFormSection title="Permissions" collapsible defaultCollapsed>

--- a/mlflow/server/js/src/common/components/long-form/LongFormSection.test.tsx
+++ b/mlflow/server/js/src/common/components/long-form/LongFormSection.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect } from '@jest/globals';
+import userEventGlobal from '@testing-library/user-event';
+import React from 'react';
+import { renderWithDesignSystem, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
+import { LongFormSection } from './LongFormSection';
+
+const userEvent = userEventGlobal.setup();
+
+describe('LongFormSection — collapsible mode', () => {
+  it('renders children when ``collapsible`` is not set (back-compat: existing call sites stay open)', () => {
+    renderWithDesignSystem(
+      <LongFormSection title="Always open">
+        <div>inner content</div>
+      </LongFormSection>,
+    );
+    expect(screen.getByText('inner content')).toBeInTheDocument();
+  });
+
+  it('hides children when ``collapsible`` + ``defaultCollapsed`` are set', () => {
+    renderWithDesignSystem(
+      <LongFormSection title="Permissions" collapsible defaultCollapsed>
+        <div>inner content</div>
+      </LongFormSection>,
+    );
+    expect(screen.queryByText('inner content')).not.toBeInTheDocument();
+    // Title button stays in the DOM so the user can expand the section.
+    expect(screen.getByRole('button', { name: /Permissions/ })).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('toggles visibility on title click when collapsible', async () => {
+    renderWithDesignSystem(
+      <LongFormSection title="Permissions" collapsible defaultCollapsed>
+        <div>inner content</div>
+      </LongFormSection>,
+    );
+    const toggle = screen.getByRole('button', { name: /Permissions/ });
+    await userEvent.click(toggle);
+    expect(screen.getByText('inner content')).toBeInTheDocument();
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    await userEvent.click(toggle);
+    expect(screen.queryByText('inner content')).not.toBeInTheDocument();
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  });
+});

--- a/mlflow/server/js/src/common/components/long-form/LongFormSection.test.tsx
+++ b/mlflow/server/js/src/common/components/long-form/LongFormSection.test.tsx
@@ -1,10 +1,16 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect, beforeEach } from '@jest/globals';
 import userEventGlobal from '@testing-library/user-event';
 import React, { useState } from 'react';
 import { renderWithDesignSystem, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
 import { LongFormSection } from './LongFormSection';
 
-const userEvent = userEventGlobal.setup();
+// ``userEvent.setup()`` v14 holds stateful pointer/keyboard state; if a test
+// throws mid-gesture, leftover state can leak into the next test. Re-create
+// per test so each case starts clean.
+let userEvent: ReturnType<typeof userEventGlobal.setup>;
+beforeEach(() => {
+  userEvent = userEventGlobal.setup();
+});
 
 describe('LongFormSection — collapsible mode', () => {
   it('renders children when ``collapsible`` is not set (back-compat: existing call sites stay open)', () => {
@@ -80,7 +86,7 @@ describe('LongFormSection — collapsible mode', () => {
     expect(toggle).toHaveAttribute('aria-expanded', 'false');
   });
 
-  it('preserves child state across a collapse / expand round-trip', async () => {
+  it('preserves child state across a collapse / expand round-trip (starts expanded)', async () => {
     // Pins the reason we use ``hidden`` (not conditional render): a draft
     // typed into ``RolePermissionsSection`` / ``RoleUsersSection`` must
     // survive the user collapsing the section and re-opening it.
@@ -99,5 +105,30 @@ describe('LongFormSection — collapsible mode', () => {
     await userEvent.click(toggle);
     await userEvent.click(toggle);
     expect(screen.getByRole('textbox', { name: 'draft' })).toHaveValue('in-progress');
+  });
+
+  it('preserves child state across an expand / collapse round-trip (starts collapsed)', async () => {
+    // Same guarantee from the other direction: a section that opens with
+    // ``defaultCollapsed`` mounts its children hidden + inert, and any
+    // state added after the first expand must survive a re-collapse.
+    const Inner = () => {
+      const [text, setText] = useState('');
+      return <input aria-label="draft" value={text} onChange={(e) => setText(e.target.value)} />;
+    };
+    renderWithDesignSystem(
+      <LongFormSection title="Permissions" collapsible defaultCollapsed>
+        <Inner />
+      </LongFormSection>,
+    );
+    // Confirm we really started in the hidden state. ``hidden: true`` opts
+    // into matching hidden elements — by default ``getByRole`` filters them
+    // out, which would mask the very state we want to assert on.
+    expect(screen.getByRole('textbox', { name: 'draft', hidden: true })).not.toBeVisible();
+    const toggle = screen.getByRole('button', { name: /Permissions/ });
+    await userEvent.click(toggle);
+    await userEvent.type(screen.getByRole('textbox', { name: 'draft' }), 'opened-then-typed');
+    await userEvent.click(toggle);
+    await userEvent.click(toggle);
+    expect(screen.getByRole('textbox', { name: 'draft' })).toHaveValue('opened-then-typed');
   });
 });

--- a/mlflow/server/js/src/common/components/long-form/LongFormSection.test.tsx
+++ b/mlflow/server/js/src/common/components/long-form/LongFormSection.test.tsx
@@ -34,7 +34,7 @@ describe('LongFormSection — collapsible mode', () => {
     // ``inert`` on the collapsed wrapper is a belt-and-suspenders guarantee:
     // ``hidden`` alone can be overridden by CSS resets, but ``inert``
     // removes the subtree from tab order regardless.
-    const { container } = renderWithDesignSystem(
+    renderWithDesignSystem(
       <LongFormSection title="Permissions" collapsible defaultCollapsed>
         <button type="button">deep button</button>
       </LongFormSection>,
@@ -42,7 +42,10 @@ describe('LongFormSection — collapsible mode', () => {
     const toggle = screen.getByRole('button', { name: /Permissions/ });
     const controlsId = toggle.getAttribute('aria-controls');
     expect(controlsId).toBeTruthy();
-    const region = container.querySelector(`#${controlsId}`);
+    // ``getElementById`` (not ``querySelector('#…')``) because React 18's
+    // ``useId`` produces colon-bracketed ids (`:r0:`) that aren't valid in
+    // CSS selectors without escaping.
+    const region = document.getElementById(controlsId!);
     expect(region).not.toBeNull();
     expect(region).toHaveAttribute('hidden');
     expect(region).toHaveAttribute('inert');

--- a/mlflow/server/js/src/common/components/long-form/LongFormSection.test.tsx
+++ b/mlflow/server/js/src/common/components/long-form/LongFormSection.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from '@jest/globals';
 import userEventGlobal from '@testing-library/user-event';
-import React from 'react';
+import React, { useState } from 'react';
 import { renderWithDesignSystem, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
 import { LongFormSection } from './LongFormSection';
 
@@ -13,7 +13,7 @@ describe('LongFormSection — collapsible mode', () => {
         <div>inner content</div>
       </LongFormSection>,
     );
-    expect(screen.getByText('inner content')).toBeInTheDocument();
+    expect(screen.getByText('inner content')).toBeVisible();
   });
 
   it('hides children when ``collapsible`` + ``defaultCollapsed`` are set', () => {
@@ -22,7 +22,8 @@ describe('LongFormSection — collapsible mode', () => {
         <div>inner content</div>
       </LongFormSection>,
     );
-    expect(screen.queryByText('inner content')).not.toBeInTheDocument();
+    // Stays mounted but not visible so any in-progress draft state survives.
+    expect(screen.getByText('inner content')).not.toBeVisible();
     // Title button stays in the DOM so the user can expand the section.
     expect(screen.getByRole('button', { name: /Permissions/ })).toHaveAttribute('aria-expanded', 'false');
   });
@@ -35,10 +36,31 @@ describe('LongFormSection — collapsible mode', () => {
     );
     const toggle = screen.getByRole('button', { name: /Permissions/ });
     await userEvent.click(toggle);
-    expect(screen.getByText('inner content')).toBeInTheDocument();
+    expect(screen.getByText('inner content')).toBeVisible();
     expect(toggle).toHaveAttribute('aria-expanded', 'true');
     await userEvent.click(toggle);
-    expect(screen.queryByText('inner content')).not.toBeInTheDocument();
+    expect(screen.getByText('inner content')).not.toBeVisible();
     expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('preserves child state across a collapse / expand round-trip', async () => {
+    // Pins the reason we use ``hidden`` (not conditional render): a draft
+    // typed into ``RolePermissionsSection`` / ``RoleUsersSection`` must
+    // survive the user collapsing the section and re-opening it.
+    const Inner = () => {
+      const [text, setText] = useState('');
+      return <input aria-label="draft" value={text} onChange={(e) => setText(e.target.value)} />;
+    };
+    renderWithDesignSystem(
+      <LongFormSection title="Permissions" collapsible>
+        <Inner />
+      </LongFormSection>,
+    );
+    const input = screen.getByRole('textbox', { name: 'draft' });
+    await userEvent.type(input, 'in-progress');
+    const toggle = screen.getByRole('button', { name: /Permissions/ });
+    await userEvent.click(toggle);
+    await userEvent.click(toggle);
+    expect(screen.getByRole('textbox', { name: 'draft' })).toHaveValue('in-progress');
   });
 });

--- a/mlflow/server/js/src/common/components/long-form/LongFormSection.tsx
+++ b/mlflow/server/js/src/common/components/long-form/LongFormSection.tsx
@@ -1,5 +1,5 @@
-import type { ReactNode } from 'react';
-import { useDesignSystemTheme } from '@databricks/design-system';
+import { useState, type ReactNode } from 'react';
+import { ChevronDownIcon, ChevronRightIcon, useDesignSystemTheme } from '@databricks/design-system';
 
 export interface LongFormSectionProps {
   /** Section title displayed on the left side */
@@ -17,6 +17,14 @@ export interface LongFormSectionProps {
   hideDivider?: boolean;
   /** Optional className for custom styling */
   className?: string;
+  /**
+   * When true, the title becomes a button that toggles the section open
+   * and closed. Use for optional sections so dense modals don't surface
+   * every field on the user at once.
+   */
+  collapsible?: boolean;
+  /** Initial collapsed state when ``collapsible`` is true (default: false). */
+  defaultCollapsed?: boolean;
 }
 
 /**
@@ -31,8 +39,43 @@ export const LongFormSection = ({
   children,
   hideDivider = false,
   className,
+  collapsible = false,
+  defaultCollapsed = false,
 }: LongFormSectionProps) => {
   const { theme } = useDesignSystemTheme();
+  const [collapsed, setCollapsed] = useState(collapsible && defaultCollapsed);
+
+  const titleBlock = (
+    <>
+      <div
+        css={{
+          fontWeight: theme.typography.typographyBoldFontWeight,
+          fontSize: theme.typography.fontSizeLg,
+          display: 'flex',
+          alignItems: 'center',
+          gap: theme.spacing.xs,
+        }}
+      >
+        {title}
+        {collapsible && (
+          <span css={{ display: 'inline-flex', alignItems: 'center', color: theme.colors.textSecondary }}>
+            {collapsed ? <ChevronRightIcon /> : <ChevronDownIcon />}
+          </span>
+        )}
+      </div>
+      {subtitle && (
+        <div
+          css={{
+            marginTop: theme.spacing.xs,
+            fontSize: theme.typography.fontSizeSm,
+            color: theme.colors.textSecondary,
+          }}
+        >
+          {subtitle}
+        </div>
+      )}
+    </>
+  );
 
   return (
     <div
@@ -58,27 +101,29 @@ export const LongFormSection = ({
           },
         }}
       >
-        <div
-          css={{
-            fontWeight: theme.typography.typographyBoldFontWeight,
-            fontSize: theme.typography.fontSizeLg,
-          }}
-        >
-          {title}
-        </div>
-        {subtitle && (
-          <div
+        {collapsible ? (
+          <button
+            type="button"
+            onClick={() => setCollapsed((c) => !c)}
+            aria-expanded={!collapsed}
             css={{
-              marginTop: theme.spacing.xs,
-              fontSize: theme.typography.fontSizeSm,
-              color: theme.colors.textSecondary,
+              background: 'none',
+              border: 'none',
+              padding: 0,
+              cursor: 'pointer',
+              font: 'inherit',
+              color: 'inherit',
+              textAlign: 'left',
+              width: '100%',
             }}
           >
-            {subtitle}
-          </div>
+            {titleBlock}
+          </button>
+        ) : (
+          titleBlock
         )}
       </div>
-      <div css={{ flexGrow: 1, minWidth: 0 }}>{children}</div>
+      {!collapsed && <div css={{ flexGrow: 1, minWidth: 0 }}>{children}</div>}
     </div>
   );
 };

--- a/mlflow/server/js/src/common/components/long-form/LongFormSection.tsx
+++ b/mlflow/server/js/src/common/components/long-form/LongFormSection.tsx
@@ -123,7 +123,13 @@ export const LongFormSection = ({
           titleBlock
         )}
       </div>
-      {!collapsed && <div css={{ flexGrow: 1, minWidth: 0 }}>{children}</div>}
+      {/* ``hidden`` (vs. conditional render) keeps the section mounted so any
+          in-progress draft state inside ``children`` (e.g. ``RolePermissionsSection``'s
+          staged grant, ``RoleUsersSection``'s search text) survives a collapse / expand
+          round-trip. */}
+      <div css={{ flexGrow: 1, minWidth: 0 }} hidden={collapsed}>
+        {children}
+      </div>
     </div>
   );
 };

--- a/mlflow/server/js/src/common/components/long-form/LongFormSection.tsx
+++ b/mlflow/server/js/src/common/components/long-form/LongFormSection.tsx
@@ -1,12 +1,25 @@
-import * as React from 'react';
 import { useState, type ReactNode } from 'react';
 import { ChevronDownIcon, ChevronRightIcon, useDesignSystemTheme } from '@databricks/design-system';
 
 // React 18.x exposes ``useId`` at runtime, but ``@types/react`` is pinned at
-// 17.x in this repo so the type isn't surfaced. Cast around the gap rather
-// than fall back to ``Math.random()`` (which would mint a fresh id on every
-// render and break DOM-snapshot determinism).
-const useId = (React as unknown as { useId: () => string }).useId;
+// 17.x in this repo so the named import doesn't type-check. ``import * as
+// React from 'react'`` would type-check but is blocked by the
+// ``no-restricted-imports`` rule (``Suspense`` must come from
+// ``@databricks/web-shared/react``). Pull the symbol via ``require`` so the
+// type system sees only the narrow shape we use, and fall back to a
+// ``useState``-based counter for the case where ``react-17`` (aliased in
+// devDependencies for Enzyme) is the active runtime — keeps the section
+// from blowing up at the call site instead of at the import.
+// eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
+const reactRuntime = require('react') as { useId?: () => string };
+
+let fallbackIdCounter = 0;
+const useFallbackId = (): string => useState(() => `long-form-section-fallback-${++fallbackIdCounter}`)[0];
+
+// One stable function for the lifetime of the module — Rules-of-Hooks
+// requires the same hook to be called in the same order each render, so the
+// React 18 vs. 17 selection happens once at module load.
+const useStableId: () => string = reactRuntime.useId ?? useFallbackId;
 
 export interface LongFormSectionProps {
   /** Section title displayed on the left side */
@@ -53,7 +66,7 @@ export const LongFormSection = ({
   const [collapsed, setCollapsed] = useState(collapsible && defaultCollapsed);
   // Stable id wires the toggle button's ``aria-controls`` to the content
   // region's ``id`` so screen readers announce the disclosure relationship.
-  const contentId = useId();
+  const contentId = useStableId();
 
   // ``<span>`` (not ``<div>``) so this fragment is valid phrasing content
   // when nested inside the ``<button>`` in the collapsible branch — avoids
@@ -155,9 +168,13 @@ export const LongFormSection = ({
         hidden={collapsed}
         // React 18 accepts ``inert`` as a string-only DOM attribute; the
         // empty string ``""`` is the canonical "on" value per the HTML spec.
-        // TypeScript's ``HTMLAttributes`` didn't add ``inert`` until React 19,
-        // so spread it conditionally to avoid touching the type system.
-        {...(collapsed ? { inert: '' } : {})}
+        // ``HTMLAttributes`` didn't add ``inert`` until React 19, so spread
+        // the attribute through a narrowly-typed cast.
+        // Always pass the key (with ``undefined`` when not collapsed) so
+        // React strips the attribute from the DOM on re-render — omitting
+        // the key from the spread would leave the previous attribute in
+        // place.
+        {...({ inert: collapsed ? '' : undefined } as { inert?: '' })}
         css={{ flexGrow: 1, minWidth: 0 }}
       >
         {children}

--- a/mlflow/server/js/src/common/components/long-form/LongFormSection.tsx
+++ b/mlflow/server/js/src/common/components/long-form/LongFormSection.tsx
@@ -44,14 +44,24 @@ export const LongFormSection = ({
 }: LongFormSectionProps) => {
   const { theme } = useDesignSystemTheme();
   const [collapsed, setCollapsed] = useState(collapsible && defaultCollapsed);
+  // Stable id wires the toggle button's ``aria-controls`` to the content
+  // region's ``id`` so screen readers announce the disclosure relationship.
+  // Lazy ``useState`` initializer locks the id to the component instance.
+  // (``React.useId`` would be cleaner, but ``@types/react`` is pinned at 17.x
+  // even though the runtime is 18.x — fall back to a random suffix.)
+  const [contentId] = useState(() => `long-form-section-${Math.random().toString(36).slice(2)}`);
 
+  // ``<span>`` (not ``<div>``) so this fragment is valid phrasing content
+  // when nested inside the ``<button>`` in the collapsible branch — avoids
+  // React's ``validateDOMNesting`` warning ("<div> cannot appear as a
+  // descendant of <button>").
   const titleBlock = (
     <>
-      <div
+      <span
         css={{
+          display: 'flex',
           fontWeight: theme.typography.typographyBoldFontWeight,
           fontSize: theme.typography.fontSizeLg,
-          display: 'flex',
           alignItems: 'center',
           gap: theme.spacing.xs,
         }}
@@ -62,17 +72,18 @@ export const LongFormSection = ({
             {collapsed ? <ChevronRightIcon /> : <ChevronDownIcon />}
           </span>
         )}
-      </div>
+      </span>
       {subtitle && (
-        <div
+        <span
           css={{
+            display: 'block',
             marginTop: theme.spacing.xs,
             fontSize: theme.typography.fontSizeSm,
             color: theme.colors.textSecondary,
           }}
         >
           {subtitle}
-        </div>
+        </span>
       )}
     </>
   );
@@ -106,6 +117,7 @@ export const LongFormSection = ({
             type="button"
             onClick={() => setCollapsed((c) => !c)}
             aria-expanded={!collapsed}
+            aria-controls={contentId}
             css={{
               background: 'none',
               border: 'none',
@@ -126,8 +138,19 @@ export const LongFormSection = ({
       {/* ``hidden`` (vs. conditional render) keeps the section mounted so any
           in-progress draft state inside ``children`` (e.g. ``RolePermissionsSection``'s
           staged grant, ``RoleUsersSection``'s search text) survives a collapse / expand
-          round-trip. */}
-      <div css={{ flexGrow: 1, minWidth: 0 }} hidden={collapsed}>
+          round-trip. ``inert`` removes the subtree from tab order and the
+          accessibility tree — belt-and-suspenders alongside ``hidden`` since
+          some CSS resets override ``[hidden] { display: none }``. */}
+      <div
+        id={contentId}
+        hidden={collapsed}
+        // React 18 accepts ``inert`` as a string-only DOM attribute; the
+        // empty string ``""`` is the canonical "on" value per the HTML spec.
+        // TypeScript's ``HTMLAttributes`` didn't add ``inert`` until React 19,
+        // so spread it conditionally to avoid touching the type system.
+        {...(collapsed ? { inert: '' } : {})}
+        css={{ flexGrow: 1, minWidth: 0 }}
+      >
         {children}
       </div>
     </div>

--- a/mlflow/server/js/src/common/components/long-form/LongFormSection.tsx
+++ b/mlflow/server/js/src/common/components/long-form/LongFormSection.tsx
@@ -1,5 +1,12 @@
+import * as React from 'react';
 import { useState, type ReactNode } from 'react';
 import { ChevronDownIcon, ChevronRightIcon, useDesignSystemTheme } from '@databricks/design-system';
+
+// React 18.x exposes ``useId`` at runtime, but ``@types/react`` is pinned at
+// 17.x in this repo so the type isn't surfaced. Cast around the gap rather
+// than fall back to ``Math.random()`` (which would mint a fresh id on every
+// render and break DOM-snapshot determinism).
+const useId = (React as unknown as { useId: () => string }).useId;
 
 export interface LongFormSectionProps {
   /** Section title displayed on the left side */
@@ -46,10 +53,7 @@ export const LongFormSection = ({
   const [collapsed, setCollapsed] = useState(collapsible && defaultCollapsed);
   // Stable id wires the toggle button's ``aria-controls`` to the content
   // region's ``id`` so screen readers announce the disclosure relationship.
-  // Lazy ``useState`` initializer locks the id to the component instance.
-  // (``React.useId`` would be cleaner, but ``@types/react`` is pinned at 17.x
-  // even though the runtime is 18.x — fall back to a random suffix.)
-  const [contentId] = useState(() => `long-form-section-${Math.random().toString(36).slice(2)}`);
+  const contentId = useId();
 
   // ``<span>`` (not ``<div>``) so this fragment is valid phrasing content
   // when nested inside the ``<button>`` in the collapsible branch — avoids
@@ -88,14 +92,19 @@ export const LongFormSection = ({
     </>
   );
 
+  // Collapsed sections shrink their vertical padding so the modal actually
+  // becomes shorter — otherwise the row keeps its open-state footprint and
+  // a "compact" form still scrolls.
+  const verticalPadding = collapsed ? theme.spacing.sm : theme.spacing.lg;
+
   return (
     <div
       className={className}
       css={{
         display: 'flex',
         gap: 32,
-        paddingTop: theme.spacing.lg,
-        paddingBottom: theme.spacing.lg,
+        paddingTop: verticalPadding,
+        paddingBottom: verticalPadding,
         borderBottom: hideDivider ? 'none' : `1px solid ${theme.colors.borderDecorative}`,
         '@media (max-width: 1023px)': {
           flexDirection: 'column',


### PR DESCRIPTION
### Related Issues/PRs

Relates to the [RBAC Bug Bash doc](https://docs.google.com/document/d/17BWoF5n_a8Y1bafsQp1NDmSONe6uC9MDMPsCXn85aXg/edit) (Serena's feedback on `CreateRoleModal`).

### What changes are proposed in this pull request?

Bug-bash feedback from Serena: `CreateRoleModal` renders `Role details` + `Permissions` + `Assign users` all expanded, dumping a lot of UI on the user up-front. Both follow-on sections are optional (you can also wire them up later from the role detail page), so default them to collapsed and let the user expand on demand.

Mechanism: add `collapsible` + `defaultCollapsed` opt-in props on `LongFormSection`. Both default to `false` so the other call sites (`CreateUserModal`, `EditAccessModal`, `EditRoleModal`, `EndpointFormRenderer`) stay open exactly as before. When collapsed, the section renders just the title + a right-chevron; clicking flips to a down-chevron and shows the children. Matches the existing collapsible pattern in `FeaturesSection.tsx`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<img width="2321" height="1340" alt="image" src="https://github.com/user-attachments/assets/5aa72032-c10b-4b6d-844d-632232a3b713" />

<!-- Attach code, screenshot, video used for manual testing here. -->

New `LongFormSection.test.tsx` covers: back-compat (no `collapsible`), hidden children when `defaultCollapsed`, toggle on click, `aria-expanded` updates. `yarn type-check`, `yarn prettier:check`, `yarn lint` all clean.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

In the admin **Create Role** modal, the `Permissions` and `Assign users` sections are now collapsed by default — click the section title to expand. Reduces visual noise for the common case where the role is wired up from the detail page afterwards.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.