### PR TITLE
Drop `CI: false` workaround in js.yml `Run build`

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -101,9 +101,5 @@ jobs:
           retention-days: 3
           if-no-files-found: ignore
       - name: Run build
-        env:
-          # Prevent warnings (emitted from react-pdf) from being treated as errors
-          # https://github.com/wojtekmaj/react-pdf/issues/280
-          CI: false
         run: |
           yarn build


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Removes the `CI: false` env var (and its `react-pdf` comment) from the `Run build` step in `.github/workflows/js.yml`. The workaround was added years ago to suppress `react-pdf` warnings being treated as errors by CRA. CI will tell us if the warnings still surface; if not, we can keep the build strict.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)