### PR TITLE
Fix: Correct tool result translation in MLflow Bedrock gateway

### DIFF
--- a/mlflow/gateway/providers/bedrock.py
+++ b/mlflow/gateway/providers/bedrock.py
@@ -316,19 +316,11 @@ class AmazonBedrockProvider(BaseProvider):
         system_prompts = []
         converse_messages = []
 
-        for msg in messages:
+        index = 0
+        while index < len(messages):
+            msg = messages[index]
             role = msg.get("role", "user")
-            content = msg.get("content", "")
-
-            # Normalize content: extract text from list of content parts
-            if content is None:
-                content = ""
-            elif isinstance(content, list):
-                content = "\n".join(
-                    p.get("text", "")
-                    for p in content
-                    if isinstance(p, dict) and p.get("type") == "text"
-                )
+            content = self._normalize_content_text(msg.get("content"))
 
             if role == "system":
                 system_prompts.append({"text": content})
@@ -381,22 +373,29 @@ class AmazonBedrockProvider(BaseProvider):
                     "content": assistant_content,
                 })
             elif role == "tool":
+                tool_result_content = []
+                while index < len(messages) and messages[index].get("role") == "tool":
+                    tool_msg = messages[index]
+                    tool_result_content.append({
+                        "toolResult": {
+                            "toolUseId": tool_msg.get("tool_call_id", ""),
+                            "content": [
+                                {"text": self._normalize_content_text(tool_msg.get("content"))}
+                            ],
+                        }
+                    })
+                    index += 1
                 converse_messages.append({
                     "role": "user",
-                    "content": [
-                        {
-                            "toolResult": {
-                                "toolUseId": msg.get("tool_call_id", ""),
-                                "content": [{"text": content}],
-                            }
-                        }
-                    ],
+                    "content": tool_result_content,
                 })
+                continue
             else:
                 converse_messages.append({
                     "role": "user",
                     "content": [{"text": content}],
                 })
+            index += 1
 
         kwargs = {
             "modelId": self.config.model.name,
@@ -438,6 +437,18 @@ class AmazonBedrockProvider(BaseProvider):
                 kwargs["toolConfig"] = {"tools": bedrock_tools}
 
         return kwargs
+
+    @staticmethod
+    def _normalize_content_text(content: Any) -> str:
+        if content is None:
+            return ""
+        if isinstance(content, list):
+            return "\n".join(
+                part.get("text", "")
+                for part in content
+                if isinstance(part, dict) and part.get("type") == "text"
+            )
+        return str(content)
 
     def _converse_to_chat_response(self, response: dict[str, Any]) -> chat.ResponsePayload:
         """Convert Bedrock Converse response to OpenAI chat format."""

--- a/tests/gateway/providers/test_bedrock.py
+++ b/tests/gateway/providers/test_bedrock.py
@@ -656,6 +656,64 @@ async def test_bedrock_converse_serializes_assistant_tool_call_history():
     assistant_blocks = call_kwargs["messages"][1]["content"]
     tool_uses = [b["toolUse"] for b in assistant_blocks if "toolUse" in b]
     assert tool_uses == [{"toolUseId": "tool_abc123", "name": "add", "input": {"a": 17, "b": 25}}]
+    tool_results = [b["toolResult"] for b in call_kwargs["messages"][2]["content"] if "toolResult" in b]
+    assert tool_results == [{"toolUseId": "tool_abc123", "content": [{"text": "42"}]}]
+    mock_client.converse.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_bedrock_converse_groups_consecutive_tool_results_into_one_user_message():
+    provider = _make_converse_provider()
+    mock_client = mock.Mock()
+    mock_client.converse.return_value = _converse_response()
+
+    with mock.patch.object(provider, "get_bedrock_client", return_value=mock_client):
+        payload = chat.RequestPayload(
+            messages=[
+                {"role": "user", "content": "Compute both sums"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "tool_abc123",
+                            "type": "function",
+                            "function": {"name": "add", "arguments": '{"a": 17, "b": 25}'},
+                        },
+                        {
+                            "id": "tool_def456",
+                            "type": "function",
+                            "function": {"name": "add", "arguments": '{"a": 10, "b": 5}'},
+                        },
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "tool_abc123", "content": "42"},
+                {"role": "tool", "tool_call_id": "tool_def456", "content": "15"},
+            ],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "add",
+                        "description": "Add two integers.",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"a": {"type": "integer"}, "b": {"type": "integer"}},
+                            "required": ["a", "b"],
+                        },
+                    },
+                }
+            ],
+        )
+        await provider.chat(payload)
+
+    call_kwargs = mock_client.converse.call_args.kwargs
+    assert len(call_kwargs["messages"]) == 3
+    tool_results = [b["toolResult"] for b in call_kwargs["messages"][2]["content"] if "toolResult" in b]
+    assert tool_results == [
+        {"toolUseId": "tool_abc123", "content": [{"text": "42"}]},
+        {"toolUseId": "tool_def456", "content": [{"text": "15"}]},
+    ]
     mock_client.converse.assert_called_once()
 
 


