### PR TITLE
[OpenCode] Support Databricks Unity Catalog trace location via `MLFLOW_TRACE_LOCATION`

### DIFF
--- a/libs/typescript/integrations/opencode/README.md
+++ b/libs/typescript/integrations/opencode/README.md
@@ -38,11 +38,28 @@ export MLFLOW_EXPERIMENT_ID=123
 
 The plugin is configured via environment variables:
 
-| Variable                | Required | Description                                                |
-| ----------------------- | -------- | ---------------------------------------------------------- |
-| `MLFLOW_TRACKING_URI`   | Yes      | MLflow tracking server URI (e.g., `http://localhost:5000`) |
-| `MLFLOW_EXPERIMENT_ID`  | Yes      | MLflow experiment ID                                       |
-| `MLFLOW_OPENCODE_DEBUG` | No       | Set to `true` to enable debug logging                      |
+| Variable                | Required | Description                                                                          |
+| ----------------------- | -------- | ------------------------------------------------------------------------------------ |
+| `MLFLOW_TRACKING_URI`   | Yes      | MLflow tracking server URI (e.g., `http://localhost:5000`)                           |
+| `MLFLOW_EXPERIMENT_ID`  | Yes      | MLflow experiment ID                                                                 |
+| `MLFLOW_TRACE_LOCATION` | No       | Databricks Unity Catalog trace location as `catalog.schema.table_prefix` (see below) |
+| `MLFLOW_OPENCODE_DEBUG` | No       | Set to `true` to enable debug logging                                                |
+
+### Databricks Unity Catalog trace location
+
+To route traces to a Databricks Unity Catalog location instead of the default
+experiment-backed path, set `MLFLOW_TRACE_LOCATION` to a fully-qualified
+`catalog.schema.table_prefix`:
+
+```bash
+export MLFLOW_TRACKING_URI=databricks
+export MLFLOW_EXPERIMENT_ID=123
+export MLFLOW_TRACE_LOCATION=my_catalog.my_schema.my_prefix
+```
+
+All three parts are required. The UC trace location must already be provisioned
+in the workspace; the plugin does not create it. When set, traces are written
+via the Unity Catalog ingestion path (V4 trace IDs).
 
 ## Viewing Traces
 

