### PR TITLE
Skip copying local artifacts to temp directories for artifact serving

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -19,6 +19,7 @@ from cachetools import TTLCache
 from flask import Request, Response, current_app, jsonify, request, send_file
 from google.protobuf import descriptor
 from google.protobuf.json_format import ParseError
+from werkzeug.http import quote_header_value
 
 import mlflow
 from mlflow.client import MlflowClient
@@ -1093,8 +1094,10 @@ def _content_disposition_attachment(filename: str) -> str:
         )
         # safe = RFC 5987 attr-char
         quoted = urllib.parse.quote(filename, safe="!#$&+-.^_`|~")
-        return f"attachment; filename={ascii_fallback}; filename*=UTF-8''{quoted}"
-    return f"attachment; filename={filename}"
+        quoted_ascii_fallback = quote_header_value(ascii_fallback, allow_token=True)
+        return f"attachment; filename={quoted_ascii_fallback}; filename*=UTF-8''{quoted}"
+    quoted_filename = quote_header_value(filename, allow_token=True)
+    return f"attachment; filename={quoted_filename}"
 
 
 def _response_with_file_attachment_headers(file_path, response):
@@ -1111,13 +1114,36 @@ def _response_with_file_attachment_headers(file_path, response):
     return response
 
 
+def _create_artifact_file_response(file_path: str, artifact_name: str) -> Response:
+    """Serve a local file while preserving the logical artifact name for downloads."""
+    if os.path.isdir(file_path):
+        raise MlflowException.invalid_parameter_value(
+            f"Artifact path refers to a directory, not a file: '{artifact_name}'"
+        )
+    file_sender_response = send_file(file_path, mimetype=_guess_mime_type(file_path))
+    file_sender_response.headers["Content-Disposition"] = _content_disposition_attachment(
+        pathlib.Path(artifact_name).name
+    )
+    return _response_with_file_attachment_headers(file_path, file_sender_response)
+
+
 def _send_artifact(artifact_repository, path):
-    file_path = os.path.abspath(artifact_repository.download_artifacts(path))
     # Always send artifacts as attachments to prevent the browser from displaying them on our web
     # server's domain, which might enable XSS.
-    mime_type = _guess_mime_type(file_path)
-    file_sender_response = send_file(file_path, mimetype=mime_type, as_attachment=True)
-    return _response_with_file_attachment_headers(file_path, file_sender_response)
+    if (local_path := artifact_repository.get_local_path(path)) is not None:
+        return _create_artifact_file_response(os.path.abspath(local_path), path)
+
+    tmp_dir = tempfile.TemporaryDirectory()
+    try:
+        file_path = os.path.abspath(
+            artifact_repository.download_artifacts(path, dst_path=tmp_dir.name)
+        )
+        response = _create_artifact_file_response(file_path, path)
+        response.call_on_close(tmp_dir.cleanup)
+        return response
+    except Exception:
+        tmp_dir.cleanup()
+        raise
 
 
 def catch_mlflow_exception(func):
@@ -3487,12 +3513,20 @@ def _download_artifact(artifact_path):
     """
     artifact_path = validate_path_is_safe(artifact_path)
     artifact_path = _get_workspace_scoped_repo_path_if_enabled(artifact_path)
-    tmp_dir = tempfile.TemporaryDirectory()
     artifact_repo = _get_artifact_repo_mlflow_artifacts()
-    dst = artifact_repo.download_artifacts(artifact_path, tmp_dir.name)
 
-    # Ref: https://stackoverflow.com/a/24613980/6943581
-    file_handle = open(dst, "rb")  # noqa: SIM115
+    if (local_path := artifact_repo.get_local_path(artifact_path)) is not None:
+        return _create_artifact_file_response(os.path.abspath(local_path), artifact_path)
+
+    tmp_dir = tempfile.TemporaryDirectory()
+    try:
+        dst = os.path.abspath(artifact_repo.download_artifacts(artifact_path, tmp_dir.name))
+
+        # Ref: https://stackoverflow.com/a/24613980/6943581
+        file_handle = open(dst, "rb")  # noqa: SIM115
+    except Exception:
+        tmp_dir.cleanup()
+        raise
 
     def stream_and_remove_file():
         while chunk := file_handle.read(ARTIFACT_STREAM_CHUNK_SIZE):

--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -229,6 +229,18 @@ class ArtifactRepository:
             os.makedirs(local_dir_path, exist_ok=True)
         return local_file_path
 
+    def get_local_path(self, artifact_path: str) -> str | None:
+        """
+        Return a safe absolute filesystem path for the specified artifact when it is already
+        directly accessible by the server.
+
+        Backends that cannot safely expose a local filesystem path should return ``None`` and rely
+        on ``download_artifacts()`` to materialize the artifact locally. Backends that support
+        local paths should raise their usual exceptions for missing or invalid artifacts rather than
+        silently returning ``None``.
+        """
+        return None
+
     def _iter_artifacts_recursive(self, path):
         dir_content = [
             file_info

--- a/mlflow/store/artifact/local_artifact_repo.py
+++ b/mlflow/store/artifact/local_artifact_repo.py
@@ -34,6 +34,17 @@ class LocalArtifactRepository(ArtifactRepository):
     def artifact_dir(self):
         return self._artifact_dir
 
+    def get_local_path(self, artifact_path: str) -> str:
+        artifact_path = validate_path_is_safe(artifact_path)
+        local_artifact_path = os.path.join(self.artifact_dir, os.path.normpath(artifact_path))
+        validate_path_within_directory(self.artifact_dir, local_artifact_path)
+        if not os.path.exists(local_artifact_path):
+            raise MlflowException(
+                f"No such artifact: '{artifact_path}'",
+                error_code=RESOURCE_DOES_NOT_EXIST,
+            )
+        return os.path.abspath(local_artifact_path)
+
     def log_artifact(self, local_file, artifact_path=None):
         verify_artifact_path(artifact_path)
         # NOTE: The artifact_path is expected to be in posix format.
@@ -88,15 +99,7 @@ class LocalArtifactRepository(ArtifactRepository):
         """
         if dst_path:
             return super().download_artifacts(artifact_path, dst_path)
