### PR TITLE
Cache HuggingFace Hub dataset metadata in CI

### DIFF
--- a/.github/actions/cache-hf/action.yml
+++ b/.github/actions/cache-hf/action.yml
@@ -1,0 +1,11 @@
+name: "cache-hf"
+description: "Cache HuggingFace Hub artifacts to avoid 429s in CI"
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      with:
+        path: ~/.cache/huggingface/hub/datasets--*
+        key: ${{ runner.os }}-hf-datasets-${{ hashFiles('tests/data/test_huggingface_dataset_and_source.py') }}
+        restore-keys: |
+          ${{ runner.os }}-hf-datasets

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -97,6 +97,7 @@ jobs:
             -r requirements/test-requirements.txt \
             -r requirements/extra-ml-requirements.txt
       - uses: ./.github/actions/show-versions
+      - uses: ./.github/actions/cache-hf
       - name: Import check
         run: |
           # `-I` is used to avoid importing modules from user-specific site-packages
@@ -418,6 +419,7 @@ jobs:
             pyspark datasets tensorflow torch transformers openai \
             tests/resources/mlflow-test-plugin
       - uses: ./.github/actions/show-versions
+      - uses: ./.github/actions/cache-hf
       - name: Download Hadoop winutils for Spark
         run: |
           git clone https://github.com/cdarlint/winutils /tmp/winutils

--- a/.github/workflows/protobuf-cross-test.yml
+++ b/.github/workflows/protobuf-cross-test.yml
@@ -75,6 +75,7 @@ jobs:
             torch transformers \
             "protobuf==$PROTOBUF_MAJOR_VERSION.*"
       - uses: ./.github/actions/show-versions
+      - uses: ./.github/actions/cache-hf
       - name: Run tests
         env:
           SPLITS: ${{ matrix.splits }}

--- a/.github/workflows/test-requirements.yml
+++ b/.github/workflows/test-requirements.yml
@@ -96,6 +96,7 @@ jobs:
           source ./dev/install-common-deps.sh --ml
           uv pip install --system '.[gateway]'
       - uses: ./.github/actions/show-versions
+      - uses: ./.github/actions/cache-hf
       - name: Run tests
         env:
           SPLITS: ${{ matrix.splits }}

--- a/tests/data/test_huggingface_dataset_and_source.py
+++ b/tests/data/test_huggingface_dataset_and_source.py
@@ -4,7 +4,6 @@ import os
 import datasets
 import pandas as pd
 import pytest
-from huggingface_hub.errors import HfHubHTTPError
 
 import mlflow.data
 import mlflow.data.huggingface_dataset
@@ -27,28 +26,23 @@ pytestmark = skip_if_hf_hub_unhealthy()
 def prefetch_huggingface_datasets():
     """Pre-warm the HF cache so individual tests don't hit the Hub and risk HTTP 429s."""
 
-    try:
-        datasets.load_dataset("cornell-movie-review-data/rotten_tomatoes", split="train")
-        datasets.load_dataset(
-            "cornell-movie-review-data/rotten_tomatoes",
-            split="train",
-            revision="aa13bc287fa6fcab6daf52f0dfb9994269ffea28",
-            trust_remote_code=True,
-        )
-        datasets.load_dataset(
-            "cornell-movie-review-data/rotten_tomatoes",
-            split="train",
-            revision="c33cbf965006dba64f134f7bef69c53d5d0d285d",
-        )
-        datasets.load_dataset(
-            "fka/awesome-chatgpt-prompts",
-            data_files={"train": "prompts.csv"},
-            split="train",
-        )
-    except HfHubHTTPError as e:
-        if e.response.status_code == 429:
-            pytest.skip(f"HF Hub rate-limited: {e}")
-        raise
+    datasets.load_dataset("cornell-movie-review-data/rotten_tomatoes", split="train")
+    datasets.load_dataset(
+        "cornell-movie-review-data/rotten_tomatoes",
+        split="train",
+        revision="aa13bc287fa6fcab6daf52f0dfb9994269ffea28",
+        trust_remote_code=True,
+    )
+    datasets.load_dataset(
+        "cornell-movie-review-data/rotten_tomatoes",
+        split="train",
+        revision="c33cbf965006dba64f134f7bef69c53d5d0d285d",
+    )
+    datasets.load_dataset(
+        "fka/awesome-chatgpt-prompts",
+        data_files={"train": "prompts.csv"},
+        split="train",
+    )
 
 
 def test_from_huggingface_dataset_constructs_expected_dataset():

