### PR TITLE
Improve realism of MLFlow demo traces

### DIFF
--- a/mlflow/demo/data.py
+++ b/mlflow/demo/data.py
@@ -375,7 +375,7 @@ AGENT_TRACES: list[DemoTrace] = [
         ),
         v2_response=(
             "With annual compounding, $10,000 at 5% interest for 10 years grows to "
-            "$16,288.95. The formula is: Principal x (1 + rate)^years = 10000 x 1.05^10. "
+            "**$16,288.95**. The formula is: Principal x (1 + rate)^years = 10000 x 1.05^10. "
             "You'll earn $6,288.95 in interest over the period."
         ),
         expected_response=(
@@ -388,6 +388,11 @@ AGENT_TRACES: list[DemoTrace] = [
                 name="calculator",
                 input={"expression": "10000 * (1.05 ** 10)", "precision": 2},
                 output={"result": 16288.95, "formula": "10000 * 1.05^10"},
+            ),
+            ToolCall(
+                name="format_currency",
+                input={"amount": 16288.95, "locale": "en-US"},
+                output={"formatted": "$16,288.95", "currency": "USD"},
             ),
         ],
     ),
@@ -715,27 +720,70 @@ SESSION_TRACES: list[DemoTrace] = [
             "or chunk size."
         ),
         v2_response=(
-            "Retrieval issues are common! Here's how to diagnose:\n\n"
-            "1. **In MLflow Traces**, click on the RETRIEVER span to see:\n"
-            "   - Retrieved document IDs and relevance scores\n"
-            "   - The query embedding used\n\n"
-            "2. **Common fixes**:\n"
-            "   - Lower your similarity threshold (try 0.7 instead of 0.8)\n"
-            "   - Experiment with chunk sizes (512 tokens often works well)\n"
-            "   - Try a different embedding model\n\n"
-            "3. **Track experiments**: Log retrieval params to compare:\n"
+            "Let me dig into your recent traces to confirm.\n\n"
+            "I pulled 50 recent RETRIEVER spans and scored them: the **average relevance "
+            "is 0.62**, with **18 low-scoring cases** clustered on long-form queries. The "
+            "pattern fits a too-strict similarity threshold combined with chunks that cut "
+            "mid-sentence.\n\n"
+            "**Recommended config changes:**\n"
+            "- Lower similarity threshold: `0.8 → 0.75` (captures borderline-relevant chunks)\n"
+            "- Increase chunk size: `256 → 512` tokens (reduces mid-sentence cutoffs)\n\n"
             "```python\n"
-            "mlflow.log_params({'chunk_size': 512, 'threshold': 0.7})\n"
-            "```"
+            "mlflow.log_params({'chunk_size': 512, 'threshold': 0.75})\n"
+            "```\n\n"
+            "Want me to also try a different embedding model?"
         ),
         expected_response=(
-            "Check RETRIEVER span in traces for scores. Try adjusting similarity threshold, "
-            "chunk size, or embedding model. Log params to compare experiments."
+            "Inspect RETRIEVER spans in traces for scores. Lower threshold to 0.75 and "
+            "increase chunk size to 512 to fix long-form query retrieval."
         ),
         trace_type="session",
         session_id="session-rag-debug",
         session_user="bob@example.com",
         turn_index=2,
+        tools=[
+            ToolCall(
+                name="search_traces",
+                input={
+                    "experiment_name": "rag-app",
+                    "filter": "span_type='RETRIEVER'",
+                    "limit": 50,
+                },
+                output={
+                    "trace_ids": [f"trace_{i:03d}" for i in range(50)],
+                    "count": 50,
+                },
+            ),
+            ToolCall(
+                name="analyze_retrieval_quality",
+                input={"trace_ids": [f"trace_{i:03d}" for i in range(50)]},
+                output={
+                    "avg_score": 0.62,
+                    "low_score_count": 18,
+                    "common_failure_pattern": "long-form queries",
+                },
+            ),
+            ToolCall(
+                name="recommend_config_changes",
+                input={
+                    "current_threshold": 0.8,
+                    "current_chunk_size": 256,
+                    "analysis": {
+                        "avg_score": 0.62,
+                        "low_score_count": 18,
+                        "common_failure_pattern": "long-form queries",
+                    },
+                },
+                output={
+                    "similarity_threshold": 0.75,
+                    "chunk_size": 512,
+                    "rationale": (
+                        "Lower threshold to capture borderline-relevant chunks; "
+                        "larger chunks reduce mid-sentence cutoffs."
+                    ),
+                },
+            ),
+        ],
     ),
     DemoTrace(
         query="How do I compare different retrieval configurations systematically?",
@@ -826,16 +874,27 @@ SESSION_TRACES: list[DemoTrace] = [
             "```bash\n"
             "docker push your-registry/my-classifier:v1\n"
             "```\n\n"
-            "3. **Deploy to K8s** (example deployment.yaml):\n"
+            "3. **Deploy to K8s** — I generated the manifest for you (2 replicas on port 8080):\n"
             "```yaml\n"
             "apiVersion: apps/v1\n"
             "kind: Deployment\n"
+            "metadata:\n"
+            "  name: my-classifier\n"
             "spec:\n"
-            "  containers:\n"
-            "  - name: model\n"
-            "    image: your-registry/my-classifier:v1\n"
-            "    ports:\n"
-            "    - containerPort: 8080\n"
+            "  replicas: 2\n"
+            "  selector:\n"
+            "    matchLabels:\n"
+            "      app: my-classifier\n"
+            "  template:\n"
+            "    metadata:\n"
+            "      labels:\n"
+            "        app: my-classifier\n"
+            "    spec:\n"
+            "      containers:\n"
+            "      - name: model\n"
+            "        image: your-registry/my-classifier:v1\n"
+            "        ports:\n"
+            "        - containerPort: 8080\n"
             "```\n\n"
             "The container exposes a `/invocations` endpoint compatible with MLflow's format."
         ),
@@ -847,6 +906,42 @@ SESSION_TRACES: list[DemoTrace] = [
         session_id="session-deployment",
         session_user="carol@example.com",
         turn_index=2,
+        tools=[
+            ToolCall(
+                name="generate_k8s_manifest",
+                input={
+                    "model_uri": "models:/my-classifier/1",
+                    "image": "your-registry/my-classifier:v1",
+                    "replicas": 2,
+                    "port": 8080,
+                },
+                output={
+                    "manifest": (
+                        "apiVersion: apps/v1\n"
+                        "kind: Deployment\n"
+                        "metadata:\n"
+                        "  name: my-classifier\n"
+                        "spec:\n"
+                        "  replicas: 2\n"
+                        "  selector:\n"
+                        "    matchLabels:\n"
+                        "      app: my-classifier\n"
+                        "  template:\n"
+                        "    metadata:\n"
+                        "      labels:\n"
+                        "        app: my-classifier\n"
+                        "    spec:\n"
+                        "      containers:\n"
+                        "      - name: model\n"
+                        "        image: your-registry/my-classifier:v1\n"
+                        "        ports:\n"
+                        "        - containerPort: 8080"
+                    ),
+                    "service_endpoint": "/invocations",
+                    "estimated_pod_count": 2,
+                },
+            ),
+        ],
     ),
 ]
 

--- a/mlflow/demo/generators/traces.py
+++ b/mlflow/demo/generators/traces.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import copy
 import hashlib
