### PR TITLE
Fix `mlflow.openai.autolog` span type resolution for `ChatCompletions` subclasses

### DIFF
--- a/mlflow/openai/autolog.py
+++ b/mlflow/openai/autolog.py
@@ -173,7 +173,7 @@ def _autolog(
         safe_patch(FLAVOR_NAME, Responses, "parse", patched_call)
 
 
-def _get_span_type_and_message_format(task: type) -> tuple[str, str]:
+def _get_span_type(task: type) -> str:
     from openai.resources.chat.completions import AsyncCompletions as AsyncChatCompletions
     from openai.resources.chat.completions import Completions as ChatCompletions
     from openai.resources.completions import AsyncCompletions, Completions
@@ -219,7 +219,12 @@ def _get_span_type_and_message_format(task: type) -> tuple[str, str]:
     except ImportError:
         pass
 
-    return span_type_mapping.get(task, (SpanType.UNKNOWN, None))
+    # Walk the MRO so subclasses (e.g. third-party wrappers like
+    # `DatabricksOpenAI`'s `ChatCompletions`) resolve to the right type.
+    for base_cls, span_type in span_type_mapping.items():
+        if issubclass(task, base_cls):
+            return span_type
+    return SpanType.UNKNOWN
 
 
 def _try_parse_raw_response(response: Any) -> Any:
@@ -303,7 +308,7 @@ def _start_span(
     inputs: dict[str, Any],
     run_id: str,
 ):
-    span_type = _get_span_type_and_message_format(instance.__class__)
+    span_type = _get_span_type(instance.__class__)
     # Record input parameters to attributes
     attributes = {k: v for k, v in inputs.items() if k not in ("messages", "input")}
     if span_type in (SpanType.CHAT_MODEL, SpanType.LLM):

--- a/tests/openai/test_openai_autolog.py
+++ b/tests/openai/test_openai_autolog.py
@@ -6,6 +6,9 @@ from unittest import mock
 import httpx
 import openai
 import pytest
+from openai.resources.chat.completions import Completions as ChatCompletions
+from openai.resources.completions import Completions
+from openai.resources.embeddings import Embeddings
 from packaging.version import Version
 from pydantic import BaseModel
 
@@ -13,6 +16,7 @@ import mlflow
 from mlflow.entities import SpanLogLevel
 from mlflow.entities.span import SpanType
 from mlflow.exceptions import MlflowException
+from mlflow.openai.autolog import _get_span_type
 from mlflow.openai.utils.chat_schema import _parse_tools
 from mlflow.tracing.constant import (
     STREAM_CHUNK_EVENT_VALUE_KEY,
@@ -159,12 +163,6 @@ def test_get_span_type_resolves_subclasses():
     # third-party clients (e.g. DatabricksOpenAI) subclass the OpenAI resource
     # classes, so exact dict lookup misses and a previous fallback returned an
     # unhashable tuple, breaking span log-level resolution downstream.
-    from openai.resources.chat.completions import Completions as ChatCompletions
-    from openai.resources.completions import Completions
-    from openai.resources.embeddings import Embeddings
-
-    from mlflow.openai.autolog import _get_span_type
-
     class CustomChatCompletions(ChatCompletions):
         pass
 

--- a/tests/openai/test_openai_autolog.py
+++ b/tests/openai/test_openai_autolog.py
@@ -154,6 +154,27 @@ async def test_chat_completions_autolog(client, mock_litellm_cost):
         }
 
 
+def test_get_span_type_resolves_subclasses():
+    # Regression test for https://github.com/mlflow/mlflow/issues/23754:
+    # third-party clients (e.g. DatabricksOpenAI) subclass the OpenAI resource
+    # classes, so exact dict lookup misses and a previous fallback returned an
+    # unhashable tuple, breaking span log-level resolution downstream.
+    from openai.resources.chat.completions import Completions as ChatCompletions
+    from openai.resources.completions import Completions
+    from openai.resources.embeddings import Embeddings
+
+    from mlflow.openai.autolog import _get_span_type
+
+    class CustomChatCompletions(ChatCompletions):
+        pass
+
+    assert _get_span_type(CustomChatCompletions) == SpanType.CHAT_MODEL
+    assert _get_span_type(ChatCompletions) == SpanType.CHAT_MODEL
+    assert _get_span_type(Completions) == SpanType.LLM
+    assert _get_span_type(Embeddings) == SpanType.EMBEDDING
+    assert _get_span_type(object) == SpanType.UNKNOWN
+
+
 @pytest.mark.asyncio
 @pytest.mark.skipif(
     Version(openai.__version__) < Version("1.66"), reason="Cost tracking does not work before 1.66"


### PR DESCRIPTION
### Related Issues/PRs

Closes #23754

### What changes are proposed in this pull request?

`mlflow.openai.autolog()` started emitting `WARNING mlflow.entities.span: Failed to end span <id>: unhashable type: 'list'` in 3.13.0 for any client that wraps OpenAI via a subclass of `ChatCompletions` (e.g. `DatabricksOpenAI`).

Two interacting bugs caused this:

1. `_get_span_type_and_message_format` did an exact dict-key lookup on `task`, so subclasses missed and hit the fallback `(SpanType.UNKNOWN, None)`. Every other value in the mapping was a plain string, so only the fallback was a tuple. The tuple flowed into the span as `span_type`, got JSON-serialized, and came back as a list.
2. The new span log-level resolution added in #23017 calls `default_log_level_for_span_type(span_type)`, which does `span_type in frozenset({...})` — that needs a hashable value, so the list raised `TypeError: unhashable type: 'list'` when ending the span.

This PR renames the helper to `_get_span_type` and walks the MRO via `issubclass`, so subclasses resolve correctly (`SubclassedChatCompletions` → `CHAT_MODEL`) and the fallback returns the plain string `SpanType.UNKNOWN`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added `test_get_span_type_resolves_subclasses` covering subclasses, direct classes, and the `object` fallback.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fixes a regression in 3.13.0 where `mlflow.openai.autolog()` failed to record spans for OpenAI clients implemented as subclasses of `ChatCompletions` (e.g. `DatabricksOpenAI`).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)