### PR TITLE
Prefer routed ASGI paths in FastAPI auth checks.

### DIFF
--- a/mlflow/server/asgi_utils.py
+++ b/mlflow/server/asgi_utils.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from starlette.requests import Request as StarletteRequest
+
+
+def get_routed_asgi_path(request: StarletteRequest) -> str:
+    """Return the routed ASGI path for a FastAPI request.
+
+    Prefer ``request.scope["path"]`` because Starlette reconstructs
+    ``request.url.path`` from the Host header, which can diverge from the actual
+    routed path when the Host header is malformed. Fall back to ``request.url``
+    only if the ASGI scope path is unavailable.
+    """
+
+    scope = getattr(request, "scope", None)
+    if isinstance(scope, dict):
+        scope_path = scope.get("path")
+        if isinstance(scope_path, str) and scope_path:
+            return scope_path
+
+    return str(getattr(getattr(request, "url", None), "path", "") or "")

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -201,6 +201,7 @@ from mlflow.protos.webhooks_pb2 import (
     WebhookService,
 )
 from mlflow.server import app
+from mlflow.server.asgi_utils import get_routed_asgi_path
 from mlflow.server.auth.config import DEFAULT_AUTHORIZATION_FUNCTION, read_auth_config
 from mlflow.server.auth.entities import GetUserPermissionResult, User
 from mlflow.server.auth.logo import MLFLOW_LOGO
@@ -3934,6 +3935,7 @@ def _authenticate_fastapi_request(request: StarletteRequest) -> User | None:
     if "Authorization" not in request.headers:
         return None
 
+    request_path = get_routed_asgi_path(request)
     auth = request.headers["Authorization"]
     try:
         scheme, credentials = auth.split()
@@ -3951,7 +3953,7 @@ def _authenticate_fastapi_request(request: StarletteRequest) -> User | None:
         internal_token = _MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN.get()
         if (
             internal_token
-            and request.url.path.startswith("/gateway/")
+            and request_path.startswith("/gateway/")
             and secrets.compare_digest(password, internal_token)
         ):
             return store.get_user(username)
@@ -4126,7 +4128,7 @@ def add_fastapi_permission_middleware(app: FastAPI) -> None:
 
     @app.middleware("http")
     async def fastapi_permission_middleware(request, call_next):
-        path = request.url.path
+        path = get_routed_asgi_path(request)
 
         # Skip unprotected routes
         if is_unprotected_route(path):

--- a/mlflow/server/fastapi_app.py
+++ b/mlflow/server/fastapi_app.py
@@ -21,6 +21,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.gateway.constants import MLFLOW_GATEWAY_DURATION_HEADER, MLFLOW_GATEWAY_OVERHEAD_HEADER
 from mlflow.gateway.providers.utils import provider_call_duration_ms
 from mlflow.server import app as flask_app
+from mlflow.server.asgi_utils import get_routed_asgi_path
 from mlflow.server.assistant.api import assistant_router
 from mlflow.server.fastapi_security import init_fastapi_security
 from mlflow.server.gateway_api import gateway_router
@@ -89,7 +90,7 @@ def add_fastapi_workspace_middleware(fastapi_app: FastAPI) -> None:
     async def workspace_context_middleware(request: Request, call_next):
         try:
             workspace = resolve_workspace_for_request_if_enabled(
-                request.url.path,
+                get_routed_asgi_path(request),
                 request.headers.get(WORKSPACE_HEADER_NAME),
             )
         except MlflowException as e:
@@ -114,7 +115,7 @@ def add_gateway_timing_middleware(fastapi_app: FastAPI) -> None:
 
     @fastapi_app.middleware("http")
     async def gateway_timing_middleware(request: Request, call_next):
-        if not request.url.path.startswith("/gateway/"):
+        if not get_routed_asgi_path(request).startswith("/gateway/"):
             return await call_next(request)
 
         # Reset the ContextVar so the handler task starts at 0. The handler task

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -5,6 +5,7 @@ pytest-asyncio
 pytest-repeat
 pytest-cov
 pytest-timeout
+httpx
 moto>=4.2.0,<5,!=4.2.5
 azure-storage-blob>=12.0.0
 azure-storage-file-datalake>=12.9.1

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -32,6 +32,7 @@ from mlflow.protos.databricks_pb2 import (
     ErrorCode,
 )
 from mlflow.server import auth as auth_module
