### PR TITLE
[Claude Code] Support UC trace location via `MLFLOW_TRACE_LOCATION`

### DIFF
--- a/libs/typescript/integrations/claude-code/README.md
+++ b/libs/typescript/integrations/claude-code/README.md
@@ -27,24 +27,9 @@ export MLFLOW_TRACKING_URI=http://localhost:5000
 export MLFLOW_EXPERIMENT_ID=<experiment-id>
 ```
 
-To send traces to a Databricks Unity Catalog trace location instead of an MLflow experiment, also set `MLFLOW_TRACE_LOCATION` to a `catalog.schema.table_prefix` value (the UC location must already be provisioned in the workspace):
-
-```bash
-export MLFLOW_TRACKING_URI=databricks
-export MLFLOW_EXPERIMENT_ID=<experiment-id>
-export MLFLOW_TRACE_LOCATION=my_catalog.my_schema.my_prefix
-```
-
 ### Tracing the Claude Code CLI
 
 Install the bundled Stop-hook plugin once; it will trace every CLI session automatically. See the [docs](https://mlflow.org/docs/latest/genai/tracing/integrations/claude-code) for plugin setup.
-
-You can also configure tracing (including the optional UC trace location) with the bundled CLI:
-
-```bash
-mlflow-claude-code setup --user --tracking-uri databricks \
-  --experiment-id <experiment-id> --trace-location my_catalog.my_schema.my_prefix
-```
 
 ### Tracing the Claude Agent SDK
 

--- a/libs/typescript/integrations/claude-code/README.md
+++ b/libs/typescript/integrations/claude-code/README.md
@@ -27,9 +27,24 @@ export MLFLOW_TRACKING_URI=http://localhost:5000
 export MLFLOW_EXPERIMENT_ID=<experiment-id>
 ```
 
