### PR TITLE
Clarify trace archival max-traces behavior.

### DIFF
--- a/docs/docs/self-hosting/architecture/tracking-server.mdx
+++ b/docs/docs/self-hosting/architecture/tracking-server.mdx
@@ -180,6 +180,7 @@ trace_archival:
   location: s3://mlflow-trace-archive
   retention: 30d
   interval_seconds: 300
+  # Optional: omit this key to make each scheduler pass unbounded.
   max_traces_per_pass: 1000
   long_retention_allowlist:
     # Experiment ID for customer-support-agent-prod
@@ -204,7 +205,8 @@ mlflow server \
 ```
 
 - `interval_seconds` controls how often the scheduler checks for archival work.
-- `max_traces_per_pass` limits the amount of work in a single pass.
+- `max_traces_per_pass` limits the amount of work in a single pass. If you omit it, the pass is
+  unbounded and MLflow archives every eligible trace it can process in that run.
 - `long_retention_allowlist` contains experiment IDs that are allowed to keep traces longer than the
   broader server or workspace policy.
 
@@ -217,6 +219,13 @@ When workspaces are enabled, trace archival settings are resolved in the followi
 4. If an experiment requests a longer retention period than the broader server or workspace policy,
    that longer retention is only honored when the experiment's ID appears in
    `long_retention_allowlist`.
+
+The archival budget remains server-owned even when workspaces are enabled. `max_traces_per_pass`
+applies to the entire scheduler pass, not to each workspace independently. On each pass MLflow
+shuffles the workspace order, then processes one workspace at a time. That means a workspace visited
+earlier in the shuffled order can consume some or all of the remaining pass budget before later
+workspaces are considered. Within a workspace, `archive-now` candidates are still prioritized before
+regular retention-based archival.
 
 For example, if the global default is 30 days, a workspace is configured for 90 days, and
 experiment `123` is configured for 14 days, traces for experiment `123` are retained for 14 days.


### PR DESCRIPTION
### Related Issues/PRs

Closes | Relates to https://github.com/mlflow/mlflow/pull/23366

### What changes are proposed in this pull request?

Document that omitting `max_traces_per_pass` leaves scheduler passes unbounded and that the pass budget is shared across workspaces.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
