### PR TITLE
Print dev server URLs and drop stale port docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,17 +30,10 @@ MLflow is an open-source platform for managing the end-to-end machine learning l
 
 ```bash
 # Start both MLflow backend and React frontend dev servers
-# (The script will automatically clean up any existing servers)
 uv run dev/run_dev_server.py > /tmp/mlflow-dev-server.log 2>&1 &
 
-# Monitor the logs
+# Monitor the logs (server URLs are printed there)
 tail -f /tmp/mlflow-dev-server.log
-
-# Servers will be available at:
-# - MLflow backend: http://localhost:5000
-# - React frontend: http://localhost:3000
-# If 5000 or 3000 is already in use, the script falls back to the next free
-# port and prints the chosen port in the log.
 ```
 
 This uses `uv` (fast Python package manager) to automatically manage dependencies and run the development environment.
@@ -66,14 +59,10 @@ export MLFLOW_TRACKING_URI="databricks"                        # Must be set to 
 export MLFLOW_REGISTRY_URI="databricks-uc"                     # Use "databricks-uc" for Unity Catalog, or "databricks" for workspace model registry
 
 # Start the dev server with these environment variables
-# (The script will automatically clean up any existing servers)
 uv run dev/run_dev_server.py > /tmp/mlflow-dev-server.log 2>&1 &
 
-# Monitor the logs
+# Monitor the logs (server URLs are printed there)
 tail -f /tmp/mlflow-dev-server.log
-
-# The MLflow server will now proxy tracking and model registry requests to Databricks
-# Access the UI at http://localhost:3000 to see your Databricks experiments and models
 ```
 
 **Note**: The MLflow server acts as a proxy, forwarding API requests to your Databricks workspace while serving the local React frontend. This allows you to develop and test UI changes against real Databricks data.

--- a/dev/run_dev_server.py
+++ b/dev/run_dev_server.py
@@ -131,7 +131,7 @@ def main() -> None:
     backend_port = find_free_port(5000)
     frontend_port = find_free_port(3000, avoid=frozenset({backend_port}))
     print(f"Backend:  http://localhost:{backend_port}")
-    print(f"Frontend: http://localhost:{frontend_port}")
+    print(f"Frontend: http://localhost:{frontend_port} (with hot reload)")
 
     children: list[subprocess.Popen[bytes]] = []
     tmp_paths: list[Path] = []

--- a/dev/run_dev_server.py
+++ b/dev/run_dev_server.py
@@ -130,10 +130,8 @@ def main() -> None:
 
     backend_port = find_free_port(5000)
     frontend_port = find_free_port(3000, avoid=frozenset({backend_port}))
-    if backend_port != 5000:
-        print(f"Port 5000 is in use; using {backend_port} for the MLflow backend.")
-    if frontend_port != 3000:
-        print(f"Port 3000 is in use; using {frontend_port} for the React dev server.")
+    print(f"MLflow backend:   http://localhost:{backend_port}")
+    print(f"React dev server: http://localhost:{frontend_port}")
 
     children: list[subprocess.Popen[bytes]] = []
     tmp_paths: list[Path] = []

--- a/dev/run_dev_server.py
+++ b/dev/run_dev_server.py
@@ -130,8 +130,8 @@ def main() -> None:
 
     backend_port = find_free_port(5000)
     frontend_port = find_free_port(3000, avoid=frozenset({backend_port}))
-    print(f"MLflow backend:   http://localhost:{backend_port}")
-    print(f"React dev server: http://localhost:{frontend_port}")
+    print(f"Backend:  http://localhost:{backend_port}")
+    print(f"Frontend: http://localhost:{frontend_port}")
 
     children: list[subprocess.Popen[bytes]] = []
     tmp_paths: list[Path] = []

--- a/mlflow/server/js/CLAUDE.md
+++ b/mlflow/server/js/CLAUDE.md
@@ -21,14 +21,9 @@ Before implementing any feature:
 # MUST be run from the repository root
 uv run dev/run_dev_server.py > /tmp/mlflow-dev-server.log 2>&1 &
 
-# Monitor the logs
+# Monitor the logs (server URLs are printed there; the React dev server
+# supports hot reload)
 tail -f /tmp/mlflow-dev-server.log
-
-# Servers will be available at:
-# - MLflow backend: http://localhost:5000
-# - React frontend: http://localhost:3000 (with hot reload)
-# If 5000 or 3000 is already in use, the script falls back to the next free
-# port and prints the chosen port in the log.
 ```
 
 This provides fast edit-refresh for UI development - changes to React components will automatically reload in the browser.

--- a/mlflow/server/js/CLAUDE.md
+++ b/mlflow/server/js/CLAUDE.md
@@ -21,8 +21,8 @@ Before implementing any feature:
 # MUST be run from the repository root
 uv run dev/run_dev_server.py > /tmp/mlflow-dev-server.log 2>&1 &
 
-# Monitor the logs (server URLs are printed there; the React dev server
-# supports hot reload)
+# Monitor the logs (server URLs are printed there; the frontend dev
+# server supports hot reload)
 tail -f /tmp/mlflow-dev-server.log
 ```
 

--- a/mlflow/server/js/CLAUDE.md
+++ b/mlflow/server/js/CLAUDE.md
@@ -21,8 +21,7 @@ Before implementing any feature:
 # MUST be run from the repository root
 uv run dev/run_dev_server.py > /tmp/mlflow-dev-server.log 2>&1 &
 
-# Monitor the logs (server URLs are printed there; the frontend dev
-# server supports hot reload)
+# Monitor the logs (server URLs are printed there)
 tail -f /tmp/mlflow-dev-server.log
 ```
 


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

- `dev/run_dev_server.py` now unconditionally prints the chosen backend and frontend URLs (e.g. `Backend: http://localhost:5014`). Previously it only printed when a port had to fall back, so if 5000/3000 were both free the URLs were never logged.
- `CLAUDE.md` and `mlflow/server/js/CLAUDE.md`: drop the hardcoded `localhost:5000` / `localhost:3000` block and the "fall back to the next free port" sentence — the script now writes the actual URLs to the log, so the docs just tell you to read it. Also drops the misleading "(The script will automatically clean up any existing servers)" comment; the script only reaps its own children, not pre-existing dev servers.

### How is this PR tested?

- [x] Manual tests

Ran `uv run dev/run_dev_server.py > /tmp/mlflow-dev-server.log 2>&1 &` locally; port 5000 was held by macOS Control Center, so the script picked alternate ports and the log started with:

```
Backend:  http://localhost:5014
Frontend: http://localhost:3013
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release