### PR TITLE
Disable Create button in Create Prompt modal when required fields are empty

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsPage.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsPage.test.tsx
@@ -193,6 +193,58 @@ describe('PromptsPage', () => {
     );
   });
 
+  it('should disable the Create button while required fields are empty', async () => {
+    server.use(getMockedRegisteredPromptsResponse(0));
+
+    renderTestComponent();
+    await waitFor(() => {
+      expect(screen.getByTestId('create-prompt-empty-state-button')).toBeInTheDocument();
+    });
+    await userEvent.click(screen.getByTestId('create-prompt-empty-state-button'));
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    const createButton = screen.getByRole('button', { name: 'Create' });
+
+    expect(createButton).toBeDisabled();
+
+    await userEvent.type(screen.getByLabelText('Name:'), 'my-prompt');
+    expect(createButton).toBeDisabled();
+
+    await userEvent.type(screen.getByLabelText('Prompt:'), 'hello');
+    expect(createButton).toBeEnabled();
+
+    await userEvent.clear(screen.getByLabelText('Name:'));
+    expect(createButton).toBeDisabled();
+
+    await userEvent.type(screen.getByLabelText('Name:'), '   ');
+    expect(createButton).toBeDisabled();
+  });
+
+  it('should disable the Create button in chat mode while user message content is empty', async () => {
+    server.use(getMockedRegisteredPromptsResponse(0));
+
+    renderTestComponent();
+    await waitFor(() => {
+      expect(screen.getByTestId('create-prompt-empty-state-button')).toBeInTheDocument();
+    });
+    await userEvent.click(screen.getByTestId('create-prompt-empty-state-button'));
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    await userEvent.type(screen.getByLabelText('Name:'), 'my-chat-prompt');
+    await userEvent.click(screen.getByRole('radio', { name: 'Chat' }));
+
+    const createButton = screen.getByRole('button', { name: 'Create' });
+    expect(createButton).toBeDisabled();
+
+    const content = document.querySelector('textarea[name="chatMessages.0.content"]') as HTMLTextAreaElement;
+    await userEvent.type(content, 'Hello');
+    expect(createButton).toBeEnabled();
+  });
+
   describe('Experiment-scoped prompts', () => {
     it('should render experiment-scoped prompts with filtering', async () => {
       const experimentId = '123';

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useCreatePromptModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useCreatePromptModal.tsx
@@ -87,7 +87,7 @@ export const useCreatePromptModal = ({
 
   const isPromptContentEmpty =
     watchedPromptType === PROMPT_TYPE_CHAT
-      ? watchedChatMessages.some((m) => !m.content || !m.content.trim())
+      ? watchedChatMessages.length === 0 || watchedChatMessages.some((m) => !m.content || !m.content.trim())
       : !watchedDraftValue?.trim();
   const isSubmitDisabled = (isCreatingNewPrompt && !watchedDraftName?.trim()) || isPromptContentEmpty;
 

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useCreatePromptModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useCreatePromptModal.tsx
@@ -80,6 +80,17 @@ export const useCreatePromptModal = ({
 
   const { mutate: mutateCreateVersion, error, reset: errorsReset, isLoading } = useCreateRegisteredPromptMutation();
 
+  const watchedDraftName = form.watch('draftName');
+  const watchedDraftValue = form.watch('draftValue');
+  const watchedChatMessages = form.watch('chatMessages');
+  const watchedPromptType = form.watch('promptType');
+
+  const isPromptContentEmpty =
+    watchedPromptType === PROMPT_TYPE_CHAT
+      ? watchedChatMessages.some((m) => !m.content || !m.content.trim())
+      : !watchedDraftValue?.trim();
+  const isSubmitDisabled = (isCreatingNewPrompt && !watchedDraftName?.trim()) || isPromptContentEmpty;
+
   const modalElement = (
     <FormProvider {...form}>
       <Modal
@@ -105,7 +116,7 @@ export const useCreatePromptModal = ({
             description="A label for the confirm button in the create prompt modal in the prompt management UI"
           />
         }
-        okButtonProps={{ loading: isLoading }}
+        okButtonProps={{ loading: isLoading, disabled: isSubmitDisabled }}
         onOk={form.handleSubmit(async (values) => {
           const promptName =
             isCreatingPromptVersion && registeredPrompt?.name ? registeredPrompt?.name : values.draftName;


### PR DESCRIPTION
### Related Issues/PRs

Closes #23694

### What changes are proposed in this pull request?

Disable the **Create** button in the Create Prompt modal while required fields are empty. Per the discussion in #23694 (comment), this is the scoped-down version (button-disable only, no inline validation), bringing the modal in line with other create-modals in the app (e.g. `CreateExperimentModal`, `CreateEvaluationDatasetModal`) that already disable submit on empty required fields. Pattern/range checks still run on submit, so frontend/backend validation logic isn't duplicated.

Required-field rules:
- Create-prompt mode: `draftName` non-empty (trimmed).
- Always: prompt content non-empty (text → `draftValue` trimmed; chat → no message with empty/whitespace content).

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests

**Before:** Create button stays enabled with empty fields; error only appears after submit.

https://github.com/user-attachments/assets/45a10047-0d30-43ed-b82a-037378d619c9

**After:** Create button is disabled until required fields are non-empty.

https://github.com/user-attachments/assets/6c0f7557-9c07-4fc7-866d-f2683d1f5463

Manually verified each state via Playwright against `dev/run_dev_server.py`:

| state | result |
|---|---|
| Open modal, both fields empty | disabled |
| Name only | disabled |
| Name + Prompt | enabled |
| Clear Name | disabled |
| Whitespace-only Prompt | disabled |
| Chat mode, empty user message | disabled |
| Chat mode, filled user message | enabled |
| Invalid name (with spaces) + Prompt | enabled, **no inline error** (preserves existing on-submit validation) |

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The Create button in the Create Prompt modal is now disabled until the required Name and Prompt fields are filled.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)