### PR TITLE
Fix: Correct tool result translation in MLflow Bedrock gateway

### DIFF
--- a/mlflow/gateway/providers/bedrock.py
+++ b/mlflow/gateway/providers/bedrock.py
@@ -316,19 +316,11 @@ class AmazonBedrockProvider(BaseProvider):
         system_prompts = []
         converse_messages = []
 
-        for msg in messages:
+        index = 0
+        while index < len(messages):
+            msg = messages[index]
             role = msg.get("role", "user")
-            content = msg.get("content", "")
-
-            # Normalize content: extract text from list of content parts
-            if content is None:
-                content = ""
-            elif isinstance(content, list):
-                content = "\n".join(
-                    p.get("text", "")
-                    for p in content
-                    if isinstance(p, dict) and p.get("type") == "text"
-                )
+            content = self._normalize_content_text(msg.get("content"))
 
             if role == "system":
                 system_prompts.append({"text": content})
@@ -381,22 +373,29 @@ class AmazonBedrockProvider(BaseProvider):
                     "content": assistant_content,
                 })
             elif role == "tool":
+                tool_result_content = []
+                while index < len(messages) and messages[index].get("role") == "tool":
+                    tool_msg = messages[index]
+                    tool_result_content.append({
+                        "toolResult": {
+                            "toolUseId": tool_msg.get("tool_call_id", ""),
+                            "content": [
+                                {"text": self._normalize_content_text(tool_msg.get("content"))}
+                            ],
+                        }
+                    })
+                    index += 1
                 converse_messages.append({
                     "role": "user",
-                    "content": [
-                        {
-                            "toolResult": {
-                                "toolUseId": msg.get("tool_call_id", ""),
-                                "content": [{"text": content}],
-                            }
-                        }
-                    ],
+                    "content": tool_result_content,
                 })
+                continue
             else:
                 converse_messages.append({
                     "role": "user",
                     "content": [{"text": content}],
                 })
+            index += 1
 
         kwargs = {
             "modelId": self.config.model.name,
@@ -438,6 +437,18 @@ class AmazonBedrockProvider(BaseProvider):
                 kwargs["toolConfig"] = {"tools": bedrock_tools}
 
         return kwargs
+
+    @staticmethod
+    def _normalize_content_text(content: Any) -> str:
+        if content is None:
+            return ""
+        if isinstance(content, list):
+            return "\n".join(
+                part.get("text", "")
+                for part in content
+                if isinstance(part, dict) and part.get("type") == "text"
+            )
+        return str(content)
 
     def _converse_to_chat_response(self, response: dict[str, Any]) -> chat.ResponsePayload:
         """Convert Bedrock Converse response to OpenAI chat format."""

--- a/tests/gateway/providers/test_bedrock.py
+++ b/tests/gateway/providers/test_bedrock.py
@@ -656,6 +656,64 @@ async def test_bedrock_converse_serializes_assistant_tool_call_history():
     assistant_blocks = call_kwargs["messages"][1]["content"]
     tool_uses = [b["toolUse"] for b in assistant_blocks if "toolUse" in b]
     assert tool_uses == [{"toolUseId": "tool_abc123", "name": "add", "input": {"a": 17, "b": 25}}]
+    tool_results = [b["toolResult"] for b in call_kwargs["messages"][2]["content"] if "toolResult" in b]
+    assert tool_results == [{"toolUseId": "tool_abc123", "content": [{"text": "42"}]}]
+    mock_client.converse.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_bedrock_converse_groups_consecutive_tool_results_into_one_user_message():
+    provider = _make_converse_provider()
+    mock_client = mock.Mock()
+    mock_client.converse.return_value = _converse_response()
+
+    with mock.patch.object(provider, "get_bedrock_client", return_value=mock_client):
+        payload = chat.RequestPayload(
+            messages=[
+                {"role": "user", "content": "Compute both sums"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "tool_abc123",
+                            "type": "function",
+                            "function": {"name": "add", "arguments": '{"a": 17, "b": 25}'},
+                        },
+                        {
+                            "id": "tool_def456",
+                            "type": "function",
+                            "function": {"name": "add", "arguments": '{"a": 10, "b": 5}'},
+                        },
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "tool_abc123", "content": "42"},
+                {"role": "tool", "tool_call_id": "tool_def456", "content": "15"},
+            ],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "add",
+                        "description": "Add two integers.",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"a": {"type": "integer"}, "b": {"type": "integer"}},
+                            "required": ["a", "b"],
+                        },
+                    },
+                }
+            ],
+        )
+        await provider.chat(payload)
+
+    call_kwargs = mock_client.converse.call_args.kwargs
+    assert len(call_kwargs["messages"]) == 3
+    tool_results = [b["toolResult"] for b in call_kwargs["messages"][2]["content"] if "toolResult" in b]
+    assert tool_results == [
+        {"toolUseId": "tool_abc123", "content": [{"text": "42"}]},
+        {"toolUseId": "tool_def456", "content": [{"text": "15"}]},
+    ]
     mock_client.converse.assert_called_once()
 
 


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

Relates to https://github.com/mlflow/mlflow/pull/23223

Open question is the gateway intended to validate and enforce proper responses or act as a pass though. If the gateway is to enforce proper formatting that will exclude many models and variations on parameters, calls.

### What changes are proposed in this pull request?

This PR fixes MLflow Gateway's Bedrock `ConverseStream` translation for OpenAI-compatible tool-call conversations.

When clients send OpenAI-style `tool_calls` followed by `role="tool"` messages, MLflow Gateway can translate the conversation into a Bedrock payload that is missing the required matching `toolResult` content block. Bedrock rejects the request with:

```text
ValidationException: Expected toolResult blocks at messages.2.content for the following Ids: tooluse_KGM1758uVYBTlv3Qc8DpwH
```

This change ensures tool result messages are converted into valid Bedrock `toolResult` blocks with the expected `toolUseId`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Manual testing:

Connected OpenCode to MLflow Gateway with Bedrock-backed GLM-4.7 and GLM-5 model routes. Verified that tool-call conversations no longer fail with the missing `toolResult` validation error.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?


- [ ] No.


#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
