### PR TITLE
Pin `opentelemetry-sdk<1.40` for mistralai 2.x cross-version tests

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -1014,6 +1014,12 @@ mistral:
     minimum: "1.7.1"
     maximum: "2.4.5"
     requirements:
+      # mistralai 2.x hard-pins opentelemetry-semantic-conventions==0.60b1, which is only
+      # paired with opentelemetry-sdk 1.39.x. mlflow's `.[extras]` install pulls in the
+      # newest sdk, leaving an inconsistent api/sdk/semconv trio that breaks span start
+      # with `TraceFlags.RANDOM_TRACE_ID` AttributeError. Hold the sdk back so the trio
+      # stays aligned with mistralai's semconv pin.
+      ">= 2.0.0": ["opentelemetry-sdk<1.40"]
     run: pytest tests/mistral
     test_tracing_sdk: true
     test_every_n_versions: 10


### PR DESCRIPTION
### Related Issues/PRs

Relates to the failing `Cross version tests / test1 (mistral / autologging / 2.4.5)` job: https://github.com/mlflow/dev/actions/runs/26580483553/job/78375124608

### What changes are proposed in this pull request?

Hold `opentelemetry-sdk<1.40` for the mistralai 2.x cross-version matrix so the API/SDK/semconv trio stays consistent.

mistralai 2.x pins `opentelemetry-semantic-conventions<0.61,>=0.60b1`, which only matches `semconv==0.60b1`. Each `opentelemetry-sdk` release hard-pairs `opentelemetry-api==X.Y.Z` and `opentelemetry-semantic-conventions==0.Yb*`, so only `sdk 1.39.x` is compatible with that semconv pin.

In the cross-version job, mlflow's `uv pip install --system .[extras]` step pulls the newest SDK (currently 1.42.1). The subsequent `uv pip install --system 'mistralai==2.4.5'` then downgrades only `api` (to 1.39.1) and `semconv` (to 0.60b1) to satisfy mistralai's pins, but leaves `sdk` at 1.42.1. The resulting trio:

| Package | Installed | Expected for sdk 1.42.1 |
| --- | --- | --- |
| `opentelemetry-api` | 1.39.1 | 1.42.1 |
| `opentelemetry-sdk` | 1.42.1 | 1.42.1 |
| `opentelemetry-semantic-conventions` | 0.60b1 | 0.63b1 |

At span start the SDK calls `TraceFlags.RANDOM_TRACE_ID` (added to the API in 1.42.0), which raises `AttributeError`. MLflow's `start_span` swallows it as a warning and never records the trace, so `tests/mistral/test_mistral_autolog.py` fails three tests with `assert 0 == 1` (empty `traces`).

Pinning `opentelemetry-sdk<1.40` for the mistralai 2.x matrix forces the SDK to align with the semconv that mistralai requires, restoring a consistent install.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release