### PR TITLE
[1/N] Review assignments: entity, validation, SQL store

### DIFF
--- a/mlflow/genai/review_assignments/__init__.py
+++ b/mlflow/genai/review_assignments/__init__.py
@@ -1,0 +1,30 @@
+"""OSS-native review assignments for SME labeling workflows.
+
+A ``ReviewAssignment`` is one row per ``(target, reviewer)`` pair: the
+piece of state that says "this trace needs review from this person."
+The companion workflow lives in MLflow's review UI, where reviewers
+post Feedback assessments against the assigned target; the assignment's
+``state`` then auto-flips ``pending -> in_progress`` on the first
+matching assessment write, and reviewers explicitly mark it
+``complete`` when done.
+
+The fluent SDK surface (``assign_traces``, ``list_my_assignments``,
+``mark_assignment_complete``, etc.) lands in stack 3 of this PR
+series; this stack ships the entity, validation, and SQL store.
+"""
+
+from mlflow.genai.review_assignments.review_assignments import (
+    BulkCreateFailure,
+    BulkCreateReviewAssignmentsResult,
+    ReviewAssignment,
+    ReviewAssignmentState,
+    ReviewTargetType,
+)
+
+__all__ = [
+    "BulkCreateFailure",
+    "BulkCreateReviewAssignmentsResult",
+    "ReviewAssignment",
+    "ReviewAssignmentState",
+    "ReviewTargetType",
+]

--- a/mlflow/genai/review_assignments/__init__.py
+++ b/mlflow/genai/review_assignments/__init__.py
@@ -3,10 +3,10 @@
 A ``ReviewAssignment`` is one row per ``(target, reviewer)`` pair: the
 piece of state that says "this trace needs review from this person."
 The companion workflow lives in MLflow's review UI, where reviewers
-post Feedback assessments against the assigned target; the assignment's
-``state`` then auto-flips ``pending -> in_progress`` on the first
-matching assessment write, and reviewers explicitly mark it
-``complete`` when done.
+post Feedback assessments against the assigned target and explicitly
+mark the assignment ``complete`` when done. The assignment has two
+states, ``pending`` and ``complete``; writing an assessment does not
+change the state.
 
 The fluent SDK surface (``assign_traces``, ``list_my_assignments``,
 ``mark_assignment_complete``, etc.) lands in stack 3 of this PR

--- a/mlflow/genai/review_assignments/review_assignments.py
+++ b/mlflow/genai/review_assignments/review_assignments.py
@@ -5,17 +5,9 @@ from mlflow.genai.utils.enum_utils import StrEnum
 
 
 class ReviewTargetType(StrEnum):
-    """What kind of object is being reviewed.
-
-    v1 ships ``TRACE`` only. ``SESSION`` and ``SPAN`` are reserved on
-    the wire (the proto enum carries them) so existing assignment rows
-    keep their target-type discriminator stable when those review
-    surfaces land in later releases.
-    """
+    """What kind of object is being reviewed."""
 
     TRACE = "trace"
-    SESSION = "session"
-    SPAN = "span"
 
 
 class ReviewAssignmentState(StrEnum):

--- a/mlflow/genai/review_assignments/review_assignments.py
+++ b/mlflow/genai/review_assignments/review_assignments.py
@@ -13,21 +13,18 @@ class ReviewTargetType(StrEnum):
 class ReviewAssignmentState(StrEnum):
     """Per-assignment workflow state.
 
+    Two states only. State changes only on explicit reviewer action —
+    writing an assessment against the target does NOT advance the
+    assignment.
+
     Transitions:
-        - ``PENDING`` -> ``IN_PROGRESS``: auto-flipped server-side in
-          the same transaction as the first ``log_feedback`` write
-          where ``source.source_id`` matches ``reviewer``
-          (case-insensitively).
-        - ``IN_PROGRESS`` -> ``COMPLETE``: explicit reviewer action via
-          ``mark_assignment_complete``.
-        - ``COMPLETE`` -> ``IN_PROGRESS``: explicit reopen via
-          ``update_review_assignment(state=...)``. ``PENDING`` is a
-          one-way state (post-first-assessment there's no clean
-          way back).
+        - ``PENDING`` -> ``COMPLETE``: explicit "Mark complete" action
+          (sets ``completed_time_ms``).
+        - ``COMPLETE`` -> ``PENDING``: explicit reopen (clears
+          ``completed_time_ms`` back to ``None``).
     """
 
     PENDING = "pending"
-    IN_PROGRESS = "in_progress"
     COMPLETE = "complete"
 
 
@@ -43,9 +40,9 @@ class ReviewAssignment:
     ``reviewer`` and ``assigner`` are free-form strings that should
     match whatever shape ``AssessmentSource.source_id`` takes in the
     caller's deployment — typically email on Databricks, username
-    elsewhere. The store layer compares ``reviewer`` against
-    ``source.source_id`` case-insensitively for the state-flip side
-    effect; callers don't have to worry about casing drift.
+    elsewhere. ``reviewer`` is lowercased on write so the UI can match a
+    reviewer's assignments against their assessments without casing
+    drift.
     """
 
     assignment_id: str

--- a/mlflow/genai/review_assignments/review_assignments.py
+++ b/mlflow/genai/review_assignments/review_assignments.py
@@ -1,0 +1,109 @@
+from dataclasses import dataclass, field
+from typing import NamedTuple
+
+from mlflow.genai.utils.enum_utils import StrEnum
+
+
+class ReviewTargetType(StrEnum):
+    """What kind of object is being reviewed.
+
+    v1 ships ``TRACE`` only. ``SESSION`` and ``SPAN`` are reserved on
+    the wire (the proto enum carries them) so existing assignment rows
+    keep their target-type discriminator stable when those review
+    surfaces land in later releases.
+    """
+
+    TRACE = "trace"
+    SESSION = "session"
+    SPAN = "span"
+
+
+class ReviewAssignmentState(StrEnum):
+    """Per-assignment workflow state.
+
+    Transitions:
+        - ``PENDING`` -> ``IN_PROGRESS``: auto-flipped server-side in
+          the same transaction as the first ``log_feedback`` write
+          where ``source.source_id`` matches ``reviewer``
+          (case-insensitively).
+        - ``IN_PROGRESS`` -> ``COMPLETE``: explicit reviewer action via
+          ``mark_assignment_complete``.
+        - ``COMPLETE`` -> ``IN_PROGRESS``: explicit reopen via
+          ``update_review_assignment(state=...)``. ``PENDING`` is a
+          one-way state (post-first-assessment there's no clean
+          way back).
+    """
+
+    PENDING = "pending"
+    IN_PROGRESS = "in_progress"
+    COMPLETE = "complete"
+
+
+@dataclass
+class ReviewAssignment:
+    """One row of the review-assignment table.
+
+    Identity is the composite ``(target_id, reviewer)``: a single
+    reviewer is at most once assigned to a single target. Repeated
+    assignment is silently a no-op (bulk-create returns the existing
+    row in the ``existing`` bucket).
+
+    ``reviewer`` and ``assigner`` are free-form strings that should
+    match whatever shape ``AssessmentSource.source_id`` takes in the
+    caller's deployment — typically email on Databricks, username
+    elsewhere. The store layer compares ``reviewer`` against
+    ``source.source_id`` case-insensitively for the state-flip side
+    effect; callers don't have to worry about casing drift.
+    """
+
+    assignment_id: str
+    experiment_id: str
+    target_type: ReviewTargetType
+    target_id: str
+    reviewer: str
+    assigner: str
+    state: ReviewAssignmentState
+    creation_time_ms: int
+    last_update_time_ms: int
+    completed_time_ms: int | None = field(default=None)
+
+
+class BulkCreateFailure(NamedTuple):
+    """One element of ``BulkCreateReviewAssignmentsResult.failed``.
+
+    ``target_id`` and ``reviewer`` identify the row that didn't land;
+    ``error_message`` is a human-readable explanation. Validation
+    failures are the typical reason — see
+    ``mlflow.genai.review_assignments.validation``.
+    """
+
+    target_id: str
+    reviewer: str
+    error_message: str
+
+
+@dataclass
+class BulkCreateReviewAssignmentsResult:
+    """Outcome of :py:meth:`bulk_create_review_assignments`.
+
+    The three buckets are disjoint: every input ``(target_id, reviewer)``
+    pair lands in exactly one. Callers can size-check
+    ``len(created) + len(existing) + len(failed) == N * M`` to verify
+    no rows were silently dropped.
+    """
+
+    created: list[ReviewAssignment]
+    """Newly-inserted assignments."""
+
+    existing: list[str]
+    """``assignment_id`` strings for rows that already existed at the
+    unique key. Idempotent re-runs of the same bulk-assign land here.
+    Intentionally only the id, not the full entity: re-fetch via
+    ``get_review_assignment`` if the caller needs the state /
+    timestamps of the existing rows. This keeps the bulk-assign
+    response small for the typical "N x M with mostly new pairs" case
+    where the existing bucket can be sized in the thousands."""
+
+    failed: list[BulkCreateFailure]
+    """Per-row validation failures. The whole batch is still a single
+    transaction; failed rows don't roll back the rest."""

--- a/mlflow/genai/review_assignments/validation.py
+++ b/mlflow/genai/review_assignments/validation.py
@@ -25,14 +25,6 @@ REVIEWER_MAX_LENGTH = 250
 ASSIGNER_MAX_LENGTH = 250
 TARGET_ID_MAX_LENGTH = 50
 
-# Target types accepted by v1. The enum carries ``SESSION`` and
-# ``SPAN`` for forward-compat (so existing rows keep their
-# discriminator stable when those surfaces ship), but the validator
-# rejects them today to avoid storing assignments that no UI surface
-# can render. When session/span review lands, drop the relevant entry
-# from this set and re-test.
-_V1_ALLOWED_TARGET_TYPES: frozenset[ReviewTargetType] = frozenset({ReviewTargetType.TRACE})
-
 
 def _invalid(message: str) -> MlflowException:
     return MlflowException(message, error_code=INVALID_PARAMETER_VALUE)
@@ -46,21 +38,13 @@ def _validate_non_empty_string(value: object, field: str, max_length: int) -> No
 
 
 def _coerce_target_type(target_type: object) -> ReviewTargetType:
-    """Coerce caller input to ``ReviewTargetType`` and v1-reject."""
     if isinstance(target_type, ReviewTargetType):
-        coerced = target_type
-    else:
-        if target_type not in ReviewTargetType:
-            raise _invalid(
-                f"`target_type` must be one of {ReviewTargetType.values()}; got {target_type!r}."
-            )
-        coerced = ReviewTargetType(target_type)
-    if coerced not in _V1_ALLOWED_TARGET_TYPES:
+        return target_type
+    if target_type not in ReviewTargetType:
         raise _invalid(
-            f"`target_type` {coerced.value!r} is not supported in this release; "
-            f"v1 only accepts {[t.value for t in _V1_ALLOWED_TARGET_TYPES]}."
+            f"`target_type` must be one of {ReviewTargetType.values()}; got {target_type!r}."
         )
-    return coerced
+    return ReviewTargetType(target_type)
 
 
 def _validate_state(state: object) -> None:

