### PR TITLE
Propagate caller `ContextVars` through async trace export

### DIFF
--- a/mlflow/tracing/export/async_export_queue.py
+++ b/mlflow/tracing/export/async_export_queue.py
@@ -1,4 +1,5 @@
 import atexit
+import contextvars
 import logging
 import threading
 import time
@@ -23,11 +24,18 @@ class Task:
     handler: Callable[..., Any]
     args: Sequence[Any]
     error_msg: str = ""
+    # Caller's ContextVar snapshot. ThreadPoolExecutor does not propagate ContextVars to
+    # worker threads, so handlers that depend on request-scoped state (e.g. the active
+    # workspace set by the server middleware) must run inside this captured context.
+    context: contextvars.Context | None = None
 
     def handle(self) -> None:
         """Handle the task execution. This method must not raise any exception."""
         try:
-            self.handler(*self.args)
+            if self.context is not None:
+                self.context.run(self.handler, *self.args)
+            else:
+                self.handler(*self.args)
         except Exception as e:
             _logger.warning(
                 f"{self.error_msg} Error: {e}.",
@@ -53,6 +61,12 @@ class AsyncTraceExportQueue:
 
     def put(self, task: Task):
         """Put a new task to the queue for processing."""
+        # Snapshot the caller's ContextVars so handlers run with the same
+        # request-scoped state (e.g. active workspace) on the worker thread.
+        # Honor any context already attached by the caller (e.g. captured at
+        # the originating thread by the span exporter).
+        if task.context is None:
+            task.context = contextvars.copy_context()
         if not self.is_active():
             if self._stop_event.is_set():
                 # Queue was terminated via flush(terminate=True); _stop_event will never be

--- a/mlflow/tracing/export/inference_table.py
+++ b/mlflow/tracing/export/inference_table.py
@@ -114,6 +114,7 @@ class InferenceTableSpanExporter(SpanExporter):
                             handler=self._log_trace_to_mlflow_backend,
                             args=(trace, manager_trace.prompts),
                             error_msg=f"Failed to log trace {trace.info.trace_id}.",
+                            context=manager_trace.context,
                         )
                     )
                 except Exception as e:

--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -1,6 +1,8 @@
+import contextvars
 import logging
 import threading
 from collections import defaultdict
+from dataclasses import dataclass, field
 from typing import Sequence
 
 from opentelemetry.sdk.trace import ReadableSpan
@@ -29,6 +31,17 @@ from mlflow.utils.databricks_utils import is_in_databricks_notebook
 from mlflow.utils.uri import is_databricks_uri
 
 _logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _SpanExportGroup:
+    """Spans bound for a single experiment, paired with the originating context."""
+
+    spans: list[Span] = field(default_factory=list)
+    # ContextVar snapshot from the originating thread of the first trace in the group.
+    # Workspaces partition experiment IDs, so all traces sharing an experiment_id share a
+    # workspace and any one of their captured contexts is equivalent for export-time use.
+    context: contextvars.Context | None = None
 
 
 class MlflowV3SpanExporter(SpanExporter):
@@ -87,21 +100,22 @@ class MlflowV3SpanExporter(SpanExporter):
             return
 
         mlflow_spans_by_experiment = self._collect_mlflow_spans_for_export(spans)
-        for experiment_id, spans_to_log in mlflow_spans_by_experiment.items():
+        for experiment_id, group in mlflow_spans_by_experiment.items():
             if self._should_log_async():
                 self._async_queue.put(
                     task=Task(
                         handler=self._log_spans,
-                        args=(experiment_id, spans_to_log),
+                        args=(experiment_id, group.spans),
                         error_msg="Failed to log spans to the trace server.",
+                        context=group.context,
                     )
                 )
             else:
-                self._log_spans(experiment_id, spans_to_log)
+                self._log_spans(experiment_id, group.spans)
 
     def _collect_mlflow_spans_for_export(
         self, spans: Sequence[ReadableSpan]
-    ) -> dict[str, list[Span]]:
+    ) -> dict[str, _SpanExportGroup]:
         """
         Collect MLflow spans from ReadableSpans for export, grouped by experiment_id.
 
@@ -113,10 +127,11 @@ class MlflowV3SpanExporter(SpanExporter):
             spans: Sequence of ReadableSpan objects.
 
         Returns:
-            Dictionary mapping experiment_id to list of MLflow Span objects.
+            Dictionary mapping experiment_id to an export group holding the spans and the
+            originating thread's captured context for that experiment.
         """
         manager = InMemoryTraceManager.get_instance()
-        spans_by_experiment = defaultdict(list)
+        groups: dict[str, _SpanExportGroup] = defaultdict(_SpanExportGroup)
 
         for span in spans:
             mlflow_trace_id = manager.get_mlflow_trace_id_from_otel_id(span.context.trace_id)
