### PR TITLE
Add workspace support to Claude Code plugin

### DIFF
--- a/libs/typescript/integrations/claude-code/src/commands/setup.ts
+++ b/libs/typescript/integrations/claude-code/src/commands/setup.ts
@@ -15,6 +15,7 @@ export interface SetupOptions extends ConfigPathOptions {
   experimentId?: string;
   experimentName?: string;
   traceLocation?: string;
+  workspace?: string;
 }
 
 export interface ParsedSetupArgs extends SetupOptions {
@@ -39,6 +40,8 @@ export function parseSetupArgs(args: string[]): ParsedSetupArgs {
       // Treat a missing value as empty (not undefined) so validation fails
       // loudly instead of silently ignoring the flag.
       parsed.traceLocation = args[++i] ?? '';
+    } else if (arg === '--workspace') {
+      parsed.workspace = args[++i];
     }
   }
   return parsed;
@@ -51,6 +54,7 @@ function printSummary(
     experimentId: string;
     experimentName?: string;
     traceLocation?: string;
+    workspace?: string;
   },
 ): void {
   console.error('\nCurrent configuration');
@@ -63,6 +67,9 @@ function printSummary(
   }
   if (config.traceLocation) {
     console.error(`  Trace location: ${config.traceLocation}`);
+  }
+  if (config.workspace) {
+    console.error(`  Workspace: ${config.workspace}`);
   }
 }
 
@@ -126,6 +133,7 @@ export async function runSetup(args: string[], options: SetupOptions = {}): Prom
       experimentId: resolved.experimentId,
       experimentName: resolved.experimentName,
       traceLocation: merged.traceLocation,
+      workspace: merged.workspace,
     });
 
     console.error(`\n${settingsFileExisted ? 'Updated' : 'Created'} ${settingsPath}`);
@@ -142,6 +150,7 @@ export async function runSetup(args: string[], options: SetupOptions = {}): Prom
       experimentId: resolved.experimentId,
       experimentName: resolved.experimentName,
       traceLocation: merged.traceLocation,
+      workspace: merged.workspace,
     });
   } catch (error) {
     console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
@@ -164,6 +173,7 @@ export function runStatus(options: ConfigPathOptions = {}): void {
   if (config.traceLocation) {
     console.error(`  Trace location: ${config.traceLocation}`);
   }
+  console.error(`  Workspace: ${config.workspace ?? 'not set'}`);
 
   if (!config.enabled) {
     console.error('\nTracing is disabled. Run `mlflow-claude-code setup` to configure it.');

--- a/libs/typescript/integrations/claude-code/src/config.ts
+++ b/libs/typescript/integrations/claude-code/src/config.ts
@@ -16,6 +16,7 @@ export const MLFLOW_EXPERIMENT_NAME = 'MLFLOW_EXPERIMENT_NAME';
  * workspace; the SDK does not create it.
  */
 export const MLFLOW_TRACE_LOCATION = 'MLFLOW_TRACE_LOCATION';
+export const MLFLOW_WORKSPACE = 'MLFLOW_WORKSPACE';
 
 type ConfigSource = 'environment' | 'project' | 'user' | 'none';
 
@@ -31,6 +32,7 @@ export interface TracingConfig {
   experimentName?: string;
   /** Raw `catalog.schema.table_prefix` UC trace location, if configured. */
   traceLocation?: string;
+  workspace?: string;
   source: ConfigSource;
   settingsPath?: string;
 }
@@ -82,6 +84,7 @@ function hasAnyTracingKey(env: Record<string, string | undefined>): boolean {
     MLFLOW_EXPERIMENT_ID,
     MLFLOW_EXPERIMENT_NAME,
     MLFLOW_TRACE_LOCATION,
+    MLFLOW_WORKSPACE,
   ].some((key) => env[key] !== undefined);
 }
 
@@ -106,6 +109,7 @@ function parseTracingConfig(
     experimentId: env[MLFLOW_EXPERIMENT_ID],
     experimentName: env[MLFLOW_EXPERIMENT_NAME],
     traceLocation: env[MLFLOW_TRACE_LOCATION],
+    workspace: env[MLFLOW_WORKSPACE],
     source,
     settingsPath,
   };
@@ -160,6 +164,7 @@ export function getEffectiveTracingConfig(options: ConfigPathOptions = {}): Trac
     experimentId: userConfig.experimentId,
     experimentName: userConfig.experimentName,
     traceLocation: userConfig.traceLocation,
+    workspace: userConfig.workspace,
     ...(hasTracingConfig(projectConfig)
       ? {
           enabled: projectConfig.enabled,
@@ -167,6 +172,7 @@ export function getEffectiveTracingConfig(options: ConfigPathOptions = {}): Trac
           experimentId: projectConfig.experimentId,
           experimentName: projectConfig.experimentName,
           traceLocation: projectConfig.traceLocation,
+          workspace: projectConfig.workspace,
         }
       : {}),
   };
@@ -179,6 +185,7 @@ export function getEffectiveTracingConfig(options: ConfigPathOptions = {}): Trac
     experimentId: process.env[MLFLOW_EXPERIMENT_ID] ?? merged.experimentId,
     experimentName: process.env[MLFLOW_EXPERIMENT_NAME] ?? merged.experimentName,
     traceLocation: process.env[MLFLOW_TRACE_LOCATION] ?? merged.traceLocation,
+    workspace: process.env[MLFLOW_WORKSPACE] ?? merged.workspace,
     source: 'none',
   };
 