+from mlflow.server.asgi_utils import get_routed_asgi_path
 from mlflow.server.auth import _authenticate_fastapi_request, _re_compile_path
 from mlflow.server.auth.routes import (
     AJAX_LIST_USERS,
@@ -2975,8 +2976,9 @@ def enable_auth_cache():
         yield cache
 
 
-def _make_request(path, authorization=None):
+def _make_request(path, authorization=None, *, scope_path=None):
     request = mock.Mock()
+    request.scope = {"path": scope_path or path}
     request.url.path = path
     request.headers = {}
     if authorization:
@@ -2985,6 +2987,20 @@ def _make_request(path, authorization=None):
 
 
 # -- Basic auth with internal token (trusted internal requests) --
+
+
+def test_get_fastapi_request_path_prefers_scope_path():
+    request = _make_request("/reconstructed/path", scope_path="/routed/path")
+
+    assert get_routed_asgi_path(request) == "/routed/path"
+
+
+@pytest.mark.parametrize("scope", [None, {}, {"path": ""}, {"path": 123}])
+def test_get_fastapi_request_path_falls_back_to_url(scope):
+    request = _make_request("/reconstructed/path")
+    request.scope = scope
+
+    assert get_routed_asgi_path(request) == "/reconstructed/path"
 
 
 def test_basic_auth_with_internal_token_returns_user(
@@ -3012,6 +3028,42 @@ def test_basic_auth_with_internal_token_deleted_user_returns_none(
     user = _authenticate_fastapi_request(request)
 
     assert user is None
+
+
+def test_basic_auth_with_internal_token_uses_scope_path(
+    mock_auth_store, mock_auth_config, monkeypatch
+):
+    monkeypatch.setenv(_MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN.name, "internal-secret")
+    credentials = base64.b64encode(b"alice:internal-secret").decode("ascii")
+    request = _make_request(
+        "/gateway/mlflow/v1/chat",
+        f"Basic {credentials}",
+        scope_path="/api/3.0/mlflow/experiments/list",
+    )
+
+    user = _authenticate_fastapi_request(request)
+
+    assert user.username == "alice"
+    mock_auth_store.authenticate_user.assert_called_once_with("alice", "internal-secret")
+    mock_auth_store.get_user.assert_called_once_with("alice")
+
+
+@pytest.mark.parametrize(
+    "fastapi_client",
+    [{"MLFLOW_SERVER_DISABLE_SECURITY_MIDDLEWARE": "true"}],
+    indirect=True,
+)
+def test_malformed_host_does_not_skip_fastapi_auth(fastapi_client, monkeypatch):
+    monkeypatch.delenv(MLFLOW_TRACKING_USERNAME.name, raising=False)
+    monkeypatch.delenv(MLFLOW_TRACKING_PASSWORD.name, raising=False)
+
+    response = requests.post(
+        url=fastapi_client.tracking_uri + "/ajax-api/3.0/jobs/search",
+        headers={"Host": "example.com/health?x="},
+        json={},
+    )
+
+    assert response.status_code == 401
 
 
 def test_basic_auth_with_wrong_password_falls_through_to_authenticate(

--- a/tests/server/test_workspace_middleware.py
+++ b/tests/server/test_workspace_middleware.py
@@ -114,6 +114,34 @@ def test_fastapi_workspace_middleware_handles_missing_header(monkeypatch):
     assert workspace_context.get_request_workspace() is None
 
 
+def test_fastapi_workspace_middleware_prefers_routed_path(monkeypatch):
+    app, ping_path = _fastapi_workspace_app(monkeypatch)
+    seen: dict[str, str] = {}
+
+    def resolve(path, header):
+        seen["path"] = path
+        return Workspace(name=header)
+
+    monkeypatch.setattr(
+        "mlflow.server.fastapi_app.resolve_workspace_for_request_if_enabled",
+        resolve,
+    )
+
+    client = TestClient(app)
+    resp = client.get(
+        ping_path,
+        headers={
+            WORKSPACE_HEADER_NAME: "team-fast",
+            "Host": "example.com/api/3.0/mlflow/server-info?x=",
+        },
+    )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"workspace": "team-fast"}
+    assert seen["path"] == ping_path
+    assert workspace_context.get_request_workspace() is None
+
+
 def test_server_info_workspaces_enabled(monkeypatch):
     monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
     client = flask_app.test_client()


### PR DESCRIPTION


### Related Issues/PRs

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

Use the dispatched request path for basic-auth route classification so middleware decisions follow the actual routed endpoint, and raise the Starlette floor with aligned test dependencies for a more robust FastAPI test environment.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
