### PR TITLE
Daemon implementation for coding agents batched tracing

### DIFF
--- a/libs/typescript/core/esbuild.config.mjs
+++ b/libs/typescript/core/esbuild.config.mjs
@@ -1,0 +1,30 @@
+/**
+ * Bundles the WAL uploader daemon into a single, executable CJS file.
+ *
+ * Why a bundle:
+ *   - The daemon is spawned as a child process by the supervisor (see
+ *     `src/exporters/wal/supervisor.ts`), which resolves it at runtime
+ *     via `@mlflow/core/package.json` + `bundle/daemon.cjs`. Shipping a
+ *     single self-contained file means we don't have to worry about
+ *     transitive `dist/` files or `node_modules` layout in the target
+ *     environment.
+ *   - The `#!/usr/bin/env node` banner + `chmod 0o755` makes the bundle
+ *     directly executable, which is how the npm `bin` field invokes it.
+ */
+
+import { build } from 'esbuild';
+import { chmodSync } from 'node:fs';
+
+const outfile = 'bundle/daemon.cjs';
+
+await build({
+  entryPoints: ['dist/exporters/wal/daemon.js'],
+  bundle: true,
+  platform: 'node',
+  format: 'cjs',
+  outfile,
+  external: ['node:*'],
+  banner: { js: '#!/usr/bin/env node' },
+});
+
+chmodSync(outfile, 0o755);

--- a/libs/typescript/core/package.json
+++ b/libs/typescript/core/package.json
@@ -26,8 +26,11 @@
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "bin": {
+    "mlflow-trace-daemon": "./bundle/daemon.cjs"
+  },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node esbuild.config.mjs",
     "test": "jest",
     "lint": "eslint . --ext .ts --max-warnings 0",
     "lint:fix": "eslint . --ext .ts --fix",
@@ -50,6 +53,7 @@
     "@types/node": "^20.4.5",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
+    "esbuild": "^0.25.0",
     "eslint": "^8.57.1",
     "jest": "^29.6.2",
     "msw": "^2.10.3",
@@ -63,6 +67,7 @@
     "node": ">=18"
   },
   "files": [
-    "dist/"
+    "dist/",
+    "bundle/"
   ]
 }

--- a/libs/typescript/core/src/exporters/wal/daemon.ts
+++ b/libs/typescript/core/src/exporters/wal/daemon.ts
@@ -18,7 +18,7 @@ import { BATCH_INTERVAL_MS, IDLE_MS, LOG_RETENTION_DAYS, RETRY_TIMEOUT_MS } from
 import { createIpcConnectionHandler } from './ipc';
 import { getDaemonLogPath, getLockSocketPath, getWalDir } from './paths';
 import { PidLock, tryAcquirePidLock } from './pid_lock';
-import { appendDeadLetter, appendRecord, compact, readPending, walSize } from './storage';
+import { appendDeadLetter, compact, readPending, walSize } from './storage';
 import { isDaemonAlive } from './supervisor';
 import { WalRecord } from './types';
 
@@ -454,8 +454,9 @@ async function handleUploadFailure(
     `Retry record ${record.id} → ${retry.id} (trace ${traceId}, attempts=${nextAttempts}, ` +
       `delay=${delayMs}ms, elapsed=${elapsedMs}ms): ${formatError(err)}`,
   );
-  await writer.submitTombstone(record.id);
-  await appendRecord(retry);
+  // Both submissions ride the same `BatchingWriter` tick: one `writev`,
+  // one `fsync`, atomic. Either both lines are durable or neither is.
+  await Promise.all([writer.submit(retry), writer.submitTombstone(record.id)]);
 }
 
 export type ClientFactory = (trackingUri: string) => MlflowClient;

