### PR TITLE
Auto-close duplicate community PRs in `duplicate-prs` workflow

### DIFF
--- a/.github/workflows/duplicate-prs.js
+++ b/.github/workflows/duplicate-prs.js
@@ -7,7 +7,7 @@ const DAYS_TO_CONSIDER = 14;
 const DUPLICATE_LABEL = "duplicate";
 
 const duplicateMessage = (author, issueNumber, keeperPR) =>
-  `@${author} This PR appears to reference the same issue (#${issueNumber}) as #${keeperPR} (opened earlier). If your change is already covered, please consider closing this PR.`;
+  `@${author} This PR appears to reference the same issue (#${issueNumber}) as #${keeperPR} (opened earlier). Closing as a duplicate.`;
 
 // GraphQL query to fetch open PRs created in the last 14 days
 const QUERY = `
@@ -146,12 +146,20 @@ module.exports = async ({ context, github }) => {
           labels: [DUPLICATE_LABEL],
         });
 
-        // Post comment encouraging author to close if duplicate
+        // Post comment explaining the closure
         await github.rest.issues.createComment({
           owner,
           repo,
           issue_number: pr.number,
           body: duplicateMessage(pr.author.login, issueNumber, keeper.number),
+        });
+
+        // Close the duplicate PR
+        await github.rest.pulls.update({
+          owner,
+          repo,
+          pull_number: pr.number,
+          state: "closed",
         });
 
         labelCount++;

--- a/.github/workflows/duplicate-prs.js
+++ b/.github/workflows/duplicate-prs.js
@@ -119,7 +119,7 @@ module.exports = async ({ context, github }) => {
     console.log(`Found ${prsByIssue.size} issues with associated PRs`);
 
     // Process each issue that has multiple PRs
-    let labelCount = 0;
+    let closedCount = 0;
     for (const [issueNumber, prs] of prsByIssue.entries()) {
       if (prs.length <= 1) {
         // Only one PR for this issue, no duplicates
@@ -136,25 +136,11 @@ module.exports = async ({ context, github }) => {
       console.log(`  Keeping PR #${keeper.number} (oldest, created ${keeper.createdAt})`);
 
       for (const pr of duplicates) {
-        console.log(`  Labeling PR #${pr.number} as duplicate (created ${pr.createdAt})`);
+        console.log(`  Closing PR #${pr.number} as duplicate (created ${pr.createdAt})`);
 
-        // Add duplicate label
-        await github.rest.issues.addLabels({
-          owner,
-          repo,
-          issue_number: pr.number,
-          labels: [DUPLICATE_LABEL],
-        });
-
-        // Post comment explaining the closure
-        await github.rest.issues.createComment({
-          owner,
-          repo,
-          issue_number: pr.number,
-          body: duplicateMessage(pr.author.login, issueNumber, keeper.number),
-        });
-
-        // Close the duplicate PR
+        // Close first so a failure here leaves the PR open and unlabeled,
+        // letting the next run retry. If we labeled first and then failed
+        // to close, shouldProcessPR would skip the PR forever.
         await github.rest.pulls.update({
           owner,
           repo,
@@ -162,11 +148,25 @@ module.exports = async ({ context, github }) => {
           state: "closed",
         });
 
-        labelCount++;
+        await github.rest.issues.addLabels({
+          owner,
+          repo,
+          issue_number: pr.number,
+          labels: [DUPLICATE_LABEL],
+        });
+
+        await github.rest.issues.createComment({
+          owner,
+          repo,
+          issue_number: pr.number,
+          body: duplicateMessage(pr.author.login, issueNumber, keeper.number),
+        });
+
+        closedCount++;
       }
     }
 
-    console.log(`Labeled ${labelCount} duplicate PRs.`);
+    console.log(`Closed ${closedCount} duplicate PRs.`);
   } catch (error) {
     if (error.status === 429 || error.message?.includes("rate limit")) {
       console.log(`Rate limit hit. Exiting gracefully.`);


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Update `.github/workflows/duplicate-prs.js` so that when a newer community PR is detected as duplicating an earlier open PR (same closing-issue reference), the workflow now:

1. Adds the `duplicate` label (unchanged)
2. Posts a comment that announces the closure (instead of asking the author to close)
3. Closes the duplicate PR via `pulls.update({ state: "closed" })`

The keeper (oldest) PR is left untouched. The workflow already has `pull-requests: write`, so no permission changes are needed.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release