### PR TITLE
fix(hdfs): use maxsplit=1 in _parse_extra_conf to handle values containing "="

### DIFF
--- a/mlflow/store/artifact/hdfs_artifact_repo.py
+++ b/mlflow/store/artifact/hdfs_artifact_repo.py
@@ -202,7 +202,7 @@ def _parse_extra_conf(extra_conf):
     if extra_conf:
 
         def as_pair(config):
-            key, val = config.split("=")
+            key, val = config.split("=", 1)
             return key, val
 
         list_of_key_val = [as_pair(conf) for conf in extra_conf.split(",")]

--- a/tests/store/artifact/test_hdfs_artifact_repo.py
+++ b/tests/store/artifact/test_hdfs_artifact_repo.py
@@ -194,6 +194,12 @@ def test_parse_extra_conf():
         _parse_extra_conf("missing_equals_sign")
 
 
+def test_parse_extra_conf_value_contains_equals():
+    # Values such as Kerberos auth_to_local rules contain "=" — must not crash.
+    result = _parse_extra_conf("hadoop.security.auth_to_local=RULE:[2:$1=$0]")
+    assert result == {"hadoop.security.auth_to_local": "RULE:[2:$1=$0]"}
+
+
 def test_delete_artifacts(hdfs_system_mock):
     repo = HdfsArtifactRepository("hdfs:/some_path/maybe/path/")
     hdfs_system_mock.return_value.get_file_info.return_value = pyarrow.fs.FileInfo(


### PR DESCRIPTION
## What's broken

`HdfsArtifactRepository` raises `ValueError: too many values to unpack` whenever `MLFLOW_PYARROW_EXTRA_CONF` contains a config value that itself includes `=`. Kerberos `auth_to_local` rules (`RULE:[2:$1=$0]`) and URL query parameters are common examples. Any such environment variable causes the `hdfs_system` context manager to crash before a filesystem connection is ever opened.

## Why it happens

`_parse_extra_conf` splits each `key=value` token with `config.split("=")` and no `maxsplit`. When the value portion contains one or more `=` characters the split produces more than two elements, so the two-target tuple assignment raises `ValueError`.

## Fix

Changed line 205 from `config.split("=")` to `config.split("=", 1)`. With `maxsplit=1` the split halts after the first `=`, putting the key in the first slot and the full remaining string (including any embedded `=`) in the second.

## Test

Added `test_parse_extra_conf_value_contains_equals` to `tests/store/artifact/test_hdfs_artifact_repo.py`. It calls `_parse_extra_conf` with a Kerberos auth_to_local rule and asserts the key and full value are parsed correctly without raising.

Fixes #23724