### PR TITLE
Flush async trace queue before generating MLFlow demo traces

### DIFF
--- a/mlflow/demo/generators/evaluation.py
+++ b/mlflow/demo/generators/evaluation.py
@@ -280,6 +280,7 @@ class EvaluationDemoGenerator(BaseDemoGenerator):
             filter_string=" AND ".join(filter_parts),
             max_results=100,
             return_type="list",
+            flush=True,
         )
 
     def _add_expectations_to_traces(self, traces: list[Trace]) -> int:

--- a/mlflow/demo/generators/issues.py
+++ b/mlflow/demo/generators/issues.py
@@ -47,7 +47,7 @@ class IssuesDemoGenerator(BaseDemoGenerator):
 
         experiment_id = experiment.experiment_id
         traces = mlflow.search_traces(
-            locations=[experiment_id], max_results=1000, return_type="list"
+            locations=[experiment_id], max_results=1000, return_type="list", flush=True
         )
         failing_traces_by_assessment = {}
 

--- a/mlflow/demo/generators/traces.py
+++ b/mlflow/demo/generators/traces.py
@@ -237,6 +237,7 @@ class TracesDemoGenerator(BaseDemoGenerator):
             traces = mlflow.search_traces(
                 locations=[experiment.experiment_id],
                 max_results=1,
+                flush=True,
             )
             return len(traces) > 0
         except Exception:

--- a/tests/demo/test_search_traces_flush.py
+++ b/tests/demo/test_search_traces_flush.py
@@ -1,0 +1,42 @@
+from unittest import mock
+
+from mlflow import set_experiment
+from mlflow.demo.base import DEMO_EXPERIMENT_NAME
+from mlflow.demo.generators.evaluation import EvaluationDemoGenerator
+from mlflow.demo.generators.issues import IssuesDemoGenerator
+from mlflow.demo.generators.traces import TracesDemoGenerator
+
+
+def test_evaluation_fetch_demo_traces_passes_flush():
+    with mock.patch(
+        "mlflow.demo.generators.evaluation.mlflow.search_traces",
+        return_value=[],
+    ) as mock_search:
+        EvaluationDemoGenerator()._fetch_demo_traces(experiment_id="0", version="v2", session=True)
+
+    mock_search.assert_called_once()
+    assert mock_search.call_args.kwargs.get("flush") is True
+
+
+def test_issues_generate_passes_flush():
+    set_experiment(DEMO_EXPERIMENT_NAME)
+    with mock.patch(
+        "mlflow.demo.generators.issues.mlflow.search_traces",
+        return_value=[],
+    ) as mock_search:
+        IssuesDemoGenerator().generate()
+
+    mock_search.assert_called_once()
+    assert mock_search.call_args.kwargs.get("flush") is True
+
+
+def test_traces_data_exists_passes_flush():
+    set_experiment(DEMO_EXPERIMENT_NAME)
+    with mock.patch(
+        "mlflow.demo.generators.traces.mlflow.search_traces",
+        return_value=[],
+    ) as mock_search:
+        TracesDemoGenerator()._data_exists()
+
+    mock_search.assert_called_once()
+    assert mock_search.call_args.kwargs.get("flush") is True


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

Not applicable

### What changes are proposed in this pull request?

 Fixes a minor race condition that crashes `uvx mlflow demo` during evaluation generation with `MlflowException: The dataset is empty. Please provide a non-empty dataset.`

Relatively minor as this was only observed on a cold start of a fresh clone of MLFlow.

  **Stack trace observed:**

```
  2026/05/27 11:04:26 INFO mlflow.demo: Generating demo data for
  'DemoFeature.EVALUATION'
  Traceback (most recent call last):
    File ".../mlflow/cli/demo.py", line 155, in demo
      _run_with_new_server(port, no_browser, debug, refresh)
    File ".../mlflow/cli/demo.py", line 262, in _run_with_new_server
      results = generate_all_demos(refresh=refresh)
    File ".../mlflow/demo/init.py", line 44, in generate_all_demos
      result = generator.generate()
    File ".../mlflow/demo/generators/evaluation.py", line 210, in generate
      improved_session_run_id = self._create_evaluation_run(
          traces=v2_session,
          experiment_id=experiment_id,
          run_name="improved-session-evaluation",
      )
    File ".../mlflow/demo/generators/evaluation.py", line 393, in
  _create_evaluation_run
      result = mlflow.genai.evaluate(data=traces, scorers=demo_scorers)
    File ".../mlflow/genai/evaluation/utils.py", line 138, in
  _convert_eval_set_to_df
      raise MlflowException.invalid_parameter_value(
          "The dataset is empty. Please provide a non-empty dataset."
      )
  mlflow.exceptions.MlflowException: The dataset is empty. Please provide a
  non-empty dataset.
```

Root Cause:
* MLFlow buffers trace writes in an in-memory `AsyncTraceExportQueue` which is slowly drained
* Demo generators call `mlflow.search_traces` which queries the store directly, before the v2 session traces are drained, so `search_traces` return an empty list
* Fix is to add `flush=True` to the call sites in demo generator consumers. Given that these are demo generators, the loss of async optimisation should be acceptable. 

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

* `uv run mlflow demo` works
<img width="1561" height="627" alt="Screenshot 2026-05-27 at 12 01 50 PM" src="https://github.com/user-attachments/assets/425467ba-0d0d-46a3-881e-45f4ee911ded" />

* Added regression guard using mocks to ensure flush is always set (suggested by Claude, may be unnecessary so open to removing)


### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. 

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
 Fixes a race condition that caused `uvx mlflow demo` to crash during evaluation generation with `MlflowException: The dataset is empty`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
