### PR TITLE
Use stdlib `importlib.metadata` in llama_index tests

### DIFF
--- a/tests/llama_index/test_llama_index_autolog.py
+++ b/tests/llama_index/test_llama_index_autolog.py
@@ -1,6 +1,6 @@
+from importlib import metadata
 from unittest import mock
 
-import importlib_metadata
 import pytest
 from llama_index.core.chat_engine.types import ChatMode
 from llama_index.core.instrumentation import get_dispatcher
@@ -14,7 +14,7 @@ from mlflow.tracing.constant import TraceMetadataKey
 
 from tests.tracing.helper import get_traces, skip_when_testing_trace_sdk
 
-llama_core_version = Version(importlib_metadata.version("llama-index-core"))
+llama_core_version = Version(metadata.version("llama-index-core"))
 
 
 def test_autolog_enable_tracing(multi_index):

--- a/tests/llama_index/test_llama_index_tracer.py
+++ b/tests/llama_index/test_llama_index_tracer.py
@@ -3,11 +3,11 @@ import base64
 import inspect
 import random
 from dataclasses import asdict
+from importlib import metadata
 from pathlib import Path
 from typing import Any
 from unittest.mock import ANY
 
-import importlib_metadata
 import llama_index.core
 import openai
 import pytest
@@ -39,13 +39,13 @@ from mlflow.version import IS_TRACING_SDK_ONLY
 
 from tests.tracing.helper import get_traces, skip_when_testing_trace_sdk
 
-llama_core_version = Version(importlib_metadata.version("llama-index-core"))
-llama_oai_version = Version(importlib_metadata.version("llama-index-llms-openai"))
+llama_core_version = Version(metadata.version("llama-index-core"))
+llama_oai_version = Version(metadata.version("llama-index-llms-openai"))
 
 # Detect llama-index-workflows version to handle API changes
 try:
-    llama_workflows_version = Version(importlib_metadata.version("llama-index-workflows"))
-except importlib_metadata.PackageNotFoundError:
+    llama_workflows_version = Version(metadata.version("llama-index-workflows"))
+except metadata.PackageNotFoundError:
     llama_workflows_version = None
 
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to the failing `Cross version tests / test1 (llama_index / tracing-sdk / 0.14.16)` job: https://github.com/mlflow/dev/actions/runs/26580483553/job/78375124609

### What changes are proposed in this pull request?

Switch `tests/llama_index/test_llama_index_autolog.py` and `tests/llama_index/test_llama_index_tracer.py` from the third-party `importlib_metadata` backport to the stdlib `importlib.metadata`.

The `tracing-sdk` cross-version category installs only `libs/tracing` + `pytest pytest-asyncio pytest-cov` (`.github/workflows/cross-version-tests.yml:179-181`); it does not install `mlflow[extras]` or `requirements/test-requirements.txt`. `importlib_metadata` is declared as a runtime dep on `pyproject.toml` and `libs/skinny/pyproject.toml`, but **not** on `libs/tracing/pyproject.toml`, so it is absent in that env. Test collection then fails with `ModuleNotFoundError: No module named 'importlib_metadata'`.

`importlib.metadata.version` and `PackageNotFoundError` have been in the stdlib since Python 3.8, well within mlflow's `python>=3.10` floor, so no backport is needed.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release