### PR TITLE
Extend `redundant-test-docstring` clint rule to flag module docstrings

### DIFF
--- a/dev/benchmarks/tracing/test_trace_perf.py
+++ b/dev/benchmarks/tracing/test_trace_perf.py
@@ -1,10 +1,7 @@
-"""Performance benchmarks for MLflow tracing.
-
-Run via:
-    uv run pytest dev/benchmarks/tracing/ \\
-        --benchmark-only \\
-        --benchmark-json=benchmark-results.json
-"""
+# Run via:
+#     uv run pytest dev/benchmarks/tracing/ \
+#         --benchmark-only \
+#         --benchmark-json=benchmark-results.json
 
 import random
 

--- a/dev/benchmarks/tracing/test_trace_perf.py
+++ b/dev/benchmarks/tracing/test_trace_perf.py
@@ -1,8 +1,3 @@
-# Run via:
-#     uv run pytest dev/benchmarks/tracing/ \
-#         --benchmark-only \
-#         --benchmark-json=benchmark-results.json
-
 import random
 
 from _data import generate_trace_data

--- a/dev/clint/src/clint/rules/redundant_test_docstring.py
+++ b/dev/clint/src/clint/rules/redundant_test_docstring.py
@@ -1,9 +1,10 @@
-"""Rule to detect redundant docstrings in test functions and classes.
+"""Rule to detect redundant docstrings in test files.
 
-This rule flags ALL single-line docstrings in test functions and classes.
-Single-line docstrings in tests rarely provide meaningful context and are
-typically redundant. Multi-line docstrings are always allowed as they
-generally provide meaningful context.
+This rule flags:
+- ALL single-line docstrings in test functions and classes (multi-line
+  function/class docstrings are allowed since they generally provide
+  meaningful context).
+- ALL module-level docstrings in test files (single- or multi-line).
 """
 
 import ast
@@ -46,26 +47,18 @@ class RedundantTestDocstring(Rule):
 
     @staticmethod
     def check_module(module: ast.Module, path_name: str) -> ast.Constant | None:
-        """Check if module-level docstring is redundant."""
         if not (path_name.startswith("test_") or path_name.endswith("_test.py")):
             return None
 
-        # Check raw docstring for multiline detection
         if (
             module.body
             and isinstance(module.body[0], ast.Expr)
             and isinstance(module.body[0].value, ast.Constant)
             and isinstance(module.body[0].value.value, str)
         ):
-            raw_docstring = module.body[0].value.value
-            # Only flag single-line module docstrings
-            if "\n" not in raw_docstring:
-                return module.body[0].value
+            return module.body[0].value
 
         return None
 
     def _message(self) -> str:
-        return (
-            "Single-line docstrings in tests rarely provide meaningful context. "
-            "Consider removing it."
-        )
+        return "Docstrings in test files rarely provide meaningful context. Consider removing it."

--- a/dev/clint/tests/rules/test_redundant_test_docstring.py
+++ b/dev/clint/tests/rules/test_redundant_test_docstring.py
@@ -193,7 +193,7 @@ def test_something():
     assert "rarely provide meaningful context" in violations[0].rule.message
 
 
-def test_module_multiline_docstrings_are_allowed(index: SymbolIndex) -> None:
+def test_module_multiline_docstrings_are_flagged(index: SymbolIndex) -> None:
     code = '''"""
 This is a test module.
 It has multiple lines.
@@ -204,7 +204,8 @@ def test_something():
 
     config = Config(select={RedundantTestDocstring.name})
     violations = lint_file(Path("test_module.py"), code, config, index)
-    assert len(violations) == 0
+    assert len(violations) == 1
+    assert isinstance(violations[0].rule, RedundantTestDocstring)
 
 
 def test_module_without_docstring_is_not_flagged(index: SymbolIndex) -> None:

--- a/tests/assistant/providers/test_ollama_provider.py
+++ b/tests/assistant/providers/test_ollama_provider.py
@@ -1,10 +1,3 @@
-"""Tests for the Ollama preset of OpenAICompatibleProvider.
-
-Covers the Ollama-specific bits: `/api/tags` listing and the OAI-compat
-chat path the preset is wired to call. The shared SSE/tool-call/think-block
-behavior is exercised in `test_openai_compatible_provider.py`.
-"""
-
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/assistant/providers/test_openai_compatible_provider.py
+++ b/tests/assistant/providers/test_openai_compatible_provider.py
@@ -1,10 +1,3 @@
-"""Tests for the shared OpenAI-compatible streaming provider.
-
-Exercises the wire-level concerns (SSE parsing, `[DONE]` tolerance, chunked
-`tool_calls` accumulation, `<think>` stripping, session encoding/trimming,
-auth headers) using a stub list_models_fn so no preset-specific code is hit.
-"""
-
 import json
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/tests/demo/test_cli.py
+++ b/tests/demo/test_cli.py
@@ -1,9 +1,3 @@
-"""Tests for the mlflow demo CLI command.
-
-Includes both quick help/registration tests and functional tests that
-invoke the actual CLI command with a mocked server.
-"""
-
 import socket
 import sys
 from unittest import mock

