### PR TITLE
Improve dev experience on coding agents for multiple git workflows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ tail -f /tmp/mlflow-dev-server.log
 
 ### Running Multiple Worktrees Concurrently
 
-`dev/run-dev-server.sh` kills sibling dev servers on startup (see the note above), so it cannot run two environments at once. To work in several git worktrees simultaneously, skip the wrapper and start the two processes directly — this is the workflow documented in `CONTRIBUTING.md`, and neither process kills the other. Give each worktree its own port pair:
+`dev/run-dev-server.sh` kills sibling dev servers on startup (see the note above), so it cannot run two environments at once. To work in several git worktrees simultaneously, skip the wrapper and start the two processes directly, and neither process kills the other. Give each worktree its own port pair:
 
 ```bash
 # Pick a unique port pair per worktree, e.g. A=5000/3000, B=5001/3001

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,8 @@ tail -f /tmp/mlflow-dev-server.log
 
 This uses `uv` (fast Python package manager) to automatically manage dependencies and run the development environment.
 
+> **Note — single environment only.** On startup `dev/run-dev-server.sh` kills _all_ running MLflow `--dev` backends and `yarn start` frontends, matching by command line rather than by directory. That is fine when you run one dev environment at a time, but it will tear down dev servers started from **other git worktrees**. To run multiple worktrees at once, see [Running Multiple Worktrees Concurrently](#running-multiple-worktrees-concurrently) below.
+
 ## Debugging
 
 For debugging errors, enable debug logging (must be set before importing mlflow):
@@ -75,6 +77,36 @@ tail -f /tmp/mlflow-dev-server.log
 ```
 
 **Note**: The MLflow server acts as a proxy, forwarding API requests to your Databricks workspace while serving the local React frontend. This allows you to develop and test UI changes against real Databricks data.
+
+### Running Multiple Worktrees Concurrently
+
+`dev/run-dev-server.sh` kills sibling dev servers on startup (see the note above), so it cannot run two environments at once. To work in several git worktrees simultaneously, skip the wrapper and start the two processes directly — this is the workflow documented in `CONTRIBUTING.md`, and neither process kills the other. Give each worktree its own port pair:
+
+```bash
+# Pick a unique port pair per worktree, e.g. A=5000/3000, B=5001/3001
+BACKEND_PORT=5001
+FRONTEND_PORT=3001
+
+# Terminal 1 — backend (./mlflow.db, ./mlruns, ./mlartifacts are per-worktree)
+uv run mlflow server --port "$BACKEND_PORT" --dev
+
+# Terminal 2 — frontend
+cd mlflow/server/js
+yarn install   # first time per worktree; node_modules is not shared across worktrees
+PORT="$FRONTEND_PORT" \
+MLFLOW_PROXY="http://127.0.0.1:$BACKEND_PORT" \
+MLFLOW_DEV_PROXY_MODE=false \
+yarn start
+# open http://localhost:$FRONTEND_PORT
+```
+
+Nuances:
+
+- `--dev` gives the backend autoreload + debug logging — it is the only thing the wrapper adds over a bare `mlflow server`.
+- `MLFLOW_PROXY` must point at _this_ worktree's backend. If it doesn't, the UI silently talks to a different (or the default `:5000`) backend and shows the wrong worktree's data — this is the most common mistake.
+- `MLFLOW_DEV_PROXY_MODE=false` tells craco to actually use the proxy server.
+- The backend store and artifacts are resolved relative to the current directory (`./mlflow.db`, `./mlruns`, `./mlartifacts`), so each worktree root is isolated automatically. Pointing `MLFLOW_TRACKING_URI`/`MLFLOW_BACKEND_STORE_URI` at an absolute path defeats this isolation.
+- This is a dev-only workflow. Production builds the frontend (`yarn build`) and serves it from the backend, with no separate JS server and no proxy.
 
 ## Development Commands
 

--- a/mlflow/server/js/CLAUDE.md
+++ b/mlflow/server/js/CLAUDE.md
@@ -31,6 +31,8 @@ tail -f /tmp/mlflow-dev-server.log
 
 This provides fast edit-refresh for UI development - changes to React components will automatically reload in the browser.
 
+> **Running multiple git worktrees?** `dev/run-dev-server.sh` kills sibling dev servers on startup and assumes ports `5000`/`3000`, so it cannot run two environments at once. For concurrent worktrees, use the two-process flow with per-worktree ports documented in the root `CLAUDE.md` → "Running Multiple Worktrees Concurrently".
+
 ## Available Yarn Scripts
 
 When running from the repository root, use this pattern:


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Not applicable 

### What changes are proposed in this pull request?

This project improves developer experience on Coding agents. Currently, the `CLAUDE.md` file references `dev/run-dev-server.sh` which does `kill` on all MLFLow processes. This is not compatible with a git worktree development workflow on local. Therefore, we add more notes in the file to ask users with multiple workflows to avoid using this file. 

I'm open to removing this `dev/run-dev-server.sh` file, not sure if its' heavily used at this point. 

Changes to the wording were suggested by Claude.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

```
> I'll first check whether this is a worktree (since killing sibling dev servers is a concern here) before starting the servers.
>  There are dev servers running from other worktrees (ports 5001, 51723, 6065). The wrapper dev/run-dev-server.sh would kill all of them — exactly the danger documented in CLAUDE.md.
  Since this is one of three active worktrees, I'll use the direct two-process workflow with a unique port pair instead. Let me check which ports are free.
```

<!-- Attach code, screenshot, video used for manual testing here. -->

Manually tested the changes on my machine. 

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
