### PR TITLE
Set HTTP tracking URI during in-process demo generation

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -6389,9 +6389,13 @@ def _generate_demo():
 
     with _demo_generate_lock:
         # Generators run in-process; mlflow-artifacts:// URI resolution needs
-        # the tracking URI to point back at this server via http(s).
+        # the tracking URI to point back at this server via http(s). Include
+        # the static prefix so prefixed deployments route to /<prefix>/api/...
         original_tracking_uri = mlflow.get_tracking_uri()
-        mlflow.set_tracking_uri(request.host_url.rstrip("/"))
+        tracking_uri = request.host_url.rstrip("/")
+        if prefix := os.environ.get(STATIC_PREFIX_ENV_VAR):
+            tracking_uri += "/" + prefix.strip("/")
+        mlflow.set_tracking_uri(tracking_uri)
         try:
             results = generate_all_demos(features=features)
         finally:

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -6388,11 +6388,8 @@ def _generate_demo():
         })
 
     with _demo_generate_lock:
-        # Generators run inside the server process where the global tracking URI
-        # defaults to the backend store. The evaluation generator logs artifacts
-        # via `mlflow-artifacts://`, which requires the tracking URI to be an
-        # http(s) URL pointing back at this server so the artifact repo can
-        # resolve the URI through the artifact proxy.
+        # Generators run in-process; mlflow-artifacts:// URI resolution needs
+        # the tracking URI to point back at this server via http(s).
         original_tracking_uri = mlflow.get_tracking_uri()
         mlflow.set_tracking_uri(request.host_url.rstrip("/"))
         try:

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -6388,7 +6388,17 @@ def _generate_demo():
         })
 
     with _demo_generate_lock:
-        results = generate_all_demos(features=features)
+        # Generators run inside the server process where the global tracking URI
+        # defaults to the backend store. The evaluation generator logs artifacts
+        # via `mlflow-artifacts://`, which requires the tracking URI to be an
+        # http(s) URL pointing back at this server so the artifact repo can
+        # resolve the URI through the artifact proxy.
+        original_tracking_uri = mlflow.get_tracking_uri()
+        mlflow.set_tracking_uri(request.host_url.rstrip("/"))
+        try:
+            results = generate_all_demos(features=features)
+        finally:
+            mlflow.set_tracking_uri(original_tracking_uri)
 
     experiment = store.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
     experiment_id = experiment.experiment_id if experiment else None

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -5808,3 +5808,43 @@ def test_get_rest_path_respects_static_prefix(monkeypatch):
         _get_ajax_path("/mlflow/experiments/search")
         == "/myapp/ajax-api/2.0/mlflow/experiments/search"
     )
+
+
+def test_generate_demo_sets_http_tracking_uri(mock_tracking_store):
+    mock_tracking_store.get_experiment_by_name.return_value = None
+    captured = {}
+
+    def fake_generate_all_demos(features=None):
+        captured["tracking_uri"] = mlflow.get_tracking_uri()
+        return []
+
+    original_uri = mlflow.get_tracking_uri()
+    with (
+        mock.patch("mlflow.demo.generate_all_demos", side_effect=fake_generate_all_demos),
+        app.test_client() as c,
+    ):
+        response = c.post(
+            "/ajax-api/3.0/mlflow/demo/generate",
+            json={},
+            base_url="http://demo.test:5000",
+        )
+
+    assert response.status_code == 200
+    assert captured["tracking_uri"] == "http://demo.test:5000"
+    assert mlflow.get_tracking_uri() == original_uri
+
+
+def test_generate_demo_restores_tracking_uri_on_error(mock_tracking_store):
+    mock_tracking_store.get_experiment_by_name.return_value = None
+
+    def boom(features=None):
+        raise RuntimeError("generator failed")
+
+    original_uri = mlflow.get_tracking_uri()
+    with (
+        mock.patch("mlflow.demo.generate_all_demos", side_effect=boom),
+        app.test_client() as c,
+    ):
+        c.post("/ajax-api/3.0/mlflow/demo/generate", json={})
+
+    assert mlflow.get_tracking_uri() == original_uri

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -5845,6 +5845,7 @@ def test_generate_demo_restores_tracking_uri_on_error(mock_tracking_store):
         mock.patch("mlflow.demo.generate_all_demos", side_effect=boom),
         app.test_client() as c,
     ):