--- a/tests/demo/test_demo_integration.py
+++ b/tests/demo/test_demo_integration.py
@@ -1,9 +1,3 @@
-"""Integration tests for the demo data framework.
-
-These tests run against a real MLflow tracking server to verify that demo data
-is correctly persisted, retrieved, and cleaned up on version bumps.
-"""
-
 from pathlib import Path
 
 import pytest

--- a/tests/gemini/test_gemini_autolog.py
+++ b/tests/gemini/test_gemini_autolog.py
@@ -1,7 +1,5 @@
-"""
-This file contains unit tests for the new Gemini Python SDK
-https://github.com/googleapis/python-genai
-"""
+# Tests for the new Gemini Python SDK:
+# https://github.com/googleapis/python-genai
 
 import asyncio
 import base64

--- a/tests/gemini/test_legacy_gemini_autolog.py
+++ b/tests/gemini/test_legacy_gemini_autolog.py
@@ -1,7 +1,5 @@
-"""
-This file contains unit tests for the legacy Gemini Python SDK
-https://github.com/google-gemini/generative-ai-python
-"""
+# Tests for the legacy Gemini Python SDK:
+# https://github.com/google-gemini/generative-ai-python
 
 import base64
 from unittest.mock import patch

--- a/tests/genai/judges/adapters/test_base_adapter.py
+++ b/tests/genai/judges/adapters/test_base_adapter.py
@@ -1,10 +1,3 @@
-"""Tests for BaseJudgeAdapter template method and inline Databricks telemetry.
-
-Uses a minimal FakeAdapter stub so these tests are adapter-agnostic —
-they verify the base class behavior without coupling to any specific
-adapter implementation.
-"""
-
 from unittest import mock
 
 import pytest

--- a/tests/genai/judges/utils/test_invocation_utils.py
+++ b/tests/genai/judges/utils/test_invocation_utils.py
@@ -1,11 +1,3 @@
-"""Tests for invoke_judge_model and get_chat_completions_with_structured_output.
-
-These tests verify routing (which adapter is selected), payload passthrough,
-and output parsing. Adapter internals (RetryPolicy, litellm.Message types,
-cost tracking, response_format caching) are tested in the adapter-specific
-test files (test_litellm_adapter.py, test_gateway_adapter.py).
-"""
-
 import json
 from unittest import mock
 

--- a/tests/genai/optimize/test_job.py
+++ b/tests/genai/optimize/test_job.py
@@ -1,10 +1,3 @@
-"""
-Unit tests for the optimize_prompts_job wrapper.
-
-These tests focus on the helper functions and job function logic without
-requiring a full job execution infrastructure.
-"""
-
 import sys
 from unittest import mock
 

--- a/tests/genai/scorers/test_scorer_telemetry.py
+++ b/tests/genai/scorers/test_scorer_telemetry.py
@@ -1,7 +1,3 @@
-"""Tests for scorer telemetry behavior, specifically testing that nested scorer calls
-skip telemetry recording while top-level calls record telemetry correctly.
-"""
-
 import asyncio
 import json
 import threading

--- a/tests/models/test_container.py
+++ b/tests/models/test_container.py
@@ -1,9 +1,3 @@
-"""
-Tests for mlflow.models.container module.
-
-Includes security tests for command injection prevention.
-"""
-
 import os
 from unittest import mock
 

--- a/tests/pyfunc/docker/test_docker_flavors.py
+++ b/tests/pyfunc/docker/test_docker_flavors.py
@@ -1,13 +1,6 @@
-"""
-This test class is used for comprehensive testing of serving docker images for all MLflow flavors.
-As such, it is not intended to be run on a regular basis and is skipped by default. Rather, it
-should be run manually when making changes to the core docker logic.
-
-To run this test, run the following command manually
-
-    $ pytest tests/pyfunc/test_docker_flavors.py
-
-"""
+# Skipped by default; run manually when making changes to the core docker logic:
+#
+#     $ pytest tests/pyfunc/test_docker_flavors.py
 
 import contextlib
 import os

--- a/tests/pyfunc/docker/test_docker_flavors.py
+++ b/tests/pyfunc/docker/test_docker_flavors.py
@@ -1,7 +1,3 @@
-# Skipped by default; run manually when making changes to the core docker logic:
-#
-#     $ pytest tests/pyfunc/test_docker_flavors.py
-
 import contextlib
 import os
 import shutil

--- a/tests/pyfunc/test_uv_model_logging.py
+++ b/tests/pyfunc/test_uv_model_logging.py
@@ -1,15 +1,3 @@
-"""
-Integration tests for uv package manager support in model logging and loading.
-
-Tests the end-to-end workflow:
-1. uv project detection during log_model()
-2. Artifact generation (uv.lock, pyproject.toml, .python-version, requirements.txt)
-3. Model loading with uv artifacts
-
-These tests use REAL uv calls (not mocked) where possible, following MLflow best practices.
-Tests requiring uv are skipped if uv is not installed or below minimum version.
-"""
-
 import platform
 import shutil
 import subprocess

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -1,8 +1,3 @@
-"""
-Integration test which starts a local Tracking Server on an ephemeral port,
-and ensures authentication is working.
-"""
-
 import base64
 import re
 import subprocess

