### PR TITLE
Fix issue detection custom LLM base URL handling

### DIFF
--- a/mlflow/genai/discovery/clustering.py
+++ b/mlflow/genai/discovery/clustering.py
@@ -35,6 +35,7 @@ def cluster_by_llm(
     model: str,
     categories: list[str] | None = None,
     token_counter: _TokenCounter | None = None,
+    base_url: str | None = None,
 ) -> list[list[int]]:
     """
     Use an LLM to group failure labels by execution path and symptom.
@@ -50,6 +51,7 @@ def cluster_by_llm(
         model: Model URI for the clustering LLM.
         categories: Optional issue categories to use as a grouping signal.
         token_counter: Optional token counter for tracking LLM usage.
+        base_url: Optional base URL for direct provider LLM requests.
 
     Returns:
         List of index lists, where each inner list is a cluster of label indices.
@@ -67,6 +69,7 @@ def cluster_by_llm(
         [{"role": "user", "content": prompt}],
         response_format=_ClusterResponse,
         token_counter=token_counter,
+        base_url=base_url,
     )
     content = (response.choices[0].message.content or "").strip()
     if not content:
@@ -103,6 +106,7 @@ def summarize_cluster(
     categories: list[str],
     label_to_analysis: list[int] | None = None,
     token_counter: _TokenCounter | None = None,
+    base_url: str | None = None,
 ) -> _IdentifiedIssue:
     """
     Summarize a cluster of analyses into a single identified issue.
@@ -119,6 +123,7 @@ def summarize_cluster(
         label_to_analysis: Mapping from label index to analysis index.
             When ``None``, label indices are used as analysis indices directly.
         token_counter: Optional token counter for tracking LLM usage.
+        base_url: Optional base URL for direct provider LLM requests.
 
     Returns:
         An ``_IdentifiedIssue`` with synthesized fields and analysis indices.
@@ -152,6 +157,7 @@ def summarize_cluster(
         ],
         response_format=_IdentifiedIssue,
         token_counter=token_counter,
+        base_url=base_url,
     )
 
     content = (response.choices[0].message.content or "").strip()
@@ -174,6 +180,7 @@ def recluster_singletons(
     max_issues: int,
     categories: list[str],
     token_counter: _TokenCounter | None = None,
+    base_url: str | None = None,
 ) -> list[_IdentifiedIssue]:
     """
     Re-cluster singleton issues via a second LLM pass to find better groupings.
@@ -186,6 +193,7 @@ def recluster_singletons(
         max_issues: Maximum number of groups to produce.
         categories: List of valid category names to filter extracted categories.
         token_counter: Optional token counter for tracking LLM usage.
+        base_url: Optional base URL for direct provider LLM requests.
 
     Returns:
         List of issues after re-clustering (merged or original singletons).
@@ -198,7 +206,9 @@ def recluster_singletons(
         idx = singleton.example_indices[0]
         singleton_labels.append(analysis_labels.get(idx, singleton.name))
 
-    new_groups = cluster_by_llm(singleton_labels, max_issues, model, token_counter=token_counter)
+    new_groups = cluster_by_llm(
+        singleton_labels, max_issues, model, token_counter=token_counter, base_url=base_url
+    )
 
     result: list[_IdentifiedIssue] = []
     for group in new_groups:
@@ -208,7 +218,12 @@ def recluster_singletons(
         # Each singleton has exactly one analysis index in example_indices
         merged_indices = [singletons[group_idx].example_indices[0] for group_idx in group]
         merged_issue = summarize_cluster(
-            merged_indices, analyses, model, categories=categories, token_counter=token_counter
+            merged_indices,
+            analyses,
+            model,
+            categories=categories,
+            token_counter=token_counter,
+            base_url=base_url,
         )
         if merged_issue.severity >= IssueSeverity.LOW:
             result.append(merged_issue)

--- a/mlflow/genai/discovery/extraction.py
+++ b/mlflow/genai/discovery/extraction.py
@@ -173,6 +173,7 @@ def extract_failure_labels(
     analyses: list[_ConversationAnalysis],
     model: str,
     token_counter: _TokenCounter | None = None,
+    base_url: str | None = None,
 ) -> tuple[list[str], list[int]]:
     """
     Extract short failure labels that combine execution path with symptom.
