### PR TITLE
Pin `safetensors>=0.8.0rc0` for `diffusers>=0.38.0` cross-version tests

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -542,6 +542,9 @@ diffusers:
     maximum: "0.37.1"
     requirements:
       ">= 0.0.0": ["transformers", "safetensors", "accelerate", "peft", "torch"]
+      # diffusers>=0.38.0 depends on safetensors>=0.8.0rc0 (pre-release).
+      # Explicitly specifying the prerelease requirement allows uv to resolve it without --prerelease=allow.
+      ">= 0.38.0": ["safetensors>=0.8.0rc0"]
     run: |
       pytest tests/diffusers/test_diffusers_model_export.py
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

`diffusers==0.38.0` depends on `safetensors>=0.8.0rc0` (a pre-release), so `uv pip install` fails to resolve the cross-version test matrix without `--prerelease=allow`:

```
× No solution found when resolving dependencies:
╰─▶ Because diffusers==0.38.0 depends on safetensors>=0.8.0rc0 and
    only safetensors<0.8.0rc0 is available, we can conclude that
    diffusers==0.38.0 cannot be used.
```

Add a version-scoped requirement (`>= 0.38.0`: `safetensors>=0.8.0rc0`) so uv accepts the pre-release for this matrix entry only, leaving the rest of the matrix on stable `safetensors`. Mirrors the existing pattern used for `semantic-kernel` / `azure-ai-agents`.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release