### PR TITLE
prompts: enable inline validation and disable Create when invalid (reopened)

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsPage.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsPage.test.tsx
@@ -139,6 +139,49 @@ describe('PromptsPage', () => {
     });
   });
 
+  it('should validate the create prompt form while typing', async () => {
+    server.use(getMockedRegisteredPromptsResponse(0), getMockedRegisteredPromptCreateResponse());
+
+    renderTestComponent();
+    await waitFor(() => {
+      expect(screen.getByTestId('create-prompt-empty-state-button')).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByTestId('create-prompt-empty-state-button'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    const createButton = screen.getByRole('button', { name: 'Create' });
+    expect(createButton).toBeDisabled();
+
+    await userEvent.type(screen.getByLabelText(/Name:/), 'my new prompt');
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Only alphanumeric characters, underscores, hyphens, and dots are allowed'),
+      ).toBeInTheDocument();
+    });
+    expect(createButton).toBeDisabled();
+
+    await userEvent.clear(screen.getByLabelText(/Name:/));
+    await userEvent.type(screen.getByLabelText(/Name:/), 'prompt-valid');
+    await userEvent.type(screen.getByLabelText(/Prompt:/), 'lorem ipsum');
+
+    await waitFor(() => {
+      expect(createButton).toBeEnabled();
+    });
+
+    await userEvent.click(screen.getByText('Advanced settings (optional)'));
+    await userEvent.type(screen.getByLabelText('Temperature'), 'abc');
+
+    await waitFor(() => {
+      expect(screen.getByText('Temperature must be a number >= 0')).toBeInTheDocument();
+    });
+    expect(createButton).toBeDisabled();
+  });
+
   it('should create a new chat prompt version', async () => {
     const createVersionSpy = jest.fn();
     server.use(

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/ChatMessageCreator.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/ChatMessageCreator.tsx
@@ -94,6 +94,7 @@ export const ChatMessageCreator = ({ name }: { name: string }) => {
   const { fields, insert, remove, replace } = useFieldArray({ control, name });
   const { theme } = useDesignSystemTheme();
   const { formatMessage } = useIntl();
+  const contentErrors = (formState.errors?.[name] as any) ?? [];
 
   const addMessageAfter = (index: number) => insert(index + 1, { role: 'user', content: '' });
 
@@ -123,13 +124,25 @@ export const ChatMessageCreator = ({ name }: { name: string }) => {
               )}
             />
           </Fragment>
-          <RHFControlledComponents.TextArea
-            componentId="mlflow.prompts.chat_creator.content"
-            name={`${name}.${index}.content`}
-            control={control}
-            autoSize={{ minRows: 1, maxRows: 6 }}
-            css={{ width: '100%' }}
-          />
+          <div>
+            <RHFControlledComponents.TextArea
+              componentId="mlflow.prompts.chat_creator.content"
+              name={`${name}.${index}.content`}
+              control={control}
+              autoSize={{ minRows: 1, maxRows: 6 }}
+              css={{ width: '100%' }}
+              rules={{
+                required: formatMessage({
+                  defaultMessage: 'Prompt content is required',
+                  description: 'Validation message for empty chat prompt message content',
+                }),
+              }}
+              validationState={contentErrors?.[index]?.content ? 'error' : undefined}
+            />
+            {contentErrors?.[index]?.content && (
+              <FormUI.Message type="error" message={contentErrors[index].content.message} />
+            )}
+          </div>
           <Button
             componentId="mlflow.prompts.chat_creator.add_after"
             type="tertiary"

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/ModelConfigForm.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/ModelConfigForm.tsx
@@ -16,6 +16,7 @@ import { useCallback } from 'react';
 import { useFormContext, Controller } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useProviderModelData } from '../hooks/useProviderModelData';
+import { validateModelConfig } from '../utils';
 
 export const ModelConfigForm = () => {
   const { theme } = useDesignSystemTheme();
@@ -41,6 +42,21 @@ export const ModelConfigForm = () => {
   const handleProviderChange = useCallback(() => {
     setValue(getFieldName('modelName'), '');
   }, [setValue, getFieldName]);
+
+  const optionalNumberRule = useCallback(
+    (fieldName: keyof ReturnType<typeof validateModelConfig>) => ({
+      validate: (value: string) => {
+        const trimmed = value?.trim();
+        if (!trimmed) {
+          return true;
+        }
+
+        const errors = validateModelConfig({ [fieldName]: trimmed } as any);
+        return errors[fieldName] || true;
+      },
+    }),
+    [],
+  );
 
   const { providers, providersLoading, models, modelsLoading } = useProviderModelData(
     selectedProvider,
@@ -199,11 +215,19 @@ export const ModelConfigForm = () => {
             <FormUI.Label htmlFor="mlflow.prompts.model_config.temperature">
               <FormattedMessage defaultMessage="Temperature" description="Label for temperature input" />
             </FormUI.Label>
+            <FormUI.Hint>
+              <FormattedMessage
+                defaultMessage="Enter a number greater than or equal to 0."
+                description="Hint for the temperature input in model config form"
+              />
+            </FormUI.Hint>
             <RHFControlledComponents.Input
               control={control}
               id="mlflow.prompts.model_config.temperature"
               componentId="mlflow.prompts.model_config.temperature"
               name={getFieldName('temperature')}
+              placeholder="0.7"
+              rules={optionalNumberRule('temperature')}
               validationState={getError('temperature') ? 'error' : undefined}
             />
             {getError('temperature') && <FormUI.Message type="error" message={getError('temperature')?.message} />}
@@ -214,11 +238,19 @@ export const ModelConfigForm = () => {
             <FormUI.Label htmlFor="mlflow.prompts.model_config.maxTokens">
               <FormattedMessage defaultMessage="Max Tokens" description="Label for max tokens input" />
             </FormUI.Label>
+            <FormUI.Hint>
+              <FormattedMessage
+                defaultMessage="Enter a positive integer."
+                description="Hint for the max tokens input in model config form"
+              />
+            </FormUI.Hint>
             <RHFControlledComponents.Input
               control={control}
               id="mlflow.prompts.model_config.maxTokens"
               componentId="mlflow.prompts.model_config.maxTokens"
               name={getFieldName('maxTokens')}
+              placeholder="1024"
+              rules={optionalNumberRule('maxTokens')}
               validationState={getError('maxTokens') ? 'error' : undefined}
             />
             {getError('maxTokens') && <FormUI.Message type="error" message={getError('maxTokens')?.message} />}
@@ -229,11 +261,19 @@ export const ModelConfigForm = () => {
             <FormUI.Label htmlFor="mlflow.prompts.model_config.topP">
               <FormattedMessage defaultMessage="Top P" description="Label for top P input" />
             </FormUI.Label>
+            <FormUI.Hint>
+              <FormattedMessage
+                defaultMessage="Enter a number between 0 and 1."
+                description="Hint for the top p input in model config form"
+              />
+            </FormUI.Hint>
             <RHFControlledComponents.Input
               control={control}
               id="mlflow.prompts.model_config.topP"
               componentId="mlflow.prompts.model_config.topP"
               name={getFieldName('topP')}
+              placeholder="0.9"
+              rules={optionalNumberRule('topP')}
               validationState={getError('topP') ? 'error' : undefined}
             />
             {getError('topP') && <FormUI.Message type="error" message={getError('topP')?.message} />}
@@ -244,11 +284,19 @@ export const ModelConfigForm = () => {
             <FormUI.Label htmlFor="mlflow.prompts.model_config.topK">
               <FormattedMessage defaultMessage="Top K" description="Label for top K input" />
             </FormUI.Label>
+            <FormUI.Hint>
+              <FormattedMessage
+                defaultMessage="Enter a positive integer."
+                description="Hint for the top k input in model config form"
+              />
+            </FormUI.Hint>
             <RHFControlledComponents.Input
               control={control}
               id="mlflow.prompts.model_config.topK"
               componentId="mlflow.prompts.model_config.topK"
               name={getFieldName('topK')}
+              placeholder="40"
+              rules={optionalNumberRule('topK')}
               validationState={getError('topK') ? 'error' : undefined}
             />
             {getError('topK') && <FormUI.Message type="error" message={getError('topK')?.message} />}
@@ -259,11 +307,19 @@ export const ModelConfigForm = () => {
             <FormUI.Label htmlFor="mlflow.prompts.model_config.frequencyPenalty">
               <FormattedMessage defaultMessage="Frequency Penalty" description="Label for frequency penalty input" />
             </FormUI.Label>
+            <FormUI.Hint>
+              <FormattedMessage
+                defaultMessage="Enter a number between -2 and 2."
+                description="Hint for the frequency penalty input in model config form"
+              />
+            </FormUI.Hint>
             <RHFControlledComponents.Input
               control={control}
               id="mlflow.prompts.model_config.frequencyPenalty"
               componentId="mlflow.prompts.model_config.frequencyPenalty"
               name={getFieldName('frequencyPenalty')}
+              placeholder="0"
+              rules={optionalNumberRule('frequencyPenalty')}
               validationState={getError('frequencyPenalty') ? 'error' : undefined}
             />
             {getError('frequencyPenalty') && (
@@ -276,11 +332,19 @@ export const ModelConfigForm = () => {
             <FormUI.Label htmlFor="mlflow.prompts.model_config.presencePenalty">
               <FormattedMessage defaultMessage="Presence Penalty" description="Label for presence penalty input" />
             </FormUI.Label>
+            <FormUI.Hint>
+              <FormattedMessage
+                defaultMessage="Enter a number between -2 and 2."
+                description="Hint for the presence penalty input in model config form"
+              />
+            </FormUI.Hint>
             <RHFControlledComponents.Input
               control={control}
               id="mlflow.prompts.model_config.presencePenalty"
               componentId="mlflow.prompts.model_config.presencePenalty"
               name={getFieldName('presencePenalty')}
+              placeholder="0"
+              rules={optionalNumberRule('presencePenalty')}
               validationState={getError('presencePenalty') ? 'error' : undefined}
             />
             {getError('presencePenalty') && (
@@ -306,6 +370,12 @@ export const ModelConfigForm = () => {
               defaultMessage: 'e.g., END, ###, STOP',
               description: 'Placeholder for stop sequences input',
             })}
+            rules={{
+              validate: (value) => {
+                const trimmed = value?.trim();
+                return trimmed ? true : true;
+              },
+            }}
             validationState={getError('stopSequences') ? 'error' : undefined}
           />
           {getError('stopSequences') && <FormUI.Message type="error" message={getError('stopSequences')?.message} />}

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useCreatePromptModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useCreatePromptModal.tsx
@@ -63,6 +63,8 @@ export const useCreatePromptModal = ({
     modelConfig: PromptModelConfigFormData;
     responseFormatJson: string;
   }>({
+    mode: 'onChange',
+    reValidateMode: 'onChange',
     defaultValues: {
       draftName: '',
       draftValue: '',
@@ -77,8 +79,13 @@ export const useCreatePromptModal = ({
 
   const isCreatingNewPrompt = mode === CreatePromptModalMode.CreatePrompt;
   const isCreatingPromptVersion = mode === CreatePromptModalMode.CreatePromptVersion;
-
   const { mutate: mutateCreateVersion, error, reset: errorsReset, isLoading } = useCreateRegisteredPromptMutation();
+  const promptType = form.watch('promptType');
+  const chatMessages = form.watch('chatMessages');
+  const isSubmitDisabled =
+    isLoading ||
+    !form.formState.isValid ||
+    (promptType === PROMPT_TYPE_CHAT && chatMessages.some((message) => !message.content || !message.content.trim()));
 
   const modalElement = (
     <FormProvider {...form}>
@@ -105,7 +112,7 @@ export const useCreatePromptModal = ({
             description="A label for the confirm button in the create prompt modal in the prompt management UI"
           />
         }
-        okButtonProps={{ loading: isLoading }}
+        okButtonProps={{ loading: isLoading, disabled: isSubmitDisabled }}
         onOk={form.handleSubmit(async (values) => {
           const promptName =
             isCreatingPromptVersion && registeredPrompt?.name ? registeredPrompt?.name : values.draftName;
@@ -198,7 +205,15 @@ export const useCreatePromptModal = ({
         )}
         {isCreatingNewPrompt && (
           <>
-            <FormUI.Label htmlFor="mlflow.prompts.create.name">Name:</FormUI.Label>
+            <FormUI.Label htmlFor="mlflow.prompts.create.name">
+              Name: *
+            </FormUI.Label>
+            <FormUI.Hint>
+              <FormattedMessage
+                defaultMessage="Use alphanumeric characters, underscores, hyphens, and dots only."
+                description="Hint for the prompt name field in the prompt creation modal"
+              />
+            </FormUI.Hint>
             <RHFControlledComponents.Input
               control={form.control}
               id="mlflow.prompts.create.name"
@@ -241,31 +256,35 @@ export const useCreatePromptModal = ({
         <Controller
           control={form.control}
           name="promptType"
-          render={({ field }) => (
-            <SegmentedControlGroup
-              name="promptType"
-              componentId="promptType"
-              value={field.value}
-              onChange={field.onChange}
-            >
-              <SegmentedControlButton value={PROMPT_TYPE_TEXT}>
-                <FormattedMessage
-                  defaultMessage="Text"
-                  description="Label for text prompt type in the prompt creation modal"
-                />
-              </SegmentedControlButton>
-              <SegmentedControlButton value={PROMPT_TYPE_CHAT}>
-                <FormattedMessage
-                  defaultMessage="Chat"
-                  description="Label for chat prompt type in the prompt creation modal"
-                />
-              </SegmentedControlButton>
-            </SegmentedControlGroup>
-          )}
+          render={({ field }) => {
+            return (
+              <SegmentedControlGroup
+                name="promptType"
+                componentId="promptType"
+                value={field.value}
+                onChange={field.onChange}
+              >
+                <SegmentedControlButton value={PROMPT_TYPE_TEXT}>
+                  <FormattedMessage
+                    defaultMessage="Text"
+                    description="Label for text prompt type in the prompt creation modal"
+                  />
+                </SegmentedControlButton>
+                <SegmentedControlButton value={PROMPT_TYPE_CHAT}>
+                  <FormattedMessage
+                    defaultMessage="Chat"
+                    description="Label for chat prompt type in the prompt creation modal"
+                  />
+                </SegmentedControlButton>
+              </SegmentedControlGroup>
+            );
+          }}
         />
         <Spacer />
-        <FormUI.Label htmlFor="mlflow.prompts.create.content">Prompt:</FormUI.Label>
-        {form.watch('promptType') === PROMPT_TYPE_CHAT ? (
+        <FormUI.Label htmlFor="mlflow.prompts.create.content">
+          Prompt: *
+        </FormUI.Label>
+        {promptType === PROMPT_TYPE_CHAT ? (
           <ChatMessageCreator name="chatMessages" />
         ) : (
           <RHFControlledComponents.TextArea
@@ -290,7 +309,7 @@ export const useCreatePromptModal = ({
             validationState={form.formState.errors.draftValue ? 'error' : undefined}
           />
         )}
-        {form.watch('promptType') === PROMPT_TYPE_TEXT && form.formState.errors.draftValue && (
+        {promptType === PROMPT_TYPE_TEXT && form.formState.errors.draftValue && (
           <FormUI.Message type="error" message={form.formState.errors.draftValue.message} />
         )}
         <Spacer />
@@ -337,6 +356,12 @@ export const useCreatePromptModal = ({
               name="responseFormatJson"
               autoSize={{ minRows: 4, maxRows: 12 }}
               placeholder='{"type": "object", "properties": { ... }}'
+              rules={{
+                validate: (value) => {
+                  const validation = validateResponseFormatJson(value);
+                  return validation.valid || validation.error;
+                },
+              }}
               validationState={form.formState.errors.responseFormatJson ? 'error' : undefined}
             />
             {form.formState.errors.responseFormatJson && (


### PR DESCRIPTION
Reopening this change as a new PR since the previous one was closed without merging (original: #23715).

Fixes inline validation for the Create Prompt modal: switch to `react-hook-form` onChange validation, add field-level rules and hints, and disable the Create button while the form is invalid. Adds a focused regression test.

Files changed: `useCreatePromptModal.tsx`, `ModelConfigForm.tsx`, `ChatMessageCreator.tsx`, `PromptsPage.test.tsx`.

This PR includes a signed commit (DCO) and addresses bug reported in #23694.