@@ -187,6 +188,7 @@ def extract_failure_labels(
         analyses: Conversation analyses to generate labels for.
         model: Model URI for the label-generation LLM.
         token_counter: Optional token counter for tracking LLM usage.
+        base_url: Optional base URL for direct provider LLM requests.
 
     Returns:
         A tuple of (labels, label_to_analysis) where label_to_analysis[i]
@@ -206,6 +208,7 @@ def extract_failure_labels(
                 {"role": "user", "content": rationale},
             ],
             token_counter=token_counter,
+            base_url=base_url,
         )
         content = response.choices[0].message.content.strip()
         symptoms = [line.lstrip("- ").strip() for line in content.splitlines() if line.strip()]

--- a/mlflow/genai/discovery/job.py
+++ b/mlflow/genai/discovery/job.py
@@ -42,6 +42,17 @@ def _fetch_provider_credentials(
     return credentials
 
 
+def _fetch_provider_base_url(store: SqlAlchemyStore, secret_id: str) -> str | None:
+    """
+    Retrieve the optional provider base URL from secret auth config.
+
+    The base URL is not a secret value; it is stored alongside other provider
+    configuration fields such as Azure API version.
+    """
+    auth_config = store.get_secret_info(secret_id=secret_id).auth_config or {}
+    return auth_config.get("api_base")
+
+
 @job(name="invoke_issue_detection", max_workers=MLFLOW_SERVER_JUDGE_INVOKE_MAX_WORKERS.get())
 def invoke_issue_detection_job(
     experiment_id: str,
@@ -49,6 +60,7 @@ def invoke_issue_detection_job(
     categories: list[str],
     run_id: str,
     model: str | None = None,
+    base_url: str | None = None,
 ):
     """
     Job function to run issue detection on traces.
@@ -68,6 +80,7 @@ def invoke_issue_detection_job(
             model=model,
             run_id=run_id,
             categories=categories,
+            base_url=base_url,
         )
         client.set_terminated(run_id, RunStatus.to_string(RunStatus.FINISHED))
         client.set_tag(run_id, "total_cost_usd", result.total_cost_usd)

--- a/mlflow/genai/discovery/pipeline.py
+++ b/mlflow/genai/discovery/pipeline.py
@@ -133,6 +133,7 @@ def _annotate_issue_traces(
     trace_to_session: dict[str, str] | None = None,
     session_first_trace: dict[str, str] | None = None,
     token_counter: _TokenCounter | None = None,
+    base_url: str | None = None,
 ) -> None:
     """
     Log an Issue assessment for each issue on affected traces.
@@ -185,6 +186,7 @@ def _annotate_issue_traces(
                     {"role": "user", "content": user_content},
                 ],
                 token_counter=token_counter,
+                base_url=base_url,
             )
             annotation = (response.choices[0].message.content or "").strip()
         except Exception:
@@ -361,6 +363,7 @@ def _dedup_issues(
     issues: list[_IdentifiedIssue],
     model: str = DEFAULT_MODEL,
     token_counter: _TokenCounter | None = None,
+    base_url: str | None = None,
 ) -> list[_IdentifiedIssue]:
     """Deduplicate issues by asking the LLM to identify groups of equivalent issues."""
     if len(issues) < 2:
@@ -378,6 +381,7 @@ def _dedup_issues(
             [{"role": "user", "content": prompt}],
             response_format=_DedupGroups,
             token_counter=token_counter,
+            base_url=base_url,
         )
         result = _DedupGroups.model_validate_json(response.choices[0].message.content)
     except Exception:
@@ -436,6 +440,7 @@ def _merge_singleton_issues(
     max_issues: int,
     categories: list[str],
     token_counter: _TokenCounter | None = None,
+    base_url: str | None = None,
 ) -> list[_IdentifiedIssue]:
     singletons = [i for i in identified if len(i.example_indices) == 1]
     multi_member = [i for i in identified if len(i.example_indices) > 1]
@@ -450,6 +455,7 @@ def _merge_singleton_issues(
         max_issues,
         categories=categories,
         token_counter=token_counter,
+        base_url=base_url,
     )
     return multi_member + merged
 
@@ -460,12 +466,14 @@ def _cluster_and_identify(
     max_issues: int,
     categories: list[str],
     token_counter: _TokenCounter | None = None,
+    base_url: str | None = None,
 ) -> list[_IdentifiedIssue]:
     """Cluster analyses into identified issues via LLM-based labeling and grouping."""
     labels, label_to_analysis = extract_failure_labels(
         analyses,
         model,
         token_counter=token_counter,
+        base_url=base_url,
     )
     for i, label in enumerate(labels):
         _logger.debug("  [%d] %s", i, label)
@@ -479,6 +487,7 @@ def _cluster_and_identify(
             model,
             categories=categories,
             token_counter=token_counter,
+            base_url=base_url,
         )
     _logger.debug("Clustering produced %d groups", len(cluster_groups))
 
@@ -490,6 +499,7 @@ def _cluster_and_identify(
             label_to_analysis=label_to_analysis,
             categories=categories,
             token_counter=token_counter,
+            base_url=base_url,
         )
 
     max_workers = min(MLFLOW_GENAI_EVAL_MAX_WORKERS.get(), len(cluster_groups))
@@ -504,7 +514,9 @@ def _cluster_and_identify(
             summaries[future_to_idx[future]] = future.result()
 
     identified = _resplit_incoherent_clusters(cluster_groups, summaries, summarize_fn)
-    identified = _dedup_issues(identified, model=model, token_counter=token_counter)
+    identified = _dedup_issues(
+        identified, model=model, token_counter=token_counter, base_url=base_url
+    )
 
     analysis_labels: dict[int, str] = {}
     for label, analysis_idx in zip(labels, label_to_analysis):
@@ -517,6 +529,7 @@ def _cluster_and_identify(
         max_issues,
         categories=categories,
         token_counter=token_counter,
+        base_url=base_url,
     )
 
 
@@ -564,6 +577,7 @@ def build_issue_discovery_scorer(
     model: str | None = None,
     use_conversation: bool = True,
     latency_stats: dict[str, float] | None = None,
+    base_url: str | None = None,
 ) -> Scorer:
     model = model or DEFAULT_MODEL
     categories = categories if categories is not None else DEFAULT_CATEGORIES
@@ -579,6 +593,7 @@ def build_issue_discovery_scorer(
         model=model,
         feedback_value_type=dict[str, str],
         include_timing_in_conversation=include_timing,
+        base_url=base_url,
     )
 
 
@@ -592,6 +607,7 @@ def discover_issues(
     filter_string: str | None = None,
     run_id: str | None = None,
     categories: list[str] = DEFAULT_CATEGORIES,
+    base_url: str | None = None,
 ) -> DiscoverIssuesResult:
     """
     Discover quality and operational issues in traces.
@@ -620,6 +636,7 @@ def discover_issues(
             Ignored when ``traces`` is provided.
         run_id: Run ID to attach issues to. If not provided, a new run will be created.
         categories: Issue categories to search for.
+        base_url: Optional base URL to route direct provider LLM requests through.
 
     Returns:
         A :class:`DiscoverIssuesResult` with discovered issues, run IDs,
@@ -679,6 +696,7 @@ def discover_issues(
             model=model,
             use_conversation=use_conversation,
             latency_stats=latency_stats,
+            base_url=base_url,
         )
         scorers = [default_scorer]
 
@@ -763,7 +781,12 @@ def discover_issues(
     # ---- Phase 3: Cluster & identify ----
     update_status_details({"stage": "Clustering issues..."})
     identified = _cluster_and_identify(
-        analyses, model, max_issues, categories=categories, token_counter=token_counter
+        analyses,
+        model,
+        max_issues,
+        categories=categories,
+        token_counter=token_counter,
+        base_url=base_url,
     )
 
     if not identified:
@@ -801,6 +824,7 @@ def discover_issues(
         trace_to_session=trace_to_session if use_conversation else None,
         session_first_trace=session_first_trace,
         token_counter=token_counter,
+        base_url=base_url,
     )
 
     update_status_details({"stage": "Generating summary..."})

--- a/mlflow/genai/judges/adapters/gateway_adapter.py
+++ b/mlflow/genai/judges/adapters/gateway_adapter.py
@@ -543,7 +543,7 @@ class GatewayAdapter(BaseJudgeAdapter):
         # Each provider's get_endpoint_url() returns the full endpoint path
         # (e.g. OpenAI: .../chat/completions, Anthropic: .../messages).
         provider_instance = _get_provider_instance(provider, model_name, base_url=base_url)
-        endpoint = base_url or provider_instance.get_endpoint_url("llm/v1/chat")
+        endpoint = provider_instance.get_endpoint_url("llm/v1/chat")
         headers = dict(provider_instance.headers or {})
         # Tag gateway requests so the server can attribute traffic to the judge
         if provider == "gateway":

--- a/mlflow/genai/utils/llm_utils.py
+++ b/mlflow/genai/utils/llm_utils.py
@@ -116,6 +116,7 @@ def _call_llm(
     response_format: type[pydantic.BaseModel] | None = None,
     token_counter: _TokenCounter | None = None,
     inference_params: dict[str, Any] | None = None,
+    base_url: str | None = None,
     max_tokens: int = _DEFAULT_MAX_TOKENS,
     num_retries: int = _DEFAULT_NUM_RETRIES,
 ) -> Any:
@@ -127,6 +128,7 @@ def _call_llm(
             response_format=response_format,
             token_counter=token_counter,
             inference_params=inference_params,
+            base_url=base_url,
             max_tokens=max_tokens,
             num_retries=num_retries,
         )
@@ -137,6 +139,7 @@ def _call_llm(
         response_format=response_format,
         token_counter=token_counter,
         inference_params=inference_params,
+        base_url=base_url,
         max_tokens=max_tokens,
         num_retries=num_retries,
     )
@@ -150,6 +153,7 @@ def _call_llm_via_litellm(
     response_format: type[pydantic.BaseModel] | None = None,
     token_counter: _TokenCounter | None = None,
     inference_params: dict[str, Any] | None = None,
+    base_url: str | None = None,
     max_tokens: int = _DEFAULT_MAX_TOKENS,
     num_retries: int = _DEFAULT_NUM_RETRIES,
 ) -> Any:
@@ -167,7 +171,7 @@ def _call_llm_via_litellm(
         extra_headers = config.extra_headers
     else:
         litellm_model = convert_mlflow_uri_to_litellm(model)
-        api_base = None
+        api_base = base_url
         api_key = None
         extra_headers = None
 
@@ -200,6 +204,7 @@ def _call_llm_via_gateway(
     response_format: type[pydantic.BaseModel] | None = None,
     token_counter: _TokenCounter | None = None,
     inference_params: dict[str, Any] | None = None,
+    base_url: str | None = None,
     max_tokens: int = _DEFAULT_MAX_TOKENS,
     num_retries: int = _DEFAULT_NUM_RETRIES,
 ) -> Any:
@@ -213,7 +218,7 @@ def _call_llm_via_gateway(
     # and Anthropic which both support structured outputs. Also missing:
     # no context window management and no per-request cost tracking.
     provider_name, model_name = _parse_model_uri(model)
-    provider = _get_provider_instance(provider_name, model_name)
+    provider = _get_provider_instance(provider_name, model_name, base_url=base_url)
 
     payload = {"messages": messages, "max_completion_tokens": max_tokens}
     if inference_params:

--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -324,11 +324,9 @@ def _get_provider_instance(
     Args:
         provider: The provider name (e.g. "openai", "anthropic").
         model: The model name (e.g. "gpt-4").
-        base_url: When provided for the ``"gateway"`` provider, skips
-            ``_resolve_gateway_uri()`` and constructs the provider directly
-            from this URL. Used when the caller already knows the gateway URL
-            (e.g. inside the gateway server process where ``MLFLOW_TRACKING_URI``
-            points to the backend store, not an HTTP endpoint).
+        base_url: Optional base URL for direct provider calls. For the
+            ``"gateway"`` provider, skips ``_resolve_gateway_uri()`` and constructs
+            the provider directly from this URL.
     """
     from mlflow.gateway.config import Provider
 
@@ -350,7 +348,10 @@ def _get_provider_instance(
             raise MlflowException.invalid_parameter_value(
                 "OPENAI_API_KEY environment variable must be set to use the openai provider."
             )
-        config = OpenAIConfig(openai_api_key=os.environ["OPENAI_API_KEY"])
+        config = OpenAIConfig(
+            openai_api_key=os.environ["OPENAI_API_KEY"],
+            openai_api_base=base_url,
+        )
         return OpenAIProvider(_get_route_config(config))
 
     elif provider == Provider.AZURE:
@@ -371,7 +372,10 @@ def _get_provider_instance(
     elif provider == Provider.ANTHROPIC:
         from mlflow.gateway.providers.anthropic import AnthropicConfig, AnthropicProvider
 
-        config = AnthropicConfig(anthropic_api_key=os.environ.get("ANTHROPIC_API_KEY"))
+        config = AnthropicConfig(
+            anthropic_api_key=os.environ.get("ANTHROPIC_API_KEY"),
+            anthropic_api_base=base_url or "https://api.anthropic.com/v1",
+        )
         return AnthropicProvider(_get_route_config(config))
 
     elif normalize_provider_name(provider) == Provider.BEDROCK:

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -4452,7 +4452,11 @@ def _invoke_issue_detection_handler():
 
     This is a UI-only AJAX endpoint for running issue detection from the frontend.
     """
-    from mlflow.genai.discovery.job import _fetch_provider_credentials, invoke_issue_detection_job
+    from mlflow.genai.discovery.job import (
+        _fetch_provider_base_url,
+        _fetch_provider_credentials,
+        invoke_issue_detection_job,
+    )
     from mlflow.server.jobs import submit_job
 
     _validate_content_type(request, ["application/json"])
@@ -4486,8 +4490,10 @@ def _invoke_issue_detection_handler():
     if secret_id:
         store = _get_tracking_store()
         credentials = _fetch_provider_credentials(store, provider, secret_id)
+        base_url = None if endpoint_name else _fetch_provider_base_url(store, secret_id)
     else:
         credentials = None
+        base_url = None
 
     # Create the run upfront so we can return run_id immediately
     model_name = f"gateway:/{endpoint_name}" if endpoint_name else f"{provider}:/{model}"
@@ -4513,6 +4519,7 @@ def _invoke_issue_detection_handler():
             "categories": categories,
             "run_id": run_id,
             "model": model_name,
+            "base_url": base_url,
         },
         extra_envs=credentials,
     )

--- a/tests/genai/discovery/test_job.py
+++ b/tests/genai/discovery/test_job.py
@@ -5,6 +5,7 @@ import pytest
 from mlflow.entities.run_status import RunStatus
 from mlflow.exceptions import MlflowException
 from mlflow.genai.discovery.job import (
+    _fetch_provider_base_url,
     _fetch_provider_credentials,
     invoke_issue_detection_job,
 )
@@ -121,6 +122,16 @@ def test_fetch_provider_credentials_azure_partial_auth_config():
     }
 
 
+def test_fetch_provider_base_url():
+    mock_store = mock.MagicMock()
+    mock_store.get_secret_info.return_value.auth_config = {
+        "api_base": "https://llm-proxy.example.com/v1"
+    }
+
+    assert _fetch_provider_base_url(mock_store, "secret-123") == "https://llm-proxy.example.com/v1"
+    mock_store.get_secret_info.assert_called_once_with(secret_id="secret-123")
+
+
 def test_invoke_issue_detection_job_has_metadata():
     assert hasattr(invoke_issue_detection_job, "_job_fn_metadata")
     metadata = invoke_issue_detection_job._job_fn_metadata
@@ -141,7 +152,9 @@ def test_invoke_issue_detection_job_success():
 
     with (
         mock.patch("mlflow.genai.discovery.job.MlflowClient", return_value=mock_client),
-        mock.patch("mlflow.genai.discovery.job.discover_issues", return_value=mock_result),
+        mock.patch(
+            "mlflow.genai.discovery.job.discover_issues", return_value=mock_result
+        ) as mock_discover_issues,
     ):
         mock_client._tracing_client.batch_get_traces.return_value = mock_traces
 
@@ -151,6 +164,7 @@ def test_invoke_issue_detection_job_success():
             categories=["correctness", "safety"],
             run_id="run-123",
             model="openai:/gpt-4o",
+            base_url="https://llm-proxy.example.com/v1",
         )
 
         mock_client.link_traces_to_run.assert_called_once_with(["trace-1", "trace-2"], "run-123")
@@ -164,6 +178,9 @@ def test_invoke_issue_detection_job_success():
         assert result["issues"] == 3
         assert result["total_traces_analyzed"] == 2
         assert result["total_cost_usd"] == 0.15
+        assert mock_discover_issues.call_args.kwargs["base_url"] == (
+            "https://llm-proxy.example.com/v1"
+        )
 
 
 def test_invoke_issue_detection_job_with_endpoint():

--- a/tests/genai/discovery/test_pipeline.py
+++ b/tests/genai/discovery/test_pipeline.py
@@ -856,6 +856,14 @@ def test_build_issue_discovery_scorer_custom_model():
     assert scorer.model == "openai:/gpt-5"
 
 
+def test_build_issue_discovery_scorer_custom_base_url():
+    scorer = build_issue_discovery_scorer(
+        model="openai:/custom-model",
+        base_url="https://llm-proxy.example.com/v1",
+    )
+    assert scorer._base_url == "https://llm-proxy.example.com/v1"
+
+
 def test_build_satisfaction_instructions_categories_conversation():
     instructions = build_satisfaction_instructions(
         use_conversation=True, categories=["hallucination", "tool errors"]

--- a/tests/genai/judges/adapters/test_gateway_adapter.py
+++ b/tests/genai/judges/adapters/test_gateway_adapter.py
@@ -984,10 +984,11 @@ def test_response_format_capability_cached_globally():
 def test_custom_base_url_overrides_provider():
     response_json = _chat_response(json.dumps({"result": "yes"}))
 
+    provider = _mock_provider(endpoint_url="https://custom.proxy.com/v1/messages")
     with (
         mock.patch(
             "mlflow.genai.judges.adapters.gateway_adapter._get_provider_instance",
-            return_value=_mock_provider(),
+            return_value=provider,
         ),
         mock.patch(
             "mlflow.genai.judges.adapters.gateway_adapter.send_chat_request",
@@ -1004,7 +1005,8 @@ def test_custom_base_url_overrides_provider():
         )
 
     call_kwargs = mock_send.call_args[1]
-    assert "custom.proxy.com" in call_kwargs["endpoint"]
+    assert call_kwargs["endpoint"] == "https://custom.proxy.com/v1/messages"
+    provider.get_endpoint_url.assert_called_once_with("llm/v1/chat")
 
 
 # --- _get_max_context_tokens tests ---

--- a/tests/genai/utils/test_llm_utils.py
+++ b/tests/genai/utils/test_llm_utils.py
@@ -202,6 +202,30 @@ def test_call_llm_handles_non_gateway_models():
         assert result == mock_response
 
 
+def test_call_llm_forwards_base_url_to_litellm_for_non_gateway_models():
+    mock_response = mock.MagicMock()
+    mock_response.usage = mock.MagicMock(prompt_tokens=10, completion_tokens=20)
+
+    with (
+        mock.patch("mlflow.genai.utils.llm_utils._is_litellm_available", return_value=True),
+        mock.patch(
+            "mlflow.metrics.genai.model_utils.convert_mlflow_uri_to_litellm",
+            return_value="openai/custom-model",
+        ),
+        mock.patch(
+            "mlflow.genai.judges.adapters.litellm_adapter._invoke_litellm",
+            return_value=mock_response,
+        ) as mock_invoke,
+    ):
+        _call_llm(
+            "openai:/custom-model",
+            [{"role": "user", "content": "test"}],
+            base_url="https://llm-proxy.example.com/v1",
+        )
+
+    assert mock_invoke.call_args.kwargs["api_base"] == "https://llm-proxy.example.com/v1"
+
+
 def test_call_llm_with_json_mode():
     mock_response = mock.MagicMock()
     with (
@@ -366,7 +390,7 @@ def test_call_llm_via_gateway_dispatches_gateway_uri_without_litellm():
         messages = [{"role": "user", "content": "test"}]
         result = _call_llm("gateway:/my-endpoint", messages)
 
-    mock_get_provider.assert_called_once_with("gateway", "my-endpoint")
+    mock_get_provider.assert_called_once_with("gateway", "my-endpoint", base_url=None)
     mock_send.assert_called_once()
     assert result.choices[0].message.content == "gateway response"
 

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -5600,6 +5600,10 @@ def test_invoke_issue_detection_handler_success(monkeypatch):
             "mlflow.genai.discovery.job._fetch_provider_credentials",
             return_value={"OPENAI_API_KEY": "test-key"},
         ) as mock_fetch_creds,
+        mock.patch(
+            "mlflow.genai.discovery.job._fetch_provider_base_url",
+            return_value="https://llm-proxy.example.com/v1",
+        ) as mock_fetch_base_url,
         mock.patch("mlflow.server.jobs.submit_job", return_value=mock_job) as mock_submit_job,
         mock.patch("mlflow.start_run", return_value=mock_run),
         mock.patch("mlflow.set_tag"),
@@ -5617,12 +5621,14 @@ def test_invoke_issue_detection_handler_success(monkeypatch):
         assert json_response["run_id"] == "run-123"
 
         mock_fetch_creds.assert_called_once_with(mock_store.return_value, "openai", "secret-123")
+        mock_fetch_base_url.assert_called_once_with(mock_store.return_value, "secret-123")
         mock_submit_job.assert_called_once()
         call_kwargs = mock_submit_job.call_args.kwargs
         assert call_kwargs["params"]["experiment_id"] == "exp-123"
         assert call_kwargs["params"]["trace_ids"] == ["trace-1", "trace-2"]
         assert call_kwargs["params"]["categories"] == ["correctness", "safety"]
         assert call_kwargs["params"]["model"] == "openai:/gpt-4o"
+        assert call_kwargs["params"]["base_url"] == "https://llm-proxy.example.com/v1"
         assert call_kwargs["extra_envs"] == {"OPENAI_API_KEY": "test-key"}
 
 
@@ -5661,6 +5667,7 @@ def test_invoke_issue_detection_handler_with_endpoint(monkeypatch):
             "mlflow.genai.discovery.job._fetch_provider_credentials",
             return_value={"OPENAI_API_KEY": "test-key"},
         ),
+        mock.patch("mlflow.genai.discovery.job._fetch_provider_base_url") as mock_fetch_base_url,
         mock.patch("mlflow.server.jobs.submit_job", return_value=mock_job) as mock_submit_job,
         mock.patch("mlflow.start_run", return_value=mock_run),
         mock.patch("mlflow.set_tag"),
@@ -5679,6 +5686,8 @@ def test_invoke_issue_detection_handler_with_endpoint(monkeypatch):
 
         call_kwargs = mock_submit_job.call_args.kwargs
         assert call_kwargs["params"]["model"] == "gateway:/my-endpoint"
+        assert call_kwargs["params"]["base_url"] is None
+        mock_fetch_base_url.assert_not_called()
 
 
 def test_invoke_issue_detection_handler_missing_required_params(monkeypatch):


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

Closes #23648

### What changes are proposed in this pull request?

When a user runs "Detect Issues" with "Configure model directly" and selects a provider secret with a custom `api_base`, issue discovery does not consistently pass that base URL through the full LLM call path. The scorer can fall back to the provider default, and later issue discovery phases can also lose the custom base URL.

This PR threads the configured provider `api_base` through the full issue detection flow:

- The issue invocation handler reads the selected secret's `auth_config.api_base` and passes it to the background issue detection job.
- The issue detection job passes `base_url` into `discover_issues`.
- The discovery pipeline forwards `base_url` into the scorer, label extraction, clustering, deduplication, singleton merging, and issue annotation LLM calls.
- The shared LLM utility passes `base_url` to LiteLLM for direct provider calls and to the gateway fallback path when LiteLLM is unavailable.
- The provider factory uses the custom base URL when constructing OpenAI and Anthropic provider configs.
- The judge gateway adapter asks the provider to construct the final chat endpoint from the configured base URL, so provider-specific paths such as `/chat/completions` for OpenAI-compatible providers and `/messages` for Anthropic are appended correctly.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Unit tests:

- `tests/server/test_handlers.py`
- `tests/genai/discovery/test_job.py`
- `tests/genai/discovery/test_pipeline.py`
- `tests/genai/utils/test_llm_utils.py`
- `tests/genai/judges/adapters/test_gateway_adapter.py`

Manual end-to-end:

Ran the "Detect Issues" → "Configure model directly" flow locally with an OpenAI-compatible provider using `api_base = https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1`.

Before the fix, the scorer attempted to call `https://api.openai.com/v1/chat/completions` or treated the custom base URL as the final endpoint. After the fix, issue detection successfully called the OpenAI-compatible `/v1/chat/completions` endpoint and completed.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fix the "Detect Issues" UI flow so custom provider base URLs configured through "Configure model directly" are honored across the issue discovery scorer and issue detection LLM calls.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release