-        c.post("/ajax-api/3.0/mlflow/demo/generate", json={})
+        response = c.post("/ajax-api/3.0/mlflow/demo/generate", json={})
 
+    assert response.status_code == 500
     assert mlflow.get_tracking_uri() == original_uri

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -5847,7 +5847,9 @@ def test_generate_demo_includes_static_prefix(mock_tracking_store, monkeypatch):
         return []
 
     with (
-        mock.patch("mlflow.demo.generate_all_demos", side_effect=fake_generate_all_demos),
+        mock.patch(
+            "mlflow.demo.generate_all_demos", side_effect=fake_generate_all_demos
+        ) as mock_generate,
         app.test_client() as c,
     ):
         c.post(
@@ -5856,6 +5858,7 @@ def test_generate_demo_includes_static_prefix(mock_tracking_store, monkeypatch):
             base_url="http://demo.test:5000",
         )
 
+    mock_generate.assert_called_once()
     assert captured["tracking_uri"] == "http://demo.test:5000/myapp"
 
 

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -5820,7 +5820,9 @@ def test_generate_demo_sets_http_tracking_uri(mock_tracking_store):
 
     original_uri = mlflow.get_tracking_uri()
     with (
-        mock.patch("mlflow.demo.generate_all_demos", side_effect=fake_generate_all_demos),
+        mock.patch(
+            "mlflow.demo.generate_all_demos", side_effect=fake_generate_all_demos
+        ) as mock_generate,
         app.test_client() as c,
     ):
         response = c.post(
@@ -5829,9 +5831,32 @@ def test_generate_demo_sets_http_tracking_uri(mock_tracking_store):
             base_url="http://demo.test:5000",
         )
 
+    mock_generate.assert_called_once()
     assert response.status_code == 200
     assert captured["tracking_uri"] == "http://demo.test:5000"
     assert mlflow.get_tracking_uri() == original_uri
+
+
+def test_generate_demo_includes_static_prefix(mock_tracking_store, monkeypatch):
+    mock_tracking_store.get_experiment_by_name.return_value = None
+    monkeypatch.setenv(STATIC_PREFIX_ENV_VAR, "/myapp")
+    captured = {}
+
+    def fake_generate_all_demos(features=None):
+        captured["tracking_uri"] = mlflow.get_tracking_uri()
+        return []
+
+    with (
+        mock.patch("mlflow.demo.generate_all_demos", side_effect=fake_generate_all_demos),
+        app.test_client() as c,
+    ):
+        c.post(
+            "/ajax-api/3.0/mlflow/demo/generate",
+            json={},
+            base_url="http://demo.test:5000",
+        )
+
+    assert captured["tracking_uri"] == "http://demo.test:5000/myapp"
 
 
 def test_generate_demo_restores_tracking_uri_on_error(mock_tracking_store):


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

The `/ajax-api/3.0/mlflow/demo/generate` handler runs generators inside the MLflow server process, where the global tracking URI defaults to the backend store (e.g. `sqlite:/mlflow.db`). The evaluation generator logs artifacts via `mlflow-artifacts://` URIs, whose resolution requires the tracking URI to be an http(s) URL pointing back at the server so the artifact repo can route through the artifact proxy.

On v3.12.0 this surfaced as a 500 from the endpoint when the `evaluation` feature ran, leaving the demo experiment without any evaluation runs and without the `mlflow.demo.version.evaluation` tag (see `demo.mlflow.org`). On main the error is downgraded to warnings, but trace attachments still fail to upload silently.

Set the tracking URI to `request.host_url` (plus `_MLFLOW_STATIC_PREFIX` when set) for the duration of generation and restore it afterwards.

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests

Manual: started `mlflow server --backend-store-uri sqlite:///mlflow.db` locally and posted to `/ajax-api/3.0/mlflow/demo/generate`. Before: 30+ `mlflow-artifacts URI was supplied` warnings. After: zero such warnings, all five generators complete, `mlflow.demo.version.evaluation` set. Verified the evaluation-runs page is populated in the UI preview.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)