### PR TITLE
Collapse optional sections by default in Create User modal

### DIFF
--- a/mlflow/server/js/src/admin/components/CreateUserModal.test.tsx
+++ b/mlflow/server/js/src/admin/components/CreateUserModal.test.tsx
@@ -10,8 +10,11 @@ beforeEach(() => {
   userEvent = userEventGlobal.setup();
 });
 
-const mockCreateUserMutateAsync = jest.fn();
-const mockGrantPermissionMutateAsync = jest.fn();
+// Typed as ``(...args: any[]) => any`` so ``mockResolvedValue`` accepts the
+// realistic response shapes the component awaits. ``jest.fn()``'s default
+// signature is ``() => never``, which would reject the payload.
+const mockCreateUserMutateAsync = jest.fn<(...args: any[]) => any>();
+const mockGrantPermissionMutateAsync = jest.fn<(...args: any[]) => any>();
 
 jest.mock('../hooks', () => ({
   AdminQueryKeys: {

--- a/mlflow/server/js/src/admin/components/CreateUserModal.test.tsx
+++ b/mlflow/server/js/src/admin/components/CreateUserModal.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import userEventGlobal from '@testing-library/user-event';
+import React from 'react';
+import { renderWithDesignSystem, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
+
+import { CreateUserModal } from './CreateUserModal';
+
+let userEvent: ReturnType<typeof userEventGlobal.setup>;
+beforeEach(() => {
+  userEvent = userEventGlobal.setup();
+});
+
+const mockCreateUserMutateAsync = jest.fn();
+const mockGrantPermissionMutateAsync = jest.fn();
+
+jest.mock('../hooks', () => ({
+  AdminQueryKeys: {
+    users: ['admin_users'],
+    roles: ['admin_roles'],
+    roleUsers: (roleId: number) => ['admin_role_users', roleId],
+    resourceOptions: (resourceType: string) => ['admin_resource_options', resourceType],
+  },
+  useCreateUser: () => ({ mutateAsync: mockCreateUserMutateAsync }),
+  useCurrentUserIsAdmin: () => true,
+  useGrantUserPermission: () => ({ mutateAsync: mockGrantPermissionMutateAsync }),
+  useResourceOptionsQuery: () => ({ options: [], isLoading: false, error: null }),
+  useRolesQuery: () => ({ data: { roles: [] }, isLoading: false, error: null }),
+  useWorkspaceOptions: () => ['default'],
+}));
+
+jest.mock('../../workspaces/utils/WorkspaceUtils', () => ({
+  useActiveWorkspace: () => 'default',
+}));
+
+jest.mock('../../workspaces/hooks/useWorkspaces', () => ({
+  useWorkspaces: () => ({ workspaces: [{ name: 'default' }], isLoading: false }),
+}));
+
+jest.mock('../../experiment-tracking/hooks/useServerInfo', () => ({
+  useWorkspacesEnabled: () => ({ workspacesEnabled: false }),
+}));
+
+jest.mock('@mlflow/mlflow/src/common/utils/reactQueryHooks', () => ({
+  useQueryClient: () => ({ invalidateQueries: jest.fn() }),
+}));
+
+// The submit path also reaches AdminApi directly; stub the methods we touch
+// so a click submit doesn't end up making real network calls.
+jest.mock('../api', () => ({
+  AdminApi: {
+    assignRole: jest.fn(),
+    updateAdmin: jest.fn(),
+  },
+}));
+
+describe('CreateUserModal — collapsible optional sections', () => {
+  beforeEach(() => {
+    mockCreateUserMutateAsync.mockReset();
+    mockGrantPermissionMutateAsync.mockReset();
+  });
+
+  it('renders Role assignment + Direct permissions collapsed and Admin status expanded', () => {
+    // Locks the rationale documented next to ``Admin status`` in the modal:
+    // multi-field optional sections collapse for density; a single-Switch
+    // section stays open because hiding a one-liner behind a click is just
+    // extra friction.
+    renderWithDesignSystem(<CreateUserModal open onClose={jest.fn()} />);
+    expect(screen.getByRole('button', { name: /Role assignment/ })).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.getByRole('button', { name: /Direct permissions/ })).toHaveAttribute('aria-expanded', 'false');
+    // ``Admin status`` is rendered (the admin mock returns true) but is not
+    // collapsible, so it must not surface a toggle button.
+    expect(screen.getByText('Admin status')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Admin status/ })).not.toBeInTheDocument();
+  });
+
+  it('submits with the optional sections still collapsed (only username + password required)', async () => {
+    // The whole point of collapsing the optional sections is that the admin
+    // shouldn't have to interact with them to create a user. Pin that the
+    // submit path works against the default-collapsed state.
+    mockCreateUserMutateAsync.mockResolvedValue({ user: { username: 'newbie' } });
+    renderWithDesignSystem(<CreateUserModal open onClose={jest.fn()} />);
+
+    await userEvent.type(screen.getByPlaceholderText('Enter username'), 'newbie');
+    await userEvent.type(screen.getByPlaceholderText('Enter password'), 'hunter2');
+    // Sanity-check we're still in the default-collapsed state before submit
+    // — otherwise the test isn't really exercising what we claim.
+    expect(screen.getByRole('button', { name: /Role assignment/ })).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.getByRole('button', { name: /Direct permissions/ })).toHaveAttribute('aria-expanded', 'false');
+
+    await userEvent.click(screen.getByRole('button', { name: /^Create user$/ }));
+
+    expect(mockCreateUserMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ username: 'newbie', password: 'hunter2' }),
+    );
+  });
+});

