### PR TITLE
Surface stderr from `gh release view` in `publish_model_catalog.sh`

### DIFF
--- a/dev/publish_model_catalog.sh
+++ b/dev/publish_model_catalog.sh
@@ -41,7 +41,7 @@ fi
 echo "Files:       $file_count"
 
 # Create release if it doesn't exist
-if ! gh release view "$TAG" --repo "$REPO" &>/dev/null; then
+if ! gh release view "$TAG" --repo "$REPO" >/dev/null; then
   echo "Creating release $TAG ..."
   gh release create "$TAG" \
     --repo "$REPO" \


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

The existence check in `dev/publish_model_catalog.sh` used `&>/dev/null`, which discards both stdout and stderr from `gh release view`. When the call failed for any reason other than 404 (transient network, auth, 5xx), the script silently fell through to `gh release create` and surfaced a misleading `HTTP 422: Release.tag_name already exists` instead of the real cause.

Dropping the `&` keeps the noisy release-details stdout suppressed but lets stderr — connection errors, `HTTP 401`, `release not found`, etc. — reach the runner log so failures are diagnosable. Real example: https://github.com/mlflow/mlflow/actions/runs/26483316984/job/77985199428.

### How is this PR tested?

- [x] Manual tests

Verified locally:
- Existing release (`mlflow/mlflow:model-catalog/latest`) → exit 0, no output, `gh release create` skipped.
- Missing tag → `release not found` printed on stderr, `gh release create` invoked.
- Auth/network failures → `HTTP 401: Bad credentials` / `error connecting to ...` printed on stderr.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release