--- a/libs/typescript/integrations/opencode/package.json
+++ b/libs/typescript/integrations/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlflow/opencode",
-  "version": "0.2.0",
+  "version": "0.3.0-rc.0",
   "description": "OpenCode integration package for MLflow Tracing",
   "repository": {
     "type": "git",

--- a/libs/typescript/integrations/opencode/src/index.ts
+++ b/libs/typescript/integrations/opencode/src/index.ts
@@ -10,6 +10,8 @@
  *   3. Set environment variables:
  *      export MLFLOW_TRACKING_URI=http://localhost:5000
  *      export MLFLOW_EXPERIMENT_ID=123
+ *      # Optional: route traces to a Databricks Unity Catalog location
+ *      export MLFLOW_TRACE_LOCATION=catalog.schema.table_prefix
  *   4. Run opencode normally - tracing happens automatically
  */
 
@@ -101,9 +103,37 @@ interface Message {
   parts?: MessagePart[];
 }
 
+interface UnityCatalogTraceLocation {
+  catalogName: string;
+  schemaName: string;
+  tablePrefix: string;
+}
+
+/**
+ * Parse a `catalog.schema.table_prefix` string into a UC trace location.
+ * Returns null when the value is empty or not exactly three non-empty,
+ * dot-separated parts. All three parts are required because the SDK does not
+ * upsert UC trace locations.
+ */
+export function parseTraceLocation(value: string | undefined): UnityCatalogTraceLocation | null {
+  if (!value || value.trim().length === 0) {
+    return null;
+  }
+  const parts = value.trim().split('.');
+  if (parts.length !== 3 || parts.some((part) => part.trim().length === 0)) {
+    return null;
+  }
+  const [catalogName, schemaName, tablePrefix] = parts.map((part) => part.trim());
+  return { catalogName, schemaName, tablePrefix };
+}
+
 /**
  * Initialize the MLflow tracing SDK if not already initialized.
  * Requires MLFLOW_TRACKING_URI and MLFLOW_EXPERIMENT_ID environment variables.
+ * When MLFLOW_TRACE_LOCATION is set (in `catalog.schema.table_prefix` form),
+ * traces are routed to the Databricks Unity Catalog destination (V4) instead
+ * of the V3 experiment-backed path. The UC location must already be
+ * provisioned in the workspace; the SDK does not create it.
  */
 function ensureInitialized(): boolean {
   if (initialized) {
@@ -112,6 +142,7 @@ function ensureInitialized(): boolean {
 
   const trackingUri = process.env.MLFLOW_TRACKING_URI;
   const experimentId = process.env.MLFLOW_EXPERIMENT_ID;
+  const rawTraceLocation = process.env.MLFLOW_TRACE_LOCATION;
 
   if (!trackingUri) {
     if (DEBUG) {
@@ -127,8 +158,22 @@ function ensureInitialized(): boolean {
     return false;
   }
 
+  let traceLocation: UnityCatalogTraceLocation | null = null;
+  if (rawTraceLocation && rawTraceLocation.trim().length > 0) {
+    traceLocation = parseTraceLocation(rawTraceLocation);
+    if (!traceLocation) {
+      if (DEBUG) {
+        console.error(
+          `[mlflow] MLFLOW_TRACE_LOCATION must be in 'catalog.schema.table_prefix' format, ` +
+            `got '${rawTraceLocation}'`,
+        );
+      }
+      return false;
+    }
+  }
+
   try {
-    init({ trackingUri, experimentId });
+    init({ trackingUri, experimentId, ...(traceLocation ? { traceLocation } : {}) });
     initialized = true;
     if (DEBUG) {
       console.error('[mlflow] SDK initialized successfully');

--- a/libs/typescript/integrations/opencode/tests/index.test.ts
+++ b/libs/typescript/integrations/opencode/tests/index.test.ts
@@ -201,6 +201,7 @@ describe('MLflowTracingPlugin', () => {
     process.env = { ...originalEnv };
     delete process.env.MLFLOW_TRACKING_URI;
     delete process.env.MLFLOW_EXPERIMENT_ID;
+    delete process.env.MLFLOW_TRACE_LOCATION;
   });
 
   afterAll(() => {

--- a/libs/typescript/integrations/opencode/tests/trace_location.test.ts
+++ b/libs/typescript/integrations/opencode/tests/trace_location.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for Databricks Unity Catalog trace location support in the
+ * MLflow OpenCode integration.
+ */
+
+import type { PluginInput } from '@opencode-ai/plugin';
+
+interface PluginClient {
+  session: {
+    messages: jest.Mock;
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type EventParams = any;
+
+jest.mock('@mlflow/core', () => {
+  const mockSpan = {
+    traceId: 'mock-trace-id',
+    setAttribute: jest.fn(),
+    setOutputs: jest.fn(),
+    end: jest.fn(),
+  };
+
+  const mockTrace = {
+    info: { requestPreview: '', responsePreview: '', traceMetadata: {} },
+  };
+
+  return {
+    init: jest.fn(),
+    startSpan: jest.fn(() => mockSpan),
+    flushTraces: jest.fn().mockResolvedValue(undefined),
+    SpanType: { LLM: 'LLM', TOOL: 'TOOL', AGENT: 'AGENT' },
+    SpanAttributeKey: { TOKEN_USAGE: 'token_usage' },
+    TraceMetadataKey: {
+      TRACE_SESSION: 'mlflow.trace.session',
+      TRACE_USER: 'mlflow.trace.user',
+    },
+    InMemoryTraceManager: {
+      getInstance: jest.fn(() => ({ getTrace: jest.fn(() => mockTrace) })),
+    },
+  };
+});
+
+import { MLflowTracingPlugin, parseTraceLocation } from '../src';
+import * as mlflowTracing from '@mlflow/core';
+
+const createMockClient = (messagesData: unknown[] = []): PluginClient => ({
+  session: {
+    messages: jest.fn().mockResolvedValue({ data: messagesData }),
+  },
+});
+
+const createPluginInput = (client: PluginClient): PluginInput =>
+  ({ client }) as unknown as PluginInput;
+
+const createSessionIdleEvent = (sessionID: string): EventParams => ({
+  event: { type: 'session.idle', properties: { sessionID } },
+});
+
+const createUserMessage = (text: string) => ({
+  info: { role: 'user', time: { created: 1000, completed: 1000 } },
+  parts: [{ type: 'text', text }],
+});
+
+const createAssistantTextMessage = (text: string) => ({
+  info: {
+    role: 'assistant',
+    modelID: 'claude-3-opus',
+    providerID: 'anthropic',
+    tokens: { input: 100, output: 50 },
+    time: { created: 1100, completed: 2000 },
+  },
+  parts: [{ type: 'text', text }],
+});
+
+describe('parseTraceLocation', () => {
+  it('parses a valid catalog.schema.table_prefix string', () => {
+    expect(parseTraceLocation('my_catalog.my_schema.my_prefix')).toEqual({
+      catalogName: 'my_catalog',
+      schemaName: 'my_schema',
+      tablePrefix: 'my_prefix',
+    });
+  });
+
+  it('trims surrounding whitespace on each part', () => {
+    expect(parseTraceLocation('  cat . sch . pref ')).toEqual({
+      catalogName: 'cat',
+      schemaName: 'sch',
+      tablePrefix: 'pref',
+    });
+  });
+
+  it.each([
+    ['undefined', undefined],
+    ['empty string', ''],
+    ['whitespace only', '   '],
+    ['two parts', 'catalog.schema'],
+    ['four parts', 'a.b.c.d'],
+    ['empty middle part', 'catalog..prefix'],
+    ['trailing dot', 'catalog.schema.'],
+  ])('returns null for %s', (_label, value) => {
+    expect(parseTraceLocation(value)).toBeNull();
+  });
+});
+
+describe('MLFLOW_TRACE_LOCATION wiring', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.MLFLOW_TRACKING_URI;
+    delete process.env.MLFLOW_EXPERIMENT_ID;
+    delete process.env.MLFLOW_TRACE_LOCATION;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('does not initialize when MLFLOW_TRACE_LOCATION is malformed', async () => {
+    process.env.MLFLOW_TRACKING_URI = 'databricks';
+    process.env.MLFLOW_EXPERIMENT_ID = 'exp-123';
+    process.env.MLFLOW_TRACE_LOCATION = 'not-a-valid-location';
+
+    const messages = [createUserMessage('Hi'), createAssistantTextMessage('Hello')];
+    const mockClient = createMockClient(messages);
+    const hooks = await MLflowTracingPlugin(createPluginInput(mockClient));
+
+    await hooks.event!(createSessionIdleEvent('bad-uc-session'));
+
+    expect(mlflowTracing.init).not.toHaveBeenCalled();
+    expect(mockClient.session.messages).not.toHaveBeenCalled();
+  });
+
+  it('passes the parsed UC trace location to init', async () => {
+    process.env.MLFLOW_TRACKING_URI = 'databricks';
+    process.env.MLFLOW_EXPERIMENT_ID = 'exp-123';
+    process.env.MLFLOW_TRACE_LOCATION = 'my_catalog.my_schema.my_prefix';
+
+    const messages = [createUserMessage('Hi'), createAssistantTextMessage('Hello')];
+    const mockClient = createMockClient(messages);
+    const hooks = await MLflowTracingPlugin(createPluginInput(mockClient));
+
+    await hooks.event!(createSessionIdleEvent('uc-session'));
+
+    expect(mlflowTracing.init).toHaveBeenCalledWith({
+      trackingUri: 'databricks',
+      experimentId: 'exp-123',
+      traceLocation: {
+        catalogName: 'my_catalog',
+        schemaName: 'my_schema',
+        tablePrefix: 'my_prefix',
+      },
+    });
+  });
+});

--- a/libs/typescript/package-lock.json
+++ b/libs/typescript/package-lock.json
@@ -171,7 +171,7 @@
     },
     "integrations/opencode": {
       "name": "@mlflow/opencode",
-      "version": "0.2.0",
+      "version": "0.3.0-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@mlflow/core": ">=0.2.0 || >=0.3.0-rc.0"


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23770

### What changes are proposed in this pull request?

Adds optional Databricks Unity Catalog (UC) trace location support to the `@mlflow/opencode` tracing plugin, mirroring what #23770 added for Claude Code.

When the new `MLFLOW_TRACE_LOCATION` environment variable is set to a fully-qualified `catalog.schema.table_prefix`, the plugin routes OpenCode traces to the UC destination (V4 ingestion path) instead of the default experiment-backed (V3) path. When unset, behavior is unchanged.

Details:
- New `parseTraceLocation()` helper validates exactly three non-empty, dot-separated parts (all required, since the SDK does not upsert UC locations) and trims whitespace.
- `ensureInitialized()` parses the location and threads it into `init({ trackingUri, experimentId, traceLocation })`. A malformed value aborts initialization (DEBUG-gated, consistent with the plugin's silent-by-design contract).
- `MLFLOW_EXPERIMENT_ID` remains required, since `@mlflow/core`'s `init()` requires it even on the UC path.
- README documents the new variable and a dedicated UC section.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New `tests/trace_location.test.ts` covers `parseTraceLocation` (valid, whitespace, 2/4 parts, empty/trailing parts) plus wiring tests asserting `init` receives the parsed `traceLocation` and that a malformed value blocks initialization. All 44 OpenCode tests pass; `tsc`, `eslint` (root config, including tests), and `prettier` are clean.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The OpenCode tracing plugin now supports routing traces to a Databricks Unity Catalog location via the `MLFLOW_TRACE_LOCATION` environment variable (`catalog.schema.table_prefix`).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.