### PR TITLE
Updated eval runs to provide traces code snippet if the current experiment has traces

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/RunEvaluationButton.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/RunEvaluationButton.test.tsx
@@ -61,7 +61,7 @@ describe('RunEvaluationButton', () => {
     await userEvent.click(copyButton);
 
     expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(1);
-    return (navigator.clipboard.writeText as jest.Mock).mock.calls[0][0] as string;
+    return jest.mocked(navigator.clipboard.writeText).mock.calls[0][0] as string;
   };
 
   it('renders the dataset-based snippet and copies it when the experiment has no traces', async () => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/RunEvaluationButton.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/RunEvaluationButton.test.tsx
@@ -67,6 +67,7 @@ describe('RunEvaluationButton', () => {
   it('renders the dataset-based snippet and copies it when the experiment has no traces', async () => {
     mockUseTraceMetricsQuery.mockReturnValue({
       data: { data_points: [{ values: { [AggregationType.COUNT]: 0 } }] },
+      isSuccess: true,
     });
 
     renderButton('exp-1');
@@ -82,6 +83,7 @@ describe('RunEvaluationButton', () => {
   it('renders the trace-based snippet and copies it when the experiment has traces', async () => {
     mockUseTraceMetricsQuery.mockReturnValue({
       data: { data_points: [{ values: { [AggregationType.COUNT]: 5 } }] },
+      isSuccess: true,
     });
 
     renderButton('exp-7');
@@ -92,5 +94,20 @@ describe('RunEvaluationButton', () => {
     expect(copied).toContain('mlflow.search_traces(max_results=20)');
     expect(copied).not.toContain('eval_dataset');
     expect(copied).not.toContain('predict_fn=predict');
+  });
+
+  it('hides the snippet and copy button until the trace count query resolves', async () => {
+    // Simulate the trace count query still in flight after the modal opens.
+    mockUseTraceMetricsQuery.mockReturnValue({ data: undefined, isSuccess: false });
+
+    renderButton('exp-1');
+    await userEvent.click(screen.getByRole('button', { name: 'Run evaluation' }));
+
+    // Modal is open, but the snippet and its copy button must not be present yet —
+    // otherwise a fast click could capture the wrong (default-dataset) snippet for
+    // an experiment that actually has traces.
+    expect(document.querySelector(COPY_BUTTON_SELECTOR)).toBeNull();
+    expect(screen.queryByText(/eval_dataset = \[\{/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/mlflow\.search_traces/)).not.toBeInTheDocument();
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/RunEvaluationButton.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/RunEvaluationButton.test.tsx
@@ -1,0 +1,96 @@
+import { describe, beforeAll, beforeEach, afterEach, afterAll, jest, it, expect } from '@jest/globals';
+import React from 'react';
+import { DesignSystemProvider } from '@databricks/design-system';
+import { renderWithIntl, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
+import { waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AggregationType } from '@databricks/web-shared/model-trace-explorer';
+
+import { RunEvaluationButton } from './RunEvaluationButton';
+
+const mockUseTraceMetricsQuery = jest.fn();
+jest.mock('../experiment-overview/hooks/useTraceMetricsQuery', () => ({
+  __esModule: true,
+  useTraceMetricsQuery: (...args: unknown[]) => mockUseTraceMetricsQuery(...args),
+}));
+
+const COPY_BUTTON_SELECTOR = '[data-component-id="mlflow.eval-runs.start-run-modal.copy-snippet"]';
+
+describe('RunEvaluationButton', () => {
+  let originalClipboard: typeof navigator.clipboard;
+
+  beforeAll(() => {
+    originalClipboard = navigator.clipboard;
+  });
+
+  beforeEach(() => {
+    Object.defineProperty(global.navigator, 'clipboard', {
+      value: { writeText: jest.fn(() => Promise.resolve()) },
+      writable: true,
+    });
+    mockUseTraceMetricsQuery.mockReset();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    Object.defineProperty(global.navigator, 'clipboard', {
+      value: originalClipboard,
+      writable: true,
+    });
+  });
+
+  const renderButton = (experimentId = 'exp-1') =>
+    renderWithIntl(
+      <DesignSystemProvider>
+        <RunEvaluationButton experimentId={experimentId} />
+      </DesignSystemProvider>,
+    );
+
+  // Open the modal and click its copy button. Returns the string passed to clipboard.writeText.
+  const openModalAndCopy = async (): Promise<string> => {
+    await userEvent.click(screen.getByRole('button', { name: 'Run evaluation' }));
+
+    const copyButton = await waitFor(() => {
+      const el = document.querySelector<HTMLElement>(COPY_BUTTON_SELECTOR);
+      expect(el).not.toBeNull();
+      return el!;
+    });
+    await userEvent.click(copyButton);
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(1);
+    return (navigator.clipboard.writeText as jest.Mock).mock.calls[0][0] as string;
+  };
+
+  it('renders the dataset-based snippet and copies it when the experiment has no traces', async () => {
+    mockUseTraceMetricsQuery.mockReturnValue({
+      data: { data_points: [{ values: { [AggregationType.COUNT]: 0 } }] },
+    });
+
+    renderButton('exp-1');
+
+    const copied = await openModalAndCopy();
+
+    expect(copied).toContain('mlflow.set_experiment(experiment_id="exp-1")');
+    expect(copied).toContain('eval_dataset = [{');
+    expect(copied).toContain('predict_fn=predict');
+    expect(copied).not.toContain('mlflow.search_traces');
+  });
+
+  it('renders the trace-based snippet and copies it when the experiment has traces', async () => {
+    mockUseTraceMetricsQuery.mockReturnValue({
+      data: { data_points: [{ values: { [AggregationType.COUNT]: 5 } }] },
+    });
+
+    renderButton('exp-7');
+
+    const copied = await openModalAndCopy();
+
+    expect(copied).toContain('mlflow.set_experiment(experiment_id="exp-7")');
+    expect(copied).toContain('mlflow.search_traces(max_results=20)');
+    expect(copied).not.toContain('eval_dataset');
+    expect(copied).not.toContain('predict_fn=predict');
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/RunEvaluationButton.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/RunEvaluationButton.tsx
@@ -1,4 +1,4 @@
-import { Button, ChartLineIcon, Modal, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { Button, ChartLineIcon, Modal, Spinner, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { CodeSnippet, SnippetCopyAction } from '@mlflow/mlflow/src/shared/web-shared/snippet';
 import { AggregationType, MetricViewType, TraceMetricKey } from '@databricks/web-shared/model-trace-explorer';
 import { useState } from 'react';
@@ -56,7 +56,6 @@ from mlflow.genai.scorers import (
 )
 
 os.environ["OPENAI_API_KEY"] = "your-api-key-here"  # Replace with your API key
-mlflow.set_tracking_uri("http://localhost:5000")
 mlflow.set_experiment(experiment_id="${experimentId}")
 
 # Step 1: Pull traces to evaluate.
@@ -87,7 +86,7 @@ export const RunEvaluationButton = ({ experimentId }: { experimentId: string }) 
       description="Instructions for running the evaluation code in OSS"
     />
   );
-  const { data: traceMetrics } = useTraceMetricsQuery({
+  const { data: traceMetrics, isSuccess: isTraceMetricsLoaded } = useTraceMetricsQuery({
     experimentIds: [experimentId],
     viewType: MetricViewType.TRACES,
     metricName: TraceMetricKey.TRACE_COUNT,
@@ -97,7 +96,7 @@ export const RunEvaluationButton = ({ experimentId }: { experimentId: string }) 
   const traceCount = Number(traceMetrics?.data_points?.[0]?.values?.[AggregationType.COUNT] ?? 0);
   const hasTraces = traceCount > 0;
   const codeSnippet = hasTraces ? getTraceCodeSnippet(experimentId) : getDatasetCodeSnippet(experimentId);
-  const evalCodeSnippet = (
+  const evalCodeSnippet = isTraceMetricsLoaded ? (
     <div css={{ position: 'relative' }}>
       <SnippetCopyAction
         componentId="mlflow.eval-runs.start-run-modal.copy-snippet"
@@ -107,6 +106,10 @@ export const RunEvaluationButton = ({ experimentId }: { experimentId: string }) 
       <CodeSnippet theme={theme.isDarkMode ? 'duotoneDark' : 'light'} language="python">
         {codeSnippet}
       </CodeSnippet>
+    </div>
+  ) : (
+    <div css={{ display: 'flex', justifyContent: 'center', padding: theme.spacing.lg }}>
+      <Spinner />
     </div>
   );
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/RunEvaluationButton.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/RunEvaluationButton.tsx
@@ -1,9 +1,11 @@
 import { Button, ChartLineIcon, Modal, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { CodeSnippet, SnippetCopyAction } from '@mlflow/mlflow/src/shared/web-shared/snippet';
+import { AggregationType, MetricViewType, TraceMetricKey } from '@databricks/web-shared/model-trace-explorer';
 import { useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
+import { useTraceMetricsQuery } from '../experiment-overview/hooks/useTraceMetricsQuery';
 
-const getCodeSnippet = (experimentId: string, scorersDocLink?: string) => `import mlflow
+const getDatasetCodeSnippet = (experimentId: string, scorersDocLink?: string) => `import mlflow
 from mlflow.genai import evaluate
 from mlflow.genai.scorers import (
     Safety,
@@ -42,6 +44,34 @@ evaluate(
 
 # Results will appear back in this UI`;
 
+const getTraceCodeSnippet = (experimentId: string) => `import mlflow
+from mlflow.genai import evaluate
+from mlflow.genai.scorers import (
+    Safety,
+    RelevanceToQuery,
+    Guidelines,
+)
+
+mlflow.set_experiment(experiment_id="${experimentId}")
+
+# Step 1: Pull traces to evaluate.
+# Adjust max_results, or add a filter_string for time/status, etc.
+# See: https://mlflow.org/docs/latest/genai/eval-monitor/running-evaluation/traces/
+traces = mlflow.search_traces(max_results=20)
+
+# Step 2: Run evaluation. No predict_fn needed — inputs/outputs
+# are extracted from the trace objects automatically.
+evaluate(
+  data=traces,
+  scorers=[
+    Safety(),
+    RelevanceToQuery(),
+    Guidelines(name="conciseness", guidelines="Responses must be concise."),
+  ],
+)
+
+# Results will appear back in this UI`;
+
 export const RunEvaluationButton = ({ experimentId }: { experimentId: string }) => {
   const intl = useIntl();
   const { theme } = useDesignSystemTheme();
@@ -52,7 +82,16 @@ export const RunEvaluationButton = ({ experimentId }: { experimentId: string }) 
       description="Instructions for running the evaluation code in OSS"
     />
   );
-  const codeSnippet = getCodeSnippet(experimentId);
+  const { data: traceMetrics } = useTraceMetricsQuery({
+    experimentIds: [experimentId],
+    viewType: MetricViewType.TRACES,
+    metricName: TraceMetricKey.TRACE_COUNT,
+    aggregations: [{ aggregation_type: AggregationType.COUNT }],
+    enabled: isOpen,
+  });
+  const traceCount = Number(traceMetrics?.data_points?.[0]?.values?.[AggregationType.COUNT] ?? 0);
+  const hasTraces = traceCount > 0;
+  const codeSnippet = hasTraces ? getTraceCodeSnippet(experimentId) : getDatasetCodeSnippet(experimentId);
   const evalCodeSnippet = (
     <div css={{ position: 'relative' }}>
       <SnippetCopyAction

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/RunEvaluationButton.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/RunEvaluationButton.tsx
@@ -6,6 +6,7 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import { useTraceMetricsQuery } from '../experiment-overview/hooks/useTraceMetricsQuery';
 
 const getDatasetCodeSnippet = (experimentId: string, scorersDocLink?: string) => `import mlflow
+import os
 from mlflow.genai import evaluate
 from mlflow.genai.scorers import (
     Safety,
@@ -13,6 +14,7 @@ from mlflow.genai.scorers import (
     Guidelines,
 )
 
+os.environ["OPENAI_API_KEY"] = "your-api-key-here"  # Replace with your API key
 mlflow.set_experiment(experiment_id="${experimentId}")
 
 # Step 1: Define evaluation dataset
@@ -45,6 +47,7 @@ evaluate(
 # Results will appear back in this UI`;
 
 const getTraceCodeSnippet = (experimentId: string) => `import mlflow
+import os
 from mlflow.genai import evaluate
 from mlflow.genai.scorers import (
     Safety,
@@ -52,6 +55,8 @@ from mlflow.genai.scorers import (
     Guidelines,
 )
 
+os.environ["OPENAI_API_KEY"] = "your-api-key-here"  # Replace with your API key
+mlflow.set_tracking_uri("http://localhost:5000")
 mlflow.set_experiment(experiment_id="${experimentId}")
 
 # Step 1: Pull traces to evaluate.


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/23737/files) to review incremental changes.
- [stack/run-eval-changes](https://github.com/mlflow/mlflow/pull/23735) [[Files changed](https://github.com/mlflow/mlflow/pull/23735/files)] [MERGED]
  - [**stack/run-eval-dynamic-traces-snippet**](https://github.com/mlflow/mlflow/pull/23737) [[Files changed](https://github.com/mlflow/mlflow/pull/23737/files)]
    - [stack/run-eval-traces-eval](https://github.com/mlflow/mlflow/pull/23758) [[Files changed](https://github.com/mlflow/mlflow/pull/23758/files/2aa9532cbb9750f1146c3d55793f4718b79439ba..f9c0e6ab786d7b169be3b1bd45d20168062fac25)]

---------
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

This PR introduces a traces code snippet that allows the users to run evaluations on their existing traces (if there are traces available in their current selected experiment)

Auto-switch the Run evaluation modal's Python snippet to a trace-based example (mlflow.search_traces(max_results=20) + evaluate(data=traces, ...)) when the current experiment already has traces. We fall back to the existing dataset/predict_fn snippet otherwise.

New unit tests is also added to verify that the copy button writes the correct snippet variant to the clipboard for both the no-traces and has-traces paths.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

When there is traces in their current experiment (code traces provided allows the user to run eval on their current traces as an example):

<img width="771" height="811" alt="When there is no traces in the current experiment" src="https://github.com/user-attachments/assets/9931d9b7-38b5-42d8-9115-bbc601536da7" />

When there are no traces in their current experiment, we default to the generic data eval set example:

<img width="688" height="824" alt="When there is traces in the current experiment" src="https://github.com/user-attachments/assets/8ec3ae22-604f-4276-9d8e-c2211ae2ab8f" />

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

Users' can now copy the code snippet to evaluated their existing traces (if there are currently traces available in their selected experiment)

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
