### PR TITLE
security: fix chunked encoding bypass in upload-artifact and zip slip in project utils

### DIFF
--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -11,7 +11,7 @@ from io import BytesIO
 from mlflow import tracking
 from mlflow.entities import Param, SourceType
 from mlflow.environment_variables import MLFLOW_EXPERIMENT_ID, MLFLOW_RUN_ID, MLFLOW_TRACKING_URI
-from mlflow.exceptions import ExecutionException
+from mlflow.exceptions import ExecutionException, INVALID_PARAMETER_VALUE, MlflowException
 from mlflow.projects import _project_spec
 from mlflow.tracking import fluent
 from mlflow.tracking.context.default_context import _get_user
@@ -177,6 +177,14 @@ def _fetch_project(uri, version=None):
 
 def _unzip_repo(zip_file, dst_dir):
     with zipfile.ZipFile(zip_file) as zip_in:
+        for member in zip_in.infolist():
+            member_path = os.path.join(dst_dir, member.filename)
+            member_path = os.path.normpath(member_path)
+            if not member_path.startswith(os.path.normpath(dst_dir) + os.sep):
+                raise MlflowException(
+                    message=f"Zip file member {member.filename} attempts path traversal",
+                    error_code=INVALID_PARAMETER_VALUE,
+                )
         zip_in.extractall(dst_dir)
 
 

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -2350,16 +2350,18 @@ def upload_artifact_handler():
         )
     path = validate_path_is_safe(path)
 
-    if request.content_length and request.content_length > 10 * 1024 * 1024:
-        raise MlflowException(
-            message="Artifact size is too large. Max size is 10MB.",
-            error_code=INVALID_PARAMETER_VALUE,
-        )
-
     data = request.data
     if not data:
         raise MlflowException(
             message="Request must specify data.",
+            error_code=INVALID_PARAMETER_VALUE,
+        )
+
+    # Security: enforce size limit even when content_length is None
+    # (e.g., chunked transfer encoding)
+    if len(data) > 10 * 1024 * 1024:
+        raise MlflowException(
+            message="Artifact size is too large. Max size is 10MB.",
             error_code=INVALID_PARAMETER_VALUE,
         )
 

--- a/tests/projects/test_utils.py
+++ b/tests/projects/test_utils.py
@@ -19,6 +19,7 @@ from mlflow.projects.utils import (
     _is_valid_branch_name,
     _is_zip_uri,
     _parse_subdirectory,
+    _unzip_repo,
     fetch_and_validate_project,
     get_or_create_run,
     load_project,
@@ -263,3 +264,16 @@ def test_fetch_create_and_log(tmp_path):
         assert entry_point_name == run.data.tags[MLFLOW_PROJECT_ENTRY_POINT]
         assert project_uri == run.data.tags[MLFLOW_SOURCE_NAME]
         assert user_param == run.data.params
+
+
+def test_unzip_repo_rejects_path_traversal(tmp_path):
+    """Verify that zip files with path traversal members are rejected."""
+    import io
+    from mlflow.exceptions import MlflowException
+
+    malicious_zip = tmp_path / "malicious.zip"
+    with zipfile.ZipFile(malicious_zip, "w") as zf:
+        zf.writestr("../../../etc/passwd", "pwned")
+
+    with pytest.raises(MlflowException, match="path traversal"):
+        _unzip_repo(str(malicious_zip), str(tmp_path / "dst"))

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -2336,6 +2336,20 @@ def test_upload_artifact_handler_rejects_invalid_requests(mlflow_client):
     )
     assert_response(response, "Request must specify data.")
 
+    # Test that size limit is enforced even with chunked transfer encoding
+    # (content_length is None for chunked encoding)
+    large_data = "x" * (10 * 1024 * 1024 + 1)
+    response = requests.post(
+        f"{mlflow_client.tracking_uri}/ajax-api/2.0/mlflow/upload-artifact",
+        params={
+            "run_uuid": created_run.info.run_id,
+            "path": "test.txt",
+        },
+        data=large_data,
+        headers={"Transfer-Encoding": "chunked"},
+    )
+    assert_response(response, "Artifact size is too large")
+
 
 def test_upload_artifact_handler(mlflow_client):
     experiment_id = mlflow_client.create_experiment("upload_artifacts_test")


### PR DESCRIPTION
This PR fixes two security vulnerabilities:

**1. Chunked Transfer Encoding Size Limit Bypass**
**File:** mlflow/server/handlers.py
**CWE:** CWE-400 (Uncontrolled Resource Consumption)

upload_artifact_handler() enforced a 10MB size limit using request.content_length, which is None under chunked transfer encoding. An attacker could bypass the limit and upload unlimited data, causing disk exhaustion.

**Fix:** Check len(data) after reading request.data, which works regardless of transfer encoding.

**2. Zip Slip in Project Utils**
**File:** mlflow/projects/utils.py
**CWE:** CWE-22 (Path Traversal)

_unzip_repo() used zipfile.extractall() without validating member paths. A malicious zip in mlflow run <zip-url> could write arbitrary files outside the destination directory.

**Fix:** Validate each zip member stays within dst_dir before extraction.

**Tests:** Added tests for both vulnerabilities.