--- a/mlflow/genai/review_assignments/validation.py
+++ b/mlflow/genai/review_assignments/validation.py
@@ -1,0 +1,187 @@
+"""Server-side validation and normalization for review assignments.
+
+Called from the store layer's create / bulk-create / update paths.
+Length caps are aligned with the SQL column widths so a payload that
+passes validation also fits the table (no silent truncation).
+
+This module is store-layer-internal; callers should not import it
+directly.
+"""
+
+from __future__ import annotations
+
+from mlflow.exceptions import MlflowException
+from mlflow.genai.review_assignments.review_assignments import (
+    ReviewAssignmentState,
+    ReviewTargetType,
+)
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
+
+# Aligned with `SqlReviewAssignment` column widths. The 250 mirrors
+# `SqlAssessments.source_id` so the state-flip side effect, which
+# compares `reviewer` against `source.source_id`, never sees a
+# `reviewer` value that wouldn't fit the assessment side.
+REVIEWER_MAX_LENGTH = 250
+ASSIGNER_MAX_LENGTH = 250
+TARGET_ID_MAX_LENGTH = 50
+
+# Target types accepted by v1. The enum carries ``SESSION`` and
+# ``SPAN`` for forward-compat (so existing rows keep their
+# discriminator stable when those surfaces ship), but the validator
+# rejects them today to avoid storing assignments that no UI surface
+# can render. When session/span review lands, drop the relevant entry
+# from this set and re-test.
+_V1_ALLOWED_TARGET_TYPES: frozenset[ReviewTargetType] = frozenset({ReviewTargetType.TRACE})
+
+
+def _invalid(message: str) -> MlflowException:
+    return MlflowException(message, error_code=INVALID_PARAMETER_VALUE)
+
+
+def _validate_non_empty_string(value: object, field: str, max_length: int) -> None:
+    if not isinstance(value, str) or len(value) == 0:
+        raise _invalid(f"`{field}` must be a non-empty string; got {value!r}.")
+    if len(value) > max_length:
+        raise _invalid(f"`{field}` must be at most {max_length} characters; got {len(value)}.")
+
+
+def _coerce_target_type(target_type: object) -> ReviewTargetType:
+    """Coerce caller input to ``ReviewTargetType`` and v1-reject."""
+    if isinstance(target_type, ReviewTargetType):
+        coerced = target_type
+    else:
+        if target_type not in ReviewTargetType:
+            raise _invalid(
+                f"`target_type` must be one of {ReviewTargetType.values()}; got {target_type!r}."
+            )
+        coerced = ReviewTargetType(target_type)
+    if coerced not in _V1_ALLOWED_TARGET_TYPES:
+        raise _invalid(
+            f"`target_type` {coerced.value!r} is not supported in this release; "
+            f"v1 only accepts {[t.value for t in _V1_ALLOWED_TARGET_TYPES]}."
+        )
+    return coerced
+
+
+def _validate_state(state: object) -> None:
+    if isinstance(state, ReviewAssignmentState):
+        return
+    if state not in ReviewAssignmentState:
+        raise _invalid(f"`state` must be one of {ReviewAssignmentState.values()}; got {state!r}.")
+
+
+# Allowed state transitions enforced by ``update_review_assignment``.
+# ``PENDING`` is a one-way state — once an assessment write flips it
+# to ``IN_PROGRESS``, there's no clean way back, so we don't permit
+# the caller to manually walk back either. Same-state transitions are
+# allowed (the store treats them as no-ops anyway).
+_STATE_TRANSITIONS: dict[ReviewAssignmentState, frozenset[ReviewAssignmentState]] = {
+    ReviewAssignmentState.PENDING: frozenset({
+        ReviewAssignmentState.PENDING,
+        ReviewAssignmentState.IN_PROGRESS,
+    }),
+    ReviewAssignmentState.IN_PROGRESS: frozenset({
+        ReviewAssignmentState.IN_PROGRESS,
+        ReviewAssignmentState.COMPLETE,
+    }),
+    ReviewAssignmentState.COMPLETE: frozenset({
+        ReviewAssignmentState.COMPLETE,
+        ReviewAssignmentState.IN_PROGRESS,
+    }),
+}
+
+
+def _validate_transition(current: ReviewAssignmentState, new: ReviewAssignmentState) -> None:
+    if new not in _STATE_TRANSITIONS[current]:
+        raise _invalid(
+            f"Illegal state transition: {current.value!r} -> {new.value!r}. "
+            f"Allowed from {current.value!r}: "
+            f"{sorted(s.value for s in _STATE_TRANSITIONS[current])}."
+        )
+
+
+def normalize_reviewer(reviewer: object) -> str:
+    """Lowercase + strip a reviewer identifier.
+
+    Identity comparisons against ``AssessmentSource.source_id`` are
+    case-insensitive, so we normalize once at write time and store the
+    canonical form. This lets the UNIQUE constraint on raw
+    ``reviewer`` actually enforce one-row-per-reviewer (lower-casing
+    on the read side leaves the constraint case-preserving and allows
+    duplicates to race in) and lets indexed lookups use the column
+    directly.
+    """
+    if not isinstance(reviewer, str):
+        raise _invalid(f"`reviewer` must be a string; got {reviewer!r}.")
+    return reviewer.strip().lower()
+
+
+def normalize_target_id(target_id: object) -> str:
+    """Strip a target identifier.
+
+    Trace ids are case-sensitive (UUID/hex), so only strip whitespace.
+    """
+    if not isinstance(target_id, str):
+        raise _invalid(f"`target_id` must be a string; got {target_id!r}.")
+    return target_id.strip()
+
+
+def normalize_assigner(assigner: object) -> str:
+    """Strip an assigner identifier.
+
+    ``assigner`` is audit data; we preserve casing so the UI can show
+    it as the user typed, but trim whitespace so a stray newline from
+    a clipboard paste doesn't show up in the audit trail.
+    """
+    if not isinstance(assigner, str):
+        raise _invalid(f"`assigner` must be a string; got {assigner!r}.")
+    return assigner.strip()
+
+
+def validate_assignment_for_create(
+    *,
+    target_type: object,
+    target_id: str,
+    reviewer: str,
+    assigner: str,
+) -> ReviewTargetType:
+    """Validate a single assignment about to be inserted.
+
+    Called per-row by both the single-create and bulk-create paths;
+    bulk-create runs this on each tuple before opening the transaction
+    so a partial bad payload fails fast. Returns the coerced
+    ``ReviewTargetType`` so the caller doesn't have to re-coerce.
+
+    ``experiment_id`` is intentionally NOT validated here — the
+    store-layer ``_validate_experiment_exists`` check that fires
+    inside the write transaction covers both "exists" and "valid id
+    shape" and produces the canonical error code mapping.
+    """
+    coerced_target_type = _coerce_target_type(target_type)
+    _validate_non_empty_string(target_id, "target_id", TARGET_ID_MAX_LENGTH)
+    _validate_non_empty_string(reviewer, "reviewer", REVIEWER_MAX_LENGTH)
+    _validate_non_empty_string(assigner, "assigner", ASSIGNER_MAX_LENGTH)
+    return coerced_target_type
+
+
+def validate_assignment_for_update(
+    *,
+    current_state: ReviewAssignmentState,
+    new_state: object,
+) -> ReviewAssignmentState:
+    """Validate a workflow state update against the transition table.
+
+    Returns the coerced ``ReviewAssignmentState`` so the caller can
+    write it directly. Only ``state`` is mutable today; identity and
+    audit fields are immutable. If/when additional mutable fields are
+    added, extend this validator and the store's
+    ``update_review_assignment`` accordingly.
+    """
+    _validate_state(new_state)
+    coerced = (
+        ReviewAssignmentState(new_state)
+        if not isinstance(new_state, ReviewAssignmentState)
+        else new_state
+    )
+    _validate_transition(current_state, coerced)
+    return coerced