--- a/tests/server/jobs/test_scorer_invocation.py
+++ b/tests/server/jobs/test_scorer_invocation.py
@@ -1,12 +1,3 @@
-"""
-E2E integration tests for async scorer invocation via the MLflow server.
-
-These tests spin up a real MLflow server with job execution enabled and test
-the full flow of invoking scorers on traces asynchronously.
-
-The MLflow AI Gateway is mocked to avoid real LLM calls during testing.
-"""
-
 import json
 import os
 import signal

--- a/tests/store/model_registry/test_rest_store_webhooks.py
+++ b/tests/store/model_registry/test_rest_store_webhooks.py
@@ -1,8 +1,3 @@
-"""
-This test file verifies webhook CRUD operations with the REST client,
-testing both server handlers and the REST client together.
-"""
-
 from pathlib import Path
 from typing import Iterator
 

--- a/tests/store/test_workspace_model_coverage.py
+++ b/tests/store/test_workspace_model_coverage.py
@@ -1,11 +1,3 @@
-"""Verify that every SQLAlchemy model with a ``workspace`` column is handled
-by at least one workspace store's ``_get_query`` method.
-
-If a new model is added with a ``workspace`` column but the developer forgets
-to add it to ``_get_query``, that model's queries will bypass workspace
-isolation.  This test catches that gap.
-"""
-
 import ast
 from pathlib import Path
 

--- a/tests/test_skinny_client_anthropic_import.py
+++ b/tests/test_skinny_client_anthropic_import.py
@@ -1,10 +1,7 @@
-"""Test that mlflow.types.chat can be imported without numpy.
-
-This verifies the fix for https://github.com/mlflow/mlflow/issues/21779
-where mlflow-skinny users couldn't use mlflow.anthropic.autolog() because
-importing mlflow.types.chat transitively pulled in numpy via
-mlflow.types.__init__ -> mlflow.types.llm -> mlflow.types.schema.
-"""
+# Regression test for https://github.com/mlflow/mlflow/issues/21779:
+# mlflow-skinny users couldn't use mlflow.anthropic.autolog() because importing
+# mlflow.types.chat transitively pulled in numpy via
+# mlflow.types.__init__ -> mlflow.types.llm -> mlflow.types.schema.
 
 import importlib.util
 import os

--- a/tests/tracing/test_enablement.py
+++ b/tests/tracing/test_enablement.py
@@ -1,7 +1,3 @@
-"""
-Tests for mlflow.tracing.enablement module
-"""
-
 from unittest import mock
 
 import pytest

--- a/tests/tracing/test_otel_logging.py
+++ b/tests/tracing/test_otel_logging.py
@@ -1,10 +1,3 @@
-"""
-Tests for OpenTelemetry client integration with MLflow otel_api.py endpoint.
-
-This test suite verifies that the experiment ID header functionality works correctly
-when using OpenTelemetry clients to send spans to MLflow's OTel endpoint.
-"""
-
 import gzip
 import time
 import zlib

--- a/tests/tracking/_model_registry/test_model_registry_client.py
+++ b/tests/tracking/_model_registry/test_model_registry_client.py
@@ -1,8 +1,3 @@
-"""
-Simple unit tests to confirm that ModelRegistryClient properly calls the registry Store methods
-and returns values when required.
-"""
-
 from unittest import mock
 from unittest.mock import ANY
 

--- a/tests/tracking/test_model_registry.py
+++ b/tests/tracking/test_model_registry.py
@@ -1,8 +1,3 @@
-"""
-Integration test which starts a local Tracking Server on an ephemeral port,
-and ensures we can use the tracking API to communicate with it.
-"""
-
 import time
 from pathlib import Path
 

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -1,8 +1,3 @@
-"""
-Integration test which starts a local Tracking Server on an ephemeral port,
-and ensures we can use the tracking API to communicate with it.
-"""
-
 import json
 import logging
 import math


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

Extend the `redundant-test-docstring` clint rule so it flags any module-level docstring in test files (single- or multi-line), not just single-line ones. Test files no longer carry boilerplate "Tests for X" / "Integration test which..." headers that the diff already shows.

- `dev/clint/src/clint/rules/redundant_test_docstring.py`: `check_module` now returns the docstring node for any module-level docstring; message reworded to drop the "Single-line" qualifier.
- 24 test files: boilerplate module docstrings removed. Five kept their non-obvious context as a short comment: benchmark run command, `test_docker_flavors.py` manual-run note, both gemini SDK URLs, and the skinny-client GH issue link (#21779).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

`dev/clint/tests/rules/test_redundant_test_docstring.py` has the previous `test_module_multiline_docstrings_are_allowed` inverted to `..._are_flagged` to match the new behavior. Verified `uv run clint .` is clean across the repo.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release