### PR TITLE
Add MlflowWalSpanExporter to hand traces off to the WAL daemon

### DIFF
--- a/libs/typescript/core/src/core/provider.ts
+++ b/libs/typescript/core/src/core/provider.ts
@@ -1,18 +1,33 @@
 import { trace, Tracer } from '@opentelemetry/api';
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { SpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { MlflowClient } from '../clients';
 import { MlflowSpanExporter, MlflowSpanProcessor } from '../exporters/mlflow';
 import {
   DatabricksUCTableSpanExporter,
   DatabricksUCTableSpanProcessor,
 } from '../exporters/uc_table';
-import { NodeSDK } from '@opentelemetry/sdk-node';
-import { SpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { MlflowWalSpanExporter } from '../exporters/wal';
 import { getConfig, getAuthProvider, type UnityCatalogLocationOptions } from './config';
-import { MlflowClient } from '../clients';
 import type { UnityCatalogLocation } from './entities/trace_location';
 
 let sdk: NodeSDK | null = null;
 // Keep a reference to the active span processor for flushing.
 let processor: SpanProcessor | null = null;
+
+/**
+ * Whether to route trace export through the asynchronous WAL +
+ * daemon path instead of the legacy synchronous HTTP exporter
+ * for the MlflowSpanProcessor.
+ */
+export function asyncExportEnabled(): boolean {
+  const raw = process.env.MLFLOW_ENABLE_ASYNC_TRACE_LOGGING;
+  if (raw === undefined || raw === '') {
+    return false;
+  }
+  const lower = raw.toLowerCase();
+  return lower === '1' || lower === 'true';
+}
 
 /**
  * Initialize the OpenTelemetry SDK and span processor.
@@ -51,8 +66,18 @@ export function initializeSDK(): void {
       const ucExporter = new DatabricksUCTableSpanExporter(client);
       processor = new DatabricksUCTableSpanProcessor(ucExporter, ucLocation);
     } else {
-      const exporter = new MlflowSpanExporter(client);
-      processor = new MlflowSpanProcessor(exporter);
+      if (asyncExportEnabled()) {
+        // WAL path: the hook submits records to a daemon over IPC; the
+        // bundled daemon performs the actual auth setup, fsyncs the
+        // record to `queue.log`, and runs the HTTP upload in a separate
+        // process. The IPC client spawns the daemon on first use, so no
+        // client construction or supervisor wiring is needed here.
+        const mlflowWalExporter = new MlflowWalSpanExporter();
+        processor = new MlflowSpanProcessor(mlflowWalExporter);
+      } else {
+        const exporter = new MlflowSpanExporter(client);
+        processor = new MlflowSpanProcessor(exporter);
+      }
     }
 
     sdk = new NodeSDK({ spanProcessors: [processor] });
@@ -87,6 +112,11 @@ export function getTracer(module_name: string): Tracer {
 
 /**
  * Force flush all pending trace exports.
+ *
+ * In WAL mode this only awaits on-disk durability of the WAL appends,
+ * not the upstream HTTP upload — that's the daemon's job and the
+ * caller (e.g. the Claude Code Stop hook) is intentionally decoupled
+ * from backend latency.
  */
 export async function flushTraces(): Promise<void> {
   await processor?.forceFlush();

--- a/libs/typescript/core/src/core/provider.ts
+++ b/libs/typescript/core/src/core/provider.ts
@@ -10,24 +10,11 @@ import {
 import { MlflowWalSpanExporter } from '../exporters/wal';
 import { getConfig, getAuthProvider, type UnityCatalogLocationOptions } from './config';
 import type { UnityCatalogLocation } from './entities/trace_location';
+import { asyncExportEnabled } from './utils/env';
 
 let sdk: NodeSDK | null = null;
 // Keep a reference to the active span processor for flushing.
 let processor: SpanProcessor | null = null;
-
-/**
- * Whether to route trace export through the asynchronous WAL +
- * daemon path instead of the legacy synchronous HTTP exporter
- * for the MlflowSpanProcessor.
- */
-export function asyncExportEnabled(): boolean {
-  const raw = process.env.MLFLOW_ENABLE_ASYNC_TRACE_LOGGING;
-  if (raw === undefined || raw === '') {
-    return false;
-  }
-  const lower = raw.toLowerCase();
-  return lower === '1' || lower === 'true';
-}
 
 /**
  * Initialize the OpenTelemetry SDK and span processor.

--- a/libs/typescript/core/src/core/utils/env.ts
+++ b/libs/typescript/core/src/core/utils/env.ts
@@ -35,3 +35,17 @@ export const readNonNegativeInt = (envName: string, fallback: number): number =>
   }
   return parsed;
 };
+
+/**
+ * Whether to route trace export through an on-dick WAL queue
+ * drained by a background daemon, instead of the synchronous
+ * HTTP exporter.
+ */
+export function asyncExportEnabled(): boolean {
+  const raw = process.env.MLFLOW_ENABLE_ASYNC_TRACE_LOGGING;
+  if (raw === undefined || raw === '') {
+    return false;
+  }
+  const lower = raw.toLowerCase();
+  return lower === '1' || lower === 'true';
+}

--- a/libs/typescript/core/src/core/utils/env.ts
+++ b/libs/typescript/core/src/core/utils/env.ts
@@ -37,7 +37,7 @@ export const readNonNegativeInt = (envName: string, fallback: number): number =>
 };
 
 /**
- * Whether to route trace export through an on-dick WAL queue
+ * Whether to route trace export through an on-disk WAL queue
  * drained by a background daemon, instead of the synchronous
  * HTTP exporter.
  */

--- a/libs/typescript/core/src/exporters/wal/exporter.ts
+++ b/libs/typescript/core/src/exporters/wal/exporter.ts
@@ -1,0 +1,87 @@
+import { randomUUID } from 'node:crypto';
+import { ExportResult, ExportResultCode } from '@opentelemetry/core';
+import { ReadableSpan as OTelReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-base';
+import { getConfig } from '../../core/config';
+import { InMemoryTraceManager } from '../../core/trace_manager';
+import { submitRecord } from './ipc';
+import { WalRecord } from './types';
+
+/**
+ * Hook-side submit function. Returns once the daemon has fsynced the
+ * record to `queue.log` (ack-after-fsync). Injectable so tests can
+ * swap in a stub without spinning up an actual daemon.
+ */
+export type SubmitRecord = (record: WalRecord) => Promise<void>;
+
+/**
+ * Asynchronous SpanExporter that decouples the user's Stop hook from
+ * backend latency for MlflowSpanProcessor.
+ *
+ * {@link forceFlush} awaits only the IPC submits, *not* the upstream
+ * upload. That gives the Stop hook the exact "trace is durable on this
+ * machine, then return" semantics it needs to bound its runtime.
+ */
+export class MlflowWalSpanExporter implements SpanExporter {
+  private _pendingSubmits: Set<Promise<void>> = new Set();
+  private _submit: SubmitRecord;
+
+  constructor(opts: { submit?: SubmitRecord } = {}) {
+    this._submit = opts.submit ?? submitRecord;
+  }
+
+  export(spans: OTelReadableSpan[], resultCallback: (result: ExportResult) => void): void {
+    for (const span of spans) {
+      if (span.parentSpanContext?.spanId) {
+        continue;
+      }
+
+      const traceManager = InMemoryTraceManager.getInstance();
+      const trace = traceManager.popTrace(span.spanContext().traceId);
+      if (!trace) {
+        console.warn(`No trace found for span ${span.name}. Skipping.`);
+        continue;
+      }
+
+      traceManager.lastActiveTraceId = trace.info.traceId;
+
+      const cfg = getConfig();
+      const record: WalRecord = {
+        id: randomUUID(),
+        trackingUri: cfg.trackingUri,
+        experimentId: cfg.experimentId,
+        traceInfo: trace.info.toJson() as unknown as Record<string, unknown>,
+        traceData: trace.data.toJson(),
+        attempts: 0,
+        nextAttemptAt: 0,
+        createdAt: Date.now(),
+      };
+
+      const pending = this._submit(record).catch((err) => {
+        console.error(
+          `[mlflow][wal] Failed to submit WAL record for trace ${trace.info.traceId}:`,
+          err,
+        );
+      });
+      this._pendingSubmits.add(pending);
+
+      void pending.finally(() => this._pendingSubmits.delete(pending));
+    }
+
+    resultCallback({ code: ExportResultCode.SUCCESS });
+  }
+
+  /**
+   * Resolves once every IPC submit that was in flight when this method
+   * was called has been acknowledged (post-fsync). Matches OTel's
+   * "flush currently pending" semantic — concurrent `export()` calls
+   * during the await are not waited on, and the next `forceFlush` will
+   * pick them up.
+   */
+  async forceFlush(): Promise<void> {
+    await Promise.all([...this._pendingSubmits]);
+  }
+
+  async shutdown(): Promise<void> {
+    await this.forceFlush();
+  }
+}

--- a/libs/typescript/core/src/exporters/wal/exporter.ts
+++ b/libs/typescript/core/src/exporters/wal/exporter.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { ExportResult, ExportResultCode } from '@opentelemetry/core';
 import { ReadableSpan as OTelReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-base';
-import { getConfig } from '../../core/config';
+import { getConfig, MLflowTracingConfig } from '../../core/config';
 import { InMemoryTraceManager } from '../../core/trace_manager';
 import { submitRecord } from './ipc';
 import { WalRecord } from './types';
@@ -24,12 +24,30 @@ export type SubmitRecord = (record: WalRecord) => Promise<void>;
 export class MlflowWalSpanExporter implements SpanExporter {
   private _pendingSubmits: Set<Promise<void>> = new Set();
   private _submit: SubmitRecord;
+  private _shuttingDown = false;
 
   constructor(opts: { submit?: SubmitRecord } = {}) {
     this._submit = opts.submit ?? submitRecord;
   }
 
   export(spans: OTelReadableSpan[], resultCallback: (result: ExportResult) => void): void {
+    if (this._shuttingDown) {
+      resultCallback({ code: ExportResultCode.FAILED });
+      return;
+    }
+
+    let cfg: MLflowTracingConfig;
+    try {
+      cfg = getConfig();
+    } catch (err) {
+      console.warn(
+        '[mlflow][wal] Tracing config unavailable; Spans will be lost until config is set.',
+        err,
+      );
+      resultCallback({ code: ExportResultCode.FAILED });
+      return;
+    }
+
     for (const span of spans) {
       if (span.parentSpanContext?.spanId) {
         continue;
@@ -44,7 +62,6 @@ export class MlflowWalSpanExporter implements SpanExporter {
 
       traceManager.lastActiveTraceId = trace.info.traceId;
 
-      const cfg = getConfig();
       const record: WalRecord = {
         id: randomUUID(),
         trackingUri: cfg.trackingUri,
@@ -75,13 +92,21 @@ export class MlflowWalSpanExporter implements SpanExporter {
    * was called has been acknowledged (post-fsync). Matches OTel's
    * "flush currently pending" semantic — concurrent `export()` calls
    * during the await are not waited on, and the next `forceFlush` will
-   * pick them up.
+   * pick them up. For "drain everything before exit" semantics, use
+   * {@link shutdown}.
    */
   async forceFlush(): Promise<void> {
     await Promise.all([...this._pendingSubmits]);
   }
 
+  /**
+   * Stop accepting new exports and drain every in-flight IPC submit to
+   * convergence before resolving.
+   */
   async shutdown(): Promise<void> {
-    await this.forceFlush();
+    this._shuttingDown = true;
+    while (this._pendingSubmits.size > 0) {
+      await Promise.all([...this._pendingSubmits]);
+    }
   }
 }

--- a/libs/typescript/core/src/exporters/wal/index.ts
+++ b/libs/typescript/core/src/exporters/wal/index.ts
@@ -1,10 +1,5 @@
 /**
  * Public entry point for the WAL exporter package.
- *
- * Only `MlflowWalSpanExporter` is re-exported here; the daemon,
- * supervisor, storage and clients modules are implementation details
- * that are either bundled into the standalone daemon binary or
- * imported directly by tests, not part of the @mlflow/core public API.
  */
 
 export { MlflowWalSpanExporter } from './exporter';

--- a/libs/typescript/core/src/exporters/wal/index.ts
+++ b/libs/typescript/core/src/exporters/wal/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Public entry point for the WAL exporter package.
+ *
+ * Only `MlflowWalSpanExporter` is re-exported here; the daemon,
+ * supervisor, storage and clients modules are implementation details
+ * that are either bundled into the standalone daemon binary or
+ * imported directly by tests, not part of the @mlflow/core public API.
+ */
+
+export { MlflowWalSpanExporter } from './exporter';

--- a/libs/typescript/core/src/exporters/wal/supervisor.ts
+++ b/libs/typescript/core/src/exporters/wal/supervisor.ts
@@ -1,6 +1,6 @@
 /**
  * Daemon supervisor - handles the "is the uploader daemon alive? if not,
- * spawn one" check invoked by `WalSpanExporter` on each WAL append.
+ * spawn one" check invoked by `MlflowWalSpanExporter` on each WAL append.
  */
 
 import { spawn } from 'node:child_process';

--- a/libs/typescript/core/tests/exporters/wal/exporter.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/exporter.test.ts
@@ -243,7 +243,15 @@ describe('wal/exporter', () => {
     expect(popTraceSpy).not.toHaveBeenCalled();
   });
 
-  it('shutdown drains submits that land after the flag is set but before the loop converges', async () => {
+  it('shutdown awaits all in-flight submits, not just the first to resolve', async () => {
+    // Both `export()` calls run synchronously to completion before
+    // `shutdown()` is invoked, so both submit promises are already
+    // in `_pendingSubmits` when the drain loop takes its first
+    // snapshot. (The `_shuttingDown` flag in `export()` makes the
+    // "submit lands after the flag is set" scenario structurally
+    // impossible in single-threaded JS — once the flag flips, every
+    // export call short-circuits with FAILED before touching the
+    // Set.
     let releaseFirst: (() => void) | undefined;
     let releaseSecond: (() => void) | undefined;
     const submit = jest
@@ -266,13 +274,10 @@ describe('wal/exporter', () => {
       .mockReturnValueOnce(makeTrace('tr-first'))
       .mockReturnValueOnce(makeTrace('tr-second'));
 
-    // Submit #1 is in flight before shutdown is called.
+    // Two submits enter `_pendingSubmits` synchronously, parked on
+    // their respective `release*` resolvers.
     const cb1 = captureExportResult();
     exporter.export([makeSpan({ traceId: 'otel-1', rootSpan: true })], cb1.callback);
-
-    // Simulate the race: submit #2 is initiated BEFORE shutdown flips
-    // the flag (i.e., upstream processor's export is interleaved with
-    // shutdown). #2 lands in `_pendingSubmits` and must be drained.
     const cb2 = captureExportResult();
     exporter.export([makeSpan({ traceId: 'otel-2', rootSpan: true })], cb2.callback);
 
@@ -281,9 +286,9 @@ describe('wal/exporter', () => {
       shutdownResolved = true;
     });
 
-    // Release #1; #2 is still parked, so shutdown must stay pending —
-    // proving the drain loop is awaiting more than just the original
-    // snapshot.
+    // Release submit #1 only. #2 is still parked, so `Promise.all`
+    // inside the drain loop must remain pending — proving shutdown
+    // awaits both, not just one.
     await new Promise((resolve) => setImmediate(resolve));
     releaseFirst?.();
     await new Promise((resolve) => setImmediate(resolve));

--- a/libs/typescript/core/tests/exporters/wal/exporter.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/exporter.test.ts
@@ -1,0 +1,234 @@
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { ExportResult, ExportResultCode } from '@opentelemetry/core';
+import { ReadableSpan as OTelReadableSpan } from '@opentelemetry/sdk-trace-base';
+import { MlflowWalSpanExporter } from '../../../src/exporters/wal/exporter';
+import { init } from '../../../src/core/config';
+import { InMemoryTraceManager } from '../../../src/core/trace_manager';
+import { Trace } from '../../../src/core/entities/trace';
+import { TraceInfo } from '../../../src/core/entities/trace_info';
+import { TraceData } from '../../../src/core/entities/trace_data';
+import { createTraceLocationFromExperimentId } from '../../../src/core/entities/trace_location';
+import { TraceState } from '../../../src/core/entities/trace_state';
+import type { WalRecord } from '../../../src/exporters/wal/types';
+
+function makeTrace(traceId: string): Trace {
+  const info = new TraceInfo({
+    traceId,
+    traceLocation: createTraceLocationFromExperimentId('exp-test'),
+    requestTime: 1_700_000_000_000,
+    state: TraceState.OK,
+    executionDuration: 42,
+    traceMetadata: { 'mlflow.trace.schemaVersion': '3' },
+    tags: {},
+    assessments: [],
+  });
+  const data = new TraceData([]);
+  return new Trace(info, data);
+}
+
+function makeSpan(opts: { traceId: string; rootSpan: boolean; name?: string }): OTelReadableSpan {
+  return {
+    name: opts.name ?? (opts.rootSpan ? 'root' : 'child'),
+    spanContext: () => ({ traceId: opts.traceId, spanId: 'span-id' }),
+    parentSpanContext: opts.rootSpan ? undefined : { spanId: 'parent-span-id' },
+  } as unknown as OTelReadableSpan;
+}
+
+function captureExportResult(): {
+  callback: (r: ExportResult) => void;
+  promise: Promise<ExportResult>;
+} {
+  let resolveFn: (r: ExportResult) => void = () => {};
+  const promise = new Promise<ExportResult>((resolve) => {
+    resolveFn = resolve;
+  });
+  return { callback: resolveFn, promise };
+}
+
+describe('wal/exporter', () => {
+  let walDir: string;
+  let popTraceSpy: jest.SpyInstance;
+  // Capture the developer's pre-test value so we restore (not just unset)
+  // in afterEach. Mirrors the pattern in paths.test.ts so running
+  // `MLFLOW_WAL_DIR=/some/dir jest` doesn't lose the override for later
+  // tests in the same worker.
+  const originalWalDir = process.env.MLFLOW_WAL_DIR;
+
+  beforeEach(async () => {
+    walDir = await mkdtemp(join(tmpdir(), 'mlflow-wal-exporter-'));
+    process.env.MLFLOW_WAL_DIR = walDir;
+
+    init({ trackingUri: 'http://localhost:5000', experimentId: 'exp-test' });
+
+    popTraceSpy = jest.spyOn(InMemoryTraceManager.getInstance(), 'popTrace');
+  });
+
+  afterEach(async () => {
+    popTraceSpy.mockRestore();
+    if (originalWalDir === undefined) {
+      delete process.env.MLFLOW_WAL_DIR;
+    } else {
+      process.env.MLFLOW_WAL_DIR = originalWalDir;
+    }
+    await rm(walDir, { recursive: true, force: true });
+  });
+
+  it('submits one WAL record per root span via the injected submitter', async () => {
+    const submit = jest.fn<Promise<void>, [WalRecord]>().mockResolvedValue(undefined);
+    const exporter = new MlflowWalSpanExporter({ submit });
+
+    popTraceSpy.mockReturnValue(makeTrace('tr-abc'));
+    const span = makeSpan({ traceId: 'otel-1', rootSpan: true });
+
+    const { callback, promise } = captureExportResult();
+    exporter.export([span], callback);
+
+    expect((await promise).code).toBe(ExportResultCode.SUCCESS);
+    await exporter.forceFlush();
+
+    expect(submit).toHaveBeenCalledTimes(1);
+    const record = submit.mock.calls[0][0];
+    expect(record.trackingUri).toBe('http://localhost:5000');
+    expect(record.experimentId).toBe('exp-test');
+    expect((record.traceInfo as { trace_id: string }).trace_id).toBe('tr-abc');
+    expect(typeof record.id).toBe('string');
+    expect(record.id.length).toBeGreaterThan(0);
+  });
+
+  it('skips non-root spans without invoking the submitter', async () => {
+    const submit = jest.fn<Promise<void>, [WalRecord]>().mockResolvedValue(undefined);
+    const exporter = new MlflowWalSpanExporter({ submit });
+
+    const childSpan = makeSpan({ traceId: 'otel-1', rootSpan: false });
+    const { callback, promise } = captureExportResult();
+    exporter.export([childSpan], callback);
+
+    expect((await promise).code).toBe(ExportResultCode.SUCCESS);
+    expect(submit).not.toHaveBeenCalled();
+    expect(popTraceSpy).not.toHaveBeenCalled();
+
+    await exporter.forceFlush();
+  });
+
+  it('warns and skips when popTrace returns null', async () => {
+    const submit = jest.fn<Promise<void>, [WalRecord]>().mockResolvedValue(undefined);
+    const exporter = new MlflowWalSpanExporter({ submit });
+
+    popTraceSpy.mockReturnValue(null);
+    const span = makeSpan({ traceId: 'otel-missing', rootSpan: true, name: 'orphan' });
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { callback, promise } = captureExportResult();
+      exporter.export([span], callback);
+
+      expect((await promise).code).toBe(ExportResultCode.SUCCESS);
+      expect(submit).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('No trace found for span orphan'),
+      );
+
+      await exporter.forceFlush();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('handles a batch with mixed root and child spans', async () => {
+    const submit = jest.fn<Promise<void>, [WalRecord]>().mockResolvedValue(undefined);
+    const exporter = new MlflowWalSpanExporter({ submit });
+
+    popTraceSpy.mockReturnValueOnce(makeTrace('tr-1')).mockReturnValueOnce(makeTrace('tr-2'));
+
+    const spans = [
+      makeSpan({ traceId: 'otel-1', rootSpan: true, name: 'root-1' }),
+      makeSpan({ traceId: 'otel-1', rootSpan: false, name: 'child' }),
+      makeSpan({ traceId: 'otel-2', rootSpan: true, name: 'root-2' }),
+    ];
+    const { callback, promise } = captureExportResult();
+    exporter.export(spans, callback);
+
+    expect((await promise).code).toBe(ExportResultCode.SUCCESS);
+    expect(submit).toHaveBeenCalledTimes(2);
+    expect(popTraceSpy).toHaveBeenCalledTimes(2);
+
+    await exporter.forceFlush();
+
+    const traceIds = submit.mock.calls
+      .map(([record]) => (record.traceInfo as { trace_id: string }).trace_id)
+      .sort();
+    expect(traceIds).toEqual(['tr-1', 'tr-2']);
+  });
+
+  it('forceFlush resolves only once every in-flight submit has acked', async () => {
+    let release: (() => void) | undefined;
+    const submit = jest.fn<Promise<void>, [WalRecord]>().mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve;
+        }),
+    );
+    const exporter = new MlflowWalSpanExporter({ submit });
+
+    popTraceSpy.mockReturnValue(makeTrace('tr-flush'));
+    const span = makeSpan({ traceId: 'otel-1', rootSpan: true });
+
+    const { callback } = captureExportResult();
+    exporter.export([span], callback);
+
+    let flushResolved = false;
+    const flush = exporter.forceFlush().then(() => {
+      flushResolved = true;
+    });
+    // The submit is parked on `release`; until we resolve it, forceFlush
+    // must remain pending. Yield a few microtasks to give any premature
+    // resolution a chance to surface.
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(flushResolved).toBe(false);
+
+    release?.();
+    await flush;
+    expect(flushResolved).toBe(true);
+  });
+
+  it('shutdown defers to forceFlush', async () => {
+    const exporter = new MlflowWalSpanExporter({ submit: () => Promise.resolve() });
+    const flushSpy = jest.spyOn(exporter, 'forceFlush');
+    await exporter.shutdown();
+    expect(flushSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs and swallows submit failures so OTel never observes them', async () => {
+    const submit = jest
+      .fn<Promise<void>, [WalRecord]>()
+      .mockRejectedValue(new Error('daemon unreachable'));
+    const exporter = new MlflowWalSpanExporter({ submit });
+
+    popTraceSpy.mockReturnValue(makeTrace('tr-err'));
+    const span = makeSpan({ traceId: 'otel-1', rootSpan: true });
+
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const { callback, promise } = captureExportResult();
+      exporter.export([span], callback);
+
+      // OTel sees SUCCESS regardless of submit outcome — the exporter
+      // owns durability semantics and must not bubble per-record
+      // failures into the OTel result callback (which would surface as
+      // an SDK-level error users can't act on).
+      expect((await promise).code).toBe(ExportResultCode.SUCCESS);
+
+      await exporter.forceFlush();
+      expect(submit).toHaveBeenCalledTimes(1);
+      expect(errSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to submit WAL record for trace tr-err'),
+        expect.any(Error),
+      );
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+});

--- a/libs/typescript/core/tests/exporters/wal/exporter.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/exporter.test.ts
@@ -4,7 +4,7 @@ import { join } from 'path';
 import { ExportResult, ExportResultCode } from '@opentelemetry/core';
 import { ReadableSpan as OTelReadableSpan } from '@opentelemetry/sdk-trace-base';
 import { MlflowWalSpanExporter } from '../../../src/exporters/wal/exporter';
-import { init } from '../../../src/core/config';
+import { init, resetConfig } from '../../../src/core/config';
 import { InMemoryTraceManager } from '../../../src/core/trace_manager';
 import { Trace } from '../../../src/core/entities/trace';
 import { TraceInfo } from '../../../src/core/entities/trace_info';
@@ -67,6 +67,7 @@ describe('wal/exporter', () => {
 
   afterEach(async () => {
     popTraceSpy.mockRestore();
+    InMemoryTraceManager.reset();
     if (originalWalDir === undefined) {
       delete process.env.MLFLOW_WAL_DIR;
     } else {
@@ -194,11 +195,135 @@ describe('wal/exporter', () => {
     expect(flushResolved).toBe(true);
   });
 
-  it('shutdown defers to forceFlush', async () => {
-    const exporter = new MlflowWalSpanExporter({ submit: () => Promise.resolve() });
-    const flushSpy = jest.spyOn(exporter, 'forceFlush');
+  it('shutdown awaits in-flight submits before resolving', async () => {
+    let release: (() => void) | undefined;
+    const submit = jest.fn<Promise<void>, [WalRecord]>().mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve;
+        }),
+    );
+    const exporter = new MlflowWalSpanExporter({ submit });
+
+    popTraceSpy.mockReturnValue(makeTrace('tr-shutdown'));
+    const { callback } = captureExportResult();
+    exporter.export([makeSpan({ traceId: 'otel-1', rootSpan: true })], callback);
+
+    let shutdownResolved = false;
+    const shutdownPromise = exporter.shutdown().then(() => {
+      shutdownResolved = true;
+    });
+
+    // The submit is parked; shutdown must remain pending until we
+    // release it. Yield a few microtasks so any premature resolution
+    // surfaces here rather than silently passing.
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(shutdownResolved).toBe(false);
+
+    release?.();
+    await shutdownPromise;
+    expect(shutdownResolved).toBe(true);
+  });
+
+  it('shutdown rejects subsequent export calls with FAILED per OTel spec', async () => {
+    // OTel SpanExporter.Shutdown spec: "After the call to Shutdown
+    // subsequent calls to Export are not allowed and SHOULD return
+    // a failure." Locks in the post-shutdown contract.
+    const submit = jest.fn<Promise<void>, [WalRecord]>().mockResolvedValue(undefined);
+    const exporter = new MlflowWalSpanExporter({ submit });
     await exporter.shutdown();
-    expect(flushSpy).toHaveBeenCalledTimes(1);
+
+    popTraceSpy.mockReturnValue(makeTrace('tr-post-shutdown'));
+    const { callback, promise } = captureExportResult();
+    exporter.export([makeSpan({ traceId: 'otel-post', rootSpan: true })], callback);
+
+    expect((await promise).code).toBe(ExportResultCode.FAILED);
+    expect(submit).not.toHaveBeenCalled();
+    expect(popTraceSpy).not.toHaveBeenCalled();
+  });
+
+  it('shutdown drains submits that land after the flag is set but before the loop converges', async () => {
+    let releaseFirst: (() => void) | undefined;
+    let releaseSecond: (() => void) | undefined;
+    const submit = jest
+      .fn<Promise<void>, [WalRecord]>()
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            releaseFirst = resolve;
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            releaseSecond = resolve;
+          }),
+      );
+    const exporter = new MlflowWalSpanExporter({ submit });
+
+    popTraceSpy
+      .mockReturnValueOnce(makeTrace('tr-first'))
+      .mockReturnValueOnce(makeTrace('tr-second'));
+
+    // Submit #1 is in flight before shutdown is called.
+    const cb1 = captureExportResult();
+    exporter.export([makeSpan({ traceId: 'otel-1', rootSpan: true })], cb1.callback);
+
+    // Simulate the race: submit #2 is initiated BEFORE shutdown flips
+    // the flag (i.e., upstream processor's export is interleaved with
+    // shutdown). #2 lands in `_pendingSubmits` and must be drained.
+    const cb2 = captureExportResult();
+    exporter.export([makeSpan({ traceId: 'otel-2', rootSpan: true })], cb2.callback);
+
+    let shutdownResolved = false;
+    const shutdownPromise = exporter.shutdown().then(() => {
+      shutdownResolved = true;
+    });
+
+    // Release #1; #2 is still parked, so shutdown must stay pending —
+    // proving the drain loop is awaiting more than just the original
+    // snapshot.
+    await new Promise((resolve) => setImmediate(resolve));
+    releaseFirst?.();
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(shutdownResolved).toBe(false);
+
+    releaseSecond?.();
+    await shutdownPromise;
+    expect(shutdownResolved).toBe(true);
+    expect(submit).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns FAILED and warns when getConfig() throws (init not called)', async () => {
+    resetConfig();
+
+    const submit = jest.fn<Promise<void>, [WalRecord]>().mockResolvedValue(undefined);
+    const exporter = new MlflowWalSpanExporter({ submit });
+
+    popTraceSpy.mockReturnValue(makeTrace('tr-no-config'));
+    const span = makeSpan({ traceId: 'otel-no-config', rootSpan: true });
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { callback, promise } = captureExportResult();
+      exporter.export([span], callback);
+
+      const result = await promise;
+      expect(result.code).toBe(ExportResultCode.FAILED);
+      expect(submit).not.toHaveBeenCalled();
+      expect(popTraceSpy).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Tracing config unavailable'),
+        expect.any(Error),
+      );
+    } finally {
+      warnSpy.mockRestore();
+      // Restore config defensively so a downstream test that forgets
+      // to re-init doesn't observe the cleared global state.
+      init({ trackingUri: 'http://localhost:5000', experimentId: 'exp-test' });
+    }
   });
 
   it('logs and swallows submit failures so OTel never observes them', async () => {


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/23641/files) to review incremental changes.
- [stack/ipc-batch-cc-tracing](https://github.com/mlflow/mlflow/pull/23579) [[Files changed](https://github.com/mlflow/mlflow/pull/23579/files)] [MERGED]
  - [stack/daemon-impl-batch-tracing](https://github.com/mlflow/mlflow/pull/23605) [[Files changed](https://github.com/mlflow/mlflow/pull/23605/files)] [MERGED]
    - [**stack/walspan-impl**](https://github.com/mlflow/mlflow/pull/23641) [[Files changed](https://github.com/mlflow/mlflow/pull/23641/files)]

---------
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

Add MlflowWalSpanExporter to hand traces off to the WAL daemon

Hook-side OTel exporter for async trace export. The WAL daemon
(committed earlier) is the actual upload pipeline; this commit wires
the OpenTelemetry SDK to that daemon via IPC.

- exporter.ts: new MlflowWalSpanExporter implementing SpanExporter.
  Each root span is serialized into a WalRecord and handed off via an
  injected submitter (defaults to the IPC client in ipc.ts). forceFlush
  awaits a snapshot of in-flight submits — ack-after-fsync from the
  daemon — not the upstream HTTP upload, so the hook's await is bounded
  by local disk latency instead of backend roundtrip.
- index.ts: public re-export of MlflowWalSpanExporter; daemon,
  supervisor, storage and ipc remain internal.
- exporter.test.ts: unit tests against a stubbed submitter covering
  root/child span filtering, WalRecord construction, pending-submit
  tracking, and forceFlush semantics. No real daemon is spawned.
- provider.ts: add asyncExportEnabled() reading
  MLFLOW_ENABLE_ASYNC_TRACE_LOGGING; in the non-UC branch, route to
  MlflowWalSpanExporter when set, otherwise keep the existing
  synchronous MlflowSpanExporter. UC traceLocation continues to take
  precedence over async export since the WAL daemon does not yet
  support V4/UC uploads.
- provider.ts: extend flushTraces JSDoc to document WAL-mode semantics
  (durability on local disk, not backend HTTP completion).
- supervisor.ts: update stale JSDoc reference to the new
  MlflowWalSpanExporter symbol name.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Claude code tracing now supports batched processing

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
