### PR TITLE
Lower `per_page` to 30 in `fetch-logs` job listing

### DIFF
--- a/.claude/skills/src/skills/github/client.py
+++ b/.claude/skills/src/skills/github/client.py
@@ -123,15 +123,18 @@ class GitHubClient:
             if attempt is not None
             else f"/repos/{owner}/{repo}/actions/runs/{run_id}/jobs"
         )
+        # GitHub 502s this endpoint with per_page=100 on runs with many jobs
+        # (e.g. cross-version matrices with 300+ jobs).
+        per_page = 30
         page = 1
         while True:
-            data = await self._get_json(endpoint, {"per_page": 100, "page": page})
+            data = await self._get_json(endpoint, {"per_page": per_page, "page": page})
             jobs = data.get("jobs", [])
             if not jobs:
                 break
             for job in jobs:
                 yield Job.model_validate(job)
-            if len(jobs) < 100:
+            if len(jobs) < per_page:
                 break
             page += 1
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

`GitHubClient.get_jobs` in the `fetch-logs` skill paginates the
`/actions/runs/{id}/jobs` endpoint with `per_page=100`. GitHub returns 502
from that endpoint on runs with many jobs (e.g. cross-version matrices with
300+ jobs), which breaks `/analyze-ci` on those runs.

Lower `per_page` to 30. The smaller page size returns successfully on the
same runs.

### How is this PR tested?

- [x] Manual tests

Reran `fetch-logs` against a 380-job cross-version run that previously 502'd
and confirmed all failed jobs are listed.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release