### PR TITLE
Add POST /mlflow/genai/evaluate/invoke handler & job for UI-triggered eval runs

### DIFF
--- a/mlflow/genai/evaluation/job.py
+++ b/mlflow/genai/evaluation/job.py
@@ -1,0 +1,61 @@
+"""Huey job function for the UI-triggered `mlflow.genai.evaluate` flow.
+
+This module backs the `POST /ajax-api/3.0/mlflow/genai/evaluate/invoke` endpoint
+used by the "Run evaluation" modal's "Run judges" button.
+"""
+
+import logging
+import os
+
+import mlflow
+from mlflow.client import MlflowClient
+from mlflow.entities.run_status import RunStatus
+from mlflow.environment_variables import (
+    _MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN,
+    MLFLOW_SERVER_JUDGE_INVOKE_MAX_WORKERS,
+)
+from mlflow.genai.scorers.base import Scorer
+from mlflow.server.jobs import job
+from mlflow.store.tracking import MAX_TRACE_LINKS_PER_REQUEST
+
+_logger = logging.getLogger(__name__)
+
+
+@job(name="invoke_genai_evaluate", max_workers=MLFLOW_SERVER_JUDGE_INVOKE_MAX_WORKERS.get())
+def invoke_genai_evaluate_job(
+    experiment_id: str,
+    trace_ids: list[str],
+    serialized_scorers: list[str],
+    run_id: str,
+    username: str | None = None,
+):
+    """
+    Run `mlflow.genai.evaluate` against a fixed set of traces and scorers,
+    writing all outputs (dataset input, assessments, aggregate metrics) into
+    the pre-existing run identified by `run_id`.
+    """
+    if username is not None:
+        os.environ["MLFLOW_TRACKING_USERNAME"] = username
+        if internal_token := _MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN.get():
+            os.environ["MLFLOW_TRACKING_PASSWORD"] = internal_token
+
+    client = MlflowClient()
+    try:
+        for i in range(0, len(trace_ids), MAX_TRACE_LINKS_PER_REQUEST):
+            client.link_traces_to_run(trace_ids[i : i + MAX_TRACE_LINKS_PER_REQUEST], run_id)
+
+        traces = client._tracing_client.batch_get_traces(trace_ids)
+        scorers = [Scorer.model_validate_json(s) for s in serialized_scorers]
+
+        with mlflow.start_run(run_id=run_id):
+            mlflow.genai.evaluate(data=traces, scorers=scorers)
+
+        client.set_terminated(run_id, RunStatus.to_string(RunStatus.FINISHED))
+        return {
+            "run_id": run_id,
+            "total_traces": len(trace_ids),
+            "scorer_count": len(scorers),
+        }
+    except Exception:
+        client.set_terminated(run_id, RunStatus.to_string(RunStatus.FAILED))
+        raise

--- a/mlflow/genai/evaluation/job.py
+++ b/mlflow/genai/evaluation/job.py
@@ -23,7 +23,6 @@ _logger = logging.getLogger(__name__)
 
 @job(name="invoke_genai_evaluate", max_workers=MLFLOW_SERVER_JUDGE_INVOKE_MAX_WORKERS.get())
 def invoke_genai_evaluate_job(
-    experiment_id: str,
     trace_ids: list[str],
     serialized_scorers: list[str],
     run_id: str,

--- a/mlflow/genai/evaluation/job.py
+++ b/mlflow/genai/evaluation/job.py
@@ -40,22 +40,21 @@ def invoke_genai_evaluate_job(
             os.environ["MLFLOW_TRACKING_PASSWORD"] = internal_token
 
     client = MlflowClient()
+
     try:
         for i in range(0, len(trace_ids), MAX_TRACE_LINKS_PER_REQUEST):
             client.link_traces_to_run(trace_ids[i : i + MAX_TRACE_LINKS_PER_REQUEST], run_id)
-
         traces = client._tracing_client.batch_get_traces(trace_ids)
         scorers = [Scorer.model_validate_json(s) for s in serialized_scorers]
-
-        with mlflow.start_run(run_id=run_id):
-            mlflow.genai.evaluate(data=traces, scorers=scorers)
-
-        client.set_terminated(run_id, RunStatus.to_string(RunStatus.FINISHED))
-        return {
-            "run_id": run_id,
-            "total_traces": len(trace_ids),
-            "scorer_count": len(scorers),
-        }
     except Exception:
         client.set_terminated(run_id, RunStatus.to_string(RunStatus.FAILED))
         raise
+
+    with mlflow.start_run(run_id=run_id):
+        mlflow.genai.evaluate(data=traces, scorers=scorers)
+
+    return {
+        "run_id": run_id,
+        "total_traces": len(trace_ids),
+        "scorer_count": len(scorers),
+    }

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -4704,7 +4704,7 @@ def _invoke_genai_evaluate_handler():
 
     # Create the run upfront so we can return run_id immediately, so the run
     # shows up on /evaluation-runs even before the job has produced artifacts.
-    tags = [RunTag(MLFLOW_RUN_TYPE, MLFLOW_RUN_TYPE_GENAI_EVALUATE)]
+    tags = {MLFLOW_RUN_TYPE: MLFLOW_RUN_TYPE_GENAI_EVALUATE}
     client = MlflowClient()
     run = client.create_run(experiment_id=experiment_id, tags=tags)
     run_id = run.info.run_id

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -340,8 +340,10 @@ from mlflow.utils.databricks_utils import get_databricks_host_creds
 from mlflow.utils.file_utils import local_file_uri_to_path
 from mlflow.utils.mime_type_utils import _guess_mime_type
 from mlflow.utils.mlflow_tags import (
+    MLFLOW_GENAI_EVALUATE_JOB_ID,
     MLFLOW_ISSUE_DETECTION_JOB_ID,
     MLFLOW_RUN_TYPE,
+    MLFLOW_RUN_TYPE_GENAI_EVALUATE,
     MLFLOW_RUN_TYPE_ISSUE_DETECTION,
     MLFLOW_TRACE_ARCHIVAL_FAILURE,
     MLFLOW_TRACE_ARCHIVE_LOCATION,
@@ -4663,6 +4665,74 @@ def _invoke_issue_detection_handler():
 
 @catch_mlflow_exception
 @_disable_if_artifacts_only
+def _invoke_genai_evaluate_handler():
+    """
+    Run mlflow.genai.evaluate(...) against the chosen traces + scorers as an
+    async job, attached to a brand-new MLflow eval run.
+
+    This is a UI-only AJAX endpoint that backs the "Run evaluation" feature on
+    the Evaluation Runs page.
+    """
+    from mlflow.genai.evaluation.job import invoke_genai_evaluate_job
+    from mlflow.server.jobs import submit_job
+
+    _validate_content_type(request, ["application/json"])
+
+    request_json = _get_validated_flask_request_json(
+        schema={
+            "experiment_id": [_assert_required, _assert_string],
+            "trace_ids": [_assert_required, _assert_array],
+            "serialized_scorers": [_assert_required, _assert_array],
+        }
+    )
+
+    experiment_id = request_json["experiment_id"]
+    trace_ids = request_json["trace_ids"]
+    serialized_scorers = request_json["serialized_scorers"]
+
+    if not trace_ids:
+        raise MlflowException(
+            "Please select at least one trace to evaluate.",
+            error_code=INVALID_PARAMETER_VALUE,
+        )
+    if not serialized_scorers:
+        raise MlflowException(
+            "Please select at least one judge.",
+            error_code=INVALID_PARAMETER_VALUE,
+        )
+
+    # Create the run upfront so we can return run_id immediately. The same
+    # MLFLOW_RUN_TYPE tag that mlflow.genai.evaluate sets internally is set
+    # here too, so the run shows up on /evaluation-runs even before the job
+    # has produced any artifacts, and the eval-runs list-row dispatcher can
+    # tell our runs apart from Detect Issues / training runs.
+    tags = {MLFLOW_RUN_TYPE: MLFLOW_RUN_TYPE_GENAI_EVALUATE}
+    run = mlflow.start_run(experiment_id=experiment_id, tags=tags)
+    run_id = run.info.run_id
+
+    # Propagate user identity so judge LLM calls go through gateway auth as the
+    # caller, not the server admin (same as ``_invoke_scorer_handler``).
+    username = request.authorization.username if request.authorization else None
+
+    job = submit_job(
+        function=invoke_genai_evaluate_job,
+        params={
+            "experiment_id": experiment_id,
+            "trace_ids": trace_ids,
+            "serialized_scorers": serialized_scorers,
+            "run_id": run_id,
+            "username": username,
+        },
+    )
+
+    mlflow.set_tag(MLFLOW_GENAI_EVALUATE_JOB_ID, job.job_id)
+    mlflow.end_run(RunStatus.to_string(RunStatus.RUNNING))
+
+    return jsonify({"job_id": job.job_id, "run_id": run_id})
+
+
+@catch_mlflow_exception
+@_disable_if_artifacts_only
 def _get_job(job_id):
     from mlflow.server.jobs import get_job
 
@@ -6400,6 +6470,7 @@ def get_endpoints(get_handler=get_handler):
         + get_gateway_endpoints()
         + get_demo_endpoints()
         + get_issues_detection_endpoints()
+        + get_genai_evaluate_endpoints()
         + get_job_endpoints()
     )
 
@@ -6440,6 +6511,16 @@ def get_issues_detection_endpoints():
         (
             _get_ajax_path("/mlflow/issues/invoke", version=3),
             _invoke_issue_detection_handler,
+            ["POST"],
+        ),
+    ]
+
+
+def get_genai_evaluate_endpoints():
+    return [
+        (
+            _get_ajax_path("/mlflow/genai/evaluate/invoke", version=3),
+            _invoke_genai_evaluate_handler,
             ["POST"],
         ),
     ]

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -4701,17 +4701,12 @@ def _invoke_genai_evaluate_handler():
             error_code=INVALID_PARAMETER_VALUE,
         )
 
