### PR TITLE
Reword `FileStore` maintenance-mode error and document escape hatch

### DIFF
--- a/docs/docs/self-hosting/architecture/backend-store.mdx
+++ b/docs/docs/self-hosting/architecture/backend-store.mdx
@@ -32,7 +32,7 @@ To use file-based storage, specify `--backend-store-uri ./mlruns` when starting 
 
 :::warning[TO BE DEPRECATED SOON]
 
-File system backend is in Keep-the-Light-On (KTLO) mode and is no longer receiving new feature updates. We strongly recommend using the database backend (now the default) for better performance and reliability. See [Migrate from File Store](/self-hosting/migrate-from-file-store) for how to migrate existing data.
+File system backend is in maintenance mode and will not receive further updates. We strongly recommend using the database backend (now the default) for better performance and reliability. See [Migrate from File Store](/self-hosting/migrate-from-file-store) for how to migrate existing data.
 
 :::
 

--- a/docs/docs/self-hosting/migrate-from-file-store.mdx
+++ b/docs/docs/self-hosting/migrate-from-file-store.mdx
@@ -85,7 +85,7 @@ The migration tool preserves your data exactly as it was in the FileStore. No ti
 ## Continue Using the Filesystem Backend
 
 :::warning
-The filesystem backend is in maintenance mode and will not receive further updates or new features. The recommended path is to [migrate](#quick-start) to a database backend using `mlflow migrate-filestore`, which preserves your existing data losslessly.
+The filesystem backend is in maintenance mode and will not receive further updates. The recommended path is to [migrate](#quick-start) to a database backend using `mlflow migrate-filestore`, which preserves your existing data losslessly.
 :::
 
 This escape hatch exists for the rare case where migration is genuinely not an option (for example, browsing read-only `mlruns` data synced from an HPC cluster that cannot run a database, or sharing a directory snapshot across machines via `rsync`). If your workflow does not have such a constraint, please use the migration tool above instead.

--- a/docs/docs/self-hosting/migrate-from-file-store.mdx
+++ b/docs/docs/self-hosting/migrate-from-file-store.mdx
@@ -82,6 +82,21 @@ The migration tool preserves your data exactly as it was in the FileStore. No ti
 - **Target database must be empty.** The migration tool refuses to write to a database that already contains data to prevent conflicts. If the target file already exists, you will be prompted to overwrite it.
 - **SQLite only.** The migration tool only supports SQLite as the target database. FileStore generates large experiment IDs that exceed the 32-bit integer limit enforced by PostgreSQL and MySQL, but SQLite handles them natively.
 
+## Continue Using the Filesystem Backend
+
+:::warning
+The filesystem backend is in maintenance mode and will not receive further updates or new features. The recommended path is to [migrate](#quick-start) to a database backend using `mlflow migrate-filestore`, which preserves your existing data losslessly.
+:::
+
+This escape hatch exists for the rare case where migration is genuinely not an option (for example, browsing read-only `mlruns` data synced from an HPC cluster that cannot run a database, or sharing a directory snapshot across machines via `rsync`). If your workflow does not have such a constraint, please use the migration tool above instead.
+
+To opt out of the error and continue using the filesystem backend, set the `MLFLOW_ALLOW_FILE_STORE` environment variable before starting the MLflow server or running any client code:
+
+```bash
+export MLFLOW_ALLOW_FILE_STORE=true
+mlflow server --backend-store-uri ./mlruns
+```
+
 ## Feedback
 
 If you run into issues or have feedback (e.g., support for PostgreSQL/MySQL), please comment on [GitHub issue #18534](https://github.com/mlflow/mlflow/issues/18534).

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1553,7 +1553,7 @@ MLFLOW_LOG_UV_FILES = _BooleanEnvironmentVariable("MLFLOW_LOG_UV_FILES", True)
 
 
 #: Specifies whether to allow using the filesystem backend for tracking and model
-#: registry, which is in maintenance mode (no further updates or new features).
+#: registry, which is in maintenance mode (no further updates).
 #: Set to ``True`` to opt out of the error raised when instantiating the file-based
 #: stores and continue using the filesystem backend.
 #: (default: ``False``)

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1552,9 +1552,10 @@ MLFLOW_UV_AUTO_DETECT = _BooleanEnvironmentVariable("MLFLOW_UV_AUTO_DETECT", Tru
 MLFLOW_LOG_UV_FILES = _BooleanEnvironmentVariable("MLFLOW_LOG_UV_FILES", True)
 
 
-#: Specifies whether to allow using the deprecated filesystem backend for tracking
-#: and model registry. Set to ``True`` to opt out of the error raised when
-#: instantiating the file-based stores.
+#: Specifies whether to allow using the filesystem backend for tracking and model
+#: registry, which is in maintenance mode (no further updates or new features).
+#: Set to ``True`` to opt out of the error raised when instantiating the file-based
+#: stores and continue using the filesystem backend.
 #: (default: ``False``)
 MLFLOW_ALLOW_FILE_STORE = _BooleanEnvironmentVariable("MLFLOW_ALLOW_FILE_STORE", False)
 

--- a/mlflow/store/model_registry/file_store.py
+++ b/mlflow/store/model_registry/file_store.py
@@ -136,16 +136,15 @@ class FileStore(AbstractStore):
         if not MLFLOW_ALLOW_FILE_STORE.get():
             raise MlflowException(
                 "The filesystem model registry backend (e.g., './mlruns') is in maintenance "
-                "mode and will not receive further updates or new features. Please migrate "
+                "mode and will not receive further updates. Please migrate "
                 "to a database backend (e.g., 'sqlite:///mlflow.db') to access the latest "
                 "MLflow features. The `mlflow migrate-filestore` tool migrates your existing "
                 "data losslessly. See "
                 "https://mlflow.org/docs/latest/self-hosting/migrate-from-file-store "
-                "for migration guidance. As a last resort, if the filesystem backend is "
-                "absolutely required for your workflow, see "
-                "https://mlflow.org/docs/latest/self-hosting/migrate-from-file-store"
-                "#continue-using-the-filesystem-backend "
-                "for how to bypass this exception.",
+                "for migration guidance. If the filesystem backend is "
+                "required for your workflow, see "
+                "https://mlflow.org/docs/latest/self-hosting/migrate-from-file-store#continue-using-the-filesystem-backend "  # noqa: E501
+                "for how to opt out of this exception by setting `MLFLOW_ALLOW_FILE_STORE=true`.",
                 error_code=INVALID_PARAMETER_VALUE,
             )
         self.root_directory = local_file_uri_to_path(root_directory or _default_root_dir())

--- a/mlflow/store/model_registry/file_store.py
+++ b/mlflow/store/model_registry/file_store.py
@@ -144,7 +144,8 @@ class FileStore(AbstractStore):
                 "for migration guidance. As a last resort, if the filesystem backend is "
                 "absolutely required for your workflow, see "
                 "https://mlflow.org/docs/latest/self-hosting/migrate-from-file-store"
-                "#continue-using-the-filesystem-backend.",
+                "#continue-using-the-filesystem-backend "
+                "for how to bypass this exception.",
                 error_code=INVALID_PARAMETER_VALUE,
             )
         self.root_directory = local_file_uri_to_path(root_directory or _default_root_dir())

--- a/mlflow/store/model_registry/file_store.py
+++ b/mlflow/store/model_registry/file_store.py
@@ -141,10 +141,8 @@ class FileStore(AbstractStore):
                 "MLflow features. The `mlflow migrate-filestore` tool migrates your existing "
                 "data losslessly. See "
                 "https://mlflow.org/docs/latest/self-hosting/migrate-from-file-store "
-                "for migration guidance. If the filesystem backend is "
-                "required for your workflow, see "
-                "https://mlflow.org/docs/latest/self-hosting/migrate-from-file-store#continue-using-the-filesystem-backend "  # noqa: E501
-                "for how to opt out of this exception by setting `MLFLOW_ALLOW_FILE_STORE=true`.",
+                "for migration guidance. If the filesystem backend is required for your "
+                "workflow, set `MLFLOW_ALLOW_FILE_STORE=true` to opt out of this exception.",
                 error_code=INVALID_PARAMETER_VALUE,
             )
         self.root_directory = local_file_uri_to_path(root_directory or _default_root_dir())

--- a/mlflow/store/model_registry/file_store.py
+++ b/mlflow/store/model_registry/file_store.py
@@ -135,11 +135,16 @@ class FileStore(AbstractStore):
         super().__init__()
         if not MLFLOW_ALLOW_FILE_STORE.get():
             raise MlflowException(
-                "The filesystem model registry backend (e.g., './mlruns') is no longer supported. "
-                "Please migrate to a database backend (e.g., 'sqlite:///mlflow.db'). "
-                "See https://mlflow.org/docs/latest/self-hosting/migrate-from-file-store "
-                "for migration guidance. Set the environment variable "
-                f"'{MLFLOW_ALLOW_FILE_STORE.name}=true' to temporarily opt out of this error.",
+                "The filesystem model registry backend (e.g., './mlruns') is in maintenance "
+                "mode and will not receive further updates or new features. Please migrate "
+                "to a database backend (e.g., 'sqlite:///mlflow.db') to access the latest "
+                "MLflow features. The `mlflow migrate-filestore` tool migrates your existing "
+                "data losslessly. See "
+                "https://mlflow.org/docs/latest/self-hosting/migrate-from-file-store "
+                "for migration guidance. As a last resort, if the filesystem backend is "
+                "absolutely required for your workflow, see "
+                "https://mlflow.org/docs/latest/self-hosting/migrate-from-file-store"
+                "#continue-using-the-filesystem-backend.",
                 error_code=INVALID_PARAMETER_VALUE,
             )
         self.root_directory = local_file_uri_to_path(root_directory or _default_root_dir())

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -232,7 +232,8 @@ class FileStore(AbstractStore):
                 "for migration guidance. As a last resort, if the filesystem backend is "
                 "absolutely required for your workflow, see "
                 "https://mlflow.org/docs/latest/self-hosting/migrate-from-file-store"
-                "#continue-using-the-filesystem-backend.",
+                "#continue-using-the-filesystem-backend "
+                "for how to bypass this exception.",
                 error_code=INVALID_PARAMETER_VALUE,
             )
         self.root_directory = local_file_uri_to_path(root_directory or _default_root_dir())

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -224,16 +224,15 @@ class FileStore(AbstractStore):
         if not MLFLOW_ALLOW_FILE_STORE.get():
             raise MlflowException(
                 "The filesystem tracking backend (e.g., './mlruns') is in maintenance mode "
-                "and will not receive further updates or new features. Please migrate to a "
+                "and will not receive further updates. Please migrate to a "
                 "database backend (e.g., 'sqlite:///mlflow.db') to access the latest MLflow "
                 "features. The `mlflow migrate-filestore` tool migrates your existing data "
                 "losslessly. See "
                 "https://mlflow.org/docs/latest/self-hosting/migrate-from-file-store "
-                "for migration guidance. As a last resort, if the filesystem backend is "
-                "absolutely required for your workflow, see "
-                "https://mlflow.org/docs/latest/self-hosting/migrate-from-file-store"
-                "#continue-using-the-filesystem-backend "
-                "for how to bypass this exception.",
+                "for migration guidance. If the filesystem backend is "
+                "required for your workflow, see "
+                "https://mlflow.org/docs/latest/self-hosting/migrate-from-file-store#continue-using-the-filesystem-backend "  # noqa: E501
+                "for how to opt out of this exception by setting `MLFLOW_ALLOW_FILE_STORE=true`.",
                 error_code=INVALID_PARAMETER_VALUE,
             )
         self.root_directory = local_file_uri_to_path(root_directory or _default_root_dir())

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -223,11 +223,16 @@ class FileStore(AbstractStore):
         super().__init__()
         if not MLFLOW_ALLOW_FILE_STORE.get():
             raise MlflowException(
-                "The filesystem tracking backend (e.g., './mlruns') is no longer supported. "
-                "Please migrate to a database backend (e.g., 'sqlite:///mlflow.db'). "
-                "See https://mlflow.org/docs/latest/self-hosting/migrate-from-file-store "
-                "for migration guidance. Set the environment variable "
-                f"'{MLFLOW_ALLOW_FILE_STORE.name}=true' to temporarily opt out of this error.",
+                "The filesystem tracking backend (e.g., './mlruns') is in maintenance mode "
+                "and will not receive further updates or new features. Please migrate to a "
+                "database backend (e.g., 'sqlite:///mlflow.db') to access the latest MLflow "
+                "features. The `mlflow migrate-filestore` tool migrates your existing data "
+                "losslessly. See "
+                "https://mlflow.org/docs/latest/self-hosting/migrate-from-file-store "
+                "for migration guidance. As a last resort, if the filesystem backend is "
+                "absolutely required for your workflow, see "
+                "https://mlflow.org/docs/latest/self-hosting/migrate-from-file-store"
+                "#continue-using-the-filesystem-backend.",
                 error_code=INVALID_PARAMETER_VALUE,
             )
         self.root_directory = local_file_uri_to_path(root_directory or _default_root_dir())

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -229,10 +229,8 @@ class FileStore(AbstractStore):
                 "features. The `mlflow migrate-filestore` tool migrates your existing data "
                 "losslessly. See "
                 "https://mlflow.org/docs/latest/self-hosting/migrate-from-file-store "
-                "for migration guidance. If the filesystem backend is "
-                "required for your workflow, see "
-                "https://mlflow.org/docs/latest/self-hosting/migrate-from-file-store#continue-using-the-filesystem-backend "  # noqa: E501
-                "for how to opt out of this exception by setting `MLFLOW_ALLOW_FILE_STORE=true`.",
+                "for migration guidance. If the filesystem backend is required for your "
+                "workflow, set `MLFLOW_ALLOW_FILE_STORE=true` to opt out of this exception.",
                 error_code=INVALID_PARAMETER_VALUE,
             )
         self.root_directory = local_file_uri_to_path(root_directory or _default_root_dir())


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23634

### What changes are proposed in this pull request?

Soften the error raised when instantiating the filesystem tracking and model registry stores. The current message says the backend is "no longer supported", which reads as a hard removal even though `MLFLOW_ALLOW_FILE_STORE=true` still lets users opt in. Reframe as "maintenance mode" (matching the existing wording in `docs/self-hosting/architecture/backend-store.mdx`) and lead with `mlflow migrate-filestore` as the recommended path.

The error no longer hardcodes the env var name. Instead it links to a new docs section in `migrate-from-file-store.mdx` that documents the env var as an escape hatch for workflows where migration is genuinely not an option (e.g., browsing `mlruns` synced from an HPC cluster, sharing a directory snapshot via `rsync` — the use cases called out in the issue).

Before:

> The filesystem tracking backend (e.g., './mlruns') is no longer supported. Please migrate to a database backend (e.g., 'sqlite:///mlflow.db'). See https://mlflow.org/docs/latest/self-hosting/migrate-from-file-store for migration guidance. Set the environment variable 'MLFLOW_ALLOW_FILE_STORE=true' to temporarily opt out of this error.

After:

> The filesystem tracking backend (e.g., './mlruns') is in maintenance mode and will not receive further updates or new features. Please migrate to a database backend (e.g., 'sqlite:///mlflow.db') to access the latest MLflow features. The \`mlflow migrate-filestore\` tool migrates your existing data losslessly. See https://mlflow.org/docs/latest/self-hosting/migrate-from-file-store for migration guidance. As a last resort, if the filesystem backend is absolutely required for your workflow, see https://mlflow.org/docs/latest/self-hosting/migrate-from-file-store#continue-using-the-filesystem-backend.

### How is this PR tested?

- [x] Manual tests

Verified locally that `FileStore('/tmp/test')` raises with the new message and that `MLFLOW_ALLOW_FILE_STORE=true FileStore('/tmp/test')` still succeeds.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [x] Instructions

Added a "Continue Using the Filesystem Backend" section to `docs/self-hosting/migrate-from-file-store.mdx` that documents the `MLFLOW_ALLOW_FILE_STORE` escape hatch and frames it explicitly as a last resort, with concrete legitimate use cases.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The error message raised when starting MLflow against a filesystem backend now clearly distinguishes the recommended migration path (`mlflow migrate-filestore`) from the `MLFLOW_ALLOW_FILE_STORE` escape hatch, and links to docs that explain when each applies.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] \`area/tracking\`: Tracking Service, tracking client APIs, autologging
- [x] \`area/model-registry\`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] \`area/docs\`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] \`rn/bug-fix\` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release