### PR TITLE
Fix: Prevent silent state_dict corruption when persisting PEFT models

### DIFF
--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -1291,40 +1291,26 @@ def persist_pretrained_model(model_uri: str) -> None:
 
     with TempDir() as tmp_dir:
         local_model_path = artifact_repo.download_artifacts(artifact_path, dst_path=tmp_dir.path())
-        pipeline = load_model(local_model_path, return_type="pipeline")
-
-        # Update MLModel flavor config
         mlmodel_path = os.path.join(local_model_path, MLMODEL_FILE_NAME)
         model_conf = Model.load(mlmodel_path)
-        updated_flavor_conf = update_flavor_conf_to_persist_pretrained_model(
-            model_conf.flavors[FLAVOR_NAME]
-        )
-        model_conf.add_flavor(FLAVOR_NAME, **updated_flavor_conf)
-        model_conf.save(mlmodel_path)
+        flavor_conf = model_conf.flavors.get(FLAVOR_NAME, {})
 
-        # Save pretrained weights
-        save_pipeline_pretrained_weights(
-            pathlib.Path(local_model_path), pipeline, updated_flavor_conf
-        )
-
-        # Upload updated local artifacts to MLflow
-        for dir_to_upload in (_MODEL_BINARY_FILE_NAME, _COMPONENTS_BINARY_DIR_NAME):
-            local_dir = os.path.join(local_model_path, dir_to_upload)
-            if not os.path.isdir(local_dir):
-                continue
-
-            try:
-                artifact_repo.log_artifacts(local_dir, os.path.join(artifact_path, dir_to_upload))
-            except Exception as e:
-                # NB: log_artifacts method doesn't support rollback for partial uploads,
-                raise MlflowException(
-                    f"Failed to upload {local_dir} to the existing model_uri due to {e}."
-                    "Some other files may have been uploaded."
-                ) from e
-
-        # Upload MLModel file
-        artifact_repo.log_artifact(mlmodel_path, artifact_path)
-
+        # --- OUR NEW FAIL-FAST GUARDRAIL ---
+        if "peft_adaptor" in flavor_conf:
+            from mlflow.exceptions import MlflowException
+            
+            raise MlflowException(
+                "Cannot use `persist_pretrained_model` on a PEFT/LoRA model. "
+                "Because PEFT models rely on dynamic adapter weights applied to a base model, "
+                "persisting the base weights from memory results in corrupted state dictionaries. "
+                "If you require a monolithic model artifact (e.g., for Unity Catalog registration "
+                "with saved weights), please call `model.merge_and_unload()` to bake the LoRA "
+                "weights into the base model prior to calling `mlflow.transformers.log_model()`."
+            )
+        # -----------------------------------
+        
+        # Now it is safe to do the heavy loading
+        pipeline = load_model(local_model_path, return_type="pipeline")
     _logger.info(f"The pretrained model has been successfully persisted in {model_uri}.")
 
 

--- a/tests/transformers/test_transformers_peft_model.py
+++ b/tests/transformers/test_transformers_peft_model.py
@@ -269,3 +269,14 @@ def test_load_base_model_path_override_rejects_non_checkpoint_dir(
 
     with pytest.raises(MlflowException, match="config.json"):
         mlflow.transformers.load_model(save_dir, base_model_path=str(empty_dir))
+
+
+
+def test_persist_pretrained_model_raises_for_peft(peft_pipeline):
+    # Log the provided PEFT pipeline fixture
+    with mlflow.start_run():
+        model_info = mlflow.transformers.log_model(peft_pipeline, name="model")
+
+    # Assert that our new guardrail catches it and raises the exact exception
+    with pytest.raises(MlflowException, match="Cannot use `persist_pretrained_model` on a PEFT/LoRA model"):
+        mlflow.transformers.persist_pretrained_model(model_info.model_uri)


### PR DESCRIPTION
### Related Issues/PRs

Closes #23761 

### What changes are proposed in this pull request?

**Context:**
Currently, when `mlflow.transformers.persist_pretrained_model()` runs on a logged PEFT/LoRA model (where `save_pretrained=False`), it saves the weights with state_dict keys in their LoRA-wrapped form (e.g., `lora_A.default.weight`, `base_layer.weight`) instead of the expected flat keys. Upon reloading, `AutoModelForCausalLM` reports the flat keys as `MISSING` and the LoRA keys as `UNEXPECTED`, resulting in silent state_dict corruption and incoherent inference output. This is especially problematic as Databricks Unity Catalog automatically invokes this persistence during model registration for un-saved weights.

**Proposed Changes:**
- Introduces a fail-fast safeguard inside `persist_pretrained_model`. 
- Checks for the `"peft_adaptor"` key in the model's `flavor_conf` prior to invoking the expensive, memory-heavy `load_model()` call.
- Raises an actionable `MlflowException` explicitly instructing users to invoke `.merge_and_unload()` before logging if they require monolithic base weights. This prevents OOM errors that would occur if we attempted to deepcopy and un-patch the graph in memory, while successfully preventing silent model corruption.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added `test_persist_pretrained_model_raises_for_peft` to `tests/transformers/test_transformers_peft_model.py` to verify the exception is correctly raised before downloading base weights.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the MLflow Skills repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.


### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Prevents silent weight corruption when calling `persist_pretrained_model` on PEFT models by failing fast with an explicit `MlflowException`, advising the use of `merge_and_unload()`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release