### PR TITLE
Update MiniMax model catalog: add M3 and M2.7

### DIFF
--- a/mlflow/utils/model_catalog/minimax.json
+++ b/mlflow/utils/model_catalog/minimax.json
@@ -1,110 +1,65 @@
 {
   "schema_version": "1.0",
   "models": {
-    "MiniMax-M2": {
+    "MiniMax-M3": {
       "mode": "chat",
       "context_window": {
-        "max_input": 200000,
-        "max_output": 8192
+        "max_input": 524288,
+        "max_output": 128000
       },
       "pricing": {
-        "input_per_million_tokens": 0.3,
-        "output_per_million_tokens": 1.2,
-        "cache_read_per_million_tokens": 0.03,
-        "cache_write_per_million_tokens": 0.375
-      },
-      "capabilities": {
-        "function_calling": true,
-        "vision": false,
-        "reasoning": true,
-        "prompt_caching": true,
-        "response_schema": false
-      },
-      "last_updated_at": "2026-04-24"
-    },
-    "MiniMax-M2.1": {
-      "mode": "chat",
-      "context_window": {
-        "max_input": 1000000,
-        "max_output": 8192
-      },
-      "pricing": {
-        "input_per_million_tokens": 0.3,
-        "output_per_million_tokens": 1.2,
-        "cache_read_per_million_tokens": 0.03,
-        "cache_write_per_million_tokens": 0.375
-      },
-      "capabilities": {
-        "function_calling": true,
-        "vision": false,
-        "reasoning": true,
-        "prompt_caching": true,
-        "response_schema": false
-      },
-      "last_updated_at": "2026-04-24"
-    },
-    "MiniMax-M2.1-lightning": {
-      "mode": "chat",
-      "context_window": {
-        "max_input": 1000000,
-        "max_output": 8192
-      },
-      "pricing": {
-        "input_per_million_tokens": 0.3,
+        "input_per_million_tokens": 0.6,
         "output_per_million_tokens": 2.4,
-        "cache_read_per_million_tokens": 0.03,
-        "cache_write_per_million_tokens": 0.375
+        "cache_read_per_million_tokens": 0.12
       },
       "capabilities": {
         "function_calling": true,
-        "vision": false,
+        "vision": true,
         "reasoning": true,
         "prompt_caching": true,
         "response_schema": false
       },
-      "last_updated_at": "2026-04-24"
+      "last_updated_at": "2026-06-02"
     },
-    "MiniMax-M2.5": {
+    "MiniMax-M2.7": {
       "mode": "chat",
       "context_window": {
-        "max_input": 1000000,
-        "max_output": 8192
+        "max_input": 204800,
+        "max_output": 131072,
+        "max_tokens": 131072
       },
       "pricing": {
         "input_per_million_tokens": 0.3,
-        "output_per_million_tokens": 1.2,
-        "cache_read_per_million_tokens": 0.03,
-        "cache_write_per_million_tokens": 0.375
+        "output_per_million_tokens": 1.2
       },
       "capabilities": {
         "function_calling": true,
         "vision": false,
         "reasoning": true,
-        "prompt_caching": true,
+        "prompt_caching": false,
         "response_schema": false
       },
-      "last_updated_at": "2026-04-24"
+      "last_updated_at": "2026-06-02"
     },
-    "MiniMax-M2.5-lightning": {
+    "MiniMax-M2.7-highspeed": {
       "mode": "chat",
       "context_window": {
-        "max_input": 1000000,
-        "max_output": 8192
+        "max_input": 204800,
+        "max_output": 131072,
+        "max_tokens": 131072
       },
       "pricing": {
         "input_per_million_tokens": 0.3,
-        "output_per_million_tokens": 2.4,
-        "cache_read_per_million_tokens": 0.03,
-        "cache_write_per_million_tokens": 0.375
+        "output_per_million_tokens": 2.4
       },
       "capabilities": {
         "function_calling": true,
         "vision": false,
         "reasoning": true,
-        "prompt_caching": true,
+        "prompt_caching": false,
         "response_schema": false
       },
-      "last_updated_at": "2026-04-24"
+      "last_updated_at": "2026-06-02"
     }
   }
 }


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

Refresh the bundled `mlflow/utils/model_catalog/minimax.json` so it reflects the current generation of MiniMax chat models:

- Add `MiniMax-M3` — 512K input / 128K output, supports vision, function calling, reasoning, and prompt caching read.
- Add `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` — the current stable generation (200K / 128K output, function calling + reasoning).
- Drop the older `MiniMax-M2`, `MiniMax-M2.1`, `MiniMax-M2.1-lightning`, `MiniMax-M2.5`, and `MiniMax-M2.5-lightning` entries.

Pricing and context-window values follow the public MiniMax pricing guide (https://platform.minimax.io/docs/guides/pricing-paygo). Only the canonical `minimax.json` catalog is touched; vendor-hosted entries in `bedrock.json`, `openrouter.json`, `novita.json`, etc. are left to `dev/update_model_catalog.py` to sync.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Verified locally that `mlflow.utils.providers._parse_catalog_models()` loads the new file and produces the expected `ModelInfo` dicts (correct `max_input_tokens`, per-token costs, and capability flags) for all three models.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Bundled MiniMax model catalog now lists `MiniMax-M3`, `MiniMax-M2.7`, and `MiniMax-M2.7-highspeed`; older M2 / M2.1 / M2.5 entries have been removed.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release