### PR TITLE
docs: fix admonition rendering broken by Docusaurus 3.10

### DIFF
--- a/docs/docs/classic-ml/dataset/index.mdx
+++ b/docs/docs/classic-ml/dataset/index.mdx
@@ -239,7 +239,7 @@ Dataset schema: {"mlflow_colspec": [
 Dataset source: <DatasetSource object>
 ```
 
-:::note Dataset Properties
+:::note[Dataset Properties]
 The `profile` and `schema` properties are implementation-specific and may vary depending on the dataset type (PandasDataset, SparkDataset, etc.). Some dataset types may return `None` for these properties.
 :::
 
@@ -325,7 +325,7 @@ The UI displays:
 
 One of the most powerful features of MLflow datasets is their seamless integration with MLflow's evaluation capabilities. MLflow automatically converts various data types to `EvaluationDataset` objects internally when using `mlflow.models.evaluate()`.
 
-:::info EvaluationDataset
+:::info[EvaluationDataset]
 MLflow uses an internal `EvaluationDataset` class when working with `mlflow.models.evaluate()`. This dataset type is automatically created from your input data and provides optimized hashing and metadata tracking specifically for evaluation workflows.
 :::
 

--- a/docs/docs/classic-ml/deep-learning/pytorch/index.mdx
+++ b/docs/docs/classic-ml/deep-learning/pytorch/index.mdx
@@ -84,7 +84,7 @@ for epoch in range(10):
 
 Autologging captures training metrics, model parameters, optimizer configuration, and model checkpoints automatically.
 
-:::note PyTorch Lightning Support
+:::note[PyTorch Lightning Support]
 MLflow's autologging works seamlessly with PyTorch Lightning. For vanilla PyTorch with custom training loops, use manual logging as shown in the section below.
 :::
 
@@ -215,7 +215,7 @@ For PyTorch training, monitoring GPU metrics is especially valuable for:
 - Optimizing batch sizes based on GPU memory usage
 - Comparing resource efficiency across different model architectures
 
-:::tip Advanced Configuration
+:::tip[Advanced Configuration]
 
 You can customize system metrics collection frequency and behavior. See the **[System Metrics documentation](/ml/tracking/system-metrics)** for detailed configuration options.
 

--- a/docs/docs/classic-ml/deep-learning/transformers/guide/index.mdx
+++ b/docs/docs/classic-ml/deep-learning/transformers/guide/index.mdx
@@ -39,7 +39,7 @@ In the current version, audio and text-based large language
 models are supported for use with `pyfunc`, while computer vision, multi-modal, timeseries,
 reinforcement learning, and graph models are only supported for native type loading via <APILink fn="mlflow.transformers.load_model" />
 
-:::warning attention
+:::warning[attention]
 Not all `transformers` pipeline types are supported. See the table below for the list of currently supported Pipeline
 types that can be loaded as `pyfunc`.
 
@@ -49,7 +49,7 @@ Future releases of MLflow will introduce `pyfunc` support for these additional t
 The table below shows the mapping of `transformers` pipeline types to the [python_function (pyfunc) model flavor](/ml/model#pyfunc-model-flavor)
 data type inputs and outputs.
 
-:::warning important
+:::warning[important]
 The inputs and outputs of the `pyfunc` implementation of these pipelines _are not guaranteed to match_ the input types and output types that would
 return from a native use of a given pipeline type. If your use case requires access to scores, top_k results, or other additional references within
 the output from a pipeline inference call, please use the native implementation by loading via <APILink fn="mlflow.transformers.load_model" /> to
@@ -363,7 +363,7 @@ After logging, the components are automatically inserted into the appropriate `P
 The components that are logged can be retrieved in their original structure (a dictionary) by setting the attribute `return_type` to "components" in the `load_model()` API.
 :::
 
-:::warning attention
+:::warning[attention]
 Not all model types are compatible with the pipeline API constructor via component elements. Incompatible models will raise an
 `MLflowException` error stating that the model is missing the _name_or_path_ attribute. In
 the event that this occurs, please construct the model directly via the `transformers.pipeline(<repo name>)` API and save the pipeline object directly.

--- a/docs/docs/classic-ml/deep-learning/transformers/task/index.mdx
+++ b/docs/docs/classic-ml/deep-learning/transformers/task/index.mdx
@@ -214,7 +214,7 @@ with mlflow.start_run():
     )
 ```
 
-:::warning attention
+:::warning[attention]
 The `stop` parameter can be used to specify the stop sequence for the `llm/v1/chat` and `llm/v1/completions` tasks.
 We emulate the behavior of the `stop` parameter in the OpenAI APIs by passing the
 [stopping_criteria](https://huggingface.co/docs/transformers/main_classes/text_generation#transformers.GenerationMixin.generate.stopping_criteria)

--- a/docs/docs/classic-ml/evaluation/index.mdx
+++ b/docs/docs/classic-ml/evaluation/index.mdx
@@ -11,7 +11,7 @@ import TabItem from "@theme/TabItem";
 
 # Model Evaluation
 
-:::warning Classic ML Evaluation System
+:::warning[Classic ML Evaluation System]
 
 This documentation covers MLflow's **classic evaluation system** (`mlflow.models.evaluate`) which uses `EvaluationMetric` and `make_metric` for custom metrics.
 
@@ -355,7 +355,7 @@ Define custom evaluation metrics and create specialized visualizations.
 
 ### Custom Metrics
 
-:::note Classic System Only
+:::note[Classic System Only]
 
 The `make_metric` function is part of MLflow's classic evaluation system.
 

--- a/docs/docs/classic-ml/getting-started/deep-learning.mdx
+++ b/docs/docs/classic-ml/getting-started/deep-learning.mdx
@@ -10,7 +10,7 @@ import ImageBox from "@site/src/components/ImageBox";
 
 # Deep Learning Quickstart
 
-:::tip MLflow Assistant
+:::tip[MLflow Assistant]
 Need help setting up tracking? Try <ins>[MLflow Assistant](/genai/getting-started/try-assistant)</ins> - a powerful AI assistant that can help you set up MLflow tracking for your project.
 :::
 

--- a/docs/docs/classic-ml/getting-started/hyperparameter-tuning/index.mdx
+++ b/docs/docs/classic-ml/getting-started/hyperparameter-tuning/index.mdx
@@ -10,7 +10,7 @@ import ImageBox from "@site/src/components/ImageBox";
 
 # Tracking Hyperparameter Tuning with MLflow
 
-:::tip MLflow Assistant
+:::tip[MLflow Assistant]
 Need help setting up tracking? Try <ins>[MLflow Assistant](/genai/getting-started/try-assistant)</ins> - a powerful AI assistant that can help you set up MLflow tracking for your project.
 :::
 
@@ -35,7 +35,7 @@ pip install mlflow optuna
 
 Then, follow the instructions in the [Set Up MLflow](/ml/getting-started/running-notebooks) guide to set up MLflow.
 
-:::tip Team Collaboration and Managed Setup
+:::tip[Team Collaboration and Managed Setup]
 For production environments or team collaboration, consider hosting a shared <ins>[MLflow Tracking Server](/self-hosting)</ins>. For a fully-managed solution, get started with Databricks Free Trial by visiting the <ins>[Databricks Trial Signup Page](https://signup.databricks.com/?destination_url=/ml/experiments-signup?source=OSS_DOCS&dbx_source=TRY_MLFLOW&signup_experience_step=EXPRESS&provider=MLFLOW&utm_source=OSS_DOCS)</ins> and follow the instructions outlined there.
 :::
 

--- a/docs/docs/classic-ml/getting-started/quickstart.mdx
+++ b/docs/docs/classic-ml/getting-started/quickstart.mdx
@@ -13,7 +13,7 @@ Looking for using MLflow for LLMs/Agent development? Checkout the <ins>[MLflow f
 
 :::
 
-:::tip MLflow Assistant
+:::tip[MLflow Assistant]
 Need help setting up tracking? Try <ins>[MLflow Assistant](/genai/getting-started/try-assistant)</ins> - a powerful AI assistant that can help you set up MLflow tracking for your project.
 :::
 

--- a/docs/docs/classic-ml/getting-started/running-notebooks/index.mdx
+++ b/docs/docs/classic-ml/getting-started/running-notebooks/index.mdx
@@ -10,7 +10,7 @@ import TabsWrapper from "@site/src/components/TabsWrapper";
 
 # Connect Your Development Environment to MLflow
 
-:::tip MLflow Assistant
+:::tip[MLflow Assistant]
 Need help setting up MLflow? Try <ins>[MLflow Assistant](/genai/getting-started/try-assistant)</ins> - a powerful AI assistant that can help you set up MLflow for your project.
 :::
 

--- a/docs/docs/classic-ml/model-registry/workflow.mdx
+++ b/docs/docs/classic-ml/model-registry/workflow.mdx
@@ -486,7 +486,7 @@ client.rename_registered_model(
 
 ### Listing and Searching MLflow Models
 
-:::warning important
+:::warning[important]
 
      When using MLflow ≥ 2.21.0 clients with older Model Registry servers (< 2.21.0), search API behavior may differ from expected results. This version mismatch can cause inconsistent search outcomes or missing results. To ensure consistent behavior, please align MLflow versions by either upgrading your server to MLflow 2.21.0 or newer (recommended) or downgrading your client to match your server version.
 

--- a/docs/docs/classic-ml/model/dependencies/index.mdx
+++ b/docs/docs/classic-ml/model/dependencies/index.mdx
@@ -817,7 +817,7 @@ model dependencies and save them as part of the MLflow Model metadata. However, 
 for certain libraries. This can cause errors when serving your model, such as "ModuleNotFoundError" or "ImportError". Below are some steps that can help to diagnose
 and fix missing dependency errors.
 
-:::tip hint
+:::tip[hint]
 To reduce the possibility of dependency errors, you can add `input_example` when saving your model. This enables MLflow to
 perform a model prediction before saving the model, thereby capturing the dependencies used during the prediction.
 Please refer to [Model Input Example](/ml/model/signatures) for additional, detailed usage of this parameter.

--- a/docs/docs/classic-ml/model/index.mdx
+++ b/docs/docs/classic-ml/model/index.mdx
@@ -100,7 +100,7 @@ This file contains the name and version of the model referenced in the MLflow Mo
 and will be used for deployment and other purposes.
 :::
 
-:::warning attention
+:::warning[attention]
 If you log a model within Databricks, MLflow also creates a `metadata` subdirectory within
 the model directory. This subdirectory contains the lightweight copy of aforementioned
 metadata files for internal use.
@@ -111,7 +111,7 @@ metadata files for internal use.
 MLflow records the environment variables that are used during model inference in `environment_variables.txt`
 file when logging a model.
 
-:::warning attention
+:::warning[attention]
 `environment_variables.txt` file **only contains names** of the environment variables that are used during
 model inference, **values are not stored**.
 :::
@@ -165,7 +165,7 @@ Environment variable `TEST_API_KEY` is logged in the environment_variables.txt f
 TEST_API_KEY
 ```
 
-:::warning attention
+:::warning[attention]
 Before you deploy a model to a serving endpoint, **review the environment_variables.txt file** to ensure
 all necessary environment variables for model inference are set. Note that **not all environment variables
 listed in the file are always required for model inference.** For detailed instructions on setting

--- a/docs/docs/classic-ml/model/models-from-code/index.mdx
+++ b/docs/docs/classic-ml/model/models-from-code/index.mdx
@@ -8,11 +8,11 @@ import { APILink } from "@site/src/components/APILink";
 
 # Models From Code
 
-:::info availability
+:::info[availability]
 Models from Code is available in MLflow 2.12.2 and above. For earlier versions, use the legacy serialization methods outlined in the [Custom Python Model](/ml/model#custom-python-models) documentation.
 :::
 
-:::note target use cases
+:::note[target use cases]
 Models from Code is designed for models without optimized weights (GenAI Agents, applications, custom logic). For traditional ML/DL models with trained weights, use the built-in `log_model()` APIs or custom `PythonModel` with `mlflow.pyfunc.log_model()`.
 :::
 
@@ -56,11 +56,11 @@ Only include imports you actually use. MLflow infers requirements from all top-l
 
 Non-pip installable packages must be specified via `code_paths`. The system doesn't automatically capture external references beyond standard package imports.
 
-:::tip development workflow
+:::tip[development workflow]
 Use a linter to identify unused imports while developing. This keeps your model's requirements clean and deployment lightweight.
 :::
 
-:::warning security consideration
+:::warning[security consideration]
 Model code is stored in plain text. Never include sensitive information like API keys or passwords in your scripts. Use environment variables or secure configuration management instead.
 :::
 

--- a/docs/docs/classic-ml/model/signatures/index.mdx
+++ b/docs/docs/classic-ml/model/signatures/index.mdx
@@ -32,7 +32,7 @@ Model signatures and input examples provide crucial benefits:
 - **Deployment Safety**: Enable MLflow deployment tools to validate requests automatically
 - **UI Integration**: Allow MLflow UI to display clear model requirements
 
-:::warning Databricks Unity Catalog Requirement
+:::warning[Databricks Unity Catalog Requirement]
 **Model signatures are REQUIRED for registering models in Databricks Unity Catalog.** Unity Catalog enforces concrete type definitions for all registered models and will reject models without proper signatures. Always include a signature when logging models that you plan to register in Databricks environments.
 
 ```python
@@ -81,7 +81,7 @@ MLflow automatically:
 2. **Validates the model works with the example**
 3. **Stores both signature and example with your model**
 
-:::info Automatic Signature Inference
+:::info[Automatic Signature Inference]
 MLflow automatically generates model signatures when you provide an `input_example` during model logging. This works for all model flavors and is the recommended approach for most use cases.
 :::
 
@@ -176,7 +176,7 @@ np.array([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [1, 2, 3]]])  # Shape: (2, 2, 3)
 
 ## Type Hints for Model Signatures
 
-:::info Version Compatibility
+:::info[Version Compatibility]
 Type hint support was introduced in MLflow 2.20.0. If you are using an earlier version of MLflow, see [the Working with Signatures](#working-with-signatures) section.
 :::
 
@@ -236,7 +236,7 @@ Simple tabular data (DataFrames work fine with input examples), legacy codebases
 
 ### Input Type Requirements
 
-:::warning Signature Interface
+:::warning[Signature Interface]
 Input signatures must be `List[...]` since PythonModel expects batch data:
 
 ```python
@@ -486,7 +486,7 @@ except Exception as e:
 
 ### Validation Scope
 
-:::note Output Validation
+:::note[Output Validation]
 MLflow validates **input data** against type hints but does **not validate model output**. The output type hint is used only for model signature inference.
 :::
 
@@ -690,7 +690,7 @@ class MyModel(mlflow.pyfunc.PythonModel):
 - Use `TypeFromExample` when you want flexibility without explicit typing
 - Test validation locally before deployment
 
-:::warning Important Notes
+:::warning[Important Notes]
 
 - **Never pass explicit `signature` parameter** when using type hints - MLflow will use the inferred signature and warn if they don't match
 - **Union types become AnyType** - use Pydantic discriminated unions for proper validation
@@ -706,7 +706,7 @@ class MyModel(mlflow.pyfunc.PythonModel):
 
 **Python to MLflow type mappings:**
 
-:::note Type Restrictions
+:::note[Type Restrictions]
 Usage of these types support only scalar definitions or 1-dimensional Arrays. Mixed types are not permitted.
 :::
 
@@ -754,7 +754,7 @@ pd.DataFrame({
 
 ### Compatibility Notes
 
-:::warning version compatibility
+:::warning[version compatibility]
 
 **Version Requirements:**
 

--- a/docs/docs/classic-ml/plugins/index.mdx
+++ b/docs/docs/classic-ml/plugins/index.mdx
@@ -35,7 +35,7 @@ Open http://localhost:5000 to see your tracked experiment:
 
 ![Quickstart UI](/images/quickstart/quickstart_ui_screenshot.png)
 
-:::tip Plugin Benefits
+:::tip[Plugin Benefits]
 Plugins let you integrate MLflow with your existing infrastructure without modifying core MLflow code, ensuring smooth upgrades and maintenance.
 :::
 

--- a/docs/docs/classic-ml/projects/index.mdx
+++ b/docs/docs/classic-ml/projects/index.mdx
@@ -39,7 +39,7 @@ result = mlflow.run(
 result = mlflow.run(".", entry_point="train", parameters={"epochs": 100}, synchronous=True)
 ```
 
-:::tip Project Structure
+:::tip[Project Structure]
 Any directory with a `MLproject` file or containing `.py`/`.sh` files can be run as an MLflow Project. No complex setup required!
 :::
 
@@ -140,7 +140,7 @@ MLflow supports four parameter types with automatic validation and transformatio
 | **path**   | Local file paths | `data.csv`, `s3://bucket/file` | Downloads remote URIs to local files |
 | **uri**    | Any URI          | `s3://bucket/`, `./local/path` | Converts relative paths to absolute  |
 
-:::note Parameter Resolution
+:::note[Parameter Resolution]
 `path` parameters automatically download remote files (S3, GCS, etc.) to local storage before execution. Use `uri` for applications that can read directly from remote storage.
 :::
 
@@ -210,7 +210,7 @@ entry_points:
     command: "python train_model.py --gpus {gpu_count}"
 ```
 
-:::warning Conda Terms
+:::warning[Conda Terms]
 By using Conda, you agree to [Anaconda's Terms of Service](https://legal.anaconda.com/policies/en/?name=terms-of-service).
 :::
 

--- a/docs/docs/classic-ml/tracking/autolog/index.mdx
+++ b/docs/docs/classic-ml/tracking/autolog/index.mdx
@@ -434,7 +434,7 @@ Autologging captures the following information:
 
 :::
 
-:::warning important
+:::warning[important]
 With Pyspark 3.2.0 or above, Spark datasource autologging requires `PYSPARK_PIN_THREAD` environment variable to be set to `false`.
 :::
 

--- a/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
+++ b/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
@@ -7,13 +7,13 @@ import { APILink } from "@site/src/components/APILink";
 
 # Pickle-Free Model format
 
-:::note Experimental
+:::note[Experimental]
 This feature is experimental and may change in future releases.
 :::
 
 Saving models with Python's `pickle` or `cloudpickle` relies on Python's object serialization mechanism, which can execute arbitrary code during deserialization. MLflow supports safer **pickle-free** saving formats for several model flavors. Prefer these formats when possible.
 
-:::warning Upcoming Default Behavior Change
+:::warning[Upcoming Default Behavior Change]
 Pickle-free saving formats will become the **default** in an upcoming MLflow release. **Most users (scikit-learn, LightGBM, LangChain, custom Python) will see no breaking change.** PyTorch users should review the [requirements](#pickle-free-format-for-pytorch-model) — `input_example` will be required and `torch.jit.ScriptModule` is not supported.
 To avoid getting affected by the change, pin the MLflow version or specify `serialization_format="pickle"` in the model logging code.
 :::
@@ -77,7 +77,7 @@ See <APILink fn="mlflow.sklearn.log_model" /> and <APILink fn="mlflow.sklearn.sa
 
 When saving a PyTorch model, saving with `serialization_format="pt2"` uses `torch.export.save` and stores the model as a traced graph instead of pickle serialization format.
 
-:::danger Requirements and Limitations
+:::danger[Requirements and Limitations]
 
 - `torch` >= 2.4
 - An **input_example** is required (and only `Tensor` type inputs are supported for the exported model)

--- a/docs/docs/classic-ml/tracking/quickstart/index.mdx
+++ b/docs/docs/classic-ml/tracking/quickstart/index.mdx
@@ -9,7 +9,7 @@ import ImageBox from "@site/src/components/ImageBox";
 
 # MLflow Tracking Quickstart
 
-:::tip MLflow Assistant
+:::tip[MLflow Assistant]
 Need help setting up tracking? Try <ins>[MLflow Assistant](/genai/getting-started/try-assistant)</ins> - a powerful AI assistant that can help you set up MLflow tracking for your project.
 :::
 

--- a/docs/docs/classic-ml/tracking/tracking-api/index.mdx
+++ b/docs/docs/classic-ml/tracking/tracking-api/index.mdx
@@ -218,7 +218,7 @@ Ideal for custom training loops, advanced experimentation, or when you need prec
   </tbody>
 </Table>
 
-:::note api-parity
+:::note[api-parity]
 The Python API provides the most comprehensive feature set. Java and R APIs offer core functionality with ongoing feature additions in each release.
 :::
 
@@ -550,7 +550,7 @@ MLflow automatically sets several system tags to capture execution context:
 | `mlflow.docker.image.name` | Docker image used                        | Docker environments    |
 | `mlflow.note.content`      | **User-editable** description            | Manual only            |
 
-:::tip pro-tip
+:::tip[pro-tip]
 Use `mlflow.note.content` to document experiment insights, hypotheses, or results directly in the MLflow UI. This tag appears in a dedicated Notes section on the run page.
 :::
 

--- a/docs/docs/classic-ml/traditional-ml/prophet/index.mdx
+++ b/docs/docs/classic-ml/traditional-ml/prophet/index.mdx
@@ -11,7 +11,7 @@ import { TrendingUp, GitBranch, CheckCircle, Package } from "lucide-react";
 
 MLflow's Prophet integration provides experiment tracking, model versioning, and deployment capabilities for time series forecasting workflows.
 
-:::note No Autologging for Prophet
+:::note[No Autologging for Prophet]
 
 Prophet does not support autologging to prevent overwhelming the tracking server. Time series forecasting often involves training hundreds or thousands of models (e.g., one per product or location), which would create excessive load on the tracking server if autologging were enabled. Use manual logging with bulk APIs for large-scale forecasting workflows.
 
@@ -272,7 +272,7 @@ def train_hierarchical_forecasts(data_dict):
                 mlflow.prophet.log_model(pr_model=model, name=f"model_{series_name}")
 ```
 
-:::tip High-Volume Model Training
+:::tip[High-Volume Model Training]
 
 When training many Prophet models (e.g., for thousands of products), use bulk logging to reduce tracking server load:
 

--- a/docs/docs/classic-ml/traditional-ml/sklearn/index.mdx
+++ b/docs/docs/classic-ml/traditional-ml/sklearn/index.mdx
@@ -76,7 +76,7 @@ with mlflow.start_run():
 
 Autologging captures all model parameters, training metrics, the trained model, and model signatures.
 
-:::tip Tracking Server Setup
+:::tip[Tracking Server Setup]
 Running locally? MLflow stores experiments in the current directory by default. For team collaboration or remote tracking, **[set up a tracking server](/ml/tracking/tutorials/remote-server)**.
 :::
 
@@ -200,7 +200,7 @@ with mlflow.start_run():
     mlflow.log_metric("best_accuracy", study.best_value)
 ```
 
-:::note Nested Runs
+:::note[Nested Runs]
 The `nested=True` parameter creates child runs for each trial under the parent run, enabling hierarchical organization of hyperparameter tuning experiments. Learn more about **[hierarchical runs](/ml/tracking/tracking-api#hierarchical-runs-with-parent-child-relationships)**.
 :::
 

--- a/docs/docs/classic-ml/traditional-ml/tutorials/hyperparameter-tuning/part2-logging-plots/index.mdx
+++ b/docs/docs/classic-ml/traditional-ml/tutorials/hyperparameter-tuning/part2-logging-plots/index.mdx
@@ -311,7 +311,7 @@ After downloading the notebook and opening it with Jupyter:
 4. Use the `mlflow.log_artifacts()` (not `mlflow.log_artifact()`) to log the directory contents to the run.
 5. Validate the rendering of the plots within the MLflow UI.
 
-:::info hint
+:::info[hint]
 The `log_artifacts()` API has an optional `artifact_path` argument that can be overridden from the default of `None` in to segregate these additional plots
 in their own directory within the MLflow artifact store (and the UI). This can be very beneficial if you're logging dozens of plots that have distinct categorical
 groupings among them, without the need for filling the UI display pane in the artifact viewer with a large amount of files in the main root directory.

--- a/docs/docs/classic-ml/traditional-ml/xgboost/index.mdx
+++ b/docs/docs/classic-ml/traditional-ml/xgboost/index.mdx
@@ -84,7 +84,7 @@ with mlflow.start_run():
 
 Autologging captures parameters, metrics per iteration, feature importance with visualizations, and the trained model.
 
-:::tip Tracking Server Setup
+:::tip[Tracking Server Setup]
 Running locally? MLflow stores experiments in the current directory by default. For team collaboration or remote tracking, **[set up a tracking server](/ml/tracking/tutorials/remote-server)**.
 :::
 
@@ -284,7 +284,7 @@ with mlflow.start_run():
     )
 ```
 
-:::tip Model Format
+:::tip[Model Format]
 Use `model_format="json"` for the best portability across XGBoost versions. The `json` format is human-readable and cross-platform compatible.
 :::
 

--- a/docs/docs/genai/eval-monitor/legacy-llm-evaluation.mdx
+++ b/docs/docs/genai/eval-monitor/legacy-llm-evaluation.mdx
@@ -79,7 +79,7 @@ MLflow is rapidly evolving ([changelog](https://github.com/mlflow/mlflow/release
   ]}
 />
 
-:::tip Before you start the migration
+:::tip[Before you start the migration]
 
 Before starting the migration, we highly recommend you to visit the <ins>[Evaluation Guide](/genai/eval-monitor)</ins> and go through the <ins>[Quickstart](/genai/eval-monitor/quickstart)</ins> to get a sense of the new evaluation suite. Basic understanding of the concepts will help you to migrate your existing workload smoothly.
 

--- a/docs/docs/genai/eval-monitor/quickstart.mdx
+++ b/docs/docs/genai/eval-monitor/quickstart.mdx
@@ -8,7 +8,7 @@ import TabsWrapper from '@site/src/components/TabsWrapper';
 
 # Evaluation Quickstart
 
-:::tip MLflow Assistant
+:::tip[MLflow Assistant]
 Need help setting up evaluation? Try <ins>[MLflow Assistant](/genai/getting-started/try-assistant)</ins> - a powerful AI assistant that can help you set up evaluation for your project.
 :::
 

--- a/docs/docs/genai/eval-monitor/running-evaluation/traces.mdx
+++ b/docs/docs/genai/eval-monitor/running-evaluation/traces.mdx
@@ -228,7 +228,7 @@ email_scorers = [
 ]
 ```
 
-:::tip Scoring Intermediate Information in Traces
+:::tip[Scoring Intermediate Information in Traces]
 
 Scorers have access to the complete MLflow traces, including spans, attributes, and outputs. This allows you to evaluate the agent's behavior precisely, not only the final output, such as the **tool call trajectory**, the **sub-agents routing**, the **retrieved document recall**, etc. See <ins>[Parsing Traces for Scoring](/genai/eval-monitor/scorers/custom#parsing-traces-for-scoring)</ins> for more details.
 

--- a/docs/docs/genai/eval-monitor/scorers/index.mdx
+++ b/docs/docs/genai/eval-monitor/scorers/index.mdx
@@ -143,7 +143,7 @@ In practice, out-of-the-box judges such as 'Groundedness' or 'Safety' struggle t
   ]}
 />
 
-:::tip Pro tip: Version Control Judges
+:::tip[Pro tip: Version Control Judges]
 
 As you iterate on the judge, version control becomes important. MLflow can track <ins>[Judge Versions](/genai/eval-monitor/scorers/versioning)</ins> to help you maintain changes and share the improved judges with your team.
 

--- a/docs/docs/genai/eval-monitor/scorers/llm-judge/predefined.mdx
+++ b/docs/docs/genai/eval-monitor/scorers/llm-judge/predefined.mdx
@@ -115,7 +115,7 @@ results = mlflow.genai.evaluate(
 
 Multi-turn judges evaluate entire conversation sessions rather than individual turns. They require traces with session IDs and are experimental in MLflow 3.7.0. See [Track Users and Sessions](/genai/tracing/track-users-sessions/)
 
-:::info Multi-Turn Evaluation Requirements
+:::info[Multi-Turn Evaluation Requirements]
 Multi-turn judges require:
 
 1. **Session IDs**: Traces must have `mlflow.trace.session` metadata
@@ -132,7 +132,7 @@ Multi-turn judges require:
 | <APILink fn="mlflow.genai.scorers.KnowledgeRetention">KnowledgeRetention</APILink>\*\*                             | Does the assistant correctly retain information from earlier user inputs?  | Yes               |
 | <APILink fn="mlflow.genai.scorers.UserFrustration">UserFrustration</APILink>\*\*                                   | Is the user frustrated? Was the frustration resolved?                      | Yes               |
 
-:::note Availability
+:::note[Availability]
 Safety and RetrievalRelevance judges are currently only available in [Databricks managed MLflow](https://docs.databricks.com/mlflow3/genai/eval-monitor/) and will be open-sourced soon.
 :::
 

--- a/docs/docs/genai/eval-monitor/scorers/llm-judge/prompt.mdx
+++ b/docs/docs/genai/eval-monitor/scorers/llm-judge/prompt.mdx
@@ -75,7 +75,7 @@ The prompt template for the judge must have:
 - Placeholders for input values with **double curly braces**, e.g., `{{conversation}}`.
 - Choices for the judge to select from as output, enclosed in **square brackets**, e.g., `[[fully_resolved]]`. The choice name can contain alphanumeric characters and underscores.
 
-:::tip Handling Parsing Errors
+:::tip[Handling Parsing Errors]
 
 MLflow uses raw prompt-based instructions for handling structured outputs to make the API generic to all LLM providers. This may not be strict enough to enforce structured outputs in all cases. If you see output parsing errors frequently, consider using <ins>[code-based custom scorers](/genai/eval-monitor/scorers/custom)</ins> and invoke the specific structured output API for the LLM provider you are using to get more reliable results.
 

--- a/docs/docs/genai/eval-monitor/scorers/third-party/index.mdx
+++ b/docs/docs/genai/eval-monitor/scorers/third-party/index.mdx
@@ -58,6 +58,6 @@ Click an integration below to get started with detailed setup instructions.
   />
 </TilesGrid>
 
-:::info Missing an Integration?
+:::info[Missing an Integration?]
 Is your favorite evaluation framework missing? Consider [submitting a feature request](https://github.com/mlflow/mlflow/issues/new?assignees=&labels=enhancement&projects=&template=feature_request_template.yaml&title=%5BFR%5D).
 :::

--- a/docs/docs/genai/flavors/chat-model-guide/index.mdx
+++ b/docs/docs/genai/flavors/chat-model-guide/index.mdx
@@ -9,7 +9,7 @@ import { Table } from "@site/src/components/Table";
 
 # Tutorial: Custom LLM and AI Agent Models using ChatModel
 
-:::warning attention
+:::warning[attention]
 Starting in MLflow 3.0.0, we recommend <APILink fn="mlflow.pyfunc.ResponsesAgent">`ResponsesAgent`</APILink> instead of <APILink fn="mlflow.pyfunc.ChatModel">`ChatModel`</APILink>. See more details in the [ResponsesAgent Introduction](/genai/flavors/responses-agent-intro).
 :::
 

--- a/docs/docs/genai/flavors/chat-model-intro/index.mdx
+++ b/docs/docs/genai/flavors/chat-model-intro/index.mdx
@@ -7,7 +7,7 @@ import { Table } from "@site/src/components/Table";
 
 # Tutorial: Getting Started with ChatModel
 
-:::warning attention
+:::warning[attention]
 Starting in MLflow 3.0.0, we recommend <APILink fn="mlflow.pyfunc.ResponsesAgent">`ResponsesAgent`</APILink> instead of <APILink fn="mlflow.pyfunc.ChatModel">`ChatModel`</APILink>. See more details in the [ResponsesAgent Introduction](/genai/flavors/responses-agent-intro).
 :::
 

--- a/docs/docs/genai/flavors/custom-pyfunc-for-llms/index.mdx
+++ b/docs/docs/genai/flavors/custom-pyfunc-for-llms/index.mdx
@@ -7,7 +7,7 @@ import { CardGroup, PageCard } from "@site/src/components/Card";
 
 # Deploying Advanced LLMs with Custom PyFuncs in MLflow
 
-:::warning attention
+:::warning[attention]
 Starting in MLflow 3.0.0, we recommend <APILink fn="mlflow.pyfunc.ResponsesAgent">`ResponsesAgent`</APILink> instead of <APILink fn="mlflow.pyfunc.ChatModel">`ChatModel`</APILink>. See more details in the [ResponsesAgent Introduction](/genai/flavors/responses-agent-intro).
 :::
 

--- a/docs/docs/genai/flavors/dspy/index.mdx
+++ b/docs/docs/genai/flavors/dspy/index.mdx
@@ -8,7 +8,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 # MLflow DSPy Flavor
 
-:::warning attention
+:::warning[attention]
 The `dspy` flavor is under active development and is marked as Experimental. Public APIs are
 subject to change and new features may be added as the flavor evolves.
 :::

--- a/docs/docs/genai/flavors/index.mdx
+++ b/docs/docs/genai/flavors/index.mdx
@@ -9,7 +9,7 @@ import { CardGroup, SmallLogoCard } from "@site/src/components/Card";
 
 MLflow 3 delivers built-in support for packaging and deploying applications written with the LLM and AI agent frameworks you depend on. Whether you're orchestrating chains with LangChain or LangGraph, indexing documents in LlamaIndex, wiring up agent patterns via ChatModel and ResponseAgent, or rolling your own with a PythonModel, MLflow provides native packaging and deployment APIs ("flavors") to streamline your path to production.
 
-:::note OpenAI Model Logging Deprecated
+:::note[OpenAI Model Logging Deprecated]
 The `mlflow.openai.log_model()` API has been deprecated. If you were using it to save prompts, please migrate to the [MLflow Prompt Registry](/genai/prompt-registry), which provides superior versioning, aliasing, lineage tracking, and collaboration features for managing prompts separately from models.
 :::
 
@@ -32,7 +32,7 @@ Before you begin, make sure you have:
 - Credentials or API keys for your chosen provider (e.g., `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`)
 - An MLflow Tracking Server (local or remote)
 
-:::tip Ready to dive in?
+:::tip[Ready to dive in?]
 Pick your integration from the list below and follow the concise guide—each one gets you up and running in under 10 minutes.
 :::
 

--- a/docs/docs/genai/getting-started/connect-environment.mdx
+++ b/docs/docs/genai/getting-started/connect-environment.mdx
@@ -9,7 +9,7 @@ import ServerSetup from "@site/src/content/setup_server.mdx";
 
 # Set Up MLflow Server
 
-:::tip MLflow Assistant
+:::tip[MLflow Assistant]
 Need help with this setup? Try <ins>[MLflow Assistant](/genai/getting-started/try-assistant)</ins> - a powerful AI assistant that understands your codebase and can set up MLflow for you.
 :::
 

--- a/docs/docs/genai/governance/ai-gateway/benchmarks.mdx
+++ b/docs/docs/genai/governance/ai-gateway/benchmarks.mdx
@@ -28,7 +28,7 @@ curl -si -X POST http://localhost:5000/gateway/my-endpoint/mlflow/invocations \
 # X-MLflow-Gateway-Overhead-Duration-Ms: 3
 ```
 
-:::note Streaming responses
+:::note[Streaming responses]
 For streaming responses, only `X-MLflow-Gateway-Duration-Ms` is present. It reflects gateway setup
 time up to the point the stream starts (time-to-first-stream), not the full streaming duration.
 `X-MLflow-Gateway-Overhead-Duration-Ms` is absent because provider timing is not tracked for

--- a/docs/docs/genai/prompt-registry/evaluate-prompts.mdx
+++ b/docs/docs/genai/prompt-registry/evaluate-prompts.mdx
@@ -6,7 +6,7 @@ import TabItem from "@theme/TabItem";
 
 Combining [MLflow Prompt Registry](/genai/prompt-registry) with [MLflow LLM Evaluation](/genai/eval-monitor) enables you to evaluate prompt performance across different models and datasets, and track the evaluation results in a centralized registry. You can also inspect model outputs from the **traces** logged during evaluation to understand how the model responds to different prompts.
 
-:::tip Key Benefits of MLflow Prompt Evaluation
+:::tip[Key Benefits of MLflow Prompt Evaluation]
 
 - **Effective Evaluation**: `MLflow's LLM Evaluation API provides a simple and consistent way to evaluate prompts across different models and datasets without writing boilerplate code.
 - **Compare Results**: Compare evaluation results with ease in the MLflow UI.

--- a/docs/docs/genai/prompt-registry/manage-prompt-lifecycles-with-aliases.mdx
+++ b/docs/docs/genai/prompt-registry/manage-prompt-lifecycles-with-aliases.mdx
@@ -20,7 +20,7 @@ The design of the prompt registry is inspired by version control systems like Gi
 - **✉️ Commit message**: When creating a new prompt version, you can provide a commit message to document the changes made in the new version. This helps you and your team understand the context of the changes and track the evolution of the prompt over time.
 - **🔍 Difference view**: The MLflow UI provides a side-by-side comparison of prompt versions, highlighting the changes between versions. This makes it easy to understand the differences and track the evolution of the prompt.
 
-:::tip Why not use Git?
+:::tip[Why not use Git?]
 
 Hard-coding prompt text in source code is indeed a common practice, but it has several limitations. An LLM application or AI agent project often contains multiple prompts for different components/tasks, as well as all software artifacts. Tracking the change of a single prompt with a monotonic Git tree is challenging.
 

--- a/docs/docs/genai/prompt-registry/optimize-prompts.mdx
+++ b/docs/docs/genai/prompt-registry/optimize-prompts.mdx
@@ -22,7 +22,7 @@ MLflow supports multiple optimization algorithms to improve your prompts:
 
 See [Choosing Your Optimizer](#choosing-your-optimizer) for guidance on which optimizer to use for your specific needs.
 
-:::tip Why Use MLflow Prompt Optimization?
+:::tip[Why Use MLflow Prompt Optimization?]
 
 - **Zero Framework Lock-in**: Works with ANY agent framework—LangChain, OpenAI Agent, CrewAI, or custom solutions
 - **Minimal Code Changes**: Add a few lines to start optimizing; no architectural rewrites needed
@@ -137,7 +137,7 @@ GEPA is a prompt optimization technique that uses natural language reflection to
 - Tasks where you have clear evaluation metrics and a dataset of decent size (e.g., 100+ records)
 - Tasks where quality is critical to your system (e.g., medical agents, financial agents, etc.), so that the optimization cost and longer prompt as produced by GEPA is worth it
 
-:::tip Reduce the Cost of GEPA Optimization
+:::tip[Reduce the Cost of GEPA Optimization]
 
 The cost of GEPA optimization is tightly coupled with the reflection model you use and the max number of metric calls you allow. You can reduce the cost by using a cheaper reflection model or reducing the max number of metric calls.
 

--- a/docs/docs/genai/prompt-registry/rewrite-prompts.mdx
+++ b/docs/docs/genai/prompt-registry/rewrite-prompts.mdx
@@ -10,7 +10,7 @@ import { CardGroup, Card } from "@site/src/components/Card";
 
 When migrating to a new language model, you often discover that your carefully crafted prompts don't work as well with the new model. MLflow's <APILink fn="mlflow.genai.optimize_prompts" /> API helps you **automatically rewrite prompts** to maintain output quality when switching models, using your existing application's outputs as training data.
 
-:::tip Key Benefits
+:::tip[Key Benefits]
 
 - **Model Migration**: Seamlessly switch between language models while maintaining output consistency
 - **Automatic Optimization**: Automatically rewrites prompts based on your existing data

--- a/docs/docs/genai/serving/index.mdx
+++ b/docs/docs/genai/serving/index.mdx
@@ -476,7 +476,7 @@ print("Model version info:", info.json())
 
 Ready to build more advanced serving applications? Explore these specialized topics:
 
-:::tip Get Started
+:::tip[Get Started]
 The examples in each section are designed to be practical and ready-to-use. Start with the Quick Start above, then explore the use cases that match your deployment needs.
 :::
 

--- a/docs/docs/genai/tracing/app-instrumentation/automatic.mdx
+++ b/docs/docs/genai/tracing/app-instrumentation/automatic.mdx
@@ -45,7 +45,7 @@ Each integration automatically captures your application's logic and intermediat
 
 <br />
 
-:::info Missing your favorite library?
+:::info[Missing your favorite library?]
 Is your favorite library missing from the list? Consider <ins>[contributing to MLflow Tracing](/genai/tracing/integrations/contribute)</ins> or <ins>[submitting a feature request](https://github.com/mlflow/mlflow/issues/new?assignees=&labels=enhancement&projects=&template=feature_request_template.yaml&title=%5BFR%5D)</ins> to our Github repository.
 :::
 

--- a/docs/docs/genai/tracing/app-instrumentation/manual-tracing.mdx
+++ b/docs/docs/genai/tracing/app-instrumentation/manual-tracing.mdx
@@ -35,7 +35,7 @@ The `@mlflow.trace` decorator currently supports the following types of function
 
 The following code is a minimum example of using the decorator for tracing Python functions.
 
-:::tip Decorator Order
+:::tip[Decorator Order]
 To ensure complete observability, the `@mlflow.trace` decorator should generally be the **outermost** one if using multiple decorators. See [Using @mlflow.trace with Other Decorators](#using-mlflowtrace-with-other-decorators) for a detailed explanation and examples.
 :::
 
@@ -384,7 +384,7 @@ class MyClass {
 
 By setting `request_preview` and `response_preview` on the trace (typically the root span), you control how the overall interaction is summarized in the main trace list view, making it easier to identify and understand traces at a glance.
 
-:::tip Images and Audio Content in MLflow Traces
+:::tip[Images and Audio Content in MLflow Traces]
 You can attach images and audio to spans using content parts lists in `set_inputs()` and `set_outputs()`:
 
 ```python
@@ -581,7 +581,7 @@ If an `Exception` is raised during processing of a trace-instrumented operation,
 
 ---
 
-:::note Python Only Features
+:::note[Python Only Features]
 The below documentation applies only to the MLflow Python SDK.
 :::
 

--- a/docs/docs/genai/tracing/integrations/contribute.mdx
+++ b/docs/docs/genai/tracing/integrations/contribute.mdx
@@ -101,7 +101,7 @@ With the design approved, start implementation:
 3. **Define `mlflow.xxx.autolog() function`**: This function will be the main entry point for the integration, which enables tracing when called (e.g., <APILink fn="mlflow.llama_index.autolog" />).
 4. **Write Tests**: Cover edge cases like asynchronous calls, custom data types, and streaming outputs if the library supports them.
 
-:::warning attention
+:::warning[attention]
 There are a few gotchas to watch out for when integrating with MLflow Tracing:
 
 - **Error Handling**: Ensure exceptions are captured and logged to spans with type, message, and stack trace.
@@ -129,7 +129,7 @@ npm run build
 npm run test
 ```
 
-:::warning attention
+:::warning[attention]
 
 - **Trace Shape**: Align span names, attributes, and metadata with the Python integrations so downstream UI components interpret traces correctly.
 - **Streaming & Async Workloads**: Buffer streaming responses or async iterators before logging outputs so they remain consumable by the caller.

--- a/docs/docs/genai/tracing/integrations/index.mdx
+++ b/docs/docs/genai/tracing/integrations/index.mdx
@@ -54,6 +54,6 @@ Click any integration below to get started with detailed setup instructions.
 <TracingIntegrations category="No-Code" cardGroupProps={{ isSmall: true, cols: 3 }} />
 <br />
 
-:::info Missing an Integration?
+:::info[Missing an Integration?]
 Is your favorite library missing? Consider [contributing](/genai/tracing/integrations/contribute) or [submitting a feature request](https://github.com/mlflow/mlflow/issues/new?assignees=&labels=enhancement&projects=&template=feature_request_template.yaml&title=%5BFR%5D).
 :::

--- a/docs/docs/genai/tracing/integrations/listing/anthropic.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/anthropic.mdx
@@ -139,7 +139,7 @@ MLflow supports automatic tracing for the following Anthropic APIs:
 
 To request support for additional APIs, please open a [feature request](https://github.com/mlflow/mlflow/issues) on GitHub.
 
-:::tip Image Support in Anthropic Traces
+:::tip[Image Support in Anthropic Traces]
 MLflow automatically captures images sent to Anthropic models and normalizes them to the standard trace format. See [Multimodal Content and Attachments in Traces](/genai/tracing/observe-with-traces/multimodal) for examples.
 :::
 

--- a/docs/docs/genai/tracing/integrations/listing/databricks-ai-gateway.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/databricks-ai-gateway.mdx
@@ -18,7 +18,7 @@ import { Users, BookOpen, Scale } from "lucide-react";
 
 [Databricks AI Gateway](https://docs.databricks.com/en/ai-gateway/index.html) (formerly Mosaic AI Gateway) is the Databricks solution for governing and monitoring access to generative AI models and their associated model serving endpoints. It is a centralized service that brings governance, monitoring, and production readiness to model serving endpoints.
 
-:::tip Looking for Databricks Foundation Model APIs?
+:::tip[Looking for Databricks Foundation Model APIs?]
 This guide covers tracing LLM calls through **Databricks AI Gateway**. If you're using Databricks Foundation Model APIs directly, see the <ins>[Databricks Integration](/genai/tracing/integrations/listing/databricks)</ins> guide instead.
 :::
 

--- a/docs/docs/genai/tracing/integrations/listing/databricks.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/databricks.mdx
@@ -26,7 +26,7 @@ import { Users, BookOpen, Scale } from "lucide-react";
 
 Databricks offers a fully managed MLflow service as a part of their platform. This is the easiest way to get started with MLflow tracing, without having to set up any infrastructure. If you are using Databricks Foundation Model APIs, it is no brainer to use the managed MLflow for end-to-end [LLMOps](https://mlflow.org/llmops) including tracing.
 
-:::warning Visit Databricks documentation
+:::warning[Visit Databricks documentation]
 
 This guide only covers how to trace Databricks Foundation Model APIs using MLflow tracing. For more details on how to get started with MLflow tracing on Databricks (e.g., tracing agent deployed on Databricks), please refer to the [Databricks documentation](https://docs.databricks.com/aws/en/mlflow3/genai/).
 

--- a/docs/docs/genai/tracing/integrations/listing/goose.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/goose.mdx
@@ -18,7 +18,7 @@ import TileCard from "@site/src/components/TileCard";
 
 [MLflow Tracing](/genai/tracing) provides automatic tracing capability for [Goose](https://github.com/block/goose), an open-source AI agent by Block that automates engineering tasks on your local machine. MLflow supports tracing for Goose through the [OpenTelemetry](/genai/tracing/opentelemetry) integration.
 
-:::tip What is Goose?
+:::tip[What is Goose?]
 [Goose](https://block.github.io/goose/) is an open-source, on-device AI agent built by Block. It goes beyond code suggestions — Goose can autonomously write and execute code, manage files, run shell commands, interact with APIs, browse the web, and orchestrate pipelines. It works with any LLM provider and is extensible through [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) servers.
 :::
 
@@ -46,7 +46,7 @@ mlflow server --port 5000
 
 This example uses SQLite as the backend store. To use other types of SQL databases such as PostgreSQL, MySQL, and MSSQL, change the store URI as described in the [backend store documentation](/self-hosting/architecture/backend-store).
 
-:::tip Managed MLflow
+:::tip[Managed MLflow]
 For a fully managed experience with built-in authentication, scalable storage, and team collaboration, [try Managed MLflow for free](/genai/getting-started/databricks-trial/).
 :::
 
@@ -59,7 +59,7 @@ export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:5000
 export OTEL_EXPORTER_OTLP_HEADERS=x-mlflow-experiment-id=0
 ```
 
-:::note About `x-mlflow-experiment-id`
+:::note[About `x-mlflow-experiment-id`]
 The `x-mlflow-experiment-id` header tells MLflow which experiment to associate the traces with. You can use `0` for the default experiment, or specify a custom experiment ID. To create a new experiment and get its ID, run:
 
 ```bash

--- a/docs/docs/genai/tracing/integrations/listing/langchain.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/langchain.mdx
@@ -257,7 +257,7 @@ pip install openai==1.30.5 langchain==0.2.1 langchain-openai==0.1.8 langchain-co
 
 :::
 
-:::tip Image Support for LangChain Traces
+:::tip[Image Support for LangChain Traces]
 MLflow captures image content parts passed through LangChain models. See [Multimodal Content and Attachments in Traces](/genai/tracing/observe-with-traces/multimodal) for details.
 :::
 

--- a/docs/docs/genai/tracing/integrations/listing/langgraph.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/langgraph.mdx
@@ -239,7 +239,7 @@ This way, the span for the `check_code` node will have child spans, which record
 
 ![LangGraph Child Span](/images/llms/tracing/langgraph-child-span.png)
 
-:::info Async Context Propagation
+:::info[Async Context Propagation]
 When using async methods like `ainvoke()` with manual `@mlflow.trace` decorators inside LangGraph nodes or tools, enable inline tracer execution to ensure proper context propagation:
 
 ```python

--- a/docs/docs/genai/tracing/integrations/listing/litellm-proxy.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/litellm-proxy.mdx
@@ -23,7 +23,7 @@ import { Users, BookOpen, Scale } from "lucide-react";
 
 <ImageBox src="/images/llms/litellm-proxy/litellm-proxy-tracing.png" alt="LiteLLM Proxy Tracing" />
 
-:::tip Looking for LiteLLM SDK?
+:::tip[Looking for LiteLLM SDK?]
 This guide covers the **LiteLLM Proxy Server**. If you're using the LiteLLM Python SDK directly in your application, see the [LiteLLM SDK Integration](/genai/tracing/integrations/listing/litellm) guide instead.
 :::
 

--- a/docs/docs/genai/tracing/integrations/listing/livekit.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/livekit.mdx
@@ -20,7 +20,7 @@ import TileCard from "@site/src/components/TileCard";
 
 [MLflow Tracing](/genai/tracing) provides automatic tracing capability for [LiveKit Agents](https://github.com/livekit/agents), an open-source framework for building real-time multimodal AI applications. MLflow supports tracing for LiveKit Agents through the [OpenTelemetry](/genai/tracing/opentelemetry) integration.
 
-:::tip What is LiveKit Agents?
+:::tip[What is LiveKit Agents?]
 LiveKit Agents is a framework for building real-time, multimodal AI applications. It enables developers to create voice-enabled AI assistants that can:
 
 - Process speech-to-text (STT) in real-time
@@ -66,7 +66,7 @@ export LIVEKIT_API_SECRET=your-api-secret
 export OPENAI_API_KEY=your-openai-api-key
 ```
 
-:::note About `x-mlflow-experiment-id`
+:::note[About `x-mlflow-experiment-id`]
 The `x-mlflow-experiment-id` header tells MLflow which experiment to associate the traces with. You can use `0` for the default experiment, or specify a custom experiment ID. To create a new experiment and get its ID, run:
 
 ```bash
@@ -76,7 +76,7 @@ mlflow experiments create --experiment-name "my-livekit-experiment"
 This will output the experiment ID which you can use in the header.
 :::
 
-:::tip Free LiveKit Cloud Account
+:::tip[Free LiveKit Cloud Account]
 [LiveKit Cloud](https://cloud.livekit.io) offers a free tier with no credit card required. Sign up to get your `LIVEKIT_URL`, `LIVEKIT_API_KEY`, and `LIVEKIT_API_SECRET`.
 :::
 

--- a/docs/docs/genai/tracing/integrations/listing/n8n.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/n8n.mdx
@@ -83,7 +83,7 @@ Configure credentials in n8n for both the LLM endpoint and MLflow.
 | MLflow Tracking URI  | Yes      | Your MLflow tracking server URI           | `http://localhost:5000` or `databricks` |
 | MLflow Experiment ID | Yes      | Experiment ID where traces will be logged | `1234567890`                            |
 
-:::tip Databricks users
+:::tip[Databricks users]
 Set the **Tracking URI** to `databricks` and provide your Databricks personal access token as the **MLflow Tracking Token**.
 :::
 

--- a/docs/docs/genai/tracing/integrations/listing/openai.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/openai.mdx
@@ -173,7 +173,7 @@ See [OpenAI Agents SDK Tracing](/genai/tracing/integrations/listing/openai-agent
 | :----: | :---: |
 |   ✅   |  ✅   |
 
-:::tip Image and Audio Support for OpenAI Traces
+:::tip[Image and Audio Support for OpenAI Traces]
 MLflow automatically captures images and audio sent to OpenAI models. See [Multimodal Content and Attachments in Traces](/genai/tracing/observe-with-traces/multimodal) for examples and supported formats.
 :::
 

--- a/docs/docs/genai/tracing/integrations/listing/openhands.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/openhands.mdx
@@ -151,7 +151,7 @@ MLflow automatically tracks token usage for each LLM call within OpenHands agent
 
 <ImageBox src="/images/llms/openhands/openhands-token-usage.png" alt="OpenHands Token Usage" />
 
-:::tip Governing OpenHands Agents with AI Gateway
+:::tip[Governing OpenHands Agents with AI Gateway]
 
 [AI Gateway](/genai/governance/ai-gateway) provides centralized governance for all LLM traffic from OpenHands, including budget control, usage tracking, and secret management.
 

--- a/docs/docs/genai/tracing/integrations/listing/pydantic-ai-gateway.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/pydantic-ai-gateway.mdx
@@ -24,7 +24,7 @@ Since Pydantic AI Gateway exposes OpenAI and Anthropic-compatible APIs, you can 
 
 <ImageBox src="/images/llms/pydantic-ai/pydanticai-gateway-tracing.png" alt="Pydantic AI Gateway Tracing" />
 
-:::tip Looking for PydanticAI Agent Framework?
+:::tip[Looking for PydanticAI Agent Framework?]
 This guide covers tracing LLM calls through **Pydantic AI Gateway**. If you're building agents using the Pydantic AI framework directly, see the <ins>[PydanticAI Integration](/genai/tracing/integrations/listing/pydantic_ai)</ins> guide instead.
 :::
 

--- a/docs/docs/genai/tracing/integrations/listing/voltagent.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/voltagent.mdx
@@ -15,7 +15,7 @@ import ImageBox from "@site/src/components/ImageBox";
 
 [MLflow Tracing](/genai/tracing) provides automatic tracing capability for [VoltAgent](https://github.com/VoltAgent/voltagent), an open-source TypeScript framework for building AI agents. MLflow supports tracing for VoltAgent through the [OpenTelemetry](/genai/tracing/opentelemetry) integration.
 
-:::tip What is VoltAgent?
+:::tip[What is VoltAgent?]
 VoltAgent is an open-source TypeScript framework that simplifies the development of AI agent applications by providing modular building blocks, standardized patterns, and abstractions. Whether you're creating chatbots, virtual assistants, automated workflows, or complex multi-agent systems, VoltAgent handles the underlying complexity, allowing you to focus on defining your agents' capabilities and logic.
 :::
 
@@ -48,7 +48,7 @@ Install the OpenTelemetry SDK and OTLP protobuf exporter:
 npm install @opentelemetry/sdk-trace-base @opentelemetry/exporter-trace-otlp-proto dotenv
 ```
 
-:::note MLflow Trace Translation
+:::note[MLflow Trace Translation]
 MLflow automatically translates VoltAgent's semantic conventions for optimal UI visualization:
 
 - **Chat UI**: Converts VoltAgent's message format to standard chat format with `role` and `content` fields for rich message display

--- a/docs/docs/genai/tracing/observe-with-traces/delete-traces.mdx
+++ b/docs/docs/genai/tracing/observe-with-traces/delete-traces.mdx
@@ -5,7 +5,7 @@ import ImageBox from "@site/src/components/ImageBox";
 
 You can delete traces based on specific criteria using the <APILink fn="mlflow.client.MlflowClient.delete_traces" /> method. This method allows you to delete traces by **timestamp** or **trace IDs**.
 
-:::warning Deletion is irreversible
+:::warning[Deletion is irreversible]
 Deleting a trace cannot be undone. Ensure that the parameters provided to the `delete_traces` API meet the intended range for deletion.
 :::
 

--- a/docs/docs/genai/tracing/observe-with-traces/ui.mdx
+++ b/docs/docs/genai/tracing/observe-with-traces/ui.mdx
@@ -13,7 +13,7 @@ as well as inspecting the details of each trace.
 
 The trace table you see first when you open the "Traces" page includes high-level information about the traces, such as the trace ID, the inputs / outputs of the root span, and more. The table displays the following columns.
 
-:::tip Not Seeing All Columns?
+:::tip[Not Seeing All Columns?]
 
 Trace table does not display all fields by default. Some columns are hidden by default and can be enabled via the column selector.
 
@@ -38,7 +38,7 @@ Trace table does not display all fields by default. Some columns are hidden by d
 | Assessments    | Feedback scores logged to the trace, either by a human or an automated evaluation.                                                                            | See [Collecting User Feedback](/genai/tracing/collect-user-feedback) and [Evaluating Traces](/genai/eval-monitor) for how to log assessments.                                                                                                                        |
 | Expectations   | Ground truth values annotated to the trace.                                                                                                                   | See [Ground Truth Expectations](/genai/assessments/expectations) for how to log expectations.                                                                                                                                                                        |
 
-:::info Traces ingested via OTLP
+:::info[Traces ingested via OTLP]
 
 Traces ingested through the [OTLP endpoint](/genai/tracing/opentelemetry/ingest) go through automatic attribute translation to derive these columns from framework-specific OpenTelemetry attributes. MLflow supports translation for OpenTelemetry GenAI Semantic Conventions, and various frameworks including OpenLLMetry, OpenInference, Langfuse, and more. Please see the [Attribute Mapping Reference](/genai/tracing/opentelemetry/attribute-mapping) for details on how each framework's attributes are mapped to these columns.
 
@@ -58,7 +58,7 @@ By clicking on a trace ID `tr-...` or the request link in the trace table, you c
 
 <ImageBox src="/images/llms/tracing/trace-ui-detail-view.png" alt="Browsing single trace" />
 
-:::tip Multimodal Content and Attachments
+:::tip[Multimodal Content and Attachments]
 MLflow renders images, audio, and supported attachment types inline in the trace viewer. For supported formats,
 framework examples, and how to use the `Attachment` class for binary content, see
 [Multimodal Content and Attachments in Traces](/genai/tracing/observe-with-traces/multimodal).

--- a/docs/docs/genai/tracing/prod-tracing.mdx
+++ b/docs/docs/genai/tracing/prod-tracing.mdx
@@ -48,7 +48,7 @@ For production deployments, we recommend the [Production Tracing SDK](#using-the
 
 <br/>
 
-:::warning Compatibility Warning
+:::warning[Compatibility Warning]
 When installing the MLflow Tracing SDK, make sure the environment **does not have** the full MLflow package installed. Having both packages in the same environment might cause conflicts and unexpected behaviors.
 :::
 

--- a/docs/docs/genai/tracing/quickstart/index.mdx
+++ b/docs/docs/genai/tracing/quickstart/index.mdx
@@ -174,7 +174,7 @@ For a deeper dive into using MLflow together with OpenTelemetry, see the [OpenTe
 
 After running the code above, go to the MLflow UI and select the "My Application" experiment, and then select the "Traces" tab. It should show the newly created trace.
 
-:::tip Learn More About Tracing UI
+:::tip[Learn More About Tracing UI]
 
 The "Traces" page includes rich information about the trace and supports various actions such as searching, filtering, adding feedbacks, and more. See [View Traces](/genai/tracing/observe-with-traces/ui) for comprehensive guide about how to get the most out of the MLflow Tracing UI.
 

--- a/docs/docs/genai/tracing/search-traces.mdx
+++ b/docs/docs/genai/tracing/search-traces.mdx
@@ -419,7 +419,7 @@ print(f"Found {len(all_traces)} total traces")
 
 ### MLflow Version Compatibility
 
-:::note Schema Changes in MLflow 3
+:::note[Schema Changes in MLflow 3]
 **DataFrame Schema**: The format depends on the MLflow version used to **call** the `search_traces` API, not the version used to log the traces. MLflow 3.x uses different column names than 2.x.
 :::
 

--- a/docs/docs/genai/tracing/token-usage-cost/index.mdx
+++ b/docs/docs/genai/tracing/token-usage-cost/index.mdx
@@ -53,7 +53,7 @@ uv run mlflow server
 </Tabs>
 </TabsWrapper>
 
-:::tip What is the GenAI extra?
+:::tip[What is the GenAI extra?]
 
 The `[genai]` extra enables other powerful features such as <ins>[AI Gateway](/genai/governance/ai-gateway)</ins>, <ins>[Automatic Evaluation](/genai/eval-monitor/automatic-evaluations/)</ins>, and <ins>[Prompt Optimization](/genai/prompt-registry/optimize-prompts)</ins>. It is recommended to start your MLflow server with the extra installed, even if you don't need cost tracking.
 

--- a/docs/docs/genai/version-tracking/quickstart.mdx
+++ b/docs/docs/genai/version-tracking/quickstart.mdx
@@ -16,7 +16,7 @@ Build and track a LangChain-based chatbot with MLflow's version management capab
 
 ### Install Required Packages
 
-:::note MLflow 3 Required
+:::note[MLflow 3 Required]
 This quickstart requires MLflow version 3.0 or higher for full LLM and AI agent functionality.
 :::
 

--- a/docs/docs/prompts/index.mdx
+++ b/docs/docs/prompts/index.mdx
@@ -15,7 +15,7 @@ import TabItem from "@theme/TabItem";
 
 **MLflow Prompt Registry** is a powerful tool that streamlines prompt engineering and management in your LLM applications and AI agents. It enables you to version, track, and reuse prompts across your organization, helping maintain consistency and improving collaboration in prompt development.
 
-:::tip Key Features
+:::tip[Key Features]
 
 - **Reusability** - Store and manage prompts in a centralized registry and reuse them across multiple applications.
 - **Version Control** - Track the evolution of your prompts with Git-inspired commit-based versioning and side-by-side comparison of prompt versions with diff highlighting.

--- a/docs/docs/self-hosting/architecture/artifact-store.mdx
+++ b/docs/docs/self-hosting/architecture/artifact-store.mdx
@@ -20,7 +20,7 @@ provider credentials as you would for accessing them in any other capacity. For 
 and `AWS_SECRET_ACCESS_KEY` environment variables, use an IAM role, or configure a default
 profile in `~/.aws/credentials`.
 
-:::warning important
+:::warning[important]
 Access of credentials and configurations for the artifact storage location are configured **once during the tracking server initialization** instead
 of having to provide access credentials for artifact-based operations through the client APIs. Note that **all users who have access to the
 Tracking Server in this mode will have access to artifacts served through this assumed role**.
@@ -39,7 +39,7 @@ retrieve the location of the artifacts for historical runs using the <APILink fn
 Also, `artifact_location` is a property recorded on <APILink fn="mlflow.entities.Experiment">`mlflow.entities.Experiment`</APILink> for setting the
 default location to store artifacts for all runs for models within a given experiment.
 
-:::warning important
+:::warning[important]
 If you do not specify a `--default-artifact-root` or an artifact URI when creating the experiment
 (for example, `mlflow experiments create --artifact-location s3://<my-bucket>`), the artifact root
 will be set as a path inside the local file store (the hard drive of the computer executing your run). Typically this is not an appropriate location, as the client and

--- a/docs/docs/self-hosting/architecture/backend-store.mdx
+++ b/docs/docs/self-hosting/architecture/backend-store.mdx
@@ -58,7 +58,7 @@ MLflow supports the following types of tracking URI for backend stores:
   Refer to Access the MLflow tracking server from outside Databricks [[AWS]](http://docs.databricks.com/applications/mlflow/access-hosted-tracking-server.html)
   [[Azure]](http://docs.microsoft.com/azure/databricks/applications/mlflow/access-hosted-tracking-server).
 
-:::warning database-requirements
+:::warning[database-requirements]
 **Database-Backed Store Requirements**
 
 When using database-backed stores, please note:
@@ -68,7 +68,7 @@ When using database-backed stores, please note:
 - **Schema Migrations**: `mlflow server` will fail against a database with an out-of-date schema. Always run `mlflow db upgrade [db_uri]` to upgrade your database schema before starting the server. Schema migrations can result in database downtime and may take longer on larger databases. **Always backup your database before running migrations.**
   :::
 
-:::note parameter-limits
+:::note[parameter-limits]
 In Sep 2023, we increased the max length for params recorded in a Run from 500 to 8k (but we limit param value max length to 6000 internally).
 [mlflow/2d6e25af4d3e_increase_max_param_val_length](https://github.com/mlflow/mlflow/blob/master/mlflow/store/db_migrations/versions/2d6e25af4d3e_increase_max_param_val_length.py)
 is a non-invertible migration script that increases the cap in existing database to 8k. Please be careful if you want to upgrade and backup your database before upgrading.

--- a/docs/docs/self-hosting/architecture/tracking-server.mdx
+++ b/docs/docs/self-hosting/architecture/tracking-server.mdx
@@ -35,7 +35,7 @@ INFO:     Uvicorn running on http://127.0.0.1:8080 (Press CTRL+C to quit)
 
 There are many options to configure the server, refer to [Configure Server](#configure-server) for more details.
 
-:::warning important
+:::warning[important]
 The server listens on http://localhost:5000 by default and only accepts
 connections from the local machine. To let the server accept connections
 from other machines, you will need to pass `--host 0.0.0.0` to listen on
@@ -49,7 +49,7 @@ to specify which domains can access your server. See [Security Configuration](/s
 for details.
 :::
 
-:::tip Read-only Filesystems
+:::tip[Read-only Filesystems]
 When running in containers with read-only root filesystems (common in Kubernetes with `securityContext.readOnlyRootFilesystem: true`),
 configure remote artifact storage using `--artifacts-destination` (artifact serving is enabled by default). The tracking server does not create
 local directories at startup when using remote artifact storage, making it compatible with read-only environments.
@@ -255,7 +255,7 @@ mlflow server \
 
 With this setting, MLflow server works as a proxy for accessing remote artifacts. The MLflow clients make HTTP request to the server for fetching artifacts.
 
-:::warning important
+:::warning[important]
 If you are using remote storage, you have to configure the credentials for the server to access the artifacts. Be aware of that The MLflow artifact proxied
 access service enables users to have an _assumed role of access to all artifacts_ that are accessible to the Tracking Server. Refer [Manage Access](/self-hosting/architecture/artifact-store#artifacts-stores-manage-access) for further details.
 :::
@@ -269,7 +269,7 @@ explicit object store destination (e.g., "s3:/my_bucket/mlartifacts") for interf
 - `mlflow-artifacts://<host>:<port>/mlartifacts`
 - `mlflow-artifacts:/mlartifacts`
 
-:::warning important
+:::warning[important]
 The MLflow client caches artifact location information on a per-run basis.
 It is therefore not recommended to alter a run's artifact location before it has terminated.
 :::
@@ -288,7 +288,7 @@ With this setting, the MLflow client still makes minimum HTTP requests to the tr
 but can directly upload artifacts to / download artifacts from the remote storage. While this might not be a good practice for access and
 security governance, it could be useful when you want to avoid the overhead of proxying artifacts through the tracking server.
 
-:::info Use the right configuration keys
+:::info[Use the right configuration keys]
 
 The two options `--serve-artifacts` and `--default-artifact-root` look similar, but they are used for different purposes. When you pick the wrong one, the artifact logging requests will not go through the expected route and may cause access issues. The rule of thumb is:
 

--- a/docs/docs/self-hosting/index.mdx
+++ b/docs/docs/self-hosting/index.mdx
@@ -10,7 +10,7 @@ sidebar_position: 1
 
 MLflow is fully open-source. Thousands of users and organizations run their own MLflow instances to meet their specific needs. Being open-source and trusted by the popular cloud providers, MLflow is the best choice for teams/organizations that worry about vendor lock-in.
 
-:::warning Default Storage Backend Change
+:::warning[Default Storage Backend Change]
 
 As of MLflow 3.7.0, the default tracking backend has changed from file-based storage (`./mlruns`) to SQLite database (`sqlite:///mlflow.db`) for better performance and reliability.
 
@@ -120,7 +120,7 @@ MLflow support [username/password login](./security/basic-http-auth) via basic H
 
 MLflow also provides built-in [network protection](./security/network) middleware to protect your tracking server from network exposure.
 
-:::tip Try Managed MLflow
+:::tip[Try Managed MLflow]
 
 Need highly secure MLflow server? Check out <ins>[Databricks Managed MLflow](https://www.databricks.com/product/managed-mlflow)</ins> to get fully managed MLflow servers with unified governance and security.
 

--- a/docs/docs/self-hosting/migration.mdx
+++ b/docs/docs/self-hosting/migration.mdx
@@ -31,7 +31,7 @@ mlflow db upgrade <backend-store-url>
 
 The command will update the database schema to the latest version using [Alembic](https://alembic.sqlalchemy.org/).
 
-:::warning important
+:::warning[important]
 
 Schema migrations can be slow and are not guaranteed to be transactional. Always take a backup of the database before running the migration.
 

--- a/docs/docs/self-hosting/security/basic-http-auth.mdx
+++ b/docs/docs/self-hosting/security/basic-http-auth.mdx
@@ -1294,7 +1294,7 @@ response = requests.get(
 
 ## Creating a New User
 
-:::warning important
+:::warning[important]
 To create a new user, you are required to authenticate with admin privileges.
 :::
 

--- a/docs/docs/self-hosting/security/network.mdx
+++ b/docs/docs/self-hosting/security/network.mdx
@@ -141,7 +141,7 @@ with mlflow.start_run():
     mlflow.log_metric("rmse", 0.1)
 ```
 
-:::info Host vs Allowed Hosts
+:::info[Host vs Allowed Hosts]
 
 :::
 

--- a/docs/docs/self-hosting/security/secure-installs.md
+++ b/docs/docs/self-hosting/security/secure-installs.md
@@ -51,7 +51,7 @@ pip install --require-hashes --only-binary :all: -r requirements.txt
 
 Both pip and uv support filtering packages by their upload date, ensuring that dependency resolution only considers packages published before a known point in time. This protects against newly published malicious versions and enables reproducible builds.
 
-:::tip Choosing a date
+:::tip[Choosing a date]
 Use an absolute timestamp set to the last date you audited or verified your dependencies. This ensures reproducible installs. Relative durations like `"7 days"` are convenient for rolling policies but produce different results over time.
 :::
 

--- a/docs/docs/self-hosting/webhooks/index.mdx
+++ b/docs/docs/self-hosting/webhooks/index.mdx
@@ -21,7 +21,7 @@ MLflow webhooks enable real-time notifications when specific events occur in the
 - **Multiple event types** including model/prompt creation, versioning, and tagging
 - **Built-in testing** to verify webhook connectivity
 
-:::note Authorization
+:::note[Authorization]
 
 When [MLflow Authentication](/self-hosting/security/basic-http-auth) is enabled, all webhook
 operations (create, list, get, update, delete, and test) require **admin privileges**. Non-admin

--- a/docs/docs/self-hosting/workspaces/configuration.mdx
+++ b/docs/docs/self-hosting/workspaces/configuration.mdx
@@ -56,7 +56,7 @@ mlflow db move-resources <database_uri> \
 The `--resource-type` value is the database table name (`experiments`, `registered_models`,
 `evaluation_datasets`, `webhooks`, `jobs`).
 
-:::note Gateway resources not supported
+:::note[Gateway resources not supported]
 Gateway resources (`secrets`, `endpoints`, `model_definitions`, `budget_policies`) are not
 supported by this command because they have inter-table foreign-key dependencies that make moving
 them independently unsafe.
@@ -142,7 +142,7 @@ This setting controls how the reserved `default` workspace interacts with `defau
 - **`true`**: The `default` workspace inherits `default_permission` for all authenticated users. The
   `default` workspace also appears in `mlflow.list_workspaces()` results for every user.
 
-:::warning Recommendation for existing instances
+:::warning[Recommendation for existing instances]
 If you are enabling workspaces on an existing MLflow instance that already uses basic-auth, set
 `grant_default_workspace_access = true` for backwards compatibility. Without this, all existing
 resources (which live in the `default` workspace) will become inaccessible to non-admin users who

--- a/docs/docs/self-hosting/workspaces/getting-started.mdx
+++ b/docs/docs/self-hosting/workspaces/getting-started.mdx
@@ -11,13 +11,13 @@ Before enabling workspaces, ensure you have:
 - A configured `--default-artifact-root`
 - Database migrations applied via `mlflow db upgrade`
 
-:::warning File-based backends not supported
+:::warning[File-based backends not supported]
 
 Workspaces require a SQL database backend store. File-based tracking and model registry stores (for example `./mlruns` or `file:///...`) are not supported when workspaces are enabled.
 
 :::
 
-:::warning Custom experiment artifact locations are not supported
+:::warning[Custom experiment artifact locations are not supported]
 
 For security, experiments cannot override artifact locations when workspaces are enabled. Workspace
 stores can customize the artifact location at the workspace level.
@@ -214,7 +214,7 @@ mlflow.update_workspace(
 )
 ```
 
-:::note Workspace names are immutable
+:::note[Workspace names are immutable]
 
 Workspace names cannot be changed after creation. Only the description can be updated.
 

--- a/docs/docs/self-hosting/workspaces/index.mdx
+++ b/docs/docs/self-hosting/workspaces/index.mdx
@@ -31,7 +31,7 @@ Use workspaces when you need:
 Workspaces provide logical separation and authorization controls inside one MLflow server. For strict data-plane or compliance isolation, run independent MLflow deployments instead of sharing a server.
 ::::
 
-:::warning Requirements
+:::warning[Requirements]
 
 Workspaces require a SQL database backend store. File-based backends are not supported when workspaces are enabled.
 
@@ -77,7 +77,7 @@ Run artifact roots are derived from the experiment location:
 
 For backward compatibility, resources that existed before enabling workspaces in the reserved `default` workspace keep their stored artifact locations (which may be unprefixed) and remain accessible.
 
-:::note Client-specified artifact locations
+:::note[Client-specified artifact locations]
 
 When workspaces are enabled, client-supplied `artifact_location` values are rejected to prevent bypassing workspace isolation. The server automatically manages artifact locations to ensure proper isolation.
 
@@ -85,7 +85,7 @@ When workspaces are enabled, client-supplied `artifact_location` values are reje
 
 ## Quick Start
 
-:::info Backend and enablement
+:::info[Backend and enablement]
 Workspaces require the SQL backend (file backend not supported). Enable with `MLFLOW_ENABLE_WORKSPACES=1` and configure a workspace provider (the default SQL provider is used when one is not specified).
 :::
 


### PR DESCRIPTION
### Related Issues/PRs

Surfaces during work on #23633: spotted that the `:::info[Title]` form was required for the Claude Code docs to render correctly. Sweep of the rest of the docs found the same issue everywhere.

### What changes are proposed in this pull request?

Docusaurus 3.10 (introduced in #22869) tightened MDX parsing of the deprecated space-title admonition syntax (`:::info Title`), causing **132 admonitions across 80 docs pages** to render as raw `<p>:::xxx Title</p>` paragraphs instead of formatted callout boxes.

This PR mechanically converts every space-title admonition to Docusaurus 3's documented bracket-title form (`:::xxx[Title]`). The conversion touches only the admonition marker lines; surrounding content is unchanged. The full transformation was:

```bash
grep -lrE '^:::(info|note|warning|tip|caution|danger) [^[]' docs/docs/ \
  | xargs -n1 perl -i -pe \
    's/^:::(info|note|warning|tip|caution|danger) (.+)$/:::$1\[$2\]/'
```

Prettier ran clean on all touched files (no formatting diffs).

### How is this PR tested?

- [x] Manual tests

Verified before / after with the dev server (`yarn start`) on a sample of pages:

- `/self-hosting` (`:::warning Default Storage Backend Change`, `:::tip Try Managed MLflow`) - both broke before, render as alert boxes now.
- `/genai/tracing/integrations/listing/langgraph` (`:::info Async Context Propagation`) - same.
- A handful of `classic-ml/`, `genai/eval-monitor/`, and `genai/prompt-registry/` pages also confirmed visually.

The check was scripted - find each admonition marker in the rendered DOM and verify it sits inside `.theme-admonition-*` / `.alert--*` containers rather than as a stray `<p>` element.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the MLflow Skills repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Admonition callout boxes across the MLflow docs (warnings, info notes, tips) now render correctly again instead of as raw `:::xxx` text.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
