### PR TITLE
Enforce upload artifact size for chunked requests

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -2350,16 +2350,16 @@ def upload_artifact_handler():
         )
     path = validate_path_is_safe(path)
 
-    if request.content_length and request.content_length > 10 * 1024 * 1024:
-        raise MlflowException(
-            message="Artifact size is too large. Max size is 10MB.",
-            error_code=INVALID_PARAMETER_VALUE,
-        )
-
     data = request.data
     if not data:
         raise MlflowException(
             message="Request must specify data.",
+            error_code=INVALID_PARAMETER_VALUE,
+        )
+
+    if len(data) > 10 * 1024 * 1024:
+        raise MlflowException(
+            message="Artifact size is too large. Max size is 10MB.",
             error_code=INVALID_PARAMETER_VALUE,
         )
 

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -2350,6 +2350,12 @@ def upload_artifact_handler():
         )
     path = validate_path_is_safe(path)
 
+    if request.content_length and request.content_length > 10 * 1024 * 1024:
+        raise MlflowException(
+            message="Artifact size is too large. Max size is 10MB.",
+            error_code=INVALID_PARAMETER_VALUE,
+        )
+
     data = request.data
     if not data:
         raise MlflowException(

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -2336,7 +2336,7 @@ def test_upload_artifact_handler_rejects_invalid_requests(mlflow_client):
     )
     assert_response(response, "Request must specify data.")
 
-    large_data = "x" * (10 * 1024 * 1024 + 1)
+    large_data = b"x" * (10 * 1024 * 1024 + 1)
     response = requests.post(
         f"{mlflow_client.tracking_uri}/ajax-api/2.0/mlflow/upload-artifact",
         params={
@@ -2344,7 +2344,6 @@ def test_upload_artifact_handler_rejects_invalid_requests(mlflow_client):
             "path": "test.txt",
         },
         data=large_data,
-        headers={"Transfer-Encoding": "chunked"},
     )
     assert_response(response, "Artifact size is too large")
 

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -2336,6 +2336,18 @@ def test_upload_artifact_handler_rejects_invalid_requests(mlflow_client):
     )
     assert_response(response, "Request must specify data.")
 
+    large_data = "x" * (10 * 1024 * 1024 + 1)
+    response = requests.post(
+        f"{mlflow_client.tracking_uri}/ajax-api/2.0/mlflow/upload-artifact",
+        params={
+            "run_uuid": created_run.info.run_id,
+            "path": "test.txt",
+        },
+        data=large_data,
+        headers={"Transfer-Encoding": "chunked"},
+    )
+    assert_response(response, "Artifact size is too large")
+
 
 def test_upload_artifact_handler(mlflow_client):
     experiment_id = mlflow_client.create_experiment("upload_artifacts_test")


### PR DESCRIPTION
### Related Issues/PRs

Split out from #23647 per maintainer request.

### What changes are proposed in this pull request?

This PR enforces the upload-artifact 10MB limit using the cheap `request.content_length` pre-check before validating the actual request body length from `request.data`.

The previous guard only checked `request.content_length`. Under transfer modes where `content_length` is absent, such as chunked transfer encoding, the size check could be skipped before the artifact bytes were written.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added `test_upload_artifact_handler_rejects_invalid_requests` coverage for an oversized upload request.

Local validation:

```bash
python -m py_compile mlflow/server/handlers.py tests/tracking/test_rest_tracking.py
git diff --check
uv run pytest tests/tracking/test_rest_tracking.py -q -k upload_artifact_handler_rejects_invalid_requests
```

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I have updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the Small Bugfixes and Documentation Updates section
- [ ] `rn/breaking-change` - The PR will be mentioned in the Breaking Changes section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release