### PR DESCRIPTION
# [BUG] Bedrock Gateway mis-translates tool results for ConverseStream

## Where did you encounter this bug?

Local machine

## MLflow version

```text
- Client: 3.12.0
- Tracking server: 3.12.0
```

## System information

```text
- MLflow server: Python 3.10
- Backend: AWS Bedrock ConverseStream via MLflow Gateway
- Client: OpenCode connected to MLflow Gateway
- Models observed: GLM-4.7 and GLM-5
```

## Describe the problem

Is MLflow Gateway intended to validate/transform LLM tool-call responses, or should it behave as a pass-through compatibility layer?

When connecting OpenCode to MLflow Gateway with Bedrock-backed GLM-4.7 and GLM-5 routes, tool-use requests fail in MLflow’s Bedrock provider. Bedrock rejects the translated `ConverseStream` request because a tool-use id is not followed by the required `toolResult` block.

Expected: MLflow translates OpenAI `tool_calls` / `tool` messages into valid Bedrock `toolUse` / `toolResult` blocks, or passes through compatible payloads without breaking tool-call ordering.

Actual:

```text
ValidationException: Expected toolResult blocks at messages.2.content for the following Ids:
tooluse_KGM1758uVYBTlv3Qc8DpwH
```

## Tracking information

```shell
Gateway endpoint: <MLFLOW_GATEWAY_OPENAI_COMPAT_URL>
Model routes: <GLM_4_7_ROUTE>, <GLM_5_ROUTE> -> Bedrock ConverseStream
```

## Code to reproduce issue

```python
from openai import OpenAI

client = OpenAI(base_url="<MLFLOW_GATEWAY_OPENAI_COMPAT_URL>", api_key="REPLACE_ME")

client.chat.completions.create(
  model="<GLM_5_OR_GLM_4_7_ROUTE>",
  messages=[
    {"role": "user", "content": "Use the read tool."},
    {
      "role": "assistant",
      "content": None,
      "tool_calls": [{
        "id": "tooluse_KGM1758uVYBTlv3Qc8DpwH",
        "type": "function",
        "function": {"name": "read", "arguments": "{\"filePath\":\"x\"}"},
      }],
    },
    {
      "role": "tool",
      "tool_call_id": "tooluse_KGM1758uVYBTlv3Qc8DpwH",
      "content": "file contents",
    },
  ],
  tools=[{
    "type": "function",
    "function": {
      "name": "read",
      "parameters": {
        "type": "object",
        "properties": {"filePath": {"type": "string"}},
        "required": ["filePath"],
      },
    },
  }],
  stream=True,
)
```

## Stack trace

```text
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/mlflow/tracing/fluent.py", line 484, in wrapper
    value = await generator.__anext__()
  File "/usr/local/lib/python3.10/site-packages/mlflow/gateway/tracing_utils.py", line 244, in wrapper
    async for item in func(*args, **kwargs):
  File "/usr/local/lib/python3.10/site-packages/mlflow/server/gateway_api.py", line 785, in _guarded_stream
    async for chunk in provider.chat_stream(chat.RequestPayload(**request_dict)):
  File "/usr/local/lib/python3.10/site-packages/mlflow/gateway/providers/base.py", line 656, in chat_stream
    async for i in prov.chat_stream(payload):
  File "/usr/local/lib/python3.10/site-packages/mlflow/gateway/providers/base.py", line 202, in chat_stream
    async for chunk in self._maybe_trace_stream_method(
  File "/usr/local/lib/python3.10/site-packages/mlflow/gateway/providers/base.py", line 519, in _maybe_trace_stream_method
    async for chunk in method(*args, **kwargs):
  File "/usr/local/lib/python3.10/site-packages/mlflow/gateway/providers/bedrock.py", line 676, in _chat_stream
    raise _stream_error[0]
  File "/usr/local/lib/python3.10/site-packages/mlflow/gateway/providers/bedrock.py", line 659, in _consume_stream
    response = self.get_bedrock_client().converse_stream(**kwargs)
  File "/usr/local/lib/python3.10/site-packages/botocore/client.py", line 606, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/lib/python3.10/site-packages/botocore/context.py", line 123, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/botocore/client.py", line 1094, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.errorfactory.ValidationException: An error occurred (ValidationException) when calling the ConverseStream operation: Expected toolResult blocks at messages.2.content for the following Ids: tooluse_KGM1758uVYBTlv3Qc8DpwH
```

## Components

- [x] `area/gateway`
- [x] `area/tracing`
