### PR TITLE
Use CLI for Claude Code plugin install in docs

### DIFF
--- a/docs/docs/genai/tracing/integrations/listing/claude_code.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/claude_code.mdx
@@ -58,17 +58,13 @@ The in-Claude `/plugin marketplace add` command clones the full `mlflow/mlflow` 
 
 ### Step 2. Install the plugin
 
-Launch Claude Code in the same repo, then install the plugin from inside Claude Code:
+From your terminal:
 
 ```bash
-claude
+claude plugin install mlflow-tracing@mlflow-plugins
 ```
 
-```text
-/plugin install mlflow-tracing@mlflow-plugins
-```
-
-Restart Claude Code so the plugin is loaded.
+Launch Claude Code (restart it if it's already running) to load the plugin.
 
 ### Step 3. Run the setup command
 

--- a/docs/docs/genai/tracing/integrations/listing/claude_code.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/claude_code.mdx
@@ -64,7 +64,7 @@ From your terminal:
 claude plugin install mlflow-tracing@mlflow-plugins
 ```
 
-Launch Claude Code (restart it if it's already running) to load the plugin.
+Run `claude` to launch Claude Code (or restart it if it's already running) so the plugin is loaded.
 
 ### Step 3. Run the setup command
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23633

### What changes are proposed in this pull request?

Step 2 of the Claude Code tracing docs walked users into Claude Code to run `/plugin install mlflow-tracing@mlflow-plugins`. The rest of the steps were terminal commands, so swap step 2 to `claude plugin install ...` for consistency and rewrite the trailing line to cover both "launch" and "restart" cases.

### How is this PR tested?

- [x] Manual tests

Previewed locally with `npm start` in `docs/`.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)