### PR TITLE
Reorder columns for evaluation run tables

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTable.utils.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTable.utils.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect } from '@jest/globals';
 
-import { getSimulationColumnsToAdd } from './GenAiTracesTable.utils';
-import { SIMULATION_GOAL_COLUMN_ID, SIMULATION_PERSONA_COLUMN_ID } from './hooks/useTableColumns';
+import { getSimulationColumnsToAdd, sortGroupedColumns } from './GenAiTracesTable.utils';
+import {
+  RESPONSE_COLUMN_ID,
+  SIMULATION_GOAL_COLUMN_ID,
+  SIMULATION_PERSONA_COLUMN_ID,
+  createAssessmentColumnId,
+  createExpectationColumnId,
+} from './hooks/useTableColumns';
 import { SIMULATION_GOAL_KEY, SIMULATION_PERSONA_KEY } from './utils/SessionGroupingUtils';
 import type { TracesTableColumn } from './types';
 import { TracesTableColumnType, TracesTableColumnGroup } from './types';
@@ -57,5 +63,44 @@ describe('getSimulationColumnsToAdd', () => {
   it('returns only columns available in allColumns', () => {
     expect(getSimulationColumnsToAdd([createTrace(bothMetadata)], [goalColumn], [])).toEqual([goalColumn]);
     expect(getSimulationColumnsToAdd([createTrace(bothMetadata)], [], [])).toEqual([]);
+  });
+});
+
+describe('sortGroupedColumns — base / expectations / assessments / other ordering', () => {
+  const responseCol: TracesTableColumn = {
+    id: RESPONSE_COLUMN_ID,
+    label: 'Response',
+    type: TracesTableColumnType.TRACE_INFO,
+    group: TracesTableColumnGroup.BASE,
+  };
+  const expectedResponseCol: TracesTableColumn = {
+    id: createExpectationColumnId('expected_response'),
+    label: 'expected_response',
+    type: TracesTableColumnType.EXPECTATION,
+    group: TracesTableColumnGroup.EXPECTATION,
+    expectationName: 'expected_response',
+  };
+  const executionTimeCol: TracesTableColumn = {
+    id: 'execution_duration',
+    label: 'Execution time',
+    type: TracesTableColumnType.TRACE_INFO,
+    group: TracesTableColumnGroup.INFO,
+  };
+  const qualityCol: TracesTableColumn = {
+    id: createAssessmentColumnId('quality'),
+    label: 'quality',
+    type: TracesTableColumnType.ASSESSMENT,
+    group: TracesTableColumnGroup.ASSESSMENT,
+  };
+
+  it('orders columns as: BASE → EXPECTATION → ASSESSMENT → INFO', () => {
+    // Scramble the input so order in the array can't accidentally pass the test.
+    const sorted = sortGroupedColumns([executionTimeCol, qualityCol, expectedResponseCol, responseCol]);
+    expect(sorted.map((c) => c.id)).toEqual([
+      responseCol.id,
+      expectedResponseCol.id,
+      qualityCol.id,
+      executionTimeCol.id,
+    ]);
   });
 });

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTable.utils.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTable.utils.test.ts
@@ -80,6 +80,13 @@ describe('sortGroupedColumns — base / expectations / assessments / other order
     group: TracesTableColumnGroup.EXPECTATION,
     expectationName: 'expected_response',
   };
+  const expectedFactsCol: TracesTableColumn = {
+    id: createExpectationColumnId('expected_facts'),
+    label: 'expected_facts',
+    type: TracesTableColumnType.EXPECTATION,
+    group: TracesTableColumnGroup.EXPECTATION,
+    expectationName: 'expected_facts',
+  };
   const executionTimeCol: TracesTableColumn = {
     id: 'execution_duration',
     label: 'Execution time',
@@ -102,5 +109,12 @@ describe('sortGroupedColumns — base / expectations / assessments / other order
       qualityCol.id,
       executionTimeCol.id,
     ]);
