### PR TITLE
Document backtick handling in `gh pr` heredoc bodies in `CLAUDE.md`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,7 +191,22 @@ git push origin <your-branch>
 
 ### Creating Pull Requests
 
-When creating pull requests, read the instructions at the top of [the PR template](./.github/pull_request_template.md) and follow them carefully.
+- Follow the instructions at the top of [the PR template](./.github/pull_request_template.md) carefully.
+- Inside `gh pr ... --body "$(cat <<'EOF' ... EOF)"`, write backticks plain. The quoted `'EOF'` delimiter already suppresses command substitution, so escaping as `` \` `` is unnecessary and the backslashes get persisted in the PR body, rendering literally instead of as code spans.
+
+  ```bash
+  # Bad
+  gh pr create --body "$(cat <<'EOF'
+  Updated \`pyproject.toml\` to bump the version.
+  EOF
+  )"
+
+  # Good
+  gh pr create --body "$(cat <<'EOF'
+  Updated `pyproject.toml` to bump the version.
+  EOF
+  )"
+  ```
 
 ### Checking CI Status
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,15 +195,9 @@ git push origin <your-branch>
 - Inside `gh pr ... --body "$(cat <<'EOF' ... EOF)"`, write backticks plain. The quoted `'EOF'` delimiter already suppresses command substitution, so escaping as `` \` `` is unnecessary and the backslashes get persisted in the PR body, rendering literally instead of as code spans.
 
   ```bash
-  # Bad
   gh pr create --body "$(cat <<'EOF'
-  Updated \`pyproject.toml\` to bump the version.
-  EOF
-  )"
-
-  # Good
-  gh pr create --body "$(cat <<'EOF'
-  Updated `pyproject.toml` to bump the version.
+  Updated \`pyproject.toml\` to bump the version. # BAD
+  Updated `pyproject.toml` to bump the version.   # GOOD
   EOF
   )"
   ```


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Add a note under `CLAUDE.md` > Creating Pull Requests warning against escaping backticks inside `gh pr ... --body "$(cat <<'EOF' ... EOF)"`. The quoted `'EOF'` delimiter already suppresses command substitution, so backslash-escapes around backticks are unnecessary and the backslashes end up persisted in the rendered PR body (see #23637 for a recent example).

Includes a bad/good snippet so the rule is concrete.

### How is this PR tested?

- [x] Manual tests

Rendered the updated section locally to confirm the code block reads correctly.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)