### PR TITLE
Restore `mlflow.crewai` autolog on crewai 1.14.5

### DIFF
--- a/mlflow/crewai/__init__.py
+++ b/mlflow/crewai/__init__.py
@@ -47,15 +47,20 @@ def autolog(
     _memory_method = (
         "_save_to_memory" if CREWAI_VERSION >= Version("1.10.0") else "_create_long_term_memory"
     )
+    # crewai 1.14.5 renamed the module and class: base_agent_executor_mixin.CrewAgentExecutorMixin
+    # -> base_agent_executor.BaseAgentExecutor
+    _executor_path = (
+        "crewai.agents.agent_builder.base_agent_executor.BaseAgentExecutor"
+        if CREWAI_VERSION >= Version("1.14.5")
+        else "crewai.agents.agent_builder.base_agent_executor_mixin.CrewAgentExecutorMixin"
+    )
     class_method_map = {
         "crewai.Crew": ["kickoff", "kickoff_for_each", "train"],
         "crewai.Agent": ["execute_task"],
         "crewai.Task": ["execute_sync"],
         "crewai.LLM": ["call"],
         "crewai.Flow": ["kickoff"],
-        "crewai.agents.agent_builder.base_agent_executor_mixin.CrewAgentExecutorMixin": [
-            _memory_method
-        ],
+        _executor_path: [_memory_method],
     }
     standalone_method_map = {}
 

--- a/mlflow/crewai/autolog.py
+++ b/mlflow/crewai/autolog.py
@@ -41,10 +41,21 @@ def patched_standalone_call(original, *args, **kwargs):
         return result
 
 
+def _is_internal_flow(instance) -> bool:
+    # crewai 1.x runs an experimental AgentExecutor (a Flow subclass) inside
+    # Agent.execute_task. Skip span creation for it since the Agent span already
+    # bounds the same work and crewai marks it with suppress_flow_events=True.
+    try:
+        from crewai.experimental.agent_executor import AgentExecutor
+    except ImportError:
+        return False
+    return isinstance(instance, AgentExecutor)
+
+
 def patched_class_call(original, self, *args, **kwargs):
     config = AutoLoggingConfig.init(flavor_name=mlflow.crewai.FLAVOR_NAME)
 
-    if not config.log_traces:
+    if not config.log_traces or _is_internal_flow(self):
         return original(self, *args, **kwargs)
 
     default_name = f"{self.__class__.__name__}.{original.__name__}"
@@ -201,12 +212,18 @@ def _get_span_type(instance) -> str:
             return SpanType.LLM
         elif isinstance(instance, Flow):
             return SpanType.CHAIN
-        elif isinstance(
-            instance, crewai.agents.agent_builder.base_agent_executor_mixin.CrewAgentExecutorMixin
-        ):
+        CREWAI_VERSION = Version(crewai.__version__)
+        # crewai 1.14.5 renamed base_agent_executor_mixin.CrewAgentExecutorMixin to
+        # base_agent_executor.BaseAgentExecutor
+        if CREWAI_VERSION >= Version("1.14.5"):
+            executor_cls = crewai.agents.agent_builder.base_agent_executor.BaseAgentExecutor
+        else:
+            executor_cls = (
+                crewai.agents.agent_builder.base_agent_executor_mixin.CrewAgentExecutorMixin
+            )
+        if isinstance(instance, executor_cls):
             return SpanType.MEMORY
 
-        CREWAI_VERSION = Version(crewai.__version__)
         # Knowledge and Memory are not available before 0.83.0
         if CREWAI_VERSION >= Version("0.83.0"):
             memory_classes = (

--- a/mlflow/crewai/autolog.py
+++ b/mlflow/crewai/autolog.py
@@ -42,7 +42,7 @@ def patched_standalone_call(original, *args, **kwargs):
 
 
 def _is_internal_flow(instance) -> bool:
-    # crewai 1.x runs an experimental AgentExecutor (a Flow subclass) inside
+    # crewai >= 1.14.5 runs an experimental AgentExecutor (a Flow subclass) inside
     # Agent.execute_task. Skip span creation for it since the Agent span already
     # bounds the same work and crewai marks it with suppress_flow_events=True.
     try:

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -892,7 +892,7 @@ crewai:
       uv pip install --system git+https://github.com/crewAIInc/crewAI#subdirectory=lib/crewai
   autologging:
     minimum: "0.121.0"
-    maximum: "1.14.4"
+    maximum: "1.14.5"
     unsupported: ["==0.114.0"]
     requirements:
     run: pytest tests/crewai

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -123,7 +123,7 @@ _ML_PACKAGE_VERSIONS = {
         },
         "autologging": {
             "minimum": "0.121.0",
-            "maximum": "1.14.4"
+            "maximum": "1.14.5"
         }
     },
     "agno": {


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

crewai 1.14.5 ships two breaking changes that disrupt `mlflow.crewai` autologging:

1. `crewai.agents.agent_builder.base_agent_executor_mixin.CrewAgentExecutorMixin` was renamed to `crewai.agents.agent_builder.base_agent_executor.BaseAgentExecutor`. `_apply_patches` raised `ModuleNotFoundError`, was caught, and silently aborted the rest of the autolog setup.
2. `Agent.execute_task` now runs an internal experimental `AgentExecutor` (a `Flow` subclass marked `suppress_flow_events = True`). Because MLflow patches `Flow.kickoff`, an extra `AgentExecutor.kickoff` span leaked into every trace.

This PR version-gates the executor module/class path and skips span creation for the internal `AgentExecutor`.

### How is this PR tested?

- [x] Existing unit/integration tests

`uv run --with 'crewai==1.14.5,crewai-tools,litellm' pytest tests/crewai/` passes (16 passed, 4 skipped), and the same command on `crewai==1.14.4` still passes.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Restore `mlflow.crewai` autologging for crewai 1.14.5 by tracking renamed internals and suppressing crewai's new internal `AgentExecutor` span.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release