+import json
 import logging
 import random
 import re
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Literal
+from typing import Any, Literal
 
 import mlflow
 from mlflow.demo.base import (
@@ -24,6 +25,7 @@ from mlflow.demo.data import (
     SESSION_TRACES,
     DemoTrace,
     MultimodalDemoTrace,
+    ToolCall,
     get_multimodal_traces,
 )
 from mlflow.entities import SpanType
@@ -113,6 +115,13 @@ GEMINI_3_PRO = _Model(name="gemini-3-pro", provider="google", pricing=(2.00, 12.
 
 _DEMO_MODELS = (GPT_5_2, CLAUDE_SONNET_4_5, GEMINI_3_PRO)
 
+# Names match what each provider's autolog integration emits for the chat-completion call.
+_PROVIDER_TO_LLM_SPAN_NAME = {
+    "openai": "chat.completions.create",
+    "anthropic": "messages.create",
+    "google": "generate_content",
+}
+
 
 def _compute_cost(model: _Model, prompt_tokens: int, completion_tokens: int) -> dict[str, float]:
     """Compute synthetic cost using approximate per-model pricing."""
@@ -124,6 +133,147 @@ def _compute_cost(model: _Model, prompt_tokens: int, completion_tokens: int) -> 
         "output_cost": output_cost,
         "total_cost": input_cost + output_cost,
     }
+
+
+def _json_type(value: Any) -> str:
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, int):
+        return "integer"
+    if isinstance(value, float):
+        return "number"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, dict):
+        return "object"
+    return "string"
+
+
+def _tool_schemas(tools: list[ToolCall]) -> list[dict[str, Any]]:
+    """Build OpenAI-style function schemas from a list of ToolCall objects."""
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": tool.name,
+                "description": f"Call the {tool.name} tool.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {k: {"type": _json_type(v)} for k, v in tool.input.items()},
+                    "required": list(tool.input.keys()),
+                },
+            },
+        }
+        for tool in tools
+    ]
+
+
+def _llm_attributes(model: _Model, in_toks: int, out_toks: int) -> dict[str, Any]:
+    return {
+        SpanAttributeKey.CHAT_USAGE: {
+            "input_tokens": in_toks,
+            "output_tokens": out_toks,
+            "total_tokens": in_toks + out_toks,
+        },
+        SpanAttributeKey.MODEL: model.name,
+        SpanAttributeKey.MODEL_PROVIDER: model.provider,
+        SpanAttributeKey.LLM_COST: _compute_cost(model, in_toks, out_toks),
+    }
+
+
+def _emit_react_children(
+    root,
+    tools: list[ToolCall],
+    model: _Model,
+    system_content: str,
+    user_query: str,
+    response: str,
+    start_ns: int,
+    end_ns: int,
+) -> None:
+    """Emit ReAct-style child spans under `root`.
+
+    For N tools, emits N+1 LLM spans alternating with N TOOL spans:
+    LLM(decide call_1) → TOOL(1) → LLM(decide call_2) → TOOL(2) → … → LLM(final).
+
+    If there are no tools, emits a single LLM span.
+    """
+    span_name = _PROVIDER_TO_LLM_SPAN_NAME[model.provider]
+    tool_schemas = _tool_schemas(tools)
+    schemas_token_overhead = _estimate_tokens(json.dumps(tool_schemas))
+    messages = [
+        {"role": "system", "content": system_content},
+        {"role": "user", "content": user_query},
+    ]
+    total_spans = 2 * len(tools) + 1
+    span_duration = max(1, (end_ns - start_ns - 10_000) // total_spans)
+    cursor = start_ns + 5_000
+
+    for idx, tool in enumerate(tools, start=1):
+        call_id = f"call_{idx:03d}"
+        arguments_json = json.dumps(tool.input)
+        tool_call = {
+            "id": call_id,
+            "type": "function",
+            "function": {"name": tool.name, "arguments": arguments_json},
+        }
+
+        in_toks = _estimate_tokens(json.dumps(messages)) + schemas_token_overhead
+        out_toks = _estimate_tokens(tool.name + arguments_json) + 5
+        llm = mlflow.start_span_no_context(
+            name=span_name,
+            span_type=SpanType.LLM,
+            parent_span=root,
+            inputs={"messages": list(messages), "model": model.name, "tools": tool_schemas},
+            attributes=_llm_attributes(model, in_toks, out_toks),
+            start_time_ns=cursor,
+        )
+        llm.set_outputs({
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [tool_call],
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ]
+        })
+        llm.end(end_time_ns=cursor + span_duration)
+        cursor += span_duration
+
+        messages.append({"role": "assistant", "content": None, "tool_calls": [tool_call]})
+
+        tool_span = mlflow.start_span_no_context(
+            name=tool.name,
+            span_type=SpanType.TOOL,
+            parent_span=root,
+            inputs=tool.input,
+            start_time_ns=cursor,
+        )
+        tool_span.set_outputs(tool.output)
+        tool_span.end(end_time_ns=cursor + span_duration)
+        cursor += span_duration
+
+        messages.append({
+            "role": "tool",
+            "tool_call_id": call_id,
+            "content": json.dumps(tool.output),
+        })
+
+    in_toks = _estimate_tokens(json.dumps(messages)) + schemas_token_overhead
+    out_toks = _estimate_tokens(response)
+    final = mlflow.start_span_no_context(
+        name=span_name,
+        span_type=SpanType.LLM,
+        parent_span=root,
+        inputs={"messages": list(messages), "model": model.name, "tools": tool_schemas},
+        attributes=_llm_attributes(model, in_toks, out_toks),
+        start_time_ns=cursor,
+    )
+    final.set_outputs({"choices": [{"message": {"role": "assistant", "content": response}}]})
+    final.end(end_time_ns=end_ns - 5_000)
 
 
 class TracesDemoGenerator(BaseDemoGenerator):
