### PR TITLE
feat: add search traces to typescript sdk

### DIFF
--- a/libs/typescript/core/src/clients/client.ts
+++ b/libs/typescript/core/src/clients/client.ts
@@ -8,6 +8,7 @@ import {
   GetExperiment,
   GetExperimentByName,
   GetTraceInfoV3,
+  SearchTracesV3,
   StartTraceV3,
 } from './spec';
 import { makeRequest, MlflowHttpError } from './utils';
@@ -15,9 +16,28 @@ import { TraceData } from '../core/entities/trace_data';
 import { ArtifactsClient, getArtifactsClient } from './artifacts';
 import { AuthProvider, HeadersProvider } from '../auth';
 import { DATABRICKS_UC_TABLE_HEADER } from '../core/constants';
+import {
+  createTraceLocationFromExperimentId,
+  serializeTraceLocation,
+  type TraceLocation,
+} from '../core/entities/trace_location';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
 import type { ReadableSpan as OTelReadableSpan } from '@opentelemetry/sdk-trace-base';
 import { ExportResultCode, type ExportResult } from '@opentelemetry/core';
+
+export interface SearchTracesOptions {
+  experimentIds?: string[];
+  locations?: TraceLocation[];
+  filter?: string;
+  maxResults?: number;
+  orderBy?: string[];
+  pageToken?: string;
+}
+
+export interface SearchTracesResult {
+  traces: TraceInfo[];
+  nextPageToken?: string;
+}
 
 /**
  * Client for MLflow tracing operations.
@@ -179,6 +199,39 @@ export class MlflowClient {
     }
 
     throw new Error(`Invalid response format: missing trace_info: ${JSON.stringify(response)}`);
+  }
+
+  /**
+   * Search trace metadata using the V3 traces API.
+   */
+  async searchTraces(options: SearchTracesOptions): Promise<SearchTracesResult> {
+    const locations = [
+      ...(options.locations ?? []),
+      ...(options.experimentIds ?? []).map(createTraceLocationFromExperimentId),
+    ];
+    if (locations.length === 0) {
+      throw new Error('searchTraces requires at least one experiment ID or trace location.');
+    }
+
+    const url = SearchTracesV3.getEndpoint(this.hostUrl);
+    const payload: SearchTracesV3.Request = {
+      locations: locations.map(serializeTraceLocation),
+      filter: options.filter,
+      max_results: options.maxResults,
+      order_by: options.orderBy,
+      page_token: options.pageToken,
+    };
+    const response = await makeRequest<SearchTracesV3.Response>(
+      'POST',
+      url,
+      this.headersProvider,
+      payload,
+    );
+
+    return {
+      traces: response.traces.map((trace) => TraceInfo.fromJson(trace)),
+      nextPageToken: response.next_page_token || undefined,
+    };
   }
 
   /**

--- a/libs/typescript/core/src/clients/index.ts
+++ b/libs/typescript/core/src/clients/index.ts
@@ -1,2 +1,3 @@
 export { MlflowClient } from './client';
+export type { SearchTracesOptions, SearchTracesResult } from './client';
 export { MlflowHttpError } from './utils';

--- a/libs/typescript/core/src/clients/spec.ts
+++ b/libs/typescript/core/src/clients/spec.ts
@@ -6,6 +6,7 @@
  */
 
 import type { TraceInfo } from '../core/entities/trace_info';
+import type { SerializedTraceLocation } from '../core/entities/trace_location';
 import { ArtifactCredentialType } from './artifacts/databricks';
 
 /**
@@ -38,6 +39,26 @@ export namespace GetTraceInfoV3 {
     trace: {
       trace_info: Parameters<typeof TraceInfo.fromJson>[0];
     };
+  }
+}
+
+/**
+ * Search trace metadata using the V3 traces API.
+ */
+export namespace SearchTracesV3 {
+  export const getEndpoint = (host: string) => `${host}/api/3.0/mlflow/traces/search`;
+
+  export interface Request {
+    locations: SerializedTraceLocation[];
+    filter?: string;
+    max_results?: number;
+    order_by?: string[];
+    page_token?: string;
+  }
+
+  export interface Response {
+    traces: Parameters<typeof TraceInfo.fromJson>[0][];
+    next_page_token?: string;
   }
 }
 

