### PR TITLE
Fix PDF artifact viewer `import.meta` SyntaxError

### DIFF
--- a/mlflow/server/js/PdfjsStripImportMetaLoader/index.js
+++ b/mlflow/server/js/PdfjsStripImportMetaLoader/index.js
@@ -1,0 +1,4 @@
+module.exports = function pdfjsStripImportMetaLoader(source) {
+  this.cacheable();
+  return source.replace(/import\.meta\.url/g, '""');
+};

--- a/mlflow/server/js/craco.config.js
+++ b/mlflow/server/js/craco.config.js
@@ -97,11 +97,15 @@ function configureIframeCSSPublicPaths(config, env) {
  *      paths instead of module specifiers.
  *      → Skip babel-loader for pdfjs-dist.
  *
- *   2. Webpack inlines `import.meta.url` for .mjs source files, substituting
- *      `file://<absolute-path>/pdf.mjs`. pdfjs uses this only in Node-specific
- *      code (NodeCanvasFactory), dead code in the browser, but the string
- *      still ships in the bundle.
- *      → Disable `import.meta` evaluation for pdfjs files.
+ *   2. pdfjs uses `import.meta.url` inside Node-only code paths
+ *      (NodeCanvasFactory). Webpack's default is to substitute it with the
+ *      source file's absolute `file://` URL, which leaks the build machine
+ *      path. The previous fix set `parser.javascript.importMeta = false`,
+ *      but that switch tells webpack to leave the token alone, shipping a
+ *      literal `import.meta.url` into a classic-script chunk and triggering
+ *      `SyntaxError: Cannot use 'import.meta' outside a module` in the
+ *      browser (mlflow/mlflow#23720).
+ *      → Strip `import.meta.url` to `""` before webpack parses the file.
  */
 function preservePdfjsBundles(config) {
   const pdfjsPattern = /[\\/]node_modules[\\/]pdfjs-dist[\\/]/;
@@ -130,7 +134,8 @@ function preservePdfjsBundles(config) {
   }
   config.module.rules.push({
     test: pdfjsPattern,
-    parser: { importMeta: false },
+    enforce: 'pre',
+    use: [require.resolve('./PdfjsStripImportMetaLoader')],
   });
   return config;
 }


### PR DESCRIPTION
### Related Issues/PRs

Closes #23720

### What changes are proposed in this pull request?

`preservePdfjsBundles()` in `craco.config.js` (added in #23349 to close #23291) set `parser.javascript.importMeta = false` on pdfjs files. That switch doesn't strip `import.meta` from the source — it tells webpack to leave the token alone, so the literal `createRequire(import.meta.url)` from pdfjs-dist's `NodeCanvasFactory` shipped into a classic-script chunk. Browsers reject `import.meta` outside an ES module at parse time, so the chunk never executed and the PDF viewer rendered the React error boundary.

This PR replaces the broken parser rule with a tiny webpack loader (`PdfjsStripImportMetaLoader`) that substitutes `import.meta.url` → `""` before webpack parses pdfjs sources. The `_createCanvas` Node code path that reads it is dead in browsers, so the empty string is never used at runtime. The babel-loader exclusion — the half of #23349 that actually fixed #23291's worker import path leak — is left intact.

Full diagnosis and side-by-side proof from the 3.12.0 / 3.13.0 wheels: https://github.com/mlflow/mlflow/issues/23720#issuecomment-4598010904

### How is this PR tested?

- [x] Manual tests

Built the production bundle locally and clicked a PDF artifact in Chromium against a local mlflow server.

**Before** (master, viewer dies on chunk parse):

https://github.com/user-attachments/assets/d260f80b-e4d5-4e49-a53f-2d3fbfe35178

**After** (this branch, PDF renders with pagination):

<img width="1280" alt="pdf-fixed" src="https://github.com/user-attachments/assets/5f1d516e-fd9c-4645-a6b2-2479eda4ba8e" />

`grep -c import.meta build/static/js/*.chunk.js` returns 0 after the fix; the surviving `createRequire("")(...)` sits in dead code.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fixes the PDF artifact viewer in the OSS UI, which was broken in 3.13.0 by a chunk-level `import.meta` SyntaxError.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
