### PR TITLE
Add TypeScript types and API client for MCP server registry

### DIFF
--- a/mlflow/server/js/src/mcp-registry/api.ts
+++ b/mlflow/server/js/src/mcp-registry/api.ts
@@ -1,0 +1,251 @@
+import { fetchAPI, getAjaxUrl, HTTPMethods } from '../common/utils/FetchUtils';
+import type {
+  MCPServer,
+  MCPServerVersion,
+  MCPAccessBinding,
+  CreateMCPServerRequest,
+  UpdateMCPServerRequest,
+  CreateMCPServerVersionRequest,
+  UpdateMCPServerVersionRequest,
+  CreateMCPAccessBindingRequest,
+  UpdateMCPAccessBindingRequest,
+  SetMCPServerTagRequest,
+  SetMCPServerAliasRequest,
+  SearchMCPServersParams,
+  SearchMCPServerVersionsParams,
+  SearchMCPAccessBindingsParams,
+  SearchMCPServersResponse,
+  SearchMCPServerVersionsResponse,
+  SearchMCPAccessBindingsResponse,
+} from './types';
+
+const BASE_URL = 'ajax-api/3.0/mlflow/mcp-servers';
+
+function buildSearchParams(params: Record<string, string | number | string[] | undefined>): string {
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined) {
+      continue;
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        searchParams.append(key, item);
+      }
+    } else {
+      searchParams.append(key, String(value));
+    }
+  }
+  const queryString = searchParams.toString();
+  return queryString ? `?${queryString}` : '';
+}
+
+// MCP Server endpoints
+
+export const MCPRegistryApi = {
+  createMCPServer: (request: CreateMCPServerRequest): Promise<MCPServer> => {
+    return fetchAPI(getAjaxUrl(BASE_URL), {
+      method: HTTPMethods.POST,
+      body: request,
+    }) as Promise<MCPServer>;
+  },
+
+  searchMCPServers: (params: SearchMCPServersParams = {}): Promise<SearchMCPServersResponse> => {
+    const query = buildSearchParams({
+      filter_string: params.filter_string,
+      max_results: params.max_results,
+      order_by: params.order_by,
+      page_token: params.page_token,
+    });
+    return fetchAPI(getAjaxUrl(`${BASE_URL}${query}`)) as Promise<SearchMCPServersResponse>;
+  },
+
+  getMCPServer: (name: string): Promise<MCPServer> => {
+    return fetchAPI(getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}`)) as Promise<MCPServer>;
+  },
+
+  updateMCPServer: (name: string, request: UpdateMCPServerRequest): Promise<MCPServer> => {
+    return fetchAPI(getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}`), {
+      method: HTTPMethods.PATCH,
+      body: request,
+    }) as Promise<MCPServer>;
+  },
+
+  deleteMCPServer: (name: string): Promise<void> => {
+    return fetchAPI(getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}`), {
+      method: HTTPMethods.DELETE,
+    }) as Promise<void>;
+  },
+
+  // MCP Server Version endpoints
+
+  createMCPServerVersion: (name: string, request: CreateMCPServerVersionRequest): Promise<MCPServerVersion> => {
+    return fetchAPI(getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/versions`), {
+      method: HTTPMethods.POST,
+      body: request,
+    }) as Promise<MCPServerVersion>;
+  },
+
+  searchMCPServerVersions: (
+    name: string,
+    params: SearchMCPServerVersionsParams = {},
+  ): Promise<SearchMCPServerVersionsResponse> => {
+    const query = buildSearchParams({
+      filter_string: params.filter_string,
+      max_results: params.max_results,
+      order_by: params.order_by,
+      page_token: params.page_token,
+    });
+    return fetchAPI(
+      getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/versions${query}`),
+    ) as Promise<SearchMCPServerVersionsResponse>;
+  },
+
+  getMCPServerVersion: (name: string, version: string): Promise<MCPServerVersion> => {
+    return fetchAPI(
+      getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/versions/${encodeURIComponent(version)}`),
+    ) as Promise<MCPServerVersion>;
+  },
+
+  updateMCPServerVersion: (
+    name: string,
+    version: string,
+    request: UpdateMCPServerVersionRequest,
+  ): Promise<MCPServerVersion> => {
+    return fetchAPI(getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/versions/${encodeURIComponent(version)}`), {
+      method: HTTPMethods.PATCH,
+      body: request,
+    }) as Promise<MCPServerVersion>;
+  },
+
+  deleteMCPServerVersion: (name: string, version: string): Promise<void> => {
+    return fetchAPI(getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/versions/${encodeURIComponent(version)}`), {
+      method: HTTPMethods.DELETE,
+    }) as Promise<void>;
+  },
+
+  getLatestMCPServerVersion: (name: string): Promise<MCPServerVersion> => {
+    return fetchAPI(getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/versions/latest`)) as Promise<MCPServerVersion>;
+  },
+
+  // MCP Access Binding endpoints
+
+  createMCPAccessBinding: (name: string, request: CreateMCPAccessBindingRequest): Promise<MCPAccessBinding> => {
+    return fetchAPI(getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/bindings`), {
+      method: HTTPMethods.POST,
+      body: request,
+    }) as Promise<MCPAccessBinding>;
+  },
+
+  searchMCPAccessBindingsAll: (
+    params: SearchMCPAccessBindingsParams = {},
+  ): Promise<SearchMCPAccessBindingsResponse> => {
+    const query = buildSearchParams({
+      server_version: params.server_version,
+      server_alias: params.server_alias,
+      filter_string: params.filter_string,
+      max_results: params.max_results,
+      order_by: params.order_by,
+      page_token: params.page_token,
+    });
+    return fetchAPI(getAjaxUrl(`${BASE_URL}/bindings${query}`)) as Promise<SearchMCPAccessBindingsResponse>;
+  },
+
+  searchMCPAccessBindings: (
+    name: string,
+    params: SearchMCPAccessBindingsParams = {},
+  ): Promise<SearchMCPAccessBindingsResponse> => {
+    const query = buildSearchParams({
+      server_version: params.server_version,
+      server_alias: params.server_alias,
+      filter_string: params.filter_string,
+      max_results: params.max_results,
+      order_by: params.order_by,
+      page_token: params.page_token,
+    });
+    return fetchAPI(
+      getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/bindings${query}`),
+    ) as Promise<SearchMCPAccessBindingsResponse>;
+  },
+
+  getMCPAccessBinding: (name: string, bindingId: number): Promise<MCPAccessBinding> => {
+    return fetchAPI(
+      getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/bindings/${bindingId}`),
+    ) as Promise<MCPAccessBinding>;
+  },
+
+  updateMCPAccessBinding: (
+    name: string,
+    bindingId: number,
+    request: UpdateMCPAccessBindingRequest,
+  ): Promise<MCPAccessBinding> => {
+    return fetchAPI(getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/bindings/${bindingId}`), {
+      method: HTTPMethods.PATCH,
+      body: request,
+    }) as Promise<MCPAccessBinding>;
+  },
+
+  deleteMCPAccessBinding: (name: string, bindingId: number): Promise<void> => {
+    return fetchAPI(getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/bindings/${bindingId}`), {
+      method: HTTPMethods.DELETE,
+    }) as Promise<void>;
+  },
+
+  // MCP Server Tag endpoints
+
+  setMCPServerTag: (name: string, request: SetMCPServerTagRequest): Promise<void> => {
+    return fetchAPI(getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/tags`), {
+      method: HTTPMethods.POST,
+      body: request,
+    }) as Promise<void>;
+  },
+
+  deleteMCPServerTag: (name: string, key: string): Promise<void> => {
+    return fetchAPI(getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/tags/${encodeURIComponent(key)}`), {
+      method: HTTPMethods.DELETE,
+    }) as Promise<void>;
+  },
+
+  // MCP Server Version Tag endpoints
+
+  setMCPServerVersionTag: (name: string, version: string, request: SetMCPServerTagRequest): Promise<void> => {
+    return fetchAPI(
+      getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/versions/${encodeURIComponent(version)}/tags`),
+      {
+        method: HTTPMethods.POST,
+        body: request,
+      },
+    ) as Promise<void>;
+  },
+
+  deleteMCPServerVersionTag: (name: string, version: string, key: string): Promise<void> => {
+    return fetchAPI(
+      getAjaxUrl(
+        `${BASE_URL}/${encodeURIComponent(name)}/versions/${encodeURIComponent(version)}/tags/${encodeURIComponent(key)}`,
+      ),
+      {
+        method: HTTPMethods.DELETE,
+      },
+    ) as Promise<void>;
+  },
+
+  // MCP Server Alias endpoints
+
+  setMCPServerAlias: (name: string, request: SetMCPServerAliasRequest): Promise<void> => {
+    return fetchAPI(getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/aliases`), {
+      method: HTTPMethods.POST,
+      body: request,
+    }) as Promise<void>;
+  },
+
+  getMCPServerVersionByAlias: (name: string, alias: string): Promise<MCPServerVersion> => {
+    return fetchAPI(
+      getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/aliases/${encodeURIComponent(alias)}`),
+    ) as Promise<MCPServerVersion>;
+  },
+
+  deleteMCPServerAlias: (name: string, alias: string): Promise<void> => {
+    return fetchAPI(getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/aliases/${encodeURIComponent(alias)}`), {
+      method: HTTPMethods.DELETE,
+    }) as Promise<void>;
+  },
+};