@@ -334,7 +484,7 @@ class TracesDemoGenerator(BaseDemoGenerator):
 
         model = GPT_5_2
         llm = mlflow.start_span_no_context(
-            name="generate_response",
+            name=_PROVIDER_TO_LLM_SPAN_NAME[model.provider],
             span_type=SpanType.LLM,
             parent_span=root,
             inputs={
@@ -373,12 +523,6 @@ class TracesDemoGenerator(BaseDemoGenerator):
         end_ns: int,
     ) -> str | None:
         response = self._get_response(trace_def, version)
-        prompt_tokens = _estimate_tokens(trace_def.query) + 100
-        completion_tokens = _estimate_tokens(response)
-
-        total_duration = end_ns - start_ns
-        tool_duration = int(total_duration * 0.3)
-        llm_start = start_ns + tool_duration + 10000
 
         root = mlflow.start_span_no_context(
             name="agent",
@@ -388,46 +532,16 @@ class TracesDemoGenerator(BaseDemoGenerator):
             start_time_ns=start_ns,
         )
 
-        tool_start = start_ns + 5000
-        for tool in trace_def.tools:
-            tool_span = mlflow.start_span_no_context(
-                name=tool.name,
-                span_type=SpanType.TOOL,
-                parent_span=root,
-                inputs=tool.input,
-                start_time_ns=tool_start,
-            )
-            tool_span.set_outputs(tool.output)
-            tool_span.end(end_time_ns=tool_start + tool_duration // len(trace_def.tools))
-            tool_start += tool_duration // len(trace_def.tools) + 1000
-
-        model = CLAUDE_SONNET_4_5
-        llm = mlflow.start_span_no_context(
-            name="generate_response",
-            span_type=SpanType.LLM,
-            parent_span=root,
-            inputs={
-                "messages": [
-                    {"role": "system", "content": "You are a helpful assistant with tools."},
-                    {"role": "user", "content": trace_def.query},
-                ],
-                "tool_results": [t.output for t in trace_def.tools],
-                "model": model.name,
-            },
-            attributes={
-                SpanAttributeKey.CHAT_USAGE: {
-                    "input_tokens": prompt_tokens,
-                    "output_tokens": completion_tokens,
-                    "total_tokens": prompt_tokens + completion_tokens,
-                },
-                SpanAttributeKey.MODEL: model.name,
-                SpanAttributeKey.MODEL_PROVIDER: model.provider,
-                SpanAttributeKey.LLM_COST: _compute_cost(model, prompt_tokens, completion_tokens),
-            },
-            start_time_ns=llm_start,
+        _emit_react_children(
+            root=root,
+            tools=trace_def.tools,
+            model=CLAUDE_SONNET_4_5,
+            system_content="You are a helpful assistant with tools.",
+            user_query=trace_def.query,
+            response=response,
+            start_ns=start_ns,
+            end_ns=end_ns,
         )
-        llm.set_outputs({"choices": [{"message": {"role": "assistant", "content": response}}]})
-        llm.end(end_time_ns=end_ns - 5000)
 
         root.set_outputs({"choices": [{"message": {"role": "assistant", "content": response}}]})
         root.end(end_time_ns=end_ns)
@@ -500,7 +614,7 @@ class TracesDemoGenerator(BaseDemoGenerator):
 
         model = GEMINI_3_PRO
         llm = mlflow.start_span_no_context(
-            name="generate_response",
+            name=_PROVIDER_TO_LLM_SPAN_NAME[model.provider],
             span_type=SpanType.LLM,
             parent_span=root,
             inputs={
@@ -706,12 +820,6 @@ class TracesDemoGenerator(BaseDemoGenerator):
     ) -> str | None:
         """Create a single turn in a conversation session."""
         response = self._get_response(trace_def, version)
-        prompt_tokens = _estimate_tokens(trace_def.query) + 80
-        completion_tokens = _estimate_tokens(response)
-
-        total_duration = end_ns - start_ns
-        tool_end = start_ns + int(total_duration * 0.3)
-        llm_start = tool_end + 1000
 
         root = mlflow.start_span_no_context(
             name="chat_agent",
@@ -726,45 +834,16 @@ class TracesDemoGenerator(BaseDemoGenerator):
             start_time_ns=start_ns,
         )
 
-        tool_start = start_ns + 5000
-        for tool in trace_def.tools:
-            tool_span = mlflow.start_span_no_context(
-                name=tool.name,
-                span_type=SpanType.TOOL,
-                parent_span=root,
-                inputs=tool.input,
-                start_time_ns=tool_start,
-            )
-            tool_span.set_outputs(tool.output)
-            tool_span.end(end_time_ns=tool_end)
-            tool_start = tool_end + 1000
-
-        model = _DEMO_MODELS[turn % len(_DEMO_MODELS)]
-        llm = mlflow.start_span_no_context(
-            name="generate_response",
-            span_type=SpanType.LLM,
-            parent_span=root,
-            inputs={
-                "messages": [
-                    {"role": "system", "content": "You are an MLflow assistant."},
-                    {"role": "user", "content": trace_def.query},
-                ],
-                "model": model.name,
-            },
-            attributes={
-                SpanAttributeKey.CHAT_USAGE: {
-                    "input_tokens": prompt_tokens,
-                    "output_tokens": completion_tokens,
-                    "total_tokens": prompt_tokens + completion_tokens,
-                },
-                SpanAttributeKey.MODEL: model.name,
-                SpanAttributeKey.MODEL_PROVIDER: model.provider,
-                SpanAttributeKey.LLM_COST: _compute_cost(model, prompt_tokens, completion_tokens),
-            },
-            start_time_ns=llm_start,
+        _emit_react_children(
+            root=root,
+            tools=trace_def.tools,
+            model=_DEMO_MODELS[turn % len(_DEMO_MODELS)],
+            system_content="You are an MLflow assistant.",
+            user_query=trace_def.query,
+            response=response,
+            start_ns=start_ns,
+            end_ns=end_ns,
         )
-        llm.set_outputs({"choices": [{"message": {"role": "assistant", "content": response}}]})
-        llm.end(end_time_ns=end_ns - 5000)
 
         root.set_outputs({"choices": [{"message": {"role": "assistant", "content": response}}]})
         root.end(end_time_ns=end_ns)

--- a/mlflow/demo/generators/traces.py
+++ b/mlflow/demo/generators/traces.py
@@ -115,7 +115,8 @@ GEMINI_3_PRO = _Model(name="gemini-3-pro", provider="google", pricing=(2.00, 12.
 
 _DEMO_MODELS = (GPT_5_2, CLAUDE_SONNET_4_5, GEMINI_3_PRO)
 
-# Names match what each provider's autolog integration emits for the chat-completion call.
+# LLM spans use canonical SDK method names
+# Not 100% accurate against production but should be sufficiently understandable for demo purposes
 _PROVIDER_TO_LLM_SPAN_NAME = {
     "openai": "chat.completions.create",
     "anthropic": "messages.create",

--- a/mlflow/demo/generators/traces.py
+++ b/mlflow/demo/generators/traces.py
@@ -138,6 +138,9 @@ def _compute_cost(model: _Model, prompt_tokens: int, completion_tokens: int) -> 
 
 
 def _json_type(value: Any) -> str:
+    # Intentionally shallow: nested dicts/lists are reported as bare "object"/"array"
+    # without `properties`/`items`. Fine for a demo schema where we only need the
+    # top-level parameter shape; not a general-purpose JSON Schema generator.
     if isinstance(value, bool):
         return "boolean"
     if isinstance(value, int):
@@ -214,6 +217,8 @@ def _emit_react_children(
     messages = [{"role": "system", "content": system_content}]
     messages.extend(prior_messages or [])
     messages.append({"role": "user", "content": user_query})
+    # span_duration is only used inside the per-tool loop below; when `tools` is empty
+    # the loop is skipped and the lone final LLM span runs from `cursor` to `end_ns - 5_000`.
     total_spans = 2 * len(tools) + 1
     span_duration = max(1, (end_ns - start_ns - 10_000) // total_spans)
     cursor = start_ns + 5_000

--- a/mlflow/demo/generators/traces.py
+++ b/mlflow/demo/generators/traces.py
@@ -598,7 +598,10 @@ class TracesDemoGenerator(BaseDemoGenerator):
         root = mlflow.start_span_no_context(
             name="prompt_chain",
             span_type=SpanType.CHAIN,
-            inputs={"messages": [{"role": "user", "content": trace_def.query}]},
+            inputs={
+                "messages": [{"role": "user", "content": trace_def.query}],
+                "template_variables": variables,
+            },
             metadata={DEMO_VERSION_TAG: version, DEMO_TRACE_TYPE_TAG: "prompt"},
             start_time_ns=start_ns,
         )
@@ -609,7 +612,7 @@ class TracesDemoGenerator(BaseDemoGenerator):
             parent_span=root,
             inputs={
                 "template": actual_template,
-                "variables": variables,
+                "template_variables": variables,
             },
             start_time_ns=start_ns + 1000,
         )

--- a/mlflow/demo/generators/traces.py
+++ b/mlflow/demo/generators/traces.py
@@ -217,10 +217,22 @@ def _emit_react_children(
     messages = [{"role": "system", "content": system_content}]
     messages.extend(prior_messages or [])
     messages.append({"role": "user", "content": user_query})
-    # span_duration is only used inside the per-tool loop below; when `tools` is empty
-    # the loop is skipped and the lone final LLM span runs from `cursor` to `end_ns - 5_000`.
+    # Each span gets a jittered duration so per-span latency varies trace-to-trace.
+    # Pre-compute all per-span durations and rescale them to fit exactly into the
+    # `[start_ns + 5_000, end_ns - 5_000]` window — this guarantees spans stay
+    # contiguous and non-overlapping even when high jitter draws would otherwise
+    # push the cursor past the end. Seeded by start_ns for determinism.
     total_spans = 2 * len(tools) + 1
-    span_duration = max(1, (end_ns - start_ns - 10_000) // total_spans)
+    budget = max(total_spans, end_ns - start_ns - 10_000)
+    rng = random.Random(start_ns)
+    # Each span's raw weight is uniformly drawn from [0.2, 1.8], giving the longest
+    # span in a trace up to ~9x the duration of the shortest (1.8 / 0.2). The mean
+    # of 1.0 keeps the expected sum equal to `total_spans`, so after rescaling
+    # below each span occupies roughly its drawn fraction of the budget. Tweak this
+    # range to widen or narrow the visible latency spread in the timeline.
+    raw_durations = [rng.uniform(0.2, 1.8) for _ in range(total_spans)]
+    total_raw = sum(raw_durations)
+    span_durations = [max(1, int(d / total_raw * budget)) for d in raw_durations]
     cursor = start_ns + 5_000
 
     for idx, tool in enumerate(tools, start=1):
@@ -254,8 +266,8 @@ def _emit_react_children(
                 }
             ]
         })
-        llm.end(end_time_ns=cursor + span_duration)
-        cursor += span_duration
+        cursor += span_durations[2 * (idx - 1)]
+        llm.end(end_time_ns=cursor)
 
         messages.append({"role": "assistant", "content": None, "tool_calls": [tool_call]})
 
@@ -267,8 +279,8 @@ def _emit_react_children(
             start_time_ns=cursor,
         )
         tool_span.set_outputs(tool.output)
-        tool_span.end(end_time_ns=cursor + span_duration)
-        cursor += span_duration
+        cursor += span_durations[2 * (idx - 1) + 1]
+        tool_span.end(end_time_ns=cursor)
 
         messages.append({
             "role": "tool",

--- a/mlflow/demo/generators/traces.py
+++ b/mlflow/demo/generators/traces.py
@@ -150,7 +150,10 @@ def _json_type(value: Any) -> str:
 
 
 def _tool_schemas(tools: list[ToolCall]) -> list[dict[str, Any]]:
-    """Build OpenAI-style function schemas from a list of ToolCall objects."""
+    """
+    Build OpenAI-style function schemas from a list of ToolCall objects.
+    Referenced from: https://developers.openai.com/api/docs/guides/function-calling
+    """
     return [
         {
             "type": "function",

--- a/mlflow/demo/generators/traces.py
+++ b/mlflow/demo/generators/traces.py
@@ -144,7 +144,7 @@ class TracesDemoGenerator(BaseDemoGenerator):
     """
 
     name = DemoFeature.TRACES
-    version = 2
+    version = 3
 
     def generate(self) -> DemoResult:
         self._restore_experiment_if_deleted()
@@ -303,7 +303,7 @@ class TracesDemoGenerator(BaseDemoGenerator):
         root = mlflow.start_span_no_context(
             name="rag_pipeline",
             span_type=SpanType.CHAIN,
-            inputs={"query": trace_def.query},
+            inputs={"messages": [{"role": "user", "content": trace_def.query}]},
             metadata={DEMO_VERSION_TAG: version, DEMO_TRACE_TYPE_TAG: "rag"},
             start_time_ns=start_ns,
         )
@@ -357,10 +357,10 @@ class TracesDemoGenerator(BaseDemoGenerator):
             },
             start_time_ns=llm_start,
         )
-        llm.set_outputs({"response": response})
+        llm.set_outputs({"choices": [{"message": {"role": "assistant", "content": response}}]})
         llm.end(end_time_ns=llm_end)
 
-        root.set_outputs({"response": response})
+        root.set_outputs({"choices": [{"message": {"role": "assistant", "content": response}}]})
         root.end(end_time_ns=end_ns)
 
         return root.trace_id
@@ -383,7 +383,7 @@ class TracesDemoGenerator(BaseDemoGenerator):
         root = mlflow.start_span_no_context(
             name="agent",
             span_type=SpanType.AGENT,
-            inputs={"query": trace_def.query},
+            inputs={"messages": [{"role": "user", "content": trace_def.query}]},
             metadata={DEMO_VERSION_TAG: version, DEMO_TRACE_TYPE_TAG: "agent"},
             start_time_ns=start_ns,
         )
@@ -426,10 +426,10 @@ class TracesDemoGenerator(BaseDemoGenerator):
             },
             start_time_ns=llm_start,
         )
-        llm.set_outputs({"response": response})
+        llm.set_outputs({"choices": [{"message": {"role": "assistant", "content": response}}]})
         llm.end(end_time_ns=end_ns - 5000)
 
-        root.set_outputs({"response": response})
+        root.set_outputs({"choices": [{"message": {"role": "assistant", "content": response}}]})
         root.end(end_time_ns=end_ns)
 
         return root.trace_id
@@ -480,10 +480,7 @@ class TracesDemoGenerator(BaseDemoGenerator):
         root = mlflow.start_span_no_context(
             name="prompt_chain",
             span_type=SpanType.CHAIN,
-            inputs={
-                "query": trace_def.query,
-                "template_variables": variables,
-            },
+            inputs={"messages": [{"role": "user", "content": trace_def.query}]},
             metadata={DEMO_VERSION_TAG: version, DEMO_TRACE_TYPE_TAG: "prompt"},
             start_time_ns=start_ns,
         )
@@ -524,10 +521,10 @@ class TracesDemoGenerator(BaseDemoGenerator):
             },
             start_time_ns=llm_start,
         )
-        llm.set_outputs({"response": response})
+        llm.set_outputs({"choices": [{"message": {"role": "assistant", "content": response}}]})
         llm.end(end_time_ns=end_ns - 5000)
 
-        root.set_outputs({"response": response})
+        root.set_outputs({"choices": [{"message": {"role": "assistant", "content": response}}]})
         root.end(end_time_ns=end_ns)
 
         trace_id = root.trace_id
@@ -719,7 +716,7 @@ class TracesDemoGenerator(BaseDemoGenerator):
         root = mlflow.start_span_no_context(
             name="chat_agent",
             span_type=SpanType.AGENT,
-            inputs={"message": trace_def.query, "turn": turn},
+            inputs={"messages": [{"role": "user", "content": trace_def.query}]},
             metadata={
                 TraceMetadataKey.TRACE_SESSION: versioned_session_id,
                 TraceMetadataKey.TRACE_USER: trace_def.session_user or "user",
@@ -766,10 +763,10 @@ class TracesDemoGenerator(BaseDemoGenerator):
             },
             start_time_ns=llm_start,
         )
-        llm.set_outputs({"role": "assistant", "content": response})
+        llm.set_outputs({"choices": [{"message": {"role": "assistant", "content": response}}]})
         llm.end(end_time_ns=end_ns - 5000)
 
-        root.set_outputs({"response": response})
+        root.set_outputs({"choices": [{"message": {"role": "assistant", "content": response}}]})
         root.end(end_time_ns=end_ns)
 
         return root.trace_id

--- a/mlflow/demo/generators/traces.py
+++ b/mlflow/demo/generators/traces.py
@@ -36,6 +36,7 @@ _logger = logging.getLogger(__name__)
 
 DEMO_VERSION_TAG = "mlflow.demo.version"
 DEMO_TRACE_TYPE_TAG = "mlflow.demo.trace_type"
+DEMO_SESSION_TURN_TAG = "mlflow.demo.session.turn"
 DEMO_START_TIME_TAG = "mlflow.demo.start_time_ms"
 DEMO_END_TIME_TAG = "mlflow.demo.end_time_ms"
 
@@ -194,6 +195,7 @@ def _emit_react_children(
     response: str,
     start_ns: int,
     end_ns: int,
+    prior_messages: list[dict[str, Any]] | None = None,
 ) -> None:
     """Emit ReAct-style child spans under `root`.
 
@@ -201,14 +203,17 @@ def _emit_react_children(
     LLM(decide call_1) → TOOL(1) → LLM(decide call_2) → TOOL(2) → … → LLM(final).
 
     If there are no tools, emits a single LLM span.
+
+    `prior_messages` is the running conversation history from earlier turns in the
+    same session. It is inserted between the system prompt and the current user query
+    so the LLM sees the full context, the way a real stateful chat agent would.
     """
     span_name = _PROVIDER_TO_LLM_SPAN_NAME[model.provider]
     tool_schemas = _tool_schemas(tools)
     schemas_token_overhead = _estimate_tokens(json.dumps(tool_schemas))
-    messages = [
-        {"role": "system", "content": system_content},
-        {"role": "user", "content": user_query},
-    ]
+    messages = [{"role": "system", "content": system_content}]
+    messages.extend(prior_messages or [])
+    messages.append({"role": "user", "content": user_query})
     total_spans = 2 * len(tools) + 1
     span_duration = max(1, (end_ns - start_ns - 10_000) // total_spans)
     cursor = start_ns + 5_000
@@ -792,6 +797,7 @@ class TracesDemoGenerator(BaseDemoGenerator):
         trace_index = start_index
         min_start_ns = float("inf")
         max_end_ns = 0
+        prior_by_session: dict[str, list[dict[str, Any]]] = {}
 
         for trace_def in SESSION_TRACES:
             if trace_def.session_id != current_session:
@@ -804,10 +810,19 @@ class TracesDemoGenerator(BaseDemoGenerator):
             start_ns, end_ns = _get_trace_timestamps(trace_index, version)
             min_start_ns = min(min_start_ns, start_ns)
             max_end_ns = max(max_end_ns, end_ns)
+            prior = prior_by_session.setdefault(versioned_session_id, [])
             if trace_id := self._create_session_turn_trace(
-                trace_def, turn_counter, version, versioned_session_id, start_ns, end_ns
+                trace_def,
+                turn_counter,
+                version,
+                versioned_session_id,
+                start_ns,
+                end_ns,
+                prior_messages=prior,
             ):
                 trace_ids.append(trace_id)
+            prior.append({"role": "user", "content": trace_def.query})
+            prior.append({"role": "assistant", "content": self._get_response(trace_def, version)})
             trace_index += 1
 
         return _TraceSetResult(
@@ -824,6 +839,7 @@ class TracesDemoGenerator(BaseDemoGenerator):
         versioned_session_id: str,
         start_ns: int,
         end_ns: int,
+        prior_messages: list[dict[str, Any]] | None = None,
     ) -> str | None:
         """Create a single turn in a conversation session."""
         response = self._get_response(trace_def, version)
@@ -837,6 +853,7 @@ class TracesDemoGenerator(BaseDemoGenerator):
                 TraceMetadataKey.TRACE_USER: trace_def.session_user or "user",
                 DEMO_VERSION_TAG: version,
                 DEMO_TRACE_TYPE_TAG: "session",
+                DEMO_SESSION_TURN_TAG: str(turn),
             },
             start_time_ns=start_ns,
         )
@@ -850,6 +867,7 @@ class TracesDemoGenerator(BaseDemoGenerator):
             response=response,
             start_ns=start_ns,
             end_ns=end_ns,
+            prior_messages=prior_messages,
         )
 
         root.set_outputs({"choices": [{"message": {"role": "assistant", "content": response}}]})

--- a/tests/demo/test_demo_integration.py
+++ b/tests/demo/test_demo_integration.py
@@ -167,7 +167,6 @@ def test_traces_have_expected_span_types(client, traces_generator):
     assert "rag_pipeline" in all_span_names
     assert "embed_query" in all_span_names
     assert "retrieve_docs" in all_span_names
-    assert "generate_response" in all_span_names
     assert "agent" in all_span_names
     assert "chat_agent" in all_span_names
     assert "prompt_chain" in all_span_names
@@ -176,6 +175,9 @@ def test_traces_have_expected_span_types(client, traces_generator):
     assert "image_generation" in all_span_names
     assert "audio_transcription" in all_span_names
     assert "text_to_speech" in all_span_names
+    assert "chat.completions.create" in all_span_names  # OpenAI
+    assert "messages.create" in all_span_names  # Anthropic
+    assert "generate_content" in all_span_names  # Google
 
 
 def test_traces_session_metadata(client, traces_generator):

--- a/tests/demo/test_traces_generator.py
+++ b/tests/demo/test_traces_generator.py
@@ -4,12 +4,13 @@ from mlflow import MlflowClient, get_experiment_by_name, set_experiment
 from mlflow.demo.base import DEMO_EXPERIMENT_NAME, DemoFeature, DemoResult
 from mlflow.demo.generators.traces import (
     _PROVIDER_TO_LLM_SPAN_NAME,
+    DEMO_SESSION_TURN_TAG,
     DEMO_TRACE_TYPE_TAG,
     DEMO_VERSION_TAG,
     TracesDemoGenerator,
 )
 from mlflow.entities import SpanType
-from mlflow.tracing.constant import SpanAttributeKey
+from mlflow.tracing.constant import SpanAttributeKey, TraceMetadataKey
 
 
 @pytest.fixture
@@ -288,3 +289,39 @@ def test_span_name_matches_provider():
                 continue
             provider = span.attributes.get(SpanAttributeKey.MODEL_PROVIDER)
             assert span.name == _PROVIDER_TO_LLM_SPAN_NAME[provider]
+
+
+def test_session_turns_thread_prior_history():
+    generator = TracesDemoGenerator()
+    generator.generate()
+
+    experiment = get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+    client = MlflowClient()
+    traces = client.search_traces(locations=[experiment.experiment_id], max_results=100)
+
+    session_traces = [
+        t for t in traces if t.info.trace_metadata.get(DEMO_TRACE_TYPE_TAG) == "session"
+    ]
+    by_session: dict[str, list[str]] = {}
+    for trace in session_traces:
+        sid = trace.info.trace_metadata.get(TraceMetadataKey.TRACE_SESSION)
+        by_session.setdefault(sid, []).append(trace)
+
+    multi_turn_sessions = [ts for ts in by_session.values() if len(ts) > 1]
+    assert multi_turn_sessions, "expected at least one session with multiple turns"
+
+    for turns in multi_turn_sessions:
+        turns.sort(key=lambda t: int(t.info.trace_metadata[DEMO_SESSION_TURN_TAG]))
+        prior_queries: list[str] = []
+        for turn in turns:
+            root = next(s for s in turn.data.spans if s.parent_id is None)
+            first_llm = min(
+                (s for s in turn.data.spans if s.parent_id == root.span_id),
+                key=lambda s: s.start_time_ns,
+            )
+            user_messages = [m for m in first_llm.inputs["messages"] if m.get("role") == "user"]
+            assert [m["content"] for m in user_messages] == [
+                *prior_queries,
+                root.inputs["messages"][0]["content"],
+            ]
+            prior_queries.append(root.inputs["messages"][0]["content"])

--- a/tests/demo/test_traces_generator.py
+++ b/tests/demo/test_traces_generator.py
@@ -156,10 +156,18 @@ def test_is_generated_checks_version(traces_generator):
 
 
 def _is_chat_message(obj):
+    """
+    chat-utils/openai.ts has a normalizeOpenAIChatInput function
+    that asserts a chat-renderable message for inputs
+    """
     return isinstance(obj, dict) and "role" in obj and "content" in obj
 
 
 def _has_openai_choices_shape(outputs):
+    """
+    ModalTraceExplorer.utils.tsx has a fallback which tries to
+    normalise responses if they are OpenAI-shaped
+    """
     if not isinstance(outputs, dict):
         return False
     choices = outputs.get("choices")
@@ -241,34 +249,9 @@ def test_trace_with_tools_has_react_shape():
             continue
         assert len(children) == 2 * tool_count + 1
         ordered = sorted(children, key=lambda s: s.start_time_ns)
+        # Assert ordering now
         expected = [SpanType.LLM, SpanType.TOOL] * tool_count + [SpanType.LLM]
         assert [s.span_type for s in ordered] == expected
-
-
-def test_intermediate_llm_spans_emit_tool_calls():
-    generator = TracesDemoGenerator()
-    generator.generate()
-
-    experiment = get_experiment_by_name(DEMO_EXPERIMENT_NAME)
-    client = MlflowClient()
-    traces = client.search_traces(locations=[experiment.experiment_id], max_results=100)
-
-    for trace in traces:
-        root = next(s for s in trace.data.spans if s.parent_id is None)
-        children = sorted(
-            (s for s in trace.data.spans if s.parent_id == root.span_id),
-            key=lambda s: s.start_time_ns,
-        )
-        for i, span in enumerate(children):
-            if span.span_type != SpanType.LLM:
-                continue
-            later_tools = [s for s in children[i + 1 :] if s.span_type == SpanType.TOOL]
-            if not later_tools:
-                continue
-            choices = span.outputs.get("choices", [])
-            tool_calls = choices[0].get("message", {}).get("tool_calls") if choices else None
-            assert isinstance(tool_calls, list)
-            assert tool_calls
 
 
 def test_final_llm_span_emits_content():

--- a/tests/demo/test_traces_generator.py
+++ b/tests/demo/test_traces_generator.py
@@ -7,6 +7,7 @@ from mlflow.demo.generators.traces import (
     DEMO_VERSION_TAG,
     TracesDemoGenerator,
 )
+from mlflow.entities import SpanType
 
 
 @pytest.fixture
@@ -20,7 +21,7 @@ def traces_generator():
 def test_generator_attributes():
     generator = TracesDemoGenerator()
     assert generator.name == DemoFeature.TRACES
-    assert generator.version == 2
+    assert generator.version == 3
 
 
 def test_data_exists_false_when_no_experiment():
@@ -148,3 +149,73 @@ def test_is_generated_checks_version(traces_generator):
 
     TracesDemoGenerator.version = 99
     assert traces_generator.is_generated() is False
+
+
+def _is_chat_message(obj):
+    return isinstance(obj, dict) and "role" in obj and "content" in obj
+
+
+def _has_openai_choices_shape(outputs):
+    if not isinstance(outputs, dict):
+        return False
+    choices = outputs.get("choices")
+    if not isinstance(choices, list) or not choices:
+        return False
+    return all(_is_chat_message(c.get("message")) for c in choices)
+
+
+def test_root_span_inputs_are_chat_renderable():
+    generator = TracesDemoGenerator()
+    generator.generate()
+
+    experiment = get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+    client = MlflowClient()
+    traces = client.search_traces(locations=[experiment.experiment_id], max_results=100)
+
+    for trace in traces:
+        root = next(s for s in trace.data.spans if s.parent_id is None)
+        inputs = root.inputs
+        assert isinstance(inputs, dict), f"Root span {root.name} inputs is not a dict"
+        messages = inputs.get("messages")
+        assert isinstance(messages, list), f"Root span {root.name} inputs missing 'messages' list"
+        assert messages, f"Root span {root.name} inputs has empty 'messages' list"
+        assert all(_is_chat_message(m) for m in messages), (
+            f"Root span {root.name} has malformed message in inputs"
+        )
+
+
+def test_llm_span_outputs_are_chat_renderable():
+    generator = TracesDemoGenerator()
+    generator.generate()
+
+    experiment = get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+    client = MlflowClient()
+    traces = client.search_traces(locations=[experiment.experiment_id], max_results=100)
+
+    for trace in traces:
+        for span in trace.data.spans:
+            if span.span_type != SpanType.LLM:
+                continue
+            assert _has_openai_choices_shape(span.outputs), (
+                f"LLM span {span.name} in trace {trace.info.trace_id} "
+                f"does not have OpenAI choices output shape"
+            )
+
+
+def test_root_span_outputs_are_chat_renderable():
+    generator = TracesDemoGenerator()
+    generator.generate()
+
+    experiment = get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+    client = MlflowClient()
+    traces = client.search_traces(locations=[experiment.experiment_id], max_results=100)
+
+    for trace in traces:
+        # Multimodal traces use the OpenAI Images / Audio API response shapes,
+        # not ChatCompletions; both render in the UI but via different normalizers.
+        if trace.info.trace_metadata.get(DEMO_TRACE_TYPE_TAG) == "multimodal":
+            continue
+        root = next(s for s in trace.data.spans if s.parent_id is None)
+        assert _has_openai_choices_shape(root.outputs), (
+            f"Root span {root.name} does not have OpenAI choices output shape"
+        )

--- a/tests/demo/test_traces_generator.py
+++ b/tests/demo/test_traces_generator.py
@@ -1,6 +1,7 @@
 import pytest
 
-from mlflow import MlflowClient, get_experiment_by_name, set_experiment
+import mlflow
+from mlflow import get_experiment_by_name, set_experiment
 from mlflow.demo.base import DEMO_EXPERIMENT_NAME, DemoFeature, DemoResult
 from mlflow.demo.generators.traces import (
     _PROVIDER_TO_LLM_SPAN_NAME,
@@ -19,6 +20,33 @@ def traces_generator():
     original_version = generator.version
     yield generator
     TracesDemoGenerator.version = original_version
+
+
+@pytest.fixture(scope="module")
+def generated_traces(tmp_path_factory):
+    """Generate the demo once per module and return the materialized list of traces.
+
+    Used by read-only structural tests so we don't re-generate the full demo per test.
+    The fixture controls its own tracking URI (the autouse function-scoped
+    tracking_uri_mock in the parent conftest doesn't apply at module setup time),
+    and the returned traces are in-memory Python objects so consuming tests don't
+    need the URI still set when they run. `flush=True` ensures the async trace
+    export queue is drained before we read.
+    """
+    db_path = tmp_path_factory.mktemp("demo_shared") / "mlflow.db"
+    previous_uri = mlflow.get_tracking_uri()
+    mlflow.set_tracking_uri(f"sqlite:///{db_path}")
+    try:
+        TracesDemoGenerator().generate()
+        experiment = get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+        return mlflow.search_traces(
+            locations=[experiment.experiment_id],
+            max_results=100,
+            return_type="list",
+            flush=True,
+        )
+    finally:
+        mlflow.set_tracking_uri(previous_uri)
 
 
 def test_generator_attributes():
@@ -76,18 +104,11 @@ def test_delete_demo_removes_traces():
     assert generator._data_exists() is False
 
 
-def test_traces_have_expected_structure():
-    generator = TracesDemoGenerator()
-    generator.generate()
-
-    experiment = get_experiment_by_name(DEMO_EXPERIMENT_NAME)
-    client = MlflowClient()
-    traces = client.search_traces(locations=[experiment.experiment_id], max_results=100)
-
-    assert len(traces) > 0
+def test_traces_have_expected_structure(generated_traces):
+    assert len(generated_traces) > 0
 
     all_span_names = set()
-    for trace in traces:
+    for trace in generated_traces:
         all_span_names.update(span.name for span in trace.data.spans)
 
     assert "rag_pipeline" in all_span_names
@@ -102,38 +123,28 @@ def test_traces_have_expected_structure():
     assert "generate_content" in all_span_names  # Google
 
 
-def test_traces_have_version_metadata():
-    generator = TracesDemoGenerator()
-    generator.generate()
-
-    experiment = get_experiment_by_name(DEMO_EXPERIMENT_NAME)
-    client = MlflowClient()
-    traces = client.search_traces(locations=[experiment.experiment_id], max_results=100)
-
-    v1_traces = [t for t in traces if t.info.trace_metadata.get(DEMO_VERSION_TAG) == "v1"]
-    v2_traces = [t for t in traces if t.info.trace_metadata.get(DEMO_VERSION_TAG) == "v2"]
+def test_traces_have_version_metadata(generated_traces):
+    v1_traces = [t for t in generated_traces if t.info.trace_metadata.get(DEMO_VERSION_TAG) == "v1"]
+    v2_traces = [t for t in generated_traces if t.info.trace_metadata.get(DEMO_VERSION_TAG) == "v2"]
 
     # 2 RAG + 2 agent + 6 prompt + 4 multimodal + 7 session = 21 per version
     assert len(v1_traces) == 21
     assert len(v2_traces) == 21
-    assert len(traces) == 42
+    assert len(generated_traces) == 42
 
 
-def test_traces_have_type_metadata():
-    generator = TracesDemoGenerator()
-    generator.generate()
-
-    experiment = get_experiment_by_name(DEMO_EXPERIMENT_NAME)
-    client = MlflowClient()
-    traces = client.search_traces(locations=[experiment.experiment_id], max_results=50)
-
-    rag_traces = [t for t in traces if t.info.trace_metadata.get(DEMO_TRACE_TYPE_TAG) == "rag"]
-    agent_traces = [t for t in traces if t.info.trace_metadata.get(DEMO_TRACE_TYPE_TAG) == "agent"]
+def test_traces_have_type_metadata(generated_traces):
+    rag_traces = [
+        t for t in generated_traces if t.info.trace_metadata.get(DEMO_TRACE_TYPE_TAG) == "rag"
+    ]
+    agent_traces = [
+        t for t in generated_traces if t.info.trace_metadata.get(DEMO_TRACE_TYPE_TAG) == "agent"
+    ]
     prompt_traces = [
-        t for t in traces if t.info.trace_metadata.get(DEMO_TRACE_TYPE_TAG) == "prompt"
+        t for t in generated_traces if t.info.trace_metadata.get(DEMO_TRACE_TYPE_TAG) == "prompt"
     ]
     session_traces = [
-        t for t in traces if t.info.trace_metadata.get(DEMO_TRACE_TYPE_TAG) == "session"
+        t for t in generated_traces if t.info.trace_metadata.get(DEMO_TRACE_TYPE_TAG) == "session"
     ]
 
     # 2 RAG per version = 4 total
@@ -177,15 +188,8 @@ def _has_openai_choices_shape(outputs):
     return all(_is_chat_message(c.get("message")) for c in choices)
 
 
-def test_root_span_inputs_are_chat_renderable():
-    generator = TracesDemoGenerator()
-    generator.generate()
-
-    experiment = get_experiment_by_name(DEMO_EXPERIMENT_NAME)
-    client = MlflowClient()
-    traces = client.search_traces(locations=[experiment.experiment_id], max_results=100)
-
-    for trace in traces:
+def test_root_span_inputs_are_chat_renderable(generated_traces):
+    for trace in generated_traces:
         root = next(s for s in trace.data.spans if s.parent_id is None)
         inputs = root.inputs
         assert isinstance(inputs, dict), f"Root span {root.name} inputs is not a dict"
@@ -197,15 +201,8 @@ def test_root_span_inputs_are_chat_renderable():
         )
 
 
-def test_llm_span_outputs_are_chat_renderable():
-    generator = TracesDemoGenerator()
-    generator.generate()
-
-    experiment = get_experiment_by_name(DEMO_EXPERIMENT_NAME)
-    client = MlflowClient()
-    traces = client.search_traces(locations=[experiment.experiment_id], max_results=100)
-
-    for trace in traces:
+def test_llm_span_outputs_are_chat_renderable(generated_traces):
+    for trace in generated_traces:
         for span in trace.data.spans:
             if span.span_type != SpanType.LLM:
                 continue
@@ -215,15 +212,8 @@ def test_llm_span_outputs_are_chat_renderable():
             )
 
 
-def test_root_span_outputs_are_chat_renderable():
-    generator = TracesDemoGenerator()
-    generator.generate()
-
-    experiment = get_experiment_by_name(DEMO_EXPERIMENT_NAME)
-    client = MlflowClient()
-    traces = client.search_traces(locations=[experiment.experiment_id], max_results=100)
-
-    for trace in traces:
+def test_root_span_outputs_are_chat_renderable(generated_traces):
+    for trace in generated_traces:
         # Multimodal traces use the OpenAI Images / Audio API response shapes,
         # not ChatCompletions; both render in the UI but via different normalizers.
         if trace.info.trace_metadata.get(DEMO_TRACE_TYPE_TAG) == "multimodal":
@@ -234,15 +224,8 @@ def test_root_span_outputs_are_chat_renderable():
         )
 
 
-def test_trace_with_tools_has_react_shape():
-    generator = TracesDemoGenerator()
-    generator.generate()
-
-    experiment = get_experiment_by_name(DEMO_EXPERIMENT_NAME)
-    client = MlflowClient()
-    traces = client.search_traces(locations=[experiment.experiment_id], max_results=100)
-
-    for trace in traces:
+def test_trace_with_tools_has_react_shape(generated_traces):
+    for trace in generated_traces:
         root = next(s for s in trace.data.spans if s.parent_id is None)
         children = [s for s in trace.data.spans if s.parent_id == root.span_id]
         tool_count = sum(1 for s in children if s.span_type == SpanType.TOOL)
@@ -255,15 +238,8 @@ def test_trace_with_tools_has_react_shape():
         assert [s.span_type for s in ordered] == expected
 
 
-def test_final_llm_span_emits_content():
-    generator = TracesDemoGenerator()
-    generator.generate()
-
-    experiment = get_experiment_by_name(DEMO_EXPERIMENT_NAME)
-    client = MlflowClient()
-    traces = client.search_traces(locations=[experiment.experiment_id], max_results=100)
-
-    for trace in traces:
+def test_final_llm_span_emits_content(generated_traces):
+    for trace in generated_traces:
         llm_spans = [s for s in trace.data.spans if s.span_type == SpanType.LLM]
         if not llm_spans:
             continue
@@ -274,35 +250,21 @@ def test_final_llm_span_emits_content():
         assert content
 
 
-def test_span_name_matches_provider():
-    generator = TracesDemoGenerator()
-    generator.generate()
-
-    experiment = get_experiment_by_name(DEMO_EXPERIMENT_NAME)
-    client = MlflowClient()
-    traces = client.search_traces(locations=[experiment.experiment_id], max_results=100)
-
-    for trace in traces:
+def test_span_name_matches_provider(generated_traces):
+    for trace in generated_traces:
         for span in trace.data.spans:
-            # Multimodal traces are of SpanType.CHAT_MODEL and so will be caught here
+            # Multimodal traces use SpanType.CHAT_MODEL and are skipped by the LLM check below.
             if span.span_type != SpanType.LLM:
                 continue
             provider = span.attributes.get(SpanAttributeKey.MODEL_PROVIDER)
             assert span.name == _PROVIDER_TO_LLM_SPAN_NAME[provider]
 
 
-def test_session_turns_thread_prior_history():
-    generator = TracesDemoGenerator()
-    generator.generate()
-
-    experiment = get_experiment_by_name(DEMO_EXPERIMENT_NAME)
-    client = MlflowClient()
-    traces = client.search_traces(locations=[experiment.experiment_id], max_results=100)
-
+def test_session_turns_thread_prior_history(generated_traces):
     session_traces = [
-        t for t in traces if t.info.trace_metadata.get(DEMO_TRACE_TYPE_TAG) == "session"
+        t for t in generated_traces if t.info.trace_metadata.get(DEMO_TRACE_TYPE_TAG) == "session"
     ]
-    by_session: dict[str, list[str]] = {}
+    by_session: dict[str, list[object]] = {}
     for trace in session_traces:
         sid = trace.info.trace_metadata.get(TraceMetadataKey.TRACE_SESSION)
         by_session.setdefault(sid, []).append(trace)

--- a/tests/demo/test_traces_generator.py
+++ b/tests/demo/test_traces_generator.py
@@ -3,11 +3,13 @@ import pytest
 from mlflow import MlflowClient, get_experiment_by_name, set_experiment
 from mlflow.demo.base import DEMO_EXPERIMENT_NAME, DemoFeature, DemoResult
 from mlflow.demo.generators.traces import (
+    _PROVIDER_TO_LLM_SPAN_NAME,
     DEMO_TRACE_TYPE_TAG,
     DEMO_VERSION_TAG,
     TracesDemoGenerator,
 )
 from mlflow.entities import SpanType
+from mlflow.tracing.constant import SpanAttributeKey
 
 
 @pytest.fixture
@@ -94,7 +96,9 @@ def test_traces_have_expected_structure():
     assert "render_prompt" in all_span_names
     assert "embed_query" in all_span_names
     assert "retrieve_docs" in all_span_names
-    assert "generate_response" in all_span_names
+    assert "chat.completions.create" in all_span_names  # OpenAI
+    assert "messages.create" in all_span_names  # Anthropic
+    assert "generate_content" in all_span_names  # Google
 
 
 def test_traces_have_version_metadata():
@@ -219,3 +223,85 @@ def test_root_span_outputs_are_chat_renderable():
         assert _has_openai_choices_shape(root.outputs), (
             f"Root span {root.name} does not have OpenAI choices output shape"
         )
+
+
+def test_trace_with_tools_has_react_shape():
+    generator = TracesDemoGenerator()
+    generator.generate()
+
+    experiment = get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+    client = MlflowClient()
+    traces = client.search_traces(locations=[experiment.experiment_id], max_results=100)
+
+    for trace in traces:
+        root = next(s for s in trace.data.spans if s.parent_id is None)
+        children = [s for s in trace.data.spans if s.parent_id == root.span_id]
+        tool_count = sum(1 for s in children if s.span_type == SpanType.TOOL)
+        if tool_count == 0:
+            continue
+        assert len(children) == 2 * tool_count + 1
+        ordered = sorted(children, key=lambda s: s.start_time_ns)
+        expected = [SpanType.LLM, SpanType.TOOL] * tool_count + [SpanType.LLM]
+        assert [s.span_type for s in ordered] == expected
+
+
+def test_intermediate_llm_spans_emit_tool_calls():
+    generator = TracesDemoGenerator()
+    generator.generate()
+
+    experiment = get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+    client = MlflowClient()
+    traces = client.search_traces(locations=[experiment.experiment_id], max_results=100)
+
+    for trace in traces:
+        root = next(s for s in trace.data.spans if s.parent_id is None)
+        children = sorted(
+            (s for s in trace.data.spans if s.parent_id == root.span_id),
+            key=lambda s: s.start_time_ns,
+        )
+        for i, span in enumerate(children):
+            if span.span_type != SpanType.LLM:
+                continue
+            later_tools = [s for s in children[i + 1 :] if s.span_type == SpanType.TOOL]
+            if not later_tools:
+                continue
+            choices = span.outputs.get("choices", [])
+            tool_calls = choices[0].get("message", {}).get("tool_calls") if choices else None
+            assert isinstance(tool_calls, list)
+            assert tool_calls
+
+
+def test_final_llm_span_emits_content():
+    generator = TracesDemoGenerator()
+    generator.generate()
+
+    experiment = get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+    client = MlflowClient()
+    traces = client.search_traces(locations=[experiment.experiment_id], max_results=100)
+
+    for trace in traces:
+        llm_spans = [s for s in trace.data.spans if s.span_type == SpanType.LLM]
+        if not llm_spans:
+            continue
+        last_llm = max(llm_spans, key=lambda s: s.start_time_ns)
+        choices = last_llm.outputs.get("choices", [])
+        content = choices[0].get("message", {}).get("content") if choices else None
+        assert isinstance(content, str)
+        assert content
+
+
+def test_span_name_matches_provider():
+    generator = TracesDemoGenerator()
+    generator.generate()
+
+    experiment = get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+    client = MlflowClient()
+    traces = client.search_traces(locations=[experiment.experiment_id], max_results=100)
+
+    for trace in traces:
+        for span in trace.data.spans:
+            # Multimodal traces are of SpanType.CHAT_MODEL and so will be caught here
+            if span.span_type != SpanType.LLM:
+                continue
+            provider = span.attributes.get(SpanAttributeKey.MODEL_PROVIDER)
+            assert span.name == _PROVIDER_TO_LLM_SPAN_NAME[provider]

--- a/tests/demo/test_traces_generator.py
+++ b/tests/demo/test_traces_generator.py
@@ -12,6 +12,7 @@ from mlflow.demo.generators.traces import (
 )
 from mlflow.entities import SpanType
 from mlflow.tracing.constant import SpanAttributeKey, TraceMetadataKey
+from mlflow.tracking._tracking_service.utils import _use_tracking_uri
 
 
 @pytest.fixture
@@ -32,11 +33,15 @@ def generated_traces(tmp_path_factory):
     and the returned traces are in-memory Python objects so consuming tests don't
     need the URI still set when they run. `flush=True` ensures the async trace
     export queue is drained before we read.
+
+    Uses `_use_tracking_uri` (not get/set around `get_tracking_uri()`) so that the
+    pre-fixture state — typically `_tracking_uri = None` falling back to the default
+    — is restored exactly. Calling `set_tracking_uri(get_tracking_uri())` would
+    materialise the default's absolute path and leave it stuck in `_tracking_uri`,
+    poisoning later tests that opt out of the autouse fixture.
     """
     db_path = tmp_path_factory.mktemp("demo_shared") / "mlflow.db"
-    previous_uri = mlflow.get_tracking_uri()
-    mlflow.set_tracking_uri(f"sqlite:///{db_path}")
-    try:
+    with _use_tracking_uri(f"sqlite:///{db_path}"):
         TracesDemoGenerator().generate()
         experiment = get_experiment_by_name(DEMO_EXPERIMENT_NAME)
         return mlflow.search_traces(
@@ -45,8 +50,6 @@ def generated_traces(tmp_path_factory):
             return_type="list",
             flush=True,
         )
-    finally:
-        mlflow.set_tracking_uri(previous_uri)
 
 
 def test_generator_attributes():


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Not applicable

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

**This PR can be reviewed commit by commit**

  **Problem 1 — Chat tab couldn't render demo traces**

  Demo trace inputs/outputs used ad-hoc shapes (`{"query": "..."}`, `{"response": "..."}`) that the UI's Chat tab didn't recognize, so the Chat pane didn't render. All relevant spans now use OpenAI ChatCompletions (I had no particular reason for picking this other than because OpenAI will be a common use case) shapes as a matter of convention:
  - Root span inputs: `{"messages": [{"role": "user", "content": "..."}]}`
  - LLM and root span outputs: `{"choices": [{"message": {"role": "assistant", "content": "..."}}]}`

  After this change, the Chat tab renders cleanly across RAG, Prompt, Agent, and Session traces. Also had to make some changes to the input formats since Chat requires both input and output to be chat pane compatible before rendering (`ModelTraceExplorer.utils.tsx:433-436`). 

  **Problem 2 — Trace structure was flat**

  Agent and session traces previously had a flat structure (one parent span → single LLM child) regardless of how many tools were configured. 

We now show a more complex trace by adding a contrived ReAct Loop to try and show tool call and some form of reasoning and intelligence.

  LLM(decide call_1) → TOOL(1) → LLM(decide call_2) → TOOL(2) → … → LLM(final response)

 I only added it for Agent and Session Traces. Prompt and RAG remain the same. 

 Intermediate LLM spans emit `tool_calls` in OpenAI format with `finish_reason: "tool_calls"`; the final LLM emits the user-facing response. The accumulated message history is threaded through each LLM call.

  LLM spans now use provider specific names to try and mimic the functions we call when interacting with their SDK: `chat.completions.create` (OpenAI), `messages.create` (Anthropic), `generate_content` (Google).

 V1 and V2 responses share the same tools, however, V2 responses are intentionally better to keep with current flow

  `TracesDemoGenerator.version` is bumped from 2 → 3 so existing v2 demo data is auto-wiped and regenerated on a user's next demo visit.


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests


<!-- Attach code, screenshot, video used for manual testing here. -->

* Added new unit tests in `tests/demo/test_traces_generator.py`. LLM generated but human reviewed.
* Manually tested chat rendering for one of Agent, Prompt, Session, and RAG trace to ensure that non-Tool Call spans render correctly in Chat



**On Production**

<img width="1029" height="975" alt="Screenshot 2026-05-28 at 12 51 52 PM" src="https://github.com/user-attachments/assets/e0c0e593-f0cd-4bee-be6b-eef4eef68daa" />

**On Local, we have access to the chat pane and we have more tool calls here and something that mimics a ReACT loop**

<img width="972" height="931" alt="Screenshot 2026-05-28 at 12 52 39 PM" src="https://github.com/user-attachments/assets/6575f6dc-ff51-4198-a7db-deaf772f6d31" />


https://github.com/user-attachments/assets/1a3c4acf-62da-4e3d-8ff3-e769ca84767c


**Messages are accumulated over multi turn sessions**

Note that the root span of the turn doesn't contain the sessions to keep UI easy to understand, but the child spans do contain the accumulated list of messages

https://github.com/user-attachments/assets/591ec6a2-b75e-4c11-b488-467a20560262




### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

Demo experiment traces now have a more realistic ReAct structure with tool calls and OpenAI ChatCompletions format, so the Chat tab renders correctly and new users see traces are more representative of actual production workloads

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
