### PR TITLE
Skip HF dataset tests when the Hub returns 429 during prefetch

### DIFF
--- a/tests/data/test_huggingface_dataset_and_source.py
+++ b/tests/data/test_huggingface_dataset_and_source.py
@@ -4,6 +4,7 @@ import os
 import datasets
 import pandas as pd
 import pytest
+from huggingface_hub.errors import HfHubHTTPError
 
 import mlflow.data
 import mlflow.data.huggingface_dataset
@@ -26,23 +27,28 @@ pytestmark = skip_if_hf_hub_unhealthy()
 def prefetch_huggingface_datasets():
     """Pre-warm the HF cache so individual tests don't hit the Hub and risk HTTP 429s."""
 
-    datasets.load_dataset("cornell-movie-review-data/rotten_tomatoes", split="train")
-    datasets.load_dataset(
-        "cornell-movie-review-data/rotten_tomatoes",
-        split="train",
-        revision="aa13bc287fa6fcab6daf52f0dfb9994269ffea28",
-        trust_remote_code=True,
-    )
-    datasets.load_dataset(
-        "cornell-movie-review-data/rotten_tomatoes",
-        split="train",
-        revision="c33cbf965006dba64f134f7bef69c53d5d0d285d",
-    )
-    datasets.load_dataset(
-        "fka/awesome-chatgpt-prompts",
-        data_files={"train": "prompts.csv"},
-        split="train",
-    )
+    try:
+        datasets.load_dataset("cornell-movie-review-data/rotten_tomatoes", split="train")
+        datasets.load_dataset(
+            "cornell-movie-review-data/rotten_tomatoes",
+            split="train",
+            revision="aa13bc287fa6fcab6daf52f0dfb9994269ffea28",
+            trust_remote_code=True,
+        )
+        datasets.load_dataset(
+            "cornell-movie-review-data/rotten_tomatoes",
+            split="train",
+            revision="c33cbf965006dba64f134f7bef69c53d5d0d285d",
+        )
+        datasets.load_dataset(
+            "fka/awesome-chatgpt-prompts",
+            data_files={"train": "prompts.csv"},
+            split="train",
+        )
+    except HfHubHTTPError as e:
+        if e.response is not None and e.response.status_code == 429:
+            pytest.skip(f"HF Hub returned 429 while pre-warming the cache: {e}")
+        raise
 
 
 def test_from_huggingface_dataset_constructs_expected_dataset():


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23764

### What changes are proposed in this pull request?

The `prefetch_huggingface_datasets` autouse fixture in `tests/data/test_huggingface_dataset_and_source.py` pre-warms the HF cache. When the HF Hub returns HTTP 429 on shared CI egress IPs (e.g. https://github.com/mlflow/mlflow/actions/runs/26927412848/job/79440101972), the fixture itself fails and errors out every test in the module.

Wrap the prefetch calls in `try/except HfHubHTTPError` and call `pytest.skip(...)` when the response status is 429, so the module skips instead of failing CI. Other HTTP errors still raise.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)