### PR TITLE
fix: add missing chmod in tmp dir creation (CVE-2026-4137)

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1483,6 +1483,12 @@ def _create_model_downloading_tmp_dir(should_use_nfs):
 
     root_model_cache_dir = os.path.join(root_tmp_dir, "models")
     os.makedirs(root_model_cache_dir, exist_ok=True)
+    # Restrict permissions to owner: rwx, group: r-x, others: none.
+    # This intermediate directory was created without explicit permissions,
+    # inheriting from the parent and process umask, which could result in
+    # group-writable (0o770) or world-writable permissions.
+    # See CVE-2025-10279 and CVE-2026-4137 / GHSA-f2m9-wcf4-cwwx.
+    os.chmod(root_model_cache_dir, 0o750)
 
     tmp_model_dir = tempfile.mkdtemp(dir=root_model_cache_dir)
     # mkdtemp creates a directory with permission 0o700

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -692,6 +692,13 @@ def get_or_create_tmp_dir():
 
         tmp_dir = os.path.join(repl_local_tmp_dir, "mlflow")
         os.makedirs(tmp_dir, exist_ok=True)
+        # Restrict permissions to owner: rwx, group: r-x, others: none.
+        # Without this, the directory inherits permissions from the parent
+        # and the process umask, which may result in world-writable or
+        # group-writable permissions. An attacker with write access can
+        # tamper with model artifacts and achieve arbitrary code execution.
+        # See CVE-2025-10279 and CVE-2026-4137 / GHSA-f2m9-wcf4-cwwx.
+        os.chmod(tmp_dir, 0o750)
     else:
         tmp_dir = tempfile.mkdtemp()
         # mkdtemp creates a directory with permission 0o700
@@ -727,6 +734,14 @@ def get_or_create_nfs_tmp_dir():
 
         tmp_nfs_dir = os.path.join(repl_nfs_tmp_dir, "mlflow")
         os.makedirs(tmp_nfs_dir, exist_ok=True)
+        # Restrict permissions to owner: rwx, group: r-x, others: none.
+        # Without this, the directory inherits permissions from the parent
+        # (a Databricks system directory) and the process umask, which may
+        # result in world-writable (0o777) or group-writable permissions.
+        # An attacker with write access can tamper with model artifacts and
+        # achieve arbitrary code execution via cloudpickle deserialization.
+        # See CVE-2025-10279 and CVE-2026-4137 / GHSA-f2m9-wcf4-cwwx.
+        os.chmod(tmp_nfs_dir, 0o750)
     else:
         tmp_nfs_dir = tempfile.mkdtemp(dir=nfs_root_dir)
         # mkdtemp creates a directory with permission 0o700


### PR DESCRIPTION
## Related Issues/PRs

Closes GHSA-f2m9-wcf4-cwwx (CVE-2026-4137)
Follow-up to CVE-2025-10279

## What changes are proposed in this pull request?

Adds `os.chmod(path, 0o750)` calls to three `os.makedirs()` sites that were missed in the original CVE-2025-10279 fix.

## How is this patch tested?

Manual review of the three affected code paths. Each follows the same pattern as the already-fixed `else` branches in the same functions. The fix is a single `os.chmod()` call immediately after `os.makedirs()`.

## Release Notes

### Is this a user-facing change?

- [x] No. Skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s) does this PR affect?

- [ ] `area/artifacts`
- [ ] `area/build`
- [ ] `area/deployments`
- [ ] `area/docs`
- [ ] `area/examples`
- [ ] `area/model-registry`
- [ ] `area/models`
- [ ] `area/recipes`
- [ ] `area/projects`
- [ ] `area/scoring`
- [ ] `area/server-infra`
- [x] `area/tracking`

### How should the PR be classified in the release notes?

- [ ] `rn/breaking-change`
- [ ] `rn/none`
- [x] `rn/feature`
- [ ] `rn/bug-fix`
- [ ] `rn/documentation`
- [ ] `rn/action`

## Security Impact

This completes the fix for CVE-2025-10279 (incomplete directory permission hardening).

### Affected functions:
- `get_or_create_tmp_dir()` — Databricks local path
- `get_or_create_nfs_tmp_dir()` — Databricks NFS path
- `_create_model_downloading_tmp_dir()` — intermediate "models" cache directory

### Risk without this fix:
On shared/NFS filesystems (especially Databricks), these directories can be created with group-writable or world-writable permissions. An attacker with filesystem access can place malicious cloudpickle-serialized objects in the temp directory, achieving arbitrary code execution when MLflow deserializes them.