@@ -253,6 +260,7 @@ export function writeTracingSettings(
     experimentId: string;
     experimentName?: string;
     traceLocation?: string;
+    workspace?: string;
     enabled?: boolean;
   },
 ): void {
@@ -279,6 +287,12 @@ export function writeTracingSettings(
     env[MLFLOW_TRACE_LOCATION] = config.traceLocation.trim();
   } else {
     delete env[MLFLOW_TRACE_LOCATION];
+  }
+
+  if (hasConfigValue(config.workspace)) {
+    env[MLFLOW_WORKSPACE] = config.workspace;
+  } else {
+    delete env[MLFLOW_WORKSPACE];
   }
 
   settings.env = env;
@@ -344,6 +358,7 @@ export async function ensureInitialized(): Promise<boolean> {
       trackingUri: config.trackingUri,
       experimentId: resolvedExperiment.experimentId,
       ...(traceLocation ? { traceLocation } : {}),
+      workspace: config.workspace,
     });
     initializedKey = initKey;
     return true;

--- a/libs/typescript/integrations/claude-code/tests/config.test.ts
+++ b/libs/typescript/integrations/claude-code/tests/config.test.ts
@@ -50,6 +50,7 @@ describe('Claude Code tracing config', () => {
     delete process.env.MLFLOW_EXPERIMENT_ID;
     delete process.env.MLFLOW_EXPERIMENT_NAME;
     delete process.env.MLFLOW_TRACE_LOCATION;
+    delete process.env.MLFLOW_WORKSPACE;
     initMock.mockReset();
     getExperimentByNameMock.mockReset();
     createExperimentMock.mockReset();
@@ -127,6 +128,71 @@ describe('Claude Code tracing config', () => {
       trackingUri: 'http://localhost:5000',
       experimentId: '123',
     });
+  });
+
+  it('writes and reads workspace in tracing settings', () => {
+    const settingsPath = resolveSettingsPath(true, { home: tmpHome, cwd: tmpCwd });
+    writeTracingSettings(settingsPath, {
+      trackingUri: 'http://localhost:5000',
+      experimentId: '42',
+      workspace: 'my-workspace',
+    });
+
+    const stored = JSON.parse(readFileSync(settingsPath, 'utf-8')) as {
+      env: Record<string, string>;
+    };
+    expect(stored.env).toMatchObject({
+      MLFLOW_WORKSPACE: 'my-workspace',
+    });
+
+    expect(getEffectiveTracingConfig({ home: tmpHome, cwd: tmpCwd })).toMatchObject({
+      workspace: 'my-workspace',
+    });
+  });
+
+  it('lets MLFLOW_WORKSPACE env var override saved workspace', () => {
+    writeTracingSettings(resolveSettingsPath(false, { home: tmpHome, cwd: tmpCwd }), {
+      trackingUri: 'http://saved.example',
+      experimentId: '7',
+      workspace: 'saved-ws',
+    });
+
+    process.env.MLFLOW_WORKSPACE = 'env-ws';
+
+    expect(getEffectiveTracingConfig({ home: tmpHome, cwd: tmpCwd })).toMatchObject({
+      workspace: 'env-ws',
+    });
+  });
+
+  it('omits MLFLOW_WORKSPACE from settings when workspace is not provided', () => {
+    const settingsPath = resolveSettingsPath(true, { home: tmpHome, cwd: tmpCwd });
+    writeTracingSettings(settingsPath, {
+      trackingUri: 'http://localhost:5000',
+      experimentId: '42',
+    });
+
+    const stored = JSON.parse(readFileSync(settingsPath, 'utf-8')) as {
+      env: Record<string, string>;
+    };
+    expect(stored.env).not.toHaveProperty('MLFLOW_WORKSPACE');
+
+    expect(getEffectiveTracingConfig({ home: tmpHome, cwd: tmpCwd }).workspace).toBeUndefined();
+  });
+
+  it('passes workspace to init during ensureInitialized', async () => {
+    writeTracingSettings(resolveSettingsPath(true, { home: tmpHome, cwd: tmpCwd }), {
+      trackingUri: 'http://localhost:5000',
+      experimentId: '42',
+      workspace: 'test-ws',
+    });
+    process.chdir(tmpCwd);
+
+    await expect(ensureInitialized()).resolves.toBe(true);
+    expect(initMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspace: 'test-ws',
+      }),
+    );
   });
 
   it('creates the experiment when a configured experiment name does not exist', async () => {

--- a/libs/typescript/integrations/claude-code/tests/setup.test.ts
+++ b/libs/typescript/integrations/claude-code/tests/setup.test.ts
@@ -89,6 +89,61 @@ describe('mlflow-claude-code setup', () => {
     expect(existsSync(join(tmpCwd, '.claude', 'settings.json'))).toBe(false);
   });
 
+  it('parses --workspace flag', () => {
+    expect(
+      parseSetupArgs([
+        '--project',
+        '--tracking-uri',
+        'http://localhost:5000',
+        '--experiment-id',
+        '42',
+        '--workspace',
+        'my-workspace',
+      ]),
+    ).toMatchObject({
+      projectLocal: true,
+      trackingUri: 'http://localhost:5000',
+      experimentId: '42',
+      workspace: 'my-workspace',
+    });
+  });
+
+  it('writes workspace to settings when --workspace is passed', async () => {
+    await runSetup(
+      [
+        '--project',
+        '--tracking-uri',
+        'http://localhost:5000',
+        '--experiment-id',
+        '42',
+        '--workspace',
+        'test-ws',
+      ],
+      { home: tmpHome, cwd: tmpCwd },
+    );
+
+    const settingsPath = join(tmpCwd, '.claude', 'settings.json');
+    expect(existsSync(settingsPath)).toBe(true);
+    expect(JSON.parse(readFileSync(settingsPath, 'utf-8'))).toMatchObject({
+      env: {
+        MLFLOW_WORKSPACE: 'test-ws',
+      },
+    });
+  });
+
+  it('does not write MLFLOW_WORKSPACE when --workspace is not passed', async () => {
+    await runSetup(
+      ['--project', '--tracking-uri', 'http://localhost:5000', '--experiment-id', '42'],
+      { home: tmpHome, cwd: tmpCwd },
+    );
+
+    const settingsPath = join(tmpCwd, '.claude', 'settings.json');
+    const stored = JSON.parse(readFileSync(settingsPath, 'utf-8')) as {
+      env: Record<string, string>;
+    };
+    expect(stored.env).not.toHaveProperty('MLFLOW_WORKSPACE');
+  });
+
   it('rejects missing scope flag', async () => {
     await runSetup(['--tracking-uri', 'http://localhost:5000', '--experiment-name', 'x'], {
       home: tmpHome,


### PR DESCRIPTION
### Related Issues/PRs

Closes #23744

### What changes are proposed in this pull request?

Adds multi-workspace support to the `@mlflow/claude-code` plugin, using the workspace-aware authentication support in `@mlflow/core` that landed in #23927. This enables the plugin to send traces to MLflow servers running with `--enable-workspaces`.

- `MLFLOW_WORKSPACE` flows through `TracingConfig`, `parseTracingConfig()`, `writeTracingSettings()`, `getEffectiveTracingConfig()`, and `ensureInitialized()`.
- `mlflow-claude-code setup` accepts `--workspace` and persists it in Claude Code settings.
- `mlflow-claude-code status` displays the active workspace.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Seven new test cases across the Claude Code plugin config and setup test files cover workspace persistence, precedence, SDK initialization, and CLI parsing.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The `@mlflow/claude-code` plugin now supports multi-workspace MLflow deployments via `MLFLOW_WORKSPACE`. The `mlflow-claude-code setup` command accepts a `--workspace` flag to persist the workspace in Claude Code settings.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