+To send traces to a Databricks Unity Catalog trace location instead of an MLflow experiment, also set `MLFLOW_TRACE_LOCATION` to a `catalog.schema.table_prefix` value (the UC location must already be provisioned in the workspace):
+
+```bash
+export MLFLOW_TRACKING_URI=databricks
+export MLFLOW_EXPERIMENT_ID=<experiment-id>
+export MLFLOW_TRACE_LOCATION=my_catalog.my_schema.my_prefix
+```
+
 ### Tracing the Claude Code CLI
 
 Install the bundled Stop-hook plugin once; it will trace every CLI session automatically. See the [docs](https://mlflow.org/docs/latest/genai/tracing/integrations/claude-code) for plugin setup.
+
+You can also configure tracing (including the optional UC trace location) with the bundled CLI:
+
+```bash
+mlflow-claude-code setup --user --tracking-uri databricks \
+  --experiment-id <experiment-id> --trace-location my_catalog.my_schema.my_prefix
+```
 
 ### Tracing the Claude Agent SDK
 

--- a/libs/typescript/integrations/claude-code/package.json
+++ b/libs/typescript/integrations/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlflow/claude-code",
-  "version": "0.2.0",
+  "version": "0.3.0-rc.0",
   "description": "Claude Code and Claude Agent SDK integration package for MLflow Tracing",
   "type": "module",
   "repository": {

--- a/libs/typescript/integrations/claude-code/src/cli.ts
+++ b/libs/typescript/integrations/claude-code/src/cli.ts
@@ -22,6 +22,12 @@ function printUsage(): void {
   console.error(
     '                 --experiment-name <n>  Create or reuse an MLflow experiment by name.',
   );
+  console.error(
+    '                 --trace-location <loc> Optional Databricks Unity Catalog trace',
+  );
+  console.error(
+    "                                        location as 'catalog.schema.table_prefix'.",
+  );
   console.error('');
   console.error('               Required values (all must come from the user; do not pick');
   console.error('               defaults silently):');
@@ -37,6 +43,12 @@ function printUsage(): void {
   console.error('                     --experiment-name my-exp');
   console.error(
     '                 $ mlflow-claude-code setup --user --tracking-uri databricks --experiment-id 12345',
+  );
+  console.error(
+    '                 $ mlflow-claude-code setup --user --tracking-uri databricks \\',
+  );
+  console.error(
+    '                     --experiment-id 12345 --trace-location my_catalog.my_schema.my_prefix',
   );
   console.error('');
   console.error('  status       Show the current MLflow tracing configuration.');

--- a/libs/typescript/integrations/claude-code/src/cli.ts
+++ b/libs/typescript/integrations/claude-code/src/cli.ts
@@ -22,9 +22,7 @@ function printUsage(): void {
   console.error(
     '                 --experiment-name <n>  Create or reuse an MLflow experiment by name.',
   );
-  console.error(
-    '                 --trace-location <loc> Optional Databricks Unity Catalog trace',
-  );
+  console.error('                 --trace-location <loc> Optional Databricks Unity Catalog trace');
   console.error(
     "                                        location as 'catalog.schema.table_prefix'.",
   );
@@ -44,9 +42,7 @@ function printUsage(): void {
   console.error(
     '                 $ mlflow-claude-code setup --user --tracking-uri databricks --experiment-id 12345',
   );
-  console.error(
-    '                 $ mlflow-claude-code setup --user --tracking-uri databricks \\',
-  );
+  console.error('                 $ mlflow-claude-code setup --user --tracking-uri databricks \\');
   console.error(
     '                     --experiment-id 12345 --trace-location my_catalog.my_schema.my_prefix',
   );

--- a/libs/typescript/integrations/claude-code/src/commands/setup.ts
+++ b/libs/typescript/integrations/claude-code/src/commands/setup.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'node:fs';
 import {
   getEffectiveTracingConfig,
   isValidTrackingUri,
+  parseTraceLocation,
   resolveExperiment,
   resolveSettingsPath,
   writeTracingSettings,
@@ -13,6 +14,7 @@ export interface SetupOptions extends ConfigPathOptions {
   trackingUri?: string;
   experimentId?: string;
   experimentName?: string;
+  traceLocation?: string;
 }
 
 export interface ParsedSetupArgs extends SetupOptions {
@@ -33,6 +35,8 @@ export function parseSetupArgs(args: string[]): ParsedSetupArgs {
       parsed.experimentId = args[++i];
     } else if (arg === '--experiment-name') {
       parsed.experimentName = args[++i];
+    } else if (arg === '--trace-location') {
+      parsed.traceLocation = args[++i];
     }
   }
   return parsed;
@@ -40,7 +44,12 @@ export function parseSetupArgs(args: string[]): ParsedSetupArgs {
 
 function printSummary(
   settingsPath: string,
-  config: { trackingUri: string; experimentId: string; experimentName?: string },
+  config: {
+    trackingUri: string;
+    experimentId: string;
+    experimentName?: string;
+    traceLocation?: string;
+  },
 ): void {
   console.error('\nCurrent configuration');
   console.error('  Tracing enabled: true');
@@ -49,6 +58,9 @@ function printSummary(
   console.error(`  Experiment ID: ${config.experimentId}`);
   if (config.experimentName) {
     console.error(`  Experiment name: ${config.experimentName}`);
+  }
+  if (config.traceLocation) {
+    console.error(`  Trace location: ${config.traceLocation}`);
   }
 }
 
@@ -89,6 +101,15 @@ export async function runSetup(args: string[], options: SetupOptions = {}): Prom
     return;
   }
 
+  if (merged.traceLocation && !parseTraceLocation(merged.traceLocation)) {
+    console.error(
+      `Error: invalid --trace-location: ${merged.traceLocation}. ` +
+        "Must be in 'catalog.schema.table_prefix' format.",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
   const settingsPath = resolveSettingsPath(merged.projectLocal, merged);
 
   try {
@@ -102,6 +123,7 @@ export async function runSetup(args: string[], options: SetupOptions = {}): Prom
       trackingUri: merged.trackingUri,
       experimentId: resolved.experimentId,
       experimentName: resolved.experimentName,
+      traceLocation: merged.traceLocation,
     });
 
     console.error(`\n${settingsFileExisted ? 'Updated' : 'Created'} ${settingsPath}`);
@@ -117,6 +139,7 @@ export async function runSetup(args: string[], options: SetupOptions = {}): Prom
       trackingUri: merged.trackingUri,
       experimentId: resolved.experimentId,
       experimentName: resolved.experimentName,
+      traceLocation: merged.traceLocation,
     });
   } catch (error) {
     console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
@@ -136,6 +159,9 @@ export function runStatus(options: ConfigPathOptions = {}): void {
   console.error(`  Tracking URI: ${config.trackingUri ?? 'not set'}`);
   console.error(`  Experiment ID: ${config.experimentId ?? 'not set'}`);
   console.error(`  Experiment name: ${config.experimentName ?? 'not set'}`);
+  if (config.traceLocation) {
+    console.error(`  Trace location: ${config.traceLocation}`);
+  }
 
   if (!config.enabled) {
     console.error('\nTracing is disabled. Run `mlflow-claude-code setup` to configure it.');

--- a/libs/typescript/integrations/claude-code/src/commands/setup.ts
+++ b/libs/typescript/integrations/claude-code/src/commands/setup.ts
@@ -36,7 +36,9 @@ export function parseSetupArgs(args: string[]): ParsedSetupArgs {
     } else if (arg === '--experiment-name') {
       parsed.experimentName = args[++i];
     } else if (arg === '--trace-location') {
-      parsed.traceLocation = args[++i];
+      // Treat a missing value as empty (not undefined) so validation fails
+      // loudly instead of silently ignoring the flag.
+      parsed.traceLocation = args[++i] ?? '';
     }
   }
   return parsed;
@@ -101,7 +103,7 @@ export async function runSetup(args: string[], options: SetupOptions = {}): Prom
     return;
   }
 
-  if (merged.traceLocation && !parseTraceLocation(merged.traceLocation)) {
+  if (merged.traceLocation !== undefined && !parseTraceLocation(merged.traceLocation)) {
     console.error(
       `Error: invalid --trace-location: ${merged.traceLocation}. ` +
         "Must be in 'catalog.schema.table_prefix' format.",

--- a/libs/typescript/integrations/claude-code/src/config.ts
+++ b/libs/typescript/integrations/claude-code/src/config.ts
@@ -275,7 +275,8 @@ export function writeTracingSettings(
   }
 
   if (hasConfigValue(config.traceLocation)) {
-    env[MLFLOW_TRACE_LOCATION] = config.traceLocation;
+    // Trim on write so stored settings match what parsing/init() will use.
+    env[MLFLOW_TRACE_LOCATION] = config.traceLocation.trim();
   } else {
     delete env[MLFLOW_TRACE_LOCATION];
   }

--- a/libs/typescript/integrations/claude-code/src/config.ts
+++ b/libs/typescript/integrations/claude-code/src/config.ts
@@ -8,6 +8,14 @@ export const MLFLOW_CLAUDE_TRACING_ENABLED = 'MLFLOW_CLAUDE_TRACING_ENABLED';
 export const MLFLOW_TRACKING_URI = 'MLFLOW_TRACKING_URI';
 export const MLFLOW_EXPERIMENT_ID = 'MLFLOW_EXPERIMENT_ID';
 export const MLFLOW_EXPERIMENT_NAME = 'MLFLOW_EXPERIMENT_NAME';
+/**
+ * Optional Databricks Unity Catalog trace location, in
+ * `catalog.schema.table_prefix` form. When set, Claude Code traces are routed
+ * to the UC table-prefix destination (V4 trace IDs) instead of the V3
+ * experiment-backed path. The UC location must already be provisioned in the
+ * workspace; the SDK does not create it.
+ */
+export const MLFLOW_TRACE_LOCATION = 'MLFLOW_TRACE_LOCATION';
 
 type ConfigSource = 'environment' | 'project' | 'user' | 'none';
 
@@ -21,8 +29,16 @@ export interface TracingConfig {
   trackingUri?: string;
   experimentId?: string;
   experimentName?: string;
+  /** Raw `catalog.schema.table_prefix` UC trace location, if configured. */
+  traceLocation?: string;
   source: ConfigSource;
   settingsPath?: string;
+}
+
+export interface UnityCatalogTraceLocation {
+  catalogName: string;
+  schemaName: string;
+  tablePrefix: string;
 }
 
 export interface ConfigPathOptions {
@@ -41,18 +57,41 @@ function hasConfigValue(value: string | undefined): value is string {
   return Boolean(value && value.trim().length > 0);
 }
 
+/**
+ * Parse a `catalog.schema.table_prefix` string into a UC trace location.
+ * Returns null when the value is empty or not exactly three non-empty,
+ * dot-separated parts. All three parts are required because the SDK does not
+ * upsert UC trace locations.
+ */
+export function parseTraceLocation(value: string | undefined): UnityCatalogTraceLocation | null {
+  if (!hasConfigValue(value)) {
+    return null;
+  }
+  const parts = value.trim().split('.');
+  if (parts.length !== 3 || parts.some((part) => part.trim().length === 0)) {
+    return null;
+  }
+  const [catalogName, schemaName, tablePrefix] = parts.map((part) => part.trim());
+  return { catalogName, schemaName, tablePrefix };
+}
+
 function hasAnyTracingKey(env: Record<string, string | undefined>): boolean {
   return [
     MLFLOW_CLAUDE_TRACING_ENABLED,
     MLFLOW_TRACKING_URI,
     MLFLOW_EXPERIMENT_ID,
     MLFLOW_EXPERIMENT_NAME,
+    MLFLOW_TRACE_LOCATION,
   ].some((key) => env[key] !== undefined);
 }
 
 function hasTracingConfig(config: TracingConfig): boolean {
   return Boolean(
-    config.trackingUri || config.experimentId || config.experimentName || config.enabled,
+    config.trackingUri ||
+      config.experimentId ||
+      config.experimentName ||
+      config.traceLocation ||
+      config.enabled,
   );
 }
 
@@ -66,6 +105,7 @@ function parseTracingConfig(
     trackingUri: env[MLFLOW_TRACKING_URI],
     experimentId: env[MLFLOW_EXPERIMENT_ID],
     experimentName: env[MLFLOW_EXPERIMENT_NAME],
+    traceLocation: env[MLFLOW_TRACE_LOCATION],
     source,
     settingsPath,
   };
@@ -119,12 +159,14 @@ export function getEffectiveTracingConfig(options: ConfigPathOptions = {}): Trac
     trackingUri: userConfig.trackingUri,
     experimentId: userConfig.experimentId,
     experimentName: userConfig.experimentName,
+    traceLocation: userConfig.traceLocation,
     ...(hasTracingConfig(projectConfig)
       ? {
           enabled: projectConfig.enabled,
           trackingUri: projectConfig.trackingUri,
           experimentId: projectConfig.experimentId,
           experimentName: projectConfig.experimentName,
+          traceLocation: projectConfig.traceLocation,
         }
       : {}),
   };
@@ -136,6 +178,7 @@ export function getEffectiveTracingConfig(options: ConfigPathOptions = {}): Trac
     trackingUri: process.env[MLFLOW_TRACKING_URI] ?? merged.trackingUri,
     experimentId: process.env[MLFLOW_EXPERIMENT_ID] ?? merged.experimentId,
     experimentName: process.env[MLFLOW_EXPERIMENT_NAME] ?? merged.experimentName,
+    traceLocation: process.env[MLFLOW_TRACE_LOCATION] ?? merged.traceLocation,
     source: 'none',
   };
 
@@ -205,7 +248,13 @@ export async function resolveExperiment(
 
 export function writeTracingSettings(
   settingsPath: string,
-  config: { trackingUri: string; experimentId: string; experimentName?: string; enabled?: boolean },
+  config: {
+    trackingUri: string;
+    experimentId: string;
+    experimentName?: string;
+    traceLocation?: string;
+    enabled?: boolean;
+  },
 ): void {
   const settings = loadSettings(settingsPath);
   const env = { ...(settings.env ?? {}) };
@@ -223,6 +272,12 @@ export function writeTracingSettings(
     env[MLFLOW_EXPERIMENT_NAME] = config.experimentName;
   } else {
     delete env[MLFLOW_EXPERIMENT_NAME];
+  }
+
+  if (hasConfigValue(config.traceLocation)) {
+    env[MLFLOW_TRACE_LOCATION] = config.traceLocation;
+  } else {
+    delete env[MLFLOW_TRACE_LOCATION];
   }
 
   settings.env = env;
@@ -245,11 +300,24 @@ export async function ensureInitialized(): Promise<boolean> {
     return false;
   }
 
+  let traceLocation: UnityCatalogTraceLocation | null = null;
+  if (hasConfigValue(config.traceLocation)) {
+    traceLocation = parseTraceLocation(config.traceLocation);
+    if (!traceLocation) {
+      console.error(
+        `[mlflow] MLFLOW_TRACE_LOCATION must be in 'catalog.schema.table_prefix' format, ` +
+          `got '${config.traceLocation}'`,
+      );
+      return false;
+    }
+  }
+
   // Fast path: skip network call when experimentId is already known.
   if (hasConfigValue(config.experimentId)) {
     const quickKey = JSON.stringify({
       trackingUri: config.trackingUri,
       experimentId: config.experimentId,
+      traceLocation,
     });
     if (initializedKey === quickKey) {
       return true;
@@ -265,6 +333,7 @@ export async function ensureInitialized(): Promise<boolean> {
     const initKey = JSON.stringify({
       trackingUri: config.trackingUri,
       experimentId: resolvedExperiment.experimentId,
+      traceLocation,
     });
     if (initializedKey === initKey) {
       return true;
@@ -273,6 +342,7 @@ export async function ensureInitialized(): Promise<boolean> {
     init({
       trackingUri: config.trackingUri,
       experimentId: resolvedExperiment.experimentId,
+      ...(traceLocation ? { traceLocation } : {}),
     });
     initializedKey = initKey;
     return true;

--- a/libs/typescript/integrations/claude-code/tests/config.test.ts
+++ b/libs/typescript/integrations/claude-code/tests/config.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import {
   ensureInitialized,
   getEffectiveTracingConfig,
+  parseTraceLocation,
   resolveSettingsPath,
   writeTracingSettings,
 } from '../src/config';
@@ -48,6 +49,7 @@ describe('Claude Code tracing config', () => {
     delete process.env.MLFLOW_TRACKING_URI;
     delete process.env.MLFLOW_EXPERIMENT_ID;
     delete process.env.MLFLOW_EXPERIMENT_NAME;
+    delete process.env.MLFLOW_TRACE_LOCATION;
     initMock.mockReset();
     getExperimentByNameMock.mockReset();
     createExperimentMock.mockReset();
@@ -143,5 +145,67 @@ describe('Claude Code tracing config', () => {
       trackingUri: 'http://localhost:5000',
       experimentId: '456',
     });
+  });
+
+  it('parses a catalog.schema.table_prefix trace location', () => {
+    expect(parseTraceLocation('cat.sch.pfx')).toEqual({
+      catalogName: 'cat',
+      schemaName: 'sch',
+      tablePrefix: 'pfx',
+    });
+    expect(parseTraceLocation('  cat.sch.pfx  ')).toEqual({
+      catalogName: 'cat',
+      schemaName: 'sch',
+      tablePrefix: 'pfx',
+    });
+    expect(parseTraceLocation(undefined)).toBeNull();
+    expect(parseTraceLocation('')).toBeNull();
+    expect(parseTraceLocation('cat.sch')).toBeNull();
+    expect(parseTraceLocation('cat.sch.pfx.extra')).toBeNull();
+    expect(parseTraceLocation('cat..pfx')).toBeNull();
+  });
+
+  it('persists and surfaces the trace location and passes it to init', async () => {
+    const settingsPath = resolveSettingsPath(true, { home: tmpHome, cwd: tmpCwd });
+    writeTracingSettings(settingsPath, {
+      trackingUri: 'databricks',
+      experimentId: '42',
+      traceLocation: 'my_catalog.my_schema.my_prefix',
+    });
+    process.chdir(tmpCwd);
+
+    const stored = JSON.parse(readFileSync(settingsPath, 'utf-8')) as {
+      env: Record<string, string>;
+    };
+    expect(stored.env.MLFLOW_TRACE_LOCATION).toBe('my_catalog.my_schema.my_prefix');
+
+    expect(getEffectiveTracingConfig({ home: tmpHome, cwd: tmpCwd })).toMatchObject({
+      trackingUri: 'databricks',
+      experimentId: '42',
+      traceLocation: 'my_catalog.my_schema.my_prefix',
+    });
+
+    await expect(ensureInitialized()).resolves.toBe(true);
+    expect(initMock).toHaveBeenCalledWith({
+      trackingUri: 'databricks',
+      experimentId: '42',
+      traceLocation: {
+        catalogName: 'my_catalog',
+        schemaName: 'my_schema',
+        tablePrefix: 'my_prefix',
+      },
+    });
+  });
+
+  it('refuses to initialize when the trace location is malformed', async () => {
+    writeTracingSettings(resolveSettingsPath(true, { home: tmpHome, cwd: tmpCwd }), {
+      trackingUri: 'databricks',
+      experimentId: '42',
+      traceLocation: 'not-a-valid-location',
+    });
+    process.chdir(tmpCwd);
+
+    await expect(ensureInitialized()).resolves.toBe(false);
+    expect(initMock).not.toHaveBeenCalled();
   });
 });

--- a/libs/typescript/integrations/claude-code/tests/setup.test.ts
+++ b/libs/typescript/integrations/claude-code/tests/setup.test.ts
@@ -159,6 +159,15 @@ describe('mlflow-claude-code setup', () => {
     });
   });
 
+  it('rejects --trace-location with a missing value instead of ignoring it', async () => {
+    await runSetup(
+      ['--user', '--tracking-uri', 'databricks', '--experiment-id', '42', '--trace-location'],
+      { home: tmpHome, cwd: tmpCwd },
+    );
+    expect(process.exitCode).toBe(1);
+    expect(existsSync(join(tmpHome, '.claude', 'settings.json'))).toBe(false);
+  });
+
   it('rejects an invalid --trace-location', async () => {
     await runSetup(
       [

--- a/libs/typescript/integrations/claude-code/tests/setup.test.ts
+++ b/libs/typescript/integrations/claude-code/tests/setup.test.ts
@@ -134,4 +134,45 @@ describe('mlflow-claude-code setup', () => {
     });
     expect(process.exitCode).toBe(1);
   });
+
+  it('writes the trace location when --trace-location is passed', async () => {
+    await runSetup(
+      [
+        '--user',
+        '--tracking-uri',
+        'databricks',
+        '--experiment-id',
+        '42',
+        '--trace-location',
+        'my_catalog.my_schema.my_prefix',
+      ],
+      { home: tmpHome, cwd: tmpCwd },
+    );
+
+    const settingsPath = join(tmpHome, '.claude', 'settings.json');
+    expect(JSON.parse(readFileSync(settingsPath, 'utf-8'))).toMatchObject({
+      env: {
+        MLFLOW_TRACKING_URI: 'databricks',
+        MLFLOW_EXPERIMENT_ID: '42',
+        MLFLOW_TRACE_LOCATION: 'my_catalog.my_schema.my_prefix',
+      },
+    });
+  });
+
+  it('rejects an invalid --trace-location', async () => {
+    await runSetup(
+      [
+        '--user',
+        '--tracking-uri',
+        'databricks',
+        '--experiment-id',
+        '42',
+        '--trace-location',
+        'not-valid',
+      ],
+      { home: tmpHome, cwd: tmpCwd },
+    );
+    expect(process.exitCode).toBe(1);
+    expect(existsSync(join(tmpHome, '.claude', 'settings.json'))).toBe(false);
+  });
 });

--- a/libs/typescript/package-lock.json
+++ b/libs/typescript/package-lock.json
@@ -64,7 +64,7 @@
     },
     "integrations/claude-code": {
       "name": "@mlflow/claude-code",
-      "version": "0.2.0",
+      "version": "0.3.0-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@mlflow/core": ">=0.2.0 || >=0.3.0-rc.0"


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23562

### What changes are proposed in this pull request?

- Add a `MLFLOW_TRACE_LOCATION` env var (and a matching `--trace-location` flag on `mlflow-claude-code setup`) so Claude Code tracing can target a Databricks Unity Catalog trace location instead of the experiment-backed path.
- The value is parsed/validated as `catalog.schema.table_prefix` (all three parts required) and threaded through to `@mlflow/core`'s `init()` as `traceLocation`, which routes traces through the V4 UC ingestion path.
- Surface the configured location in the `setup`/`status` output and document the env var and CLI flag in the integration README.

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests

Added `config.test.ts`/`setup.test.ts` cases for parsing, persistence, init pass-through, malformed-value rejection, and the CLI flag. Manually verified end-to-end: the built Stop-hook bundle reads `MLFLOW_TRACE_LOCATION` and writes a trace to a real Unity Catalog location.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [x] Instructions

The package README documents the new env var and `--trace-location` flag. The docs-site Claude Code integration page may want a follow-up.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Claude Code tracing can now route traces to a Databricks Unity Catalog trace location by setting `MLFLOW_TRACE_LOCATION` (or `mlflow-claude-code setup --trace-location catalog.schema.table_prefix`).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release