--- a/libs/typescript/core/src/exporters/wal/daemon.ts
+++ b/libs/typescript/core/src/exporters/wal/daemon.ts
@@ -133,7 +133,9 @@ export interface DaemonLock {
  * On Windows, named pipes are kernel-refcounted: two daemons cannot
  * bind the same pipe name simultaneously regardless of the order of
  * operations. We skip the PID lock there and rely on `listen()`'s
- * native exclusion.
+ * native exclusion — the loser of a concurrent-bind race sees
+ * `EADDRINUSE` from {@link bindUnderPidLock}, which returns `null` so
+ * we concede here the same way the PID-lock-lost path does on POSIX.
  */
 export async function acquireLock(
   onConnection: (socket: Socket) => void = defaultConnectionHandler,
@@ -153,6 +155,13 @@ export async function acquireLock(
   try {
     const socketPath = getLockSocketPath();
     const server = await bindUnderPidLock(socketPath, onConnection);
+    if (server == null) {
+      // Windows-only path: a sibling daemon won the named-pipe race.
+      // No PID lock to release (Windows path; `pidLock` is always
+      // null here). Concede the same way the POSIX PID-lock-lost case
+      // does so the caller can `process.exit(0)` cleanly.
+      return null;
+    }
     return { server, pidLock };
   } catch (err) {
     // Bind path failed after we acquired the PID lock — release it so
@@ -163,17 +172,28 @@ export async function acquireLock(
 }
 
 /**
- * Bind the lock socket under the protection of an already-held PID
- * lock. With the lock held, an `EADDRINUSE` on the first attempt can
- * only mean a leftover socket file from a daemon that crashed without
- * cleanup, so the recovery is a single unlink + rebind. A second
- * `EADDRINUSE` indicates a non-daemon process squatting on our socket
- * path and is surfaced as a fatal error.
+ * Bind the lock socket, with recovery semantics that depend on the
+ * cross-process exclusion guarantee held by the caller.
+ *
+ * Returns:
+ *   - the bound `Server` on success.
+ *   - `null` on Windows when a sibling daemon won the named-pipe bind
+ *     race. POSIX handles the equivalent "sibling won" case via the
+ *     PID lock acquisition earlier in {@link acquireLock}, so this
+ *     return value only fires on Windows.
+ *
+ * The asymmetric handling reflects platform reality: Unix domain
+ * sockets leave a filesystem entry that survives the owning process,
+ * so POSIX needs an unlink + rebind dance for orphan recovery. Windows
+ * named pipes are kernel-refcounted — when the owning process dies
+ * the pipe disappears from the kernel namespace automatically, so
+ * there is no orphan recovery to do; `EADDRINUSE` there can only mean
+ * a live sibling.
  */
 async function bindUnderPidLock(
   socketPath: string,
   onConnection: (socket: Socket) => void,
-): Promise<Server> {
+): Promise<Server | null> {
   const first = await tryBind(socketPath, onConnection);
   if (first.kind === 'bound') {
     return first.server;
@@ -182,13 +202,25 @@ async function bindUnderPidLock(
     throw first.err;
   }
 
-  if (process.platform !== 'win32') {
-    try {
-      await unlink(socketPath);
-    } catch (err) {
-      if (isErrnoException(err) && err.code !== 'ENOENT') {
-        throw err;
-      }
+  // EADDRINUSE on the first attempt. The right action depends on
+  // platform:
+  //   - Windows: no PID lock is held (named pipes provide their own
+  //     kernel-level exclusion), and there is no orphan pipe file to
+  //     unlink. EADDRINUSE here means a live sibling daemon won the
+  //     race; concede by returning null and let `acquireLock`
+  //     propagate that as a clean "another daemon is running" signal.
+  //   - POSIX: we hold the PID lock, so no sibling daemon is racing
+  //     us. EADDRINUSE must be a leftover socket file from a daemon
+  //     that crashed without cleanup. Unlink the orphan and retry.
+  if (process.platform === 'win32') {
+    return null;
+  }
+
+  try {
+    await unlink(socketPath);
+  } catch (err) {
+    if (isErrnoException(err) && err.code !== 'ENOENT') {
+      throw err;
     }
   }
 
@@ -361,7 +393,7 @@ export async function uploadOne(
         `Failed to rebuild client for ${record.trackingUri} after auth error: ${formatError(factoryErr)}`,
       );
 
-      await handleUploadFailure(record, err, writer);
+      await handleUploadFailure(record, factoryErr, writer);
       return;
     }
 
@@ -466,41 +498,46 @@ export async function processBatch(
   );
 }
 
-let shutdownRequested = false;
-
 /**
- * Wire signal handlers so the daemon finishes its current batch and
- * exits cleanly on `SIGTERM` / `SIGINT` rather than being torn down
- * mid-write. The check is consulted at the top of each loop iteration.
+ * Wire SIGTERM / SIGINT handlers to abort the supplied controller so
+ * the daemon finishes its current batch and exits cleanly rather than
+ * being torn down mid-write. The abort is consulted at the top of each
+ * {@link runBatchLoop} iteration.
  */
-function installSignalHandlers(): void {
+function installSignalHandlers(controller: AbortController): void {
   for (const sig of ['SIGTERM', 'SIGINT'] as const) {
     process.on(sig, () => {
       log(`Received ${sig}; will shut down after current batch.`);
-      shutdownRequested = true;
+      controller.abort();
     });
   }
 }
 
 /**
  * The batch loop. Broken out from {@link main} so the dependencies
- * (client factory, writer, timings) can be injected in tests without
- * standing up the full daemon lifecycle.
+ * (client factory, writer, timings, shutdown signal) can be injected
+ * in tests without standing up the full daemon lifecycle.
+ *
+ * Pass an `AbortSignal` to request a graceful shutdown — the loop
+ * finishes its current iteration and returns. Without a signal the
+ * loop only exits via the `idleMs` timeout path (or by throwing).
  */
 export async function runBatchLoop({
   factory = clientForUri,
   writer = new BatchingWriter(),
   batchIntervalMs = BATCH_INTERVAL_MS,
   idleMs = IDLE_MS,
+  signal,
 }: {
   factory?: ClientFactory;
   writer?: BatchingWriter;
   batchIntervalMs?: number;
   idleMs?: number;
+  signal?: AbortSignal;
 } = {}): Promise<void> {
   let lastNonEmpty = Date.now();
 
-  while (!shutdownRequested) {
+  while (signal?.aborted !== true) {
     try {
       const pending = await readPending();
       if (pending.length > 0) {
@@ -542,13 +579,14 @@ export async function main(): Promise<void> {
   }
 
   log(`Daemon started; pid=${process.pid}, walDir=${getWalDir()}`);
-  installSignalHandlers();
+  const shutdown = new AbortController();
+  installSignalHandlers(shutdown);
 
   let exitCode = 0;
   try {
     await pruneOldLogs().catch((err) => log(`Retention sweep failed: ${formatError(err)}`));
     await compact().catch((err) => log(`Startup compact failed: ${formatError(err)}`));
-    await runBatchLoop({ writer: ipcWriter });
+    await runBatchLoop({ writer: ipcWriter, signal: shutdown.signal });
     await compact().catch((err) => log(`Final compact failed: ${formatError(err)}`));
   } catch (err) {
     log(`Daemon main loop crashed: ${formatError(err)}`);

--- a/libs/typescript/core/src/exporters/wal/daemon.ts
+++ b/libs/typescript/core/src/exporters/wal/daemon.ts
@@ -1,0 +1,574 @@
+/**
+ * The trace-uploader daemon — long-lived background process that drains
+ * the WAL on behalf of all hooks running for this OS user.
+ */
+
+import { appendFileSync } from 'node:fs';
+import { mkdir, readdir, unlink } from 'node:fs/promises';
+import { createServer, Server, Socket } from 'node:net';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { MlflowClient } from '../../clients/client';
+import { MlflowHttpError } from '../../clients/utils';
+import { SerializedTraceData, TraceData } from '../../core/entities/trace_data';
+import { SerializedTraceInfo, TraceInfo } from '../../core/entities/trace_info';
+import { BatchingWriter } from './batching_writer';
+import { clearClientCache, clearClientForUri, clientForUri } from './clients';
+import { BATCH_INTERVAL_MS, IDLE_MS, LOG_RETENTION_DAYS, RETRY_TIMEOUT_MS } from './constants';
+import { createIpcConnectionHandler } from './ipc';
+import { getDaemonLogPath, getLockSocketPath, getWalDir } from './paths';
+import { PidLock, tryAcquirePidLock } from './pid_lock';
+import { appendDeadLetter, appendRecord, compact, readPending, walSize } from './storage';
+import { isDaemonAlive } from './supervisor';
+import { WalRecord } from './types';
+
+const MAX_BACKOFF_MS = 5 * 60_000;
+
+const COMPACTION_THRESHOLD_BYTES = 100_000;
+
+function isErrnoException(err: unknown): err is NodeJS.ErrnoException {
+  return typeof err === 'object' && err != null && 'code' in err;
+}
+
+function formatError(err: unknown): string {
+  if (err instanceof Error) {
+    return err.stack ?? err.message;
+  }
+  return String(err);
+}
+
+/**
+ * Append a single timestamped line to the daemon log file. Uses sync
+ * I/O so two concurrent log calls cannot interleave;
+ */
+export function log(line: string): void {
+  const timestamp = new Date().toISOString();
+  const fullLine = `[${timestamp}] [pid=${process.pid}] ${line}\n`;
+  try {
+    appendFileSync(getDaemonLogPath(), fullLine);
+  } catch {
+    // Failures are swallowed so a broken disk never crashes the daemon mid-batch.
+  }
+}
+
+/** Awaits `ms` real milliseconds. Used for the batch loop's pacing. */
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Exponential backoff with a fixed cap.
+ */
+export function backoff(attempt: number): number {
+  return Math.min(2_000 * 2 ** (attempt - 1), MAX_BACKOFF_MS);
+}
+
+/**
+ * Default connection handler used when {@link acquireLock} is invoked
+ * without one (e.g. by tests that only care about the lock semantic).
+ */
+function defaultConnectionHandler(socket: Socket): void {
+  socket.end();
+}
+
+/**
+ * Result of a single `listen()` attempt on the lock socket. Distinguishes
+ * the three outcomes acquireLock has to dispatch on: bound (we won),
+ * EADDRINUSE (someone else holds the path — live daemon or stale file),
+ * or any other error (unexpected).
+ */
+type BindResult =
+  | { kind: 'bound'; server: Server }
+  | { kind: 'eaddrinuse' }
+  | { kind: 'error'; err: Error };
+
+/**
+ * Try to bind a fresh server to `socketPath`. Never throws — every
+ * outcome is encoded in the returned discriminated union so callers can
+ * keep their control flow linear instead of try/catching around a
+ * Promise that resolves three different ways.
+ */
+function tryBind(socketPath: string, onConnection: (socket: Socket) => void): Promise<BindResult> {
+  return new Promise<BindResult>((resolve) => {
+    const server = createServer(onConnection);
+    server.once('error', (err: NodeJS.ErrnoException) => {
+      if (err.code === 'EADDRINUSE') {
+        resolve({ kind: 'eaddrinuse' });
+        return;
+      }
+      resolve({ kind: 'error', err });
+    });
+    server.listen(socketPath, () => resolve({ kind: 'bound', server }));
+  });
+}
+
+/**
+ * Handle returned by {@link acquireLock} on success. Pairs the bound
+ * server with the optional cross-process PID lock so {@link releaseLock}
+ * can tear both down together. `pidLock` is `null` on Windows because
+ * named pipes already provide kernel-refcounted cross-process
+ * exclusion; the file-based lock would be pure overhead there.
+ */
+export interface DaemonLock {
+  server: Server;
+  pidLock: PidLock | null;
+}
+
+/**
+ * Acquire the singleton daemon lock.
+ *
+ * Returns the {@link DaemonLock} on success, or `null` when another
+ * daemon is already running (the caller should `process.exit(0)`
+ * cleanly).
+ *
+ * ## How exclusion is enforced
+ *
+ * On POSIX, exclusion is enforced by the atomic PID lock acquired in
+ * {@link tryAcquirePidLock} *before* the socket bind. The PID lock uses
+ * `link()`, a single kernel-atomic syscall — only one process can win,
+ * the rest see `EEXIST` and concede. With the lock held, no sibling
+ * daemon is past this point at the same time as us, so the subsequent
+ * `bind()` runs uncontested.
+ *
+ * On Windows, named pipes are kernel-refcounted: two daemons cannot
+ * bind the same pipe name simultaneously regardless of the order of
+ * operations. We skip the PID lock there and rely on `listen()`'s
+ * native exclusion.
+ */
+export async function acquireLock(
+  onConnection: (socket: Socket) => void = defaultConnectionHandler,
+): Promise<DaemonLock | null> {
+  if (await isDaemonAlive()) {
+    return null;
+  }
+
+  // Cross-process exclusion gate. On POSIX this is the only mechanism
+  // that prevents two daemons from racing through stale-socket
+  // recovery and ending up both bound;
+  const pidLock = process.platform === 'win32' ? null : await tryAcquirePidLock();
+  if (process.platform !== 'win32' && pidLock == null) {
+    return null;
+  }
+
+  try {
+    const socketPath = getLockSocketPath();
+    const server = await bindUnderPidLock(socketPath, onConnection);
+    return { server, pidLock };
+  } catch (err) {
+    // Bind path failed after we acquired the PID lock — release it so
+    // the next spawn isn't blocked by our orphaned lockfile.
+    await pidLock?.release();
+    throw err;
+  }
+}
+
+/**
+ * Bind the lock socket under the protection of an already-held PID
+ * lock. With the lock held, an `EADDRINUSE` on the first attempt can
+ * only mean a leftover socket file from a daemon that crashed without
+ * cleanup, so the recovery is a single unlink + rebind. A second
+ * `EADDRINUSE` indicates a non-daemon process squatting on our socket
+ * path and is surfaced as a fatal error.
+ */
+async function bindUnderPidLock(
+  socketPath: string,
+  onConnection: (socket: Socket) => void,
+): Promise<Server> {
+  const first = await tryBind(socketPath, onConnection);
+  if (first.kind === 'bound') {
+    return first.server;
+  }
+  if (first.kind === 'error') {
+    throw first.err;
+  }
+
+  if (process.platform !== 'win32') {
+    try {
+      await unlink(socketPath);
+    } catch (err) {
+      if (isErrnoException(err) && err.code !== 'ENOENT') {
+        throw err;
+      }
+    }
+  }
+
+  const second = await tryBind(socketPath, onConnection);
+  if (second.kind === 'bound') {
+    return second.server;
+  }
+  if (second.kind === 'eaddrinuse') {
+    throw new Error(
+      `bind failed with EADDRINUSE on ${socketPath} while holding the PID lock — ` +
+        `another process is squatting on the daemon's socket path`,
+    );
+  }
+  throw second.err;
+}
+
+/**
+ * Release the lock acquired by {@link acquireLock}. Closes the server,
+ * unlinks the POSIX socket file, and (when present) releases the PID
+ * lock so the next daemon's `acquireLock` finds a clean slate.
+ */
+export async function releaseLock(server: Server, pidLock: PidLock | null = null): Promise<void> {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  if (process.platform !== 'win32') {
+    try {
+      await unlink(getLockSocketPath());
+    } catch (err) {
+      if (isErrnoException(err) && err.code !== 'ENOENT') {
+        log(`releaseLock: socket unlink failed: ${formatError(err)}`);
+      }
+    }
+  }
+  if (pidLock != null) {
+    try {
+      await pidLock.release();
+    } catch (err) {
+      log(`releaseLock: pid lock release failed: ${formatError(err)}`);
+    }
+  }
+}
+
+const ROTATED_LOG_REGEX = /^(failed|daemon)\.log\.(\d{4})-(\d{2})-(\d{2})$/;
+
+const MS_PER_DAY = 24 * 60 * 60 * 1_000;
+
+/**
+ * One-shot retention sweep for the daily-rotated `failed.log.<date>` and
+ * `daemon.log.<date>` files in the WAL dir.
+ *
+ * Called once per daemon startup, after the liveness lock is held and
+ * before the batch loop starts.
+ *
+ * The sweep is best-effort: any failure (missing dir, EPERM on a file the
+ * user hand-edited, malformed filenames) is logged at debug and
+ * swallowed. Retention housekeeping must never abort daemon startup.
+ */
+export async function pruneOldLogs(
+  opts: { now?: Date; retentionDays?: number } = {},
+): Promise<void> {
+  const retentionDays = opts.retentionDays ?? LOG_RETENTION_DAYS;
+  if (retentionDays <= 0) {
+    return;
+  }
+
+  const now = opts.now ?? new Date();
+
+  const todayUtcMs = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  const cutoffMs = todayUtcMs - retentionDays * MS_PER_DAY;
+
+  const walDir = getWalDir();
+  let entries: string[];
+  try {
+    entries = await readdir(walDir);
+  } catch (err) {
+    log(`pruneOldLogs: readdir failed for ${walDir}: ${formatError(err)}`);
+    return;
+  }
+
+  for (const name of entries) {
+    const match = ROTATED_LOG_REGEX.exec(name);
+    if (match == null) {
+      continue;
+    }
+    const [, , yyyy, mm, dd] = match;
+    const year = Number(yyyy);
+    const month = Number(mm);
+    const day = Number(dd);
+    const fileDate = new Date(Date.UTC(year, month - 1, day));
+
+    if (
+      fileDate.getUTCFullYear() !== year ||
+      fileDate.getUTCMonth() !== month - 1 ||
+      fileDate.getUTCDate() !== day
+    ) {
+      continue;
+    }
+    if (fileDate.getTime() >= cutoffMs) {
+      continue;
+    }
+
+    const fullPath = join(walDir, name);
+    try {
+      await unlink(fullPath);
+      log(`pruneOldLogs: removed ${name} (older than ${retentionDays} day(s))`);
+    } catch (err) {
+      log(`pruneOldLogs: failed to unlink ${name}: ${formatError(err)}`);
+    }
+  }
+}
+
+/**
+ * HTTP statuses that {@link uploadOne} treats as "the cached
+ * credentials are stale; rebuild and retry once."
+ */
+const AUTH_REFRESH_STATUSES: ReadonlySet<number> = new Set([401, 403]);
+
+function isAuthRefreshableError(err: unknown): boolean {
+  return err instanceof MlflowHttpError && AUTH_REFRESH_STATUSES.has(err.status);
+}
+
+/**
+ * Perform the create-trace + upload-trace-data sequence.
+ */
+async function performUpload(client: MlflowClient, record: WalRecord): Promise<void> {
+  const traceInfo = TraceInfo.fromJson(record.traceInfo as unknown as SerializedTraceInfo);
+  const traceData = TraceData.fromJson(record.traceData as SerializedTraceData);
+  const resolvedInfo = await client.createTrace(traceInfo);
+  await client.uploadTraceData(resolvedInfo, traceData);
+}
+
+/**
+ * Process a single WAL record: deserialize, push to the backend,
+ * tombstone on success or schedule retry / dead-letter on failure.
+ */
+export async function uploadOne(
+  record: WalRecord,
+  client: MlflowClient,
+  writer: BatchingWriter,
+  factory: ClientFactory = clientForUri,
+): Promise<void> {
+  // Anchor the retry-budget window the first time the daemon touches
+  // the record.
+  if (record.firstAttemptAt === undefined) {
+    record.firstAttemptAt = Date.now();
+  }
+  const traceId = (record.traceInfo as { trace_id?: string }).trace_id ?? '<unknown>';
+
+  try {
+    await performUpload(client, record);
+    await writer.submitTombstone(record.id);
+    log(`Uploaded record ${record.id} (trace ${traceId})`);
+    return;
+  } catch (err) {
+    if (!isAuthRefreshableError(err)) {
+      await handleUploadFailure(record, err, writer);
+      return;
+    }
+
+    log(
+      `Auth failure on record ${record.id} (trace ${traceId}) for ${record.trackingUri}; ` +
+        `evicting cached client and retrying once: ${formatError(err)}`,
+    );
+    clearClientForUri(record.trackingUri);
+
+    let refreshed: MlflowClient;
+    try {
+      refreshed = factory(record.trackingUri);
+    } catch (factoryErr) {
+      log(
+        `Failed to rebuild client for ${record.trackingUri} after auth error: ${formatError(factoryErr)}`,
+      );
+
+      await handleUploadFailure(record, err, writer);
+      return;
+    }
+
+    try {
+      await performUpload(refreshed, record);
+      await writer.submitTombstone(record.id);
+      log(`Uploaded record ${record.id} (trace ${traceId}) after credential refresh`);
+    } catch (retryErr) {
+      // The credential-refresh retry also failed — fall back to the
+      // normal failure machinery (backoff / dead-letter).
+      await handleUploadFailure(record, retryErr, writer);
+    }
+  }
+}
+
+/**
+ * Branch the failure path: either dead-letter the record (if the next
+ * retry's backoff would push the total elapsed time past
+ * `RETRY_TIMEOUT_MS`) or re-append it with bumped `attempts` and a
+ * future `nextAttemptAt`. Either way the original row is tombstoned so
+ * the next batch doesn't see it again.
+ *
+ * Retries use a fresh row `id` so per-attempt rows are independently
+ * addressable in the log; the MLflow trace id inside `traceInfo` and
+ * the original `firstAttemptAt` stay stable across attempts.
+ */
+async function handleUploadFailure(
+  record: WalRecord,
+  err: unknown,
+  writer: BatchingWriter,
+): Promise<void> {
+  const nextAttempts = record.attempts + 1;
+  const traceId = (record.traceInfo as { trace_id?: string }).trace_id ?? '<unknown>';
+  const delayMs = backoff(nextAttempts);
+  const anchor = record.firstAttemptAt ?? record.createdAt;
+  const now = Date.now();
+  const elapsedMs = now - anchor;
+
+  if (elapsedMs + delayMs >= RETRY_TIMEOUT_MS) {
+    log(
+      `Dead-lettering record ${record.id} (trace ${traceId}) after ${record.attempts} prior ` +
+        `attempts, elapsed=${elapsedMs}ms; next retry would push past ${RETRY_TIMEOUT_MS}ms ` +
+        `budget: ${formatError(err)}`,
+    );
+    await appendDeadLetter(record);
+    await writer.submitTombstone(record.id);
+    return;
+  }
+
+  const retry: WalRecord = {
+    ...record,
+    id: randomUUID(),
+    attempts: nextAttempts,
+    nextAttemptAt: now + delayMs,
+    firstAttemptAt: anchor,
+  };
+  log(
+    `Retry record ${record.id} → ${retry.id} (trace ${traceId}, attempts=${nextAttempts}, ` +
+      `delay=${delayMs}ms, elapsed=${elapsedMs}ms): ${formatError(err)}`,
+  );
+  await writer.submitTombstone(record.id);
+  await appendRecord(retry);
+}
+
+export type ClientFactory = (trackingUri: string) => MlflowClient;
+
+/**
+ * Group `records` by `trackingUri` and upload each group in parallel.
+ */
+export async function processBatch(
+  records: WalRecord[],
+  writer: BatchingWriter,
+  factory: ClientFactory = clientForUri,
+): Promise<void> {
+  if (records.length === 0) {
+    return;
+  }
+
+  const groups = new Map<string, WalRecord[]>();
+  for (const record of records) {
+    const list = groups.get(record.trackingUri);
+    if (list === undefined) {
+      groups.set(record.trackingUri, [record]);
+    } else {
+      list.push(record);
+    }
+  }
+
+  await Promise.all(
+    [...groups.entries()].map(async ([trackingUri, group]) => {
+      let client: MlflowClient;
+      try {
+        client = factory(trackingUri);
+      } catch (err) {
+        log(`Failed to build client for ${trackingUri}: ${formatError(err)}`);
+
+        await Promise.all(group.map((record) => handleUploadFailure(record, err, writer)));
+        return;
+      }
+      await Promise.all(group.map((record) => uploadOne(record, client, writer, factory)));
+    }),
+  );
+}
+
+let shutdownRequested = false;
+
+/**
+ * Wire signal handlers so the daemon finishes its current batch and
+ * exits cleanly on `SIGTERM` / `SIGINT` rather than being torn down
+ * mid-write. The check is consulted at the top of each loop iteration.
+ */
+function installSignalHandlers(): void {
+  for (const sig of ['SIGTERM', 'SIGINT'] as const) {
+    process.on(sig, () => {
+      log(`Received ${sig}; will shut down after current batch.`);
+      shutdownRequested = true;
+    });
+  }
+}
+
+/**
+ * The batch loop. Broken out from {@link main} so the dependencies
+ * (client factory, writer, timings) can be injected in tests without
+ * standing up the full daemon lifecycle.
+ */
+export async function runBatchLoop({
+  factory = clientForUri,
+  writer = new BatchingWriter(),
+  batchIntervalMs = BATCH_INTERVAL_MS,
+  idleMs = IDLE_MS,
+}: {
+  factory?: ClientFactory;
+  writer?: BatchingWriter;
+  batchIntervalMs?: number;
+  idleMs?: number;
+} = {}): Promise<void> {
+  let lastNonEmpty = Date.now();
+
+  while (!shutdownRequested) {
+    try {
+      const pending = await readPending();
+      if (pending.length > 0) {
+        lastNonEmpty = Date.now();
+        const now = Date.now();
+        const due = pending.filter((r) => r.nextAttemptAt <= now);
+        if (due.length > 0) {
+          await processBatch(due, writer, factory);
+        }
+      } else if (Date.now() - lastNonEmpty >= idleMs) {
+        log('WAL idle threshold reached; shutting down.');
+        return;
+      }
+
+      if ((await walSize()) > COMPACTION_THRESHOLD_BYTES) {
+        await compact().catch((err) => log(`Periodic compact failed: ${formatError(err)}`));
+      }
+    } catch (err) {
+      // Don't let a transient FS / parse error tear down the daemon.
+      log(`Batch iteration error: ${formatError(err)}`);
+    }
+
+    await sleep(batchIntervalMs);
+  }
+}
+
+/**
+ * Daemon entry point.
+ */
+export async function main(): Promise<void> {
+  await mkdir(getWalDir(), { recursive: true });
+
+  const ipcWriter = new BatchingWriter();
+  const handle = await acquireLock(createIpcConnectionHandler(ipcWriter));
+  if (handle == null) {
+    log('Another daemon is already running; exiting cleanly.');
+    process.exit(0);
+    return;
+  }
+
+  log(`Daemon started; pid=${process.pid}, walDir=${getWalDir()}`);
+  installSignalHandlers();
+
+  let exitCode = 0;
+  try {
+    await pruneOldLogs().catch((err) => log(`Retention sweep failed: ${formatError(err)}`));
+    await compact().catch((err) => log(`Startup compact failed: ${formatError(err)}`));
+    await runBatchLoop({ writer: ipcWriter });
+    await compact().catch((err) => log(`Final compact failed: ${formatError(err)}`));
+  } catch (err) {
+    log(`Daemon main loop crashed: ${formatError(err)}`);
+    exitCode = 1;
+  } finally {
+    await releaseLock(handle.server, handle.pidLock).catch((err) =>
+      log(`releaseLock failed: ${formatError(err)}`),
+    );
+    clearClientCache();
+    log(`Daemon exited with code ${exitCode}.`);
+  }
+
+  process.exit(exitCode);
+}
+
+// Run main() only when invoked directly (i.e. `node bundle/daemon.cjs`),
+// not when this module is imported by tests.
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('[mlflow][wal-daemon] fatal:', err);
+    process.exit(1);
+  });
+}

--- a/libs/typescript/core/src/exporters/wal/daemon.ts
+++ b/libs/typescript/core/src/exporters/wal/daemon.ts
@@ -541,14 +541,13 @@ export async function runBatchLoop({
   while (signal?.aborted !== true) {
     try {
       const pending = await readPending();
-      if (pending.length > 0) {
-        lastNonEmpty = Date.now();
-        const now = Date.now();
-        const due = pending.filter((r) => r.nextAttemptAt <= now);
-        if (due.length > 0) {
-          await processBatch(due, writer, factory);
-        }
-      } else if (Date.now() - lastNonEmpty >= idleMs) {
+      const now = Date.now();
+      const due = pending.filter((r) => r.nextAttemptAt <= now);
+      
+      if (due.length > 0) {
+        lastNonEmpty = now;
+        await processBatch(due, writer, factory);
+      } else if (now - lastNonEmpty >= idleMs) {
         log('WAL idle threshold reached; shutting down.');
         return;
       }

--- a/libs/typescript/core/src/exporters/wal/daemon.ts
+++ b/libs/typescript/core/src/exporters/wal/daemon.ts
@@ -543,7 +543,7 @@ export async function runBatchLoop({
       const pending = await readPending();
       const now = Date.now();
       const due = pending.filter((r) => r.nextAttemptAt <= now);
-      
+
       if (due.length > 0) {
         lastNonEmpty = now;
         await processBatch(due, writer, factory);

--- a/libs/typescript/core/src/exporters/wal/paths.ts
+++ b/libs/typescript/core/src/exporters/wal/paths.ts
@@ -61,6 +61,10 @@ export function getDaemonLogPath(now: Date = new Date()): string {
   return join(getWalDir(), `daemon.log.${dateSuffix(now)}`);
 }
 
+export function getPidLockPath(): string {
+  return join(getWalDir(), 'daemon.pid');
+}
+
 /**
  * Stable per (user, wal_dir) identifier used to scope the daemon lock
  */

--- a/libs/typescript/core/src/exporters/wal/pid_lock.ts
+++ b/libs/typescript/core/src/exporters/wal/pid_lock.ts
@@ -1,0 +1,136 @@
+/**
+ * Cross-process exclusion lock for the daemon singleton.
+ *
+ * The lock is POSIX-only; on Windows the daemon's named-pipe path is
+ * kernel-refcounted and provides cross-process exclusion natively, so
+ * `acquireLock` skips this module on `process.platform === 'win32'`.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { link, readFile, unlink, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { getPidLockPath, getWalDir } from './paths';
+
+const MAX_ACQUIRE_ATTEMPTS = 5;
+
+function isErrnoException(err: unknown): err is NodeJS.ErrnoException {
+  return typeof err === 'object' && err != null && 'code' in err;
+}
+
+export interface PidLock {
+  release(): Promise<void>;
+}
+
+/**
+ * Attempt to claim the daemon's cross-process PID lock.
+ *
+ * Returns a {@link PidLock} on success, or `null` when another live
+ * process already holds it. Throws on unrecoverable I/O errors
+ * (`EACCES`, `ENOSPC`, missing WAL dir, etc.) — callers should treat
+ * a throw as "daemon cannot start" rather than "concede to sibling."
+ */
+export async function tryAcquirePidLock(): Promise<PidLock | null> {
+  const lockPath = getPidLockPath();
+  const expectedContent = `${process.pid}\n`;
+
+  for (let attempt = 0; attempt < MAX_ACQUIRE_ATTEMPTS; attempt++) {
+    
+    const tmpPath = join(getWalDir(), `daemon.pid.${process.pid}.${randomUUID()}.tmp`);
+
+    await writeFile(tmpPath, expectedContent, { flag: 'wx' });
+
+    try {
+      await link(tmpPath, lockPath);
+      await unlink(tmpPath).catch(() => {});
+      return { release: () => releaseLockFile(lockPath, expectedContent) };
+    } catch (err) {
+      await unlink(tmpPath).catch(() => {});
+      if (!isErrnoException(err) || err.code !== 'EEXIST') {
+        throw err;
+      }
+    }
+
+    // EEXIST path. Inspect the holder to decide between conceding and
+    // recovering from a stale lockfile left by a crashed daemon.
+    let content: string;
+    try {
+      content = await readFile(lockPath, 'utf8');
+    } catch (err) {
+      if (isErrnoException(err) && err.code === 'ENOENT') {
+        // Holder released between our link attempt and our read; the
+        // path is free again, loop and reattempt the link.
+        continue;
+      }
+      throw err;
+    }
+
+    const holderPid = parsePid(content);
+    if (holderPid != null && isProcessAlive(holderPid)) {
+      return null;
+    }
+
+    // Stale or malformed. Unlink the lockfile, but only if its content
+    // is still the same bytes we just read - otherwise a successor has
+    // already taken over and we would nuke their fresh lockfile.
+    const fresh = await readFile(lockPath, 'utf8').catch(() => null);
+    if (fresh === content) {
+      await unlink(lockPath).catch(() => {});
+    }
+  }
+
+  throw new Error(
+    `tryAcquirePidLock: gave up after ${MAX_ACQUIRE_ATTEMPTS} contention attempts on ${lockPath}`,
+  );
+}
+
+/**
+ * Read the pid recorded in the daemon's lockfile, or `null` if the
+ * file is missing or unparseable. Provided as a diagnostic helper for
+ * callers (e.g. supervisor) that want to log "who owns the lock right
+ * now"; not used by acquisition itself.
+ */
+export async function readLockHolderPid(): Promise<number | null> {
+  try {
+    const content = await readFile(getPidLockPath(), 'utf8');
+    return parsePid(content);
+  } catch (err) {
+    if (isErrnoException(err) && err.code === 'ENOENT') {
+      return null;
+    }
+    throw err;
+  }
+}
+
+function parsePid(content: string): number | null {
+  const trimmed = content.trim();
+  if (trimmed === '') {
+    return null;
+  }
+  const n = Number.parseInt(trimmed, 10);
+  // PIDs are positive integers; reject 0 (which `process.kill` would
+  // interpret as "signal every process in our process group") and
+  // negatives (which would target a process group).
+  return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // `EPERM` means the process exists but we lack permission to
+    // signal it (different uid). Treat as alive — the lockfile's
+    // owner is alive enough that we should not unlink their lock.
+    if (isErrnoException(err) && err.code === 'EPERM') {
+      return true;
+    }
+    return false;
+  }
+}
+
+async function releaseLockFile(lockPath: string, expectedContent: string): Promise<void> {
+  const fresh = await readFile(lockPath, 'utf8').catch(() => null);
+  if (fresh === expectedContent) {
+    await unlink(lockPath).catch(() => {});
+  }
+}

--- a/libs/typescript/core/src/exporters/wal/pid_lock.ts
+++ b/libs/typescript/core/src/exporters/wal/pid_lock.ts
@@ -34,12 +34,10 @@ export async function tryAcquirePidLock(): Promise<PidLock | null> {
   const expectedContent = `${process.pid}\n`;
 
   for (let attempt = 0; attempt < MAX_ACQUIRE_ATTEMPTS; attempt++) {
-    
     const tmpPath = join(getWalDir(), `daemon.pid.${process.pid}.${randomUUID()}.tmp`);
 
-    await writeFile(tmpPath, expectedContent, { flag: 'wx' });
-
     try {
+      await writeFile(tmpPath, expectedContent, { flag: 'wx' });
       await link(tmpPath, lockPath);
       await unlink(tmpPath).catch(() => {});
       return { release: () => releaseLockFile(lockPath, expectedContent) };
@@ -49,7 +47,6 @@ export async function tryAcquirePidLock(): Promise<PidLock | null> {
         throw err;
       }
     }
-
     // EEXIST path. Inspect the holder to decide between conceding and
     // recovering from a stale lockfile left by a crashed daemon.
     let content: string;

--- a/libs/typescript/core/tests/exporters/wal/daemon.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/daemon.test.ts
@@ -587,7 +587,7 @@ describe('wal/daemon', () => {
   });
 
   describe('queue.log layout after retry', () => {
-    it('writes tombstone-then-append in order so readPending sees the retry', async () => {
+    it('atomically batches the retry append + original tombstone in one fsync', async () => {
       const createTrace = jest.fn().mockRejectedValueOnce(new Error('first attempt fails'));
       const client = makeClient({ createTrace });
 
@@ -596,18 +596,20 @@ describe('wal/daemon', () => {
 
       const contents = await readFile(getWalPath(), 'utf8');
       const lines = contents.trim().split('\n');
-      // Stop hook would have appended record outside of this test; here we
-      // only see the daemon's two writes: tombstone of the old id (via
-      // the BatchingWriter), then append of the new id with attempts=1
-      // (via appendRecord). The two queueWriter slots run sequentially
-      // so the on-disk order is deterministic.
+      // `handleUploadFailure`'s retry branch enqueues both the new
+      // retry row and the tombstone for the original id on the same
+      // `BatchingWriter` tick, so `drainAndFlush` packs them into a
+      // single `writev` + `fsync`. The on-disk order matches the
+      // enqueue order (append first, then tombstone) and the pair is
+      // atomic — either both lines are durable or neither is, so a
+      // crash between them is structurally impossible.
       expect(lines).toHaveLength(2);
-      const first = JSON.parse(lines[0]) as { type: string; id?: string };
-      const second = JSON.parse(lines[1]) as { type: string; record?: WalRecord };
-      expect(first.type).toBe('tombstone');
-      expect(first.id).toBe('row-order');
-      expect(second.type).toBe('append');
-      expect(second.record!.attempts).toBe(1);
+      const first = JSON.parse(lines[0]) as { type: string; record?: WalRecord };
+      const second = JSON.parse(lines[1]) as { type: string; id?: string };
+      expect(first.type).toBe('append');
+      expect(first.record!.attempts).toBe(1);
+      expect(second.type).toBe('tombstone');
+      expect(second.id).toBe('row-order');
     });
   });
 

--- a/libs/typescript/core/tests/exporters/wal/daemon.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/daemon.test.ts
@@ -1,0 +1,674 @@
+import { spawn } from 'child_process';
+import { existsSync, readFileSync } from 'fs';
+import { mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { BatchingWriter } from '../../../src/exporters/wal/batching_writer';
+import {
+  acquireLock,
+  backoff,
+  log,
+  processBatch,
+  pruneOldLogs,
+  releaseLock,
+  uploadOne,
+} from '../../../src/exporters/wal/daemon';
+import {
+  getDaemonLogPath,
+  getDeadLetterPath,
+  getLockSocketPath,
+  getPidLockPath,
+  getWalPath,
+} from '../../../src/exporters/wal/paths';
+import { readPending } from '../../../src/exporters/wal/storage';
+import type { WalRecord } from '../../../src/exporters/wal/types';
+import type { MlflowClient } from '../../../src/clients/client';
+import { MlflowHttpError } from '../../../src/clients/utils';
+import type { TraceInfo } from '../../../src/core/entities/trace_info';
+import type { TraceData } from '../../../src/core/entities/trace_data';
+
+/**
+ * Spawn a trivial child, wait for it to exit, and return its now-freed
+ * pid. Used so the integration tests can seed a stale PID lockfile
+ * with a pid that is guaranteed to fail `process.kill(pid, 0)` with
+ * ESRCH and trigger the stale-recovery branch in `tryAcquirePidLock`.
+ */
+function spawnAndReapPid(): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const child = spawn(process.execPath, ['-e', 'process.exit(0)']);
+    const pid = child.pid;
+    if (pid == null) {
+      reject(new Error('child spawn produced no pid'));
+      return;
+    }
+    child.once('exit', () => resolve(pid));
+    child.once('error', reject);
+  });
+}
+
+function makeRecord(overrides: Partial<WalRecord> = {}): WalRecord {
+  // Fields shaped so TraceInfo.fromJson / TraceData.fromJson succeed:
+  // execution_duration is the "Ns" string form expected by the parser
+  // (a raw number throws because of `.replace`), spans is an empty array.
+  const base: WalRecord = {
+    id: 'row-1',
+    trackingUri: 'http://localhost:5000',
+    experimentId: '0',
+    traceInfo: {
+      trace_id: 'tr-1',
+      trace_location: { type: 'MLFLOW_EXPERIMENT', mlflow_experiment: { experiment_id: '0' } },
+      request_time: 0,
+      execution_duration: '0s',
+      state: 'OK',
+      request_preview: '',
+      response_preview: '',
+      client_request_id: '',
+      tags: {},
+      trace_metadata: {},
+      assessments: [],
+    },
+    traceData: { spans: [] },
+    attempts: 0,
+    nextAttemptAt: 0,
+    createdAt: Date.now(),
+  };
+  return { ...base, ...overrides };
+}
+
+function makeClient(opts: { createTrace?: jest.Mock; uploadTraceData?: jest.Mock }): MlflowClient {
+  return {
+    createTrace:
+      opts.createTrace ?? jest.fn().mockImplementation((info: TraceInfo) => Promise.resolve(info)),
+    uploadTraceData:
+      opts.uploadTraceData ??
+      jest.fn().mockImplementation((_info: TraceInfo, _data: TraceData) => Promise.resolve()),
+    getHost: () => 'http://localhost:5000',
+  } as unknown as MlflowClient;
+}
+
+describe('wal/daemon', () => {
+  let walDir: string;
+  // Capture the developer's pre-test value so we restore (not just unset)
+  // in afterEach. Mirrors the pattern in paths.test.ts so running
+  // `MLFLOW_WAL_DIR=/some/dir jest` doesn't lose the override for later
+  // tests in the same worker.
+  const originalWalDir = process.env.MLFLOW_WAL_DIR;
+
+  beforeEach(async () => {
+    walDir = await mkdtemp(join(tmpdir(), 'mlflow-daemon-'));
+    process.env.MLFLOW_WAL_DIR = walDir;
+  });
+
+  afterEach(async () => {
+    if (originalWalDir === undefined) {
+      delete process.env.MLFLOW_WAL_DIR;
+    } else {
+      process.env.MLFLOW_WAL_DIR = originalWalDir;
+    }
+    await rm(walDir, { recursive: true, force: true });
+  });
+
+  describe('backoff', () => {
+    it('doubles on each attempt until the cap', () => {
+      expect(backoff(1)).toBe(2_000);
+      expect(backoff(2)).toBe(4_000);
+      expect(backoff(3)).toBe(8_000);
+      expect(backoff(8)).toBe(256_000);
+    });
+
+    it('caps at 5 minutes', () => {
+      expect(backoff(9)).toBe(300_000);
+      expect(backoff(20)).toBe(300_000);
+    });
+  });
+
+  describe('log', () => {
+    it('appends a timestamped line to the daemon log file', () => {
+      log('hello');
+      log('world');
+      const path = getDaemonLogPath();
+      // daemon.log is daily-rotated; assert the suffix is present so a
+      // regression to a single unbounded file is caught here too.
+      expect(path).toMatch(/[/\\]daemon\.log\.\d{4}-\d{2}-\d{2}$/);
+      const contents = readFileSync(path, 'utf8');
+      const lines = contents.trim().split('\n');
+      expect(lines).toHaveLength(2);
+      expect(lines[0]).toMatch(/^\[\d{4}-\d{2}-\d{2}T.+Z\] \[pid=\d+\] hello$/);
+      expect(lines[1]).toMatch(/world$/);
+    });
+
+    it('swallows write errors silently', () => {
+      // Point the log path at a directory that doesn't exist by deleting
+      // the WAL dir mid-test. appendFileSync will throw internally; log()
+      // must not propagate.
+      process.env.MLFLOW_WAL_DIR = join(walDir, 'nope', 'deeper');
+      expect(() => log('ignored')).not.toThrow();
+    });
+  });
+
+  describe('acquireLock / releaseLock', () => {
+    it('binds the lock socket and releases cleanly', async () => {
+      const handle = await acquireLock();
+      expect(handle).not.toBeNull();
+      expect(existsSync(getLockSocketPath())).toBe(true);
+      await releaseLock(handle!.server, handle!.pidLock);
+      expect(existsSync(getLockSocketPath())).toBe(false);
+    });
+
+    it('returns null when another daemon already holds the lock', async () => {
+      const first = await acquireLock();
+      expect(first).not.toBeNull();
+      try {
+        const second = await acquireLock();
+        expect(second).toBeNull();
+      } finally {
+        await releaseLock(first!.server, first!.pidLock);
+      }
+    });
+
+    it('unlinks a stale POSIX socket file before binding', async () => {
+      if (process.platform === 'win32') {
+        return; // Named pipes have no stale-file concept.
+      }
+      // Simulate a previously-crashed daemon by writing a regular file
+      // at the socket path. acquireLock should unlink it on its way to
+      // a fresh bind.
+      await writeFile(getLockSocketPath(), 'stale');
+      const handle = await acquireLock();
+      try {
+        expect(handle).not.toBeNull();
+      } finally {
+        await releaseLock(handle!.server, handle!.pidLock);
+      }
+    });
+  });
+
+  // POSIX-only PID-lock integration. On Windows the named pipe is
+  // kernel-refcounted and acquireLock returns `pidLock: null`, so
+  // there's nothing for these tests to assert. Use a describe-level
+  // skip rather than per-`it` guards so the suite reports honestly on
+  // CI ("skipped" instead of "passed in 0ms").
+  const describePosix = process.platform === 'win32' ? describe.skip : describe;
+
+  describePosix('acquireLock / releaseLock — PID lock integration', () => {
+    it('creates the pid lockfile with our pid and removes it on release', async () => {
+      const handle = await acquireLock();
+      try {
+        expect(handle).not.toBeNull();
+        expect(handle!.pidLock).not.toBeNull();
+        // Lockfile must exist alongside the socket and record our pid
+        // exactly — content-stamped release relies on the exact match.
+        expect(existsSync(getPidLockPath())).toBe(true);
+        const content = await readFile(getPidLockPath(), 'utf8');
+        expect(content).toBe(`${process.pid}\n`);
+      } finally {
+        await releaseLock(handle!.server, handle!.pidLock);
+      }
+      expect(existsSync(getPidLockPath())).toBe(false);
+    });
+
+    it('recovers from a stale pid lockfile left behind by a crashed daemon', async () => {
+      // A previously-crashed daemon's pid file with a now-dead pid.
+      // tryAcquirePidLock's liveness probe (`process.kill(pid, 0)`)
+      // should return ESRCH, the content-stamped unlink should clear
+      // the file, and acquireLock should proceed to bind normally.
+      const deadPid = await spawnAndReapPid();
+      await writeFile(getPidLockPath(), `${deadPid}\n`);
+      const handle = await acquireLock();
+      try {
+        expect(handle).not.toBeNull();
+        expect(handle!.pidLock).not.toBeNull();
+        const content = await readFile(getPidLockPath(), 'utf8');
+        expect(content).toBe(`${process.pid}\n`);
+      } finally {
+        await releaseLock(handle!.server, handle!.pidLock);
+      }
+    });
+
+    it('concedes when an alive process already holds the pid lockfile', async () => {
+      await writeFile(getPidLockPath(), `${process.pid}\n`);
+      const handle = await acquireLock();
+      expect(handle).toBeNull();
+      // Lockfile must remain untouched when we concede.
+      const content = await readFile(getPidLockPath(), 'utf8');
+      expect(content).toBe(`${process.pid}\n`);
+      // And the socket must not have been bound.
+      expect(existsSync(getLockSocketPath())).toBe(false);
+    });
+
+    it('serializes concurrent acquireLock calls to a single winner', async () => {
+      // Both calls run inside the same Node event loop, but the
+      // `link()` syscall inside tryAcquirePidLock still goes through
+      // libuv's fs threadpool and the kernel's inode lock — so exactly
+      // one wins the atomic create, and the other reads our (alive)
+      // pid and concedes via the live-holder branch.
+      const [first, second] = await Promise.all([acquireLock(), acquireLock()]);
+      try {
+        const acquired = [first, second].filter((h) => h != null);
+        const conceded = [first, second].filter((h) => h == null);
+        expect(acquired).toHaveLength(1);
+        expect(conceded).toHaveLength(1);
+        // The winner owns the socket; the loser never bound anything.
+        expect(existsSync(getLockSocketPath())).toBe(true);
+        // The winner's pid is recorded in the lockfile.
+        const content = await readFile(getPidLockPath(), 'utf8');
+        expect(content).toBe(`${process.pid}\n`);
+      } finally {
+        if (first != null) {
+          await releaseLock(first.server, first.pidLock);
+        }
+        if (second != null) {
+          await releaseLock(second.server, second.pidLock);
+        }
+      }
+    });
+
+    it('releases the pid lockfile when both socket and pid lock are unlinked together', async () => {
+      // Verifies the teardown order is symmetric to acquisition:
+      // releaseLock must remove the socket file AND the pid lockfile
+      // so a subsequent acquireLock starts from a fully-clean slate.
+      const handle = await acquireLock();
+      expect(handle).not.toBeNull();
+      expect(existsSync(getLockSocketPath())).toBe(true);
+      expect(existsSync(getPidLockPath())).toBe(true);
+      await releaseLock(handle!.server, handle!.pidLock);
+      expect(existsSync(getLockSocketPath())).toBe(false);
+      expect(existsSync(getPidLockPath())).toBe(false);
+    });
+
+    it('allows a fresh acquire after a clean release', async () => {
+      // End-to-end smoke for the acquire → release → reacquire cycle.
+      // Catches regressions where releaseLock leaves stale state that
+      // the next acquireLock cannot recover from.
+      const first = await acquireLock();
+      expect(first).not.toBeNull();
+      await releaseLock(first!.server, first!.pidLock);
+      const second = await acquireLock();
+      try {
+        expect(second).not.toBeNull();
+      } finally {
+        await releaseLock(second!.server, second!.pidLock);
+      }
+    });
+  });
+
+  describe('uploadOne', () => {
+    it('uploads the trace and tombstones the WAL row on success', async () => {
+      const createTrace = jest.fn().mockImplementation((info: TraceInfo) => Promise.resolve(info));
+      const uploadTraceData = jest
+        .fn()
+        .mockImplementation((_info: TraceInfo, _data: TraceData) => Promise.resolve());
+      const client = makeClient({ createTrace, uploadTraceData });
+
+      const record = makeRecord({ id: 'row-success' });
+      await uploadOne(record, client, new BatchingWriter());
+
+      expect(createTrace).toHaveBeenCalledTimes(1);
+      expect(uploadTraceData).toHaveBeenCalledTimes(1);
+
+      // After tombstone the record should not be in the live set.
+      const pending = await readPending();
+      expect(pending.find((r) => r.id === 'row-success')).toBeUndefined();
+    });
+
+    it('re-appends a fresh row with bumped attempts on transient failure', async () => {
+      const createTrace = jest.fn().mockRejectedValue(new Error('5xx'));
+      const client = makeClient({ createTrace });
+
+      const record = makeRecord({ id: 'row-retry', attempts: 0 });
+      const before = Date.now();
+      await uploadOne(record, client, new BatchingWriter());
+      const after = Date.now();
+
+      const pending = await readPending();
+      const retry = pending.find((r) => r.id !== 'row-retry');
+      expect(pending.find((r) => r.id === 'row-retry')).toBeUndefined();
+      expect(retry).toBeDefined();
+      expect(retry!.attempts).toBe(1);
+      // backoff(1) = 2_000 ms; the new schedule must be in [before+2s, after+2s].
+      expect(retry!.nextAttemptAt).toBeGreaterThanOrEqual(before + 2_000);
+      expect(retry!.nextAttemptAt).toBeLessThanOrEqual(after + 2_000);
+      // firstAttemptAt is anchored on the first daemon touch and pinned
+      // onto the retry row so the wall-clock retry budget is measured
+      // from a stable point even across multiple retries / restarts.
+      expect(retry!.firstAttemptAt).toBeGreaterThanOrEqual(before);
+      expect(retry!.firstAttemptAt).toBeLessThanOrEqual(after);
+    });
+
+    it('preserves firstAttemptAt across retries (anchor survives daemon respawn)', async () => {
+      const createTrace = jest.fn().mockRejectedValue(new Error('5xx'));
+      const client = makeClient({ createTrace });
+
+      // A record a previous daemon already tried twice. A new daemon
+      // picking it up must preserve the original anchor, not reset it
+      // — otherwise a record could indefinitely outlive the retry
+      // budget by piggybacking on each daemon respawn's fresh clock.
+      const originalAnchor = Date.now() - 50_000;
+      const record = makeRecord({
+        id: 'row-restart',
+        attempts: 2,
+        firstAttemptAt: originalAnchor,
+      });
+      await uploadOne(record, client, new BatchingWriter());
+
+      const pending = await readPending();
+      const retry = pending.find((r) => r.id !== 'row-restart')!;
+      expect(retry.firstAttemptAt).toBe(originalAnchor);
+      expect(retry.attempts).toBe(3);
+    });
+
+    it('dead-letters the record when elapsed retry time exceeds RETRY_TIMEOUT_MS', async () => {
+      const createTrace = jest.fn().mockRejectedValue(new Error('still broken'));
+      const client = makeClient({ createTrace });
+
+      // Backdate firstAttemptAt by more than the default 500s budget,
+      // so the next backoff (~2s) plus the elapsed wall clock blows
+      // through the deadline and the record dead-letters immediately
+      // regardless of the attempts counter.
+      const longAgo = Date.now() - 600_000;
+      const record = makeRecord({
+        id: 'row-dlq',
+        attempts: 3,
+        firstAttemptAt: longAgo,
+      });
+      await uploadOne(record, client, new BatchingWriter());
+
+      const pending = await readPending();
+      expect(pending).toHaveLength(0);
+
+      const failedContents = await readFile(getDeadLetterPath(), 'utf8');
+      const failedLines = failedContents.trim().split('\n');
+      expect(failedLines).toHaveLength(1);
+      const parsed = JSON.parse(failedLines[0]) as {
+        type: 'append';
+        record: WalRecord;
+      };
+      expect(parsed.type).toBe('append');
+      expect(parsed.record.id).toBe('row-dlq');
+    });
+
+    // The credential-refresh-on-401/403 retry path. The cached
+    // MlflowClient holds an AuthProvider snapshot from daemon start; a
+    // token rotation must surface as a transient failure that the daemon
+    // recovers from automatically rather than dead-letters forever.
+    describe('auth-refresh retry', () => {
+      it.each([
+        [401, 'Unauthorized'],
+        [403, 'Forbidden'],
+      ] as const)(
+        'evicts the cached client and retries once after a %i, succeeding the second time',
+        async (status, statusText) => {
+          const staleCreateTrace = jest
+            .fn()
+            .mockRejectedValue(new MlflowHttpError(status, statusText, ''));
+          const freshCreateTrace = jest
+            .fn()
+            .mockImplementation((info: TraceInfo) => Promise.resolve(info));
+          const freshUploadTraceData = jest.fn().mockResolvedValue(undefined);
+          const stale = makeClient({ createTrace: staleCreateTrace });
+          const fresh = makeClient({
+            createTrace: freshCreateTrace,
+            uploadTraceData: freshUploadTraceData,
+          });
+          const factory = jest.fn(() => fresh);
+
+          const record = makeRecord({ id: `row-${status}-retry` });
+          await uploadOne(record, stale, new BatchingWriter(), factory);
+
+          // First attempt used the stale client and got the auth error;
+          // the auth-refresh branch then asked the factory for a fresh
+          // client (exactly once, for this URI) and the retry pushed
+          // through successfully.
+          expect(staleCreateTrace).toHaveBeenCalledTimes(1);
+          expect(factory).toHaveBeenCalledTimes(1);
+          expect(factory).toHaveBeenCalledWith(record.trackingUri);
+          expect(freshCreateTrace).toHaveBeenCalledTimes(1);
+          expect(freshUploadTraceData).toHaveBeenCalledTimes(1);
+
+          // Successful retry: tombstoned, no live row, no dead-letter.
+          const pending = await readPending();
+          expect(pending.find((r) => r.id === record.id)).toBeUndefined();
+        },
+      );
+
+      it('falls through to handleUploadFailure when both attempts hit 401', async () => {
+        const staleCreateTrace = jest
+          .fn()
+          .mockRejectedValue(new MlflowHttpError(401, 'Unauthorized', ''));
+        const freshCreateTrace = jest
+          .fn()
+          .mockRejectedValue(new MlflowHttpError(401, 'Unauthorized', ''));
+        const stale = makeClient({ createTrace: staleCreateTrace });
+        const fresh = makeClient({ createTrace: freshCreateTrace });
+        const factory = jest.fn(() => fresh);
+
+        // Backdate firstAttemptAt past the 500s budget so the post-retry
+        // failure dead-letters immediately rather than re-appending yet
+        // another retry row we'd have to sit on.
+        const longAgo = Date.now() - 600_000;
+        const record = makeRecord({
+          id: 'row-401-persistent',
+          firstAttemptAt: longAgo,
+        });
+        await uploadOne(record, stale, new BatchingWriter(), factory);
+
+        // Both attempts ran; factory was consulted exactly once for the
+        // refresh; the second failure routed to dead-letter (not a
+        // perpetual invalidate-retry loop).
+        expect(staleCreateTrace).toHaveBeenCalledTimes(1);
+        expect(freshCreateTrace).toHaveBeenCalledTimes(1);
+        expect(factory).toHaveBeenCalledTimes(1);
+
+        const pending = await readPending();
+        expect(pending).toHaveLength(0);
+        const failedContents = await readFile(getDeadLetterPath(), 'utf8');
+        expect(failedContents).toContain('"id":"row-401-persistent"');
+      });
+
+      it('does not refresh the client on non-auth HTTP errors', async () => {
+        const createTrace = jest
+          .fn()
+          .mockRejectedValue(new MlflowHttpError(500, 'Internal Server Error', ''));
+        const client = makeClient({ createTrace });
+        const factory = jest.fn();
+
+        const record = makeRecord({ id: 'row-5xx' });
+        await uploadOne(record, client, new BatchingWriter(), factory);
+
+        // 5xx is not a credential problem — single attempt, no factory
+        // consultation, regular retry row appended by handleUploadFailure.
+        expect(createTrace).toHaveBeenCalledTimes(1);
+        expect(factory).not.toHaveBeenCalled();
+
+        const pending = await readPending();
+        const retry = pending.find((r) => r.id !== 'row-5xx');
+        expect(pending.find((r) => r.id === 'row-5xx')).toBeUndefined();
+        expect(retry).toBeDefined();
+        expect(retry!.attempts).toBe(1);
+      });
+
+      it('does not refresh the client on transport-level errors', async () => {
+        // A non-MlflowHttpError (e.g. fetch DNS / ECONNRESET / abort
+        // wrapped by makeRequest into `new Error('API request failed: ...')`)
+        // must not be confused with an auth failure — the `instanceof`
+        // gate in isAuthRefreshableError is what protects us here.
+        const createTrace = jest.fn().mockRejectedValue(new Error('ECONNRESET'));
+        const client = makeClient({ createTrace });
+        const factory = jest.fn();
+
+        const record = makeRecord({ id: 'row-transport' });
+        await uploadOne(record, client, new BatchingWriter(), factory);
+
+        expect(factory).not.toHaveBeenCalled();
+        const pending = await readPending();
+        expect(pending.find((r) => r.id !== 'row-transport')).toBeDefined();
+      });
+    });
+  });
+
+  describe('processBatch', () => {
+    it('groups records by trackingUri and calls the factory once per URI', async () => {
+      const clientA = makeClient({});
+      const clientB = makeClient({});
+      const factory = jest.fn((uri: string) => (uri.endsWith(':5001') ? clientB : clientA));
+
+      const records = [
+        makeRecord({ id: 'r1', trackingUri: 'http://localhost:5000' }),
+        makeRecord({ id: 'r2', trackingUri: 'http://localhost:5000' }),
+        makeRecord({ id: 'r3', trackingUri: 'http://localhost:5001' }),
+      ];
+
+      await processBatch(records, new BatchingWriter(), factory);
+
+      expect(factory).toHaveBeenCalledTimes(2);
+      expect(factory).toHaveBeenCalledWith('http://localhost:5000');
+      expect(factory).toHaveBeenCalledWith('http://localhost:5001');
+      const pending = await readPending();
+      // All three should have been tombstoned by their respective uploads.
+      expect(pending).toHaveLength(0);
+    });
+
+    it('no-ops on an empty input', async () => {
+      const factory = jest.fn();
+      await processBatch([], new BatchingWriter(), factory);
+      expect(factory).not.toHaveBeenCalled();
+    });
+
+    it('dead-letters records when their client factory throws', async () => {
+      const factory = jest.fn(() => {
+        throw new Error('auth provider blew up');
+      });
+
+      // Backdate firstAttemptAt past the default 500s retry budget so
+      // the synthetic factory failure dead-letters immediately instead
+      // of just bumping the retry counter.
+      const longAgo = Date.now() - 600_000;
+      const records = [makeRecord({ id: 'r-bad', firstAttemptAt: longAgo })];
+      await processBatch(records, new BatchingWriter(), factory);
+
+      const pending = await readPending();
+      expect(pending).toHaveLength(0);
+
+      const failedContents = await readFile(getDeadLetterPath(), 'utf8');
+      expect(failedContents).toContain('"id":"r-bad"');
+    });
+  });
+
+  describe('queue.log layout after retry', () => {
+    it('writes tombstone-then-append in order so readPending sees the retry', async () => {
+      const createTrace = jest.fn().mockRejectedValueOnce(new Error('first attempt fails'));
+      const client = makeClient({ createTrace });
+
+      const record = makeRecord({ id: 'row-order', attempts: 0 });
+      await uploadOne(record, client, new BatchingWriter());
+
+      const contents = await readFile(getWalPath(), 'utf8');
+      const lines = contents.trim().split('\n');
+      // Stop hook would have appended record outside of this test; here we
+      // only see the daemon's two writes: tombstone of the old id (via
+      // the BatchingWriter), then append of the new id with attempts=1
+      // (via appendRecord). The two queueWriter slots run sequentially
+      // so the on-disk order is deterministic.
+      expect(lines).toHaveLength(2);
+      const first = JSON.parse(lines[0]) as { type: string; id?: string };
+      const second = JSON.parse(lines[1]) as { type: string; record?: WalRecord };
+      expect(first.type).toBe('tombstone');
+      expect(first.id).toBe('row-order');
+      expect(second.type).toBe('append');
+      expect(second.record!.attempts).toBe(1);
+    });
+  });
+
+  describe('pruneOldLogs', () => {
+    // All retention tests pin `now` to a fixed UTC date so the cutoff
+    // arithmetic stays stable regardless of when CI happens to run.
+    const NOW = new Date('2026-05-20T12:00:00.000Z');
+
+    async function seed(names: string[]): Promise<void> {
+      for (const name of names) {
+        await writeFile(join(walDir, name), 'x');
+      }
+    }
+
+    function existsInWal(name: string): boolean {
+      return existsSync(join(walDir, name));
+    }
+
+    // Per-file existence checks are used throughout this block instead of
+    // full directory equality because `pruneOldLogs` itself calls `log()`
+    // when it unlinks a file, which writes to today's `daemon.log.<date>`
+    // and would show up in any whole-listing comparison. We assert the
+    // narrower property the function actually owns: which seeded files
+    // survive vs disappear.
+
+    it('removes files older than the retention window and keeps newer ones', async () => {
+      // retentionDays=14 with NOW=2026-05-20 → keep dates >= 2026-05-06.
+      const kept = ['failed.log.2026-05-19', 'failed.log.2026-05-06', 'daemon.log.2026-05-19'];
+      const removed = ['failed.log.2026-05-05', 'failed.log.2026-04-01', 'daemon.log.2026-05-05'];
+      await seed([...kept, ...removed]);
+
+      await pruneOldLogs({ now: NOW, retentionDays: 14 });
+
+      for (const name of kept) {
+        expect(existsInWal(name)).toBe(true);
+      }
+      for (const name of removed) {
+        expect(existsInWal(name)).toBe(false);
+      }
+    });
+
+    it('is a no-op when retention is 0 (disabled)', async () => {
+      const seeded = ['failed.log.2020-01-01', 'daemon.log.2020-01-01'];
+      await seed(seeded);
+
+      await pruneOldLogs({ now: NOW, retentionDays: 0 });
+
+      for (const name of seeded) {
+        expect(existsInWal(name)).toBe(true);
+      }
+    });
+
+    it('ignores files that do not match the rotated-log pattern', async () => {
+      // Including `queue.log`, the lock socket, files without a date
+      // suffix, malformed dates, and unrelated artifacts the operator
+      // may have dropped into the WAL dir.
+      const seeded = [
+        'queue.log',
+        'failed.log',
+        'daemon.log',
+        'failed.log.bogus',
+        'failed.log.2026-13-99',
+        'failed.log.2026-02-30',
+        'README.md',
+        'failed.log.2026-05-19.bak',
+      ];
+      await seed(seeded);
+
+      await pruneOldLogs({ now: NOW, retentionDays: 14 });
+
+      // Every seeded entry must still be there — the regex must not
+      // strip-and-reparse, and Date.UTC's overflow-tolerance must not
+      // leak into the cutoff comparison.
+      for (const name of seeded) {
+        expect(existsInWal(name)).toBe(true);
+      }
+    });
+
+    it('preserves the active queue.log even when the WAL dir is full of expired logs', async () => {
+      await seed(['queue.log', 'failed.log.2020-01-01', 'daemon.log.2020-01-01']);
+
+      await pruneOldLogs({ now: NOW, retentionDays: 14 });
+
+      expect(existsInWal('queue.log')).toBe(true);
+      expect(existsInWal('failed.log.2020-01-01')).toBe(false);
+      expect(existsInWal('daemon.log.2020-01-01')).toBe(false);
+    });
+
+    it('does not throw when the WAL directory is missing', async () => {
+      // Simulate "daemon started, then someone rm -rf'd the dir before
+      // the sweep ran". The sweep must log-and-continue, never throw.
+      process.env.MLFLOW_WAL_DIR = join(walDir, 'does-not-exist');
+      await expect(pruneOldLogs({ now: NOW, retentionDays: 14 })).resolves.toBeUndefined();
+    });
+  });
+});

--- a/libs/typescript/core/tests/exporters/wal/daemon.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/daemon.test.ts
@@ -736,9 +736,7 @@ describe('wal/daemon', () => {
       // `due.length === 0`, so a WAL populated only by future-dated
       // retries is treated as not-actively-working and the loop
       // winds down through the normal `idleMs` path.
-      await appendRecord(
-        makeRecord({ id: 'row-future', nextAttemptAt: Date.now() + 60_000 }),
-      );
+      await appendRecord(makeRecord({ id: 'row-future', nextAttemptAt: Date.now() + 60_000 }));
       const factory = jest.fn();
       const start = Date.now();
       await runBatchLoop({
@@ -757,6 +755,5 @@ describe('wal/daemon', () => {
       // `firstAttemptAt` budget — at-least-once delivery preserved.
       expect(await readPending()).toHaveLength(1);
     });
-
   });
 });

--- a/libs/typescript/core/tests/exporters/wal/daemon.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/daemon.test.ts
@@ -11,6 +11,7 @@ import {
   processBatch,
   pruneOldLogs,
   releaseLock,
+  runBatchLoop,
   uploadOne,
 } from '../../../src/exporters/wal/daemon';
 import {
@@ -20,7 +21,7 @@ import {
   getPidLockPath,
   getWalPath,
 } from '../../../src/exporters/wal/paths';
-import { readPending } from '../../../src/exporters/wal/storage';
+import { appendRecord, readPending } from '../../../src/exporters/wal/storage';
 import type { WalRecord } from '../../../src/exporters/wal/types';
 import type { MlflowClient } from '../../../src/clients/client';
 import { MlflowHttpError } from '../../../src/clients/utils';
@@ -704,5 +705,58 @@ describe('wal/daemon', () => {
       process.env.MLFLOW_WAL_DIR = join(walDir, 'does-not-exist');
       await expect(pruneOldLogs({ now: NOW, retentionDays: 14 })).resolves.toBeUndefined();
     });
+  });
+
+  describe('runBatchLoop idle semantics', () => {
+    it('shuts down via idleMs when the WAL is empty', async () => {
+      // Baseline: no records seeded → due.length === 0 every
+      // iteration → idle-shutdown branch fires on the first iteration
+      // after `idleMs` elapses.
+      const factory = jest.fn();
+      const start = Date.now();
+      await runBatchLoop({
+        factory,
+        writer: new BatchingWriter(),
+        batchIntervalMs: 10,
+        idleMs: 50,
+      });
+      const elapsed = Date.now() - start;
+      expect(elapsed).toBeGreaterThanOrEqual(50);
+      // Generous upper bound — guards against an accidental infinite
+      // loop while tolerating CI scheduler jitter.
+      expect(elapsed).toBeLessThan(2_000);
+      expect(factory).not.toHaveBeenCalled();
+    });
+
+    it('shuts down via idleMs when all pending records are future-dated', async () => {
+      // Regression test for the bug where `pending.length > 0` short-
+      // circuited the idle-shutdown check, pinning the daemon alive
+      // until each retry matured even though nothing was actually
+      // being worked on. The fix gates the idle check on
+      // `due.length === 0`, so a WAL populated only by future-dated
+      // retries is treated as not-actively-working and the loop
+      // winds down through the normal `idleMs` path.
+      await appendRecord(
+        makeRecord({ id: 'row-future', nextAttemptAt: Date.now() + 60_000 }),
+      );
+      const factory = jest.fn();
+      const start = Date.now();
+      await runBatchLoop({
+        factory,
+        writer: new BatchingWriter(),
+        batchIntervalMs: 10,
+        idleMs: 50,
+      });
+      const elapsed = Date.now() - start;
+      expect(elapsed).toBeGreaterThanOrEqual(50);
+      expect(elapsed).toBeLessThan(2_000);
+      expect(factory).not.toHaveBeenCalled();
+      // The record is still durably parked in the WAL: the supervisor's
+      // next respawn (driven by a fresh IPC submission) will pick it
+      // up and either retry or dead-letter against the original
+      // `firstAttemptAt` budget — at-least-once delivery preserved.
+      expect(await readPending()).toHaveLength(1);
+    });
+
   });
 });

--- a/libs/typescript/core/tests/exporters/wal/daemon.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/daemon.test.ts
@@ -465,6 +465,35 @@ describe('wal/daemon', () => {
         expect(failedContents).toContain('"id":"row-401-persistent"');
       });
 
+      it('dead-letters with the factory error when refresh-time factory throws', async () => {
+        const staleCreateTrace = jest
+          .fn()
+          .mockRejectedValue(new MlflowHttpError(401, 'Unauthorized', ''));
+        const stale = makeClient({ createTrace: staleCreateTrace });
+        const factory = jest.fn(() => {
+          throw new Error('credential provider blew up');
+        });
+
+        const longAgo = Date.now() - 600_000;
+        const record = makeRecord({
+          id: 'row-refresh-factory-throws',
+          firstAttemptAt: longAgo,
+        });
+        await uploadOne(record, stale, new BatchingWriter(), factory);
+
+        // Stale client was tried once and got the auth error; the
+        // refresh asked the factory once and that throw aborted the
+        // retry before any fresh client call could happen.
+        expect(staleCreateTrace).toHaveBeenCalledTimes(1);
+        expect(factory).toHaveBeenCalledTimes(1);
+        expect(factory).toHaveBeenCalledWith(record.trackingUri);
+
+        const pending = await readPending();
+        expect(pending).toHaveLength(0);
+        const failedContents = await readFile(getDeadLetterPath(), 'utf8');
+        expect(failedContents).toContain('"id":"row-refresh-factory-throws"');
+      });
+
       it('does not refresh the client on non-auth HTTP errors', async () => {
         const createTrace = jest
           .fn()
@@ -501,7 +530,10 @@ describe('wal/daemon', () => {
 
         expect(factory).not.toHaveBeenCalled();
         const pending = await readPending();
-        expect(pending.find((r) => r.id !== 'row-transport')).toBeDefined();
+        const retry = pending.find((r) => r.id !== 'row-transport');
+        expect(pending.find((r) => r.id === 'row-transport')).toBeUndefined();
+        expect(retry).toBeDefined();
+        expect(retry!.attempts).toBe(1);
       });
     });
   });

--- a/libs/typescript/core/tests/exporters/wal/pid_lock.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/pid_lock.test.ts
@@ -1,0 +1,223 @@
+import { spawn } from 'child_process';
+import { existsSync } from 'fs';
+import { mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { readLockHolderPid, tryAcquirePidLock } from '../../../src/exporters/wal/pid_lock';
+import { getPidLockPath } from '../../../src/exporters/wal/paths';
+
+// The lock is a POSIX-only mechanism — Windows daemons rely on
+// kernel-refcounted named pipes for cross-process exclusion, so the
+// entire suite is a no-op there. Wrap with a describe variant that
+// skips on Windows to keep the test report honest about coverage.
+const describePosix = process.platform === 'win32' ? describe.skip : describe;
+
+/**
+ * Spawn a trivial child, wait for it to exit, and return its now-freed
+ * pid. Used to obtain a pid that is guaranteed to fail
+ * `process.kill(pid, 0)` with ESRCH so the stale-recovery path can be
+ * exercised deterministically. The PID could in principle be recycled
+ * by the OS between the child exiting and our liveness check, but in a
+ * single-digit-millisecond test window the probability is negligible
+ * — and even if it happened, the test would falsely fail rather than
+ * silently pass, which is the safe failure mode.
+ */
+function spawnAndReapPid(): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const child = spawn(process.execPath, ['-e', 'process.exit(0)']);
+    const pid = child.pid;
+    if (pid == null) {
+      reject(new Error('child spawn produced no pid'));
+      return;
+    }
+    child.once('exit', () => resolve(pid));
+    child.once('error', reject);
+  });
+}
+
+describePosix('wal/pid_lock', () => {
+  let walDir: string;
+  // Mirror daemon.test.ts: capture the developer's pre-test value so
+  // running `MLFLOW_WAL_DIR=/some/dir jest` doesn't lose the override
+  // for later tests in the same worker.
+  const originalWalDir = process.env.MLFLOW_WAL_DIR;
+
+  beforeEach(async () => {
+    walDir = await mkdtemp(join(tmpdir(), 'mlflow-pidlock-'));
+    process.env.MLFLOW_WAL_DIR = walDir;
+  });
+
+  afterEach(async () => {
+    if (originalWalDir === undefined) {
+      delete process.env.MLFLOW_WAL_DIR;
+    } else {
+      process.env.MLFLOW_WAL_DIR = originalWalDir;
+    }
+    await rm(walDir, { recursive: true, force: true });
+  });
+
+  describe('tryAcquirePidLock', () => {
+    it('claims the lock and writes our pid when no lockfile exists', async () => {
+      const lock = await tryAcquirePidLock();
+      try {
+        expect(lock).not.toBeNull();
+        const content = await readFile(getPidLockPath(), 'utf8');
+        expect(content).toBe(`${process.pid}\n`);
+      } finally {
+        await lock?.release();
+      }
+    });
+
+    it('returns null when an alive process already holds the lock', async () => {
+      // Seed the lockfile with our own pid — guaranteed alive — so the
+      // liveness probe inside tryAcquirePidLock has to detect us and
+      // concede rather than steal the lock from ourselves.
+      await writeFile(getPidLockPath(), `${process.pid}\n`);
+      const lock = await tryAcquirePidLock();
+      expect(lock).toBeNull();
+      // Lockfile must remain untouched after a conceding acquisition.
+      const content = await readFile(getPidLockPath(), 'utf8');
+      expect(content).toBe(`${process.pid}\n`);
+    });
+
+    it('recovers from a stale lockfile whose pid is dead', async () => {
+      const deadPid = await spawnAndReapPid();
+      await writeFile(getPidLockPath(), `${deadPid}\n`);
+      const lock = await tryAcquirePidLock();
+      try {
+        expect(lock).not.toBeNull();
+        const content = await readFile(getPidLockPath(), 'utf8');
+        expect(content).toBe(`${process.pid}\n`);
+      } finally {
+        await lock?.release();
+      }
+    });
+
+    it('recovers from a malformed lockfile (non-numeric content)', async () => {
+      await writeFile(getPidLockPath(), 'this is not a pid\n');
+      const lock = await tryAcquirePidLock();
+      try {
+        expect(lock).not.toBeNull();
+        const content = await readFile(getPidLockPath(), 'utf8');
+        expect(content).toBe(`${process.pid}\n`);
+      } finally {
+        await lock?.release();
+      }
+    });
+
+    it('recovers from an empty lockfile', async () => {
+      await writeFile(getPidLockPath(), '');
+      const lock = await tryAcquirePidLock();
+      try {
+        expect(lock).not.toBeNull();
+      } finally {
+        await lock?.release();
+      }
+    });
+
+    it('rejects a lockfile that records pid 0 (process-group signal target)', async () => {
+      // pid 0 would make process.kill(0, 0) signal our entire process
+      // group; parsePid must screen it out before the liveness probe
+      // ever runs. Recovery should treat it as malformed and reclaim.
+      await writeFile(getPidLockPath(), '0\n');
+      const lock = await tryAcquirePidLock();
+      try {
+        expect(lock).not.toBeNull();
+        const content = await readFile(getPidLockPath(), 'utf8');
+        expect(content).toBe(`${process.pid}\n`);
+      } finally {
+        await lock?.release();
+      }
+    });
+
+    it('rejects a lockfile that records a negative pid (process-group signal target)', async () => {
+      await writeFile(getPidLockPath(), '-12345\n');
+      const lock = await tryAcquirePidLock();
+      try {
+        expect(lock).not.toBeNull();
+      } finally {
+        await lock?.release();
+      }
+    });
+
+    it('serializes concurrent acquirers in the same event loop to a single winner', async () => {
+      // Both acquirers run in the same Node process so they see the
+      // same `process.pid`. The link() atomicity is what arbitrates;
+      // the loser observes EEXIST, reads our own (alive) pid, and
+      // concedes via the live-holder branch.
+      const [first, second] = await Promise.all([tryAcquirePidLock(), tryAcquirePidLock()]);
+      try {
+        const acquired = [first, second].filter((l) => l != null);
+        const conceded = [first, second].filter((l) => l == null);
+        expect(acquired).toHaveLength(1);
+        expect(conceded).toHaveLength(1);
+      } finally {
+        await first?.release();
+        await second?.release();
+      }
+    });
+
+    it('cleans up the temp file on a successful acquisition', async () => {
+      const lock = await tryAcquirePidLock();
+      try {
+        // No `daemon.pid.<pid>.<uuid>.tmp` should survive a successful
+        // acquire — the implementation unlinks it after the link()
+        // succeeds so the WAL dir doesn't accumulate per-spawn garbage.
+        const { readdir } = await import('fs/promises');
+        const entries = await readdir(walDir);
+        const tmps = entries.filter((e) => e.startsWith('daemon.pid.') && e.endsWith('.tmp'));
+        expect(tmps).toEqual([]);
+      } finally {
+        await lock?.release();
+      }
+    });
+  });
+
+  describe('PidLock.release', () => {
+    it('unlinks the lockfile when content still matches our pid', async () => {
+      const lock = await tryAcquirePidLock();
+      expect(lock).not.toBeNull();
+      await lock!.release();
+      expect(existsSync(getPidLockPath())).toBe(false);
+    });
+
+    it('leaves the lockfile intact when content has been hijacked', async () => {
+      const lock = await tryAcquirePidLock();
+      expect(lock).not.toBeNull();
+      // Simulate an external rewrite (operator intervention, or a
+      // successor that erroneously stole the path while we were still
+      // running). release() must not blind-unlink the file in this
+      // case — that would erase the successor's claim.
+      await writeFile(getPidLockPath(), '99999\n');
+      await lock!.release();
+      expect(existsSync(getPidLockPath())).toBe(true);
+      const content = await readFile(getPidLockPath(), 'utf8');
+      expect(content).toBe('99999\n');
+    });
+
+    it('is idempotent', async () => {
+      const lock = await tryAcquirePidLock();
+      expect(lock).not.toBeNull();
+      await lock!.release();
+      // Second release: lockfile already gone, must be a no-op.
+      await expect(lock!.release()).resolves.toBeUndefined();
+      expect(existsSync(getPidLockPath())).toBe(false);
+    });
+  });
+
+  describe('readLockHolderPid', () => {
+    it('returns the recorded pid when a lockfile exists', async () => {
+      await writeFile(getPidLockPath(), '4242\n');
+      await expect(readLockHolderPid()).resolves.toBe(4242);
+    });
+
+    it('returns null when no lockfile exists', async () => {
+      await expect(readLockHolderPid()).resolves.toBeNull();
+    });
+
+    it('returns null when the lockfile is malformed', async () => {
+      await writeFile(getPidLockPath(), 'garbage\n');
+      await expect(readLockHolderPid()).resolves.toBeNull();
+    });
+  });
+});

--- a/libs/typescript/integrations/claude-code/esbuild.config.mjs
+++ b/libs/typescript/integrations/claude-code/esbuild.config.mjs
@@ -3,6 +3,16 @@ import { chmodSync } from 'node:fs';
 
 const banner = { js: '#!/usr/bin/env node' };
 
+// @mlflow/core's WAL supervisor resolves the daemon bundle at runtime
+// via `require.resolve('@mlflow/core/package.json')` (string-concatenated
+// to defeat static analysis) and then `path.join(..., 'bundle',
+// 'daemon.cjs')`. Marking both paths as `external` makes the intent
+// explicit and guarantees esbuild leaves any future references to them
+// alone — the daemon ships as its own binary inside @mlflow/core and
+// must be loaded from the installed package on disk, not inlined into
+// the hook bundle.
+const external = ['node:*', '@mlflow/core/package.json', '@mlflow/core/bundle/daemon.cjs'];
+
 for (const [entryPoint, outfile] of [
   ['dist/hooks/stop.js', 'bundle/stop.cjs'],
   ['dist/cli.js', 'bundle/cli.cjs'],
@@ -13,7 +23,7 @@ for (const [entryPoint, outfile] of [
     platform: 'node',
     format: 'cjs',
     outfile,
-    external: ['node:*'],
+    external,
     banner,
   });
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/23605/files) to review incremental changes.
- [stack/ipc-batch-cc-tracing](https://github.com/mlflow/mlflow/pull/23579) [[Files changed](https://github.com/mlflow/mlflow/pull/23579/files)] [MERGED]
  - [**stack/daemon-impl-batch-tracing**](https://github.com/mlflow/mlflow/pull/23605) [[Files changed](https://github.com/mlflow/mlflow/pull/23605/files)]
    - [stack/walspan-impl](https://github.com/mlflow/mlflow/pull/23641) [[Files changed](https://github.com/mlflow/mlflow/pull/23641/files/4fbb480cf88676bc72c30083c46759fe2239a206..da4c40134392aba918539d32bf5c22dd5682193a)]

---------
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Related PRs that was merged previously:
- https://github.com/mlflow/mlflow/pull/23545
- https://github.com/mlflow/mlflow/pull/23511
- https://github.com/mlflow/mlflow/pull/23464

### What changes are proposed in this pull request?

Introduces a long-lived background daemon that drains the WAL on behalf of all trace-emitting processes on a host, replacing the per-process inline upload path. Hooks now submit records to the daemon over a local IPC socket and the daemon owns batching, fsync, retry, dead-lettering, and credential refresh. This removes upload work from the hook's hot path and gives at-least-once delivery semantics with a single durable WAL writer.

### How is this PR tested?

- [X] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
