### PR TITLE
Allow passing kwargs to SentenceTransformer in `load_model` and `pyfunc.load_model`

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1076,6 +1076,7 @@ def load_model(
     suppress_warnings: bool = False,
     dst_path: str | None = None,
     model_config: str | Path | dict[str, Any] | None = None,
+    **kwargs: Any,
 ) -> PyFuncModel:
     """
     Load a model stored in Python function format.
@@ -1108,6 +1109,8 @@ def load_model(
 
             .. Note:: Experimental: This parameter may change or be removed in a future
                 release without warning.
+        kwargs: Additional keyword arguments passed directly to the flavor's ``_load_pyfunc``
+            function. Supported kwargs depend on the model flavor.
     """
 
     lineage_header_info = None
@@ -1167,9 +1170,11 @@ def load_model(
 
     try:
         if model_config:
-            model_impl = importlib.import_module(conf[MAIN])._load_pyfunc(data_path, model_config)
+            model_impl = importlib.import_module(conf[MAIN])._load_pyfunc(
+                data_path, model_config, **kwargs
+            )
         else:
-            model_impl = importlib.import_module(conf[MAIN])._load_pyfunc(data_path)
+            model_impl = importlib.import_module(conf[MAIN])._load_pyfunc(data_path, **kwargs)
     except ModuleNotFoundError as e:
         # This error message is particularly for the case when the error is caused by module
         # "databricks.feature_store.mlflow_model". But depending on the environment, the offending

--- a/mlflow/sentence_transformers/__init__.py
+++ b/mlflow/sentence_transformers/__init__.py
@@ -443,16 +443,19 @@ def _get_load_kwargs():
     return load_kwargs
 
 
-def _load_pyfunc(path, model_config: dict[str, Any] | None = None):
+def _load_pyfunc(path, model_config: dict[str, Any] | None = None, **kwargs: Any):
     """
     Load PyFunc implementation for SentenceTransformer. Called by ``pyfunc.load_model``.
 
     Args:
         path: Local filesystem path to the MLflow Model with the ``sentence_transformer`` flavor.
+        model_config: Model configuration dictionary.
+        kwargs: Additional keyword arguments passed directly to ``SentenceTransformer``.
+            These take precedence over the default load kwargs.
     """
     import sentence_transformers
 
-    load_kwargs = _get_load_kwargs()
+    load_kwargs = {**_get_load_kwargs(), **kwargs}
     model = sentence_transformers.SentenceTransformer(path, **load_kwargs)
     model_config = model_config or {}
     task = model_config.get("task", None)
@@ -460,7 +463,7 @@ def _load_pyfunc(path, model_config: dict[str, Any] | None = None):
 
 
 @docstring_version_compatibility_warning(integration_name=FLAVOR_NAME)
-def load_model(model_uri: str, dst_path: str | None = None):
+def load_model(model_uri: str, dst_path: str | None = None, **kwargs: Any):
     """
     Load a ``sentence_transformers`` object from a local file or a run.
 
@@ -479,6 +482,8 @@ def load_model(model_uri: str, dst_path: str | None = None):
         dst_path: The local filesystem path to utilize for downloading the model artifact.
             This directory must already exist if provided. If unspecified, a local output
             path will be created.
+        kwargs: Additional keyword arguments passed directly to ``SentenceTransformer``.
+            These take precedence over the default load kwargs.
 
     Returns:
         A ``sentence_transformers`` model instance
@@ -496,7 +501,7 @@ def load_model(model_uri: str, dst_path: str | None = None):
 
     _add_code_from_conf_to_system_path(local_model_path, flavor_config)
 
-    load_kwargs = _get_load_kwargs()
+    load_kwargs = {**_get_load_kwargs(), **kwargs}
     return sentence_transformers.SentenceTransformer(str(local_model_dir), **load_kwargs)
 
 

--- a/tests/sentence_transformers/test_sentence_transformers_model_export.py
+++ b/tests/sentence_transformers/test_sentence_transformers_model_export.py
@@ -68,6 +68,36 @@ def test_model_save_and_load(model_path, basic_model):
     assert all(len(x) == 384 for x in encoded_multi)
 
 
+def test_load_model_with_kwargs(model_path, basic_model):
+    mlflow.sentence_transformers.save_model(model=basic_model, path=model_path)
+    loaded_model = mlflow.sentence_transformers.load_model(model_path, truncate_dim=42)
+    encoded = loaded_model.encode("test sentence")
+    assert len(encoded) == 42
+
+
+def test_load_model_kwargs_override_defaults(model_path, basic_model):
+    mlflow.sentence_transformers.save_model(model=basic_model, path=model_path)
+    with pytest.raises(TypeError, match="unexpected keyword argument"):
+        mlflow.sentence_transformers.load_model(model_path, i_dont_exist="foo")
+
+
+def test_pyfunc_load_model_with_kwargs(basic_model, model_path):
+    import mlflow.pyfunc as pyfunc
+
+    mlflow.sentence_transformers.save_model(basic_model, model_path)
+    loaded_pyfunc = pyfunc.load_model(model_uri=model_path, truncate_dim=42)
+    embedding = loaded_pyfunc.predict("hello world")
+    assert embedding.shape == (1, 42)
+
+
+def test_pyfunc_load_model_kwargs_override_defaults(basic_model, model_path):
+    import mlflow.pyfunc as pyfunc
+
+    mlflow.sentence_transformers.save_model(basic_model, model_path)
+    with pytest.raises(TypeError, match="unexpected keyword argument"):
+        pyfunc.load_model(model_uri=model_path, i_dont_exist="foo")
+
+
 @pytest.mark.skipif(
     Version(sentence_transformers.__version__) < Version("2.4.0"),
     reason="`trust_remote_code` is not supported in Sentence Transformers < 2.3.0 "

--- a/tests/sentence_transformers/test_sentence_transformers_model_export.py
+++ b/tests/sentence_transformers/test_sentence_transformers_model_export.py
@@ -75,24 +75,34 @@ def test_load_model_with_kwargs(model_path, basic_model):
     assert len(encoded) == 42
 
 
-def test_load_model_kwargs_override_defaults(model_path, basic_model):
+def test_load_model_rejects_unknown_kwargs(model_path, basic_model):
     mlflow.sentence_transformers.save_model(model=basic_model, path=model_path)
     with pytest.raises(TypeError, match="unexpected keyword argument"):
         mlflow.sentence_transformers.load_model(model_path, i_dont_exist="foo")
 
 
-def test_pyfunc_load_model_with_kwargs(basic_model, model_path):
-    import mlflow.pyfunc as pyfunc
+@pytest.mark.skipif(
+    Version(sentence_transformers.__version__) < Version("2.3.0"),
+    reason="`trust_remote_code` is not supported before Sentence Transformers 2.3.0",
+)
+def test_load_model_kwargs_take_precedence_over_defaults(model_path, basic_model):
+    mlflow.sentence_transformers.save_model(model=basic_model, path=model_path)
+    with mock.patch(
+        "sentence_transformers.SentenceTransformer", wraps=SentenceTransformer
+    ) as mock_st:
+        mlflow.sentence_transformers.load_model(model_path, trust_remote_code=False)
+        _, call_kwargs = mock_st.call_args
+        assert call_kwargs["trust_remote_code"] is False
 
+
+def test_pyfunc_load_model_with_kwargs(basic_model, model_path):
     mlflow.sentence_transformers.save_model(basic_model, model_path)
     loaded_pyfunc = pyfunc.load_model(model_uri=model_path, truncate_dim=42)
     embedding = loaded_pyfunc.predict("hello world")
     assert embedding.shape == (1, 42)
 
 
-def test_pyfunc_load_model_kwargs_override_defaults(basic_model, model_path):
-    import mlflow.pyfunc as pyfunc
-
+def test_pyfunc_load_model_rejects_unknown_kwargs(basic_model, model_path):
     mlflow.sentence_transformers.save_model(basic_model, model_path)
     with pytest.raises(TypeError, match="unexpected keyword argument"):
         pyfunc.load_model(model_uri=model_path, i_dont_exist="foo")


### PR DESCRIPTION
### Related Issues/PRs

Closes #19705

### What changes are proposed in this pull request?

`mlflow.sentence_transformers.load_model` and `mlflow.pyfunc.load_model` had no way to forward keyword arguments to the underlying `SentenceTransformer` constructor. Callers could not use constructor parameters like `truncate_dim` (output dimension truncation) without monkey-patching or reloading the model manually.

This PR adds `**kwargs` to `mlflow.sentence_transformers.load_model`, `mlflow.sentence_transformers._load_pyfunc`, and `mlflow.pyfunc.load_model`. User-supplied kwargs are merged with the default load kwargs (`trust_remote_code`) so user values take precedence over defaults.

### How is this PR tested?

- [x] New unit/integration tests

Four tests cover the new paths:
- `test_load_model_with_kwargs` — `truncate_dim` forwarded via `load_model`
- `test_load_model_kwargs_override_defaults` — unknown kwarg raises `TypeError`
- `test_pyfunc_load_model_with_kwargs` — `truncate_dim` forwarded via `pyfunc.load_model`
- `test_pyfunc_load_model_kwargs_override_defaults` — unknown kwarg raises `TypeError` via pyfunc

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. `mlflow.sentence_transformers.load_model` and `mlflow.pyfunc.load_model` now accept extra keyword arguments that are forwarded to the `SentenceTransformer` constructor.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release