### PR TITLE
Enable auto-merge on newly created model catalog update PRs

### DIFF
--- a/.github/workflows/update-model-catalog.yml
+++ b/.github/workflows/update-model-catalog.yml
@@ -86,6 +86,7 @@ jobs:
           if [ -n "$existing_pr" ]; then
             echo "Existing open PR #$existing_pr found for branch $branch — skipping PR creation."
             echo "number=$existing_pr" >> "$GITHUB_OUTPUT"
+            echo "is_new_pr=false" >> "$GITHUB_OUTPUT"
           else
             pr_number=$(gh pr create \
               --title "Update model catalog from upstream sources" \
@@ -93,21 +94,22 @@ jobs:
               --reviewer "TomeHirata" \
               --json number --jq '.number')
             echo "number=$pr_number" >> "$GITHUB_OUTPUT"
+            echo "is_new_pr=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Comment /review on pull request
-        if: steps.diff.outputs.changed == 'true'
+        if: steps.pr.outputs.is_new_pr == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
         run: gh pr comment "$PR_NUMBER" --body "/review"
 
       - name: Enable auto-merge
-        if: steps.diff.outputs.changed == 'true'
+        if: steps.pr.outputs.is_new_pr == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
-        run: gh pr merge "$PR_NUMBER" --auto --squash
+        run: gh pr merge "$PR_NUMBER" --auto --squash || true
 
       - name: Publish to GitHub Releases
         if: steps.diff.outputs.changed == 'true'

--- a/.github/workflows/update-model-catalog.yml
+++ b/.github/workflows/update-model-catalog.yml
@@ -101,7 +101,11 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
-        run: gh pr merge "$PR_NUMBER" --auto --squash || true
+        run: |
+          output=$(gh pr merge "$PR_NUMBER" --auto --squash 2>&1) && exit 0
+          echo "$output" | grep -qi "auto-merge is already enabled" && exit 0
+          echo "$output" >&2
+          exit 1
 
       - name: Publish to GitHub Releases
         if: steps.diff.outputs.changed == 'true'

--- a/.github/workflows/update-model-catalog.yml
+++ b/.github/workflows/update-model-catalog.yml
@@ -28,7 +28,6 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
-          permission-issues: write
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -96,13 +95,6 @@ jobs:
             echo "number=$pr_number" >> "$GITHUB_OUTPUT"
             echo "is_new_pr=true" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Comment /review on pull request
-        if: steps.pr.outputs.is_new_pr == 'true'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
-        run: gh pr comment "$PR_NUMBER" --body "/review"
 
       - name: Enable auto-merge
         if: steps.pr.outputs.is_new_pr == 'true'


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23727

### What changes are proposed in this pull request?

Follow-up to #23727: removes the `/review` comment step (not needed) and keeps only auto-merge on newly created PRs. Also scopes auto-merge to new PRs only (not reused ones where a reviewer may have disabled it), and handles the "already enabled" error explicitly instead of swallowing all failures.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release