-    # Create the run upfront so we can return run_id immediately. The same
-    # MLFLOW_RUN_TYPE tag that mlflow.genai.evaluate sets internally is set
-    # here too, so the run shows up on /evaluation-runs even before the job
-    # has produced any artifacts, and the eval-runs list-row dispatcher can
-    # tell our runs apart from Detect Issues / training runs.
+    # Create the run upfront so we can return run_id immediately. So the run 
+    # shows up on /evaluation-runs even before the job has produced any artifacts.
     tags = {MLFLOW_RUN_TYPE: MLFLOW_RUN_TYPE_GENAI_EVALUATE}
     run = mlflow.start_run(experiment_id=experiment_id, tags=tags)
     run_id = run.info.run_id
 
-    # Propagate user identity so judge LLM calls go through gateway auth as the
-    # caller, not the server admin (same as ``_invoke_scorer_handler``).
     username = request.authorization.username if request.authorization else None
 
     job = submit_job(

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -21,6 +21,7 @@ from google.protobuf import descriptor
 from google.protobuf.json_format import ParseError
 
 import mlflow
+from mlflow.client import MlflowClient
 from mlflow.entities import (
     Assessment,
     DatasetInput,
@@ -4701,10 +4702,11 @@ def _invoke_genai_evaluate_handler():
             error_code=INVALID_PARAMETER_VALUE,
         )
 
-    # Create the run upfront so we can return run_id immediately. So the run
-    # shows up on /evaluation-runs even before the job has produced any artifacts.
-    tags = {MLFLOW_RUN_TYPE: MLFLOW_RUN_TYPE_GENAI_EVALUATE}
-    run = mlflow.start_run(experiment_id=experiment_id, tags=tags)
+    # Create the run upfront so we can return run_id immediately, so the run
+    # shows up on /evaluation-runs even before the job has produced artifacts.
+    tags = [RunTag(MLFLOW_RUN_TYPE, MLFLOW_RUN_TYPE_GENAI_EVALUATE)]
+    client = MlflowClient()
+    run = client.create_run(experiment_id=experiment_id, tags=tags)
     run_id = run.info.run_id
 
     username = request.authorization.username if request.authorization else None
@@ -4713,19 +4715,16 @@ def _invoke_genai_evaluate_handler():
         job = submit_job(
             function=invoke_genai_evaluate_job,
             params={
-                "experiment_id": experiment_id,
                 "trace_ids": trace_ids,
                 "serialized_scorers": serialized_scorers,
                 "run_id": run_id,
                 "username": username,
             },
         )
-        mlflow.set_tag(MLFLOW_GENAI_EVALUATE_JOB_ID, job.job_id)
+        client.set_tag(run_id, MLFLOW_GENAI_EVALUATE_JOB_ID, job.job_id)
     except Exception:
-        mlflow.end_run(RunStatus.to_string(RunStatus.FAILED))
+        client.set_terminated(run_id, RunStatus.to_string(RunStatus.FAILED))
         raise
-
-    mlflow.end_run(RunStatus.to_string(RunStatus.RUNNING))
 
     return jsonify({"job_id": job.job_id, "run_id": run_id})
 

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -4701,7 +4701,7 @@ def _invoke_genai_evaluate_handler():
             error_code=INVALID_PARAMETER_VALUE,
         )
 
-    # Create the run upfront so we can return run_id immediately. So the run 
+    # Create the run upfront so we can return run_id immediately. So the run
     # shows up on /evaluation-runs even before the job has produced any artifacts.
     tags = {MLFLOW_RUN_TYPE: MLFLOW_RUN_TYPE_GENAI_EVALUATE}
     run = mlflow.start_run(experiment_id=experiment_id, tags=tags)
@@ -4709,18 +4709,22 @@ def _invoke_genai_evaluate_handler():
 
     username = request.authorization.username if request.authorization else None
 
-    job = submit_job(
-        function=invoke_genai_evaluate_job,
-        params={
-            "experiment_id": experiment_id,
-            "trace_ids": trace_ids,
-            "serialized_scorers": serialized_scorers,
-            "run_id": run_id,
-            "username": username,
-        },
-    )
+    try:
+        job = submit_job(
+            function=invoke_genai_evaluate_job,
+            params={
+                "experiment_id": experiment_id,
+                "trace_ids": trace_ids,
+                "serialized_scorers": serialized_scorers,
+                "run_id": run_id,
+                "username": username,
+            },
+        )
+        mlflow.set_tag(MLFLOW_GENAI_EVALUATE_JOB_ID, job.job_id)
+    except Exception:
+        mlflow.end_run(RunStatus.to_string(RunStatus.FAILED))
+        raise
 
-    mlflow.set_tag(MLFLOW_GENAI_EVALUATE_JOB_ID, job.job_id)
     mlflow.end_run(RunStatus.to_string(RunStatus.RUNNING))
 
     return jsonify({"job_id": job.job_id, "run_id": run_id})

--- a/mlflow/server/jobs/__init__.py
+++ b/mlflow/server/jobs/__init__.py
@@ -24,6 +24,7 @@ _SUPPORTED_JOB_FUNCTION_LIST = [
     "mlflow.genai.scorers.job.run_online_session_scorer_job",
     "mlflow.genai.optimize.job.optimize_prompts_job",
     "mlflow.genai.discovery.job.invoke_issue_detection_job",
+    "mlflow.genai.evaluation.job.invoke_genai_evaluate_job",
 ]
 
 if supported_job_function_list_env := os.environ.get("_MLFLOW_SUPPORTED_JOB_FUNCTION_LIST"):
@@ -37,6 +38,7 @@ _ALLOWED_JOB_NAME_LIST = [
     "run_online_session_scorer",
     "optimize_prompts",
     "invoke_issue_detection",
+    "invoke_genai_evaluate",
 ]
 
 if allowed_job_name_list_env := os.environ.get("_MLFLOW_ALLOWED_JOB_NAME_LIST"):

--- a/mlflow/utils/mlflow_tags.py
+++ b/mlflow/utils/mlflow_tags.py
@@ -42,6 +42,9 @@ MLFLOW_RUN_TYPE_ISSUE_DETECTION = "issue_detection"
 # The ID of the job that is running issue detection
 MLFLOW_ISSUE_DETECTION_JOB_ID = "mlflow.issueDetection.jobId"
 
+# The ID of the job that is running the UI-triggered mlflow.genai.evaluate flow
+MLFLOW_GENAI_EVALUATE_JOB_ID = "mlflow.genaiEvaluate.jobId"
+
 MLFLOW_DATABRICKS_NOTEBOOK_ID = "mlflow.databricks.notebookID"
 MLFLOW_DATABRICKS_NOTEBOOK_PATH = "mlflow.databricks.notebookPath"
 MLFLOW_DATABRICKS_WEBAPP_URL = "mlflow.databricks.webappURL"

