### PR TITLE
Align yarn package cooldown to 7d and document policy in `CLAUDE.md`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,15 @@ If PyPI is unreachable, add `--frozen` to `uv run` commands that should use the 
 uv run --frozen pytest tests/
 ```
 
+### Package Cooldown Period
+
+7-day cooldown on new package releases. Keep these in sync:
+
+- Python: `exclude-newer = "P7D"` in `pyproject.toml` (`torch`/`torchvision` opted out).
+- JavaScript: `min-release-age=7` in `docs/.npmrc` and `libs/typescript/.npmrc`; `npmMinimalAgeGate: 7d` in `mlflow/server/js/.yarnrc.yml`.
+
+Pass `--min-release-age=7` to any new `npx` invocations.
+
 ### Testing
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ uv run --frozen pytest tests/
 7-day cooldown on new package releases. Keep these in sync:
 
 - Python: `exclude-newer = "P7D"` in `pyproject.toml` (`torch`/`torchvision` opted out).
-- JavaScript: `min-release-age=7` in `docs/.npmrc` and `libs/typescript/.npmrc`; `npmMinimalAgeGate: 7d` in `mlflow/server/js/.yarnrc.yml`.
+- JavaScript: `min-release-age=7` in `.npmrc`; `npmMinimalAgeGate: 7d` in `.yarnrc.yml`.
 
 Pass `--min-release-age=7` to any new `npx` invocations.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,8 @@ uv run --frozen pytest tests/
 
 ### Package Cooldown Period
 
-7-day cooldown on new package releases. Keep these in sync:
+7-day cooldown on new package releases to guard against compromised or broken
+versions that get pulled and yanked within a few days. Keep these in sync:
 
 - Python: `exclude-newer = "P7D"` in `pyproject.toml` (`torch`/`torchvision` opted out).
 - JavaScript: `min-release-age=7` in `.npmrc`; `npmMinimalAgeGate: 7d` in `.yarnrc.yml`.

--- a/mlflow/server/js/.yarnrc.yml
+++ b/mlflow/server/js/.yarnrc.yml
@@ -1,5 +1,5 @@
 nodeLinker: node-modules
 
-npmMinimalAgeGate: 14d
+npmMinimalAgeGate: 7d
 
 yarnPath: yarn/releases/yarn-4.12.0.cjs


### PR DESCRIPTION
### Related Issues/PRs

Relates to #

### What changes are proposed in this pull request?

- Lower `npmMinimalAgeGate` in `mlflow/server/js/.yarnrc.yml` from `14d` to `7d` so it matches `min-release-age=7` in `docs/.npmrc` and `libs/typescript/.npmrc`, and the Python `exclude-newer = "P7D"` in `pyproject.toml`.
- Add a "Package Cooldown Period" section to `CLAUDE.md` listing the three configuration points so future edits keep them in sync.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Config-only / docs-only change; no test coverage applicable.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release