### PR TITLE
Pin `google-adk<2.0` to unblock CI (`vertexai` not installed)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -250,6 +250,11 @@ constraint-dependencies = [
   # litellm 1.82.7 and 1.82.8 contain a malicious .pth file that steals credentials
   # https://github.com/BerriAI/litellm/issues/24512
   "litellm<=1.82.6",
+  # google-adk 2.0.0+ ships an unguarded `import vertexai` in
+  # google/adk/dependencies/vertexai.py without declaring vertexai as a runtime
+  # dependency, breaking the Safety scorer path on default installs.
+  # https://github.com/google/adk-python/issues/5864
+  "google-adk<2.0",
 ]
 # Prevent third-party libraries from installing uv to avoid conflicts with uv installed
 # by the standalone installer

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -5,3 +5,8 @@ xgboost<3.1.0
 # litellm 1.82.7 and 1.82.8 contain a malicious .pth file that steals credentials
 # https://github.com/BerriAI/litellm/issues/24512
 litellm<=1.82.6
+# google-adk 2.0.0+ ships an unguarded `import vertexai` in
+# google/adk/dependencies/vertexai.py without declaring vertexai as a runtime
+# dependency, breaking the Safety scorer path on default installs.
+# https://github.com/google/adk-python/issues/5864
+google-adk<2.0

--- a/uv.lock
+++ b/uv.lock
@@ -27,6 +27,7 @@ members = [
     "skills",
 ]
 constraints = [
+    { name = "google-adk", specifier = "<2.0" },
     { name = "litellm", specifier = "<=1.82.6" },
     { name = "pyspark", specifier = "<4.1.0" },
     { name = "setuptools", specifier = "<82" },


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/google/adk-python/issues/5864 (upstream)

### What changes are proposed in this pull request?

Pins `google-adk<2.0` in `requirements/constraints.txt` and the parallel `[tool.uv] constraint-dependencies` list in `pyproject.toml`, plus regenerates `uv.lock`.

`google-adk` 2.0.0 ships `google/adk/dependencies/vertexai.py` with a top-level `import vertexai` but does not declare `vertexai` in `[project.dependencies]`. A default install (no extras) of `google-adk` resolves cleanly and then crashes with `ModuleNotFoundError: No module named 'vertexai'` as soon as any consumer touches the shim, e.g. `SafetyEvaluatorV1.evaluate_invocations` (`safety_evaluator.py:54`: `from ..dependencies.vertexai import vertexai`).

MLflow's `genai` workflow installs `google-adk` unpinned (`master.yml:330`). Master's last 3 passing CI runs all resolved `google-adk==1.34.0`; runs that landed after the 2.0.0 release started failing 4 tests in `tests/genai/scorers/google_adk/test_google_adk.py`.

Pinning `<2.0` here keeps CI on the last-known-good release until upstream either:

1. declares `vertexai` in `[project.dependencies]`, or
2. moves the shim into an optional extra and guards the import.

Filed upstream as https://github.com/google/adk-python/issues/5864.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

CI on this PR will exercise the constraint via `PIP_CONSTRAINT` (set by every workflow that touches the env) and via `uv`'s constraint resolution.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Claude Code.
