### PR TITLE
Use `mktemp` for unique dev server log path in `CLAUDE.md`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,13 +30,12 @@ MLflow is an open-source platform for managing the end-to-end machine learning l
 
 ```bash
 # Start both MLflow backend and React frontend dev servers
-uv run dev/run_dev_server.py > /tmp/mlflow-dev-server.log 2>&1 &
+LOG=$(mktemp) && echo "Logs: $LOG"
+uv run dev/run_dev_server.py > "$LOG" 2>&1 &
 
 # Monitor the logs (server URLs are printed there)
-tail -f /tmp/mlflow-dev-server.log
+tail -f "$LOG"
 ```
-
-This uses `uv` (fast Python package manager) to automatically manage dependencies and run the development environment.
 
 ## Debugging
 
@@ -58,11 +57,12 @@ export DATABRICKS_TOKEN="your-databricks-token"                # Your Databricks
 export MLFLOW_TRACKING_URI="databricks"                        # Must be set to "databricks"
 export MLFLOW_REGISTRY_URI="databricks-uc"                     # Use "databricks-uc" for Unity Catalog, or "databricks" for workspace model registry
 
-# Start the dev server with these environment variables
-uv run dev/run_dev_server.py > /tmp/mlflow-dev-server.log 2>&1 &
+# Start the dev server with these environment variables (unique log per invocation)
+LOG=$(mktemp) && echo "Logs: $LOG"
+uv run dev/run_dev_server.py > "$LOG" 2>&1 &
 
 # Monitor the logs (server URLs are printed there)
-tail -f /tmp/mlflow-dev-server.log
+tail -f "$LOG"
 ```
 
 **Note**: The MLflow server acts as a proxy, forwarding API requests to your Databricks workspace while serving the local React frontend. This allows you to develop and test UI changes against real Databricks data.


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

`CLAUDE.md` previously recommended `uv run dev/run_dev_server.py > /tmp/mlflow-dev-server.log 2>&1 &`, which meant concurrent dev servers (e.g. one per worktree, or multiple Claude sessions in different terminals) all clobbered the same log file. This PR swaps the fixed path for `$(mktemp)` so each invocation gets its own unique log.

The dev script itself is intentionally untouched. The shell handles redirection as it always has.

### How is this PR tested?

- [x] Manual tests

Confirmed `mktemp` produces a unique path per call on macOS and Linux, and that the dev server output lands there.

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)