### PR TITLE
Surface upstream gateway error status when `Content-Type` is missing

### DIFF
--- a/mlflow/gateway/providers/utils.py
+++ b/mlflow/gateway/providers/utils.py
@@ -1,8 +1,11 @@
 import time
 from contextlib import asynccontextmanager
 from contextvars import ContextVar
-from typing import Any, AsyncGenerator
+from typing import TYPE_CHECKING, Any, AsyncGenerator
 from urllib.parse import urlparse, urlunparse
+
+if TYPE_CHECKING:
+    import aiohttp
 
 from mlflow.gateway.constants import (
     MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS,
@@ -34,6 +37,28 @@ async def _aiohttp_post(headers: dict[str, str], base_url: str, path: str, paylo
             yield response
 
 
+async def _extract_error_detail(
+    response: "aiohttp.ClientResponse", error: "aiohttp.ClientResponseError"
+) -> Any:
+    content_type = error.headers.get("Content-Type") if error.headers else None
+    if content_type and "application/json" in content_type:
+        try:
+            body = await response.json()
+        except Exception:
+            pass
+        else:
+            match body:
+                case {"error": {"message": str(msg)}}:
+                    return msg
+                case _:
+                    return body
+    try:
+        text = await response.text()
+    except Exception:
+        text = ""
+    return {"message": text or error.message}
+
+
 async def send_request(headers: dict[str, str], base_url: str, path: str, payload: dict[str, Any]):
     """
     Send an HTTP request to a specific URL path with given headers and payload.
@@ -57,6 +82,15 @@ async def send_request(headers: dict[str, str], base_url: str, path: str, payloa
     try:
         async with _aiohttp_post(headers, base_url, path, payload) as response:
             content_type = response.headers.get("Content-Type")
+            try:
+                response.raise_for_status()
+            except aiohttp.ClientResponseError as e:
+                # Surface upstream errors regardless of Content-Type. Some upstreams
+                # omit Content-Type on errors, which would otherwise be masked as
+                # the generic 502 raised below.
+                detail = await _extract_error_detail(response, e)
+                raise HTTPException(status_code=e.status, detail=detail)
+
             if content_type and "application/json" in content_type:
                 js = await response.json()
             elif content_type and "text/plain" in content_type:
@@ -67,11 +101,6 @@ async def send_request(headers: dict[str, str], base_url: str, path: str, payloa
                     detail=f"The returned data type from the route service is not supported. "
                     f"Received content type: {content_type}",
                 )
-            try:
-                response.raise_for_status()
-            except aiohttp.ClientResponseError as e:
-                detail = js.get("error", {}).get("message", e.message) if "error" in js else js
-                raise HTTPException(status_code=e.status, detail=detail)
     finally:
         # Record full provider HTTP time for non-streaming, even when raising.
         provider_call_duration_ms.set(

--- a/tests/gateway/providers/test_provider_utils.py
+++ b/tests/gateway/providers/test_provider_utils.py
@@ -1,12 +1,14 @@
 from unittest import mock
 
 import pytest
+from fastapi import HTTPException
 
 from mlflow.gateway.providers.utils import (
     SUPPORTED_ACCEPT_ENCODING,
     _aiohttp_post,
     proxy_root_url,
     rename_payload_keys,
+    send_request,
 )
 
 from tests.gateway.tools import MockAsyncResponse, mock_http_client
@@ -70,3 +72,46 @@ async def test_aiohttp_post_includes_supported_accept_encoding():
 )
 def test_proxy_root_url(base_url, expected):
     assert proxy_root_url(base_url) == expected
+
+
+@pytest.mark.asyncio
+async def test_send_request_surfaces_upstream_status_when_content_type_missing():
+    # Regression for https://github.com/mlflow/mlflow/issues/23617: when an
+    # upstream (e.g., Ollama replying 403 to a disallowed browser Origin)
+    # returns an error status with no Content-Type header, mlflow should
+    # forward that status instead of masking it as a generic 502.
+    mock_response = MockAsyncResponse({"headers": {}, "detail": "Origin not allowed"}, status=403)
+    mock_client = mock_http_client(mock_response)
+    with mock.patch("aiohttp.ClientSession", return_value=mock_client) as mock_session_cls:
+        with pytest.raises(HTTPException, match="Origin not allowed") as exc_info:
+            await send_request(
+                headers={"Origin": "http://localhost:5000"},
+                base_url="http://upstream",
+                path="v1/responses",
+                payload={"model": "x", "input": "hi"},
+            )
+    mock_session_cls.assert_called_once()
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        ({"error": {"message": "invalid model"}}, "invalid model"),
+        ({"error": "invalid model"}, "invalid model"),
+    ],
+)
+async def test_send_request_extracts_error_message_from_json_body(body, expected):
+    mock_response = MockAsyncResponse(body, status=400)
+    mock_client = mock_http_client(mock_response)
+    with mock.patch("aiohttp.ClientSession", return_value=mock_client) as mock_session_cls:
+        with pytest.raises(HTTPException, match=expected) as exc_info:
+            await send_request(
+                headers={},
+                base_url="http://upstream",
+                path="v1/chat/completions",
+                payload={"model": "x"},
+            )
+    mock_session_cls.assert_called_once()
+    assert exc_info.value.status_code == 400

--- a/tests/gateway/tools.py
+++ b/tests/gateway/tools.py
@@ -104,7 +104,7 @@ class MockAsyncResponse:
 
     def raise_for_status(self) -> None:
         if 400 <= self.status < 600:
-            raise aiohttp.ClientResponseError(None, None, status=self.status)
+            raise aiohttp.ClientResponseError(None, None, status=self.status, headers=self.headers)
 
     async def json(self) -> dict[str, Any]:
         return self._content


### PR DESCRIPTION
### Related Issues/PRs

Closes #23617

### What changes are proposed in this pull request?

`send_request` in `mlflow/gateway/providers/utils.py` checked the upstream `Content-Type` before the status, so non-2xx responses without a `Content-Type` header (e.g., Ollama replying 403 to a browser whose `Origin` isn't in `OLLAMA_ORIGINS`) were masked as a generic 502. Now `raise_for_status()` runs first and the upstream status is surfaced with a best-effort detail. Detail shapes for the previously-supported `application/json` and `text/plain` branches are preserved.

### How is this PR tested?

- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Gateway proxy now forwards the upstream status code when the upstream replies with no `Content-Type` header, instead of masking the failure as a 502.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