@@ -128,17 +143,23 @@ class MlflowV3SpanExporter(SpanExporter):
                 continue
             # Get experiment_id from trace info (resolved at on_start time in the
             # originating thread) to survive BatchSpanProcessor thread hops.
+            captured_context: contextvars.Context | None = None
             with manager.get_trace(mlflow_trace_id) as trace:
                 try:
                     experiment_id = trace.info.experiment_id if trace else None
                 except AttributeError:
                     # Remote/distributed traces may have trace_location=None
                     experiment_id = None
+                if trace is not None:
+                    captured_context = trace.context
             if experiment_id is None:
                 experiment_id = get_experiment_id_for_trace(span)
-            spans_by_experiment[experiment_id].append(mlflow_span)
+            group = groups[experiment_id]
+            group.spans.append(mlflow_span)
+            if group.context is None:
+                group.context = captured_context
 
-        return spans_by_experiment
+        return groups
 
     def _export_traces(self, spans: Sequence[ReadableSpan]) -> None:
         """
@@ -206,6 +227,7 @@ class MlflowV3SpanExporter(SpanExporter):
                     handler=self._log_trace,
                     args=(trace, manager_trace.prompts),
                     error_msg="Failed to log trace to the trace server.",
+                    context=manager_trace.context,
                 )
             )
         else:

--- a/mlflow/tracing/processor/base_mlflow.py
+++ b/mlflow/tracing/processor/base_mlflow.py
@@ -1,3 +1,4 @@
+import contextvars
 import json
 import logging
 import threading
@@ -197,6 +198,13 @@ class BaseMlflowSpanProcessor(OtelMetricsMixin, SimpleSpanProcessor):
             if trace_info is None:
                 return
             trace_id = trace_info.trace_id
+            # Snapshot the originating thread's ContextVars (e.g. server-resolved
+            # workspace). Export tasks dispatched via BatchSpanProcessor and
+            # AsyncTraceExportQueue run on worker threads where these would otherwise
+            # be lost.
+            with InMemoryTraceManager.get_instance().get_trace(trace_id) as trace:
+                if trace is not None:
+                    trace.context = contextvars.copy_context()
 
         InMemoryTraceManager.get_instance().register_span(create_mlflow_span(span, trace_id))
 

--- a/mlflow/tracing/trace_manager.py
+++ b/mlflow/tracing/trace_manager.py
@@ -1,4 +1,5 @@
 import contextlib
+import contextvars
 import logging
 import threading
 from dataclasses import dataclass, field
@@ -23,6 +24,10 @@ class _Trace:
     span_dict: dict[str, LiveSpan] = field(default_factory=dict)
     prompts: list[PromptVersion] = field(default_factory=list)
     is_remote_trace: bool = False
+    # ContextVar snapshot from the originating thread (set when the root span starts).
+    # Used to propagate request-scoped state (e.g. active workspace) across the
+    # BatchSpanProcessor and AsyncTraceExportQueue worker-thread hops.
+    context: contextvars.Context | None = None
 
     def to_mlflow_trace(self) -> Trace:
         trace_data = TraceData()
@@ -49,6 +54,9 @@ class ManagerTrace:
     trace: Trace
     prompts: Sequence[PromptVersion]
     is_remote_trace: bool = False
+    # ContextVar snapshot from the originating thread, forwarded from the in-memory
+    # _Trace at pop_trace() time so exporters can restore it on worker threads.
+    context: contextvars.Context | None = None
 
 
 class InMemoryTraceManager:
@@ -199,6 +207,7 @@ class InMemoryTraceManager:
                 trace=internal_trace.to_mlflow_trace(),
                 prompts=internal_trace.prompts,
                 is_remote_trace=internal_trace.is_remote_trace,
+                context=internal_trace.context,
             )
 
     def _check_timeout_update(self):

--- a/tests/tracing/export/test_async_export_queue.py
+++ b/tests/tracing/export/test_async_export_queue.py
@@ -1,3 +1,4 @@
+import contextvars
 import multiprocessing
 import threading
 import time
@@ -103,6 +104,49 @@ def test_put_after_terminate_executes_synchronously():
     queue.put(Task(handler=calls.append, args=(2,)))
 
     assert calls == [1, 2]
+
+
+def test_put_propagates_caller_contextvars_to_worker():
+    # ThreadPoolExecutor does not propagate ContextVars to worker threads.
+    # AsyncTraceExportQueue.put() must snapshot the caller's context so handlers
+    # see request-scoped state such as the active workspace set by the server
+    # middleware (regression test for https://github.com/mlflow/mlflow/issues/23748).
+    test_var: contextvars.ContextVar[str | None] = contextvars.ContextVar("test_var", default=None)
+    test_var.set("caller-value")
+
+    seen_in_worker: dict[str, str | None] = {}
+
+    def handler():
+        seen_in_worker["value"] = test_var.get()
+
+    queue = AsyncTraceExportQueue()
+    queue.put(Task(handler=handler, args=()))
+    queue.flush(terminate=True)
+
+    assert seen_in_worker["value"] == "caller-value"
+
+
+def test_put_honors_explicitly_attached_context():
+    test_var: contextvars.ContextVar[str | None] = contextvars.ContextVar("test_var", default=None)
+
+    def captured_context_factory() -> contextvars.Context:
+        ctx = contextvars.copy_context()
+        ctx.run(test_var.set, "from-explicit-context")
+        return ctx
+
+    explicit_context = captured_context_factory()
+    test_var.set("caller-thread-value")
+
+    seen_in_worker: dict[str, str | None] = {}
+
+    def handler():
+        seen_in_worker["value"] = test_var.get()
+
+    queue = AsyncTraceExportQueue()
+    queue.put(Task(handler=handler, args=(), context=explicit_context))
+    queue.flush(terminate=True)
+
+    assert seen_in_worker["value"] == "from-explicit-context"
 
 
 def test_async_queue_drop_task_when_full(monkeypatch):

--- a/tests/tracing/export/test_mlflow_v3_exporter.py
+++ b/tests/tracing/export/test_mlflow_v3_exporter.py
@@ -21,6 +21,10 @@ from mlflow.tracing.export.mlflow_v3 import MlflowV3SpanExporter
 from mlflow.tracing.provider import _get_trace_exporter
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracing.utils import generate_trace_id_v3
+from mlflow.utils.workspace_context import (
+    ServerWorkspaceContext,
+    get_request_workspace,
+)
 
 from tests.tracing.helper import create_mock_otel_span, create_test_trace_info
 
@@ -189,6 +193,42 @@ def test_export_with_batch_span_processor(monkeypatch):
     assert trace_info is not None
     assert trace_info.trace_id is not None
     assert mlflow.get_last_active_trace_id() is not None
+
+
+@pytest.mark.timeout(20)
+@pytest.mark.parametrize("use_batch_processor", ["true", "false"], ids=["bsp", "no-bsp"])
+def test_export_propagates_workspace_context_through_async_pipeline(
+    use_batch_processor, monkeypatch
+):
+    # Regression test for https://github.com/mlflow/mlflow/issues/23748: when the
+    # workspace ContextVar is set in the originating thread (by the server middleware),
+    # async trace export must restore it on the worker thread that calls the store.
+    monkeypatch.setenv("DATABRICKS_HOST", "dummy-host")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "dummy-token")
+    monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_TRACE_LOGGING", "true")
+    monkeypatch.setenv("MLFLOW_USE_BATCH_SPAN_PROCESSOR", use_batch_processor)
+
+    mlflow.set_tracking_uri("databricks")
+    mlflow.tracing.set_destination(MlflowExperimentLocation(experiment_id=_EXPERIMENT_ID))
+
+    workspace_seen_in_worker: list[str | None] = []
+
+    def fake_log_trace(self, trace, prompts):
+        workspace_seen_in_worker.append(get_request_workspace())
+
+    with mock.patch(
+        "mlflow.tracing.export.mlflow_v3.MlflowV3SpanExporter._log_trace",
+        new=fake_log_trace,
+    ):
+        with ServerWorkspaceContext("tenant-a"):
+            assert get_request_workspace() == "tenant-a"
+            _predict("hello")
+        # Exit the ContextVar scope before flushing so we prove the worker thread
+        # restores the snapshot rather than reading a still-live caller value.
+        assert get_request_workspace() is None
+        mlflow.flush_trace_async_logging(terminate=True)
+
+    assert workspace_seen_in_worker == ["tenant-a"]
 
 
 def test_async_logging_disabled_in_databricks_notebook(monkeypatch):


### PR DESCRIPTION
### Related Issues/PRs

Closes #23748

### What changes are proposed in this pull request?

When workspaces are enabled (`--enable-workspaces`) and async trace logging is on (the default), gateway and other traces fail to export with `Active workspace is required...`. The workspace `ContextVar` set by the FastAPI middleware on the request thread is dropped at two thread hops: the `BatchSpanProcessor` worker and the `AsyncTraceExportQueue`'s `ThreadPoolExecutor`. By the time `WorkspaceAwareSqlAlchemyStore._get_active_workspace()` runs, the context is gone.

This PR captures `contextvars.copy_context()` on the in-memory `_Trace` at `on_start` (still in the originating thread), forwards it through `ManagerTrace` and the export `Task`, and runs the handler via `context.run()` on the worker. `AsyncTraceExportQueue.put()` also defaults to capturing the caller's context when a `Task` arrives without one, so direct uses of the queue keep working with no API change.

Generalizes the existing experiment_id workaround in `_collect_mlflow_spans_for_export` to all request-scoped ContextVars.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix a bug where multi-tenant MLflow deployments with `--enable-workspaces` lost gateway and async traces because the active workspace was not propagated to the async export worker threads.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)