--- a/tests/genai/evaluate/test_job.py
+++ b/tests/genai/evaluate/test_job.py
@@ -1,0 +1,193 @@
+import os
+from unittest import mock
+
+import pytest
+
+from mlflow.entities.run_status import RunStatus
+from mlflow.genai.evaluation.job import invoke_genai_evaluate_job
+
+
+def _serialized_scorer(name: str = "scorer") -> str:
+    return f'{{"name": "{name}"}}'
+
+
+def test_invoke_genai_evaluate_job_has_metadata():
+    """Without ``_job_fn_metadata`` the function isn't registered with the
+    job runner and POSTs to the endpoint will silently fail to submit.
+    """
+    assert hasattr(invoke_genai_evaluate_job, "_job_fn_metadata")
+    assert invoke_genai_evaluate_job._job_fn_metadata.name == "invoke_genai_evaluate"
+
+
+def test_invoke_genai_evaluate_job_success():
+    mock_client = mock.MagicMock()
+    mock_trace = mock.MagicMock()
+    mock_client._tracing_client.batch_get_traces.return_value = [mock_trace, mock_trace]
+    mock_scorer = mock.MagicMock()
+
+    with (
+        mock.patch("mlflow.genai.evaluation.job.MlflowClient", return_value=mock_client),
+        mock.patch(
+            "mlflow.genai.evaluation.job.Scorer.model_validate_json", return_value=mock_scorer
+        ) as mock_validate,
+        mock.patch("mlflow.start_run") as mock_start_run,
+        mock.patch("mlflow.genai.evaluate") as mock_evaluate,
+    ):
+        result = invoke_genai_evaluate_job(
+            experiment_id="exp-123",
+            trace_ids=["trace-1", "trace-2"],
+            serialized_scorers=[_serialized_scorer("a"), _serialized_scorer("b")],
+            run_id="run-123",
+        )
+
+        mock_client.link_traces_to_run.assert_called_once_with(["trace-1", "trace-2"], "run-123")
+        mock_client._tracing_client.batch_get_traces.assert_called_once_with(["trace-1", "trace-2"])
+        assert mock_validate.call_count == 2
+
+        # Run reuse is the whole reason the handler creates the run upfront —
+        # if we forget ``run_id=...`` mlflow.genai.evaluate will start a fresh
+        # nested run and the UI's navigate-to-run-page link will be wrong.
+        mock_start_run.assert_called_once_with(run_id="run-123")
+
+        mock_evaluate.assert_called_once()
+        evaluate_kwargs = mock_evaluate.call_args.kwargs
+        assert evaluate_kwargs["data"] == [mock_trace, mock_trace]
+        assert evaluate_kwargs["scorers"] == [mock_scorer, mock_scorer]
+
+        mock_client.set_terminated.assert_called_once_with(
+            "run-123", RunStatus.to_string(RunStatus.FINISHED)
+        )
+        assert result == {"run_id": "run-123", "total_traces": 2, "scorer_count": 2}
+
+
+def test_invoke_genai_evaluate_job_batches_large_trace_list():
+    """``link_traces_to_run`` has a per-call cap of ``MAX_TRACE_LINKS_PER_REQUEST``
+    (100), so we must batch large trace lists or the call will be rejected.
+    """
+    mock_client = mock.MagicMock()
+    mock_traces = [mock.MagicMock() for _ in range(250)]
+    mock_client._tracing_client.batch_get_traces.return_value = mock_traces
+    trace_ids = [f"trace-{i}" for i in range(250)]
+
+    with (
+        mock.patch("mlflow.genai.evaluation.job.MlflowClient", return_value=mock_client),
+        mock.patch("mlflow.genai.evaluation.job.Scorer.model_validate_json"),
+        mock.patch("mlflow.start_run"),
+        mock.patch("mlflow.genai.evaluate"),
+    ):
+        invoke_genai_evaluate_job(
+            experiment_id="exp-123",
+            trace_ids=trace_ids,
+            serialized_scorers=[_serialized_scorer()],
+            run_id="run-123",
+        )
+
+        # 250 traces with a cap of 100 = three batches of (100, 100, 50).
+        assert mock_client.link_traces_to_run.call_count == 3
+        batch_sizes = [len(call.args[0]) for call in mock_client.link_traces_to_run.call_args_list]
+        assert batch_sizes == [100, 100, 50]
+
+
+def test_invoke_genai_evaluate_job_failure_marks_run_failed():
+    """The run must end up FAILED in the store even though the job re-raises
+    — otherwise it will show as RUNNING forever in /evaluation-runs.
+    """
+    mock_client = mock.MagicMock()
+    mock_client._tracing_client.batch_get_traces.side_effect = Exception("trace fetch failed")
+
+    with (
+        mock.patch("mlflow.genai.evaluation.job.MlflowClient", return_value=mock_client),
+        mock.patch("mlflow.start_run"),
+        mock.patch("mlflow.genai.evaluate"),
+    ):
+        with pytest.raises(Exception, match="trace fetch failed"):
+            invoke_genai_evaluate_job(
+                experiment_id="exp-123",
+                trace_ids=["trace-1"],
+                serialized_scorers=[_serialized_scorer()],
+                run_id="run-123",
+            )
+
+        mock_client.set_terminated.assert_called_once_with(
+            "run-123", RunStatus.to_string(RunStatus.FAILED)
+        )
+
+
+def test_invoke_genai_evaluate_job_failure_when_evaluate_throws():
+    """``mlflow.genai.evaluate`` swallows per-row scorer errors, so a thrown
+    exception from inside means the harness itself failed — we must still
+    flip the run to FAILED.
+    """
+    mock_client = mock.MagicMock()
+    mock_client._tracing_client.batch_get_traces.return_value = [mock.MagicMock()]
+
+    with (
+        mock.patch("mlflow.genai.evaluation.job.MlflowClient", return_value=mock_client),
+        mock.patch("mlflow.genai.evaluation.job.Scorer.model_validate_json"),
+        mock.patch("mlflow.start_run"),
+        mock.patch("mlflow.genai.evaluate", side_effect=Exception("harness boom")),
+    ):
+        with pytest.raises(Exception, match="harness boom"):
+            invoke_genai_evaluate_job(
+                experiment_id="exp-123",
+                trace_ids=["trace-1"],
+                serialized_scorers=[_serialized_scorer()],
+                run_id="run-123",
+            )
+
+        mock_client.set_terminated.assert_called_once_with(
+            "run-123", RunStatus.to_string(RunStatus.FAILED)
+        )
+
+
+def test_invoke_genai_evaluate_job_propagates_username_via_env(monkeypatch):
+    """``username`` is propagated to subprocess env vars so judge LLM calls
+    are authorised as the original caller, not the server admin. Same
+    pattern as ``invoke_scorer_job``.
+    """
+    mock_client = mock.MagicMock()
+    mock_client._tracing_client.batch_get_traces.return_value = [mock.MagicMock()]
+    monkeypatch.delenv("MLFLOW_TRACKING_USERNAME", raising=False)
+    captured_env: dict[str, str] = {}
+
+    def _capture_env(*args, **kwargs):
+        captured_env["MLFLOW_TRACKING_USERNAME"] = os.environ.get("MLFLOW_TRACKING_USERNAME", "")
+
+    with (
+        mock.patch("mlflow.genai.evaluation.job.MlflowClient", return_value=mock_client),
+        mock.patch("mlflow.genai.evaluation.job.Scorer.model_validate_json"),
+        mock.patch("mlflow.start_run"),
+        mock.patch("mlflow.genai.evaluate", side_effect=_capture_env),
+    ):
+        invoke_genai_evaluate_job(
+            experiment_id="exp-123",
+            trace_ids=["trace-1"],
+            serialized_scorers=[_serialized_scorer()],
+            run_id="run-123",
+            username="alice",
+        )
+
+        assert captured_env["MLFLOW_TRACKING_USERNAME"] == "alice"
+
+
+def test_invoke_genai_evaluate_job_skips_username_propagation_when_none(monkeypatch):
+    mock_client = mock.MagicMock()
+    mock_client._tracing_client.batch_get_traces.return_value = [mock.MagicMock()]
+    # Pre-populate the env so we can detect a write where we shouldn't see one.
+    monkeypatch.setenv("MLFLOW_TRACKING_USERNAME", "unchanged")
+
+    with (
+        mock.patch("mlflow.genai.evaluation.job.MlflowClient", return_value=mock_client),
+        mock.patch("mlflow.genai.evaluation.job.Scorer.model_validate_json"),
+        mock.patch("mlflow.start_run"),
+        mock.patch("mlflow.genai.evaluate"),
+    ):
+        invoke_genai_evaluate_job(
+            experiment_id="exp-123",
+            trace_ids=["trace-1"],
+            serialized_scorers=[_serialized_scorer()],
+            run_id="run-123",
+            username=None,
+        )
+
+        assert os.environ["MLFLOW_TRACKING_USERNAME"] == "unchanged"

--- a/tests/genai/evaluate/test_job.py
+++ b/tests/genai/evaluate/test_job.py
@@ -54,9 +54,11 @@ def test_invoke_genai_evaluate_job_success():
         assert evaluate_kwargs["data"] == [mock_trace, mock_trace]
         assert evaluate_kwargs["scorers"] == [mock_scorer, mock_scorer]
 
-        mock_client.set_terminated.assert_called_once_with(
-            "run-123", RunStatus.to_string(RunStatus.FINISHED)
-        )
+        # On the happy path the ActiveRun context manager's __exit__ writes
+        # FINISHED for us; the job must NOT also call set_terminated explicitly
+        # (that would be a duplicate write to the same run). End-to-end FINISHED
+        # transition is verified in tests/server/jobs/test_genai_evaluate_invocation.py.
+        mock_client.set_terminated.assert_not_called()
         assert result == {"run_id": "run-123", "total_traces": 2, "scorer_count": 2}
 
 
