### PR TITLE
Fix unsatisfiable contributor install in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -358,7 +358,7 @@ If you plan on doing development and testing, you will also need to
 install the following into the conda environment:
 
 ```bash
-pip install -r requirements/dev-requirements.txt
+pip install -r requirements/test-requirements.txt
 pip install -e '.[extras]'  # installs mlflow from current checkout
 pip install -e tests/resources/mlflow-test-plugin # installs `mlflow-test-plugin` that is required for running certain MLflow tests
 ```


### PR DESCRIPTION
### Related Issues/PRs

Closes #23602

### What changes are proposed in this pull request?

Point the contributor setup snippet in `CONTRIBUTING.md` at `requirements/test-requirements.txt` instead of `requirements/dev-requirements.txt`.

`dev-requirements.txt` transitively pulls in `extra-ml-requirements.txt`, which includes `semantic-kernel` (requires `jinja2>=3.1`). That conflicts with other pinned versions of `jinja2` in the resolved set, so fresh contributor installs fail with `No solution found when resolving dependencies` (reported on Windows + Git Bash in #23602, but the conflict is platform-agnostic).

`test-requirements.txt` is the set contributors actually need to run the test suite and is what `CLAUDE.md` already prescribes.

### How is this PR tested?

- [x] Manual tests

Verified the `test-requirements.txt` install resolves cleanly and the `dev-requirements.txt` install reproduces the conflict via the semantic-kernel / jinja2 path.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release