### PR TITLE
Add `TorchDataset` and `mlflow.data.from_torch()` for PyTorch dataset tracking

### DIFF
--- a/mlflow/data/dataset_registry.py
+++ b/mlflow/data/dataset_registry.py
@@ -166,3 +166,6 @@ with suppress(ImportError):
     from mlflow.data.polars_dataset import from_polars
 
     _dataset_registry.register_constructor(from_polars)
+with suppress(ImportError):
+    from mlflow.data.torch_dataset import from_torch
+    _dataset_registry.register_constructor(from_torch)

--- a/mlflow/data/torch_dataset.py
+++ b/mlflow/data/torch_dataset.py
@@ -1,0 +1,339 @@
+import json
+import logging
+from functools import cached_property
+from typing import Any
+
+import numpy as np
+
+from mlflow.data.dataset import Dataset
+from mlflow.data.dataset_source import DatasetSource
+from mlflow.data.digest_utils import MAX_ROWS, get_normalized_md5_digest
+from mlflow.data.schema import TensorDatasetSchema
+from mlflow.types.utils import _infer_schema
+
+_logger = logging.getLogger(__name__)
+
+# Number of dataset items sampled when computing the digest and schema.
+_SAMPLE_SIZE = 10
+
+
+def _tensor_to_numpy(tensor):
+    """Convert a torch.Tensor to a numpy array without importing torch at module level."""
+    return tensor.detach().cpu().numpy()
+
+
+def _sample_dataset(dataset, n: int):
+    """
+    Return up to *n* items from a ``torch.utils.data.Dataset``.
+
+    Returns a list of raw items (each item may be a Tensor, tuple, dict, etc.).
+    """
+    items = []
+    try:
+        size = len(dataset)
+        indices = range(min(n, size))
+    except TypeError:
+        # IterableDataset — iterate until we have enough
+        indices = None
+
+    if indices is not None:
+        for i in indices:
+            try:
+                items.append(dataset[i])
+            except Exception:
+                break
+    else:
+        for i, item in enumerate(dataset):
+            if i >= n:
+                break
+            items.append(item)
+
+    return items
+
+
+def _item_to_numpy(item):
+    """
+    Recursively convert a dataset item to numpy.
+
+    Handles Tensor, tuple/list of Tensors, and dict of Tensors.
+    Returns None if conversion is not possible.
+    """
+    import torch  # lazy import — torch is required but not a top-level dep
+
+    if isinstance(item, torch.Tensor):
+        return _tensor_to_numpy(item)
+    elif isinstance(item, (tuple, list)):
+        arrays = []
+        for v in item:
+            if isinstance(v, torch.Tensor):
+                arrays.append(_tensor_to_numpy(v))
+            elif isinstance(v, np.ndarray):
+                arrays.append(v)
+        return arrays if arrays else None
+    elif isinstance(item, dict):
+        result = {}
+        for k, v in item.items():
+            if isinstance(v, torch.Tensor):
+                result[str(k)] = _tensor_to_numpy(v)
+            elif isinstance(v, np.ndarray):
+                result[str(k)] = v
+        return result if result else None
+    elif isinstance(item, np.ndarray):
+        return item
+    return None
+
+
+class TorchDataset(Dataset):
+    """
+    Represents a ``torch.utils.data.Dataset`` for use with MLflow Tracking.
+
+    Use :py:func:`mlflow.data.from_torch` to construct a ``TorchDataset`` from a PyTorch
+    dataset or data loader, then pass the result to :py:func:`mlflow.log_input` to record
+    it in the active run.
+    """
+
+    def __init__(
+        self,
+        dataset,
+        source: DatasetSource,
+        targets=None,
+        name: str | None = None,
+        digest: str | None = None,
+        _dataloader_metadata: dict[str, Any] | None = None,
+    ):
+        """
+        Args:
+            dataset: A ``torch.utils.data.Dataset`` instance containing the features.
+            source: The source of the dataset.
+            targets: An optional ``torch.utils.data.Dataset`` instance containing the targets.
+            name: The name of the dataset. If unspecified, a name is generated.
+            digest: The digest (hash, fingerprint) of the dataset. If unspecified, a digest
+                is computed automatically.
+            _dataloader_metadata: Optional dict of DataLoader-level metadata (e.g.
+                ``batch_size``, ``num_workers``) captured by :py:func:`from_torch` when
+                a ``DataLoader`` is passed. Not intended for direct use.
+        """
+        self._dataset = dataset
+        self._targets = targets
+        self._dataloader_metadata = _dataloader_metadata or {}
+        super().__init__(source=source, name=name, digest=digest)
+
+    def _compute_digest(self) -> str:
+        """Computes a digest by sampling up to ``_SAMPLE_SIZE`` items from the dataset."""
+        import pandas as pd  # lazy import consistent with other MLflow dataset digest helpers
+
+        hashable_elements: list = []
+
+        def _hash_item(item):
+            arr = _item_to_numpy(item)
+            if arr is None:
+                return
+            if isinstance(arr, list):
+                arrays = arr
+            elif isinstance(arr, dict):
+                arrays = list(arr.values())
+            else:
+                arrays = [arr]
+            for a in arrays:
+                flat = a.flatten()[: MAX_ROWS]
+                try:
+                    hashable_elements.append(pd.util.hash_array(flat))
+                except TypeError:
+                    hashable_elements.append(np.int64(flat.size))
+                hashable_elements.extend(np.int64(x) for x in a.shape)
+
+        for item in _sample_dataset(self._dataset, _SAMPLE_SIZE):
+            _hash_item(item)
+
+        # Include the dataset class name so that two identically-valued datasets of different
+        # types produce different digests.
+        hashable_elements.append(type(self._dataset).__name__.encode())
+
+        if not hashable_elements:
+            # Fall back to hashing just the class name if we can't sample any data.
+            hashable_elements.append(type(self._dataset).__name__.encode())
+
+        return get_normalized_md5_digest(hashable_elements)
+
+    def to_dict(self) -> dict[str, str]:
+        """Return a JSON-serialisable config dictionary for the dataset."""
+        schema = json.dumps(self.schema.to_dict()) if self.schema else None
+        profile = self.profile
+        config = super().to_dict()
+        config.update({
+            "schema": schema,
+            "profile": json.dumps(profile) if profile is not None else None,
+        })
+        return config
+
+    @property
+    def dataset(self):
+        """The underlying ``torch.utils.data.Dataset``."""
+        return self._dataset
+
+    @property
+    def source(self) -> DatasetSource:
+        """The source of the dataset."""
+        return self._source
+
+    @property
+    def targets(self):
+        """Optional targets dataset. May be ``None``."""
+        return self._targets
+
+    @property
+    def profile(self) -> dict[str, Any] | None:
+        """
+        A profile of the dataset containing summary information such as size and type.
+        """
+        prof: dict[str, Any] = {
+            "dataset_type": type(self._dataset).__name__,
+        }
+        try:
+            prof["dataset_size"] = len(self._dataset)
+        except TypeError:
+            # IterableDataset — size unknown
+            pass
+        if self._targets is not None:
+            prof["targets_type"] = type(self._targets).__name__
+            try:
+                prof["targets_size"] = len(self._targets)
+            except TypeError:
+                pass
+        if self._dataloader_metadata:
+            prof.update(self._dataloader_metadata)
+        return prof
+
+    @cached_property
+    def schema(self) -> TensorDatasetSchema | None:
+        """
+        A :py:class:`TensorDatasetSchema <mlflow.data.schema.TensorDatasetSchema>` inferred
+        from the first item of the dataset.  Returns ``None`` if the schema cannot be inferred.
+        """
+        try:
+            items = _sample_dataset(self._dataset, 1)
+            if not items:
+                return None
+            arr = _item_to_numpy(items[0])
+            if arr is None:
+                return None
+
+            if isinstance(arr, np.ndarray):
+                features_schema = _infer_schema(arr)
+            elif isinstance(arr, list):
+                features_schema = _infer_schema(
+                    {str(i): a for i, a in enumerate(arr)}
+                )
+            elif isinstance(arr, dict):
+                features_schema = _infer_schema(arr)
+            else:
+                return None
+
+            targets_schema = None
+            if self._targets is not None:
+                t_items = _sample_dataset(self._targets, 1)
+                if t_items:
+                    t_arr = _item_to_numpy(t_items[0])
+                    if t_arr is not None:
+                        if isinstance(t_arr, np.ndarray):
+                            targets_schema = _infer_schema(t_arr)
+                        elif isinstance(t_arr, list):
+                            targets_schema = _infer_schema(
+                                {str(i): a for i, a in enumerate(t_arr)}
+                            )
+                        elif isinstance(t_arr, dict):
+                            targets_schema = _infer_schema(t_arr)
+
+            return TensorDatasetSchema(features=features_schema, targets=targets_schema)
+        except Exception as e:
+            _logger.warning("Failed to infer schema for TorchDataset. Exception: %s", e)
+            return None
+
+
+def from_torch(
+    dataset,
+    source: str | DatasetSource | None = None,
+    targets=None,
+    name: str | None = None,
+    digest: str | None = None,
+) -> TorchDataset:
+    """
+    Constructs a :py:class:`TorchDataset <mlflow.data.torch_dataset.TorchDataset>` from a
+    PyTorch dataset or data loader.
+
+    If a ``DataLoader`` is passed, the underlying dataset is extracted and DataLoader
+    metadata (``batch_size``, ``num_workers``) is preserved in the dataset profile.
+
+    Args:
+        dataset: A ``torch.utils.data.Dataset`` or ``torch.utils.data.DataLoader``.
+        source: The source from which the data was derived, e.g. a filesystem path, S3 URI,
+            HTTPS URL, etc.  May be a URI string or a
+            :py:class:`DatasetSource <mlflow.data.dataset_source.DatasetSource>` instance.
+            If ``None``, the source is inferred from the run context (code location).
+        targets: An optional ``torch.utils.data.Dataset`` containing the targets.
+        name: The name of the dataset. If unspecified, a name is generated.
+        digest: The dataset digest (hash). If unspecified, a digest is computed automatically.
+
+    Returns:
+        A :py:class:`TorchDataset <mlflow.data.torch_dataset.TorchDataset>`.
+
+    .. code-block:: python
+        :test:
+        :caption: Example
+
+        import mlflow
+        import torch
+        from torch.utils.data import TensorDataset
+
+        X = torch.randn(100, 4)
+        y = torch.randint(0, 2, (100,))
+        ds = TensorDataset(X, y)
+
+        dataset = mlflow.data.from_torch(ds, targets=None)
+        with mlflow.start_run():
+            mlflow.log_input(dataset, context="training")
+    """
+    from mlflow.data.code_dataset_source import CodeDatasetSource
+    from mlflow.data.dataset_source_registry import resolve_dataset_source
+    from mlflow.tracking.context import registry
+
+    try:
+        import torch
+    except ImportError as e:
+        raise ImportError(
+            "PyTorch is required to use `mlflow.data.from_torch`. "
+            "Install it with `pip install torch`."
+        ) from e
+
+    # Accept DataLoader — extract the underlying dataset and capture loader metadata.
+    dataloader_profile: dict[str, Any] = {}
+    if isinstance(dataset, torch.utils.data.DataLoader):
+        loader = dataset
+        dataset = loader.dataset
+        if loader.batch_size is not None:
+            dataloader_profile["batch_size"] = loader.batch_size
+        dataloader_profile["num_workers"] = loader.num_workers
+
+    if not isinstance(dataset, torch.utils.data.Dataset):
+        raise TypeError(
+            f"'dataset' must be a torch.utils.data.Dataset or torch.utils.data.DataLoader. "
+            f"Got: {type(dataset)}."
+        )
+
+    if source is not None:
+        if isinstance(source, DatasetSource):
+            resolved_source = source
+        else:
+            resolved_source = resolve_dataset_source(source)
+    else:
+        context_tags = registry.resolve_tags()
+        resolved_source = CodeDatasetSource(tags=context_tags)
+
+    return TorchDataset(
+        dataset=dataset,
+        source=resolved_source,
+        targets=targets,
+        name=name,
+        digest=digest,
+        _dataloader_metadata=dataloader_profile if dataloader_profile else None,
+    )