@@ -88,17 +90,19 @@ def test_invoke_genai_evaluate_job_batches_large_trace_list():
         assert batch_sizes == [100, 100, 50]
 
 
-def test_invoke_genai_evaluate_job_failure_marks_run_failed():
-    """The run must end up FAILED in the store even though the job re-raises
-    — otherwise it will show as RUNNING forever in /evaluation-runs.
+def test_invoke_genai_evaluate_job_setup_failure_marks_run_failed():
+    """If setup fails BEFORE the active-run context manager is entered (here:
+    ``batch_get_traces`` raising), the context manager's __exit__ never runs,
+    so the job itself must flip the run to FAILED — otherwise it'd stay
+    RUNNING forever in /evaluation-runs.
     """
     mock_client = mock.MagicMock()
     mock_client._tracing_client.batch_get_traces.side_effect = Exception("trace fetch failed")
 
     with (
         mock.patch("mlflow.genai.evaluation.job.MlflowClient", return_value=mock_client),
-        mock.patch("mlflow.start_run"),
-        mock.patch("mlflow.genai.evaluate"),
+        mock.patch("mlflow.start_run") as mock_start_run,
+        mock.patch("mlflow.genai.evaluate") as mock_evaluate,
     ):
         with pytest.raises(Exception, match="trace fetch failed"):
             invoke_genai_evaluate_job(
@@ -108,15 +112,26 @@ def test_invoke_genai_evaluate_job_failure_marks_run_failed():
                 run_id="run-123",
             )
 
+        # Setup blew up *before* we reached the with block, so neither
+        # mlflow.start_run nor mlflow.genai.evaluate should have been touched.
+        mock_start_run.assert_not_called()
+        mock_evaluate.assert_not_called()
+
+        # This is the only path where the job code itself writes the terminal
+        # status — the context manager can't help here because we never entered it.
         mock_client.set_terminated.assert_called_once_with(
             "run-123", RunStatus.to_string(RunStatus.FAILED)
         )
 
 
-def test_invoke_genai_evaluate_job_failure_when_evaluate_throws():
-    """``mlflow.genai.evaluate`` swallows per-row scorer errors, so a thrown
-    exception from inside means the harness itself failed — we must still
-    flip the run to FAILED.
+def test_invoke_genai_evaluate_job_evaluate_failure_defers_to_context_manager():
+    """When ``mlflow.genai.evaluate`` raises INSIDE the active-run context
+    manager, terminal status is owned by ``ActiveRun.__exit__`` (see
+    mlflow/tracking/fluent.py:380), so the job code itself must NOT also call
+    set_terminated. The exception must still propagate so huey records the
+    job as FAILED with the original traceback. End-to-end FAILED transition
+    is covered by tests/server/jobs/test_genai_evaluate_invocation.py
+    (``test_invoke_genai_evaluate_missing_trace_marks_run_failed``).
     """
     mock_client = mock.MagicMock()
     mock_client._tracing_client.batch_get_traces.return_value = [mock.MagicMock()]
@@ -135,9 +150,9 @@ def test_invoke_genai_evaluate_job_failure_when_evaluate_throws():
                 run_id="run-123",
             )
 
-        mock_client.set_terminated.assert_called_once_with(
-            "run-123", RunStatus.to_string(RunStatus.FAILED)
-        )
+        # Critical: must NOT call set_terminated explicitly here. Doing so
+        # would be a duplicate write on top of the context manager's __exit__.
+        mock_client.set_terminated.assert_not_called()
 
 
 def test_invoke_genai_evaluate_job_propagates_username_via_env(monkeypatch):

