### PR TITLE
Fix `transformers.load_model` crash when loading accelerate-placed models

### DIFF
--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -1461,6 +1461,15 @@ def _load_model(
 
     conf = conf | model_and_components
 
+    # If the loaded model was placed onto devices by accelerate (indicated by the presence of
+    # ``hf_device_map``), passing ``device`` to ``transformers.pipeline()`` raises a ValueError:
+    # "The model has been loaded with `accelerate` and therefore cannot be moved to a specific
+    # device."  This happens when the model was saved with quantization (e.g. BitsAndBytes) or an
+    # explicit ``device_map``.  Remove ``device`` so that the pipeline respects the existing
+    # accelerate placement.
+    if hasattr(conf.get(FlavorKey.MODEL), "hf_device_map"):
+        conf.pop("device", None)
+
     if return_type == "pipeline":
         conf.update(**kwargs)
         with suppress_logs("transformers.pipelines.base", filter_regex=_PEFT_PIPELINE_ERROR_MSG):

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -2976,6 +2976,46 @@ def test_basic_model_with_accelerate_homogeneous_mapping_works(model_path):
     assert loaded(text) == pipeline(text)
 
 
+@pytest.mark.skipif(
+    Version(transformers.__version__) > Version("4.44.2"),
+    reason="Multi-task pipeline (t5) has a loading issue with Transformers 4.45.x. "
+    "See https://github.com/huggingface/transformers/issues/33398 for more details.",
+)
+def test_load_model_with_accelerate_device_map_does_not_pass_device(model_path):
+    """
+    Regression test for https://github.com/mlflow/mlflow/issues/13439.
+
+    When a model is loaded with accelerate (``hf_device_map`` is set on the model, e.g.
+    because the original pipeline was saved with a ``device_map``), ``_load_model`` must not
+    forward the ``device`` argument to ``transformers.pipeline()``.  Doing so raises:
+    ``ValueError: The model has been loaded with `accelerate` and therefore cannot be moved
+    to a specific device.``
+    """
+    task = "translation_en_to_de"
+    architecture = "t5-small"
+    model = transformers.T5ForConditionalGeneration.from_pretrained(
+        pretrained_model_name_or_path=architecture,
+        device_map={"shared": "cpu", "encoder": "cpu", "decoder": "cpu", "lm_head": "cpu"},
+        low_cpu_mem_usage=True,
+    )
+    tokenizer = transformers.T5TokenizerFast.from_pretrained(
+        pretrained_model_name_or_path=architecture, model_max_length=100
+    )
+    pipeline = transformers.pipeline(task=task, model=model, tokenizer=tokenizer)
+    mlflow.transformers.save_model(transformers_model=pipeline, path=model_path)
+
+    # Simulate the case where a GPU is available so that _load_model auto-sets device=0.
+    # Without the fix, this would raise ValueError when the model has hf_device_map.
+    with mock.patch(
+        "mlflow.transformers.is_gpu_available", return_value=True
+    ):
+        # Should not raise ValueError
+        loaded = mlflow.transformers.load_model(model_path)
+
+    text = "Apples are delicious"
+    assert loaded(text) == pipeline(text)
+
+
 def test_qa_model_model_size_bytes(small_qa_pipeline, tmp_path):
     def _calculate_expected_size(path_or_dir):
         # this helper function does not consider subdirectories


### PR DESCRIPTION
### Related Issues/PRs

Closes #13439

### What changes are proposed in this pull request?

When a HuggingFace pipeline is saved with quantization (e.g. `BitsAndBytesConfig`)
or an explicit `device_map`, the underlying model is placed onto devices by accelerate
and exposes an `hf_device_map` attribute. On subsequent load, `_load_model` may
auto-detect a GPU and set `device=0` in the pipeline constructor kwargs. Passing both
a pre-placed model and `device` to `transformers.pipeline()` raises:
ValueError: The model has been loaded with accelerate and therefore cannot be moved
to a specific device. Please discard the device argument when creating your pipeline
object.

Fix: after merging the loaded model into the pipeline conf, check if the model has
`hf_device_map`. If so, remove `device` from conf so the pipeline respects accelerate's
existing device placement.

### How is this PR tested?

- [x] New unit/integration tests

Added `test_load_model_with_accelerate_device_map_does_not_pass_device` in
`tests/transformers/test_transformers_model_export.py`. It saves a T5 pipeline with an
all-CPU `device_map`, then loads it while mocking `is_gpu_available=True` to reproduce
the exact failure path that previously raised `ValueError`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the MLflow Skills repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. `mlflow.transformers.load_model` no longer raises `ValueError` when the
model was placed by accelerate (e.g. saved with `BitsAndBytesConfig` or `device_map`).

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix`

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release