### PR TITLE
Drop brittle `Settings.__dict__` assert in llama_index conftest

### DIFF
--- a/tests/llama_index/conftest.py
+++ b/tests/llama_index/conftest.py
@@ -76,8 +76,6 @@ def settings(monkeypatch, mock_openai):
     monkeypatch.setattr(Settings, "node_parser", SentenceSplitter(chunk_size=1024))
     monkeypatch.setattr(Settings, "transformations", [SentenceSplitter(chunk_size=1024)])
 
-    assert all(Settings.__dict__.values())  # ensure the full object is populated
-
     return Settings
 
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

`llama-index-core==0.14.22` added a new private attribute `_chat_prompt_helper: Optional[ChatPromptHelper] = None` to `_Settings`. It is populated lazily (only on first access of `Settings.chat_prompt_helper` / `chat_context_window`), so `assert all(Settings.__dict__.values())` in `tests/llama_index/conftest.py` now fails at fixture setup, erroring every test in `tests/llama_index/`. Dropping this paranoid post-monkeypatch invariant — it adds no real coverage and is brittle against any future optional private field.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release