--- a/tests/genai/evaluate/test_job.py
+++ b/tests/genai/evaluate/test_job.py
@@ -34,7 +34,6 @@ def test_invoke_genai_evaluate_job_success():
         mock.patch("mlflow.genai.evaluate") as mock_evaluate,
     ):
         result = invoke_genai_evaluate_job(
-            experiment_id="exp-123",
             trace_ids=["trace-1", "trace-2"],
             serialized_scorers=[_serialized_scorer("a"), _serialized_scorer("b")],
             run_id="run-123",
@@ -78,7 +77,6 @@ def test_invoke_genai_evaluate_job_batches_large_trace_list():
         mock.patch("mlflow.genai.evaluate"),
     ):
         invoke_genai_evaluate_job(
-            experiment_id="exp-123",
             trace_ids=trace_ids,
             serialized_scorers=[_serialized_scorer()],
             run_id="run-123",
@@ -106,7 +104,6 @@ def test_invoke_genai_evaluate_job_setup_failure_marks_run_failed():
     ):
         with pytest.raises(Exception, match="trace fetch failed"):
             invoke_genai_evaluate_job(
-                experiment_id="exp-123",
                 trace_ids=["trace-1"],
                 serialized_scorers=[_serialized_scorer()],
                 run_id="run-123",
@@ -144,7 +141,6 @@ def test_invoke_genai_evaluate_job_evaluate_failure_defers_to_context_manager():
     ):
         with pytest.raises(Exception, match="harness boom"):
             invoke_genai_evaluate_job(
-                experiment_id="exp-123",
                 trace_ids=["trace-1"],
                 serialized_scorers=[_serialized_scorer()],
                 run_id="run-123",
@@ -175,7 +171,6 @@ def test_invoke_genai_evaluate_job_propagates_username_via_env(monkeypatch):
         mock.patch("mlflow.genai.evaluate", side_effect=_capture_env),
     ):
         invoke_genai_evaluate_job(
-            experiment_id="exp-123",
             trace_ids=["trace-1"],
             serialized_scorers=[_serialized_scorer()],
             run_id="run-123",
@@ -198,7 +193,6 @@ def test_invoke_genai_evaluate_job_skips_username_propagation_when_none(monkeypa
         mock.patch("mlflow.genai.evaluate"),
     ):
         invoke_genai_evaluate_job(
-            experiment_id="exp-123",
             trace_ids=["trace-1"],
             serialized_scorers=[_serialized_scorer()],
             run_id="run-123",

--- a/tests/server/jobs/test_genai_evaluate_invocation.py
+++ b/tests/server/jobs/test_genai_evaluate_invocation.py
@@ -1,0 +1,313 @@
+# End-to-end tests for `POST /ajax-api/3.0/mlflow/genai/evaluate/invoke`.
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any, Literal
+
+import pytest
+import requests
+
+import mlflow
+from mlflow.entities import RunStatus
+from mlflow.genai.judges import make_judge
+from mlflow.utils.mlflow_tags import (
+    MLFLOW_GENAI_EVALUATE_JOB_ID,
+    MLFLOW_RUN_TYPE,
+    MLFLOW_RUN_TYPE_GENAI_EVALUATE,
+)
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt", reason="MLflow job execution is not supported on Windows"
+)
+
+
+class MockGatewayHandler(BaseHTTPRequestHandler):
+    """Always returns ``{"result":"Yes","rationale":"Mock"}`` for any model."""
+
+    def do_POST(self):
+        content_length = int(self.headers.get("Content-Length", 0))
+        # Drain the body so the client doesn't see a connection error.
+        self.rfile.read(content_length)
+
+        response = {
+            "id": "chatcmpl-mock",
+            "object": "chat.completion",
+            "created": 1234567890,
+            "model": "gpt-4o-mini",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": json.dumps({"result": "Yes", "rationale": "Mock"}),
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        }
+        body = json.dumps(response).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        pass
+
+
+class Client:
+    def __init__(self, server_url: str):
+        self.server_url = server_url
+
+    def invoke_genai_evaluate(
+        self,
+        experiment_id: str,
+        trace_ids: list[str],
+        serialized_scorers: list[str],
+    ) -> dict[str, Any]:
+        response = requests.post(
+            f"{self.server_url}/ajax-api/3.0/mlflow/genai/evaluate/invoke",
+            json={
+                "experiment_id": experiment_id,
+                "trace_ids": trace_ids,
+                "serialized_scorers": serialized_scorers,
+            },
+        )
+        if not response.ok:
+            raise AssertionError(
+                f"invoke_genai_evaluate failed with status {response.status_code}: {response.text}"
+            )
+        return response.json()
+
+    def get_job(self, job_id: str) -> dict[str, Any]:
+        response = requests.get(f"{self.server_url}/ajax-api/3.0/mlflow/jobs/{job_id}")
+        response.raise_for_status()
+        return response.json()
+
+    def wait_job(self, job_id: str, timeout: float = 60) -> dict[str, Any]:
+        beg = time.time()
+        while time.time() - beg <= timeout:
+            job_json = self.get_job(job_id)
+            if job_json["status"] in ["SUCCEEDED", "FAILED", "TIMEOUT"]:
+                return job_json
+            time.sleep(0.5)
+        raise TimeoutError(f"Job {job_id} did not complete within {timeout}s")
+
+
+@pytest.fixture(scope="module")
+def mock_gateway_server():
+    from tests.helper_functions import get_safe_port
+
+    port = get_safe_port()
+    server = HTTPServer(("127.0.0.1", port), MockGatewayHandler)
+    thread = threading.Thread(name="genai-evaluate-mock-gateway", target=server.serve_forever)
+    thread.daemon = True
+    thread.start()
+    yield f"http://127.0.0.1:{port}"
+    server.shutdown()
+
+
+@pytest.fixture(scope="module")
+def client(tmp_path_factory: pytest.TempPathFactory, mock_gateway_server: str) -> Client:
+    """Spin up an mlflow server with the new genai-evaluate job registered."""
+    from tests.helper_functions import get_safe_port
+
+    tmp_path = tmp_path_factory.mktemp("genai_evaluate_server")
+    backend_store_uri = f"sqlite:///{tmp_path / 'mlflow.db'}"
+    port = get_safe_port()
+
+    with subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "mlflow",
+            "server",
+            "-h",
+            "127.0.0.1",
+            "-p",
+            str(port),
+            "--backend-store-uri",
+            backend_store_uri,
+        ],
+        env={
+            **os.environ,
+            "MLFLOW_SERVER_ENABLE_JOB_EXECUTION": "true",
+            "_MLFLOW_SUPPORTED_JOB_FUNCTION_LIST": (
+                "mlflow.genai.evaluation.job.invoke_genai_evaluate_job"
+            ),
+            "_MLFLOW_ALLOWED_JOB_NAME_LIST": "invoke_genai_evaluate",
+            "MLFLOW_GATEWAY_URI": mock_gateway_server,
+        },
+        start_new_session=True,
+    ) as server_proc:
+        try:
+            # Server needs time for the job runner to start before we can submit.
+            time.sleep(10)
+            deadline = time.time() + 15
+            while time.time() < deadline:
+                time.sleep(1)
+                try:
+                    resp = requests.get(f"http://127.0.0.1:{port}/health")
+                except requests.ConnectionError:
+                    continue
+                if resp.status_code == 200:
+                    break
+            else:
+                raise TimeoutError("Server did not report healthy within 15 seconds")
+            yield Client(f"http://127.0.0.1:{port}")
+        finally:
+            os.killpg(server_proc.pid, signal.SIGKILL)
+
+
+@pytest.fixture
+def experiment_with_traces(client: Client):
+    """Create an experiment with 2 traces. Returns (experiment_id, trace_ids)."""
+    mlflow.set_tracking_uri(client.server_url)
+    experiment_id = mlflow.create_experiment(f"genai_evaluate_test_{time.time()}")
+    mlflow.set_experiment(experiment_id=experiment_id)
+
+    trace_ids = []
+    for i in range(2):
+        with mlflow.start_span(name=f"test_span_{i}") as span:
+            span.set_inputs({"question": f"What is {i}+{i}?"})
+            span.set_outputs(f"The answer is {i + i}")
+            trace_ids.append(span.trace_id)
+    return experiment_id, trace_ids
+
+
+def _serialized_judge(name: str = "answer_quality") -> str:
+    judge = make_judge(
+        name=name,
+        instructions="Input: {{ inputs }}\nOutput: {{ outputs }}",
+        model="gateway:/mock-judge",
+        feedback_value_type=Literal["Yes", "No"],
+    )
+    return json.dumps(judge.model_dump())
+
+
+def test_invoke_genai_evaluate_basic(client: Client, experiment_with_traces):
+    """Happy path: handler returns {job_id, run_id}, run is tagged correctly,
+    the job FINISHES, and the run ends FINISHED with traces linked to it.
+    """
+    experiment_id, trace_ids = experiment_with_traces
+
+    response = client.invoke_genai_evaluate(
+        experiment_id=experiment_id,
+        trace_ids=trace_ids,
+        serialized_scorers=[_serialized_judge()],
+    )
+
+    assert "job_id" in response
+    assert "run_id" in response
+    job_id = response["job_id"]
+    run_id = response["run_id"]
+
+    # The run should be visible on /evaluation-runs *immediately* — i.e. before
+    # the job even starts work — because the handler creates it synchronously
+    # with the right tag.
+    run = mlflow.get_run(run_id)
+    assert run.data.tags[MLFLOW_RUN_TYPE] == MLFLOW_RUN_TYPE_GENAI_EVALUATE
+    assert run.data.tags[MLFLOW_GENAI_EVALUATE_JOB_ID] == job_id
+
+    # Job must succeed; on success the job is responsible for flipping the run
+    # from RUNNING to FINISHED.
+    job_result = client.wait_job(job_id)
+    assert job_result["status"] == "SUCCEEDED", f"job failed: {job_result}"
+
+    # Re-fetch the run to confirm the terminal state transition landed in the
+    # store. RunStatus.FINISHED is an int enum; the run.status field is the
+    # string form.
+    run = mlflow.get_run(run_id)
+    assert run.info.status == RunStatus.to_string(RunStatus.FINISHED)
+
+
+def test_invoke_genai_evaluate_missing_trace_marks_run_failed(
+    client: Client, experiment_with_traces
+):
+    """If any input trace doesn't exist the harness raises; the run must end
+    FAILED rather than stuck in RUNNING.
+    """
+    experiment_id, _ = experiment_with_traces
+
+    response = client.invoke_genai_evaluate(
+        experiment_id=experiment_id,
+        trace_ids=["tr-does-not-exist-00000000000000"],
+        serialized_scorers=[_serialized_judge()],
+    )
+    job_id = response["job_id"]
+    run_id = response["run_id"]
+
+    job_result = client.wait_job(job_id)
+    assert job_result["status"] == "FAILED"
+
+    run = mlflow.get_run(run_id)
+    assert run.info.status == RunStatus.to_string(RunStatus.FAILED)
+
+
+def test_invoke_genai_evaluate_multiple_scorers_share_one_run(
+    client: Client, experiment_with_traces
+):
+    """Multiple scorers in one request must produce a SINGLE run (not one per
+    scorer). This is the whole point of the new endpoint vs. /scorer/invoke.
+    """
+    experiment_id, trace_ids = experiment_with_traces
+
+    response = client.invoke_genai_evaluate(
+        experiment_id=experiment_id,
+        trace_ids=trace_ids,
+        serialized_scorers=[
+            _serialized_judge("judge_a"),
+            _serialized_judge("judge_b"),
+            _serialized_judge("judge_c"),
+        ],
+    )
+    job_id = response["job_id"]
+    run_id = response["run_id"]
+
+    job_result = client.wait_job(job_id)
+    assert job_result["status"] == "SUCCEEDED", f"job failed: {job_result}"
+    # The job's return value is the source of truth that *all three* scorers ran
+    # inside the same job (vs. e.g. one job per scorer, which is what
+    # /scorer/invoke does). Stronger than reading a tag we wrote ourselves.
+    assert job_result["result"]["scorer_count"] == 3
+    assert job_result["result"]["run_id"] == run_id
+
+    run = mlflow.get_run(run_id)
+    assert run.info.status == RunStatus.to_string(RunStatus.FINISHED)
+
+
+def test_invoke_genai_evaluate_handler_validation_no_traces(client: Client):
+    """Empty trace_ids must be rejected before any run is created — otherwise
+    we'd litter the UI with empty placeholder runs on every malformed POST.
+    """
+    response = requests.post(
+        f"{client.server_url}/ajax-api/3.0/mlflow/genai/evaluate/invoke",
+        json={
+            "experiment_id": "0",
+            "trace_ids": [],
+            "serialized_scorers": [_serialized_judge()],
+        },
+    )
+    assert response.status_code == 400
+    assert "trace" in response.text.lower()
+
+
+def test_invoke_genai_evaluate_handler_validation_no_scorers(client: Client):
+    response = requests.post(
+        f"{client.server_url}/ajax-api/3.0/mlflow/genai/evaluate/invoke",
+        json={
+            "experiment_id": "0",
+            "trace_ids": ["any"],
+            "serialized_scorers": [],
+        },
+    )
+    assert response.status_code == 400
+    assert "judge" in response.text.lower()

--- a/tests/server/jobs/test_genai_evaluate_invocation.py
+++ b/tests/server/jobs/test_genai_evaluate_invocation.py
@@ -22,6 +22,8 @@ from mlflow.utils.mlflow_tags import (
     MLFLOW_RUN_TYPE_GENAI_EVALUATE,
 )
 
+from tests.helper_functions import get_safe_port
+
 pytestmark = pytest.mark.skipif(
     os.name == "nt", reason="MLflow job execution is not supported on Windows"
 )
@@ -104,8 +106,6 @@ class Client:
 
 @pytest.fixture(scope="module")
 def mock_gateway_server():