--- a/tests/data/test_huggingface_dataset_and_source.py
+++ b/tests/data/test_huggingface_dataset_and_source.py
@@ -1,11 +1,10 @@
 import json
 import os
-import time
-from unittest import mock
 
 import datasets
 import pandas as pd
 import pytest
+from huggingface_hub.errors import HfHubHTTPError
 
 import mlflow.data
 import mlflow.data.huggingface_dataset
@@ -25,27 +24,31 @@ pytestmark = skip_if_hf_hub_unhealthy()
 
 
 @pytest.fixture(scope="module", autouse=True)
-def mock_datasets_load_dataset():
-    """
-    `datasets.load_dataset` is flaky and sometimes fails with a network error.
-    This fixture retries the call up to 5 times with exponential backoff.
-    """
+def prefetch_huggingface_datasets():
+    """Pre-warm the HF cache so individual tests don't hit the Hub and risk HTTP 429s."""
 
-    original = datasets.load_dataset
-
-    def load_dataset(*args, **kwargs):
-        for i in range(5):
-            try:
-                return original(*args, **kwargs)
-            except Exception:
-                if i < 4:
-                    time.sleep(2**i)
-                    continue
-                raise
-
-    with mock.patch("datasets.load_dataset", wraps=load_dataset) as mock_load_dataset:
-        yield
-        mock_load_dataset.assert_called()
+    try:
+        datasets.load_dataset("cornell-movie-review-data/rotten_tomatoes", split="train")
+        datasets.load_dataset(
+            "cornell-movie-review-data/rotten_tomatoes",
+            split="train",
+            revision="aa13bc287fa6fcab6daf52f0dfb9994269ffea28",
+            trust_remote_code=True,
+        )
+        datasets.load_dataset(
+            "cornell-movie-review-data/rotten_tomatoes",
+            split="train",
+            revision="c33cbf965006dba64f134f7bef69c53d5d0d285d",
+        )
+        datasets.load_dataset(
+            "fka/awesome-chatgpt-prompts",
+            data_files={"train": "prompts.csv"},
+            split="train",
+        )
+    except HfHubHTTPError as e:
+        if e.response.status_code == 429:
+            pytest.skip(f"HF Hub rate-limited: {e}")
+        raise
 
 
 def test_from_huggingface_dataset_constructs_expected_dataset():


### PR DESCRIPTION
### Related Issues/PRs

Relates to recurring HF Hub HTTP 429 failures hitting `tests/data/test_huggingface_dataset_and_source.py` and `tests/metrics/test_metric_definitions.py::test_toxicity` on CI (example: https://github.com/mlflow/mlflow/actions/runs/26880776239/job/79279942797).

### What changes are proposed in this pull request?

- New `./.github/actions/cache-hf` composite action caches `~/.cache/huggingface/hub/datasets--*` keyed by `${{ runner.os }}-hf-datasets-${{ hashFiles('tests/data/test_huggingface_dataset_and_source.py') }}` with a `${{ runner.os }}-hf-datasets` `restore-keys` fallback. Only the dataset hub cache (~11 MB) is included; model weights under `hub/models--*` are excluded.
- Action is wired into every job that runs the HF dataset tests: `master.yml` (`python`, `windows`), `test-requirements.yml` (`core`), `protobuf-cross-test.yml` (`core_tests`).
- `tests/data/test_huggingface_dataset_and_source.py` gains a module-scope `prefetch_huggingface_datasets` fixture that pre-warms the cache for every (path, revision, data_files) combo the tests use, so individual tests read from the local cache instead of issuing HEAD requests that can be HTTP 429'd. The old per-test retry wrapper is removed since `huggingface_hub` already retries 429s internally and the workflow cache absorbs cold-start downloads.

Inspired by https://github.com/snad-space/coniferest/pull/338.

### How is this PR tested?

- [x] Existing unit/integration tests

Verified end-to-end on this branch: with the workflow cache restored from `Linux-hf-datasets`, the prefetch hits the local cache (~12 s) and all 12 tests in `test_huggingface_dataset_and_source.py` pass with per-test durations < 2 s. (https://github.com/mlflow/mlflow/actions/runs/26896667829)

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release