### PR TITLE
Bump R serve test wait budget to ~30s

### DIFF
--- a/mlflow/R/mlflow/tests/testthat/test-serve.R
+++ b/mlflow/R/mlflow/tests/testthat/test-serve.R
@@ -4,7 +4,7 @@ library("carrier")
 
 wait_for_server_to_start <- function(server_process, port) {
   status_code <- 500
-  for (i in 1:5) {
+  for (i in 1:6) {
     tryCatch(
       {
         status_code <- httr::status_code(httr::GET(sprintf("http://127.0.0.1:%d/ping/", port)))


### PR DESCRIPTION
### Related Issues/PRs

Relates to flaky R CI run [26555945908](https://github.com/mlflow/mlflow/actions/runs/26555945908/job/78227732765).

### What changes are proposed in this pull request?

Bump the polling loop in `wait_for_server_to_start` (`mlflow/R/mlflow/tests/testthat/test-serve.R`) from 5 iterations to 6, lifting the total wait budget from ~25s to ~30s. The spawned `Rscript ... mlflow_rfunc_serve` occasionally takes longer than 25s to respond to `/ping` on slow runners, which surfaces as `test-serve.R:58 mlflow can serve a model function` failing with `Failed to start the server!`.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)