### PR TITLE
Suppress browser auto-open in `dev/run_dev_server.py`

### DIFF
--- a/dev/run_dev_server.py
+++ b/dev/run_dev_server.py
@@ -98,6 +98,7 @@ def start_frontend(backend_port: int, frontend_port: int) -> subprocess.Popen[by
             "PORT": str(frontend_port),
             "MLFLOW_PROXY": f"http://localhost:{backend_port}",
             "MLFLOW_DEV_PROXY_MODE": "1",
+            "BROWSER": "none",
         },
         start_new_session=True,
     )


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Sets `BROWSER=none` in the env passed to `yarn start` from `dev/run_dev_server.py`. CRA's dev server reads this and skips auto-opening a browser tab on every launch, which is noisy when restarting the dev server frequently.

### How is this PR tested?

- [x] Manual tests

Ran `uv run dev/run_dev_server.py` and confirmed no browser tab pops open while the frontend still starts normally.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)