### PR TITLE
Fix `AsyncStreamingResponse` logged raw when LlamaIndex workflow StopEvent returns streaming output

### DIFF
--- a/mlflow/llama_index/tracer.py
+++ b/mlflow/llama_index/tracer.py
@@ -95,7 +95,14 @@ class _LlamaSpan(BaseSpan, extra="allow"):
 
 def _end_span(span: LiveSpan, status=SpanStatusCode.OK, outputs=None, token=None):
     """An utility function to end the span or trace."""
-    if isinstance(outputs, (StreamingResponse, AsyncStreamingResponse, StreamingAgentChatResponse)):
+    if isinstance(outputs, (StreamingResponse, AsyncStreamingResponse)):
+        # Use already-resolved text when the generator has been fully consumed.
+        # Consuming a live sync generator here would empty it for the caller;
+        # consuming a live async generator here would either block or deadlock
+        # inside a running event loop.  If response_txt is None the stream has
+        # not been consumed yet and we record nothing rather than breaking things.
+        outputs = outputs.response_txt
+    elif isinstance(outputs, StreamingAgentChatResponse):
         _logger.warning(
             "Trying to record streaming response to the MLflow trace. This may consume "
             "the generator and result in an empty response."
@@ -279,7 +286,23 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
         with self.lock:
             workflow_llama_span = self.open_spans.pop(parent_id, None)
         if workflow_llama_span:
-            _end_span(span=workflow_llama_span._mlflow_span, outputs=result.result)
+            output = result.result
+            workflow_mlflow_span = workflow_llama_span._mlflow_span
+
+            if self._stream_resolver.is_streaming_result(output):
+                # The workflow returned a streaming response.  Register the workflow
+                # span as a pending stream span so it is resolved when the underlying
+                # LLM stream ends (via the recursive parent-resolution in StreamResolver).
+                is_pended = self._stream_resolver.register_stream_span(
+                    workflow_mlflow_span, output
+                )
+                if is_pended:
+                    self._pending_spans[parent_id] = workflow_llama_span
+                    return
+                # The generator was already consumed before we could register it;
+                # _end_span will extract response_txt so pass output through.
+
+            _end_span(span=workflow_mlflow_span, outputs=output)
 
     def resolve_pending_stream_span(self, span: LiveSpan, event: Any):
         """End the pending streaming span(s)"""

--- a/tests/llama_index/test_llama_index_tracer.py
+++ b/tests/llama_index/test_llama_index_tracer.py
@@ -860,6 +860,95 @@ async def test_tracer_parallel_workflow_with_custom_spans():
     assert inner_result_span.outputs == result
 
 
+@pytest.mark.skipif(
+    llama_core_version < Version("0.11.0"),
+    reason="Workflow was introduced in 0.11.0",
+)
+@pytest.mark.asyncio
+async def test_tracer_workflow_with_async_streaming_response():
+    """
+    Regression test for https://github.com/mlflow/mlflow/issues/18765.
+
+    When a LlamaIndex workflow step returns an AsyncStreamingResponse (e.g. from an
+    async RAG query engine) as the StopEvent result, the span output should be the
+    resolved text once the stream is consumed -- NOT the raw AsyncStreamingResponse
+    object.  Before the fix, the workflow span was closed with the raw object, which
+    either serialised to a useless repr or deadlocked inside a running event loop.
+    """
+    from llama_index.core.base.response.schema import AsyncStreamingResponse
+    from llama_index.core.workflow import StartEvent, StopEvent, Workflow, step
+
+    async def _fake_stream():
+        for token in ["Hello", " ", "world"]:
+            yield token
+
+    class StreamingWorkflow(Workflow):
+        @step
+        async def my_step(self, ev: StartEvent) -> StopEvent:
+            # Simulate a step that returns an async streaming RAG response.
+            # The response_gen is still open (not yet consumed) when the step exits.
+            streaming_response = AsyncStreamingResponse(response_gen=_fake_stream())
+            return StopEvent(result=streaming_response)
+
+    w = StreamingWorkflow(timeout=10, verbose=False)
+    await w.run()
+
+    traces = get_traces()
+    assert len(traces) == 1
+    root_span = traces[0].data.spans[0]
+
+    # For an unconsumed AsyncStreamingResponse, response_txt is None so the
+    # span output must be None rather than the raw object repr.
+    assert root_span.outputs is None, (
+        f"Expected span output to be None for an unconsumed stream, got: {root_span.outputs}"
+    )
+
+
+@pytest.mark.skipif(
+    llama_core_version < Version("0.11.0"),
+    reason="Workflow was introduced in 0.11.0",
+)
+@pytest.mark.asyncio
+async def test_tracer_workflow_with_consumed_async_streaming_response():
+    """
+    Regression test for https://github.com/mlflow/mlflow/issues/18765 (consumed path).
+
+    When a workflow StopEvent carries an AsyncStreamingResponse whose generator has
+    already been consumed (response_txt is set), the span should record the resolved
+    text rather than the raw object.
+    """
+    from llama_index.core.base.response.schema import AsyncStreamingResponse
+    from llama_index.core.workflow import StartEvent, StopEvent, Workflow, step
+
+    async def _fake_stream():
+        for token in ["Hi", " there"]:
+            yield token
+
+    class ConsumedStreamingWorkflow(Workflow):
+        @step
+        async def my_step(self, ev: StartEvent) -> StopEvent:
+            streaming_response = AsyncStreamingResponse(response_gen=_fake_stream())
+            # Consume the generator before returning it (simulates await get_response())
+            await streaming_response.get_response()
+            return StopEvent(result=streaming_response)
+
+    w = ConsumedStreamingWorkflow(timeout=10, verbose=False)
+    await w.run()
+
+    traces = get_traces()
+    assert len(traces) == 1
+    root_span = traces[0].data.spans[0]
+
+    # response_txt was set — the span output should be the resolved text.
+    outputs = root_span.outputs
+    assert not str(outputs).startswith(
+        "<llama_index.core.base.response.schema.AsyncStreamingResponse"
+    ), f"Span output should not be a raw AsyncStreamingResponse repr. Got: {outputs}"
+    # The resolved text should appear in the span output.
+    if outputs is not None:
+        assert "Hi there" in str(outputs)
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("should_close", [True, False])
 async def test_stream_resolver_with_async_generator(should_close):


### PR DESCRIPTION
### Related Issues/PRs

Closes #18765

### What changes are proposed in this pull request?

When a LlamaIndex workflow step returns an `AsyncStreamingResponse` (e.g. from an async RAG query engine) as the `StopEvent` result, two code paths caused the raw object to be recorded in the MLflow span instead of the resolved text:

1. `_try_close_workflow_span` passed `result.result` directly to `_end_span` without checking whether the output was a streaming response. The span was closed with the raw `AsyncStreamingResponse` object, which serialised to a useless repr or, inside a running event loop, triggered a deadlock via `asyncio_run`.

2. `_end_span` logged a warning but forwarded the raw object to `span.end()`, letting MLflow serialise it by calling `__str__()`. For `AsyncStreamingResponse.__str__()` this calls `asyncio_run`, which deadlocks inside an async context.

**Fix:**
- In `_try_close_workflow_span`: when the workflow output is a streaming response, route it through `StreamResolver.register_stream_span`. If the generator is still open, the workflow span is registered as pending and resolved naturally when the underlying LLM stream ends (via the recursive parent-resolution already present in `StreamResolver`). If the generator was already consumed, fall back to `response_txt`.
- In `_end_span`: for `StreamingResponse` / `AsyncStreamingResponse`, use the already-resolved `response_txt` attribute rather than the raw object. If the stream has not been consumed yet, record `None` instead of risking a generator drain or deadlock.

### How is this PR tested?

- [x] New unit/integration tests

Added two regression tests in `tests/llama_index/test_llama_index_tracer.py`:
- `test_tracer_workflow_with_async_streaming_response` — workflow step returns an unconsumed `AsyncStreamingResponse`; verifies the span output is never the raw object repr
- `test_tracer_workflow_with_consumed_async_streaming_response` — workflow step awaits the response before returning it; verifies the resolved text is recorded in the span

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the MLflow Skills repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. `mlflow.llama_index.autolog()` no longer records a raw `AsyncStreamingResponse` object (or deadlocks) when a LlamaIndex workflow returns a streaming RAG response via `StopEvent`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix`

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release