### PR TITLE
fix: Enforce upload size limits and safe project zip extraction

### DIFF
--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -11,7 +11,7 @@ from io import BytesIO
 from mlflow import tracking
 from mlflow.entities import Param, SourceType
 from mlflow.environment_variables import MLFLOW_EXPERIMENT_ID, MLFLOW_RUN_ID, MLFLOW_TRACKING_URI
-from mlflow.exceptions import ExecutionException
+from mlflow.exceptions import ExecutionException, INVALID_PARAMETER_VALUE, MlflowException
 from mlflow.projects import _project_spec
 from mlflow.tracking import fluent
 from mlflow.tracking.context.default_context import _get_user
@@ -177,6 +177,14 @@ def _fetch_project(uri, version=None):
 
 def _unzip_repo(zip_file, dst_dir):
     with zipfile.ZipFile(zip_file) as zip_in:
+        for member in zip_in.infolist():
+            member_path = os.path.join(dst_dir, member.filename)
+            member_path = os.path.normpath(member_path)
+            if not member_path.startswith(os.path.normpath(dst_dir) + os.sep):
+                raise MlflowException(
+                    message=f"Zip file member {member.filename} attempts path traversal",
+                    error_code=INVALID_PARAMETER_VALUE,
+                )
         zip_in.extractall(dst_dir)
 
 

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -2350,16 +2350,18 @@ def upload_artifact_handler():
         )
     path = validate_path_is_safe(path)
 
-    if request.content_length and request.content_length > 10 * 1024 * 1024:
-        raise MlflowException(
-            message="Artifact size is too large. Max size is 10MB.",
-            error_code=INVALID_PARAMETER_VALUE,
-        )
-
     data = request.data
     if not data:
         raise MlflowException(
             message="Request must specify data.",
+            error_code=INVALID_PARAMETER_VALUE,
+        )
+
+    # Security: enforce size limit even when content_length is None
+    # (e.g., chunked transfer encoding)
+    if len(data) > 10 * 1024 * 1024:
+        raise MlflowException(
+            message="Artifact size is too large. Max size is 10MB.",
             error_code=INVALID_PARAMETER_VALUE,
         )
 

--- a/tests/projects/test_utils.py
+++ b/tests/projects/test_utils.py
@@ -19,6 +19,7 @@ from mlflow.projects.utils import (
     _is_valid_branch_name,
     _is_zip_uri,
     _parse_subdirectory,
+    _unzip_repo,
     fetch_and_validate_project,
     get_or_create_run,
     load_project,
@@ -263,3 +264,16 @@ def test_fetch_create_and_log(tmp_path):
         assert entry_point_name == run.data.tags[MLFLOW_PROJECT_ENTRY_POINT]
         assert project_uri == run.data.tags[MLFLOW_SOURCE_NAME]
         assert user_param == run.data.params
+
+
+def test_unzip_repo_rejects_path_traversal(tmp_path):
+    """Verify that zip files with path traversal members are rejected."""
+    import io
+    from mlflow.exceptions import MlflowException
+
+    malicious_zip = tmp_path / "malicious.zip"
+    with zipfile.ZipFile(malicious_zip, "w") as zf:
+        zf.writestr("../../../etc/passwd", "pwned")
+
+    with pytest.raises(MlflowException, match="path traversal"):
+        _unzip_repo(str(malicious_zip), str(tmp_path / "dst"))

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -2336,6 +2336,20 @@ def test_upload_artifact_handler_rejects_invalid_requests(mlflow_client):
     )
     assert_response(response, "Request must specify data.")
 
+    # Test that size limit is enforced even with chunked transfer encoding
+    # (content_length is None for chunked encoding)
+    large_data = "x" * (10 * 1024 * 1024 + 1)
+    response = requests.post(
+        f"{mlflow_client.tracking_uri}/ajax-api/2.0/mlflow/upload-artifact",
+        params={
+            "run_uuid": created_run.info.run_id,
+            "path": "test.txt",
+        },
+        data=large_data,
+        headers={"Transfer-Encoding": "chunked"},
+    )
+    assert_response(response, "Artifact size is too large")
+
 
 def test_upload_artifact_handler(mlflow_client):
     experiment_id = mlflow_client.create_experiment("upload_artifacts_test")


### PR DESCRIPTION
### Related Issues/PRs

Fixes CWE-400 (Uncontrolled Resource Consumption) and CWE-22 (Path Traversal)

### What changes are proposed in this pull request?

This PR fixes two security vulnerabilities:

1. **Chunked Transfer Encoding Size Limit Bypass** (`mlflow/server/handlers.py`)
   - `upload_artifact_handler()` enforced a 10MB size limit using `request.content_length`, which is `None` under chunked transfer encoding. An attacker could bypass the limit and upload unlimited data, causing disk exhaustion.
   - **Fix:** Check `len(data)` after reading `request.data`, which works regardless of transfer encoding.

2. **Zip Slip in Project Utils** (`mlflow/projects/utils.py`)
   - `_unzip_repo()` used `zipfile.extractall()` without validating member paths. A malicious zip in `mlflow run <zip-url>` could write arbitrary files outside the destination directory.
   - **Fix:** Validate each zip member stays within `dst_dir` before extraction.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
