### PR TITLE
Clear archive-now requests for non-archivable leftovers

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -6362,16 +6362,24 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                     if request.parsed_request.older_than_millis is not None
                     else None
                 )
-                if self._get_archive_now_remaining_state(
+                remaining_state = self._get_archive_now_remaining_state(
                     session=session,
                     experiment_id=request.experiment_id,
                     max_timestamp_millis=older_than_cutoff,
-                ) in (
+                )
+                if remaining_state in (
                     _ArchiveNowRemainingState.ARCHIVABLE,
                     _ArchiveNowRemainingState.TRANSIENT,
-                    _ArchiveNowRemainingState.BLOCKED_UNMARKED,
                 ):
                     continue
+                if remaining_state == _ArchiveNowRemainingState.BLOCKED_UNMARKED:
+                    _logger.warning(
+                        "Clearing archive-now request %r on experiment %s. Some matching traces "
+                        "still remain in the tracking store but are not currently archivable "
+                        "and are not marked with an archival failure.",
+                        request.raw_value,
+                        request.experiment_id,
+                    )
 
                 (
                     session

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
@@ -7403,7 +7403,7 @@ def test_archive_traces_marks_serializer_failures_as_malformed_and_excludes_retr
     assert TraceExperimentTagKey.ARCHIVE_NOW not in store.get_experiment(exp_id).tags
 
 
-def test_archive_traces_keeps_archive_now_when_only_unmarked_non_archivable_traces_remain(
+def test_archive_traces_clears_archive_now_when_only_unmarked_non_archivable_traces_remain(
     store: SqlAlchemyStore,
 ):
     exp_id = store.create_experiment("archive-now-terminal-non-archivable")
@@ -7418,18 +7418,26 @@ def test_archive_traces_keeps_archive_now_when_only_unmarked_non_archivable_trac
     with TempDir() as tmp:
         archive_root = Path(tmp.path("archive"))
         archive_root.mkdir()
-        archived = _archive_traces(
-            store,
-            default_trace_archival_location=archive_root.as_uri(),
-            default_retention="365d",
-            now_millis=now_millis,
-        )
+        with mock.patch.object(sqlalchemy_store_module._logger, "warning") as mock_warning:
+            archived = _archive_traces(
+                store,
+                default_trace_archival_location=archive_root.as_uri(),
+                default_retention="365d",
+                now_millis=now_millis,
+            )
 
     assert archived == 0
     trace_info = store.get_trace_info(trace_id)
     assert trace_info.tags.get(TraceTagKey.SPANS_LOCATION) is None
     assert TraceTagKey.ARCHIVAL_FAILURE not in trace_info.tags
-    assert TraceExperimentTagKey.ARCHIVE_NOW in store.get_experiment(exp_id).tags
+    assert TraceExperimentTagKey.ARCHIVE_NOW not in store.get_experiment(exp_id).tags
+    mock_warning.assert_called_once_with(
+        "Clearing archive-now request %r on experiment %s. Some matching traces "
+        "still remain in the tracking store but are not currently archivable "
+        "and are not marked with an archival failure.",
+        "{}",
+        exp_id,
+    )
 
 
 def test_archive_traces_raises_unexpected_deserialization_errors(


### PR DESCRIPTION
### Related Issues/PRs

Closes | Relates to https://github.com/mlflow/mlflow/pull/23366

### What changes are proposed in this pull request?

Warn when matching traces remain in the tracking store but cannot be archived so admins still get feedback while archive-now requests can complete.

Previously if a trace was not archivable, not transient and did not have archival failures - this would be an unknown state (for example span content is empty, but trace is marked db backed) - which would keep the archive-now tag stickied on the experiment. This change ensures that we clear the tag in this case but log a warning for the admin. 

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

When archival job encounters such cases it will log a warning for the admin: 

```
Clearing archive-now request '{"older_than": "1d"}' on experiment 1. Some matching traces still remain in the tracking store but are not currently archivable and are not marked with an archival failure.
```

And proceed with clearing the archival-now tag. 

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
