### PR TITLE
Migrate langchain sample chains to `databricks-langchain.ChatDatabricks`

### DIFF
--- a/tests/langchain/sample_code/chain.py
+++ b/tests/langchain/sample_code/chain.py
@@ -2,7 +2,16 @@ import dbutils
 
 dbutils.library.restartPython()
 
+import os
 from typing import Any
+
+# `databricks-langchain` versions older than ~0.9 eagerly construct a
+# `WorkspaceClient` inside `ChatDatabricks.__init__`, which requires
+# Databricks credentials. Cross-version test jobs pin those older releases
+# (e.g. 0.8.2 with `langchain==0.3.30`), so set fake creds before the fake
+# chat model is instantiated below.
+os.environ.setdefault("DATABRICKS_HOST", "https://fake-host")
+os.environ.setdefault("DATABRICKS_TOKEN", "fake-token")
 
 from databricks_langchain import ChatDatabricks
 from langchain_community.document_loaders import TextLoader

--- a/tests/langchain/sample_code/chain.py
+++ b/tests/langchain/sample_code/chain.py
@@ -4,14 +4,14 @@ dbutils.library.restartPython()
 
 from typing import Any
 
-from langchain_community.chat_models import ChatDatabricks, ChatMlflow
+from databricks_langchain import ChatDatabricks
 from langchain_community.document_loaders import TextLoader
 from langchain_community.embeddings.fake import FakeEmbeddings
 from langchain_community.vectorstores import FAISS
 from langchain_core.callbacks.manager import CallbackManagerForLLMRun
-from langchain_core.messages import BaseMessage
+from langchain_core.messages import AIMessage, BaseMessage
 from langchain_core.output_parsers import StrOutputParser
-from langchain_core.outputs import ChatResult
+from langchain_core.outputs import ChatGeneration, ChatResult
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.runnables import RunnablePassthrough
 from langchain_text_splitters.character import CharacterTextSplitter
@@ -35,19 +35,8 @@ def get_fake_chat_model(endpoint="fake-endpoint"):
             run_manager: CallbackManagerForLLMRun | None = None,
             **kwargs: Any,
         ) -> ChatResult:
-            response = {
-                "choices": [
-                    {
-                        "index": 0,
-                        "message": {
-                            "role": "assistant",
-                            "content": f"{base_config.get('response')}",
-                        },
-                        "finish_reason": None,
-                    }
-                ],
-            }
-            return ChatMlflow._create_chat_result(response)
+            message = AIMessage(content=str(base_config.get("response")))
+            return ChatResult(generations=[ChatGeneration(message=message)])
 
         @property
         def _llm_type(self) -> str:

--- a/tests/langchain/sample_code/no_config/chain.py
+++ b/tests/langchain/sample_code/no_config/chain.py
@@ -1,13 +1,13 @@
 from typing import Any
 
-from langchain_community.chat_models import ChatDatabricks, ChatMlflow
+from databricks_langchain import ChatDatabricks
 from langchain_community.document_loaders import TextLoader
 from langchain_community.embeddings import FakeEmbeddings
 from langchain_community.vectorstores import FAISS
 from langchain_core.callbacks.manager import CallbackManagerForLLMRun
-from langchain_core.messages import BaseMessage
+from langchain_core.messages import AIMessage, BaseMessage
 from langchain_core.output_parsers import StrOutputParser
-from langchain_core.outputs import ChatResult
+from langchain_core.outputs import ChatGeneration, ChatResult
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.runnables import RunnablePassthrough
 from langchain_text_splitters.character import CharacterTextSplitter
@@ -28,19 +28,7 @@ def get_fake_chat_model(endpoint="fake-endpoint"):
             run_manager: CallbackManagerForLLMRun | None = None,
             **kwargs: Any,
         ) -> ChatResult:
-            response = {
-                "choices": [
-                    {
-                        "index": 0,
-                        "message": {
-                            "role": "assistant",
-                            "content": "Databricks",
-                        },
-                        "finish_reason": None,
-                    }
-                ],
-            }
-            return ChatMlflow._create_chat_result(response)
+            return ChatResult(generations=[ChatGeneration(message=AIMessage(content="Databricks"))])
 
         @property
         def _llm_type(self) -> str:

--- a/tests/langchain/sample_code/no_config/chain.py
+++ b/tests/langchain/sample_code/no_config/chain.py
@@ -1,4 +1,9 @@
+import os
 from typing import Any
+
+# See `tests/langchain/sample_code/chain.py` for why fake creds are set.
+os.environ.setdefault("DATABRICKS_HOST", "https://fake-host")
+os.environ.setdefault("DATABRICKS_TOKEN", "fake-token")
 
 from databricks_langchain import ChatDatabricks
 from langchain_community.document_loaders import TextLoader


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

`langchain-community==0.4.2` (released 2026-05-22) deleted the long-deprecated
chat-model shims, including `langchain_community.chat_models.ChatDatabricks`
and `ChatMlflow._create_chat_result`. The cross-version `langchain / models / *`
jobs now fail at sample-file load time with:

```
ImportError: cannot import name 'ChatDatabricks' from 'langchain_community.chat_models'
```

Migrate the two affected sample chain files to
`from databricks_langchain import ChatDatabricks` (the upstream-recommended
location, already a test requirement for the langchain `models` group), and
build `ChatResult` directly since `ChatMlflow._create_chat_result` is also gone.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Verified that both files import successfully under
`langchain-community==0.4.2` + `databricks-langchain`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release