### PR TITLE
Skip auto-triage for security-titled issues

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -35,12 +35,30 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: python .github/workflows/triage.py test
 
+  decide:
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-slim
+    timeout-minutes: 1
+    permissions: {}
+    outputs:
+      skip: ${{ steps.decide.outputs.skip }}
+    steps:
+      - id: decide
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+        run: |
+          # Skip security reports. They should go through the security channel, not auto-triage.
+          # ${var,,} lowercases for case-insensitive match.
+          skip=$([[ "${ISSUE_TITLE,,}" == *security* ]] && echo true || echo false)
+          echo "skip=$skip" >> "$GITHUB_OUTPUT"
+
   # Main job: runs on new issues
   # All new issues are screened for prompt injection; only bug-labeled issues that pass
   # the screen proceed to triage. Comments are only posted for area/uiux bugs; other
   # bugs are triaged silently for observation.
   triage:
-    if: github.event_name == 'issues'
+    needs: decide
+    if: needs.decide.outputs.skip == 'false'
     runs-on: ubuntu-slim
     timeout-minutes: 5
     permissions:


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23500

### What changes are proposed in this pull request?

Add a `decide` job to `.github/workflows/triage.yml` that emits a `skip` output. The `triage` job now runs only when `skip == 'false'`. Today the rule skips any issue whose title contains "security" (case-insensitive).

Why: security reports should go through the security channel, not the public auto-triage flow. Issue #23500 ("Security: Mass SSRF...") is an example: the prompt-injection screener flagged it suspicious and posted a public comment, which is the wrong outcome for a security report. Putting the gate in its own job keeps future skip rules (other title patterns, label gates, etc.) in one place.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)