--- a/mlflow/pytorch/_lightning_autolog.py
+++ b/mlflow/pytorch/_lightning_autolog.py
@@ -685,6 +685,26 @@ def patched_fit(original, self, *args, **kwargs):
 
             mlflow.log_artifact(local_path=summary_file)
 
+        log_datasets = get_autologging_config(mlflow.pytorch.FLAVOR_NAME, "log_datasets", True)
+        if log_datasets:
+            try:
+                from mlflow.data.torch_dataset import from_torch
+
+                # In PyTorch Lightning, `train_dataloader` is a method on the Trainer that
+                # returns the DataLoader used for the training loop.
+                train_loader = None
+                if hasattr(self, "train_dataloader") and callable(self.train_dataloader):
+                    train_loader = self.train_dataloader()
+                if train_loader is not None:
+                    torch_dataset = from_torch(train_loader)
+                    mlflow.log_input(torch_dataset, context="training")
+            except Exception as e:
+                _logger.warning(
+                    "Failed to log training dataset via autologging. "
+                    f"root cause: {e!r}.",
+                    exc_info=True,
+                )
+
         if log_models:
             registered_model_name = get_autologging_config(
                 mlflow.pytorch.FLAVOR_NAME, "registered_model_name", None

--- a/tests/data/test_torch_dataset.py
+++ b/tests/data/test_torch_dataset.py
@@ -1,0 +1,273 @@
+"""
+Tests for mlflow.data.torch_dataset (TorchDataset + from_torch).
+
+Regression tests for https://github.com/mlflow/mlflow/issues/11764.
+"""
+
+import json
+
+import pytest
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+import mlflow
+import mlflow.data
+from mlflow.data.code_dataset_source import CodeDatasetSource
+from mlflow.data.schema import TensorDatasetSchema
+from mlflow.data.torch_dataset import TorchDataset, from_torch
+
+from tests.resources.data.dataset_source import SampleDatasetSource
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_tensor_dataset(n: int = 20, features: int = 4, classes: int = 3):
+    """Return a TensorDataset with random features and integer labels."""
+    X = torch.randn(n, features)
+    y = torch.randint(0, classes, (n,))
+    return TensorDataset(X, y)
+
+
+def _make_source():
+    return SampleDatasetSource._resolve("test:/my/uri")
+
+
+# ---------------------------------------------------------------------------
+# Construction and basic properties
+# ---------------------------------------------------------------------------
+
+
+def test_basic_construction():
+    ds = _make_tensor_dataset()
+    source = _make_source()
+    mlflow_dataset = TorchDataset(dataset=ds, source=source, name="my_dataset")
+
+    assert mlflow_dataset.name == "my_dataset"
+    assert mlflow_dataset.digest is not None
+    assert len(mlflow_dataset.digest) == 8
+    assert mlflow_dataset.dataset is ds
+    assert mlflow_dataset.targets is None
+
+
+def test_digest_is_deterministic():
+    ds = _make_tensor_dataset(n=10)
+    source = _make_source()
+    d1 = TorchDataset(dataset=ds, source=source)
+    d2 = TorchDataset(dataset=ds, source=source)
+    assert d1.digest == d2.digest
+
+
+def test_digest_differs_for_different_data():
+    torch.manual_seed(0)
+    ds1 = _make_tensor_dataset(n=10)
+    torch.manual_seed(99)
+    ds2 = _make_tensor_dataset(n=10)
+    source = _make_source()
+    assert TorchDataset(dataset=ds1, source=source).digest != TorchDataset(
+        dataset=ds2, source=source
+    ).digest
+
+
+def test_explicit_digest_is_preserved():
+    ds = _make_tensor_dataset()
+    source = _make_source()
+    mlflow_dataset = TorchDataset(dataset=ds, source=source, digest="abcd1234")
+    assert mlflow_dataset.digest == "abcd1234"
+
+
+# ---------------------------------------------------------------------------
+# Profile
+# ---------------------------------------------------------------------------
+
+
+def test_profile_contains_type_and_size():
+    ds = _make_tensor_dataset(n=15)
+    source = _make_source()
+    profile = TorchDataset(dataset=ds, source=source).profile
+
+    assert profile["dataset_type"] == "TensorDataset"
+    assert profile["dataset_size"] == 15
+
+
+def test_profile_with_targets_dataset():
+    X = torch.randn(10, 3)
+    y = torch.randint(0, 2, (10,))
+    feat_ds = TensorDataset(X)
+    tgt_ds = TensorDataset(y)
+    source = _make_source()
+    profile = TorchDataset(dataset=feat_ds, source=source, targets=tgt_ds).profile
+
+    assert "targets_type" in profile
+    assert profile["targets_size"] == 10
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+def test_schema_inferred_from_tensor_dataset():
+    ds = _make_tensor_dataset(n=5, features=4)
+    source = _make_source()
+    mlflow_dataset = TorchDataset(dataset=ds, source=source)
+
+    schema = mlflow_dataset.schema
+    # TensorDataset returns a tuple (X, y) — schema should be inferred
+    assert schema is not None
+    assert isinstance(schema, TensorDatasetSchema)
+
+
+def test_schema_is_none_when_not_inferable():
+    class NonTensorDataset(torch.utils.data.Dataset):
+        def __len__(self):
+            return 5
+
+        def __getitem__(self, idx):
+            return "some_string_item"
+
+    ds = NonTensorDataset()
+    source = _make_source()
+    # Should warn but not raise; schema returns None
+    mlflow_dataset = TorchDataset(dataset=ds, source=source)
+    assert mlflow_dataset.schema is None
+
+
+# ---------------------------------------------------------------------------
+# to_dict / to_json round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_to_dict_keys():
+    ds = _make_tensor_dataset()
+    source = _make_source()
+    mlflow_dataset = TorchDataset(dataset=ds, source=source, name="train")
+
+    d = mlflow_dataset.to_dict()
+    assert set(d.keys()) <= {"name", "digest", "source", "source_type", "schema", "profile"}
+    assert d["name"] == "train"
+    assert d["digest"] == mlflow_dataset.digest
+    assert d["source"] == mlflow_dataset.source.to_json()
+    assert d["source_type"] == mlflow_dataset.source._get_source_type()
+
+
+def test_to_json_is_valid_json():
+    ds = _make_tensor_dataset()
+    source = _make_source()
+    mlflow_dataset = TorchDataset(dataset=ds, source=source)
+    parsed = json.loads(mlflow_dataset.to_json())
+    assert "name" in parsed
+    assert "digest" in parsed
+
+
+def test_profile_serialized_in_to_dict():
+    ds = _make_tensor_dataset(n=8)
+    source = _make_source()
+    mlflow_dataset = TorchDataset(dataset=ds, source=source)
+
+    d = mlflow_dataset.to_dict()
+    profile_parsed = json.loads(d["profile"])
+    assert profile_parsed["dataset_size"] == 8
+    assert profile_parsed["dataset_type"] == "TensorDataset"
+
+
+# ---------------------------------------------------------------------------
+# from_torch() — Dataset path
+# ---------------------------------------------------------------------------
+
+
+def test_from_torch_with_dataset():
+    ds = _make_tensor_dataset(n=12)
+    mlflow_dataset = from_torch(ds, source="test:/path/to/data")
+
+    assert isinstance(mlflow_dataset, TorchDataset)
+    assert mlflow_dataset.dataset is ds
+    assert mlflow_dataset.targets is None
+    assert mlflow_dataset.digest is not None
+
+
+def test_from_torch_default_source_is_code():
+    ds = _make_tensor_dataset()
+    mlflow_dataset = from_torch(ds)
+    assert isinstance(mlflow_dataset.source, CodeDatasetSource)
+
+
+def test_from_torch_with_explicit_source_object():
+    ds = _make_tensor_dataset()
+    source = _make_source()
+    mlflow_dataset = from_torch(ds, source=source)
+    assert mlflow_dataset.source is source
+
+
+# ---------------------------------------------------------------------------
+# from_torch() — DataLoader path
+# ---------------------------------------------------------------------------
+
+
+def test_from_torch_with_dataloader_captures_batch_size():
+    ds = _make_tensor_dataset(n=20)
+    loader = DataLoader(ds, batch_size=4, num_workers=0)
+    mlflow_dataset = from_torch(loader)
+
+    assert isinstance(mlflow_dataset, TorchDataset)
+    assert mlflow_dataset.dataset is ds
+    profile = mlflow_dataset.profile
+    assert profile["batch_size"] == 4
+    assert "num_workers" in profile
+
+
+def test_from_torch_with_dataloader_extracts_underlying_dataset():
+    ds = _make_tensor_dataset(n=10)
+    loader = DataLoader(ds, batch_size=2)
+    mlflow_dataset = from_torch(loader)
+    assert mlflow_dataset.dataset is ds
+
+
+# ---------------------------------------------------------------------------
+# from_torch() — invalid input
+# ---------------------------------------------------------------------------
+
+
+def test_from_torch_raises_on_invalid_type():
+    with pytest.raises(TypeError, match="torch.utils.data.Dataset or torch.utils.data.DataLoader"):
+        from_torch([1, 2, 3])
+
+
+# ---------------------------------------------------------------------------
+# mlflow.data module registration
+# ---------------------------------------------------------------------------
+
+
+def test_from_torch_registered_in_mlflow_data():
+    # from_torch should be available directly on the mlflow.data module
+    assert hasattr(mlflow.data, "from_torch")
+    assert callable(mlflow.data.from_torch)
+
+
+def test_from_torch_via_mlflow_data():
+    ds = _make_tensor_dataset(n=5)
+    mlflow_dataset = mlflow.data.from_torch(ds)
+    assert isinstance(mlflow_dataset, TorchDataset)
+
+
+# ---------------------------------------------------------------------------
+# log_input integration
+# ---------------------------------------------------------------------------
+
+
+def test_log_input_with_torch_dataset(tmp_path):
+    ds = _make_tensor_dataset(n=10)
+    mlflow_dataset = from_torch(ds)
+
+    mlflow.set_tracking_uri(str(tmp_path / "mlruns"))
+    with mlflow.start_run() as run:
+        mlflow.log_input(mlflow_dataset, context="training")
+
+    client = mlflow.tracking.MlflowClient()
+    inputs = client.get_run(run.info.run_id).inputs
+    assert len(inputs.dataset_inputs) == 1
+    logged = inputs.dataset_inputs[0].dataset
+    assert logged.name == mlflow_dataset.name
+    assert logged.digest == mlflow_dataset.digest


### PR DESCRIPTION
### Related Issues/PRs

Closes #11764

### What changes are proposed in this pull request?

PyTorch datasets and data loaders had no equivalent in `mlflow.data`, making it impossible to use `mlflow.log_input` with PyTorch without manually constructing a `Dataset` and `DatasetSource` from scratch.

This PR adds first-class PyTorch dataset support:

**New class `mlflow.data.torch_dataset.TorchDataset`**
- `digest`: samples up to 10 items, converts tensors → numpy, produces an 8-character MD5 digest consistent with other MLflow dataset types
- `profile`: dataset class name, size (when `__len__` is available), and optional DataLoader metadata (`batch_size`, `num_workers`)
- `schema`: infers a `TensorDatasetSchema` from the first item — supports single Tensor, tuple/list of Tensors, and dict of Tensors; returns `None` gracefully if inference fails (e.g. non-tensor `IterableDataset`)

**New public API `mlflow.data.from_torch(dataset_or_loader, ...)`**
Accepts either a `torch.utils.data.Dataset` or a `torch.utils.data.DataLoader`. When a DataLoader is passed the underlying dataset is extracted and DataLoader metadata is preserved in the profile.

**Registry**: `from_torch()` is registered in `mlflow.data.dataset_registry` alongside `from_numpy`, `from_pandas`, `from_tensorflow`, etc. — available directly as `mlflow.data.from_torch()`.

**Autolog**: `mlflow.pytorch.autolog(log_datasets=True)` now automatically logs the training DataLoader as an MLflow dataset input after `Trainer.fit()` completes. Errors are caught and logged as warnings so training is never interrupted.

**Usage:**
```python
import mlflow
import torch
from torch.utils.data import TensorDataset, DataLoader

X = torch.randn(100, 4)
y = torch.randint(0, 2, (100,))
ds = TensorDataset(X, y)
loader = DataLoader(ds, batch_size=16)

dataset = mlflow.data.from_torch(loader)
with mlflow.start_run():
    mlflow.log_input(dataset, context="training")
```

### How is this PR tested?

- [x] New unit/integration tests

`tests/data/test_torch_dataset.py` covers: construction, deterministic digest, profile/schema content, `to_dict`/`to_json` round-trip, `from_torch` with Dataset and DataLoader, `mlflow.data` module registration, and `mlflow.log_input` integration.

### Does this PR require documentation update?

- [x] Yes. The new `TorchDataset` class and `from_torch()` function should be added to the MLflow data API docs.

### Does this PR require updating the MLflow Skills repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. `mlflow.data.from_torch()` and `TorchDataset` are new public APIs for tracking PyTorch datasets in MLflow experiments. `mlflow.pytorch.autolog(log_datasets=True)` now automatically logs the training dataset.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature`

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release