### PR TITLE
Coerce float `step` values to int in `Metric` constructor

### DIFF
--- a/mlflow/entities/metric.py
+++ b/mlflow/entities/metric.py
@@ -1,3 +1,5 @@
+import numbers
+
 from mlflow.entities._mlflow_object import _MlflowObject
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
@@ -30,7 +32,11 @@ class Metric(_MlflowObject):
         self._key = key
         self._value = value
         self._timestamp = timestamp
-        self._step = step
+        self._step = (
+            int(step)
+            if isinstance(step, numbers.Real) and not isinstance(step, numbers.Integral)
+            else step
+        )
         self._model_id = model_id
         self._dataset_name = dataset_name
         self._dataset_digest = dataset_digest

--- a/tests/entities/test_metric.py
+++ b/tests/entities/test_metric.py
@@ -1,5 +1,6 @@
 import re
 
+import numpy as np
 import pytest
 
 from mlflow.entities import Metric
@@ -101,3 +102,37 @@ def test_metric_from_dictionary_missing_keys():
         match=re.escape("Missing required keys ['value', 'timestamp'] in metric dictionary"),
     ):
         Metric.from_dictionary(another_incomplete_dict)
+
+
+@pytest.mark.parametrize(
+    ("float_step", "expected_int_step"),
+    [
+        (0.0, 0),
+        (1.0, 1),
+        (42.0, 42),
+        # non-integer floats are truncated toward zero (same as int())
+        (99.9, 99),
+        # numpy float types are also coerced
+        (np.float32(5.0), 5),
+        (np.float64(7.0), 7),
+    ],
+)
+def test_float_step_coerced_to_int(float_step, expected_int_step):
+    metric = Metric("loss", 0.5, 1000, float_step)
+    assert metric.step == expected_int_step
+    assert isinstance(metric.step, int)
+
+
+def test_float_step_proto_roundtrip():
+    metric = Metric("loss", 0.5, 1000, 3.0)
+    proto = metric.to_proto()
+    assert proto.step == 3
+    recovered = Metric.from_proto(proto)
+    assert recovered.step == 3
+    assert isinstance(recovered.step, int)
+
+
+def test_int_step_unchanged():
+    metric = Metric("loss", 0.5, 1000, 5)
+    assert metric.step == 5
+    assert type(metric.step) is int


### PR DESCRIPTION
### Related Issues/PRs

Closes #13278

### What changes are proposed in this pull request?

PyTorch Lightning (and other frameworks) can emit the training `step` as a Python `float` — for example when using the `OverrideEpochStepCallback` workaround described in [Lightning-AI/pytorch-lightning#2110](https://github.com/Lightning-AI/pytorch-lightning/issues/2110) to log by epoch rather than by batch. The protobuf `step` field is `int64` and rejects floats with a `TypeError` at serialization time.

The fix is a one-liner in `Metric.__init__`:

```python
self._step = int(step) if isinstance(step, float) else step
```

Coercing in the constructor is preferable to coercing inside `to_proto()` because it keeps `metric.step` consistent with its documented type ("Integer metric step") and fixes all downstream paths at once: `to_proto()`, `to_dictionary()`, and `MetricWithRunId` (which delegates to the parent constructor).

### How is this PR tested?

- [x] New unit/integration tests

Two new tests in `tests/entities/test_metric.py`:
- `test_float_step_coerced_to_int` — parametrized over `0.0`, `1.0`, `42.0`, and `99.9`; asserts both the coerced value and that `isinstance(metric.step, int)` holds.
- `test_float_step_proto_roundtrip` — creates a `Metric` with `step=3.0`, serializes to proto, and verifies the recovered step is the integer `3`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Metric logging no longer raises `TypeError` when a float is passed as `step` (e.g., from PyTorch Lightning callbacks).

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release