-    from tests.helper_functions import get_safe_port
-
     port = get_safe_port()
     server = HTTPServer(("127.0.0.1", port), MockGatewayHandler)
     thread = threading.Thread(name="genai-evaluate-mock-gateway", target=server.serve_forever)
@@ -118,8 +118,6 @@ def mock_gateway_server():
 @pytest.fixture(scope="module")
 def client(tmp_path_factory: pytest.TempPathFactory, mock_gateway_server: str) -> Client:
     """Spin up an mlflow server with the new genai-evaluate job registered."""
-    from tests.helper_functions import get_safe_port
-
     tmp_path = tmp_path_factory.mktemp("genai_evaluate_server")
     backend_store_uri = f"sqlite:///{tmp_path / 'mlflow.db'}"
     port = get_safe_port()

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -17,7 +17,6 @@ from mlflow.entities import (
     IssueSeverity,
     IssueStatus,
     RunStatus,
-    RunTag,
     ScorerVersion,
     Span,
     Trace,
@@ -5760,7 +5759,7 @@ def test_invoke_genai_evaluate_handler_success(monkeypatch):
         # is created directly in the store without touching the fluent active-run stack.
         mock_client.create_run.assert_called_once_with(
             experiment_id="exp-123",
-            tags=[RunTag("mlflow.runType", "genai_evaluate")],
+            tags={"mlflow.runType": "genai_evaluate"},
         )
 
         mock_submit_job.assert_called_once()

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -5712,6 +5712,170 @@ def test_invoke_issue_detection_handler_missing_required_params(monkeypatch):
         )
 
 
