### PR TITLE
Unpin `google-adk` and install `google-adk[gcp]` for genai tests

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -327,7 +327,7 @@ jobs:
           # install and the corresponding tests until it is republished.
           uv pip install \
             -r requirements/test-requirements.txt \
-            deepeval ragas 'arize-phoenix-evals<3.0.0' trulens trulens-providers-litellm google-adk
+            deepeval ragas 'arize-phoenix-evals<3.0.0' trulens trulens-providers-litellm 'google-adk[gcp]'
       - uses: ./.github/actions/show-versions
       - name: Run GenAI Tests (OSS)
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -250,11 +250,6 @@ constraint-dependencies = [
   # litellm 1.82.7 and 1.82.8 contain a malicious .pth file that steals credentials
   # https://github.com/BerriAI/litellm/issues/24512
   "litellm<=1.82.6",
-  # google-adk 2.0.0+ ships an unguarded `import vertexai` in
-  # google/adk/dependencies/vertexai.py without declaring vertexai as a runtime
-  # dependency, breaking the Safety scorer path on default installs.
-  # https://github.com/google/adk-python/issues/5864
-  "google-adk<2.0",
 ]
 # Prevent third-party libraries from installing uv to avoid conflicts with uv installed
 # by the standalone installer

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -5,8 +5,3 @@ xgboost<3.1.0
 # litellm 1.82.7 and 1.82.8 contain a malicious .pth file that steals credentials
 # https://github.com/BerriAI/litellm/issues/24512
 litellm<=1.82.6
-# google-adk 2.0.0+ ships an unguarded `import vertexai` in
-# google/adk/dependencies/vertexai.py without declaring vertexai as a runtime
-# dependency, breaking the Safety scorer path on default installs.
-# https://github.com/google/adk-python/issues/5864
-google-adk<2.0

--- a/uv.lock
+++ b/uv.lock
@@ -27,7 +27,6 @@ members = [
     "skills",
 ]
 constraints = [
-    { name = "google-adk", specifier = "<2.0" },
     { name = "litellm", specifier = "<=1.82.6" },
     { name = "pyspark", specifier = "<4.1.0" },
     { name = "setuptools", specifier = "<82" },


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23613 (the original pin) and upstream https://github.com/google/adk-python/issues/5864.

### What changes are proposed in this pull request?

- Removes the `google-adk<2.0` pin from `requirements/constraints.txt` and `pyproject.toml` `[tool.uv] constraint-dependencies`, and regenerates `uv.lock`.
- Updates the genai CI install step in `.github/workflows/master.yml` to install `google-adk[gcp]` instead of bare `google-adk`.

`google-adk` 2.0.0+ ships an unguarded `import vertexai` in `google/adk/dependencies/vertexai.py` without declaring `vertexai` in `[project.dependencies]`. The upstream maintainer suggested the workaround on google/adk-python#5864: install one of the GCP-bearing extras so that `vertexai` (and its `preview.example_stores` re-export) is actually present. `[gcp]` is the narrower of the two viable extras (vs. `[all]`), so we use that here.

This lets us drop the pin and pick up newer `google-adk` releases while upstream considers a proper fix (declare `vertexai` as a runtime dep, or guard the import).

### How is this PR tested?

- [x] Existing unit/integration tests

CI will exercise the new `[gcp]` extra via the `genai` job in `master.yml`. The four `tests/genai/scorers/google_adk/test_google_adk.py` tests that regressed on 2.0.0 should pass again, this time with `vertexai` actually installed.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`
- [x] `area/build`

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release