### PR TITLE
[Codex] Support UC trace location via `MLFLOW_TRACE_LOCATION`

### DIFF
--- a/libs/typescript/integrations/codex/package.json
+++ b/libs/typescript/integrations/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlflow/codex",
-  "version": "0.2.0",
+  "version": "0.3.0-rc.0",
   "description": "Codex CLI integration package for MLflow Tracing",
   "type": "module",
   "repository": {

--- a/libs/typescript/integrations/codex/src/cli.ts
+++ b/libs/typescript/integrations/codex/src/cli.ts
@@ -42,7 +42,7 @@ function printUsage(): void {
   );
   console.error(
     dim(
-      "                 --trace-location <loc> Databricks Unity Catalog trace location as\n" +
+      '                 --trace-location <loc> Databricks Unity Catalog trace location as\n' +
         "                                        'catalog.schema.table_prefix' (routes to UC ingestion)",
     ),
   );

--- a/libs/typescript/integrations/codex/src/cli.ts
+++ b/libs/typescript/integrations/codex/src/cli.ts
@@ -40,6 +40,12 @@ function printUsage(): void {
   console.error(
     dim('                 --experiment-id <id>   Bypass the prompt for the experiment ID'),
   );
+  console.error(
+    dim(
+      "                 --trace-location <loc> Databricks Unity Catalog trace location as\n" +
+        "                                        'catalog.schema.table_prefix' (routes to UC ingestion)",
+    ),
+  );
   console.error('');
   console.error(
     `  ${bold('notify-hook')}  Run the Codex notify handler. Codex appends the turn JSON as`,

--- a/libs/typescript/integrations/codex/src/commands/setup.ts
+++ b/libs/typescript/integrations/codex/src/commands/setup.ts
@@ -22,6 +22,7 @@ import { homedir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { createInterface } from 'node:readline';
 
+import { parseTraceLocation } from '../config.js';
 import { FAIL, OK, WARN, bold, cyan, dim } from '../ui.js';
 import { selectPrompt } from '../ui-select.js';
 
@@ -37,6 +38,9 @@ const DEFAULT_EXPERIMENT_ID = '0';
  * interprets as a custom scheme with an empty port).
  */
 export function isValidTrackingUri(raw: string): boolean {
+  if (raw === 'databricks' || raw.startsWith('databricks://')) {
+    return true;
+  }
   let parsed: URL;
   try {
     parsed = new URL(raw);
@@ -55,6 +59,12 @@ export interface SetupOptions {
   trackingUri?: string;
   /** Pre-supplied experiment ID. Skips the interactive prompt. */
   experimentId?: string;
+  /**
+   * Optional Databricks Unity Catalog trace location as
+   * `catalog.schema.table_prefix`. When set, traces are routed to the UC
+   * table-prefix destination instead of the experiment-backed path.
+   */
+  traceLocation?: string;
   /** Suppress prompts entirely. Uses defaults for any unset values. */
   nonInteractive?: boolean;
 }
@@ -80,7 +90,7 @@ function writeConfigWithHook(path: string, original: string | null): void {
 
 function writeTracingConfig(
   path: string,
-  config: { trackingUri: string; experimentId: string },
+  config: { trackingUri: string; experimentId: string; traceLocation?: string },
 ): void {
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, JSON.stringify(config, null, 2) + '\n', 'utf-8');
@@ -92,6 +102,7 @@ function writeTracingConfig(
  *   --non-interactive / -y
  *   --tracking-uri <url>
  *   --experiment-id <id>
+ *   --trace-location <catalog.schema.table_prefix>
  *
  * `projectLocal` is left undefined when `--project` is not passed so the
  * caller can apply its own default (interactive prompts; non-interactive
@@ -111,6 +122,8 @@ export function parseSetupArgs(
       out.trackingUri = args[++i];
     } else if (arg === '--experiment-id') {
       out.experimentId = args[++i];
+    } else if (arg === '--trace-location') {
+      out.traceLocation = args[++i];
     }
   }
   return out;
@@ -224,7 +237,7 @@ export async function runSetup(args: string[], options: SetupOptions = {}): Prom
       merged.experimentId ??
       (rl ? await askOn(rl, 'MLflow experiment ID', DEFAULT_EXPERIMENT_ID) : DEFAULT_EXPERIMENT_ID);
 
-    writeTracingConfigIfValid(tracingConfigPath, trackingUri, experimentId);
+    writeTracingConfigIfValid(tracingConfigPath, trackingUri, experimentId, merged.traceLocation);
   } finally {
     rl?.close();
   }
@@ -234,25 +247,45 @@ function writeTracingConfigIfValid(
   tracingConfigPath: string,
   trackingUri: string,
   experimentId: string,
+  traceLocation?: string,
 ): void {
   if (!isValidTrackingUri(trackingUri)) {
     console.error(
-      `${FAIL} Invalid tracking URI: ${bold(trackingUri)} — must be an absolute http:// or https:// URL.`,
+      `${FAIL} Invalid tracking URI: ${bold(trackingUri)} - must be an absolute http:// or https:// URL, or a databricks URI.`,
     );
     process.exitCode = 1;
     return;
   }
-  writeTracingConfig(tracingConfigPath, { trackingUri, experimentId });
+  if (traceLocation && !parseTraceLocation(traceLocation)) {
+    console.error(
+      `${FAIL} Invalid trace location: ${bold(traceLocation)} - must be in 'catalog.schema.table_prefix' format.`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+  writeTracingConfig(tracingConfigPath, {
+    trackingUri,
+    experimentId,
+    ...(traceLocation ? { traceLocation } : {}),
+  });
   console.error(`\n${OK} Wrote tracing config to ${cyan(tracingConfigPath)}`);
+  if (traceLocation) {
+    console.error(`  Trace location: ${bold(traceLocation)}`);
+  }
 
-  const port = new URL(trackingUri).port || '5000';
   console.error(`\n${bold('Next steps')}`);
-  console.error('  1. Start the MLflow tracking server in a separate terminal:');
-  console.error(`       ${cyan(`mlflow server --port ${port}`)}`);
+  if (trackingUri.startsWith('databricks')) {
+    const destination = traceLocation ? `UC location ${bold(traceLocation)}` : bold(trackingUri);
+    console.error(`  1. Launch ${cyan('codex')} - traces appear in ${destination} after each turn.`);
+  } else {
+    const port = new URL(trackingUri).port || '5000';
+    console.error('  1. Start the MLflow tracking server in a separate terminal:');
+    console.error(`       ${cyan(`mlflow server --port ${port}`)}`);
+    console.error(
+      `  2. Launch ${cyan('codex')} - traces appear at ${bold(trackingUri)} after each turn.`,
+    );
+  }
   console.error(
-    `  2. Launch ${cyan('codex')} — traces appear at ${bold(trackingUri)} after each turn.`,
-  );
-  console.error(
-    `\n${dim('Override per-shell with $MLFLOW_TRACKING_URI / $MLFLOW_EXPERIMENT_ID.')}`,
+    `\n${dim('Override per-shell with $MLFLOW_TRACKING_URI / $MLFLOW_EXPERIMENT_ID / $MLFLOW_TRACE_LOCATION.')}`,
   );
 }

--- a/libs/typescript/integrations/codex/src/commands/setup.ts
+++ b/libs/typescript/integrations/codex/src/commands/setup.ts
@@ -276,7 +276,9 @@ function writeTracingConfigIfValid(
   console.error(`\n${bold('Next steps')}`);
   if (trackingUri.startsWith('databricks')) {
     const destination = traceLocation ? `UC location ${bold(traceLocation)}` : bold(trackingUri);
-    console.error(`  1. Launch ${cyan('codex')} - traces appear in ${destination} after each turn.`);
+    console.error(
+      `  1. Launch ${cyan('codex')} - traces appear in ${destination} after each turn.`,
+    );
   } else {
     const port = new URL(trackingUri).port || '5000';
     console.error('  1. Start the MLflow tracking server in a separate terminal:');

--- a/libs/typescript/integrations/codex/src/config.ts
+++ b/libs/typescript/integrations/codex/src/config.ts
@@ -8,9 +8,39 @@ let initialized = false;
 
 const TRACING_CONFIG_FILE = 'mlflow-tracing.json';
 
-interface TracingConfig {
+export interface TracingConfig {
   trackingUri?: string;
   experimentId?: string;
+  /** Raw `catalog.schema.table_prefix` UC trace location, if configured. */
+  traceLocation?: string;
+}
+
+/**
+ * A Databricks Unity Catalog trace location parsed from a
+ * `catalog.schema.table_prefix` string.
+ */
+export interface UnityCatalogTraceLocation {
+  catalogName: string;
+  schemaName: string;
+  tablePrefix: string;
+}
+
+/**
+ * Parse a `catalog.schema.table_prefix` string into a UC trace location.
+ * Returns null when the value is empty or not exactly three non-empty,
+ * dot-separated parts. All three parts are required because the SDK does not
+ * create UC trace locations - the customer must point at a provisioned one.
+ */
+export function parseTraceLocation(value: string | undefined): UnityCatalogTraceLocation | null {
+  if (!value || value.trim().length === 0) {
+    return null;
+  }
+  const parts = value.trim().split('.');
+  if (parts.length !== 3 || parts.some((part) => part.trim().length === 0)) {
+    return null;
+  }
+  const [catalogName, schemaName, tablePrefix] = parts.map((part) => part.trim());
+  return { catalogName, schemaName, tablePrefix };
 }
 
 export interface ResolveConfigOptions {
@@ -33,7 +63,8 @@ function readTracingConfigFile(path: string): TracingConfig {
 
 /**
  * Resolve the effective MLflow tracing config. Precedence (highest first):
- *   1. `MLFLOW_TRACKING_URI` / `MLFLOW_EXPERIMENT_ID` environment variables
+ *   1. `MLFLOW_TRACKING_URI` / `MLFLOW_EXPERIMENT_ID` / `MLFLOW_TRACE_LOCATION`
+ *      environment variables
  *   2. `./.codex/mlflow-tracing.json` (project-local)
  *   3. `~/.codex/mlflow-tracing.json` (user-level)
  */
@@ -47,6 +78,8 @@ export function resolveTracingConfig(options: ResolveConfigOptions = {}): Tracin
       process.env.MLFLOW_TRACKING_URI ?? projectConfig.trackingUri ?? userConfig.trackingUri,
     experimentId:
       process.env.MLFLOW_EXPERIMENT_ID ?? projectConfig.experimentId ?? userConfig.experimentId,
+    traceLocation:
+      process.env.MLFLOW_TRACE_LOCATION ?? projectConfig.traceLocation ?? userConfig.traceLocation,
   };
 }
 
@@ -59,17 +92,33 @@ export function ensureInitialized(): boolean {
     return true;
   }
 
-  const { trackingUri, experimentId } = resolveTracingConfig();
+  const { trackingUri, experimentId, traceLocation: rawTraceLocation } = resolveTracingConfig();
   if (!trackingUri) {
     console.error(
-      '[mlflow] MLflow tracking URI is not configured — checked $MLFLOW_TRACKING_URI,',
+      '[mlflow] MLflow tracking URI is not configured - checked $MLFLOW_TRACKING_URI,',
       './.codex/mlflow-tracing.json, and ~/.codex/mlflow-tracing.json.',
     );
     console.error('[mlflow] Run `mlflow-codex setup` to configure.');
     return false;
   }
 
-  init({ trackingUri, experimentId });
+  let traceLocation: UnityCatalogTraceLocation | null = null;
+  if (rawTraceLocation && rawTraceLocation.trim().length > 0) {
+    traceLocation = parseTraceLocation(rawTraceLocation);
+    if (!traceLocation) {
+      console.error(
+        `[mlflow] MLFLOW_TRACE_LOCATION must be in 'catalog.schema.table_prefix' format, ` +
+          `got '${rawTraceLocation}'`,
+      );
+      return false;
+    }
+  }
+
+  init({
+    trackingUri,
+    experimentId,
+    ...(traceLocation ? { traceLocation } : {}),
+  });
   initialized = true;
   return true;
 }

--- a/libs/typescript/integrations/codex/tests/config.test.ts
+++ b/libs/typescript/integrations/codex/tests/config.test.ts
@@ -1,0 +1,173 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { parseTraceLocation, resolveTracingConfig } from '../src/config';
+
+jest.mock('@mlflow/core', () => ({ init: jest.fn() }));
+
+describe('parseTraceLocation', () => {
+  it('parses a catalog.schema.table_prefix value', () => {
+    expect(parseTraceLocation('cat.sch.pfx')).toEqual({
+      catalogName: 'cat',
+      schemaName: 'sch',
+      tablePrefix: 'pfx',
+    });
+    expect(parseTraceLocation('  cat.sch.pfx  ')).toEqual({
+      catalogName: 'cat',
+      schemaName: 'sch',
+      tablePrefix: 'pfx',
+    });
+  });
+
+  it('returns null for empty or malformed values', () => {
+    expect(parseTraceLocation(undefined)).toBeNull();
+    expect(parseTraceLocation('')).toBeNull();
+    expect(parseTraceLocation('cat.sch')).toBeNull();
+    expect(parseTraceLocation('cat.sch.pfx.extra')).toBeNull();
+    expect(parseTraceLocation('cat..pfx')).toBeNull();
+  });
+});
+
+describe('resolveTracingConfig', () => {
+  let tmpHome: string;
+  let tmpCwd: string;
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), 'codex-config-home-'));
+    tmpCwd = mkdtempSync(join(tmpdir(), 'codex-config-cwd-'));
+    delete process.env.MLFLOW_TRACKING_URI;
+    delete process.env.MLFLOW_EXPERIMENT_ID;
+    delete process.env.MLFLOW_TRACE_LOCATION;
+  });
+
+  afterEach(() => {
+    rmSync(tmpHome, { recursive: true, force: true });
+    rmSync(tmpCwd, { recursive: true, force: true });
+    delete process.env.MLFLOW_TRACKING_URI;
+    delete process.env.MLFLOW_EXPERIMENT_ID;
+    delete process.env.MLFLOW_TRACE_LOCATION;
+  });
+
+  function writeUserConfig(config: Record<string, string>): void {
+    mkdirSync(join(tmpHome, '.codex'), { recursive: true });
+    writeFileSync(
+      join(tmpHome, '.codex', 'mlflow-tracing.json'),
+      JSON.stringify(config),
+      'utf-8',
+    );
+  }
+
+  it('reads the trace location from mlflow-tracing.json', () => {
+    writeUserConfig({
+      trackingUri: 'databricks',
+      experimentId: '42',
+      traceLocation: 'my_catalog.my_schema.my_prefix',
+    });
+
+    expect(resolveTracingConfig({ home: tmpHome, cwd: tmpCwd })).toEqual({
+      trackingUri: 'databricks',
+      experimentId: '42',
+      traceLocation: 'my_catalog.my_schema.my_prefix',
+    });
+  });
+
+  it('prefers MLFLOW_TRACE_LOCATION env over the config file', () => {
+    writeUserConfig({
+      trackingUri: 'databricks',
+      experimentId: '42',
+      traceLocation: 'file_catalog.file_schema.file_prefix',
+    });
+    process.env.MLFLOW_TRACE_LOCATION = 'env_catalog.env_schema.env_prefix';
+
+    expect(resolveTracingConfig({ home: tmpHome, cwd: tmpCwd })).toMatchObject({
+      traceLocation: 'env_catalog.env_schema.env_prefix',
+    });
+  });
+
+  it('leaves the trace location undefined when not configured', () => {
+    writeUserConfig({ trackingUri: 'http://localhost:5000', experimentId: '0' });
+
+    expect(resolveTracingConfig({ home: tmpHome, cwd: tmpCwd }).traceLocation).toBeUndefined();
+  });
+});
+
+describe('ensureInitialized', () => {
+  let tmpHome: string;
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), 'codex-init-home-'));
+    delete process.env.MLFLOW_TRACKING_URI;
+    delete process.env.MLFLOW_EXPERIMENT_ID;
+    delete process.env.MLFLOW_TRACE_LOCATION;
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    rmSync(tmpHome, { recursive: true, force: true });
+    delete process.env.MLFLOW_TRACKING_URI;
+    delete process.env.MLFLOW_EXPERIMENT_ID;
+    delete process.env.MLFLOW_TRACE_LOCATION;
+  });
+
+  it('passes a parsed UC trace location to init', () => {
+    process.env.MLFLOW_TRACKING_URI = 'databricks';
+    process.env.MLFLOW_EXPERIMENT_ID = '42';
+    process.env.MLFLOW_TRACE_LOCATION = 'my_catalog.my_schema.my_prefix';
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { init } = require('@mlflow/core') as { init: jest.Mock };
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { ensureInitialized } = require('../src/config') as {
+      ensureInitialized: () => boolean;
+    };
+
+    expect(ensureInitialized()).toBe(true);
+    expect(init).toHaveBeenCalledWith({
+      trackingUri: 'databricks',
+      experimentId: '42',
+      traceLocation: {
+        catalogName: 'my_catalog',
+        schemaName: 'my_schema',
+        tablePrefix: 'my_prefix',
+      },
+    });
+  });
+
+  it('omits traceLocation when not configured', () => {
+    process.env.MLFLOW_TRACKING_URI = 'http://localhost:5000';
+    process.env.MLFLOW_EXPERIMENT_ID = '0';
+    // Set to empty (not deleted) so a stray ~/.codex/mlflow-tracing.json on the
+    // developer machine can't leak a trace location into this assertion.
+    process.env.MLFLOW_TRACE_LOCATION = '';
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { init } = require('@mlflow/core') as { init: jest.Mock };
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { ensureInitialized } = require('../src/config') as {
+      ensureInitialized: () => boolean;
+    };
+
+    expect(ensureInitialized()).toBe(true);
+    expect(init).toHaveBeenCalledWith({
+      trackingUri: 'http://localhost:5000',
+      experimentId: '0',
+    });
+  });
+
+  it('refuses to initialize when the trace location is malformed', () => {
+    process.env.MLFLOW_TRACKING_URI = 'databricks';
+    process.env.MLFLOW_EXPERIMENT_ID = '42';
+    process.env.MLFLOW_TRACE_LOCATION = 'not-a-valid-location';
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { init } = require('@mlflow/core') as { init: jest.Mock };
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { ensureInitialized } = require('../src/config') as {
+      ensureInitialized: () => boolean;
+    };
+
+    expect(ensureInitialized()).toBe(false);
+    expect(init).not.toHaveBeenCalled();
+  });
+});

