### PR TITLE
Drop `Agent` from `pr-review` allowed tools

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -8,7 +8,6 @@ allowed-tools:
   - Bash
   - Grep
   - Glob
-  - Agent
   - Edit(//tmp/review-payload.json)
 argument-hint: "<owner_repo> <pr_number> [extra_context]"
 arguments: [owner_repo, pr_number, extra_context]


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

Drops `Agent` from `.claude/skills/pr-review/SKILL.md`'s `allowed-tools`.

In recent review runs, Claude has tried to fetch the PR diff via `Agent({subagent_type: "fetch-diff", ...})`, which errors with `Agent type 'fetch-diff' not found` because `fetch-diff` is a skill, not a subagent. Claude recovers by then calling `Skill({skill: "fetch-diff"})` directly, but the failed Agent turn wastes a round-trip. Removing `Agent` from the allow-list forces the canonical `Skill` invocation and eliminates the wasted turn.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release