--- a/mlflow/server/js/src/admin/components/CreateUserModal.test.tsx
+++ b/mlflow/server/js/src/admin/components/CreateUserModal.test.tsx
@@ -14,7 +14,6 @@ beforeEach(() => {
 // realistic response shapes the component awaits. ``jest.fn()``'s default
 // signature is ``() => never``, which would reject the payload.
 const mockCreateUserMutateAsync = jest.fn<(...args: any[]) => any>();
-const mockGrantPermissionMutateAsync = jest.fn<(...args: any[]) => any>();
 
 jest.mock('../hooks', () => ({
   AdminQueryKeys: {
@@ -25,7 +24,14 @@ jest.mock('../hooks', () => ({
   },
   useCreateUser: () => ({ mutateAsync: mockCreateUserMutateAsync }),
   useCurrentUserIsAdmin: () => true,
-  useGrantUserPermission: () => ({ mutateAsync: mockGrantPermissionMutateAsync }),
+  // ``useGrantUserPermission`` is invoked by the modal even though our tests
+  // never stage a direct permission (and so the ``wantsDirect`` branch in
+  // ``handleSubmit`` is skipped). Inline the stub so we don't carry an
+  // unused captured spy.
+  useGrantUserPermission: () => ({ mutateAsync: jest.fn() }),
+  // ``useResourceOptionsQuery`` is reached by ``DirectPermissionForm`` even
+  // when its parent section is collapsed (``hidden`` keeps it mounted), so
+  // the stub has to exist; only the shape matters.
   useResourceOptionsQuery: () => ({ options: [], isLoading: false, error: null }),
   useRolesQuery: () => ({ data: { roles: [] }, isLoading: false, error: null }),
   useWorkspaceOptions: () => ['default'],
@@ -59,7 +65,6 @@ jest.mock('../api', () => ({
 describe('CreateUserModal — collapsible optional sections', () => {
   beforeEach(() => {
     mockCreateUserMutateAsync.mockReset();
-    mockGrantPermissionMutateAsync.mockReset();
   });
 
   it('renders Role assignment + Direct permissions collapsed and Admin status expanded', () => {
@@ -76,12 +81,15 @@ describe('CreateUserModal — collapsible optional sections', () => {
     expect(screen.queryByRole('button', { name: /Admin status/ })).not.toBeInTheDocument();
   });
 
-  it('submits with the optional sections still collapsed (only username + password required)', async () => {
+  it('submits with the optional sections still collapsed and closes the modal on success', async () => {
     // The whole point of collapsing the optional sections is that the admin
     // shouldn't have to interact with them to create a user. Pin that the
-    // submit path works against the default-collapsed state.
+    // submit path works against the default-collapsed state and that the
+    // modal closes itself on success (the only signal that the happy path
+    // ran end-to-end, since there's no toast / redirect to observe).
     mockCreateUserMutateAsync.mockResolvedValue({ user: { username: 'newbie' } });
-    renderWithDesignSystem(<CreateUserModal open onClose={jest.fn()} />);
+    const onClose = jest.fn();
+    renderWithDesignSystem(<CreateUserModal open onClose={onClose} />);
 
     await userEvent.type(screen.getByPlaceholderText('Enter username'), 'newbie');
     await userEvent.type(screen.getByPlaceholderText('Enter password'), 'hunter2');
@@ -95,5 +103,6 @@ describe('CreateUserModal — collapsible optional sections', () => {
     expect(mockCreateUserMutateAsync).toHaveBeenCalledWith(
       expect.objectContaining({ username: 'newbie', password: 'hunter2' }),
     );
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/mlflow/server/js/src/admin/components/CreateUserModal.tsx
+++ b/mlflow/server/js/src/admin/components/CreateUserModal.tsx
@@ -259,13 +259,13 @@ export const CreateUserModal = ({ open, onClose }: CreateUserModalProps) => {
           </div>
         </div>
       </LongFormSection>
-      <LongFormSection title="Role assignment" subtitle="(Optional)">
+      <LongFormSection title="Role assignment" collapsible defaultCollapsed>
         <Typography.Text color="secondary" css={{ display: 'block', marginBottom: theme.spacing.sm }}>
           Assign one or more existing roles to give this user reusable bundles of permissions.
         </Typography.Text>
         <RoleAssignmentForm value={roleValue} onChange={setRoleValue} disabled={submitting} />
       </LongFormSection>
-      <LongFormSection title="Direct permissions" subtitle="(Optional)" hideDivider={!isCurrentUserAdmin}>
+      <LongFormSection title="Direct permissions" collapsible defaultCollapsed hideDivider={!isCurrentUserAdmin}>
         <Typography.Text color="secondary" css={{ display: 'block', marginBottom: theme.spacing.sm }}>
           Grant one or more one-off permissions on specific resources.
         </Typography.Text>
@@ -299,7 +299,7 @@ export const CreateUserModal = ({ open, onClose }: CreateUserModalProps) => {
         />
       </LongFormSection>
       {isCurrentUserAdmin && (
-        <LongFormSection title="Admin status" subtitle="(Optional)" hideDivider>
+        <LongFormSection title="Admin status" hideDivider>
           <Typography.Text color="secondary" css={{ display: 'block', marginBottom: theme.spacing.sm }}>
             Admins can manage all users, roles, and workspaces.
           </Typography.Text>

--- a/mlflow/server/js/src/admin/components/CreateUserModal.tsx
+++ b/mlflow/server/js/src/admin/components/CreateUserModal.tsx
@@ -299,6 +299,9 @@ export const CreateUserModal = ({ open, onClose }: CreateUserModalProps) => {
         />
       </LongFormSection>
       {isCurrentUserAdmin && (
+        // Intentionally not ``collapsible``: ``Admin status`` is a single
+        // Switch row, so hiding it behind a toggle adds an extra click for
+        // no real density win (vs. the multi-field sections above).
         <LongFormSection title="Admin status" hideDivider>
           <Typography.Text color="secondary" css={{ display: 'block', marginBottom: theme.spacing.sm }}>
             Admins can manage all users, roles, and workspaces.


### PR DESCRIPTION
### Related Issues/PRs

Relates to the [RBAC Bug Bash doc](https://docs.google.com/document/d/17BWoF5n_a8Y1bafsQp1NDmSONe6uC9MDMPsCXn85aXg/edit) (Serena's "every section is expanded by default" / "avoid putting Optional under each section's title" feedback). Follow-up to #23592 (now landed) which introduced the `collapsible` + `defaultCollapsed` props on `LongFormSection`.

### What changes are proposed in this pull request?

Same treatment as #23592 / #23412 applied to `CreateUserModal`: the multi-field optional sections (`Role assignment`, `Direct permissions`) are collapsed by default and lose their `(Optional)` subtitles. `Admin status` stays expanded because it's a single Switch row — collapsing it would hide a one-liner behind a click for no real visual gain.

All the underlying behavior (ARIA disclosure-widget wiring, `inert` for focus blocking, `hidden` for state preservation, shrunk padding when collapsed, `useId` for stable region ids) lives in the `LongFormSection` component landed by #23592 and is inherited automatically — this PR is just the consumer change.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

<img width="2329" height="1283" alt="image" src="https://github.com/user-attachments/assets/90b5fb46-3e53-4a88-bafa-a5993908702a" />


`LongFormSection`'s collapsible behavior is covered by the regression tests added in #23592. Manual smoke: open Create User modal — User details and Admin status expanded; Role assignment and Direct permissions collapsed with chevrons; click each to expand. State (e.g. staged direct grant) survives a collapse/expand round-trip thanks to the `hidden` + `inert` approach in `LongFormSection`.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

In the admin **Create User** modal, the `Role assignment` and `Direct permissions` sections are now collapsed by default — click the section title to expand. Removes the `(Optional)` subtitles and reduces visual noise for the common case of just creating a user.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.