--- a/libs/typescript/integrations/codex/tests/config.test.ts
+++ b/libs/typescript/integrations/codex/tests/config.test.ts
@@ -51,11 +51,7 @@ describe('resolveTracingConfig', () => {
 
   function writeUserConfig(config: Record<string, string>): void {
     mkdirSync(join(tmpHome, '.codex'), { recursive: true });
-    writeFileSync(
-      join(tmpHome, '.codex', 'mlflow-tracing.json'),
-      JSON.stringify(config),
-      'utf-8',
-    );
+    writeFileSync(join(tmpHome, '.codex', 'mlflow-tracing.json'), JSON.stringify(config), 'utf-8');
   }
 
   it('reads the trace location from mlflow-tracing.json', () => {

--- a/libs/typescript/integrations/codex/tests/setup.test.ts
+++ b/libs/typescript/integrations/codex/tests/setup.test.ts
@@ -227,4 +227,44 @@ describe('runSetup', () => {
       rmSync(cwd, { recursive: true, force: true });
     }
   });
+
+  it('accepts a databricks tracking URI and persists the trace location', async () => {
+    await runSetup(
+      [
+        '--non-interactive',
+        '--tracking-uri',
+        'databricks',
+        '--experiment-id',
+        '42',
+        '--trace-location',
+        'my_catalog.my_schema.my_prefix',
+      ],
+      { home: tmpHome, cwd: tmpHome },
+    );
+
+    expect(process.exitCode).toBeFalsy();
+    expect(readJson(join(tmpHome, '.codex', 'mlflow-tracing.json'))).toEqual({
+      trackingUri: 'databricks',
+      experimentId: '42',
+      traceLocation: 'my_catalog.my_schema.my_prefix',
+    });
+  });
+
+  it('rejects an invalid --trace-location and exits 1 without writing config', async () => {
+    await runSetup(
+      [
+        '--non-interactive',
+        '--tracking-uri',
+        'databricks',
+        '--experiment-id',
+        '42',
+        '--trace-location',
+        'not-valid',
+      ],
+      { home: tmpHome, cwd: tmpHome },
+    );
+
+    expect(process.exitCode).toBe(1);
+    expect(existsSync(join(tmpHome, '.codex', 'mlflow-tracing.json'))).toBe(false);
+  });
 });

--- a/libs/typescript/package-lock.json
+++ b/libs/typescript/package-lock.json
@@ -92,7 +92,7 @@
     },
     "integrations/codex": {
       "name": "@mlflow/codex",
-      "version": "0.2.0",
+      "version": "0.3.0-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@mlflow/core": "^0.2.0"


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23562. Mirrors #23770 (the same change for the Claude Code integration).

### What changes are proposed in this pull request?

- Add a `MLFLOW_TRACE_LOCATION` env var (and a matching `--trace-location` flag on `mlflow-codex setup`) so Codex tracing can target a Databricks Unity Catalog trace location instead of the experiment-backed path.
- The value is parsed/validated as `catalog.schema.table_prefix` (all three parts required) and threaded through to `@mlflow/core`'s `init()` as `traceLocation`, which routes traces through the V4 UC ingestion path instead of the V3 `StartTrace` path.
- Accept `databricks` / `databricks://` tracking URIs in `mlflow-codex setup` (previously only `http(s)` URIs passed validation), so the UC flow is usable end to end via setup.
- Surface the configured location in the `setup` output.

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests

Added `tests/config.test.ts` (trace-location parsing, env/file resolution precedence, init pass-through, and malformed-value rejection) and `tests/setup.test.ts` cases for persisting the location, accepting a `databricks` tracking URI, and rejecting a malformed `--trace-location`. All 57 codex tests pass; `npm run lint` is clean at the workspace root and the bundle builds with the UC export path inlined.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Codex CLI tracing can now route traces to a Databricks Unity Catalog trace location by setting `MLFLOW_TRACE_LOCATION` (or `mlflow-codex setup --trace-location catalog.schema.table_prefix`).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.