--- a/libs/typescript/core/src/core/entities/trace_info.ts
+++ b/libs/typescript/core/src/core/entities/trace_info.ts
@@ -1,64 +1,11 @@
-import type { TraceLocation, TraceLocationType } from './trace_location';
+import {
+  deserializeTraceLocation,
+  serializeTraceLocation,
+  type SerializedTraceLocation,
+  type TraceLocation,
+} from './trace_location';
 import type { TraceState } from './trace_state';
 import { TraceMetadataKey } from '../constants';
-
-interface SerializedTraceLocation {
-  type: TraceLocationType;
-  mlflow_experiment?: { experiment_id: string };
-  inference_table?: { full_table_name: string };
-  uc_table_prefix?: {
-    catalog_name: string;
-    schema_name: string;
-    table_prefix?: string;
-    otel_spans_table_name?: string;
-    otel_logs_table_name?: string;
-    annotations_table_name?: string;
-  };
-}
-
-function serializeTraceLocation(loc: TraceLocation): SerializedTraceLocation {
-  const out: SerializedTraceLocation = { type: loc.type };
-  if (loc.mlflowExperiment) {
-    out.mlflow_experiment = { experiment_id: loc.mlflowExperiment.experimentId };
-  }
-  if (loc.inferenceTable) {
-    out.inference_table = { full_table_name: loc.inferenceTable.fullTableName };
-  }
-  if (loc.ucTablePrefix) {
-    const uc = loc.ucTablePrefix;
-    out.uc_table_prefix = {
-      catalog_name: uc.catalogName,
-      schema_name: uc.schemaName,
-      ...(uc.tablePrefix ? { table_prefix: uc.tablePrefix } : {}),
-      ...(uc.otelSpansTableName ? { otel_spans_table_name: uc.otelSpansTableName } : {}),
-      ...(uc.otelLogsTableName ? { otel_logs_table_name: uc.otelLogsTableName } : {}),
-      ...(uc.annotationsTableName ? { annotations_table_name: uc.annotationsTableName } : {}),
-    };
-  }
-  return out;
-}
-
-function deserializeTraceLocation(json: SerializedTraceLocation | undefined): TraceLocation {
-  return {
-    type: json?.type as TraceLocationType,
-    mlflowExperiment: json?.mlflow_experiment
-      ? { experimentId: json.mlflow_experiment.experiment_id }
-      : undefined,
-    inferenceTable: json?.inference_table
-      ? { fullTableName: json.inference_table.full_table_name }
-      : undefined,
-    ucTablePrefix: json?.uc_table_prefix
-      ? {
-          catalogName: json.uc_table_prefix.catalog_name,
-          schemaName: json.uc_table_prefix.schema_name,
-          tablePrefix: json.uc_table_prefix.table_prefix,
-          otelSpansTableName: json.uc_table_prefix.otel_spans_table_name,
-          otelLogsTableName: json.uc_table_prefix.otel_logs_table_name,
-          annotationsTableName: json.uc_table_prefix.annotations_table_name,
-        }
-      : undefined,
-  };
-}
 
 /**
  * Interface for token usage information

--- a/libs/typescript/core/src/core/entities/trace_location.ts
+++ b/libs/typescript/core/src/core/entities/trace_location.ts
@@ -88,6 +88,64 @@ export interface TraceLocation {
   ucTablePrefix?: UnityCatalogLocation;
 }
 
+export interface SerializedTraceLocation {
+  type: TraceLocationType;
+  mlflow_experiment?: { experiment_id: string };
+  inference_table?: { full_table_name: string };
+  uc_table_prefix?: {
+    catalog_name: string;
+    schema_name: string;
+    table_prefix?: string;
+    otel_spans_table_name?: string;
+    otel_logs_table_name?: string;
+    annotations_table_name?: string;
+  };
+}
+
+export function serializeTraceLocation(loc: TraceLocation): SerializedTraceLocation {
+  const out: SerializedTraceLocation = { type: loc.type };
+  if (loc.mlflowExperiment) {
+    out.mlflow_experiment = { experiment_id: loc.mlflowExperiment.experimentId };
+  }
+  if (loc.inferenceTable) {
+    out.inference_table = { full_table_name: loc.inferenceTable.fullTableName };
+  }
+  if (loc.ucTablePrefix) {
+    const uc = loc.ucTablePrefix;
+    out.uc_table_prefix = {
+      catalog_name: uc.catalogName,
+      schema_name: uc.schemaName,
+      ...(uc.tablePrefix ? { table_prefix: uc.tablePrefix } : {}),
+      ...(uc.otelSpansTableName ? { otel_spans_table_name: uc.otelSpansTableName } : {}),
+      ...(uc.otelLogsTableName ? { otel_logs_table_name: uc.otelLogsTableName } : {}),
+      ...(uc.annotationsTableName ? { annotations_table_name: uc.annotationsTableName } : {}),
+    };
+  }
+  return out;
+}
+
+export function deserializeTraceLocation(json: SerializedTraceLocation | undefined): TraceLocation {
+  return {
+    type: json?.type as TraceLocationType,
+    mlflowExperiment: json?.mlflow_experiment
+      ? { experimentId: json.mlflow_experiment.experiment_id }
+      : undefined,
+    inferenceTable: json?.inference_table
+      ? { fullTableName: json.inference_table.full_table_name }
+      : undefined,
+    ucTablePrefix: json?.uc_table_prefix
+      ? {
+          catalogName: json.uc_table_prefix.catalog_name,
+          schemaName: json.uc_table_prefix.schema_name,
+          tablePrefix: json.uc_table_prefix.table_prefix,
+          otelSpansTableName: json.uc_table_prefix.otel_spans_table_name,
+          otelLogsTableName: json.uc_table_prefix.otel_logs_table_name,
+          annotationsTableName: json.uc_table_prefix.annotations_table_name,
+        }
+      : undefined,
+  };
+}
+
 /**
  * Returns "catalog.schema.table_prefix" for a UC table-prefix location.
  * Throws if the prefix is not set; the prefix is required for trace IDs.

--- a/libs/typescript/core/src/index.ts
+++ b/libs/typescript/core/src/index.ts
@@ -9,7 +9,12 @@ import {
 } from './core/api';
 import { tracingContext } from './core/context';
 import { flushTraces } from './core/provider';
-import { MlflowClient, MlflowHttpError } from './clients';
+import {
+  MlflowClient,
+  MlflowHttpError,
+  type SearchTracesOptions,
+  type SearchTracesResult,
+} from './clients';
 import { InMemoryTraceManager } from './core/trace_manager';
 import { createAuthProvider } from './auth';
 
@@ -36,6 +41,7 @@ export type { Trace } from './core/entities/trace';
 export type { TraceInfo, TokenUsage } from './core/entities/trace_info';
 export type { TraceData } from './core/entities/trace_data';
 export type { TraceLocation, UnityCatalogLocation } from './core/entities/trace_location';
+export type { SearchTracesOptions, SearchTracesResult };
 export { TraceLocationType } from './core/entities/trace_location';
 export { SpanStatusCode } from './core/entities/span_status';
 export type { UpdateCurrentTraceOptions, SpanOptions, TraceOptions } from './core/api';

--- a/libs/typescript/core/tests/clients/client.test.ts
+++ b/libs/typescript/core/tests/clients/client.test.ts
@@ -121,6 +121,118 @@ describe('MlflowClient', () => {
     });
   });
 
+  describe('searchTraces', () => {
+    it('should search traces by experiment ID and page through results', async () => {
+      const firstTraceId = randomUUID();
+      const secondTraceId = randomUUID();
+      await client.createTrace(
+        new TraceInfo({
+          traceId: firstTraceId,
+          traceLocation: {
+            type: TraceLocationType.MLFLOW_EXPERIMENT,
+            mlflowExperiment: {
+              experimentId: experimentId,
+            },
+          },
+          state: TraceState.OK,
+          requestTime: 1000,
+        }),
+      );
+      await client.createTrace(
+        new TraceInfo({
+          traceId: secondTraceId,
+          traceLocation: {
+            type: TraceLocationType.MLFLOW_EXPERIMENT,
+            mlflowExperiment: {
+              experimentId: experimentId,
+            },
+          },
+          state: TraceState.OK,
+          requestTime: 2000,
+        }),
+      );
+
+      const firstPage = await client.searchTraces({
+        experimentIds: [experimentId],
+        maxResults: 1,
+        orderBy: ['timestamp_ms DESC'],
+      });
+
+      expect(firstPage.traces).toHaveLength(1);
+      expect(firstPage.traces[0]).toBeInstanceOf(TraceInfo);
+      expect([firstTraceId, secondTraceId]).toContain(firstPage.traces[0].traceId);
+      expect(firstPage.nextPageToken).toBeDefined();
+
+      const secondPage = await client.searchTraces({
+        experimentIds: [experimentId],
+        maxResults: 1,
+        orderBy: ['timestamp_ms DESC'],
+        pageToken: firstPage.nextPageToken,
+      });
+
+      const returnedTraceIds = [
+        firstPage.traces[0].traceId,
+        ...secondPage.traces.map((trace) => trace.traceId),
+      ];
+      expect(returnedTraceIds).toEqual(expect.arrayContaining([firstTraceId, secondTraceId]));
+    });
+
+    it('should search traces with a filter and explicit locations', async () => {
+      const matchingTraceId = randomUUID();
+      const otherTraceId = randomUUID();
+      await client.createTrace(
+        new TraceInfo({
+          traceId: matchingTraceId,
+          traceLocation: {
+            type: TraceLocationType.MLFLOW_EXPERIMENT,
+            mlflowExperiment: {
+              experimentId: experimentId,
+            },
+          },
+          state: TraceState.OK,
+          requestTime: 1000,
+          tags: { searchTracesFilter: 'match' },
+        }),
+      );
+      await client.createTrace(
+        new TraceInfo({
+          traceId: otherTraceId,
+          traceLocation: {
+            type: TraceLocationType.MLFLOW_EXPERIMENT,
+            mlflowExperiment: {
+              experimentId: experimentId,
+            },
+          },
+          state: TraceState.OK,
+          requestTime: 2000,
+          tags: { searchTracesFilter: 'skip' },
+        }),
+      );
+
+      const result = await client.searchTraces({
+        locations: [
+          {
+            type: TraceLocationType.MLFLOW_EXPERIMENT,
+            mlflowExperiment: {
+              experimentId: experimentId,
+            },
+          },
+        ],
+        filter: "tags.searchTracesFilter = 'match'",
+        maxResults: 10,
+      });
+
+      expect(result.traces.map((trace) => trace.traceId)).toContain(matchingTraceId);
+      expect(result.traces.map((trace) => trace.traceId)).not.toContain(otherTraceId);
+    });
+
+    it('should reject search without experiment IDs or locations', async () => {
+      await expect(client.searchTraces({})).rejects.toThrow(
+        'searchTraces requires at least one experiment ID or trace location.',
+      );
+    });
+  });
+
   describe('getExperimentByName', () => {
     it('should retrieve an existing experiment by name', async () => {
       const experiment = await client.getExperimentByName(


### PR DESCRIPTION
### Related Issues/PRs

Refs #19513

### What changes are proposed in this pull request?

This adds a focused TypeScript SDK slice for MLflow traces search:

- Adds `MlflowClient.searchTraces(options)` to `@mlflow/core`.
- Supports experiment ID shortcuts and explicit trace locations.
- Supports `filter`, `maxResults`, `orderBy`, `pageToken`, and returns `nextPageToken`.
- Reuses shared trace location serialization between `TraceInfo.toJson()` and the new search API.
- Adds client tests covering experiment ID search, explicit locations/filter, pagination inputs, and missing location validation.

Public API example:

```ts
await client.searchTraces({
  experimentIds: [experimentId],
  filter: "tags.searchTracesFilter = 'match'",
  maxResults: 10,
  orderBy: ['timestamp_ms DESC'],
});
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Commands run locally:

- `npm run build`
- `..\node_modules\.bin\eslint.cmd src\clients\client.ts src\clients\index.ts src\clients\spec.ts src\core\entities\trace_info.ts src\core\entities\trace_location.ts src\index.ts --max-warnings 0`
- `..\node_modules\.bin\prettier.cmd --check src\clients\client.ts src\clients\index.ts src\clients\spec.ts src\core\entities\trace_info.ts src\core\entities\trace_location.ts src\index.ts tests\clients\client.test.ts`

Local note: `npm test -- tests/clients/client.test.ts --runInBand` is blocked in my Windows environment because the Jest global setup starts the MLflow Python server with `uv`, and `uv` is not installed on this machine (`spawn uv ENOENT`).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Adds `searchTraces` to the `@mlflow/core` TypeScript SDK for searching trace metadata with pagination.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
