### PR TITLE
Hide experiment kebab on prompt details page

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewHeader.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewHeader.test.tsx
@@ -141,6 +141,24 @@ describe('ExperimentViewHeader', () => {
     });
   });
 
+  describe('overflow menu visibility', () => {
+    it('hides the overflow menu trigger on the prompt details route', async () => {
+      await act(async () => {
+        renderComponent(defaultExperiment, '/experiments/1/prompts/test-prompt');
+      });
+
+      expect(screen.queryByTestId('overflow-menu-trigger')).not.toBeInTheDocument();
+    });
+
+    it('keeps the overflow menu trigger on the prompts list route', async () => {
+      await act(async () => {
+        renderComponent(defaultExperiment, '/experiments/1/prompts');
+      });
+
+      expect(screen.getByTestId('overflow-menu-trigger')).toBeInTheDocument();
+    });
+  });
+
   describe('back button navigation', () => {
     it('navigates to /experiments from experiment tab pages', async () => {
       renderComponent(defaultExperiment, '/experiments/1/traces');

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewHeader.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewHeader.tsx
@@ -47,6 +47,10 @@ const getDocLinkHref = (experimentKind: ExperimentKind) => {
   return 'https://mlflow.org/docs/latest/ml/getting-started/?rel=mlflow_ui';
 };
 
+// Routes where the page itself renders item-level edit/delete actions, so the
+// experiment-level management menu would be a confusing duplicate.
+const ROUTES_WITHOUT_MANAGEMENT_MENU = [RoutePaths.experimentPageTabPromptDetails];
+
 /**
  * Header for a single experiment page. Displays title, breadcrumbs and provides
  * controls for renaming, deleting and editing permissions.
@@ -292,7 +296,7 @@ export const ExperimentViewHeader = React.memo(
           <div
             css={{ display: 'flex', gap: theme.spacing.sm, justifyContent: 'flex-end', marginLeft: theme.spacing.sm }}
           >
-            {!matchPath(RoutePaths.experimentPageTabPromptDetails, location.pathname) && (
+            {!ROUTES_WITHOUT_MANAGEMENT_MENU.some((route) => matchPath(route, location.pathname)) && (
               <ExperimentViewManagementMenu experiment={experiment} setEditing={setEditing} />
             )}
             <ExperimentViewHeaderShareButton

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewHeader.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewHeader.tsx
@@ -13,8 +13,14 @@ import {
   useDesignSystemTheme,
 } from '@databricks/design-system';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { createMLflowRoutePath, Link, useLocation, useNavigate } from '../../../../../common/utils/RoutingUtils';
-import Routes from '../../../../routes';
+import {
+  createMLflowRoutePath,
+  Link,
+  matchPath,
+  useLocation,
+  useNavigate,
+} from '../../../../../common/utils/RoutingUtils';
+import Routes, { RoutePaths } from '../../../../routes';
 import { ExperimentViewCopyTitle } from './ExperimentViewCopyTitle';
 import type { ExperimentEntity } from '../../../../types';
 import type { ExperimentPageSearchFacetsState } from '../../models/ExperimentPageSearchFacetsState';
@@ -286,7 +292,9 @@ export const ExperimentViewHeader = React.memo(
           <div
             css={{ display: 'flex', gap: theme.spacing.sm, justifyContent: 'flex-end', marginLeft: theme.spacing.sm }}
           >
-            <ExperimentViewManagementMenu experiment={experiment} setEditing={setEditing} />
+            {!matchPath(RoutePaths.experimentPageTabPromptDetails, location.pathname) && (
+              <ExperimentViewManagementMenu experiment={experiment} setEditing={setEditing} />
+            )}
             <ExperimentViewHeaderShareButton
               experimentIds={experimentIds}
               searchFacetsState={searchFacetsState}


### PR DESCRIPTION
### Related Issues/PRs

Closes #23657

### What changes are proposed in this pull request?

On the prompt details page (`/#/experiments/:experimentId/prompts/:promptName`), the top-right kebab menu still showed experiment-level actions ("Edit experiment" / "Delete") even though the page header reads "Prompts" and the inner page already renders its own prompt-level kebab. A user could accidentally delete or rename the whole experiment while intending to manage a single prompt.

This PR suppresses `ExperimentViewManagementMenu` on the `experimentPageTabPromptDetails` route by matching `location.pathname` against `RoutePaths.experimentPageTabPromptDetails` in `ExperimentViewHeader`. Other experiment tabs (Overview, Traces, Prompts list, etc.) are unaffected.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Reproduced the bug locally with a `test-experiment` + `test-prompt`, then verified the fix:

| Page | Before | After |
| --- | --- | --- |
| `/experiments/1/prompts/test-prompt` | Top-right kebab → "Edit experiment" / "Delete" | Top-right kebab hidden; only the prompt-level kebab remains |
| `/experiments/1/prompts` | Kebab present | Kebab present (unchanged) |
| `/experiments/1/overview/usage` | Kebab present | Kebab present (unchanged) |


**Before**

<img width="1280" height="720" alt="Before: experiment kebab on prompt details page" src="https://github.com/user-attachments/assets/1d5dc969-a016-496e-8569-62f28875ee65" />

**After**

<img width="1280" height="720" alt="After: kebab hidden on prompt details page" src="https://github.com/user-attachments/assets/105ece21-2075-4415-a21f-e1104887dd63" />

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fixes a misleading kebab menu on the experiment prompt details page that showed "Edit experiment" / "Delete" instead of prompt-level actions.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
