### PR TITLE
Forward OpenAI custom base URL in Detect Issues flow

### DIFF
--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -350,7 +350,10 @@ def _get_provider_instance(
             raise MlflowException.invalid_parameter_value(
                 "OPENAI_API_KEY environment variable must be set to use the openai provider."
             )
-        config = OpenAIConfig(openai_api_key=os.environ["OPENAI_API_KEY"])
+        config = OpenAIConfig(
+            openai_api_key=os.environ["OPENAI_API_KEY"],
+            openai_api_base=os.environ.get("OPENAI_API_BASE"),
+        )
         return OpenAIProvider(_get_route_config(config))
 
     elif provider == Provider.AZURE:

--- a/mlflow/utils/providers.py
+++ b/mlflow/utils/providers.py
@@ -1004,7 +1004,10 @@ AZURE_API_VERSION_ENV_VAR = "AZURE_API_VERSION"
 
 # Mapping of core providers to their environment variable names for credentials/config fields
 _CORE_PROVIDER_ENV_VARS = {
-    "openai": "OPENAI_API_KEY",
+    "openai": {
+        "api_key": "OPENAI_API_KEY",
+        "api_base": "OPENAI_API_BASE",
+    },
     "azure": {
         "api_key": AZURE_API_KEY_ENV_VAR,
         "api_base": AZURE_API_BASE_ENV_VAR,

--- a/tests/genai/discovery/test_job.py
+++ b/tests/genai/discovery/test_job.py
@@ -14,6 +14,15 @@ from mlflow.genai.discovery.job import (
     ("provider", "secret_value", "auth_config", "expected_credentials"),
     [
         ("openai", {"api_key": "test-key"}, {}, {"OPENAI_API_KEY": "test-key"}),
+        (
+            "openai",
+            {"api_key": "test-key"},
+            {"api_base": "https://custom.example.com/v1"},
+            {
+                "OPENAI_API_KEY": "test-key",
+                "OPENAI_API_BASE": "https://custom.example.com/v1",
+            },
+        ),
         ("anthropic", {"api_key": "test-key"}, {}, {"ANTHROPIC_API_KEY": "test-key"}),
         ("gemini", {"api_key": "test-key"}, {}, {"GEMINI_API_KEY": "test-key"}),
         (

--- a/tests/genai/judges/adapters/test_gateway_adapter.py
+++ b/tests/genai/judges/adapters/test_gateway_adapter.py
@@ -599,6 +599,13 @@ def test_get_provider_delegates_to_get_provider_instance(monkeypatch):
     assert "authorization" in header_keys_lower or "api-key" in header_keys_lower
 
 
+def test_get_provider_openai_honors_custom_api_base(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENAI_API_BASE", "http://127.0.0.1:9876/v1")
+    provider = _get_provider_instance("openai", "gpt-4")
+    assert provider.get_endpoint_url("llm/v1/chat").startswith("http://127.0.0.1:9876/v1")
+
+
 def test_get_provider_anthropic(monkeypatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
     provider = _get_provider_instance("anthropic", "claude-3-5-sonnet")


### PR DESCRIPTION
### Related Issues/PRs

Closes #23648

### What changes are proposed in this pull request?

A custom `api_base` configured via "Detect Issues" → "Configure model directly" was dropped on the way to the judge, so the scorer always POSTed to `api.openai.com` (the 401 in the issue). Two hops were broken:

1. `_CORE_PROVIDER_ENV_VARS["openai"]` was a plain string mapping only `api_key`, so `_fetch_provider_credentials` never surfaced `api_base` from `auth_config`. Converted to the dict form already used by Azure/Bedrock so the existing branch emits `OPENAI_API_BASE`.
2. `_get_provider_instance("openai", …)` built `OpenAIConfig` from `OPENAI_API_KEY` only, ignoring `OPENAI_API_BASE`, so `OpenAIProvider.get_endpoint_url()` still defaulted to `api.openai.com`. Now passes `os.environ.get("OPENAI_API_BASE")` through.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New unit cases in `tests/genai/discovery/test_job.py` and `tests/genai/judges/adapters/test_gateway_adapter.py`. Manually verified end-to-end against a mock OpenAI-compatible server: all 4 scorer requests hit the mock, zero to `api.openai.com`. Reproduced the original failure on master to confirm both hops are necessary.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Honor custom OpenAI-compatible base URLs in the "Detect Issues" flow instead of always calling `api.openai.com`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release