### PR TITLE
Ignore `.playwright/` and `.playwright-cli/` workspace dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,5 +148,4 @@ CLAUDE.local.md
 !.claude/settings.json
 !.claude/statusline.sh
 
-# Playwright CLI workspace (per-command page snapshots)
 .playwright-cli/

--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,6 @@ CLAUDE.local.md
 !.claude/scripts/
 !.claude/settings.json
 !.claude/statusline.sh
+
+# Playwright CLI workspace (per-command page snapshots)
+.playwright-cli/

--- a/.gitignore
+++ b/.gitignore
@@ -148,4 +148,5 @@ CLAUDE.local.md
 !.claude/settings.json
 !.claude/statusline.sh
 
+.playwright/
 .playwright-cli/


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

The [Microsoft `playwright-cli`](https://github.com/microsoft/playwright-cli) (whose Claude Code skill some contributors install with `playwright-cli install --skills`) initializes a workspace at the repo root that creates two directories:

- `.playwright/`: workspace marker created by `install --skills`
- `.playwright-cli/`: per-command page snapshot YAMLs (e.g. `.playwright-cli/page-2026-05-28T14-57-05-183Z.yml`)

Both are local debugging artifacts. Add them to `.gitignore` so they're never accidentally committed.

Verified by running `playwright-cli open` and `playwright-cli goto https://example.com` and observing snapshots land in `.playwright-cli/`.

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release