### PR TITLE
[1/N] Support addition of Skill Name Span Attribute for Claude and handle it in the storage/query layer

### DIFF
--- a/libs/typescript/core/src/core/constants.ts
+++ b/libs/typescript/core/src/core/constants.ts
@@ -84,6 +84,8 @@ export const SpanAttributeKey = {
   // This attribute indicates which flavor/format generated the LLM span. This is
   // used by downstream (e.g., UI) to determine the message format for parsing.
   MESSAGE_FORMAT: 'mlflow.message.format',
+  // This attribute, if set, indicates that the tool call is a skill and the skill name is the value.
+  SKILL_NAME: 'mlflow.skill.name',
 };
 
 /**

--- a/libs/typescript/integrations/claude-code/src/liveTracing.ts
+++ b/libs/typescript/integrations/claude-code/src/liveTracing.ts
@@ -78,6 +78,7 @@ export interface SDKUserLike {
   type: 'user';
   message: { role: 'user'; content: string | ContentBlock[] };
   parent_tool_use_id?: string | null;
+  tool_use_result?: { commandName?: string };
 }
 
 export interface SDKResultLike {
@@ -264,6 +265,9 @@ export class LiveTracingContext {
             ? toolResult.content
             : JSON.stringify(toolResult.content);
         toolSpan.setStatus(SpanStatusCode.ERROR, errorText || 'Tool execution failed');
+      }
+      if (msg.tool_use_result?.commandName) {
+        toolSpan.setAttribute(SpanAttributeKey.SKILL_NAME, msg.tool_use_result.commandName);
       }
       toolSpan.end();
       this.openToolSpans.delete(toolUseId);

--- a/libs/typescript/integrations/claude-code/src/tracing.ts
+++ b/libs/typescript/integrations/claude-code/src/tracing.ts
@@ -99,11 +99,13 @@ function findToolResults(
       // Check both entry-level and content-level toolUseResult for agentId
       const partToolUseResult = toolResult.toolUseResult ?? {};
       const agentId = entryToolUseResult.agentId ?? partToolUseResult.agentId;
+      const commandName = entryToolUseResult.commandName;
 
       results[toolUseId] = {
         content: toolResult.content ?? '',
         isError: toolResult.is_error ?? false,
         agentId,
+        ...(commandName && { commandName }),
       };
     }
   }
@@ -405,6 +407,7 @@ function createLlmAndToolSpans(
         const toolResultInfo = toolResults[toolUseId];
         const toolResult = toolResultInfo?.content ?? 'No result found';
         const toolName = toolUse.name ?? 'unknown';
+        const commandName = toolResultInfo?.commandName;
 
         const toolSpan = startSpan({
           name: `tool_${toolName}`,
@@ -415,6 +418,7 @@ function createLlmAndToolSpans(
           attributes: {
             tool_name: toolName,
             tool_id: toolUseId,
+            ...(commandName && { [SpanAttributeKey.SKILL_NAME]: commandName }),
           },
         });
 

--- a/libs/typescript/integrations/claude-code/src/types.ts
+++ b/libs/typescript/integrations/claude-code/src/types.ts
@@ -112,6 +112,7 @@ export interface ToolResultInfo {
   content: string;
   isError: boolean;
   agentId?: string;
+  commandName?: string;
 }
 
 export interface SubagentGroup {

--- a/mlflow/claude_code/tracing.py
+++ b/mlflow/claude_code/tracing.py
@@ -57,6 +57,15 @@ CLAUDE_TRACING_LEVEL = logging.WARNING - 5
 
 
 # ============================================================================
+# CONSTANTS
+# ============================================================================
+@dataclasses.dataclass
+class ToolUseResult:
+    content: Any
+    command_name: str | None
+
+
+# ============================================================================
 # LOGGING AND SETUP
 # ============================================================================
 
@@ -293,7 +302,9 @@ def _extract_content_and_tools(content: list[dict[str, Any]]) -> tuple[str, list
     return text_content, tool_uses
 
 
-def _find_tool_results(transcript: list[dict[str, Any]], start_idx: int) -> dict[str, Any]:
+def _find_tool_results(
+    transcript: list[dict[str, Any]], start_idx: int
+) -> dict[str, ToolUseResult]:
     """Find tool results following the current assistant response.
 
     Returns a mapping from tool_use_id to tool result content.
@@ -307,6 +318,7 @@ def _find_tool_results(transcript: list[dict[str, Any]], start_idx: int) -> dict
             continue
 
         msg = entry.get(MESSAGE_FIELD_MESSAGE, {})
+        command_name = msg.get(MESSAGE_FIELD_COMMAND_NAME, None)
         content = msg.get(MESSAGE_FIELD_CONTENT, [])
 
         if isinstance(content, list):
@@ -318,7 +330,9 @@ def _find_tool_results(transcript: list[dict[str, Any]], start_idx: int) -> dict
                     tool_use_id = part.get("tool_use_id")
                     result_content = part.get("content", "")
                     if tool_use_id:
-                        tool_results[tool_use_id] = result_content
+                        tool_results[tool_use_id] = ToolUseResult(
+                            content=result_content, command_name=command_name
+                        )
 
         # Stop looking once we hit the next assistant response
         if entry.get(MESSAGE_FIELD_TYPE) == MESSAGE_TYPE_ASSISTANT:
@@ -484,7 +498,7 @@ def _create_llm_and_tool_spans(
             for idx, tool_use in enumerate(tool_uses):
                 tool_start_ns = timestamp_ns + (idx * tool_duration_ns)
                 tool_use_id = tool_use.get("id", "")
-                tool_result = tool_results.get(tool_use_id, "No result found")
+                tool_result = tool_results.get(tool_use_id, None)
 
                 tool_span = mlflow.start_span_no_context(
                     name=f"tool_{tool_use.get('name', 'unknown')}",
@@ -495,10 +509,17 @@ def _create_llm_and_tool_spans(
                     attributes={
                         "tool_name": tool_use.get("name", "unknown"),
                         "tool_id": tool_use_id,
+                        **(
+                            {SpanAttributeKey.SKILL_NAME: tool_result.command_name}
+                            if tool_result and tool_result.command_name
+                            else {}
+                        ),
                     },
                 )
 
-                tool_span.set_outputs({"result": tool_result})
+                tool_span.set_outputs({
+                    "result": tool_result.content if tool_result else "No result found"
+                })
                 tool_span.end(end_time_ns=tool_start_ns + tool_duration_ns)
 
 
@@ -690,7 +711,7 @@ def _find_sdk_user_prompt(messages: list[Any]) -> str | None:
     return None
 
 
-def _build_tool_result_map(messages: list[Any]) -> dict[str, str]:
+def _build_tool_result_map(messages: list[Any]) -> dict[str, ToolUseResult]:
     """Map tool_use_id to its result content so tool spans can show outputs."""
     from claude_agent_sdk.types import ToolResultBlock, UserMessage
 
@@ -699,10 +720,13 @@ def _build_tool_result_map(messages: list[Any]) -> dict[str, str]:
         if isinstance(msg, UserMessage) and isinstance(msg.content, list):
             for block in msg.content:
                 if isinstance(block, ToolResultBlock):
+                    command_name = block.input.get("commandName", None)
                     result = block.content
                     if isinstance(result, list):
                         result = str(result)
-                    tool_result_map[block.tool_use_id] = result or ""
+                    tool_result_map[block.tool_use_id] = ToolUseResult(
+                        content=result or "", command_name=command_name
+                    )
     return tool_result_map
 
 
@@ -748,7 +772,7 @@ def _serialize_sdk_message(msg) -> dict[str, Any] | None:
 def _create_sdk_child_spans(
     messages: list[Any],
     parent_span,
-    tool_result_map: dict[str, str],
+    tool_result_map: dict[str, ToolUseResult],
 ) -> str | None:
     """Create LLM and tool child spans under ``parent_span`` from SDK messages."""
     from claude_agent_sdk.types import AssistantMessage, TextBlock, ToolUseBlock
@@ -796,7 +820,14 @@ def _create_sdk_child_spans(
                     inputs=tool_block.input,
                     attributes={"tool_name": tool_block.name, "tool_id": tool_block.id},
                 )
-                tool_span.set_outputs({"result": tool_result_map.get(tool_block.id, "")})
+                tool_result = tool_result_map.get(tool_block.id)
+                tool_span.set_outputs({
+                    "result": tool_result.content if tool_result else "No result found"
+                })
+                if tool_result and tool_result.command_name:
+                    tool_span.set_attributes({
+                        SpanAttributeKey.SKILL_NAME: tool_result.command_name
+                    })
                 tool_span.end()
 
         if anthropic_msg := _serialize_sdk_message(msg):

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -4931,10 +4931,11 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
 
                 content_json = json.dumps(span_dict, cls=TraceJSONEncoder)
 
-                # Prepare dimension attributes with model name and provider if available
+                # Prepare dimension attributes with model name, provider and skill name if available
                 dimension_attribute_keys = [
                     SpanAttributeKey.MODEL,
                     SpanAttributeKey.MODEL_PROVIDER,
+                    SpanAttributeKey.SKILL_NAME,
                 ]
                 dimension_attributes = {}
                 for key in dimension_attribute_keys:

--- a/mlflow/store/tracking/utils/sql_trace_metrics_utils.py
+++ b/mlflow/store/tracking/utils/sql_trace_metrics_utils.py
@@ -100,17 +100,23 @@ SPANS_METRICS_CONFIGS: dict[SpanMetricKey, TraceMetricsConfig] = {
             SpanMetricDimensionKey.SPAN_STATUS,
             SpanMetricDimensionKey.SPAN_MODEL_NAME,
             SpanMetricDimensionKey.SPAN_MODEL_PROVIDER,
+            SpanMetricDimensionKey.SPAN_SKILL_NAME,
         },
     ),
     SpanMetricKey.LATENCY: TraceMetricsConfig(
         aggregation_types={AggregationType.AVG, AggregationType.PERCENTILE},
-        dimensions={SpanMetricDimensionKey.SPAN_NAME, SpanMetricDimensionKey.SPAN_STATUS},
+        dimensions={
+            SpanMetricDimensionKey.SPAN_NAME,
+            SpanMetricDimensionKey.SPAN_STATUS,
+            SpanMetricDimensionKey.SPAN_SKILL_NAME,
+        },
     ),
     SpanMetricKey.INPUT_COST: TraceMetricsConfig(
         aggregation_types={AggregationType.SUM, AggregationType.AVG, AggregationType.PERCENTILE},
         dimensions={
             SpanMetricDimensionKey.SPAN_MODEL_NAME,
             SpanMetricDimensionKey.SPAN_MODEL_PROVIDER,
+            SpanMetricDimensionKey.SPAN_SKILL_NAME,
         },
     ),
     SpanMetricKey.OUTPUT_COST: TraceMetricsConfig(
@@ -118,6 +124,7 @@ SPANS_METRICS_CONFIGS: dict[SpanMetricKey, TraceMetricsConfig] = {
         dimensions={
             SpanMetricDimensionKey.SPAN_MODEL_NAME,
             SpanMetricDimensionKey.SPAN_MODEL_PROVIDER,
+            SpanMetricDimensionKey.SPAN_SKILL_NAME,
         },
     ),
     SpanMetricKey.TOTAL_COST: TraceMetricsConfig(
@@ -125,6 +132,7 @@ SPANS_METRICS_CONFIGS: dict[SpanMetricKey, TraceMetricsConfig] = {
         dimensions={
             SpanMetricDimensionKey.SPAN_MODEL_NAME,
             SpanMetricDimensionKey.SPAN_MODEL_PROVIDER,
+            SpanMetricDimensionKey.SPAN_SKILL_NAME,
         },
     ),
 }
@@ -437,6 +445,12 @@ def _apply_dimension_to_query(
                         db_type,
                         SpanAttributeKey.MODEL_PROVIDER,
                         SpanMetricDimensionKey.SPAN_MODEL_PROVIDER,
+                    )
+                case SpanMetricDimensionKey.SPAN_SKILL_NAME:
+                    return query, _get_json_dimension_column(
+                        db_type,
+                        SpanAttributeKey.SKILL_NAME,
+                        SpanMetricDimensionKey.SPAN_SKILL_NAME,
                     )
         case MetricViewType.ASSESSMENTS:
             match dimension:

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -143,6 +143,8 @@ class SpanAttributeKey:
     # survive OTLP export and can be restored to SqlTraceTag rows on the server side.
     # Each attribute is keyed as "mlflow.traceTag.<tag_key>" with the plain string value.
     TRACE_TAG_PREFIX = "mlflow.traceTag."
+    # This attribute, if set, indicates that tool call is a skill and the skill name is the value.
+    SKILL_NAME = "mlflow.skill.name"
 
 
 class TraceExperimentTagKey:
@@ -278,6 +280,7 @@ class SpanMetricDimensionKey:
     SPAN_STATUS = "span_status"
     SPAN_MODEL_NAME = "span_model_name"
     SPAN_MODEL_PROVIDER = "span_model_provider"
+    SPAN_SKILL_NAME = "span_skill_name"
 
 
 class AssessmentMetricKey:

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_query_trace_metrics.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_query_trace_metrics.py
@@ -4881,3 +4881,89 @@ def test_query_span_metrics_count_by_span_status_and_model_provider(store: SqlAl
         },
         "values": {"COUNT": 2},
     }
+
+
+def test_query_span_metrics_cost_by_skill_name(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("test_span_cost_by_skill_name")
+
+    trace_info = TraceInfo(
+        trace_id="trace1",
+        trace_location=trace_location.TraceLocation.from_experiment_id(exp_id),
+        request_time=get_current_time_millis(),
+        execution_duration=100,
+        state=TraceStatus.OK,
+        tags={TraceTagKey.TRACE_NAME: "test_trace"},
+    )
+    store.start_trace(trace_info)
+
+    spans = [
+        create_test_span(
+            "trace1",
+            "gpt4_call_1",
+            span_id=1,
+            span_type="LLM",
+            start_ns=1000000000,
+            attributes={
+                SpanAttributeKey.LLM_COST: {
+                    "input_cost": 0.01,
+                    "output_cost": 0.02,
+                    "total_cost": 0.03,
+                },
+                SpanAttributeKey.MODEL: "gpt-4",
+                SpanAttributeKey.SKILL_NAME: "skill1",
+            },
+        ),
+        create_test_span(
+            "trace1",
+            "gpt4_call_2",
+            span_id=2,
+            span_type="LLM",
+            start_ns=1100000000,
+            attributes={
+                SpanAttributeKey.LLM_COST: {
+                    "input_cost": 0.01,
+                    "output_cost": 0.02,
+                    "total_cost": 0.03,
+                },
+                SpanAttributeKey.MODEL: "gpt-4",
+                SpanAttributeKey.SKILL_NAME: "skill1",
+            },
+        ),
+        create_test_span(
+            "trace1",
+            "claude_call",
+            span_id=3,
+            span_type="LLM",
+            start_ns=1200000000,
+            attributes={
+                SpanAttributeKey.LLM_COST: {
+                    "input_cost": 0.005,
+                    "output_cost": 0.015,
+                    "total_cost": 0.02,
+                },
+                SpanAttributeKey.MODEL: "claude-3",
+                SpanAttributeKey.SKILL_NAME: "skill2",
+            },
+        ),
+    ]
+    store.log_spans(exp_id, spans)
+
+    result = store.query_trace_metrics(
+        experiment_ids=[exp_id],
+        view_type=MetricViewType.SPANS,
+        metric_name=SpanMetricKey.TOTAL_COST,
+        aggregations=[MetricAggregation(aggregation_type=AggregationType.SUM)],
+        dimensions=[SpanMetricDimensionKey.SPAN_SKILL_NAME],
+    )
+
+    assert len(result) == 2
+    assert asdict(result[0]) == {
+        "metric_name": SpanMetricKey.TOTAL_COST,
+        "dimensions": {SpanMetricDimensionKey.SPAN_SKILL_NAME: "skill1"},
+        "values": {"SUM": 0.06},
+    }
+    assert asdict(result[1]) == {
+        "metric_name": SpanMetricKey.TOTAL_COST,
+        "dimensions": {SpanMetricDimensionKey.SPAN_SKILL_NAME: "skill2"},
+        "values": {"SUM": 0.02},
+    }

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
@@ -4673,6 +4673,7 @@ def test_log_spans_creates_span_metrics(store: SqlAlchemyStore) -> None:
         }),
         SpanAttributeKey.MODEL: json.dumps("gpt-4-turbo"),
         SpanAttributeKey.MODEL_PROVIDER: json.dumps("openai"),
+        SpanAttributeKey.SKILL_NAME: json.dumps("skill1"),
     }
     span = create_mlflow_span(otel_span, trace_id, "LLM")
     store.log_spans(experiment_id, [span])
@@ -4701,6 +4702,7 @@ def test_log_spans_creates_span_metrics(store: SqlAlchemyStore) -> None:
         )
         assert sql_span.dimension_attributes[SpanAttributeKey.MODEL] == "gpt-4-turbo"
         assert sql_span.dimension_attributes[SpanAttributeKey.MODEL_PROVIDER] == "openai"
+        assert sql_span.dimension_attributes[SpanAttributeKey.SKILL_NAME] == "skill1"
 
 
 def test_log_spans_updates_trace_metrics_incrementally(store: SqlAlchemyStore) -> None:


### PR DESCRIPTION

<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

NA

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

This PR proposes changes to support insights into skills on the MLFLow UI.

Currently, MLFlow supports insights into Tools via its `overview/tool-calls` view. However, MLFlow does not distinguish between Tools and Skills. All Skills are marked as Tools.

This PR offers a way to distinguish between Skills and Tools via the addition of a new SpanAttribute called a skill name. If a Tool call has this set, it must be a Skill.

We are then able to add this new Span Attribute to the existing dimension columns, enabling the frontend to perform some aggregation based logic for the view.

The goal is to allow users to evaluate their performance of their skills based on some aggregate level metrics, such as average/min/max latency or token cost.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

MLFlow experiment overview now allows users to view performance of their skills, in addition to existing support for tool calls

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
