### PR TITLE
Run `uv.yml` at 08:00 JST via cron `timezone` field

### DIFF
--- a/.github/workflows/uv.yml
+++ b/.github/workflows/uv.yml
@@ -7,8 +7,9 @@ on:
     paths:
       - .github/workflows/uv.yml
   schedule:
-    # Run this workflow on Monday and Thursday at 1:00 UTC (10:00 JST)
-    - cron: "0 1 * * 1,4"
+    # Run this workflow on Monday and Thursday at 08:00 JST
+    - cron: "0 8 * * 1,4"
+      timezone: "Asia/Tokyo"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

GitHub Actions now supports an IANA `timezone` field alongside `cron` ([changelog](https://github.blog/changelog/2026-03-19-github-actions-late-march-2026-updates/)). Use it on `.github/workflows/uv.yml` so the schedule reads as local Tokyo time (08:00 Mon/Thu JST) instead of being expressed in UTC. No behavioral change beyond moving the run from 10:00 JST to 08:00 JST.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)