+def _make_genai_evaluate_job(job_id: str = "job-genai-1") -> JobEntity:
+    return JobEntity(
+        job_id=job_id,
+        creation_time=1234567890000,
+        job_name="invoke_genai_evaluate",
+        params='{"experiment_id": "exp-123"}',
+        timeout=None,
+        status=JobStatus.PENDING,
+        result=None,
+        retry_count=0,
+        last_update_time=1234567890000,
+        status_details=None,
+    )
+
+
+def test_invoke_genai_evaluate_handler_success(monkeypatch):
+    monkeypatch.setenv("MLFLOW_SERVER_ENABLE_JOB_EXECUTION", "true")
+
+    mock_job = _make_genai_evaluate_job()
+    mock_run = mock.MagicMock()
+    mock_run.info.run_id = "run-genai-1"
+
+    request_json = {
+        "experiment_id": "exp-123",
+        "trace_ids": ["trace-1", "trace-2"],
+        "serialized_scorers": ['{"name":"my-judge"}', '{"name":"safety"}'],
+    }
+
+    with (
+        mock.patch("mlflow.server.jobs.submit_job", return_value=mock_job) as mock_submit_job,
+        mock.patch("mlflow.start_run", return_value=mock_run) as mock_start_run,
+        mock.patch("mlflow.set_tag") as mock_set_tag,
+        mock.patch("mlflow.end_run"),
+        app.test_client() as c,
+    ):
+        resp = c.post("/ajax-api/3.0/mlflow/genai/evaluate/invoke", json=request_json)
+        assert resp.status_code == 200
+        json_response = resp.get_json()
+
+        assert json_response == {"job_id": "job-genai-1", "run_id": "run-genai-1"}
+
+        # The handler must create the run *upfront* with the right MLFLOW_RUN_TYPE tag
+        # so the run appears on /evaluation-runs immediately, before the job starts
+        # producing artifacts.
+        mock_start_run.assert_called_once()
+        start_run_kwargs = mock_start_run.call_args.kwargs
+        assert start_run_kwargs["experiment_id"] == "exp-123"
+        tags = start_run_kwargs["tags"]
+        assert tags["mlflow.runType"] == "genai_evaluate"
+
+        # The job must be invoked with all the params the job function expects;
+        # missing any of these would be a silent breakage on the worker side.
+        mock_submit_job.assert_called_once()
+        submit_kwargs = mock_submit_job.call_args.kwargs
+        assert submit_kwargs["params"]["experiment_id"] == "exp-123"
+        assert submit_kwargs["params"]["trace_ids"] == ["trace-1", "trace-2"]
+        assert submit_kwargs["params"]["serialized_scorers"] == request_json["serialized_scorers"]
+        assert submit_kwargs["params"]["run_id"] == "run-genai-1"
+        # No basic auth on the test client -> no username propagated.
+        assert submit_kwargs["params"]["username"] is None
+
+        # job-id tag is what the UI uses to poll status from the run page.
+        mock_set_tag.assert_called_once_with("mlflow.genaiEvaluate.jobId", "job-genai-1")
+
+
+def test_invoke_genai_evaluate_handler_rejects_empty_trace_ids(monkeypatch):
+    monkeypatch.setenv("MLFLOW_SERVER_ENABLE_JOB_EXECUTION", "true")
+
+    request_json = {
+        "experiment_id": "exp-123",
+        "trace_ids": [],
+        "serialized_scorers": ['{"name":"my-judge"}'],
+    }
+
+    with (
+        # Guard against accidentally creating a run for an invalid request.
+        mock.patch("mlflow.start_run") as mock_start_run,
+        mock.patch("mlflow.server.jobs.submit_job") as mock_submit_job,
+        app.test_client() as c,
+    ):
+        resp = c.post("/ajax-api/3.0/mlflow/genai/evaluate/invoke", json=request_json)
+        assert resp.status_code == 400
+        assert "Please select at least one trace to evaluate." in resp.get_json()["message"]
+        mock_start_run.assert_not_called()
+        mock_submit_job.assert_not_called()
+
+
+def test_invoke_genai_evaluate_handler_rejects_empty_serialized_scorers(monkeypatch):
+    monkeypatch.setenv("MLFLOW_SERVER_ENABLE_JOB_EXECUTION", "true")
+
+    request_json = {
+        "experiment_id": "exp-123",
+        "trace_ids": ["trace-1"],
+        "serialized_scorers": [],
+    }
+
+    with (
+        mock.patch("mlflow.start_run") as mock_start_run,
+        mock.patch("mlflow.server.jobs.submit_job") as mock_submit_job,
+        app.test_client() as c,
+    ):
+        resp = c.post("/ajax-api/3.0/mlflow/genai/evaluate/invoke", json=request_json)
+        assert resp.status_code == 400
+        assert "Please select at least one judge." in resp.get_json()["message"]
+        mock_start_run.assert_not_called()
+        mock_submit_job.assert_not_called()
+
+
+def test_invoke_genai_evaluate_handler_missing_required_fields(monkeypatch):
+    monkeypatch.setenv("MLFLOW_SERVER_ENABLE_JOB_EXECUTION", "true")
+
+    # Each call drops one of the required fields; the schema validator
+    # should reject before we ever create a run.
+    base = {
+        "experiment_id": "exp-123",
+        "trace_ids": ["trace-1"],
+        "serialized_scorers": ['{"name":"my-judge"}'],
+    }
+    for missing in ("experiment_id", "trace_ids", "serialized_scorers"):
+        request_json = {k: v for k, v in base.items() if k != missing}
+        with (
+            mock.patch("mlflow.start_run") as mock_start_run,
+            mock.patch("mlflow.server.jobs.submit_job") as mock_submit_job,
+            app.test_client() as c,
+        ):
+            resp = c.post("/ajax-api/3.0/mlflow/genai/evaluate/invoke", json=request_json)
+            assert resp.status_code == 400, f"missing={missing}: {resp.get_json()}"
+            mock_start_run.assert_not_called()
+            mock_submit_job.assert_not_called()
+
+
+def test_invoke_genai_evaluate_handler_propagates_basic_auth_username(monkeypatch):
+    """Username comes from HTTP Basic auth and feeds the job's gateway-auth
+    path so judge LLM calls are made *as* the user.
+    """
+    monkeypatch.setenv("MLFLOW_SERVER_ENABLE_JOB_EXECUTION", "true")
+
+    mock_job = _make_genai_evaluate_job("job-auth")
+    mock_run = mock.MagicMock()
+    mock_run.info.run_id = "run-auth"
+
+    request_json = {
+        "experiment_id": "exp-123",
+        "trace_ids": ["trace-1"],
+        "serialized_scorers": ['{"name":"my-judge"}'],
+    }
+
+    with (
+        mock.patch("mlflow.server.jobs.submit_job", return_value=mock_job) as mock_submit_job,
+        mock.patch("mlflow.start_run", return_value=mock_run),
+        mock.patch("mlflow.set_tag"),
+        mock.patch("mlflow.end_run"),
+        app.test_client() as c,
+    ):
+        # Encoded form of "alice:hunter2"
+        resp = c.post(
+            "/ajax-api/3.0/mlflow/genai/evaluate/invoke",
+            json=request_json,
+            headers={"Authorization": "Basic YWxpY2U6aHVudGVyMg=="},
+        )
+        assert resp.status_code == 200
+        assert mock_submit_job.call_args.kwargs["params"]["username"] == "alice"
+
+
 def test_get_job_success(mock_job_store):
     mock_job = JobEntity(
         job_id="job-123",

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -5762,8 +5762,6 @@ def test_invoke_genai_evaluate_handler_success(monkeypatch):
         tags = start_run_kwargs["tags"]
         assert tags["mlflow.runType"] == "genai_evaluate"
 
-        # The job must be invoked with all the params the job function expects;
-        # missing any of these would be a silent breakage on the worker side.
         mock_submit_job.assert_called_once()
         submit_kwargs = mock_submit_job.call_args.kwargs
         assert submit_kwargs["params"]["experiment_id"] == "exp-123"
@@ -5773,7 +5771,6 @@ def test_invoke_genai_evaluate_handler_success(monkeypatch):
         # No basic auth on the test client -> no username propagated.
         assert submit_kwargs["params"]["username"] is None
 
-        # job-id tag is what the UI uses to poll status from the run page.
         mock_set_tag.assert_called_once_with("mlflow.genaiEvaluate.jobId", "job-genai-1")
 
 
@@ -5874,6 +5871,79 @@ def test_invoke_genai_evaluate_handler_propagates_basic_auth_username(monkeypatc
         )
         assert resp.status_code == 200
         assert mock_submit_job.call_args.kwargs["params"]["username"] == "alice"
+
+
+def test_invoke_genai_evaluate_handler_marks_run_failed_when_submit_job_raises(monkeypatch):
+    """If submit_job raises after the run is created, the handler must flip the
+    run to FAILED itself — otherwise it'd be stuck in RUNNING forever because the
+    worker that would normally do that transition was never enqueued.
+    """
+    monkeypatch.setenv("MLFLOW_SERVER_ENABLE_JOB_EXECUTION", "true")
+
+    mock_run = mock.MagicMock()
+    mock_run.info.run_id = "run-fail"
+
+    request_json = {
+        "experiment_id": "exp-123",
+        "trace_ids": ["trace-1"],
+        "serialized_scorers": ['{"name":"my-judge"}'],
+    }
+
+    submit_error = MlflowException(
+        "Mlflow server job execution feature is not enabled.",
+        error_code=INVALID_PARAMETER_VALUE,
+    )
+
+    with (
+        mock.patch("mlflow.server.jobs.submit_job", side_effect=submit_error),
+        mock.patch("mlflow.start_run", return_value=mock_run),
+        mock.patch("mlflow.set_tag") as mock_set_tag,
+        mock.patch("mlflow.end_run") as mock_end_run,
+        app.test_client() as c,
+    ):
+        resp = c.post("/ajax-api/3.0/mlflow/genai/evaluate/invoke", json=request_json)
+
+        # @catch_mlflow_exception turns the re-raised MlflowException into a 4xx.
+        assert resp.status_code != 200
+        assert "job execution feature is not enabled" in resp.get_json()["message"]
+
+        # Only one end_run call, and it must be FAILED (not RUNNING). RUNNING would
+        # mean we went down the happy path; a missing call would mean we leaked
+        # the active-run stack and left the run stuck in RUNNING in the store.
+        mock_end_run.assert_called_once_with("FAILED")
+
+        # The job-id tag must not have been written — the job never existed.
+        mock_set_tag.assert_not_called()
+
+
+def test_invoke_genai_evaluate_handler_marks_run_failed_when_set_tag_raises(monkeypatch):
+    """The same try/except must also cover the post-submit set_tag call. If the
+    tag write fails (e.g. transient store error) we'd otherwise still leave the
+    run in RUNNING even though we never reached end_run(RUNNING).
+    """
+    monkeypatch.setenv("MLFLOW_SERVER_ENABLE_JOB_EXECUTION", "true")
+
+    mock_job = _make_genai_evaluate_job("job-tag-fail")
+    mock_run = mock.MagicMock()
+    mock_run.info.run_id = "run-tag-fail"
+
+    request_json = {
+        "experiment_id": "exp-123",
+        "trace_ids": ["trace-1"],
+        "serialized_scorers": ['{"name":"my-judge"}'],
+    }
+
+    with (
+        mock.patch("mlflow.server.jobs.submit_job", return_value=mock_job),
+        mock.patch("mlflow.start_run", return_value=mock_run),
+        mock.patch("mlflow.set_tag", side_effect=RuntimeError("store unavailable")),
+        mock.patch("mlflow.end_run") as mock_end_run,
+        app.test_client() as c,
+    ):
+        resp = c.post("/ajax-api/3.0/mlflow/genai/evaluate/invoke", json=request_json)
+
+        assert resp.status_code != 200
+        mock_end_run.assert_called_once_with("FAILED")
 
 
 def test_get_job_success(mock_job_store):

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -17,6 +17,7 @@ from mlflow.entities import (
     IssueSeverity,
     IssueStatus,
     RunStatus,
+    RunTag,
     ScorerVersion,
     Span,
     Trace,
@@ -5733,6 +5734,8 @@ def test_invoke_genai_evaluate_handler_success(monkeypatch):
     mock_job = _make_genai_evaluate_job()
     mock_run = mock.MagicMock()
     mock_run.info.run_id = "run-genai-1"
+    mock_client = mock.MagicMock()
+    mock_client.create_run.return_value = mock_run
 
     request_json = {
         "experiment_id": "exp-123",
@@ -5742,9 +5745,7 @@ def test_invoke_genai_evaluate_handler_success(monkeypatch):
 
     with (
         mock.patch("mlflow.server.jobs.submit_job", return_value=mock_job) as mock_submit_job,
-        mock.patch("mlflow.start_run", return_value=mock_run) as mock_start_run,
-        mock.patch("mlflow.set_tag") as mock_set_tag,
-        mock.patch("mlflow.end_run"),
+        mock.patch("mlflow.server.handlers.MlflowClient", return_value=mock_client),
         app.test_client() as c,
     ):
         resp = c.post("/ajax-api/3.0/mlflow/genai/evaluate/invoke", json=request_json)
@@ -5755,27 +5756,31 @@ def test_invoke_genai_evaluate_handler_success(monkeypatch):
 
         # The handler must create the run *upfront* with the right MLFLOW_RUN_TYPE tag
         # so the run appears on /evaluation-runs immediately, before the job starts
-        # producing artifacts.
-        mock_start_run.assert_called_once()
-        start_run_kwargs = mock_start_run.call_args.kwargs
-        assert start_run_kwargs["experiment_id"] == "exp-123"
-        tags = start_run_kwargs["tags"]
-        assert tags["mlflow.runType"] == "genai_evaluate"
+        # producing artifacts. We use MlflowClient (not mlflow.start_run) so the run
+        # is created directly in the store without touching the fluent active-run stack.
+        mock_client.create_run.assert_called_once_with(
+            experiment_id="exp-123",
+            tags=[RunTag("mlflow.runType", "genai_evaluate")],
+        )
 
         mock_submit_job.assert_called_once()
         submit_kwargs = mock_submit_job.call_args.kwargs
-        assert submit_kwargs["params"]["experiment_id"] == "exp-123"
         assert submit_kwargs["params"]["trace_ids"] == ["trace-1", "trace-2"]
         assert submit_kwargs["params"]["serialized_scorers"] == request_json["serialized_scorers"]
         assert submit_kwargs["params"]["run_id"] == "run-genai-1"
         # No basic auth on the test client -> no username propagated.
         assert submit_kwargs["params"]["username"] is None
 
-        mock_set_tag.assert_called_once_with("mlflow.genaiEvaluate.jobId", "job-genai-1")
+        mock_client.set_tag.assert_called_once_with(
+            "run-genai-1", "mlflow.genaiEvaluate.jobId", "job-genai-1"
+        )
+        mock_client.set_terminated.assert_not_called()
 
 
 def test_invoke_genai_evaluate_handler_rejects_empty_trace_ids(monkeypatch):
     monkeypatch.setenv("MLFLOW_SERVER_ENABLE_JOB_EXECUTION", "true")
+
+    mock_client = mock.MagicMock()
 
     request_json = {
         "experiment_id": "exp-123",
@@ -5784,20 +5789,22 @@ def test_invoke_genai_evaluate_handler_rejects_empty_trace_ids(monkeypatch):
     }
 
     with (
-        # Guard against accidentally creating a run for an invalid request.
-        mock.patch("mlflow.start_run") as mock_start_run,
+        mock.patch("mlflow.server.handlers.MlflowClient", return_value=mock_client),
         mock.patch("mlflow.server.jobs.submit_job") as mock_submit_job,
         app.test_client() as c,
     ):
         resp = c.post("/ajax-api/3.0/mlflow/genai/evaluate/invoke", json=request_json)
         assert resp.status_code == 400
         assert "Please select at least one trace to evaluate." in resp.get_json()["message"]
-        mock_start_run.assert_not_called()
+        # Guard against accidentally creating a run for an invalid request.
+        mock_client.create_run.assert_not_called()
         mock_submit_job.assert_not_called()
 
 
 def test_invoke_genai_evaluate_handler_rejects_empty_serialized_scorers(monkeypatch):
     monkeypatch.setenv("MLFLOW_SERVER_ENABLE_JOB_EXECUTION", "true")
+
+    mock_client = mock.MagicMock()
 
     request_json = {
         "experiment_id": "exp-123",
@@ -5806,14 +5813,14 @@ def test_invoke_genai_evaluate_handler_rejects_empty_serialized_scorers(monkeypa
     }
 
     with (
-        mock.patch("mlflow.start_run") as mock_start_run,
+        mock.patch("mlflow.server.handlers.MlflowClient", return_value=mock_client),
         mock.patch("mlflow.server.jobs.submit_job") as mock_submit_job,
         app.test_client() as c,
     ):
         resp = c.post("/ajax-api/3.0/mlflow/genai/evaluate/invoke", json=request_json)
         assert resp.status_code == 400
         assert "Please select at least one judge." in resp.get_json()["message"]
-        mock_start_run.assert_not_called()
+        mock_client.create_run.assert_not_called()
         mock_submit_job.assert_not_called()
 
 
@@ -5829,14 +5836,15 @@ def test_invoke_genai_evaluate_handler_missing_required_fields(monkeypatch):
     }
     for missing in ("experiment_id", "trace_ids", "serialized_scorers"):
         request_json = {k: v for k, v in base.items() if k != missing}
+        mock_client = mock.MagicMock()
         with (
-            mock.patch("mlflow.start_run") as mock_start_run,
+            mock.patch("mlflow.server.handlers.MlflowClient", return_value=mock_client),
             mock.patch("mlflow.server.jobs.submit_job") as mock_submit_job,
             app.test_client() as c,
         ):
             resp = c.post("/ajax-api/3.0/mlflow/genai/evaluate/invoke", json=request_json)
             assert resp.status_code == 400, f"missing={missing}: {resp.get_json()}"
-            mock_start_run.assert_not_called()
+            mock_client.create_run.assert_not_called()
             mock_submit_job.assert_not_called()
 
 
@@ -5849,6 +5857,8 @@ def test_invoke_genai_evaluate_handler_propagates_basic_auth_username(monkeypatc
     mock_job = _make_genai_evaluate_job("job-auth")
     mock_run = mock.MagicMock()
     mock_run.info.run_id = "run-auth"
+    mock_client = mock.MagicMock()
+    mock_client.create_run.return_value = mock_run
 
     request_json = {
         "experiment_id": "exp-123",
@@ -5858,9 +5868,7 @@ def test_invoke_genai_evaluate_handler_propagates_basic_auth_username(monkeypatc
 
     with (
         mock.patch("mlflow.server.jobs.submit_job", return_value=mock_job) as mock_submit_job,
-        mock.patch("mlflow.start_run", return_value=mock_run),
-        mock.patch("mlflow.set_tag"),
-        mock.patch("mlflow.end_run"),
+        mock.patch("mlflow.server.handlers.MlflowClient", return_value=mock_client),
         app.test_client() as c,
     ):
         # Encoded form of "alice:hunter2"
@@ -5882,6 +5890,8 @@ def test_invoke_genai_evaluate_handler_marks_run_failed_when_submit_job_raises(m
 
     mock_run = mock.MagicMock()
     mock_run.info.run_id = "run-fail"
+    mock_client = mock.MagicMock()
+    mock_client.create_run.return_value = mock_run
 
     request_json = {
         "experiment_id": "exp-123",
@@ -5896,9 +5906,7 @@ def test_invoke_genai_evaluate_handler_marks_run_failed_when_submit_job_raises(m
 
     with (
         mock.patch("mlflow.server.jobs.submit_job", side_effect=submit_error),
-        mock.patch("mlflow.start_run", return_value=mock_run),
-        mock.patch("mlflow.set_tag") as mock_set_tag,
-        mock.patch("mlflow.end_run") as mock_end_run,
+        mock.patch("mlflow.server.handlers.MlflowClient", return_value=mock_client),
         app.test_client() as c,
     ):
         resp = c.post("/ajax-api/3.0/mlflow/genai/evaluate/invoke", json=request_json)
@@ -5907,25 +5915,25 @@ def test_invoke_genai_evaluate_handler_marks_run_failed_when_submit_job_raises(m
         assert resp.status_code != 200
         assert "job execution feature is not enabled" in resp.get_json()["message"]
 
-        # Only one end_run call, and it must be FAILED (not RUNNING). RUNNING would
-        # mean we went down the happy path; a missing call would mean we leaked
-        # the active-run stack and left the run stuck in RUNNING in the store.
-        mock_end_run.assert_called_once_with("FAILED")
+        mock_client.set_terminated.assert_called_once_with("run-fail", "FAILED")
 
         # The job-id tag must not have been written — the job never existed.
-        mock_set_tag.assert_not_called()
+        mock_client.set_tag.assert_not_called()
 
 
 def test_invoke_genai_evaluate_handler_marks_run_failed_when_set_tag_raises(monkeypatch):
     """The same try/except must also cover the post-submit set_tag call. If the
-    tag write fails (e.g. transient store error) we'd otherwise still leave the
-    run in RUNNING even though we never reached end_run(RUNNING).
+    tag write fails (e.g. transient store error) we'd otherwise leave the run in
+    RUNNING because nothing else writes a terminal status from the handler.
     """
     monkeypatch.setenv("MLFLOW_SERVER_ENABLE_JOB_EXECUTION", "true")
 
     mock_job = _make_genai_evaluate_job("job-tag-fail")
     mock_run = mock.MagicMock()
     mock_run.info.run_id = "run-tag-fail"
+    mock_client = mock.MagicMock()
+    mock_client.create_run.return_value = mock_run
+    mock_client.set_tag.side_effect = RuntimeError("store unavailable")
 
     request_json = {
         "experiment_id": "exp-123",
@@ -5935,15 +5943,13 @@ def test_invoke_genai_evaluate_handler_marks_run_failed_when_set_tag_raises(monk
 
     with (
         mock.patch("mlflow.server.jobs.submit_job", return_value=mock_job),
-        mock.patch("mlflow.start_run", return_value=mock_run),
-        mock.patch("mlflow.set_tag", side_effect=RuntimeError("store unavailable")),
-        mock.patch("mlflow.end_run") as mock_end_run,
+        mock.patch("mlflow.server.handlers.MlflowClient", return_value=mock_client),
         app.test_client() as c,
     ):
         resp = c.post("/ajax-api/3.0/mlflow/genai/evaluate/invoke", json=request_json)
 
         assert resp.status_code != 200
-        mock_end_run.assert_called_once_with("FAILED")
+        mock_client.set_terminated.assert_called_once_with("run-tag-fail", "FAILED")
 
 
 def test_get_job_success(mock_job_store):


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/23779/files) to review incremental changes.
- [stack/run-eval-changes](https://github.com/mlflow/mlflow/pull/23735) [[Files changed](https://github.com/mlflow/mlflow/pull/23735/files)] [MERGED]
  - [stack/run-eval-dynamic-traces-snippet](https://github.com/mlflow/mlflow/pull/23737) [[Files changed](https://github.com/mlflow/mlflow/pull/23737/files)] [MERGED]
    - [stack/run-eval-traces-eval](https://github.com/mlflow/mlflow/pull/23758) [[Files changed](https://github.com/mlflow/mlflow/pull/23758/files)] [MERGED]
      - [**stack/run-eval-traces-handler**](https://github.com/mlflow/mlflow/pull/23779) [[Files changed](https://github.com/mlflow/mlflow/pull/23779/files)]
        - [stack/run-eval-traces-fe-be-wiring](https://github.com/mlflow/mlflow/pull/23781) [[Files changed](https://github.com/mlflow/mlflow/pull/23781/files/d8732cae747c0997eeab80e0075803653bed6ad3..0d017837ac79f43bd71fb6aa25c39e0f1684deb2)]

---------
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Adds a new server-side endpoint, POST /ajax-api/3.0/mlflow/genai/evaluate/invoke, plus the Huey job that backs it, so the UI's "Run evaluation → Run judge(s)" button can trigger an mlflow.genai.evaluate(...) run asynchronously and have the result show up on the Evaluation Runs page.

This is to address the gap where users are not able to trigger a direct eval run from the UI. With this PR, we will now have the handler and the job that is necessary to trigger a eval run from the Evaluation Runs page

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

**Note** that this PR only contains backend changes, but to verify its working, E2E validation is done with the full stacked PRs

Full E2E feature recording test (done with another stacked PR - https://github.com/mlflow/mlflow/pull/23781 for FE <-> BE wiring):

https://github.com/user-attachments/assets/c33fae61-0847-4b3d-be1b-497115c06061

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