--- a/mlflow/server/js/src/mcp-registry/types.ts
+++ b/mlflow/server/js/src/mcp-registry/types.ts
@@ -1,0 +1,215 @@
+export type MCPStatus = 'draft' | 'active' | 'deprecated' | 'deleted';
+
+export type MCPRemoteTransportType = 'streamable-http' | 'sse';
+
+// Entity types
+
+export interface MCPTool {
+  name: string;
+  title?: string;
+  description?: string;
+  inputSchema?: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
+  annotations?: Record<string, unknown>;
+  icons?: MCPIcon[];
+  execution?: Record<string, unknown>;
+}
+
+export interface MCPIcon {
+  src: string;
+  sizes?: string;
+  mimeType?: string;
+  theme?: string;
+}
+
+export interface MCPAccessBindingSummary {
+  binding_id: number;
+  endpoint_url: string;
+  transport_type: MCPRemoteTransportType;
+  server_version?: string;
+  server_alias?: string;
+}
+
+export interface MCPServerAlias {
+  alias: string;
+  version: string;
+}
+
+export interface MCPServer {
+  name: string;
+  display_name?: string;
+  description?: string;
+  icons?: MCPIcon[];
+  status?: MCPStatus;
+  access_bindings: MCPAccessBindingSummary[];
+  latest_version?: string;
+  aliases: MCPServerAlias[];
+  tags: Record<string, string>;
+  created_by?: string;
+  last_updated_by?: string;
+  creation_timestamp?: number;
+  last_updated_timestamp?: number;
+}
+
+export interface MCPServerVersion {
+  name: string;
+  version: string;
+  server_json: ServerJSONPayload;
+  display_name?: string;
+  status: MCPStatus;
+  tools?: MCPTool[];
+  aliases: string[];
+  tags: Record<string, string>;
+  source?: string;
+  created_by?: string;
+  last_updated_by?: string;
+  creation_timestamp?: number;
+  last_updated_timestamp?: number;
+}
+
+export interface MCPAccessBinding {
+  binding_id: number;
+  server_name: string;
+  endpoint_url: string;
+  transport_type: MCPRemoteTransportType;
+  tools?: MCPTool[];
+  server_version?: string;
+  server_alias?: string;
+  created_by?: string;
+  last_updated_by?: string;
+  creation_timestamp?: number;
+  last_updated_timestamp?: number;
+}
+
+// ServerJSON payload types use camelCase field names to match the MCP server.json specification
+
+export interface ServerJSONEnvironmentVariable {
+  name: string;
+  description?: string;
+  isRequired?: boolean;
+  isSecret?: boolean;
+}
+
+export interface ServerJSONPackage {
+  registryType: string;
+  identifier: string;
+  transport: string;
+  registryBaseUrl?: string;
+  version?: string;
+  environmentVariables?: ServerJSONEnvironmentVariable[];
+  [key: string]: unknown;
+}
+
+export interface ServerJSONRemote {
+  type: string;
+  url: string;
+  [key: string]: unknown;
+}
+
+export interface ServerJSONPayload {
+  name: string;
+  version: string;
+  title?: string;
+  description?: string;
+  packages?: ServerJSONPackage[];
+  remotes?: ServerJSONRemote[];
+  repository?: string;
+  websiteUrl?: string;
+  _meta?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+// Request types
+
+export interface CreateMCPServerRequest {
+  name: string;
+  description?: string;
+  icons?: MCPIcon[];
+}
+
+export interface UpdateMCPServerRequest {
+  display_name?: string | null;
+  description?: string | null;
+  icons?: MCPIcon[] | null;
+  latest_version?: string | null;
+}
+
+export interface CreateMCPServerVersionRequest {
+  server_json: ServerJSONPayload;
+  display_name?: string;
+  status?: MCPStatus;
+  source?: string;
+  tools?: MCPTool[];
+}
+
+export interface UpdateMCPServerVersionRequest {
+  display_name?: string | null;
+  status?: MCPStatus | null;
+  tools?: MCPTool[] | null;
+}
+
+export interface CreateMCPAccessBindingRequest {
+  server_version?: string;
+  server_alias?: string;
+  endpoint_url: string;
+  transport_type?: MCPRemoteTransportType;
+}
+
+export interface UpdateMCPAccessBindingRequest {
+  server_version?: string | null;
+  server_alias?: string | null;
+  endpoint_url?: string | null;
+  transport_type?: MCPRemoteTransportType | null;
+}
+
+export interface SetMCPServerTagRequest {
+  key: string;
+  value: string;
+}
+
+export interface SetMCPServerAliasRequest {
+  alias: string;
+  version: string;
+}
+
+// Search parameters
+
+export interface SearchMCPServersParams {
+  filter_string?: string;
+  max_results?: number;
+  order_by?: string[];
+  page_token?: string;
+}
+
+export interface SearchMCPServerVersionsParams {
+  filter_string?: string;
+  max_results?: number;
+  order_by?: string[];
+  page_token?: string;
+}
+
+export interface SearchMCPAccessBindingsParams {
+  server_version?: string;
+  server_alias?: string;
+  filter_string?: string;
+  max_results?: number;
+  order_by?: string[];
+  page_token?: string;
+}
+
+// Response types
+
+export interface SearchMCPServersResponse {
+  mcp_servers: MCPServer[];
+  next_page_token?: string;
+}
+
+export interface SearchMCPServerVersionsResponse {
+  mcp_server_versions: MCPServerVersion[];
+  next_page_token?: string;
+}
+
+export interface SearchMCPAccessBindingsResponse {
+  mcp_access_bindings: MCPAccessBinding[];
+  next_page_token?: string;
+}


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23695, #23696

### What changes are proposed in this pull request?

Adds the frontend TypeScript type definitions and API client layer for the MCP server registry, building on top of the backend work in #23695 and #23696.

**`mcp-registry/types.ts`** — TypeScript interfaces for all MCP registry entities:
- Entity types: `MCPServer`, `MCPServerVersion`, `MCPAccessBinding`, `MCPAccessBindingSummary`, `MCPServerAlias`, `MCPTool`, `MCPIcon`
- Enums: `MCPStatus`, `MCPRemoteTransportType`
- ServerJSON types: `ServerJSONPayload`, `ServerJSONPackage`, `ServerJSONRemote`, `ServerJSONEnvironmentVariable`
- Request/response types matching the Pydantic models in `mcp_server_api.py`
- Search parameter types with `filter_string`, `max_results`, `order_by`, `page_token`
- Update request fields use `T | null` to distinguish "omit" (don't touch) from "null" (clear the field)

**`mcp-registry/api.ts`** — `MCPRegistryApi` object covering all 24 REST endpoints:
- 5 server CRUD endpoints
- 6 version endpoints (CRUD + `getLatestMCPServerVersion`)
- 6 access binding endpoints (CRUD + workspace-wide search)
- 4 tag endpoints (server + version level)
- 3 alias endpoints (`set`, `getMCPServerVersionByAlias`, `delete`)

Follows the `webhooksApi.ts` pattern (modern `fetchAPI` + `getAjaxUrl` + `HTTPMethods`), with a shared `buildSearchParams` helper to reduce duplication across the three search endpoints.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Verified all files pass `yarn lint`, `yarn prettier:check`, and `yarn type-check`. Types and API signatures were cross-checked against the Pydantic models and FastAPI route handlers in #23695.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release