### PR TITLE
Fix `mlflow db upgrade` on a fresh database

### DIFF
--- a/mlflow/db.py
+++ b/mlflow/db.py
@@ -24,7 +24,10 @@ def upgrade(url):
     import mlflow.store.db.utils
 
     engine = mlflow.store.db.utils.create_sqlalchemy_engine_with_retry(url)
-    mlflow.store.db.utils._upgrade_db(engine)
+    if mlflow.store.db.utils._all_tables_exist(engine):
+        mlflow.store.db.utils._upgrade_db(engine)
+    else:
+        mlflow.store.db.utils._initialize_tables(engine)
 
 
 @commands.command("migrate-to-default-workspace")

--- a/mlflow/db.py
+++ b/mlflow/db.py
@@ -24,10 +24,10 @@ def upgrade(url):
     import mlflow.store.db.utils
 
     engine = mlflow.store.db.utils.create_sqlalchemy_engine_with_retry(url)
-    if mlflow.store.db.utils._all_tables_exist(engine):
-        mlflow.store.db.utils._upgrade_db(engine)
-    else:
+    if mlflow.store.db.utils._is_empty_database(engine):
         mlflow.store.db.utils._initialize_tables(engine)
+    else:
+        mlflow.store.db.utils._upgrade_db(engine)
 
 
 @commands.command("migrate-to-default-workspace")

--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -77,6 +77,14 @@ def _all_tables_exist(engine):
     return expected_tables.issubset(actual_tables)
 
 
+def _is_empty_database(engine):
+    # Alembic's bookkeeping table is ignored so a previously failed upgrade attempt
+    # doesn't make the DB look populated.
+    return not any(
+        not t.startswith("alembic_") for t in sqlalchemy.inspect(engine).get_table_names()
+    )
+
+
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
     InitialBase.metadata.create_all(engine)

--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -80,9 +80,7 @@ def _all_tables_exist(engine):
 def _is_empty_database(engine):
     # Alembic's bookkeeping table is ignored so a previously failed upgrade attempt
     # doesn't make the DB look populated.
-    return not any(
-        not t.startswith("alembic_") for t in sqlalchemy.inspect(engine).get_table_names()
-    )
+    return all(t.startswith("alembic_") for t in sqlalchemy.inspect(engine).get_table_names())
 
 
 def _initialize_tables(engine):

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_schema.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_schema.py
@@ -8,6 +8,7 @@ from alembic import command
 from alembic.autogenerate import compare_metadata
 from alembic.migration import MigrationContext
 from alembic.script import ScriptDirectory
+from click.testing import CliRunner
 
 import mlflow.db
 
@@ -97,6 +98,20 @@ def test_db_upgrade_initializes_fresh_database(tmp_path, expected_schema_file, d
     generated_schema_file = tmp_path.joinpath("generated-schema.sql")
     dump_db_schema(db_url, generated_schema_file)
     _assert_schema_files_equal(generated_schema_file, expected_schema_file)
+
+
+def test_db_upgrade_does_not_bootstrap_non_empty_database(db_url):
+    # Guard against silently creating MLflow tables in a foreign DB. If any
+    # non-alembic table already exists, we should attempt migrations only
+    # (which surfaces the missing-table error) rather than bootstrap.
+    engine = sqlalchemy.create_engine(db_url)
+    with engine.begin() as conn:
+        conn.execute(sqlalchemy.text("CREATE TABLE foreign_table (id INTEGER PRIMARY KEY)"))
+    res = CliRunner().invoke(mlflow.db.commands, ["upgrade", db_url])
+    assert res.exit_code != 0
+    inspector = sqlalchemy.inspect(engine)
+    assert "foreign_table" in inspector.get_table_names()
+    assert "experiments" not in inspector.get_table_names()
 
 
 def test_sqlalchemy_store_detects_schema_mismatch(db_url):

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_schema.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_schema.py
@@ -92,6 +92,13 @@ def test_running_migrations_generates_expected_schema(tmp_path, expected_schema_
     _assert_schema_files_equal(generated_schema_file, expected_schema_file)
 
 
+def test_db_upgrade_initializes_fresh_database(tmp_path, expected_schema_file, db_url):
+    invoke_cli_runner(mlflow.db.commands, ["upgrade", db_url])
+    generated_schema_file = tmp_path.joinpath("generated-schema.sql")
+    dump_db_schema(db_url, generated_schema_file)
+    _assert_schema_files_equal(generated_schema_file, expected_schema_file)
+
+
 def test_sqlalchemy_store_detects_schema_mismatch(db_url):
     def _assert_invalid_schema(engine):
         with pytest.raises(MlflowException, match="Detected out-of-date database schema."):


### PR DESCRIPTION
### Related Issues/PRs

Closes #23751

### What changes are proposed in this pull request?

`mlflow db upgrade <url>` failed when pointed at an empty database. The first alembic revision (`451aebb31d03_add_metric_step`) does `ALTER TABLE metrics`, which assumes the base schema already exists — it's normally created outside alembic by `InitialBase.metadata.create_all`, which only runs when an MLflow server initializes the store.

Reproduction (from #23751, also works on macOS):

```
mkdir mlflow_server && cd mlflow_server
uv init . --python 3.14
uv add mlflow
uv run mlflow db upgrade sqlite:///mlflow.db
# sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) no such table: metrics
# [SQL: ALTER TABLE metrics ADD COLUMN step BIGINT DEFAULT '0' NOT NULL]
```

Fix: when no tables exist, run `_initialize_tables` (which creates the base schema and runs migrations) instead of `_upgrade_db` alone. Same behavior `mlflow server` already does on startup via `_safe_initialize_tables`.

### How is this PR tested?

- [x] New unit/integration tests

Added `test_db_upgrade_initializes_fresh_database` in `tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_schema.py`, which runs the CLI against an empty SQLite URL and asserts the resulting schema matches the latest snapshot.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. `mlflow db upgrade` now bootstraps an empty database instead of failing with "no such table: metrics".

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release