### PR TITLE
Install CPU torch in autoformat docs step

### DIFF
--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -181,7 +181,9 @@ jobs:
       # ************************************************************************
       - if: steps.diff.outputs.api == 'true'
         run: |
-          uv run --group docs --with-requirements "$GITHUB_WORKSPACE/requirements/torch.txt" --extra gateway --directory docs/api_reference make dummy
+          uv sync --group docs --extra gateway
+          uv pip install -r requirements/torch.txt
+          uv run --directory docs/api_reference make dummy
       # ************************************************************************
       # Upload patch
       # ************************************************************************


### PR DESCRIPTION
### Related Issues/PRs

Relates to the segfault in https://github.com/mlflow/mlflow/actions/runs/26438081232/job/77825525494

### What changes are proposed in this pull request?

Mirror `docs.yml`'s install pattern in `autoformat.yml`:

```yaml
uv sync --group docs --extra gateway
uv pip install -r requirements/torch.txt
uv run --directory docs/api_reference make dummy
```

The previous step ran `uv run --with-requirements requirements/torch.txt --directory docs/api_reference make dummy`. The `--directory` flag pointed uv at `docs/api_reference/` (which has no `pyproject.toml`), so the root-level `[tool.uv.pip] torch-backend = "cpu"` setting was bypassed and `--with-requirements` resolved `torch` from default PyPI. That pulled the GPU wheel plus every `nvidia-*` runtime library (cuBLAS, cuDNN, cuFFT, NCCL, cuSPARSE, triton, ~2.5 GB total) onto the autoformat runner and led to a sphinx-build segfault during native-lib init alongside TensorFlow.

Routing torch through `uv pip install` at the repo root makes uv honor `torch-backend = "cpu"`, which is the same way `docs.yml` builds the API reference today.

### How is this PR tested?

- [x] Existing unit/integration tests

The `autoformat` workflow itself is the regression target; this change matches the install pattern already used by the green `docs / build` job.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)