### PR TITLE
Pin `langchain-community<0.4.2` in genai CI job

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -325,9 +325,12 @@ jobs:
           # (removed HallucinationEvaluator/RelevanceEvaluator/etc. and LiteLLMModel)
           # `guardrails-ai` is temporarily unavailable on PyPI; skip both the
           # install and the corresponding tests until it is republished.
+          # TODO: drop the langchain-community<0.4 pin once ragas releases a fix
+          # for the removed `langchain_community.chat_models.vertexai` import.
+          # https://github.com/vibrantlabsai/ragas/issues/2745
           uv pip install \
             -r requirements/test-requirements.txt \
-            deepeval ragas 'arize-phoenix-evals<3.0.0' trulens trulens-providers-litellm 'google-adk[gcp]'
+            deepeval ragas 'arize-phoenix-evals<3.0.0' 'langchain-community<0.4' trulens trulens-providers-litellm 'google-adk[gcp]'
       - uses: ./.github/actions/show-versions
       - name: Run GenAI Tests (OSS)
         run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -325,12 +325,13 @@ jobs:
           # (removed HallucinationEvaluator/RelevanceEvaluator/etc. and LiteLLMModel)
           # `guardrails-ai` is temporarily unavailable on PyPI; skip both the
           # install and the corresponding tests until it is republished.
-          # TODO: drop the langchain-community<0.4 pin once ragas releases a fix
-          # for the removed `langchain_community.chat_models.vertexai` import.
+          # TODO: drop the langchain-community<0.4.2 pin once ragas releases a
+          # fix for the removed `langchain_community.chat_models.vertexai`
+          # import (0.4.2 dropped the shim).
           # https://github.com/vibrantlabsai/ragas/issues/2745
           uv pip install \
             -r requirements/test-requirements.txt \
-            deepeval ragas 'arize-phoenix-evals<3.0.0' 'langchain-community<0.4' trulens trulens-providers-litellm 'google-adk[gcp]'
+            deepeval ragas 'arize-phoenix-evals<3.0.0' 'langchain-community<0.4.2' trulens trulens-providers-litellm 'google-adk[gcp]'
       - uses: ./.github/actions/show-versions
       - name: Run GenAI Tests (OSS)
         run: |


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/vibrantlabsai/ragas/issues/2745

### What changes are proposed in this pull request?

The `genai` CI job (`tests/genai/scorers/ragas/*`) currently fails at collection time with:

```
ModuleNotFoundError: No module named 'langchain_community.chat_models.vertexai'
```

`langchain-community` 0.4.2 cleared our 7-day cooldown gate (`exclude-newer=P7D`) yesterday and is what uv now resolves to. 0.4.2 dropped the `langchain_community.chat_models.vertexai` shim that 0.4.0/0.4.1 still shipped, but the latest released `ragas` (0.4.3) still imports `ChatVertexAI` from that path. The upstream fix PRs (vibrantlabsai/ragas#2739, #2749) are open but unmerged, so pin `langchain-community<0.4.2` on the genai install line until a fixed ragas release ships.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release