### PR TITLE
Always pass `providers` to `InferenceSession` in `_OnnxModelWrapper`

### DIFF
--- a/mlflow/onnx/__init__.py
+++ b/mlflow/onnx/__init__.py
@@ -288,34 +288,9 @@ class _OnnxModelWrapper:
                 for key, value in extra_session_config.items():
                     sess_options.add_session_config_entry(key, value)
 
-        # NOTE: Some distributions of onnxruntime require the specification of the providers
-        # argument on calling. E.g. onnxruntime-gpu. The package import call does not differentiate
-        #  which architecture specific version has been installed, as all are imported with
-        # onnxruntime. onnxruntime documentation says that from v1.9.0 some distributions require
-        #  the providers list to be provided on calling an InferenceSession. Therefore the try
-        #  catch structure below attempts to create an inference session with just the model path
-        #  as pre v1.9.0. If that fails, it will use the providers list call.
-        # At the moment this is just CUDA and CPU, and probably should be expanded.
-        # A method of user customization has been provided by adding a variable in the save_model()
-        # function, which allows the ability to pass the list of execution providers via a
-        # optional argument e.g.
-        #
-        # mlflow.onnx.save_model(..., providers=['CUDAExecutionProvider'...])
-        #
-        # For details of the execution providers construct of onnxruntime, see:
-        # https://onnxruntime.ai/docs/execution-providers/
-        #
-        # For a information on how execution providers are used with onnxruntime InferenceSession,
-        # see the API page below:
-        # https://onnxruntime.ai/docs/api/python/api_summary.html#id8
-        #
-
-        try:
-            self.rt = onnxruntime.InferenceSession(path, sess_options=sess_options)
-        except ValueError:
-            self.rt = onnxruntime.InferenceSession(
-                path, providers=providers, sess_options=sess_options
-            )
+        self.rt = onnxruntime.InferenceSession(
+            path, providers=providers, sess_options=sess_options
+        )
 
         assert len(self.rt.get_inputs()) >= 1
         self.inputs = [(inp.name, inp.type) for inp in self.rt.get_inputs()]

--- a/tests/onnx/test_onnx_model_export.py
+++ b/tests/onnx/test_onnx_model_export.py
@@ -730,3 +730,36 @@ def test_model_log_with_metadata(onnx_model):
 
     reloaded_model = mlflow.pyfunc.load_model(model_uri=model_info.model_uri)
     assert reloaded_model.metadata.metadata["metadata_key"] == "metadata_value"
+
+
+@pytest.mark.parametrize(
+    "providers",
+    [
+        None,
+        ["CPUExecutionProvider"],
+        ["CUDAExecutionProvider", "CPUExecutionProvider"],
+    ],
+)
+def test_inference_session_always_receives_providers(onnx_model, model_path, providers):
+    save_kwargs = {}
+    if providers is not None:
+        save_kwargs["onnx_execution_providers"] = providers
+
+    mlflow.onnx.save_model(onnx_model, model_path, **save_kwargs)
+
+    expected_providers = providers or mlflow.onnx.ONNX_EXECUTION_PROVIDERS
+
+    import onnxruntime
+
+    original_init = onnxruntime.InferenceSession.__init__
+
+    captured = {}
+
+    def capturing_init(self, path, providers=None, sess_options=None, **kwargs):
+        captured["providers"] = providers
+        return original_init(self, path, providers=providers, sess_options=sess_options, **kwargs)
+
+    with mock.patch.object(onnxruntime.InferenceSession, "__init__", capturing_init):
+        mlflow.pyfunc.load_model(model_path)
+
+    assert captured["providers"] == expected_providers


### PR DESCRIPTION
### Related Issues/PRs

Closes #21851

### What changes are proposed in this pull request?

`_OnnxModelWrapper.__init__` wrapped the initial `InferenceSession` call in a `try/except ValueError` block — calling it without `providers` first, and only passing them if `ValueError` was raised. This was a compatibility shim for onnxruntime < v1.9.0, which is long EOL.

Since onnxruntime 1.17+ no `ValueError` is raised for missing providers; the session silently defaults to `CPUExecutionProvider`. As a result, any user-specified GPU provider (e.g. `CUDAExecutionProvider`) passed via `mlflow.onnx.save_model(..., providers=[...])` was silently ignored at load time.

The fix removes the try/except shim and always passes `providers` to `InferenceSession`. The `providers` value is resolved earlier in `__init__` from the saved MLModel metadata (or falls back to `ONNX_EXECUTION_PROVIDERS`), so no call-site changes are needed.

### How is this PR tested?

- [x] New unit/integration tests

`test_inference_session_always_receives_providers` is parametrized over three cases:
- `providers=None` (uses the `ONNX_EXECUTION_PROVIDERS` default)
- `providers=["CPUExecutionProvider"]`
- `providers=["CUDAExecutionProvider", "CPUExecutionProvider"]`

Each case saves a model, then patches `onnxruntime.InferenceSession.__init__` to capture the `providers` kwarg, loads the model via `mlflow.pyfunc.load_model`, and asserts the captured value matches what was saved. The `CUDAExecutionProvider` case emits an expected onnxruntime warning on CPU-only machines (no hardware, but the arg is forwarded correctly, which is exactly what the bug prevented).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. ONNX models saved with GPU execution providers (e.g. `CUDAExecutionProvider`) now correctly use those providers at inference time instead of silently falling back to CPU.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release