### PR TITLE
Require top-level `permissions: {}` in workflows

### DIFF
--- a/.github/policy.rego
+++ b/.github/policy.rego
@@ -13,8 +13,19 @@ deny_jobs_without_permissions contains msg if {
 }
 
 deny_top_level_permissions contains msg if {
-	input.permissions
-	msg := "Do not use top-level permissions. Set permissions on the job level."
+	# Workflow files only (composite actions have 'runs')
+	input.jobs
+	not input.permissions
+	msg := concat("", [
+		"Workflow must set top-level 'permissions: {}' to deny all by default. ",
+		"Grant least-privilege permissions per job.",
+	])
+}
+
+deny_top_level_permissions contains msg if {
+	input.jobs
+	input.permissions != {}
+	msg := "Top-level 'permissions' must be empty ({}). Grant least-privilege permissions per job instead."
 }
 
 deny_unsafe_checkout contains msg if {

--- a/.github/workflows/advice.yml
+++ b/.github/workflows/advice.yml
@@ -9,6 +9,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   notify:
     if: >

--- a/.github/workflows/approval.yml
+++ b/.github/workflows/approval.yml
@@ -7,6 +7,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   check:
     runs-on: ubuntu-slim

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -14,6 +14,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   scan-and-assign:
     if: github.repository == 'mlflow/mlflow'

--- a/.github/workflows/auto-close-pr.yml
+++ b/.github/workflows/auto-close-pr.yml
@@ -9,6 +9,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   auto-close-pr:
     if: >-

--- a/.github/workflows/autoformat-label-notify.yml
+++ b/.github/workflows/autoformat-label-notify.yml
@@ -9,6 +9,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   notify:
     runs-on: ubuntu-slim

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -9,6 +9,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   check-comment:
     runs-on: ubuntu-slim

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -35,6 +35,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   build:
     if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -10,6 +10,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   cancel:
     runs-on: ubuntu-slim

--- a/.github/workflows/cherry-picks-warn.yml
+++ b/.github/workflows/cherry-picks-warn.yml
@@ -11,6 +11,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   notify:
     runs-on: ubuntu-slim

--- a/.github/workflows/close-security-issues.yml
+++ b/.github/workflows/close-security-issues.yml
@@ -8,6 +8,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   close:
     if: github.repository == 'mlflow/mlflow'

--- a/.github/workflows/closing-pr.yml
+++ b/.github/workflows/closing-pr.yml
@@ -10,6 +10,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   closing-pr:
     runs-on: ubuntu-slim

--- a/.github/workflows/community-label.yml
+++ b/.github/workflows/community-label.yml
@@ -9,6 +9,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   label-community:
     if: github.repository == 'mlflow/mlflow'

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -10,6 +10,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   copilot-setup-steps:
     runs-on: ubuntu-latest

--- a/.github/workflows/cross-version-test-runner.yml
+++ b/.github/workflows/cross-version-test-runner.yml
@@ -7,6 +7,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   run:
     runs-on: ubuntu-slim

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -55,6 +55,8 @@ env:
   PIP_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
   PIP_CONSTRAINT: ${{ github.workspace }}/requirements/constraints.txt
 
+permissions: {}
+
 jobs:
   set-matrix:
     runs-on: ubuntu-slim

--- a/.github/workflows/dev-setup.yml
+++ b/.github/workflows/dev-setup.yml
@@ -40,6 +40,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   linux-env-setup:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,6 +33,8 @@ defaults:
     shell: bash
     working-directory: docs
 
+permissions: {}
+
 jobs:
   check:
     if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')

--- a/.github/workflows/duplicate-prs.yml
+++ b/.github/workflows/duplicate-prs.yml
@@ -9,6 +9,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   duplicate-prs:
     if: github.repository == 'mlflow/mlflow'

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -49,6 +49,8 @@ env:
   PIP_CONSTRAINT: ${{ github.workspace }}/requirements/constraints.txt
   PYTHONFAULTHANDLER: "1"
 
+permissions: {}
+
 jobs:
   examples:
     runs-on: ubuntu-latest

--- a/.github/workflows/fs2db.yml
+++ b/.github/workflows/fs2db.yml
@@ -28,6 +28,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   e2e-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/gateway-benchmark.yml
+++ b/.github/workflows/gateway-benchmark.yml
@@ -37,6 +37,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   benchmark:
     runs-on: ubuntu-latest

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -21,6 +21,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/issue-warning.yml
+++ b/.github/workflows/issue-warning.yml
@@ -8,6 +8,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   prepend-warning:
     if: >-

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -28,6 +28,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   check-component-ids:
     if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -14,6 +14,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   labeling:
     if: (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -18,6 +18,8 @@ defaults:
     shell: bash
     working-directory: docs
 
+permissions: {}
+
 jobs:
   check-external-links:
     # Only run on the main repository

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,8 @@ env:
   PIP_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
   PIP_CONSTRAINT: ${{ github.workspace }}/requirements/constraints.txt
 
+permissions: {}
+
 jobs:
   lint:
     strategy:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -42,6 +42,8 @@ env:
   _MLFLOW_TESTING_TELEMETRY: "true"
   MLFLOW_SERVER_ENABLE_JOB_EXECUTION: "false"
 
+permissions: {}
+
 jobs:
   # python-skinny tests cover a subset of mlflow functionality
   # that is meant to be supported with a smaller dependency footprint.

--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -23,6 +23,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   review:
     # The workflow never uses the default GITHUB_TOKEN — every `gh api`

--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -11,6 +11,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   patch:
     if: (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -12,6 +12,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   label-pr-size:
     if: (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -12,6 +12,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   main:
     if: github.repository == 'mlflow/mlflow'

--- a/.github/workflows/protect.yml
+++ b/.github/workflows/protect.yml
@@ -21,6 +21,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   protect:
     # Skip this job in a merge queue

--- a/.github/workflows/protobuf-cross-test.yml
+++ b/.github/workflows/protobuf-cross-test.yml
@@ -36,6 +36,8 @@ env:
   PYTHONUTF8: "1"
   PIP_CONSTRAINT: ${{ github.workspace }}/requirements/constraints.txt
 
+permissions: {}
+
 jobs:
   core_tests:
     if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')

--- a/.github/workflows/protos.yml
+++ b/.github/workflows/protos.yml
@@ -31,6 +31,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   protos:
     if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')

--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -10,6 +10,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   push-images:
     # Only run for version tags (vX.Y.Z); skips non-version release tags like `model-catalog/latest`.

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -35,6 +35,8 @@ env:
   MLFLOW_HOME: ${{ github.workspace }}
   PIP_CONSTRAINT: ${{ github.workspace }}/requirements/constraints.txt
 
+permissions: {}
+
 jobs:
   r:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-note.yml
+++ b/.github/workflows/release-note.yml
@@ -23,6 +23,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   validate-labeled:
     if: (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot') && github.event.action != 'closed'

--- a/.github/workflows/remove-experimental-decorators.yml
+++ b/.github/workflows/remove-experimental-decorators.yml
@@ -14,6 +14,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   remove-decorators:
     runs-on: ubuntu-slim

--- a/.github/workflows/rerun-cross-version-tests.yml
+++ b/.github/workflows/rerun-cross-version-tests.yml
@@ -14,6 +14,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   set-matrix:
     runs-on: ubuntu-slim

--- a/.github/workflows/rerun-workflow-run.yml
+++ b/.github/workflows/rerun-workflow-run.yml
@@ -13,6 +13,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   rerun:
     if: github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -14,6 +14,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   upload:
     runs-on: ubuntu-slim

--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -17,6 +17,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   precheck:
     runs-on: ubuntu-slim

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -16,6 +16,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   # Auth gate: only users with admin or maintain role on the repo can trigger
   # the review (plus the Copilot bot). For issue_comment, BOTH the PR author

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -41,6 +41,8 @@ env:
   PIP_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
   PIP_CONSTRAINT: ${{ github.workspace }}/requirements/constraints.txt
 
+permissions: {}
+
 jobs:
   docker-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -18,6 +18,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   build:
     if: github.repository == 'mlflow/mlflow'

--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -9,6 +9,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   stale-prs:
     if: github.repository == 'mlflow/mlflow'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,6 +9,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   stale:
     if: github.repository == 'mlflow/mlflow'

--- a/.github/workflows/team-review.yml
+++ b/.github/workflows/team-review.yml
@@ -13,6 +13,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   review:
     runs-on: ubuntu-slim

--- a/.github/workflows/test-requirements.yml
+++ b/.github/workflows/test-requirements.yml
@@ -31,6 +31,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   skinny:
     runs-on: ubuntu-latest

--- a/.github/workflows/title.yml
+++ b/.github/workflows/title.yml
@@ -14,6 +14,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   title:
     runs-on: ubuntu-slim

--- a/.github/workflows/tracing-benchmark.yml
+++ b/.github/workflows/tracing-benchmark.yml
@@ -24,6 +24,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   benchmark:
     runs-on: ubuntu-latest

--- a/.github/workflows/tracing.yml
+++ b/.github/workflows/tracing.yml
@@ -37,6 +37,8 @@ env:
   MLFLOW_SERVER_ENABLE_JOB_EXECUTION: "false"
   PIP_CONSTRAINT: ${{ github.workspace }}/requirements/constraints.txt
 
+permissions: {}
+
 jobs:
   core:
     runs-on: ubuntu-latest

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -13,6 +13,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   # Test job: runs on PR changes against a fixed set of issues
   test:

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -28,6 +28,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   typescript-sdk:
     if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')

--- a/.github/workflows/uc-oss.yml
+++ b/.github/workflows/uc-oss.yml
@@ -26,6 +26,8 @@ env:
   MLFLOW_HOME: ${{ github.workspace }}
   MLFLOW_SERVER_ENABLE_JOB_EXECUTION: "false"
 
+permissions: {}
+
 jobs:
   uc-oss-integration-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ui-preview.yml
+++ b/.github/workflows/ui-preview.yml
@@ -27,6 +27,8 @@ defaults:
 env:
   COMMENT_MARKER: "<!-- ui-preview -->"
 
+permissions: {}
+
 jobs:
   notify:
     if: >-

--- a/.github/workflows/update-model-catalog.yml
+++ b/.github/workflows/update-model-catalog.yml
@@ -10,6 +10,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   update-model-catalog:
     if: github.repository == 'mlflow/mlflow'

--- a/.github/workflows/update-release-labels.yml
+++ b/.github/workflows/update-release-labels.yml
@@ -14,6 +14,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   update-labels:
     if: >-

--- a/.github/workflows/uv.yml
+++ b/.github/workflows/uv.yml
@@ -19,6 +19,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   uv:
     # Skip scheduled runs on forks

--- a/.github/workflows/xtest-viz.yml
+++ b/.github/workflows/xtest-viz.yml
@@ -17,6 +17,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   xtest-viz:
     runs-on: ubuntu-slim


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

- Flip the `deny_top_level_permissions` rule in `.github/policy.rego`: it now requires every workflow file to set top-level `permissions: {}` (deny-all default) instead of forbidding top-level `permissions` outright. Jobs must opt back in via their own `permissions:` block.
- Add `permissions: {}` to all 61 workflows in `.github/workflows/` to satisfy the new rule.

This follows GitHub's recommended hardening pattern: the `GITHUB_TOKEN` starts with no permissions, and each job grants the minimum it needs.

### How is this PR tested?

- [x] Existing unit/integration tests

Verified via `bin/conftest test --namespace mlflow --policy .github/policy.rego .github/workflows/*.yml` (2196 tests, all pass) and `uv run pre-commit run --files <changed>`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release