+  });
+
+  it('puts expected_response first within the EXPECTATION group', () => {
+    // expected_facts < expected_response alphabetically, so without an explicit
+    // priority the sort would put expected_facts first.
+    const sorted = sortGroupedColumns([expectedFactsCol, expectedResponseCol]);
+    expect(sorted.map((c) => c.id)).toEqual([expectedResponseCol.id, expectedFactsCol.id]);
   });
 });

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTable.utils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTable.utils.ts
@@ -31,14 +31,15 @@ import { SIMULATION_GOAL_KEY, SIMULATION_PERSONA_KEY } from './utils/SessionGrou
 import type { ModelTraceInfoV3 } from '../model-trace-explorer/ModelTrace.types';
 
 const GROUP_PRIORITY = [
-  TracesTableColumnGroup.INFO,
-  TracesTableColumnGroup.ASSESSMENT,
+  TracesTableColumnGroup.BASE,
   TracesTableColumnGroup.EXPECTATION,
+  TracesTableColumnGroup.ASSESSMENT,
+  TracesTableColumnGroup.INFO,
   TracesTableColumnGroup.TAG,
 ] as const;
 
-/** Preferred order *within* the INFO group by column ID */
-const INFO_COLUMN_PRIORITY = [
+/** Preferred within-group order by column ID, applied to BASE and INFO. */
+const COLUMN_PRIORITY = [
   TRACE_ID_COLUMN_ID,
   INPUTS_COLUMN_ID,
   RESPONSE_COLUMN_ID,
@@ -59,7 +60,7 @@ const groupRank: Record<TracesTableColumnGroup, number> = Object.fromEntries(
   GROUP_PRIORITY.map((grp, idx) => [grp, idx]),
 ) as any;
 
-const infoColumnRank: Record<string, number> = Object.fromEntries(INFO_COLUMN_PRIORITY.map((id, idx) => [id, idx]));
+const columnRank: Record<string, number> = Object.fromEntries(COLUMN_PRIORITY.map((id, idx) => [id, idx]));
 
 const assessmentColumnRank: Record<string, number> = Object.fromEntries(
   ASSESSMENT_COLUMN_PRIORITY.map((id, idx) => [id, idx]),
@@ -94,22 +95,22 @@ export function sortGroupedColumns(
       if (colB.id === INPUTS_COLUMN_ID) return 1;
     }
 
-    // 1) Compare their groups by precomputed rank
+    // 1) Compare their groups by precomputed rank.
     const groupA = colA.group ?? TracesTableColumnGroup.INFO;
     const groupB = colB.group ?? TracesTableColumnGroup.INFO;
     const groupComparison = groupRank[groupA] - groupRank[groupB];
     if (groupComparison !== 0) return groupComparison;
 
-    // 2) Same group: INFO
-    if (groupA === TracesTableColumnGroup.INFO) {
+    // 2) Same group: BASE or INFO (share the same column-priority map)
+    if (groupA === TracesTableColumnGroup.BASE || groupA === TracesTableColumnGroup.INFO) {
       // Columns in INFO_COLUMN_LAST should always appear at the end
       const isLastA = INFO_COLUMN_LAST.includes(colA.id as (typeof INFO_COLUMN_LAST)[number]);
       const isLastB = INFO_COLUMN_LAST.includes(colB.id as (typeof INFO_COLUMN_LAST)[number]);
       if (isLastA && !isLastB) return 1;
       if (!isLastA && isLastB) return -1;
 
-      const rankA = infoColumnRank[colA.id] ?? Infinity;
-      const rankB = infoColumnRank[colB.id] ?? Infinity;
+      const rankA = columnRank[colA.id] ?? Infinity;
+      const rankB = columnRank[colB.id] ?? Infinity;
       if (rankA !== rankB) return rankA - rankB;
       return colA.label.localeCompare(colB.label);
     }

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTable.utils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTable.utils.ts
@@ -23,6 +23,7 @@ import {
   ISSUES_COLUMN_ID,
   GIT_BRANCH_COLUMN_ID,
   GIT_COMMIT_COLUMN_ID,
+  createExpectationColumnId,
 } from './hooks/useTableColumns';
 import type { TracesTableColumn, EvalTraceComparisonEntry, RunEvaluationTracesDataEntry } from './types';
 import { TracesTableColumnGroup, TracesTableColumnType } from './types';
@@ -56,6 +57,9 @@ const INFO_COLUMN_LAST = [ISSUES_COLUMN_ID] as const;
 /** Preferred order *within* the ASSESSMENT group by column ID */
 const ASSESSMENT_COLUMN_PRIORITY = [KnownEvaluationResultAssessmentName.OVERALL_ASSESSMENT] as const;
 
+/** Preferred order *within* the EXPECTATION group by column ID */
+const EXPECTATION_COLUMN_PRIORITY = [createExpectationColumnId('expected_response')] as const;
+
 const groupRank: Record<TracesTableColumnGroup, number> = Object.fromEntries(
   GROUP_PRIORITY.map((grp, idx) => [grp, idx]),
 ) as any;
@@ -65,6 +69,9 @@ const infoColumnRank: Record<string, number> = Object.fromEntries(INFO_COLUMN_PR
 
 const assessmentColumnRank: Record<string, number> = Object.fromEntries(
   ASSESSMENT_COLUMN_PRIORITY.map((id, idx) => [id, idx]),
+);
+const expectationColumnRank: Record<string, number> = Object.fromEntries(
+  EXPECTATION_COLUMN_PRIORITY.map((id, idx) => [id, idx]),
 );
 
 export function sortGroupedColumns(
@@ -111,6 +118,9 @@ export function sortGroupedColumns(
     }
 
     if (groupA === TracesTableColumnGroup.EXPECTATION) {
+      const rankA = expectationColumnRank[colA.id] ?? Infinity;
+      const rankB = expectationColumnRank[colB.id] ?? Infinity;
+      if (rankA !== rankB) return rankA - rankB;
       return colA.label.localeCompare(colB.label);
     }
 

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTable.utils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTable.utils.ts
@@ -38,11 +38,11 @@ const GROUP_PRIORITY = [
   TracesTableColumnGroup.TAG,
 ] as const;
 
-/** Preferred within-group order by column ID, applied to BASE and INFO. */
-const COLUMN_PRIORITY = [
-  TRACE_ID_COLUMN_ID,
-  INPUTS_COLUMN_ID,
-  RESPONSE_COLUMN_ID,
+/** Preferred order *within* the BASE group by column ID */
+const BASE_COLUMN_PRIORITY = [TRACE_ID_COLUMN_ID, INPUTS_COLUMN_ID, RESPONSE_COLUMN_ID] as const;
+
+/** Preferred order *within* the INFO group by column ID */
+const INFO_COLUMN_PRIORITY = [
   SESSION_COLUMN_ID,
   USER_COLUMN_ID,
   TRACE_NAME_COLUMN_ID,
@@ -60,7 +60,8 @@ const groupRank: Record<TracesTableColumnGroup, number> = Object.fromEntries(
   GROUP_PRIORITY.map((grp, idx) => [grp, idx]),
 ) as any;
 
-const columnRank: Record<string, number> = Object.fromEntries(COLUMN_PRIORITY.map((id, idx) => [id, idx]));
+const baseColumnRank: Record<string, number> = Object.fromEntries(BASE_COLUMN_PRIORITY.map((id, idx) => [id, idx]));
+const infoColumnRank: Record<string, number> = Object.fromEntries(INFO_COLUMN_PRIORITY.map((id, idx) => [id, idx]));
 
 const assessmentColumnRank: Record<string, number> = Object.fromEntries(
   ASSESSMENT_COLUMN_PRIORITY.map((id, idx) => [id, idx]),
@@ -101,21 +102,29 @@ export function sortGroupedColumns(
     const groupComparison = groupRank[groupA] - groupRank[groupB];
     if (groupComparison !== 0) return groupComparison;
 
-    // 2) Same group: BASE or INFO (share the same column-priority map)
-    if (groupA === TracesTableColumnGroup.BASE || groupA === TracesTableColumnGroup.INFO) {
+    // 2) Same group: BASE
+    if (groupA === TracesTableColumnGroup.BASE) {
+      const rankA = baseColumnRank[colA.id] ?? Infinity;
+      const rankB = baseColumnRank[colB.id] ?? Infinity;
+      if (rankA !== rankB) return rankA - rankB;
+      return colA.label.localeCompare(colB.label);
+    }
+
+    // 3) Same group: INFO ("Others")
+    if (groupA === TracesTableColumnGroup.INFO) {
       // Columns in INFO_COLUMN_LAST should always appear at the end
       const isLastA = INFO_COLUMN_LAST.includes(colA.id as (typeof INFO_COLUMN_LAST)[number]);
       const isLastB = INFO_COLUMN_LAST.includes(colB.id as (typeof INFO_COLUMN_LAST)[number]);
       if (isLastA && !isLastB) return 1;
       if (!isLastA && isLastB) return -1;
 
-      const rankA = columnRank[colA.id] ?? Infinity;
-      const rankB = columnRank[colB.id] ?? Infinity;
+      const rankA = infoColumnRank[colA.id] ?? Infinity;
+      const rankB = infoColumnRank[colB.id] ?? Infinity;
       if (rankA !== rankB) return rankA - rankB;
       return colA.label.localeCompare(colB.label);
     }
 
-    // 3) Same group: ASSESSMENT
+    // 4) Same group: ASSESSMENT
     if (groupA === TracesTableColumnGroup.ASSESSMENT) {
       const rankA = assessmentColumnRank[colA.id] ?? Infinity;
       const rankB = assessmentColumnRank[colB.id] ?? Infinity;
@@ -123,12 +132,12 @@ export function sortGroupedColumns(
       return colA.label.localeCompare(colB.label);
     }
 
-    // 4) Same group: EXPECTATION
+    // 5) Same group: EXPECTATION
     if (groupA === TracesTableColumnGroup.EXPECTATION) {
       return colA.label.localeCompare(colB.label);
     }
 
-    // 5) Same group: TAG (or any other fallback)
+    // 6) Same group: TAG (or any other fallback)
     return colA.label.localeCompare(colB.label);
   });
 }

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTable.utils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTable.utils.ts
@@ -102,7 +102,7 @@ export function sortGroupedColumns(
     const groupComparison = groupRank[groupA] - groupRank[groupB];
     if (groupComparison !== 0) return groupComparison;
 
-    // 2) Same group: BASE
+    // 2) Same group: within-group ordering, in GROUP_PRIORITY order
     if (groupA === TracesTableColumnGroup.BASE) {
       const rankA = baseColumnRank[colA.id] ?? Infinity;
       const rankB = baseColumnRank[colB.id] ?? Infinity;
@@ -110,7 +110,17 @@ export function sortGroupedColumns(
       return colA.label.localeCompare(colB.label);
     }
 
-    // 3) Same group: INFO ("Others")
+    if (groupA === TracesTableColumnGroup.EXPECTATION) {
+      return colA.label.localeCompare(colB.label);
+    }
+
+    if (groupA === TracesTableColumnGroup.ASSESSMENT) {
+      const rankA = assessmentColumnRank[colA.id] ?? Infinity;
+      const rankB = assessmentColumnRank[colB.id] ?? Infinity;
+      if (rankA !== rankB) return rankA - rankB;
+      return colA.label.localeCompare(colB.label);
+    }
+
     if (groupA === TracesTableColumnGroup.INFO) {
       // Columns in INFO_COLUMN_LAST should always appear at the end
       const isLastA = INFO_COLUMN_LAST.includes(colA.id as (typeof INFO_COLUMN_LAST)[number]);
@@ -124,20 +134,7 @@ export function sortGroupedColumns(
       return colA.label.localeCompare(colB.label);
     }
 
-    // 4) Same group: ASSESSMENT
-    if (groupA === TracesTableColumnGroup.ASSESSMENT) {
-      const rankA = assessmentColumnRank[colA.id] ?? Infinity;
-      const rankB = assessmentColumnRank[colB.id] ?? Infinity;
-      if (rankA !== rankB) return rankA - rankB;
-      return colA.label.localeCompare(colB.label);
-    }
-
-    // 5) Same group: EXPECTATION
-    if (groupA === TracesTableColumnGroup.EXPECTATION) {
-      return colA.label.localeCompare(colB.label);
-    }
-
-    // 6) Same group: TAG (or any other fallback)
+    // TAG (or any other fallback)
     return colA.label.localeCompare(colB.label);
   });
 }

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/HeaderCellRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/HeaderCellRenderer.tsx
@@ -33,7 +33,7 @@ export const HeaderCellRenderer = (props: HeaderContext<EvalTraceComparisonEntry
       }}
     >
       <div>{groupName}</div>
-      {groupId === TracesTableColumnGroup.INFO ? null : visibleCount === totalCount ? (
+      {groupId === TracesTableColumnGroup.BASE ? null : visibleCount === totalCount ? (
         <div
           css={{
             color: theme.colors.textSecondary,

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/EvaluationsOverviewColumnSelectorGrouped.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/EvaluationsOverviewColumnSelectorGrouped.tsx
@@ -32,9 +32,9 @@ interface Props {
 const OPTION_HEIGHT = 32;
 
 const getGroupLabel = (group: string): string => {
-  return group === TracesTableColumnGroup.INFO
-    ? 'Attributes'
-    : TracesTableColumnGroupToLabelMap[group as TracesTableColumnGroup];
+  if (group === TracesTableColumnGroup.BASE) return 'Attributes';
+  if (group === TracesTableColumnGroup.INFO) return 'Other attributes';
+  return TracesTableColumnGroupToLabelMap[group as TracesTableColumnGroup];
 };
 
 /**

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/EvaluationsOverviewColumnSelectorGrouped.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/EvaluationsOverviewColumnSelectorGrouped.tsx
@@ -33,7 +33,6 @@ const OPTION_HEIGHT = 32;
 
 const getGroupLabel = (group: string): string => {
   if (group === TracesTableColumnGroup.BASE) return 'Attributes';
-  if (group === TracesTableColumnGroup.INFO) return 'Other attributes';
   return TracesTableColumnGroupToLabelMap[group as TracesTableColumnGroup];
 };
 

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/EvaluationsOverviewColumnSelectorGrouped.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/EvaluationsOverviewColumnSelectorGrouped.tsx
@@ -32,7 +32,7 @@ interface Props {
 const OPTION_HEIGHT = 32;
 
 const getGroupLabel = (group: string): string => {
-  if (group === TracesTableColumnGroup.BASE) return 'Attributes';
+  if (group === TracesTableColumnGroup.BASE) return 'Base Attributes';
   return TracesTableColumnGroupToLabelMap[group as TracesTableColumnGroup];
 };
 

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/EvaluationsOverviewSortDropdown.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/EvaluationsOverviewSortDropdown.tsx
@@ -78,7 +78,7 @@ export const EvaluationsOverviewSortDropdown = React.memo(
               label: column.label,
               key: column.id,
               type: TracesTableColumnType.INPUT,
-              group: TracesTableColumnGroup.INFO,
+              group: column.group ?? TracesTableColumnGroup.INFO,
             });
           } else if (column.type === TracesTableColumnType.TRACE_INFO) {
             const label =
@@ -93,7 +93,7 @@ export const EvaluationsOverviewSortDropdown = React.memo(
                 label,
                 key: column.id,
                 type: TracesTableColumnType.TRACE_INFO,
-                group: TracesTableColumnGroup.INFO,
+                group: column.group ?? TracesTableColumnGroup.INFO,
               });
             }
           }
@@ -339,7 +339,9 @@ const EvaluationsOverviewSortDropdownBodyGrouped = ({
           <React.Fragment key={groupName}>
             <DropdownMenu.Group>
               <DropdownMenu.Label>
-                {TracesTableColumnGroupToLabelMap[groupName as TracesTableColumnGroup]}
+                {groupName === TracesTableColumnGroup.BASE
+                  ? 'Base Attributes'
+                  : TracesTableColumnGroupToLabelMap[groupName as TracesTableColumnGroup]}
               </DropdownMenu.Label>
               {opts.map((opt, idx) => (
                 <DropdownMenu.CheckboxItem

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/EvaluationsOverviewSortDropdown.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/EvaluationsOverviewSortDropdown.tsx
@@ -339,9 +339,7 @@ const EvaluationsOverviewSortDropdownBodyGrouped = ({
           <React.Fragment key={groupName}>
             <DropdownMenu.Group>
               <DropdownMenu.Label>
-                {groupName === TracesTableColumnGroup.INFO
-                  ? 'Attributes'
-                  : TracesTableColumnGroupToLabelMap[groupName as TracesTableColumnGroup]}
+                {TracesTableColumnGroupToLabelMap[groupName as TracesTableColumnGroup]}
               </DropdownMenu.Label>
               {opts.map((opt, idx) => (
                 <DropdownMenu.CheckboxItem

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/hooks/useTableColumns.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/hooks/useTableColumns.tsx
@@ -108,7 +108,7 @@ export const useTableColumns = (
             description: 'Column label for request',
           }),
           type: TracesTableColumnType.INPUT,
-          group: TracesTableColumnGroup.INFO,
+          group: TracesTableColumnGroup.BASE,
           filterOrder: 0,
         },
       ];
@@ -140,7 +140,7 @@ export const useTableColumns = (
             description: 'Column label for trace ID',
           }),
           type: TracesTableColumnType.TRACE_INFO,
-          group: TracesTableColumnGroup.INFO,
+          group: TracesTableColumnGroup.BASE,
         },
         {
           id: TRACE_NAME_COLUMN_ID,
@@ -158,7 +158,7 @@ export const useTableColumns = (
             description: 'Column label for response',
           }),
           type: TracesTableColumnType.TRACE_INFO,
-          group: TracesTableColumnGroup.INFO,
+          group: TracesTableColumnGroup.BASE,
           filterOrder: 0,
         },
         {

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/types.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/types.ts
@@ -318,6 +318,7 @@ export enum TracesTableColumnType {
 // This represents columns that are grouped together.
 // For example, each assessment is its own column, but they are all grouped under the "Assessments" column group.
 export enum TracesTableColumnGroup {
+  BASE = 'BASE',
   ASSESSMENT = 'ASSESSMENT',
   EXPECTATION = 'EXPECTATION',
   TAG = 'TAG',
@@ -328,7 +329,8 @@ export const TracesTableColumnGroupToLabelMap = {
   [TracesTableColumnGroup.ASSESSMENT]: 'Assessments',
   [TracesTableColumnGroup.EXPECTATION]: 'Expectations',
   [TracesTableColumnGroup.TAG]: 'Tags',
-  // We don't show a label for the info column group
+  // We don't show a label band for BASE (first/default) or INFO ("Other") in the table header
+  [TracesTableColumnGroup.BASE]: '\u00A0',
   [TracesTableColumnGroup.INFO]: '\u00A0',
 };
 

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/types.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/types.ts
@@ -329,7 +329,7 @@ export const TracesTableColumnGroupToLabelMap = {
   [TracesTableColumnGroup.ASSESSMENT]: 'Assessments',
   [TracesTableColumnGroup.EXPECTATION]: 'Expectations',
   [TracesTableColumnGroup.TAG]: 'Tags',
-  [TracesTableColumnGroup.INFO]: 'Others',
+  [TracesTableColumnGroup.INFO]: 'Other Attributes',
   // BASE is the leading section; we don't show a label band for it in the table header
   [TracesTableColumnGroup.BASE]: '\u00A0',
 };

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/types.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/types.ts
@@ -329,9 +329,9 @@ export const TracesTableColumnGroupToLabelMap = {
   [TracesTableColumnGroup.ASSESSMENT]: 'Assessments',
   [TracesTableColumnGroup.EXPECTATION]: 'Expectations',
   [TracesTableColumnGroup.TAG]: 'Tags',
-  // We don't show a label band for BASE (first/default) or INFO ("Other") in the table header
+  [TracesTableColumnGroup.INFO]: 'Others',
+  // BASE is the leading section; we don't show a label band for it in the table header
   [TracesTableColumnGroup.BASE]: '\u00A0',
-  [TracesTableColumnGroup.INFO]: '\u00A0',
 };
 
 export interface TracesTableColumn {


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs


### What changes are proposed in this pull request?

Currently, the evaluation run table has three major column types:
1. Attributes
2. Assessment
3. Expectations

The evaluation run table displays them in order. However, there are many Attribute types. As such, it is possible for Assessment and Expectations to be shifted entirely to the right and out of the user view. 

For easier reference, this PR changes the column types

1. Base Attributes (trace_id, request, response) - the bare minimum
2. Expectations
3. Assessment
4. Other Attributes

This surfaces the higher value columns first, allowing user to compare expected response vs actual response more easily, in addition to moving the assessment information closer to the left. 


This is just my opinion, so feel free to pushback/disagree or close this PR. 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

**BEFORE**

* Assessment and expectations are on the right
* Everything is grouped under Attributes

<img width="2344" height="549" alt="Screenshot 2026-06-04 at 5 17 10 PM" src="https://github.com/user-attachments/assets/11fa2a54-8bab-4a6f-af12-57efe67db3e9" />
<img width="612" height="748" alt="Screenshot 2026-06-04 at 5 17 35 PM" src="https://github.com/user-attachments/assets/88008251-5cc0-4f31-8b47-0255c4a6aaf3" />

**NOW**
* Assessment and expectations come right after `trace_id`, `request`, `response`
* New section called "Other Attributes" added

<img width="2346" height="540" alt="Screenshot 2026-06-04 at 5 29 43 PM" src="https://github.com/user-attachments/assets/5c8c6c67-81a3-49e1-b91f-6fcee5e74f69" />

<img width="408" height="636" alt="Screenshot 2026-06-04 at 5 30 00 PM" src="https://github.com/user-attachments/assets/e4cbd76d-3091-4e69-89e3-056626e66fa2" />



### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

Reordered evaluation run tables to surface higher priority columns first


#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