-        artifact_path = validate_path_is_safe(artifact_path)
-        local_artifact_path = os.path.join(self.artifact_dir, os.path.normpath(artifact_path))
-        validate_path_within_directory(self.artifact_dir, local_artifact_path)
-        if not os.path.exists(local_artifact_path):
-            raise MlflowException(
-                f"No such artifact: '{artifact_path}'",
-                error_code=RESOURCE_DOES_NOT_EXIST,
-            )
-        return os.path.abspath(local_artifact_path)
+        return self.get_local_path(artifact_path)
 
     def list_artifacts(self, path=None):
         if path:

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -142,6 +142,7 @@ from mlflow.server.handlers import (
     _calculate_trace_filter_correlation,
     _cancel_prompt_optimization_job,
     _convert_path_parameter_to_flask_format,
+    _create_artifact_file_response,
     _create_dataset_handler,
     _create_experiment,
     _create_issue,
@@ -198,6 +199,7 @@ from mlflow.server.handlers import (
     _search_registered_models,
     _search_runs,
     _search_traces_v3,
+    _send_artifact,
     _set_dataset_tags_handler,
     _set_model_version_tag,
     _set_registered_model_alias,
@@ -3997,6 +3999,98 @@ def test_post_ui_telemetry_handler_telemetry_disabled_by_env(
         mock_get_client.assert_not_called()
 
 
+def test_send_artifact_prefers_local_path(tmp_path):
+    artifact_path = "test_model/model.pkl"
+    test_data = b"local artifact"
+    test_file = tmp_path / "model.pkl"
+    test_file.write_bytes(test_data)
+
+    mock_artifact_repo = mock.MagicMock()
+    mock_artifact_repo.get_local_path.return_value = str(test_file)
+
+    with (
+        app.test_request_context(method="GET"),
+        mock.patch("mlflow.server.handlers.tempfile.TemporaryDirectory") as mock_tmp_dir,
+    ):
+        response = _send_artifact(mock_artifact_repo, artifact_path)
+
+    response.direct_passthrough = False
+    assert response.get_data() == test_data
+    assert response.headers["Content-Disposition"] == "attachment; filename=model.pkl"
+    mock_artifact_repo.get_local_path.assert_called_once_with(artifact_path)
+    mock_artifact_repo.download_artifacts.assert_not_called()
+    mock_tmp_dir.assert_not_called()
+
+
+def test_send_artifact_falls_back_to_download_when_local_path_unavailable(tmp_path):
+    artifact_path = "test_model/model.pkl"
+    test_data = b"downloaded artifact"
+    test_file = tmp_path / "model.pkl"
+    test_file.write_bytes(test_data)
+
+    mock_artifact_repo = mock.MagicMock()
+    mock_artifact_repo.get_local_path.return_value = None
+    mock_artifact_repo.download_artifacts.return_value = str(test_file)
+
+    with app.test_request_context(method="GET"):
+        response = _send_artifact(mock_artifact_repo, artifact_path)
+
+    response.direct_passthrough = False
+    assert response.get_data() == test_data
+    assert response.headers["Content-Disposition"] == "attachment; filename=model.pkl"
+    mock_artifact_repo.get_local_path.assert_called_once_with(artifact_path)
+    mock_artifact_repo.download_artifacts.assert_called_once_with(artifact_path, dst_path=mock.ANY)
+
+
+def test_create_artifact_file_response_uses_local_path_mimetype_and_artifact_name(tmp_path):
+    test_file = tmp_path / "payload.html"
+    test_file.write_text("<html><body>ok</body></html>")
+
+    with app.test_request_context(method="GET"):
+        response = _create_artifact_file_response(str(test_file), "artifacts/model.txt")
+
+    assert response.mimetype == "text/html"
+    assert response.headers["Content-Disposition"] == "attachment; filename=model.txt"
+
+
+def test_create_artifact_file_response_quotes_token_unsafe_ascii_artifact_name(tmp_path):
+    test_file = tmp_path / "payload.html"
+    test_file.write_text("<html><body>ok</body></html>")
+
+    with app.test_request_context(method="GET"):
+        response = _create_artifact_file_response(str(test_file), "artifacts/my model;a.txt")
+
+    assert response.headers["Content-Disposition"] == 'attachment; filename="my model;a.txt"'
+
+
+def test_download_artifact_uses_local_path_fast_path(enable_serve_artifacts, tmp_path):
+    artifact_path = "test_model/model.pkl"
+    test_data = b"local artifact"
+    test_file = tmp_path / "model.pkl"
+    test_file.write_bytes(test_data)
+
+    with (
+        app.test_request_context(method="GET"),
+        mock.patch("mlflow.server.handlers._get_artifact_repo_mlflow_artifacts") as mock_repo,
+        mock.patch("mlflow.server.handlers.tempfile.TemporaryDirectory") as mock_tmp_dir,
+    ):
+        mock_tmp_dir_instance = mock.MagicMock()
+        mock_tmp_dir.return_value = mock_tmp_dir_instance
+
+        mock_artifact_repo = mock.MagicMock()
+        mock_artifact_repo.get_local_path.return_value = str(test_file)
+        mock_repo.return_value = mock_artifact_repo
+
+        response = _download_artifact(artifact_path)
+
+    response.direct_passthrough = False
+    assert response.get_data() == test_data
+    assert response.headers["Content-Disposition"] == "attachment; filename=model.pkl"
+    mock_artifact_repo.get_local_path.assert_called_once_with(artifact_path)
+    mock_artifact_repo.download_artifacts.assert_not_called()
+    mock_tmp_dir.assert_not_called()
+
+
 def test_download_artifact_streams_in_chunks(enable_serve_artifacts, tmp_path):
     # Create a test file with binary data larger than the chunk size (2MB + 1000 bytes)
     test_file_size = ARTIFACT_STREAM_CHUNK_SIZE * 2 + 1000
@@ -4017,6 +4111,7 @@ def test_download_artifact_streams_in_chunks(enable_serve_artifacts, tmp_path):
         mock_tmp_dir.return_value = mock_tmp_dir_instance
 
         mock_artifact_repo = mock.MagicMock()
+        mock_artifact_repo.get_local_path.return_value = None
         mock_artifact_repo.download_artifacts.return_value = str(test_file)
         mock_repo.return_value = mock_artifact_repo
 
@@ -4039,6 +4134,33 @@ def test_download_artifact_streams_in_chunks(enable_serve_artifacts, tmp_path):
         # Verify that all data is correctly streamed
         streamed_data = b"".join(response_chunks)
         assert streamed_data == test_data
+        mock_artifact_repo.get_local_path.assert_called_once_with(artifact_path)
+        mock_artifact_repo.download_artifacts.assert_called_once_with(artifact_path, str(tmp_path))
+
+
+def test_download_artifact_cleans_up_tmp_dir_when_download_fails(enable_serve_artifacts, tmp_path):
+    artifact_path = "test_model/model.pkl"
+
+    with (
+        app.test_request_context(method="GET"),
+        mock.patch("mlflow.server.handlers._get_artifact_repo_mlflow_artifacts") as mock_repo,
+        mock.patch("mlflow.server.handlers.tempfile.TemporaryDirectory") as mock_tmp_dir,
+    ):
+        mock_tmp_dir_instance = mock.MagicMock()
+        mock_tmp_dir_instance.name = str(tmp_path)
+        mock_tmp_dir.return_value = mock_tmp_dir_instance
+
+        mock_artifact_repo = mock.MagicMock()
+        mock_artifact_repo.get_local_path.return_value = None
+        mock_artifact_repo.download_artifacts.side_effect = RuntimeError("boom")
+        mock_repo.return_value = mock_artifact_repo
+
+        with pytest.raises(RuntimeError, match="boom"):
+            _download_artifact(artifact_path)
+
+    mock_artifact_repo.get_local_path.assert_called_once_with(artifact_path)
+    mock_artifact_repo.download_artifacts.assert_called_once_with(artifact_path, str(tmp_path))
+    mock_tmp_dir_instance.cleanup.assert_called_once()
 
 
 @pytest.mark.parametrize(
@@ -4071,11 +4193,20 @@ def test_response_with_file_attachment_headers_encodes_non_ascii_filename(
     assert header == f"attachment; filename={expected_simple}; filename*=UTF-8''{expected_quoted}"
 
 
-def test_response_with_file_attachment_headers_ascii_filename_unchanged():
+@pytest.mark.parametrize(
+    ("filename", "expected_header"),
+    [
+        ("model.pkl", "attachment; filename=model.pkl"),
+        ("my model;a.txt", 'attachment; filename="my model;a.txt"'),
+    ],
+)
+def test_response_with_file_attachment_headers_ascii_filename_preserves_werkzeug_quoting(
+    filename, expected_header
+):
     with app.test_request_context():
-        response = _response_with_file_attachment_headers("model.pkl", Response())
+        response = _response_with_file_attachment_headers(filename, Response())
 
-    assert response.headers["Content-Disposition"] == "attachment; filename=model.pkl"
+    assert response.headers["Content-Disposition"] == expected_header
 
 
 @pytest.mark.parametrize(

--- a/tests/store/artifact/test_local_artifact_repo.py
+++ b/tests/store/artifact/test_local_artifact_repo.py
@@ -103,6 +103,23 @@ def test_download_artifacts_does_not_copy(local_artifact_repo):
         )
 
 
+def test_get_local_path_returns_absolute_path(local_artifact_repo):
+    artifact_rel_path = "test.txt"
+    artifact_text = "hello world!"
+    with TempDir(chdr=True) as local_dir:
+        artifact_src_path = local_dir.path(artifact_rel_path)
+        with open(artifact_src_path, "w") as f:
+            f.write(artifact_text)
+        local_artifact_repo.log_artifact(artifact_src_path)
+
+        local_path = local_artifact_repo.get_local_path(artifact_rel_path)
+
+    assert os.path.abspath(local_path) == local_path
+    assert local_path.startswith(local_artifact_repo.artifact_dir)
+    with open(local_path) as f:
+        assert f.read() == artifact_text
+
+
 def test_download_artifacts_returns_absolute_paths(local_artifact_repo):
     artifact_rel_path = "test.txt"
     artifact_text = "hello world!"
@@ -327,6 +344,8 @@ def external_secret_dir(tmp_path):
 def _execute_operation(local_artifact_repo, operation, access_path, tmp_path):
     if operation == "download_artifacts":
         local_artifact_repo.download_artifacts(access_path)
+    elif operation == "get_local_path":
+        local_artifact_repo.get_local_path(access_path)
     elif operation == "list_artifacts":
         local_artifact_repo.list_artifacts(access_path)
     elif operation == "_download_file":
@@ -338,6 +357,7 @@ def _execute_operation(local_artifact_repo, operation, access_path, tmp_path):
     ("symlink_name", "access_path", "operation"),
     [
         ("leak", "leak/secret.txt", "download_artifacts"),
+        ("leak", "leak/secret.txt", "get_local_path"),
         ("leak", "leak", "list_artifacts"),
         ("leak", "leak/secret.txt", "_download_file"),
         ("parent_link", "parent_link/secret.txt", "download_artifacts"),
@@ -414,4 +434,10 @@ def test_download_artifacts_nonexistent_raises_resource_does_not_exist(
     dst = str(tmp_path) if dst_path_provided else None
     with pytest.raises(MlflowException, match="No such artifact") as exc_info:
         local_artifact_repo.download_artifacts("nonexistent.txt", dst_path=dst)
+    assert exc_info.value.error_code == "RESOURCE_DOES_NOT_EXIST"
+
+
+def test_get_local_path_nonexistent_raises_resource_does_not_exist(local_artifact_repo):
+    with pytest.raises(MlflowException, match="No such artifact") as exc_info:
+        local_artifact_repo.get_local_path("nonexistent.txt")
     assert exc_info.value.error_code == "RESOURCE_DOES_NOT_EXIST"


### PR DESCRIPTION
### Related Issues/PRs

Closes #23768

### What changes are proposed in this pull request?

This adds a `get_local_path` method to the artifact repository base class that returns None by default.

Any artifact repository which implements get_local_path can return a path for MLflow artifact server to directly serve instead of downloading to a temporary directory. The LocalArtifactRepository is the first one to implement this.

Resolves:
https://github.com/mlflow/mlflow/issues/23768

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