--- a/mlflow/genai/review_assignments/validation.py
+++ b/mlflow/genai/review_assignments/validation.py
@@ -18,9 +18,10 @@ from mlflow.genai.review_assignments.review_assignments import (
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 
 # Aligned with `SqlReviewAssignment` column widths. The 250 mirrors
-# `SqlAssessments.source_id` so the state-flip side effect, which
-# compares `reviewer` against `source.source_id`, never sees a
-# `reviewer` value that wouldn't fit the assessment side.
+# `SqlAssessments.source_id`: the UI surfaces a reviewer's own
+# assessments alongside their assignment, and keeping the two columns
+# the same width means a `reviewer` value can never be too long to also
+# appear as an assessment `source_id`.
 REVIEWER_MAX_LENGTH = 250
 ASSIGNER_MAX_LENGTH = 250
 TARGET_ID_MAX_LENGTH = 50
@@ -52,36 +53,6 @@ def _validate_state(state: object) -> None:
         return
     if state not in ReviewAssignmentState:
         raise _invalid(f"`state` must be one of {ReviewAssignmentState.values()}; got {state!r}.")
-
-
-# Allowed state transitions enforced by ``update_review_assignment``.
-# ``PENDING`` is a one-way state — once an assessment write flips it
-# to ``IN_PROGRESS``, there's no clean way back, so we don't permit
-# the caller to manually walk back either. Same-state transitions are
-# allowed (the store treats them as no-ops anyway).
-_STATE_TRANSITIONS: dict[ReviewAssignmentState, frozenset[ReviewAssignmentState]] = {
-    ReviewAssignmentState.PENDING: frozenset({
-        ReviewAssignmentState.PENDING,
-        ReviewAssignmentState.IN_PROGRESS,
-    }),
-    ReviewAssignmentState.IN_PROGRESS: frozenset({
-        ReviewAssignmentState.IN_PROGRESS,
-        ReviewAssignmentState.COMPLETE,
-    }),
-    ReviewAssignmentState.COMPLETE: frozenset({
-        ReviewAssignmentState.COMPLETE,
-        ReviewAssignmentState.IN_PROGRESS,
-    }),
-}
-
-
-def _validate_transition(current: ReviewAssignmentState, new: ReviewAssignmentState) -> None:
-    if new not in _STATE_TRANSITIONS[current]:
-        raise _invalid(
-            f"Illegal state transition: {current.value!r} -> {new.value!r}. "
-            f"Allowed from {current.value!r}: "
-            f"{sorted(s.value for s in _STATE_TRANSITIONS[current])}."
-        )
 
 
 def normalize_reviewer(reviewer: object) -> str:
@@ -148,24 +119,20 @@ def validate_assignment_for_create(
     return coerced_target_type
 
 
-def validate_assignment_for_update(
-    *,
-    current_state: ReviewAssignmentState,
-    new_state: object,
-) -> ReviewAssignmentState:
-    """Validate a workflow state update against the transition table.
+def validate_assignment_for_update(*, new_state: object) -> ReviewAssignmentState:
+    """Validate + coerce a workflow state update.
 
     Returns the coerced ``ReviewAssignmentState`` so the caller can
-    write it directly. Only ``state`` is mutable today; identity and
+    write it directly. With two states (``pending`` / ``complete``)
+    every transition is legal, so this only validates that ``new_state``
+    is a known state. Only ``state`` is mutable today; identity and
     audit fields are immutable. If/when additional mutable fields are
     added, extend this validator and the store's
     ``update_review_assignment`` accordingly.
     """
     _validate_state(new_state)
-    coerced = (
+    return (
         ReviewAssignmentState(new_state)
         if not isinstance(new_state, ReviewAssignmentState)
         else new_state
     )
-    _validate_transition(current_state, coerced)
-    return coerced

--- a/mlflow/store/db/workspace_utils.py
+++ b/mlflow/store/db/workspace_utils.py
@@ -22,6 +22,7 @@ MODEL_CHILD_TABLES = [
 # They must also be migrated explicitly during workspace operations.
 OTHER_WORKSPACE_CHILD_TABLES = [
     "guardrail_configs",
+    "review_assignments",
 ]
 
 

--- a/mlflow/store/db_migrations/versions/c4d2e8a16f93_add_review_assignments_table.py
+++ b/mlflow/store/db_migrations/versions/c4d2e8a16f93_add_review_assignments_table.py
@@ -1,0 +1,73 @@
+"""add review_assignments table
+
+Create Date: 2026-05-28 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c4d2e8a16f93"
+down_revision = "da6fb0208061"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "review_assignments",
+        sa.Column("assignment_id", sa.String(length=36), nullable=False),
+        sa.Column(
+            "workspace",
+            sa.String(length=63),
+            nullable=False,
+            server_default=sa.text("'default'"),
+        ),
+        sa.Column("experiment_id", sa.Integer(), nullable=False),
+        sa.Column("target_type", sa.String(length=16), nullable=False),
+        sa.Column("target_id", sa.String(length=50), nullable=False),
+        sa.Column("reviewer", sa.String(length=250), nullable=False),
+        sa.Column("assigner", sa.String(length=250), nullable=False),
+        sa.Column("state", sa.String(length=16), nullable=False),
+        sa.Column("creation_time_ms", sa.BigInteger(), nullable=False),
+        sa.Column("last_update_time_ms", sa.BigInteger(), nullable=False),
+        sa.Column("completed_time_ms", sa.BigInteger(), nullable=True),
+        sa.PrimaryKeyConstraint("assignment_id", name="review_assignments_pk"),
+        sa.ForeignKeyConstraint(
+            ["experiment_id"],
+            ["experiments.experiment_id"],
+            name="fk_review_assignments_experiment_id",
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint(
+            "workspace",
+            "target_id",
+            "reviewer",
+            name="uq_review_assignments_workspace_target_reviewer",
+        ),
+    )
+    # "My assignments" query (Reviews page tabs + list_my_assignments SDK).
+    op.create_index(
+        "idx_review_assignments_workspace_experiment_reviewer_state",
+        "review_assignments",
+        ["workspace", "experiment_id", "reviewer", "state"],
+    )
+    # "Who's reviewing this trace?" query (per-trace assignees widget).
+    op.create_index(
+        "idx_review_assignments_workspace_target_id",
+        "review_assignments",
+        ["workspace", "target_id"],
+    )
+
+
+def downgrade():
+    op.drop_index(
+        "idx_review_assignments_workspace_target_id",
+        table_name="review_assignments",
+    )
+    op.drop_index(
+        "idx_review_assignments_workspace_experiment_reviewer_state",
+        table_name="review_assignments",
+    )
+    op.drop_table("review_assignments")

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -1761,12 +1761,10 @@ class AbstractStore(GatewayStoreMixin):
 
         Args:
             experiment_id: Parent experiment.
-            target_type: One of ``"trace"`` / ``"session"`` / ``"span"``;
-                v1 only ``"trace"`` is fully wired.
+            target_type: What kind of object is being reviewed. v1 supports
+                ``"trace"`` only.
             target_id: The thing being reviewed.
             reviewer: Free-form reviewer identifier (typically email).
-                Matched case-insensitively against ``AssessmentSource.source_id``
-                by the state-flip side effect.
             assigner: Who created the assignment.
 
         Returns:
@@ -1796,7 +1794,8 @@ class AbstractStore(GatewayStoreMixin):
 
         Args:
             experiment_id: Parent experiment.
-            target_type: One of ``"trace"`` / ``"session"`` / ``"span"``.
+            target_type: What kind of object is being reviewed. v1 supports
+                ``"trace"`` only.
             target_ids: List of target IDs to assign (de-duplicated by caller).
             reviewers: List of reviewer identifiers (de-duplicated by caller).
             assigner: Who created the assignments.
@@ -1854,8 +1853,9 @@ class AbstractStore(GatewayStoreMixin):
         """Mutate the workflow state of an assignment.
 
         Only ``state`` is mutable post-create; identity and audit fields
-        are immutable. Stack 3's "mark complete" / "reopen" SDK calls
-        go through here.
+        are immutable. The "mark complete" / "reopen" SDK calls go
+        through here. Reopen (``complete -> pending``) clears
+        ``completed_time_ms``.
 
         Raises:
             MlflowException(INVALID_PARAMETER_VALUE): on validation failure.

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -28,6 +28,12 @@ from mlflow.entities.trace_metrics import (
 
 if TYPE_CHECKING:
     from mlflow.entities import EvaluationDataset
+    from mlflow.genai.review_assignments import (
+        BulkCreateReviewAssignmentsResult,
+        ReviewAssignment,
+        ReviewAssignmentState,
+        ReviewTargetType,
+    )
     from mlflow.genai.scorers.online.entities import (
         CompletedSession,
         OnlineScorer,
@@ -1732,5 +1738,137 @@ class AbstractStore(GatewayStoreMixin):
         Returns:
             List of OnlineScorer entities with serialized_scorer, sample_rate,
             and filter_string fields populated.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    # ---------- Review assignments (DAIS-2026 work item #1) ----------
+
+    def create_review_assignment(
+        self,
+        *,
+        experiment_id: str,
+        target_type: "ReviewTargetType | str",
+        target_id: str,
+        reviewer: str,
+        assigner: str,
+    ) -> "ReviewAssignment":
+        """Create a single review assignment for a target.
+
+        Identity is ``(target_id, reviewer)``; creating the same pair
+        twice is a no-op and returns the existing row. Callers wanting
+        a multi-row create should use :py:meth:`bulk_create_review_assignments`
+        which is transactional.
+
+        Args:
+            experiment_id: Parent experiment.
+            target_type: One of ``"trace"`` / ``"session"`` / ``"span"``;
+                v1 only ``"trace"`` is fully wired.
+            target_id: The thing being reviewed.
+            reviewer: Free-form reviewer identifier (typically email).
+                Matched case-insensitively against ``AssessmentSource.source_id``
+                by the state-flip side effect.
+            assigner: Who created the assignment.
+
+        Returns:
+            The created (or existing) :py:class:`ReviewAssignment`.
+
+        Raises:
+            MlflowException(INVALID_PARAMETER_VALUE): on validation failure.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def bulk_create_review_assignments(
+        self,
+        *,
+        experiment_id: str,
+        target_type: "ReviewTargetType | str",
+        target_ids: list[str],
+        reviewers: list[str],
+        assigner: str,
+    ) -> "BulkCreateReviewAssignmentsResult":
+        """Create the cross-product of (targets x reviewers) atomically.
+
+        N targets times M reviewers create N*M ``(target_id, reviewer)``
+        rows. Collisions on the unique constraint are silently no-op'd
+        and reported in the ``existing`` bucket of the result; per-row
+        validation errors are reported in the ``failed`` bucket. The
+        whole batch is one DB transaction.
+
+        Args:
+            experiment_id: Parent experiment.
+            target_type: One of ``"trace"`` / ``"session"`` / ``"span"``.
+            target_ids: List of target IDs to assign (de-duplicated by caller).
+            reviewers: List of reviewer identifiers (de-duplicated by caller).
+            assigner: Who created the assignments.
+
+        Returns:
+            :py:class:`BulkCreateReviewAssignmentsResult` with ``created``
+            (list of new ``ReviewAssignment``), ``existing`` (list of
+            already-present ``assignment_id`` strings), and ``failed``
+            (list of ``(target_id, reviewer, error_message)`` triples).
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def get_review_assignment(self, assignment_id: str) -> "ReviewAssignment":
+        """Fetch a single assignment by its server-generated id.
+
+        Raises:
+            MlflowException(RESOURCE_DOES_NOT_EXIST): if no row matches.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def list_review_assignments(
+        self,
+        *,
+        experiment_id: str | None = None,
+        reviewer: str | None = None,
+        state: "ReviewAssignmentState | str | None" = None,
+        target_type: "ReviewTargetType | str | None" = None,
+        max_results: int | None = None,
+        page_token: str | None = None,
+    ) -> "PagedList[ReviewAssignment]":
+        """Paginated list of assignments filtered by any combination of
+        experiment / reviewer / state / target_type.
+
+        At least one of ``experiment_id`` or ``reviewer`` must be set
+        — both predicates are supported by the composite index;
+        unscoped listing would full-table-scan and is rejected with
+        ``INVALID_PARAMETER_VALUE``.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def list_review_assignments_for_target(self, target_id: str) -> list["ReviewAssignment"]:
+        """All assignments against a given target across reviewers.
+
+        Used by the per-trace "Reviewers (N)" widget to render the list
+        of assignees with their state badges.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def update_review_assignment(
+        self,
+        assignment_id: str,
+        *,
+        state: "ReviewAssignmentState | str",
+    ) -> "ReviewAssignment":
+        """Mutate the workflow state of an assignment.
+
+        Only ``state`` is mutable post-create; identity and audit fields
+        are immutable. Stack 3's "mark complete" / "reopen" SDK calls
+        go through here.
+
+        Raises:
+            MlflowException(INVALID_PARAMETER_VALUE): on validation failure.
+            MlflowException(RESOURCE_DOES_NOT_EXIST): if no row matches.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def delete_review_assignment(self, assignment_id: str) -> None:
+        """Hard-delete an assignment by id.
+
+        Idempotent: deleting a non-existent assignment is a no-op (no
+        ``RESOURCE_DOES_NOT_EXIST`` raised). The caller's UX will have
+        already shown the row; a 404 on the delete would just confuse
+        them if a concurrent delete already happened.
         """
         raise NotImplementedError(self.__class__.__name__)

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -3227,3 +3227,172 @@ class SqlGatewayGuardrailConfig(Base):
             created_by=self.created_by,
             workspace=self.workspace,
         )
+
+
+class SqlReviewAssignment(Base):
+    """
+    DB model for OSS-native review assignments (DAIS-2026 work item #1).
+
+    One row per ``(target, reviewer)`` pair: a single reviewer is at
+    most once assigned to a single target. ``state`` carries the
+    per-reviewer workflow (``pending`` -> ``in_progress`` -> ``complete``);
+    the ``pending`` -> ``in_progress`` flip is auto-triggered by the
+    store-layer ``create_assessment`` side effect on the first matching
+    Feedback write.
+
+    See ``mlflow/genai/review_assignments/review_assignments.py`` for
+    the entity dataclass and
+    ``mlflow/genai/review_assignments/validation.py`` for the
+    server-side validation rules.
+    """
+
+    __tablename__ = "review_assignments"
+
+    ASSIGNMENT_ID_PREFIX = "ra-"
+
+    assignment_id = Column(String(36), primary_key=True)
+    """
+    Assignment ID: ``String`` (limit 36 characters). *Primary Key* for
+    ``review_assignments`` table.
+    """
+
+    workspace = Column(
+        String(63),
+        nullable=False,
+        default=DEFAULT_WORKSPACE_NAME,
+        server_default=sa.text(f"'{DEFAULT_WORKSPACE_NAME}'"),
+    )
+    """
+    Workspace name that scopes this assignment.
+    """
+
+    experiment_id = Column(
+        Integer,
+        ForeignKey("experiments.experiment_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    """
+    Experiment the assignment belongs to. *Foreign Key* into ``experiments``.
+    Cascade-deletes when the parent experiment is hard-deleted. MLflow's
+    soft-delete (``lifecycle_stage='deleted'``) doesn't fire the cascade,
+    so assignments to soft-deleted experiments survive until the
+    experiment is permanently removed.
+    """
+
+    target_type = Column(String(16), nullable=False)
+    """
+    What kind of object is being reviewed: ``String`` (limit 16).
+    v1 ships ``'trace'`` only; ``'session'`` and ``'span'`` are reserved
+    for forward-compat.
+    """
+
+    target_id = Column(String(50), nullable=False)
+    """
+    The thing being reviewed — trace_id today; session_id or span_id
+    when those target types ship. ``String`` (limit 50).
+    """
+
+    reviewer = Column(String(250), nullable=False)
+    """
+    Who should review this target. Free-form string — typically email
+    on Databricks, username on auth-plugin OSS deployments, anything
+    elsewhere. ``VARCHAR(250)`` to mirror ``SqlAssessments.source_id``
+    so the state-flip side effect's case-insensitive comparison between
+    ``reviewer`` and ``source.source_id`` never sees a value that
+    wouldn't fit the assessment side.
+    """
+
+    assigner = Column(String(250), nullable=False)
+    """
+    Who created the assignment. Same shape as ``reviewer``.
+    """
+
+    state = Column(String(16), nullable=False)
+    """
+    Workflow state: one of ``'pending'``, ``'in_progress'``, ``'complete'``.
+    The pending -> in_progress flip is auto-triggered server-side; the
+    other transitions are explicit reviewer actions.
+    """
+
+    creation_time_ms = Column(BigInteger, nullable=False)
+    """
+    Assignment creation time in milliseconds since epoch.
+    """
+
+    last_update_time_ms = Column(BigInteger, nullable=False)
+    """
+    Time of the most recent state change in milliseconds since epoch.
+    Equals ``creation_time_ms`` for assignments that haven't moved off
+    ``pending``.
+    """
+
+    completed_time_ms = Column(BigInteger, nullable=True)
+    """
+    Time the assignment was marked ``complete`` in milliseconds since
+    epoch; ``NULL`` while still pending or in_progress. Preserved when
+    a complete assignment is reopened back to in_progress so the most
+    recent completion timestamp is recoverable.
+    """
+
+    __table_args__ = (
+        PrimaryKeyConstraint("assignment_id", name="review_assignments_pk"),
+        # Identity: one reviewer at most once per target. Bulk-create
+        # treats collisions on this key as silent no-ops.
+        UniqueConstraint(
+            "workspace",
+            "target_id",
+            "reviewer",
+            name="uq_review_assignments_workspace_target_reviewer",
+        ),
+        # "My assignments" query — used by the Reviews page's
+        # `state=pending` / `state=in_progress` tabs and by
+        # `list_my_assignments` SDK.
+        Index(
+            "idx_review_assignments_workspace_experiment_reviewer_state",
+            "workspace",
+            "experiment_id",
+            "reviewer",
+            "state",
+        ),
+        # "Who's reviewing this trace?" query — used by the per-trace
+        # widget that lists assignees + their state badges.
+        Index(
+            "idx_review_assignments_workspace_target_id",
+            "workspace",
+            "target_id",
+        ),
+    )
+
+    def __repr__(self):
+        return (
+            f"<SqlReviewAssignment "
+            f"(id={self.assignment_id}, target={self.target_id}, "
+            f"reviewer={self.reviewer}, state={self.state})>"
+        )
+
+    def to_mlflow_entity(self):
+        """Convert DB model to corresponding MLflow entity.
+
+        Returns:
+            :py:class:`mlflow.genai.review_assignments.ReviewAssignment`.
+        """
+        # Lazy import: `mlflow.genai.review_assignments` transitively
+        # touches entities that import this module at load time.
+        from mlflow.genai.review_assignments import (
+            ReviewAssignment,
+            ReviewAssignmentState,
+            ReviewTargetType,
+        )
+
+        return ReviewAssignment(
+            assignment_id=self.assignment_id,
+            experiment_id=str(self.experiment_id),
+            target_type=ReviewTargetType(self.target_type),
+            target_id=self.target_id,
+            reviewer=self.reviewer,
+            assigner=self.assigner,
+            state=ReviewAssignmentState(self.state),
+            creation_time_ms=self.creation_time_ms,
+            last_update_time_ms=self.last_update_time_ms,
+            completed_time_ms=self.completed_time_ms,
+        )

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -8320,13 +8320,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 )
 
             current_state = ReviewAssignmentState(sql_assignment.state)
-            # Transition-aware validation: enforces the FSM documented
-            # on ``ReviewAssignmentState`` so callers can't manually
-            # walk the workflow back to ``pending``.
-            new_enum = validate_assignment_for_update(
-                current_state=current_state,
-                new_state=state,
-            )
+            new_enum = validate_assignment_for_update(new_state=state)
 
             # Don't bump timestamps if nothing changed; lets reviewers
             # toggle freely in the UI without polluting the audit log.
@@ -8338,10 +8332,9 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             sql_assignment.last_update_time_ms = now_ms
             if new_enum == ReviewAssignmentState.COMPLETE:
                 sql_assignment.completed_time_ms = now_ms
-            # On reopen (complete -> in_progress), keep
-            # ``completed_time_ms`` populated with the prior completion
-            # stamp so callers can still surface "last completed at"
-            # even after a reopen.
+            else:
+                # Reopen (complete -> pending) clears the completion stamp.
+                sql_assignment.completed_time_ms = None
             session.flush()
             return sql_assignment.to_mlflow_entity()
 

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -90,6 +90,7 @@ from mlflow.genai.judges.instructions_judge import (
     EXPECTATIONS_FIELD,
     InstructionsJudge,
 )
+from mlflow.genai.review_assignments import ReviewAssignmentState
 from mlflow.genai.scorers.base import Scorer
 from mlflow.genai.scorers.online.entities import (
     CompletedSession,
@@ -151,6 +152,7 @@ from mlflow.store.tracking.dbmodels.models import (
     SqlMetric,
     SqlOnlineScoringConfig,
     SqlParam,
+    SqlReviewAssignment,
     SqlRun,
     SqlScorer,
     SqlScorerVersion,
@@ -811,6 +813,24 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             # loading_relationships.html#relationship-loading-techniques
             sqlalchemy.orm.subqueryload(SqlExperiment.tags),
         ]
+
+    def _validate_experiment_exists(self, session, experiment_id):
+        """Raise an ``MlflowException`` if the target experiment isn't usable.
+
+        Raises:
+            MlflowException with ``INVALID_PARAMETER_VALUE`` if
+                ``experiment_id`` isn't a parseable integer.
+            MlflowException with ``RESOURCE_DOES_NOT_EXIST`` if no
+                active experiment matches (including soft-deleted ones).
+
+        Used by store methods that create rows scoped to an experiment
+        (e.g. review assignments) so the caller hears about a bad
+        ``experiment_id`` immediately rather than via a downstream
+        foreign-key error from the DB driver.
+        """
+        # Delegate to the canonical lookup so we get lifecycle filtering
+        # and the same error-code mapping the rest of the store uses.
+        self._get_experiment(session, experiment_id, ViewType.ACTIVE_ONLY)
 
     def get_experiment(self, experiment_id):
         effective_retention_context = (
@@ -7947,6 +7967,390 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 secret_id=sql_secret.secret_id,
                 secret_name=sql_secret.secret_name,
             )
+
+    # ------------------------------------------------------------------
+    # Review assignments (DAIS-2026 work item #1). See
+    # ``mlflow/genai/review_assignments/review_assignments.py`` for the
+    # entity dataclasses and ``validation.py`` for the validation +
+    # normalization rules.
+    # ------------------------------------------------------------------
+
+    def _review_assignment_query(self, session):
+        return self._get_query(session, SqlReviewAssignment)
+
+    @staticmethod
+    def _build_review_assignment(
+        *,
+        experiment_id,
+        target_type,
+        target_id,
+        reviewer,
+        assigner,
+        now_ms,
+    ):
+        """Construct an unsaved ``SqlReviewAssignment`` with a fresh id.
+
+        Inputs MUST already be validated + normalized (lowercased
+        reviewer, stripped target_id / assigner) by the caller.
+        Workspace is filled in by ``_with_workspace_field``.
+        """
+        return SqlReviewAssignment(
+            assignment_id=f"{SqlReviewAssignment.ASSIGNMENT_ID_PREFIX}{uuid.uuid4().hex}",
+            experiment_id=int(experiment_id),
+            target_type=str(target_type),
+            target_id=target_id,
+            reviewer=reviewer,
+            assigner=assigner,
+            state=str(ReviewAssignmentState.PENDING),
+            creation_time_ms=now_ms,
+            last_update_time_ms=now_ms,
+            completed_time_ms=None,
+        )
+
+    def _lookup_review_assignment_pair(self, session, target_id, reviewer):
+        """Fetch the row for a ``(target_id, reviewer)`` unique key.
+
+        Inputs MUST already be normalized (``reviewer`` lowercased,
+        ``target_id`` stripped). The constraint is on the case-preserving
+        column; because we always normalize on write, an indexed
+        equality lookup is sufficient and uses the composite UNIQUE
+        index directly.
+        """
+        return (
+            self
+            ._review_assignment_query(session)
+            .filter(
+                SqlReviewAssignment.target_id == target_id,
+                SqlReviewAssignment.reviewer == reviewer,
+            )
+            .one_or_none()
+        )
+
+    def create_review_assignment(
+        self,
+        *,
+        experiment_id,
+        target_type,
+        target_id,
+        reviewer,
+        assigner,
+    ):
+        """See :py:meth:`AbstractStore.create_review_assignment`."""
+        from mlflow.genai.review_assignments.validation import (
+            normalize_assigner,
+            normalize_reviewer,
+            normalize_target_id,
+            validate_assignment_for_create,
+        )
+
+        # Normalize first so validation rules (non-empty, length caps)
+        # apply to the canonical form actually stored.
+        reviewer = normalize_reviewer(reviewer)
+        target_id = normalize_target_id(target_id)
+        assigner = normalize_assigner(assigner)
+        coerced_target_type = validate_assignment_for_create(
+            target_type=target_type,
+            target_id=target_id,
+            reviewer=reviewer,
+            assigner=assigner,
+        )
+
+        with self.ManagedSessionMaker(read_only=False) as session:
+            self._validate_experiment_exists(session, experiment_id)
+
+            # Pre-check on the unique key. Creating the same
+            # ``(target_id, reviewer)`` twice is a no-op — return the
+            # existing row so SDK callers can treat single-create as
+            # idempotent without a separate retry path.
+            existing = self._lookup_review_assignment_pair(session, target_id, reviewer)
+            if existing is not None:
+                return existing.to_mlflow_entity()
+
+            now_ms = get_current_time_millis()
+            sql_assignment = self._with_workspace_field(
+                self._build_review_assignment(
+                    experiment_id=experiment_id,
+                    target_type=coerced_target_type,
+                    target_id=target_id,
+                    reviewer=reviewer,
+                    assigner=assigner,
+                    now_ms=now_ms,
+                )
+            )
+            session.add(sql_assignment)
+            try:
+                # SAVEPOINT around the flush so an IntegrityError
+                # rolls back only this row, not any prior inserts in
+                # the surrounding transaction.
+                with session.begin_nested():
+                    session.flush()
+            except IntegrityError:
+                # Race: a parallel transaction inserted the same
+                # (target_id, reviewer) between the pre-check and
+                # the flush. Re-query and return the now-existing
+                # row so the caller still sees idempotent behaviour.
+                existing = self._lookup_review_assignment_pair(session, target_id, reviewer)
+                if existing is None:
+                    # IntegrityError from something other than the
+                    # unique-key collision (e.g. FK violation). Re-raise
+                    # so the caller gets a real error rather than a
+                    # silent miss.
+                    raise
+                return existing.to_mlflow_entity()
+            return sql_assignment.to_mlflow_entity()
+
+    def bulk_create_review_assignments(
+        self,
+        *,
+        experiment_id,
+        target_type,
+        target_ids,
+        reviewers,
+        assigner,
+    ):
+        """See :py:meth:`AbstractStore.bulk_create_review_assignments`."""
+        from mlflow.genai.review_assignments import (
+            BulkCreateFailure,
+            BulkCreateReviewAssignmentsResult,
+        )
+        from mlflow.genai.review_assignments.validation import (
+            normalize_assigner,
+            normalize_reviewer,
+            normalize_target_id,
+            validate_assignment_for_create,
+        )
+
+        # Normalize assigner once — same value across the whole batch.
+        # A bad assigner is a whole-batch failure (it's not per-pair).
+        assigner = normalize_assigner(assigner)
+
+        # Pre-flight: normalize + validate every pair. Failures land
+        # in the ``failed`` bucket with the raw caller-provided
+        # identifiers so the caller can find them again in their
+        # source data. Successful pairs go through normalized.
+        validated_pairs = []
+        failed = []
+        coerced_target_type = None
+        for target_id in target_ids:
+            for reviewer in reviewers:
+                try:
+                    normalized_target_id = normalize_target_id(target_id)
+                    normalized_reviewer = normalize_reviewer(reviewer)
+                    coerced_target_type = validate_assignment_for_create(
+                        target_type=target_type,
+                        target_id=normalized_target_id,
+                        reviewer=normalized_reviewer,
+                        assigner=assigner,
+                    )
+                except MlflowException as e:
+                    failed.append(
+                        BulkCreateFailure(
+                            target_id=str(target_id),
+                            reviewer=str(reviewer),
+                            error_message=str(e),
+                        )
+                    )
+                else:
+                    validated_pairs.append((normalized_target_id, normalized_reviewer))
+
+        created = []
+        existing_ids = []
+        with self.ManagedSessionMaker(read_only=False) as session:
+            # Validate experiment existence BEFORE per-pair work so a
+            # bad experiment_id raises immediately rather than
+            # silently producing N*M failures with misleading
+            # validation error messages.
+            self._validate_experiment_exists(session, experiment_id)
+
+            # Per-pair pass over the validated pairs. SAVEPOINT around
+            # each flush so a race-condition collision on row K
+            # doesn't roll back rows 1..K-1 already flushed in this
+            # transaction.
+            now_ms = get_current_time_millis()
+            for target_id, reviewer in validated_pairs:
+                hit = self._lookup_review_assignment_pair(session, target_id, reviewer)
+                if hit is not None:
+                    existing_ids.append(hit.assignment_id)
+                    continue
+                sql_assignment = self._with_workspace_field(
+                    self._build_review_assignment(
+                        experiment_id=experiment_id,
+                        target_type=coerced_target_type,
+                        target_id=target_id,
+                        reviewer=reviewer,
+                        assigner=assigner,
+                        now_ms=now_ms,
+                    )
+                )
+                session.add(sql_assignment)
+                try:
+                    with session.begin_nested():
+                        session.flush()
+                except IntegrityError:
+                    # Parallel writer inserted the same row mid-batch.
+                    # SAVEPOINT rolled back only this row; re-fetch
+                    # and record the now-existing id rather than
+                    # failing the whole batch. If the collision wasn't
+                    # the unique key (e.g. FK violation), the lookup
+                    # will miss and we re-raise to surface the real
+                    # error.
+                    hit = self._lookup_review_assignment_pair(session, target_id, reviewer)
+                    if hit is None:
+                        raise
+                    existing_ids.append(hit.assignment_id)
+                else:
+                    created.append(sql_assignment.to_mlflow_entity())
+
+        return BulkCreateReviewAssignmentsResult(
+            created=created,
+            existing=existing_ids,
+            failed=failed,
+        )
+
+    def get_review_assignment(self, assignment_id):
+        """See :py:meth:`AbstractStore.get_review_assignment`."""
+        with self.ManagedSessionMaker() as session:
+            sql_assignment = (
+                self
+                ._review_assignment_query(session)
+                .filter(SqlReviewAssignment.assignment_id == assignment_id)
+                .one_or_none()
+            )
+            if sql_assignment is None:
+                raise MlflowException(
+                    f"Review assignment with id '{assignment_id}' not found.",
+                    error_code=RESOURCE_DOES_NOT_EXIST,
+                )
+            return sql_assignment.to_mlflow_entity()
+
+    def list_review_assignments(
+        self,
+        *,
+        experiment_id=None,
+        reviewer=None,
+        state=None,
+        target_type=None,
+        max_results=None,
+        page_token=None,
+    ):
+        """See :py:meth:`AbstractStore.list_review_assignments`."""
+        from mlflow.genai.review_assignments.validation import normalize_reviewer
+
+        # Require at least one indexed scope predicate. Without this
+        # guard a caller can full-table-scan a table that grows
+        # unboundedly per assignment; the composite index serves
+        # (experiment_id, reviewer, state) so either filter is enough.
+        if experiment_id is None and reviewer is None:
+            raise MlflowException(
+                "At least one of `experiment_id` or `reviewer` must be set when "
+                "listing review assignments.",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+        if max_results is not None:
+            self._validate_max_results_param(max_results)
+        else:
+            max_results = SEARCH_MAX_RESULTS_DEFAULT
+        offset = SearchUtils.parse_start_offset_from_page_token(page_token) if page_token else 0
+
+        with self.ManagedSessionMaker() as session:
+            query = self._review_assignment_query(session)
+            if experiment_id is not None:
+                query = query.filter(SqlReviewAssignment.experiment_id == int(experiment_id))
+            if reviewer is not None:
+                # Normalize the caller-provided value the same way the
+                # write path does so the indexed equality matches.
+                query = query.filter(SqlReviewAssignment.reviewer == normalize_reviewer(reviewer))
+            if state is not None:
+                query = query.filter(SqlReviewAssignment.state == str(state))
+            if target_type is not None:
+                query = query.filter(SqlReviewAssignment.target_type == str(target_type))
+
+            results = (
+                query
+                .order_by(
+                    SqlReviewAssignment.creation_time_ms.desc(),
+                    SqlReviewAssignment.assignment_id.asc(),
+                )
+                .offset(offset)
+                .limit(max_results + 1)
+                .all()
+            )
+
+            next_token = None
+            if len(results) > max_results:
+                results = results[:max_results]
+                next_token = SearchUtils.create_page_token(offset + max_results)
+            return PagedList(
+                [r.to_mlflow_entity() for r in results],
+                next_token,
+            )
+
+    def list_review_assignments_for_target(self, target_id):
+        """See :py:meth:`AbstractStore.list_review_assignments_for_target`."""
+        from mlflow.genai.review_assignments.validation import normalize_target_id
+
+        target_id = normalize_target_id(target_id)
+        with self.ManagedSessionMaker() as session:
+            results = (
+                self
+                ._review_assignment_query(session)
+                .filter(SqlReviewAssignment.target_id == target_id)
+                .order_by(SqlReviewAssignment.creation_time_ms.asc())
+                .all()
+            )
+            return [r.to_mlflow_entity() for r in results]
+
+    def update_review_assignment(self, assignment_id, *, state):
+        """See :py:meth:`AbstractStore.update_review_assignment`."""
+        from mlflow.genai.review_assignments.validation import (
+            validate_assignment_for_update,
+        )
+
+        with self.ManagedSessionMaker(read_only=False) as session:
+            sql_assignment = (
+                self
+                ._review_assignment_query(session)
+                .filter(SqlReviewAssignment.assignment_id == assignment_id)
+                .one_or_none()
+            )
+            if sql_assignment is None:
+                raise MlflowException(
+                    f"Review assignment with id '{assignment_id}' not found.",
+                    error_code=RESOURCE_DOES_NOT_EXIST,
+                )
+
+            current_state = ReviewAssignmentState(sql_assignment.state)
+            # Transition-aware validation: enforces the FSM documented
+            # on ``ReviewAssignmentState`` so callers can't manually
+            # walk the workflow back to ``pending``.
+            new_enum = validate_assignment_for_update(
+                current_state=current_state,
+                new_state=state,
+            )
+
+            # Don't bump timestamps if nothing changed; lets reviewers
+            # toggle freely in the UI without polluting the audit log.
+            if current_state == new_enum:
+                return sql_assignment.to_mlflow_entity()
+
+            now_ms = get_current_time_millis()
+            sql_assignment.state = str(new_enum)
+            sql_assignment.last_update_time_ms = now_ms
+            if new_enum == ReviewAssignmentState.COMPLETE:
+                sql_assignment.completed_time_ms = now_ms
+            # On reopen (complete -> in_progress), keep
+            # ``completed_time_ms`` populated with the prior completion
+            # stamp so callers can still surface "last completed at"
+            # even after a reopen.
+            session.flush()
+            return sql_assignment.to_mlflow_entity()
+
+    def delete_review_assignment(self, assignment_id):
+        """See :py:meth:`AbstractStore.delete_review_assignment`."""
+        with self.ManagedSessionMaker(read_only=False) as session:
+            self._review_assignment_query(session).filter(
+                SqlReviewAssignment.assignment_id == assignment_id
+            ).delete(synchronize_session=False)
 
 
 def _get_sqlalchemy_filter_clauses(parsed, session, dialect):

--- a/mlflow/store/tracking/sqlalchemy_workspace_store.py
+++ b/mlflow/store/tracking/sqlalchemy_workspace_store.py
@@ -33,6 +33,7 @@ from mlflow.store.tracking.dbmodels.models import (
     SqlIssue,
     SqlLoggedModel,
     SqlOnlineScoringConfig,
+    SqlReviewAssignment,
     SqlRun,
     SqlScorer,
     SqlTraceInfo,
@@ -85,6 +86,12 @@ class WorkspaceAwareSqlAlchemyStore(WorkspaceAwareMixin, SqlAlchemyStore):
             return query.join(
                 SqlExperiment, SqlIssue.experiment_id == SqlExperiment.experiment_id
             ).filter(SqlExperiment.workspace == workspace)
+
+        if model is SqlReviewAssignment:
+            # ReviewAssignment carries its own workspace column (not
+            # joined via experiments) for symmetry with other
+            # OTHER_WORKSPACE_CHILD_TABLES entries. Filter directly.
+            return query.filter(SqlReviewAssignment.workspace == workspace)
 
         if model is SqlLoggedModel:
             workspace_experiment_ids = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -487,6 +487,8 @@ tpe = "tpe"                        # Tree-structured Parzen Estimator (hyperopt/
 TPE = "TPE"                        # Tree-structured Parzen Estimator (hyperopt/optuna)
 indx = "indx"                      # intentional shorthand for index
 Tru = "Tru"                        # TruLens library name prefix
+SME = "SME"                        # subject-matter expert
+SMEs = "SMEs"                      # subject-matter experts
 
 # https://github.com/crate-ci/typos/blob/master/docs/reference.md
 [tool.typos.files]

--- a/tests/db/schemas/mssql.sql
+++ b/tests/db/schemas/mssql.sql
@@ -295,6 +295,23 @@ CREATE TABLE registered_model_tags (
 )
 
 
+CREATE TABLE review_assignments (
+	assignment_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	workspace VARCHAR(63) COLLATE "SQL_Latin1_General_CP1_CI_AS" DEFAULT ('default') NOT NULL,
+	experiment_id INTEGER NOT NULL,
+	target_type VARCHAR(16) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	target_id VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	reviewer VARCHAR(250) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	assigner VARCHAR(250) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	state VARCHAR(16) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	creation_time_ms BIGINT NOT NULL,
+	last_update_time_ms BIGINT NOT NULL,
+	completed_time_ms BIGINT,
+	CONSTRAINT review_assignments_pk PRIMARY KEY (assignment_id),
+	CONSTRAINT fk_review_assignments_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
+)
+
+
 CREATE TABLE runs (
 	run_uuid VARCHAR(32) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	name VARCHAR(250) COLLATE "SQL_Latin1_General_CP1_CI_AS",
@@ -333,7 +350,7 @@ CREATE TABLE trace_info (
 	client_request_id VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	request_preview VARCHAR(1000) COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	response_preview VARCHAR(1000) COLLATE "SQL_Latin1_General_CP1_CI_AS",
-	db_payload_generation INTEGER DEFAULT '0' NOT NULL,
+	db_payload_generation INTEGER DEFAULT ('0') NOT NULL,
 	CONSTRAINT trace_info_pk PRIMARY KEY (request_id),
 	CONSTRAINT fk_trace_info_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
 )
@@ -405,38 +422,6 @@ CREATE TABLE endpoint_tags (
 	endpoint_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	CONSTRAINT endpoint_tag_pk PRIMARY KEY (key, endpoint_id),
 	CONSTRAINT fk_endpoint_tags_endpoint_id FOREIGN KEY(endpoint_id) REFERENCES endpoints (endpoint_id) ON DELETE CASCADE
-)
-
-
-CREATE TABLE guardrails (
-	guardrail_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
-	name VARCHAR(255) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
-	scorer_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
-	scorer_version INTEGER NOT NULL,
-	stage VARCHAR(32) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
-	action VARCHAR(32) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
-	action_endpoint_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS",
-	created_by VARCHAR(255) COLLATE "SQL_Latin1_General_CP1_CI_AS",
-	created_at BIGINT NOT NULL,
-	last_updated_by VARCHAR(255) COLLATE "SQL_Latin1_General_CP1_CI_AS",
-	last_updated_at BIGINT NOT NULL,
-	workspace VARCHAR(63) COLLATE "SQL_Latin1_General_CP1_CI_AS" DEFAULT ('default') NOT NULL,
-	CONSTRAINT guardrails_pk PRIMARY KEY (guardrail_id),
-	CONSTRAINT fk_guardrails_scorer_version FOREIGN KEY(scorer_id, scorer_version) REFERENCES scorer_versions (scorer_id, scorer_version),
-	CONSTRAINT fk_guardrails_action_endpoint_id FOREIGN KEY(action_endpoint_id) REFERENCES endpoints (endpoint_id) ON DELETE SET NULL
-)
-
-
-CREATE TABLE guardrail_configs (
-	endpoint_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
-	guardrail_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
-	execution_order INTEGER,
-	created_by VARCHAR(255) COLLATE "SQL_Latin1_General_CP1_CI_AS",
-	created_at BIGINT NOT NULL,
-	workspace VARCHAR(63) COLLATE "SQL_Latin1_General_CP1_CI_AS" DEFAULT ('default') NOT NULL,
-	CONSTRAINT guardrail_configs_pk PRIMARY KEY (endpoint_id, guardrail_id),
-	CONSTRAINT fk_guardrail_configs_endpoint_id FOREIGN KEY(endpoint_id) REFERENCES endpoints (endpoint_id) ON DELETE CASCADE,
-	CONSTRAINT fk_guardrail_configs_guardrail_id FOREIGN KEY(guardrail_id) REFERENCES guardrails (guardrail_id) ON DELETE CASCADE
 )
 
 
@@ -620,6 +605,25 @@ CREATE TABLE trace_tags (
 )
 
 
+CREATE TABLE guardrails (
+	guardrail_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	name VARCHAR(255) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	scorer_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	scorer_version INTEGER NOT NULL,
+	stage VARCHAR(32) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	action VARCHAR(32) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	action_endpoint_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	created_by VARCHAR(255) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	created_at BIGINT NOT NULL,
+	last_updated_by VARCHAR(255) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	last_updated_at BIGINT NOT NULL,
+	workspace VARCHAR(63) COLLATE "SQL_Latin1_General_CP1_CI_AS" DEFAULT ('default') NOT NULL,
+	CONSTRAINT guardrails_pk PRIMARY KEY (guardrail_id),
+	CONSTRAINT fk_guardrails_action_endpoint_id FOREIGN KEY(action_endpoint_id) REFERENCES endpoints (endpoint_id) ON DELETE SET NULL,
+	CONSTRAINT fk_guardrails_scorer_version FOREIGN KEY(scorer_id, scorer_version) REFERENCES scorer_versions (scorer_id, scorer_version)
+)
+
+
 CREATE TABLE span_metrics (
 	trace_id VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	span_id VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
@@ -627,4 +631,17 @@ CREATE TABLE span_metrics (
 	value FLOAT,
 	CONSTRAINT span_metrics_pk PRIMARY KEY (trace_id, span_id, key),
 	CONSTRAINT fk_span_metrics_span FOREIGN KEY(trace_id, span_id) REFERENCES spans (trace_id, span_id) ON DELETE CASCADE
+)
+
+
+CREATE TABLE guardrail_configs (
+	endpoint_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	guardrail_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	execution_order INTEGER,
+	created_by VARCHAR(255) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	created_at BIGINT NOT NULL,
+	workspace VARCHAR(63) COLLATE "SQL_Latin1_General_CP1_CI_AS" DEFAULT ('default') NOT NULL,
+	CONSTRAINT guardrail_configs_pk PRIMARY KEY (endpoint_id, guardrail_id),
+	CONSTRAINT fk_guardrail_configs_endpoint_id FOREIGN KEY(endpoint_id) REFERENCES endpoints (endpoint_id) ON DELETE CASCADE,
+	CONSTRAINT fk_guardrail_configs_guardrail_id FOREIGN KEY(guardrail_id) REFERENCES guardrails (guardrail_id) ON DELETE CASCADE
 )

--- a/tests/db/schemas/mysql.sql
+++ b/tests/db/schemas/mysql.sql
@@ -297,6 +297,23 @@ CREATE TABLE registered_model_tags (
 )
 
 
+CREATE TABLE review_assignments (
+	assignment_id VARCHAR(36) NOT NULL,
+	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
+	experiment_id INTEGER NOT NULL,
+	target_type VARCHAR(16) NOT NULL,
+	target_id VARCHAR(50) NOT NULL,
+	reviewer VARCHAR(250) NOT NULL,
+	assigner VARCHAR(250) NOT NULL,
+	state VARCHAR(16) NOT NULL,
+	creation_time_ms BIGINT NOT NULL,
+	last_update_time_ms BIGINT NOT NULL,
+	completed_time_ms BIGINT,
+	PRIMARY KEY (assignment_id),
+	CONSTRAINT fk_review_assignments_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
+)
+
+
 CREATE TABLE runs (
 	run_uuid VARCHAR(32) NOT NULL,
 	name VARCHAR(250),
@@ -410,38 +427,6 @@ CREATE TABLE endpoint_tags (
 	endpoint_id VARCHAR(36) NOT NULL,
 	PRIMARY KEY (key, endpoint_id),
 	CONSTRAINT fk_endpoint_tags_endpoint_id FOREIGN KEY(endpoint_id) REFERENCES endpoints (endpoint_id) ON DELETE CASCADE
-)
-
-
-CREATE TABLE guardrails (
-	guardrail_id VARCHAR(36) NOT NULL,
-	name VARCHAR(255) NOT NULL,
-	scorer_id VARCHAR(36) NOT NULL,
-	scorer_version INTEGER NOT NULL,
-	stage VARCHAR(32) NOT NULL,
-	action VARCHAR(32) NOT NULL,
-	action_endpoint_id VARCHAR(36),
-	created_by VARCHAR(255),
-	created_at BIGINT NOT NULL,
-	last_updated_by VARCHAR(255),
-	last_updated_at BIGINT NOT NULL,
-	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
-	PRIMARY KEY (guardrail_id),
-	CONSTRAINT fk_guardrails_scorer_version FOREIGN KEY(scorer_id, scorer_version) REFERENCES scorer_versions (scorer_id, scorer_version),
-	CONSTRAINT fk_guardrails_action_endpoint_id FOREIGN KEY(action_endpoint_id) REFERENCES endpoints (endpoint_id) ON DELETE SET NULL
-)
-
-
-CREATE TABLE guardrail_configs (
-	endpoint_id VARCHAR(36) NOT NULL,
-	guardrail_id VARCHAR(36) NOT NULL,
-	execution_order INTEGER,
-	created_by VARCHAR(255),
-	created_at BIGINT NOT NULL,
-	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
-	PRIMARY KEY (endpoint_id, guardrail_id),
-	CONSTRAINT fk_guardrail_configs_endpoint_id FOREIGN KEY(endpoint_id) REFERENCES endpoints (endpoint_id) ON DELETE CASCADE,
-	CONSTRAINT fk_guardrail_configs_guardrail_id FOREIGN KEY(guardrail_id) REFERENCES guardrails (guardrail_id) ON DELETE CASCADE
 )
 
 
@@ -628,6 +613,25 @@ CREATE TABLE trace_tags (
 )
 
 
+CREATE TABLE guardrails (
+	guardrail_id VARCHAR(36) NOT NULL,
+	name VARCHAR(255) NOT NULL,
+	scorer_id VARCHAR(36) NOT NULL,
+	scorer_version INTEGER NOT NULL,
+	stage VARCHAR(32) NOT NULL,
+	action VARCHAR(32) NOT NULL,
+	action_endpoint_id VARCHAR(36),
+	created_by VARCHAR(255),
+	created_at BIGINT NOT NULL,
+	last_updated_by VARCHAR(255),
+	last_updated_at BIGINT NOT NULL,
+	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
+	PRIMARY KEY (guardrail_id),
+	CONSTRAINT fk_guardrails_action_endpoint_id FOREIGN KEY(action_endpoint_id) REFERENCES endpoints (endpoint_id) ON DELETE SET NULL,
+	CONSTRAINT fk_guardrails_scorer_version FOREIGN KEY(scorer_id, scorer_version) REFERENCES scorer_versions (scorer_id, scorer_version)
+)
+
+
 CREATE TABLE span_metrics (
 	trace_id VARCHAR(50) NOT NULL,
 	span_id VARCHAR(50) NOT NULL,
@@ -635,4 +639,17 @@ CREATE TABLE span_metrics (
 	value DOUBLE,
 	PRIMARY KEY (trace_id, span_id, key),
 	CONSTRAINT fk_span_metrics_span FOREIGN KEY(trace_id, span_id) REFERENCES spans (trace_id, span_id) ON DELETE CASCADE
+)
+
+
+CREATE TABLE guardrail_configs (
+	endpoint_id VARCHAR(36) NOT NULL,
+	guardrail_id VARCHAR(36) NOT NULL,
+	execution_order INTEGER,
+	created_by VARCHAR(255),
+	created_at BIGINT NOT NULL,
+	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
+	PRIMARY KEY (endpoint_id, guardrail_id),
+	CONSTRAINT fk_guardrail_configs_endpoint_id FOREIGN KEY(endpoint_id) REFERENCES endpoints (endpoint_id) ON DELETE CASCADE,
+	CONSTRAINT fk_guardrail_configs_guardrail_id FOREIGN KEY(guardrail_id) REFERENCES guardrails (guardrail_id) ON DELETE CASCADE
 )

--- a/tests/db/schemas/postgresql.sql
+++ b/tests/db/schemas/postgresql.sql
@@ -298,6 +298,24 @@ CREATE TABLE registered_model_tags (
 )
 
 
+CREATE TABLE review_assignments (
+	assignment_id VARCHAR(36) NOT NULL,
+	workspace VARCHAR(63) DEFAULT 'default'::character varying NOT NULL,
+	experiment_id INTEGER NOT NULL,
+	target_type VARCHAR(16) NOT NULL,
+	target_id VARCHAR(50) NOT NULL,
+	reviewer VARCHAR(250) NOT NULL,
+	assigner VARCHAR(250) NOT NULL,
+	state VARCHAR(16) NOT NULL,
+	creation_time_ms BIGINT NOT NULL,
+	last_update_time_ms BIGINT NOT NULL,
+	completed_time_ms BIGINT,
+	CONSTRAINT review_assignments_pk PRIMARY KEY (assignment_id),
+	CONSTRAINT fk_review_assignments_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE,
+	CONSTRAINT uq_review_assignments_workspace_target_reviewer UNIQUE (workspace, target_id, reviewer)
+)
+
+
 CREATE TABLE runs (
 	run_uuid VARCHAR(32) NOT NULL,
 	name VARCHAR(250),
@@ -339,7 +357,7 @@ CREATE TABLE trace_info (
 	client_request_id VARCHAR(50),
 	request_preview VARCHAR(1000),
 	response_preview VARCHAR(1000),
-	db_payload_generation INTEGER DEFAULT '0' NOT NULL,
+	db_payload_generation INTEGER DEFAULT 0 NOT NULL,
 	CONSTRAINT trace_info_pk PRIMARY KEY (request_id),
 	CONSTRAINT fk_trace_info_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
 )
@@ -411,38 +429,6 @@ CREATE TABLE endpoint_tags (
 	endpoint_id VARCHAR(36) NOT NULL,
 	CONSTRAINT endpoint_tag_pk PRIMARY KEY (key, endpoint_id),
 	CONSTRAINT fk_endpoint_tags_endpoint_id FOREIGN KEY(endpoint_id) REFERENCES endpoints (endpoint_id) ON DELETE CASCADE
-)
-
-
-CREATE TABLE guardrails (
-	guardrail_id VARCHAR(36) NOT NULL,
-	name VARCHAR(255) NOT NULL,
-	scorer_id VARCHAR(36) NOT NULL,
-	scorer_version INTEGER NOT NULL,
-	stage VARCHAR(32) NOT NULL,
-	action VARCHAR(32) NOT NULL,
-	action_endpoint_id VARCHAR(36),
-	created_by VARCHAR(255),
-	created_at BIGINT NOT NULL,
-	last_updated_by VARCHAR(255),
-	last_updated_at BIGINT NOT NULL,
-	workspace VARCHAR(63) DEFAULT 'default'::character varying NOT NULL,
-	CONSTRAINT guardrails_pk PRIMARY KEY (guardrail_id),
-	CONSTRAINT fk_guardrails_scorer_version FOREIGN KEY(scorer_id, scorer_version) REFERENCES scorer_versions (scorer_id, scorer_version),
-	CONSTRAINT fk_guardrails_action_endpoint_id FOREIGN KEY(action_endpoint_id) REFERENCES endpoints (endpoint_id) ON DELETE SET NULL
-)
-
-
-CREATE TABLE guardrail_configs (
-	endpoint_id VARCHAR(36) NOT NULL,
-	guardrail_id VARCHAR(36) NOT NULL,
-	execution_order INTEGER,
-	created_by VARCHAR(255),
-	created_at BIGINT NOT NULL,
-	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
-	CONSTRAINT guardrail_configs_pk PRIMARY KEY (endpoint_id, guardrail_id),
-	CONSTRAINT fk_guardrail_configs_endpoint_id FOREIGN KEY(endpoint_id) REFERENCES endpoints (endpoint_id) ON DELETE CASCADE,
-	CONSTRAINT fk_guardrail_configs_guardrail_id FOREIGN KEY(guardrail_id) REFERENCES guardrails (guardrail_id) ON DELETE CASCADE
 )
 
 
@@ -626,6 +612,25 @@ CREATE TABLE trace_tags (
 )
 
 
+CREATE TABLE guardrails (
+	guardrail_id VARCHAR(36) NOT NULL,
+	name VARCHAR(255) NOT NULL,
+	scorer_id VARCHAR(36) NOT NULL,
+	scorer_version INTEGER NOT NULL,
+	stage VARCHAR(32) NOT NULL,
+	action VARCHAR(32) NOT NULL,
+	action_endpoint_id VARCHAR(36),
+	created_by VARCHAR(255),
+	created_at BIGINT NOT NULL,
+	last_updated_by VARCHAR(255),
+	last_updated_at BIGINT NOT NULL,
+	workspace VARCHAR(63) DEFAULT 'default'::character varying NOT NULL,
+	CONSTRAINT guardrails_pk PRIMARY KEY (guardrail_id),
+	CONSTRAINT fk_guardrails_action_endpoint_id FOREIGN KEY(action_endpoint_id) REFERENCES endpoints (endpoint_id) ON DELETE SET NULL,
+	CONSTRAINT fk_guardrails_scorer_version FOREIGN KEY(scorer_id, scorer_version) REFERENCES scorer_versions (scorer_id, scorer_version)
+)
+
+
 CREATE TABLE span_metrics (
 	trace_id VARCHAR(50) NOT NULL,
 	span_id VARCHAR(50) NOT NULL,
@@ -633,4 +638,17 @@ CREATE TABLE span_metrics (
 	value DOUBLE PRECISION,
 	CONSTRAINT span_metrics_pk PRIMARY KEY (trace_id, span_id, key),
 	CONSTRAINT fk_span_metrics_span FOREIGN KEY(trace_id, span_id) REFERENCES spans (trace_id, span_id) ON DELETE CASCADE
+)
+
+
+CREATE TABLE guardrail_configs (
+	endpoint_id VARCHAR(36) NOT NULL,
+	guardrail_id VARCHAR(36) NOT NULL,
+	execution_order INTEGER,
+	created_by VARCHAR(255),
+	created_at BIGINT NOT NULL,
+	workspace VARCHAR(63) DEFAULT 'default'::character varying NOT NULL,
+	CONSTRAINT guardrail_configs_pk PRIMARY KEY (endpoint_id, guardrail_id),
+	CONSTRAINT fk_guardrail_configs_endpoint_id FOREIGN KEY(endpoint_id) REFERENCES endpoints (endpoint_id) ON DELETE CASCADE,
+	CONSTRAINT fk_guardrail_configs_guardrail_id FOREIGN KEY(guardrail_id) REFERENCES guardrails (guardrail_id) ON DELETE CASCADE
 )

--- a/tests/db/schemas/sqlite.sql
+++ b/tests/db/schemas/sqlite.sql
@@ -298,6 +298,24 @@ CREATE TABLE registered_model_tags (
 )
 
 
+CREATE TABLE review_assignments (
+	assignment_id VARCHAR(36) NOT NULL,
+	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
+	experiment_id INTEGER NOT NULL,
+	target_type VARCHAR(16) NOT NULL,
+	target_id VARCHAR(50) NOT NULL,
+	reviewer VARCHAR(250) NOT NULL,
+	assigner VARCHAR(250) NOT NULL,
+	state VARCHAR(16) NOT NULL,
+	creation_time_ms BIGINT NOT NULL,
+	last_update_time_ms BIGINT NOT NULL,
+	completed_time_ms BIGINT,
+	CONSTRAINT review_assignments_pk PRIMARY KEY (assignment_id),
+	CONSTRAINT fk_review_assignments_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE,
+	CONSTRAINT uq_review_assignments_workspace_target_reviewer UNIQUE (workspace, target_id, reviewer)
+)
+
+
 CREATE TABLE runs (
 	run_uuid VARCHAR(32) NOT NULL,
 	name VARCHAR(250),
@@ -636,4 +654,3 @@ CREATE TABLE guardrail_configs (
 	CONSTRAINT fk_guardrail_configs_endpoint_id FOREIGN KEY(endpoint_id) REFERENCES endpoints (endpoint_id) ON DELETE CASCADE,
 	CONSTRAINT fk_guardrail_configs_guardrail_id FOREIGN KEY(guardrail_id) REFERENCES guardrails (guardrail_id) ON DELETE CASCADE
 )
-

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -298,6 +298,24 @@ CREATE TABLE registered_model_tags (
 )
 
 
+CREATE TABLE review_assignments (
+	assignment_id VARCHAR(36) NOT NULL,
+	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
+	experiment_id INTEGER NOT NULL,
+	target_type VARCHAR(16) NOT NULL,
+	target_id VARCHAR(50) NOT NULL,
+	reviewer VARCHAR(250) NOT NULL,
+	assigner VARCHAR(250) NOT NULL,
+	state VARCHAR(16) NOT NULL,
+	creation_time_ms BIGINT NOT NULL,
+	last_update_time_ms BIGINT NOT NULL,
+	completed_time_ms BIGINT,
+	CONSTRAINT review_assignments_pk PRIMARY KEY (assignment_id),
+	CONSTRAINT fk_review_assignments_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE,
+	CONSTRAINT uq_review_assignments_workspace_target_reviewer UNIQUE (workspace, target_id, reviewer)
+)
+
+
 CREATE TABLE runs (
 	run_uuid VARCHAR(32) NOT NULL,
 	name VARCHAR(250),

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_review_assignments.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_review_assignments.py
@@ -250,13 +250,13 @@ def test_list_review_assignments_filters_by_state(store):
     exp_id = _create_experiments(store, "test_list_by_state")
     a = _create_assignment(store, exp_id, target_id="tr-1")
     _create_assignment(store, exp_id, target_id="tr-2")
-    store.update_review_assignment(a.assignment_id, state="in_progress")
+    store.update_review_assignment(a.assignment_id, state="complete")
 
     pending_page = store.list_review_assignments(experiment_id=exp_id, state="pending")
-    in_progress_page = store.list_review_assignments(experiment_id=exp_id, state="in_progress")
+    complete_page = store.list_review_assignments(experiment_id=exp_id, state="complete")
 
     assert {a.target_id for a in pending_page} == {"tr-2"}
-    assert {a.target_id for a in in_progress_page} == {"tr-1"}
+    assert {a.target_id for a in complete_page} == {"tr-1"}
 
 
 def test_list_review_assignments_requires_scope_predicate(store):
@@ -285,22 +285,18 @@ def test_list_review_assignments_for_target_returns_all_reviewers(store):
 def test_update_review_assignment_transitions_state(store):
     exp_id = _create_experiments(store, "test_update_ra_state")
     a = _create_assignment(store, exp_id)
-
-    in_progress = store.update_review_assignment(a.assignment_id, state="in_progress")
-    assert in_progress.state == ReviewAssignmentState.IN_PROGRESS
-    assert in_progress.last_update_time_ms >= a.last_update_time_ms
-    assert in_progress.completed_time_ms is None
+    assert a.state == ReviewAssignmentState.PENDING
+    assert a.completed_time_ms is None
 
     complete = store.update_review_assignment(a.assignment_id, state="complete")
     assert complete.state == ReviewAssignmentState.COMPLETE
+    assert complete.last_update_time_ms >= a.last_update_time_ms
     assert complete.completed_time_ms is not None
-    assert complete.completed_time_ms >= in_progress.last_update_time_ms
 
-    reopened = store.update_review_assignment(a.assignment_id, state="in_progress")
-    assert reopened.state == ReviewAssignmentState.IN_PROGRESS
-    # ``completed_time_ms`` is preserved on reopen so the prior
-    # completion timestamp is still recoverable.
-    assert reopened.completed_time_ms == complete.completed_time_ms
+    reopened = store.update_review_assignment(a.assignment_id, state="pending")
+    assert reopened.state == ReviewAssignmentState.PENDING
+    # Reopen clears the completion stamp.
+    assert reopened.completed_time_ms is None
 
 
 def test_update_review_assignment_noop_when_state_unchanged(store):
@@ -321,24 +317,15 @@ def test_update_review_assignment_rejects_unknown_state(store):
         store.update_review_assignment(a.assignment_id, state="not_a_state")
 
 
-@pytest.mark.parametrize(
-    ("from_state", "to_state"),
-    [
-        pytest.param("in_progress", "pending", id="in_progress-to-pending"),
-        pytest.param("complete", "pending", id="complete-to-pending"),
-    ],
-)
-def test_update_review_assignment_rejects_illegal_transitions(store, from_state, to_state):
-    exp_id = _create_experiments(store, f"test_illegal_{from_state}_{to_state}")
+def test_update_review_assignment_reopen_clears_completed_time(store):
+    exp_id = _create_experiments(store, "test_reopen_clears_completed")
     a = _create_assignment(store, exp_id)
-    # Walk to the starting state via legal transitions.
-    if from_state in ("in_progress", "complete"):
-        store.update_review_assignment(a.assignment_id, state="in_progress")
-    if from_state == "complete":
-        store.update_review_assignment(a.assignment_id, state="complete")
+    store.update_review_assignment(a.assignment_id, state="complete")
 
-    with pytest.raises(MlflowException, match="Illegal state transition"):
-        store.update_review_assignment(a.assignment_id, state=to_state)
+    reopened = store.update_review_assignment(a.assignment_id, state="pending")
+
+    assert reopened.state == ReviewAssignmentState.PENDING
+    assert reopened.completed_time_ms is None
 
 
 def test_update_review_assignment_raises_on_missing(store):

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_review_assignments.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_review_assignments.py
@@ -110,21 +110,6 @@ def test_create_review_assignment_rejects_invalid_target_type(store):
         )
 
 
-@pytest.mark.parametrize("forward_compat_type", ["session", "span"])
-def test_create_review_assignment_rejects_v1_unsupported_target_type(store, forward_compat_type):
-    # ReviewTargetType carries SESSION and SPAN for forward-compat but
-    # v1 ships TRACE only. Reject so we don't store unrenderable rows.
-    exp_id = _create_experiments(store, f"test_create_ra_{forward_compat_type}")
-    with pytest.raises(MlflowException, match="not supported in this release"):
-        store.create_review_assignment(
-            experiment_id=exp_id,
-            target_type=forward_compat_type,
-            target_id="tr-1",
-            reviewer="sme@example.com",
-            assigner="kris@example.com",
-        )
-
-
 # ---------------------------------------------------------------------------
 # bulk_create_review_assignments
 # ---------------------------------------------------------------------------

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_review_assignments.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_review_assignments.py
@@ -1,0 +1,421 @@
+import pytest
+
+from mlflow.exceptions import MlflowException
+from mlflow.genai.review_assignments import (
+    ReviewAssignment,
+    ReviewAssignmentState,
+    ReviewTargetType,
+)
+from mlflow.store.tracking.dbmodels.models import SqlReviewAssignment
+
+from tests.store.tracking.sqlalchemy_store.conftest import _create_experiments
+
+pytestmark = pytest.mark.notrackingurimock
+
+
+def _create_assignment(store, experiment_id, *, target_id="tr-1", reviewer="sme@example.com"):
+    return store.create_review_assignment(
+        experiment_id=experiment_id,
+        target_type="trace",
+        target_id=target_id,
+        reviewer=reviewer,
+        assigner="kris@example.com",
+    )
+
+
+# ---------------------------------------------------------------------------
+# create_review_assignment
+# ---------------------------------------------------------------------------
+
+
+def test_create_review_assignment_happy_path(store):
+    exp_id = _create_experiments(store, "test_create_ra_happy")
+
+    assignment = _create_assignment(store, exp_id)
+
+    assert assignment.assignment_id.startswith(SqlReviewAssignment.ASSIGNMENT_ID_PREFIX)
+    assert assignment.experiment_id == exp_id
+    assert assignment.target_type == ReviewTargetType.TRACE
+    assert assignment.target_id == "tr-1"
+    assert assignment.reviewer == "sme@example.com"
+    assert assignment.assigner == "kris@example.com"
+    assert assignment.state == ReviewAssignmentState.PENDING
+    assert assignment.creation_time_ms > 0
+    assert assignment.last_update_time_ms == assignment.creation_time_ms
+    assert assignment.completed_time_ms is None
+
+
+def test_create_review_assignment_is_idempotent_on_duplicate_pair(store):
+    exp_id = _create_experiments(store, "test_create_ra_idempotent")
+
+    first = _create_assignment(store, exp_id)
+    second = _create_assignment(store, exp_id)
+
+    assert first.assignment_id == second.assignment_id
+    assert first.creation_time_ms == second.creation_time_ms
+
+
+def test_create_review_assignment_normalizes_reviewer_casing(store):
+    # Two creates with differing-case reviewers must collapse to the
+    # same row (case-insensitive identity via lowercasing on write).
+    exp_id = _create_experiments(store, "test_create_ra_case")
+    first = _create_assignment(store, exp_id, reviewer="Alice@Example.com")
+    second = _create_assignment(store, exp_id, reviewer="ALICE@example.COM")
+    assert first.assignment_id == second.assignment_id
+    assert first.reviewer == "alice@example.com"
+
+
+def test_create_review_assignment_strips_whitespace(store):
+    exp_id = _create_experiments(store, "test_create_ra_strip")
+    first = _create_assignment(store, exp_id, target_id="tr-1", reviewer="sme@example.com")
+    second = _create_assignment(store, exp_id, target_id="  tr-1  ", reviewer="\tsme@example.com\n")
+    assert first.assignment_id == second.assignment_id
+
+
+def test_create_review_assignment_rejects_unknown_experiment(store):
+    with pytest.raises(MlflowException, match="(?i)experiment"):
+        _create_assignment(store, "999999")
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        pytest.param({"target_id": ""}, "target_id", id="empty-target-id"),
+        pytest.param({"target_id": "   "}, "target_id", id="whitespace-target-id"),
+        pytest.param({"reviewer": ""}, "reviewer", id="empty-reviewer"),
+        pytest.param({"reviewer": "a" * 251}, "at most 250", id="reviewer-too-long"),
+    ],
+)
+def test_create_review_assignment_validation_errors(store, kwargs, match):
+    exp_id = _create_experiments(store, f"test_create_ra_invalid_{kwargs}")
+    base = {"target_id": "tr-1", "reviewer": "sme@example.com"}
+    with pytest.raises(MlflowException, match=match):
+        store.create_review_assignment(
+            experiment_id=exp_id,
+            target_type="trace",
+            assigner="kris@example.com",
+            **(base | kwargs),
+        )
+
+
+def test_create_review_assignment_rejects_invalid_target_type(store):
+    exp_id = _create_experiments(store, "test_create_ra_bad_target_type")
+    with pytest.raises(MlflowException, match="target_type"):
+        store.create_review_assignment(
+            experiment_id=exp_id,
+            target_type="not_a_real_type",
+            target_id="tr-1",
+            reviewer="sme@example.com",
+            assigner="kris@example.com",
+        )
+
+
+@pytest.mark.parametrize("forward_compat_type", ["session", "span"])
+def test_create_review_assignment_rejects_v1_unsupported_target_type(store, forward_compat_type):
+    # ReviewTargetType carries SESSION and SPAN for forward-compat but
+    # v1 ships TRACE only. Reject so we don't store unrenderable rows.
+    exp_id = _create_experiments(store, f"test_create_ra_{forward_compat_type}")
+    with pytest.raises(MlflowException, match="not supported in this release"):
+        store.create_review_assignment(
+            experiment_id=exp_id,
+            target_type=forward_compat_type,
+            target_id="tr-1",
+            reviewer="sme@example.com",
+            assigner="kris@example.com",
+        )
+
+
+# ---------------------------------------------------------------------------
+# bulk_create_review_assignments
+# ---------------------------------------------------------------------------
+
+
+def test_bulk_create_review_assignments_cross_product(store):
+    exp_id = _create_experiments(store, "test_bulk_create_ra")
+
+    result = store.bulk_create_review_assignments(
+        experiment_id=exp_id,
+        target_type="trace",
+        target_ids=["tr-1", "tr-2", "tr-3"],
+        reviewers=["sme1@example.com", "sme2@example.com"],
+        assigner="kris@example.com",
+    )
+
+    # 3 targets x 2 reviewers = 6 new rows.
+    assert len(result.created) == 6
+    assert result.existing == []
+    assert result.failed == []
+    # Identity check: no two created rows share a (target_id, reviewer) pair.
+    pairs = {(a.target_id, a.reviewer) for a in result.created}
+    assert len(pairs) == 6
+
+
+def test_bulk_create_review_assignments_partial_existing(store):
+    exp_id = _create_experiments(store, "test_bulk_partial_existing")
+    # Pre-seed one of the rows the bulk call would create.
+    first = _create_assignment(store, exp_id, target_id="tr-1", reviewer="sme1@example.com")
+
+    result = store.bulk_create_review_assignments(
+        experiment_id=exp_id,
+        target_type="trace",
+        target_ids=["tr-1", "tr-2"],
+        reviewers=["sme1@example.com", "sme2@example.com"],
+        assigner="kris@example.com",
+    )
+
+    # 4 total pairs; 1 already existed.
+    assert len(result.created) == 3
+    assert result.existing == [first.assignment_id]
+    assert result.failed == []
+
+
+def test_bulk_create_review_assignments_validation_failures(store):
+    exp_id = _create_experiments(store, "test_bulk_validation_failures")
+
+    result = store.bulk_create_review_assignments(
+        experiment_id=exp_id,
+        target_type="trace",
+        target_ids=["tr-1", ""],  # second target_id is invalid
+        reviewers=["sme1@example.com", ""],  # second reviewer is invalid
+        assigner="kris@example.com",
+    )
+
+    # Valid pairs land in created (1*1); invalid pairs land in failed
+    # (the other 3 cross-product entries each fail at least one
+    # validation rule).
+    assert len(result.created) == 1
+    assert result.created[0].target_id == "tr-1"
+    assert result.created[0].reviewer == "sme1@example.com"
+    assert len(result.failed) == 3
+
+
+def test_bulk_create_review_assignments_empty_input(store):
+    # Empty target list -> empty result; no DB write attempted.
+    exp_id = _create_experiments(store, "test_bulk_empty")
+    result = store.bulk_create_review_assignments(
+        experiment_id=exp_id,
+        target_type="trace",
+        target_ids=[],
+        reviewers=["sme@example.com"],
+        assigner="kris@example.com",
+    )
+    assert result.created == []
+    assert result.existing == []
+    assert result.failed == []
+
+
+def test_bulk_create_review_assignments_rejects_unknown_experiment_early(store):
+    # Bad experiment_id raises BEFORE the per-pair pre-flight fills
+    # `failed` with N*M misleading errors.
+    with pytest.raises(MlflowException, match="(?i)experiment"):
+        store.bulk_create_review_assignments(
+            experiment_id="999999",
+            target_type="trace",
+            target_ids=["tr-1"],
+            reviewers=["sme@example.com"],
+            assigner="kris@example.com",
+        )
+
+
+# ---------------------------------------------------------------------------
+# get / list
+# ---------------------------------------------------------------------------
+
+
+def test_get_review_assignment_round_trip(store):
+    exp_id = _create_experiments(store, "test_get_ra")
+    created = _create_assignment(store, exp_id)
+
+    fetched = store.get_review_assignment(created.assignment_id)
+
+    assert fetched == created
+
+
+def test_get_review_assignment_raises_on_missing(store):
+    with pytest.raises(MlflowException, match="not found"):
+        store.get_review_assignment("ra-does-not-exist")
+
+
+def test_list_review_assignments_filters_by_experiment(store):
+    exp_a, exp_b = _create_experiments(store, ["test_list_exp_a", "test_list_exp_b"])
+    _create_assignment(store, exp_a, target_id="tr-a", reviewer="sme-a@example.com")
+    _create_assignment(store, exp_b, target_id="tr-b", reviewer="sme-b@example.com")
+
+    page = store.list_review_assignments(experiment_id=exp_a)
+
+    assert len(page) == 1
+    assert page[0].experiment_id == exp_a
+    assert page[0].target_id == "tr-a"
+
+
+def test_list_review_assignments_filters_by_reviewer_case_insensitively(store):
+    exp_id = _create_experiments(store, "test_list_by_reviewer")
+    _create_assignment(store, exp_id, target_id="tr-1", reviewer="Alice@Example.com")
+    _create_assignment(store, exp_id, target_id="tr-2", reviewer="bob@example.com")
+
+    page = store.list_review_assignments(reviewer="ALICE@example.com")
+
+    assert len(page) == 1
+    assert page[0].target_id == "tr-1"
+    # Stored as canonical lowercase.
+    assert page[0].reviewer == "alice@example.com"
+
+
+def test_list_review_assignments_filters_by_state(store):
+    exp_id = _create_experiments(store, "test_list_by_state")
+    a = _create_assignment(store, exp_id, target_id="tr-1")
+    _create_assignment(store, exp_id, target_id="tr-2")
+    store.update_review_assignment(a.assignment_id, state="in_progress")
+
+    pending_page = store.list_review_assignments(experiment_id=exp_id, state="pending")
+    in_progress_page = store.list_review_assignments(experiment_id=exp_id, state="in_progress")
+
+    assert {a.target_id for a in pending_page} == {"tr-2"}
+    assert {a.target_id for a in in_progress_page} == {"tr-1"}
+
+
+def test_list_review_assignments_requires_scope_predicate(store):
+    # No experiment_id, no reviewer -> hard error rather than a
+    # full-table scan that hides a perf foot-gun.
+    with pytest.raises(MlflowException, match="experiment_id"):
+        store.list_review_assignments(state="pending")
+
+
+def test_list_review_assignments_for_target_returns_all_reviewers(store):
+    exp_id = _create_experiments(store, "test_list_for_target")
+    _create_assignment(store, exp_id, target_id="tr-1", reviewer="alice@example.com")
+    _create_assignment(store, exp_id, target_id="tr-1", reviewer="bob@example.com")
+    _create_assignment(store, exp_id, target_id="tr-2", reviewer="alice@example.com")
+
+    rows = store.list_review_assignments_for_target("tr-1")
+
+    assert {r.reviewer for r in rows} == {"alice@example.com", "bob@example.com"}
+
+
+# ---------------------------------------------------------------------------
+# update / delete
+# ---------------------------------------------------------------------------
+
+
+def test_update_review_assignment_transitions_state(store):
+    exp_id = _create_experiments(store, "test_update_ra_state")
+    a = _create_assignment(store, exp_id)
+
+    in_progress = store.update_review_assignment(a.assignment_id, state="in_progress")
+    assert in_progress.state == ReviewAssignmentState.IN_PROGRESS
+    assert in_progress.last_update_time_ms >= a.last_update_time_ms
+    assert in_progress.completed_time_ms is None
+
+    complete = store.update_review_assignment(a.assignment_id, state="complete")
+    assert complete.state == ReviewAssignmentState.COMPLETE
+    assert complete.completed_time_ms is not None
+    assert complete.completed_time_ms >= in_progress.last_update_time_ms
+
+    reopened = store.update_review_assignment(a.assignment_id, state="in_progress")
+    assert reopened.state == ReviewAssignmentState.IN_PROGRESS
+    # ``completed_time_ms`` is preserved on reopen so the prior
+    # completion timestamp is still recoverable.
+    assert reopened.completed_time_ms == complete.completed_time_ms
+
+
+def test_update_review_assignment_noop_when_state_unchanged(store):
+    exp_id = _create_experiments(store, "test_update_ra_noop")
+    a = _create_assignment(store, exp_id)
+
+    same = store.update_review_assignment(a.assignment_id, state="pending")
+
+    # No timestamp churn for a no-op update; the row is byte-identical.
+    assert same == a
+
+
+def test_update_review_assignment_rejects_unknown_state(store):
+    exp_id = _create_experiments(store, "test_update_ra_bad_state")
+    a = _create_assignment(store, exp_id)
+
+    with pytest.raises(MlflowException, match="state"):
+        store.update_review_assignment(a.assignment_id, state="not_a_state")
+
+
+@pytest.mark.parametrize(
+    ("from_state", "to_state"),
+    [
+        pytest.param("in_progress", "pending", id="in_progress-to-pending"),
+        pytest.param("complete", "pending", id="complete-to-pending"),
+    ],
+)
+def test_update_review_assignment_rejects_illegal_transitions(store, from_state, to_state):
+    exp_id = _create_experiments(store, f"test_illegal_{from_state}_{to_state}")
+    a = _create_assignment(store, exp_id)
+    # Walk to the starting state via legal transitions.
+    if from_state in ("in_progress", "complete"):
+        store.update_review_assignment(a.assignment_id, state="in_progress")
+    if from_state == "complete":
+        store.update_review_assignment(a.assignment_id, state="complete")
+
+    with pytest.raises(MlflowException, match="Illegal state transition"):
+        store.update_review_assignment(a.assignment_id, state=to_state)
+
+
+def test_update_review_assignment_raises_on_missing(store):
+    with pytest.raises(MlflowException, match="not found"):
+        store.update_review_assignment("ra-missing", state="complete")
+
+
+def test_delete_review_assignment_removes_row(store):
+    exp_id = _create_experiments(store, "test_delete_ra")
+    a = _create_assignment(store, exp_id)
+
+    store.delete_review_assignment(a.assignment_id)
+
+    with pytest.raises(MlflowException, match="not found"):
+        store.get_review_assignment(a.assignment_id)
+
+
+def test_delete_review_assignment_is_idempotent_on_missing(store):
+    # No exception on deleting a non-existent assignment; the SDK
+    # contract treats delete as idempotent so concurrent deletes
+    # don't surprise the UI with a 404.
+    store.delete_review_assignment("ra-never-existed")
+
+
+# ---------------------------------------------------------------------------
+# Cascade-on-experiment-delete
+# ---------------------------------------------------------------------------
+
+
+def test_cascade_on_hard_delete_of_parent_experiment(store):
+    exp_id = _create_experiments(store, "test_cascade")
+    a = _create_assignment(store, exp_id)
+    # MLflow's default delete_experiment is a soft-delete (sets
+    # lifecycle_stage='deleted'); the FK cascade only fires on hard
+    # delete, so we issue one through the raw session.
+    with store.ManagedSessionMaker(read_only=False) as session:
+        from mlflow.store.tracking.dbmodels.models import SqlExperiment
+
+        session.query(SqlExperiment).filter(SqlExperiment.experiment_id == int(exp_id)).delete()
+
+    with pytest.raises(MlflowException, match="not found"):
+        store.get_review_assignment(a.assignment_id)
+
+
+def test_soft_delete_of_parent_experiment_does_not_cascade(store):
+    exp_id = _create_experiments(store, "test_soft_delete_keeps_ra")
+    a = _create_assignment(store, exp_id)
+
+    store.delete_experiment(exp_id)
+
+    # Soft-delete preserves the assignment row; the experiment is
+    # hidden from default lists but its child data isn't dropped.
+    fetched = store.get_review_assignment(a.assignment_id)
+    assert fetched.assignment_id == a.assignment_id
+
+
+# ---------------------------------------------------------------------------
+# Entity shape sanity (catches accidental dataclass field reordering)
+# ---------------------------------------------------------------------------
+
+
+def test_to_mlflow_entity_returns_review_assignment(store):
+    exp_id = _create_experiments(store, "test_entity_shape")
+    a = _create_assignment(store, exp_id)
+    assert isinstance(a, ReviewAssignment)

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_schema.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_schema.py
@@ -376,6 +376,18 @@ def _insert_row(conn, table_name, workspace, overrides=None, seed=1):
             "created_at": seed,
             "workspace": workspace,
         },
+        "review_assignments": {
+            "assignment_id": f"ra_{seed}",
+            "workspace": workspace,
+            "experiment_id": seed,
+            "target_type": "trace",
+            "target_id": f"tr_{seed}",
+            "reviewer": f"reviewer_{seed}@example.com",
+            "assigner": f"assigner_{seed}@example.com",
+            "state": "pending",
+            "creation_time_ms": seed,
+            "last_update_time_ms": seed,
+        },
         "jobs": {
             "id": f"job_{seed}",
             "creation_time": seed,

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_workspace_store.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_workspace_store.py
@@ -2398,3 +2398,70 @@ def test_guardrails_reject_missing_scorer_version_in_same_workspace(gateway_work
                 stage=GuardrailStage.BEFORE,
                 action=GuardrailAction.VALIDATION,
             )
+
+
+# ---------------------------------------------------------------------------
+# Review assignments — workspace scoping (DAIS-2026 work item #1, stack 1)
+# ---------------------------------------------------------------------------
+
+
+def _create_review_assignment_in_workspace(
+    store, workspace, *, target_id, reviewer="sme@example.com"
+):
+    with WorkspaceContext(workspace):
+        exp_id = store.create_experiment(f"exp-{workspace}-{target_id}")
+        assignment = store.create_review_assignment(
+            experiment_id=exp_id,
+            target_type="trace",
+            target_id=target_id,
+            reviewer=reviewer,
+            assigner="kris@example.com",
+        )
+    return exp_id, assignment
+
+
+def test_review_assignments_are_workspace_scoped(workspace_tracking_store):
+    # Same (target_id, reviewer) in two different workspaces creates
+    # two distinct rows; reads in workspace A never see workspace B's
+    # row (and vice versa).
+    _, a_assignment = _create_review_assignment_in_workspace(
+        workspace_tracking_store, "team-a", target_id="tr-shared"
+    )
+    _, b_assignment = _create_review_assignment_in_workspace(
+        workspace_tracking_store, "team-b", target_id="tr-shared"
+    )
+    assert a_assignment.assignment_id != b_assignment.assignment_id
+
+    with WorkspaceContext("team-a"):
+        # get_review_assignment scoped to team-a finds A but not B.
+        fetched_a = workspace_tracking_store.get_review_assignment(a_assignment.assignment_id)
+        assert fetched_a.assignment_id == a_assignment.assignment_id
+
+        with pytest.raises(MlflowException, match="not found") as excinfo:
+            workspace_tracking_store.get_review_assignment(b_assignment.assignment_id)
+        assert excinfo.value.error_code == "RESOURCE_DOES_NOT_EXIST"
+
+        # list filtered by reviewer in team-a returns only team-a's row.
+        page = workspace_tracking_store.list_review_assignments(reviewer="sme@example.com")
+        assert [a.assignment_id for a in page] == [a_assignment.assignment_id]
+
+        # list_review_assignments_for_target in team-a returns only team-a's row.
+        rows = workspace_tracking_store.list_review_assignments_for_target("tr-shared")
+        assert [r.assignment_id for r in rows] == [a_assignment.assignment_id]
+
+
+def test_review_assignment_delete_is_workspace_scoped(workspace_tracking_store):
+    # Cross-workspace delete is silently a no-op (the workspace
+    # filter excludes the other workspace's row from the delete
+    # query, leaving it intact).
+    _, a_assignment = _create_review_assignment_in_workspace(
+        workspace_tracking_store, "team-a", target_id="tr-1"
+    )
+
+    with WorkspaceContext("team-b"):
+        workspace_tracking_store.delete_review_assignment(a_assignment.assignment_id)
+
+    # team-a's row survives because team-b's delete didn't touch it.
+    with WorkspaceContext("team-a"):
+        fetched = workspace_tracking_store.get_review_assignment(a_assignment.assignment_id)
+        assert fetched.assignment_id == a_assignment.assignment_id


### PR DESCRIPTION
## 🥞 Stacked PR
- [**stack/kris/dais-2026/review-assignments/01-entity**](#) [Files changed against parent]

First PR in the DAIS-2026 review-assignments stack (work item #1). Five stacks planned: entity (this) → proto+RPC+handlers+SDK → widgets → Reviews page → docs.

---------

### Related Issues/PRs

Closes DAIS-2026 work item #1, stack 1 of 5. Design doc: internal `annotation-queue-v2.md`.

### What changes are proposed in this pull request?

Lands the data layer for the OSS-native review-assignment primitive: one row per `(target_id, reviewer)` pair carrying per-reviewer workflow state. No SDK / REST / UI yet — those land in subsequent stacks.

**Entity** (`mlflow/genai/review_assignments/`):
- `ReviewAssignment` dataclass with 10 fields.
- `ReviewAssignmentState` enum (`pending` / `complete`). Two states; writing an assessment does not change state. `complete → pending` reopen clears `completed_time_ms`.
- `ReviewTargetType` enum (`trace` only). Other surfaces (session, span) can be added in a later release that ships those review UIs — `target_type` is a free string column, so adding enum members later doesn't touch existing rows.
- `BulkCreateReviewAssignmentsResult` + `BulkCreateFailure` carrying the create / existing / failed buckets from bulk-assign.

**Validation + normalization** (`validation.py`):
- VARCHAR(250) length caps on `reviewer` / `assigner` matched to `SqlReviewAssignment` column widths, which mirror `SqlAssessments.source_id` so a `reviewer` value can never be too long to also appear as an assessment `source_id` in the review UI.
- `reviewer` lowercased + stripped on write (canonical form); `target_id` / `assigner` stripped.
- Two-state model (`pending` / `complete`), both directions legal (mark complete / reopen), so there's no transition table — the update validator only checks the new state is known.

**SQL store**:
- `SqlReviewAssignment` ORM in `dbmodels/models.py` with workspace column, `UNIQUE (workspace, target_id, reviewer)`, plus two composite indexes serving "my assignments" + "who's reviewing this trace?" queries.
- Alembic migration `c4d2e8a16f93` with the same shape.
- `review_assignments` added to `OTHER_WORKSPACE_CHILD_TABLES` so workspace-migration coverage stays accurate.
- `WorkspaceAwareSqlAlchemyStore._get_query` scopes the table workspace-aware (direct column filter; no experiment join).
- 7 `AbstractStore` methods + concrete `SqlAlchemyStore` impls covering create / bulk-create / get / list / list-for-target / update / delete.
- Bulk-create is single-transaction with **SAVEPOINT (`session.begin_nested()`)** around each per-row flush so a mid-batch IntegrityError rolls back only that row, not the rest of the batch.
- `list_review_assignments` requires at least one of `experiment_id` or `reviewer` — unscoped full-table scans would be a foot-gun at scale.

**Tests**:
- New store tests (run twice via the workspace-disabled / -enabled fixture) covering CRUD happy paths, validation errors, idempotency on bulk and single create, lowercase + whitespace normalization, cascade-on-hard-delete vs preservation-on-soft-delete of the parent experiment, mark-complete / reopen (including completed-timestamp clearing), and entity-shape sanity.
- 2 workspace-isolation tests in `test_sqlalchemy_workspace_store.py` (same `(target_id, reviewer)` across two workspaces creates two distinct rows; cross-workspace delete is a no-op).
- Workspace model-coverage test (`test_workspace_model_coverage.py`) passes — the table is scoped by the new `_get_query` branch.
- Row spec for `review_assignments` added to the `test_migrate_to_default_workspace_moves_rows` helper.

### How is this PR tested?

- [x] New unit/integration tests (73 added across the store + workspace test files)
- [x] Existing unit/integration tests (no regressions)
- [ ] Manual tests (deferred — no SDK / REST surface in this stack)

Notes for reviewers:
- SQL fixture files (`tests/db/schemas/*.sql`, `tests/resources/db/latest_schema.sql`) intentionally NOT updated in this commit; `/autoformat` will regenerate them in CI to match the new table shape.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [x] Instructions

User-facing docs land in stack 6 of this series.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

Data-layer-only stack. The SDK functions land in stack 3 and the UI in stacks 4–5.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Claude Code.


