### PR TITLE
Bump min npm to 11.16.0 in setup-node action

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -13,6 +13,7 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
     - run: |
-        # min-release-age requires npm >= 11.10.0 (https://github.com/npm/cli/releases/tag/v11.10.0)
-        npm install -g npm@"^11.10.0"
+        # allowScripts opt-in install-script policy requires npm >= 11.16.0
+        # (https://github.com/npm/cli/pull/9360)
+        npm install -g npm@"^11.16.0"
       shell: bash


### PR DESCRIPTION
### Related Issues/PRs

Relates to npm/cli#9360

### What changes are proposed in this pull request?

Bump the minimum npm pinned by `.github/actions/setup-node/action.yml` from `^11.10.0` to `^11.16.0`.

Why: npm 11.16.0 ships Phase 1 of the `allowScripts` opt-in install-script policy (npm/cli#9360). Phase 1 is advisory-only: `npm install` now prints a block listing dependencies whose install scripts haven't been reviewed via `allowScripts` in `package.json`. No install behavior changes, but bumping the floor here lets us see those advisories in CI ahead of Phase 2, which will turn the advisory into an actual block.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)