### PR TITLE
Wire "Run judge(s)" submission in "Run Eval" in Evaluations Run page to POST /mlflow/genai/evaluate/invoke

### DIFF
--- a/.github/actions/check-component-ids/componentId-registry.js
+++ b/.github/actions/check-component-ids/componentId-registry.js
@@ -1116,6 +1116,7 @@ module.exports = {
   "mlflow.eval-runs.runs-delete-modal": "",
   "mlflow.eval-runs.start-run-button": "",
   "mlflow.eval-runs.start-run-modal": "",
+  "mlflow.eval-runs.start-run-modal.error": "",
   "mlflow.eval-runs.start-run-modal.judge-llm": "",
   "mlflow.eval-runs.start-run-modal.judge-search": "",
   "mlflow.eval-runs.start-run-modal.judge-template": "",

--- a/mlflow/genai/evaluation/job.py
+++ b/mlflow/genai/evaluation/job.py
@@ -46,6 +46,7 @@ def invoke_genai_evaluate_job(
         traces = client._tracing_client.batch_get_traces(trace_ids)
         scorers = [Scorer.model_validate_json(s) for s in serialized_scorers]
     except Exception:
+        _logger.exception("genai evaluate job failed during setup for run %s", run_id)
         client.set_terminated(run_id, RunStatus.to_string(RunStatus.FAILED))
         raise
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/RunEvaluationButton.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/RunEvaluationButton.test.tsx
@@ -618,6 +618,7 @@ describe('RunEvaluationButton', () => {
 
       renderButton('exp-1');
       await user.click(screen.getByRole('button', { name: 'Run evaluation' }));
+      await user.click(getJudgeCheckboxByName('My Custom Judge'));
 
       const okButton = document.querySelector<HTMLButtonElement>(
         '[data-component-id="mlflow.eval-runs.start-run-modal.footer.ok"]',

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/RunEvaluationButton.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/RunEvaluationButton.test.tsx
@@ -618,14 +618,21 @@ describe('RunEvaluationButton', () => {
 
       renderButton('exp-1');
       await user.click(screen.getByRole('button', { name: 'Run evaluation' }));
+      // Select a judge so the OK button isn't disabled by runJudgeDisabled; this isolates
+      // the loading: isSubmitting branch as the only thing affecting the button.
       await user.click(getJudgeCheckboxByName('My Custom Judge'));
 
       const okButton = document.querySelector<HTMLButtonElement>(
         '[data-component-id="mlflow.eval-runs.start-run-modal.footer.ok"]',
       );
       expect(okButton).not.toBeNull();
-      expect(okButton).toBeDisabled();
+      // The design-system Button reflects `loading` via the btn-loading class / loading attr
+      // (it does not set the DOM disabled attribute), and swallows clicks while loading.
       expect(okButton?.className).toContain('btn-loading');
+      expect(okButton).toHaveAttribute('loading', 'true');
+      await user.click(okButton as HTMLButtonElement);
+      expect(mockInvokeMutate).not.toHaveBeenCalled();
+
       expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
     });
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/RunEvaluationButton.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/RunEvaluationButton.test.tsx
@@ -618,8 +618,6 @@ describe('RunEvaluationButton', () => {
 
       renderButton('exp-1');
       await user.click(screen.getByRole('button', { name: 'Run evaluation' }));
-      // Select a judge so the OK button isn't disabled by runJudgeDisabled; this isolates
-      // the loading: isSubmitting branch as the only thing affecting the button.
       await user.click(getJudgeCheckboxByName('My Custom Judge'));
 
       const okButton = document.querySelector<HTMLButtonElement>(
@@ -655,6 +653,37 @@ describe('RunEvaluationButton', () => {
 
       expect(mockInvokeMutate).not.toHaveBeenCalled();
       expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('surfaces a synchronous scorer-serialization error in the inline alert without calling the mutation', async () => {
+      setupReadyToSubmit();
+
+      mockUseGetScheduledScorers.mockReturnValue({
+        data: {
+          experimentId: 'exp-1',
+          scheduledScorers: [
+            {
+              name: 'Broken Judge',
+              type: 'llm',
+              isSessionLevelScorer: false,
+              llmTemplate: 'Custom',
+              instructions: '',
+              model: 'gateway:/custom-endpoint',
+              is_instructions_judge: true,
+            },
+          ],
+        },
+        isLoading: false,
+      });
+
+      renderButton('exp-1');
+      await user.click(screen.getByRole('button', { name: 'Run evaluation' }));
+      await user.click(getJudgeCheckboxByName('Broken Judge'));
+      await user.click(screen.getByRole('button', { name: 'Run judge' }));
+
+      // The error is shown inline (not swallowed) and the network call is never made.
+      expect(screen.getByText('Instructions are required for instructions-based LLM scorers')).toBeInTheDocument();
+      expect(mockInvokeMutate).not.toHaveBeenCalled();
     });
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/RunEvaluationButton.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/RunEvaluationButton.test.tsx
@@ -1,9 +1,11 @@
 import { describe, beforeEach, afterEach, jest, it, expect } from '@jest/globals';
 import React from 'react';
 import { DesignSystemProvider } from '@databricks/design-system';
+import { QueryClient, QueryClientProvider } from '@databricks/web-shared/query-client';
 import { renderWithIntl, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
 import { waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from '../../../common/utils/RoutingUtils';
 
 import { RunEvaluationButton } from './RunEvaluationButton';
 
@@ -39,6 +41,30 @@ jest.mock('../../../gateway/components/endpoint-form', () => ({
     open ? <div data-testid="create-endpoint-modal">Create Endpoint Modal</div> : null,
 }));
 
+const mockNavigate = jest.fn();
+jest.mock('../../../common/utils/RoutingUtils', () => ({
+  __esModule: true,
+  ...jest.requireActual<typeof import('../../../common/utils/RoutingUtils')>('../../../common/utils/RoutingUtils'),
+  useNavigate: () => mockNavigate,
+}));
+
+const mockInvokeMutate = jest.fn();
+const mockResetSubmit = jest.fn();
+let mockInvokeState: {
+  isLoading: boolean;
+  error: Error | null;
+} = { isLoading: false, error: null };
+
+jest.mock('./hooks/useInvokeGenAIEvaluation', () => ({
+  __esModule: true,
+  useInvokeGenAIEvaluation: () => ({
+    mutate: mockInvokeMutate,
+    isLoading: mockInvokeState.isLoading,
+    error: mockInvokeState.error,
+    reset: mockResetSubmit,
+  }),
+}));
+
 describe('RunEvaluationButton', () => {
   let user: ReturnType<typeof setupUserEvent>;
 
@@ -58,18 +84,30 @@ describe('RunEvaluationButton', () => {
       isLoading: false,
       refetch: jest.fn(),
     });
+    mockNavigate.mockReset();
+    mockInvokeMutate.mockReset();
+    mockResetSubmit.mockReset();
+    mockInvokeState = { isLoading: false, error: null };
   });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  const renderButton = (experimentId = 'exp-1') =>
-    renderWithIntl(
-      <DesignSystemProvider>
-        <RunEvaluationButton experimentId={experimentId} />
-      </DesignSystemProvider>,
+  const renderButton = (experimentId = 'exp-1') => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    return renderWithIntl(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <DesignSystemProvider>
+            <RunEvaluationButton experimentId={experimentId} />
+          </DesignSystemProvider>
+        </MemoryRouter>
+      </QueryClientProvider>,
     );
+  };
 
   it('opens straight into the trace eval flow (no tabs, no code-snippet content)', async () => {
     renderButton('exp-1');
@@ -449,6 +487,166 @@ describe('RunEvaluationButton', () => {
     // With a pre-built template selected AND an endpoint auto-selected, Run judge becomes enabled.
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Run judge' })).toBeEnabled();
+    });
+  });
+
+  describe('submission', () => {
+    const setupReadyToSubmit = () => {
+      mockUseSearchMlflowTraces.mockReturnValue({
+        data: [{ trace_id: 't-1' }, { trace_id: 't-2' }],
+        isLoading: false,
+        isFetching: false,
+      });
+      mockUseGetScheduledScorers.mockReturnValue({
+        data: {
+          experimentId: 'exp-1',
+          scheduledScorers: [
+            {
+              name: 'My Custom Judge',
+              type: 'llm',
+              isSessionLevelScorer: false,
+              llmTemplate: 'Custom',
+              instructions: 'Be strict.',
+              model: 'gateway:/custom-endpoint',
+              is_instructions_judge: true,
+            },
+          ],
+        },
+        isLoading: false,
+      });
+      mockUseEndpointsQuery.mockReturnValue({
+        data: [
+          {
+            endpoint_id: 'ep-1',
+            name: 'my-chat-endpoint',
+            created_at: 1,
+            last_updated_at: 1,
+            model_mappings: [
+              {
+                mapping_id: 'mm-1',
+                endpoint_id: 'ep-1',
+                model_definition_id: 'md-1',
+                weight: 1,
+                created_at: 1,
+                model_definition: {
+                  model_definition_id: 'md-1',
+                  name: 'model-1',
+                  provider: 'openai',
+                  model_name: 'gpt-4o',
+                  secret_id: 'secret-1',
+                  secret_name: 'secret-1',
+                  created_at: 1,
+                  last_updated_at: 1,
+                  endpoint_count: 1,
+                },
+              },
+            ],
+          },
+        ],
+        error: undefined,
+        isLoading: false,
+        refetch: jest.fn(),
+      });
+    };
+
+    it('posts the right payload when both a custom judge and a pre-built template are selected', async () => {
+      setupReadyToSubmit();
+
+      renderButton('exp-1');
+      await user.click(screen.getByRole('button', { name: 'Run evaluation' }));
+      await user.click(getJudgeCheckboxByName('My Custom Judge'));
+      await user.click(screen.getByRole('radio', { name: /Pre-built LLM-as-a-judge/ }));
+      await user.click(getJudgeCheckboxByName('Safety'));
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Run judges' })).toBeEnabled();
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Run judges' }));
+
+      expect(mockInvokeMutate).toHaveBeenCalledTimes(1);
+      const [params] = mockInvokeMutate.mock.calls[0] as [
+        { experimentId: string; traceIds: string[]; serializedScorers: string[] },
+        unknown,
+      ];
+
+      expect(params.experimentId).toBe('exp-1');
+      expect(params.traceIds).toEqual(['t-1', 't-2']);
+      expect(params.serializedScorers).toHaveLength(2);
+
+      // The custom judge keeps its own model, never the modal's endpoint.
+      const customSerialized = JSON.parse(params.serializedScorers[0]);
+      expect(customSerialized.name).toBe('My Custom Judge');
+      expect(customSerialized.instructions_judge_pydantic_data.model).toBe('gateway:/custom-endpoint');
+
+      // Pre-built templates with default instructions (like Safety) are serialized as
+      // ad-hoc instructions judges — the modal's endpoint is stamped onto their model
+      // field and the canonical template prompt is baked into the instructions.
+      const templateSerialized = JSON.parse(params.serializedScorers[1]);
+      expect(templateSerialized.name).toBe('Safety');
+      expect(templateSerialized.instructions_judge_pydantic_data.model).toBe('gateway:/my-chat-endpoint');
+      expect(templateSerialized.instructions_judge_pydantic_data.instructions).toContain('safety classifier');
+    });
+
+    it('opens the new run in the split-view side panel and resets state on success', async () => {
+      setupReadyToSubmit();
+      mockInvokeMutate.mockImplementation((...args: unknown[]) => {
+        const opts = args[1] as { onSuccess: (data: unknown) => void };
+        opts.onSuccess({ job_id: 'job-9', run_id: 'run-42' });
+      });
+
+      renderButton('exp-1');
+      await user.click(screen.getByRole('button', { name: 'Run evaluation' }));
+      await user.click(getJudgeCheckboxByName('My Custom Judge'));
+      await user.click(screen.getByRole('button', { name: 'Run judge' }));
+
+      expect(mockNavigate).toHaveBeenCalledWith({
+        pathname: '/experiments/exp-1/evaluation-runs',
+        search: '?selectedRunUuid=run-42',
+      });
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog', { name: 'Run evaluation' })).not.toBeInTheDocument();
+      });
+
+      // Re-opening shows a fresh form (no Custom Judge pre-checked).
+      await user.click(screen.getByRole('button', { name: 'Run evaluation' }));
+      expect(getJudgeCheckboxByName('My Custom Judge')).not.toBeChecked();
+    });
+
+    it('shows a loading spinner on Run judge and disables Cancel while the request is in flight', async () => {
+      setupReadyToSubmit();
+      mockInvokeState = { isLoading: true, error: null };
+
+      renderButton('exp-1');
+      await user.click(screen.getByRole('button', { name: 'Run evaluation' }));
+
+      const okButton = document.querySelector<HTMLButtonElement>(
+        '[data-component-id="mlflow.eval-runs.start-run-modal.footer.ok"]',
+      );
+      expect(okButton).not.toBeNull();
+      expect(okButton).toBeDisabled();
+      expect(okButton?.className).toContain('btn-loading');
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+    });
+
+    it('renders an inline error alert when the API call fails', async () => {
+      setupReadyToSubmit();
+      mockInvokeState = { isLoading: false, error: new Error('Boom: scorer rejected.') };
+
+      renderButton('exp-1');
+      await user.click(screen.getByRole('button', { name: 'Run evaluation' }));
+
+      expect(screen.getByText('Boom: scorer rejected.')).toBeInTheDocument();
+    });
+
+    it('does not call the mutation if the user closes the modal without submitting', async () => {
+      setupReadyToSubmit();
+
+      renderButton('exp-1');
+      await user.click(screen.getByRole('button', { name: 'Run evaluation' }));
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      expect(mockInvokeMutate).not.toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
     });
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/RunEvaluationButton.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/RunEvaluationButton.tsx
@@ -23,6 +23,7 @@ import { ExperimentPageTabName } from '../../constants';
 import { SELECTED_RUN_UUID_QUERY_PARAM } from '../../components/evaluations/hooks/useSelectedRunUuid';
 import { EndpointSelector } from '../../components/EndpointSelector';
 import { SelectTracesModal } from '../../components/SelectTracesModal';
+import { useMonitoringFiltersTimeRange } from '../../hooks/useMonitoringFilters';
 import { formatGatewayModelFromEndpoint, getEndpointNameFromGatewayModel } from '../../../gateway/utils/gatewayUtils';
 import { ScorerEvaluationScope } from '../experiment-scorers/constants';
 import { useGetScheduledScorers } from '../experiment-scorers/hooks/useGetScheduledScorers';
@@ -76,8 +77,10 @@ export const RunEvaluationButton = ({ experimentId }: { experimentId: string }) 
   };
 
   const traceSearchLocations = useMemo(() => [createTraceLocationForExperiment(experimentId)], [experimentId]);
+  const timeRange = useMonitoringFiltersTimeRange();
   const { data: traceInfos, isLoading: isLoadingTraces } = useSearchMlflowTraces({
     locations: traceSearchLocations,
+    timeRange,
     disabled: !isOpen,
   });
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/RunEvaluationButton.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/RunEvaluationButton.tsx
@@ -1,4 +1,5 @@
 import {
+  Alert,
   Button,
   ChartLineIcon,
   Checkbox,
@@ -11,17 +12,25 @@ import {
   getShadowScrollStyles,
   useDesignSystemTheme,
 } from '@databricks/design-system';
+import { useQueryClient } from '@databricks/web-shared/query-client';
 import { createTraceLocationForExperiment, useSearchMlflowTraces } from '@databricks/web-shared/genai-traces-table';
 import { isEmpty } from 'lodash';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
+import { useNavigate } from '../../../common/utils/RoutingUtils';
+import Routes from '../../routes';
+import { ExperimentPageTabName } from '../../constants';
+import { SELECTED_RUN_UUID_QUERY_PARAM } from '../../components/evaluations/hooks/useSelectedRunUuid';
 import { EndpointSelector } from '../../components/EndpointSelector';
 import { SelectTracesModal } from '../../components/SelectTracesModal';
 import { formatGatewayModelFromEndpoint, getEndpointNameFromGatewayModel } from '../../../gateway/utils/gatewayUtils';
 import { ScorerEvaluationScope } from '../experiment-scorers/constants';
 import { useGetScheduledScorers } from '../experiment-scorers/hooks/useGetScheduledScorers';
 import { useTemplateOptions } from '../experiment-scorers/llmScorerUtils';
+import { TEMPLATE_INSTRUCTIONS_MAP } from '../experiment-scorers/prompts';
 import { LLM_TEMPLATE, type LLMScorer, type ScheduledScorer } from '../experiment-scorers/types';
+import { transformScheduledScorer } from '../experiment-scorers/utils/scorerTransformUtils';
+import { useInvokeGenAIEvaluation } from './hooks/useInvokeGenAIEvaluation';
 
 type JudgeSelectionMode = 'llm' | 'template';
 
@@ -31,6 +40,9 @@ const isTraceLevelLLMScorer = (scorer: ScheduledScorer): scorer is LLMScorer =>
 export const RunEvaluationButton = ({ experimentId }: { experimentId: string }) => {
   const intl = useIntl();
   const { theme } = useDesignSystemTheme();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { displayMap } = useTemplateOptions(ScorerEvaluationScope.TRACES);
   const [isOpen, setIsOpen] = useState(false);
   const [selectedTraceIds, setSelectedTraceIds] = useState<string[]>([]);
   const [isSelectTracesModalOpen, setIsSelectTracesModalOpen] = useState(false);
@@ -41,6 +53,13 @@ export const RunEvaluationButton = ({ experimentId }: { experimentId: string }) 
   const selectedJudgeCount = selectedScorers.length + selectedTemplates.length;
   const runJudgeDisabled =
     selectedTraceIds.length === 0 || selectedJudgeCount === 0 || (hasSelectedTemplates && !currentEndpointModel);
+
+  const {
+    mutate: invokeGenAIEvaluation,
+    isLoading: isSubmitting,
+    error: submitError,
+    reset: resetSubmit,
+  } = useInvokeGenAIEvaluation();
 
   const toggleScorer = (scorer: LLMScorer) => {
     setSelectedScorers((prev) => {
@@ -80,6 +99,57 @@ export const RunEvaluationButton = ({ experimentId }: { experimentId: string }) 
     setSelectedScorers([]);
     setSelectedTemplates([]);
     setCurrentEndpointModel(undefined);
+    resetSubmit();
+  };
+
+  // Build one self-contained serialized scorer per selected judge.
+  const buildSerializedScorers = (): string[] => {
+    const fromCustom = selectedScorers.map((scorer) => transformScheduledScorer(scorer).serialized_scorer);
+
+    const fromTemplates = selectedTemplates.map((template) => {
+      const instructions = TEMPLATE_INSTRUCTIONS_MAP[template];
+      const adHocScheduledScorer: ScheduledScorer = instructions
+        ? {
+            name: displayMap[template] ?? template,
+            type: 'llm',
+            llmTemplate: LLM_TEMPLATE.CUSTOM,
+            instructions,
+            model: currentEndpointModel,
+            is_instructions_judge: true,
+            isSessionLevelScorer: false,
+          }
+        : {
+            name: displayMap[template] ?? template,
+            type: 'llm',
+            llmTemplate: template,
+            model: currentEndpointModel,
+            is_instructions_judge: false,
+            isSessionLevelScorer: false,
+          };
+      return transformScheduledScorer(adHocScheduledScorer).serialized_scorer;
+    });
+
+    return [...fromCustom, ...fromTemplates];
+  };
+
+  const handleSubmit = () => {
+    invokeGenAIEvaluation(
+      {
+        experimentId,
+        traceIds: selectedTraceIds,
+        serializedScorers: buildSerializedScorers(),
+      },
+      {
+        onSuccess: (response) => {
+          queryClient.invalidateQueries({ queryKey: ['SEARCH_RUNS', experimentId] });
+          closeAndResetSelections();
+          navigate({
+            pathname: Routes.getExperimentPageTabRoute(experimentId, ExperimentPageTabName.EvaluationRuns),
+            search: `?${SELECTED_RUN_UUID_QUERY_PARAM}=${response.run_id}`,
+          });
+        },
+      },
+    );
   };
 
   return (
@@ -111,11 +181,21 @@ export const RunEvaluationButton = ({ experimentId }: { experimentId: string }) 
                 description: 'Button text for running a single judge from the run evaluation modal',
               })
         }
-        okButtonProps={{ disabled: runJudgeDisabled }}
-        onOk={() => {}}
-        onCancel={closeAndResetSelections}
+        okButtonProps={{ disabled: runJudgeDisabled, loading: isSubmitting }}
+        cancelButtonProps={{ disabled: isSubmitting }}
+        onOk={handleSubmit}
+        onCancel={isSubmitting ? undefined : closeAndResetSelections}
       >
         <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.lg }}>
+          {submitError && (
+            <Alert
+              componentId="mlflow.eval-runs.start-run-modal.error"
+              type="error"
+              message={submitError.message}
+              closable
+              onClose={resetSubmit}
+            />
+          )}
           <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
             <Typography.Text bold>
               <FormattedMessage

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/RunEvaluationButton.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/RunEvaluationButton.tsx
@@ -43,7 +43,7 @@ export const RunEvaluationButton = ({ experimentId }: { experimentId: string }) 
   const { theme } = useDesignSystemTheme();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const { displayMap } = useTemplateOptions(ScorerEvaluationScope.TRACES);
+  const { displayMap, templateOptions } = useTemplateOptions(ScorerEvaluationScope.TRACES);
   const [isOpen, setIsOpen] = useState(false);
   const [selectedTraceIds, setSelectedTraceIds] = useState<string[]>([]);
   const [isSelectTracesModalOpen, setIsSelectTracesModalOpen] = useState(false);
@@ -249,6 +249,7 @@ export const RunEvaluationButton = ({ experimentId }: { experimentId: string }) 
             <JudgesSelectionSection
               experimentId={experimentId}
               enabled={isOpen}
+              templateOptions={templateOptions}
               selectedScorers={selectedScorers}
               selectedTemplates={selectedTemplates}
               onToggleScorer={toggleScorer}
@@ -299,6 +300,7 @@ const HIDDEN_PRE_BUILT_TEMPLATES = [LLM_TEMPLATE.CUSTOM, LLM_TEMPLATE.GUIDELINES
 const JudgesSelectionSection = ({
   experimentId,
   enabled,
+  templateOptions,
   selectedScorers,
   selectedTemplates,
   onToggleScorer,
@@ -306,6 +308,7 @@ const JudgesSelectionSection = ({
 }: {
   experimentId: string;
   enabled: boolean;
+  templateOptions: ReturnType<typeof useTemplateOptions>['templateOptions'];
   selectedScorers: LLMScorer[];
   selectedTemplates: LLM_TEMPLATE[];
   onToggleScorer: (scorer: LLMScorer) => void;
@@ -317,7 +320,6 @@ const JudgesSelectionSection = ({
   const [judgeSelectionMode, setJudgeSelectionMode] = useState<JudgeSelectionMode>('llm');
 
   const { data, isLoading: loadingScorers } = useGetScheduledScorers(experimentId, { enabled });
-  const { templateOptions } = useTemplateOptions(ScorerEvaluationScope.TRACES);
 
   const displayedLLMScorers = useMemo(() => {
     const lowercased = searchValue.toLowerCase();

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/RunEvaluationButton.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/RunEvaluationButton.tsx
@@ -62,6 +62,14 @@ export const RunEvaluationButton = ({ experimentId }: { experimentId: string }) 
     reset: resetSubmit,
   } = useInvokeGenAIEvaluation();
 
+  const [buildError, setBuildError] = useState<Error | null>(null);
+  const submissionError = submitError ?? buildError;
+
+  const clearSubmissionError = () => {
+    resetSubmit();
+    setBuildError(null);
+  };
+
   const toggleScorer = (scorer: LLMScorer) => {
     setSelectedScorers((prev) => {
       const isSelected = prev.some((s) => s.name === scorer.name);
@@ -102,10 +110,10 @@ export const RunEvaluationButton = ({ experimentId }: { experimentId: string }) 
     setSelectedScorers([]);
     setSelectedTemplates([]);
     setCurrentEndpointModel(undefined);
+    setBuildError(null);
     resetSubmit();
   };
 
-  // Build one self-contained serialized scorer per selected judge.
   const buildSerializedScorers = (): string[] => {
     const fromCustom = selectedScorers.map((scorer) => transformScheduledScorer(scorer).serialized_scorer);
 
@@ -136,11 +144,20 @@ export const RunEvaluationButton = ({ experimentId }: { experimentId: string }) 
   };
 
   const handleSubmit = () => {
+    let serializedScorers: string[];
+    try {
+      serializedScorers = buildSerializedScorers();
+    } catch (error) {
+      setBuildError(error instanceof Error ? error : new Error(String(error)));
+      return;
+    }
+    setBuildError(null);
+
     invokeGenAIEvaluation(
       {
         experimentId,
         traceIds: selectedTraceIds,
-        serializedScorers: buildSerializedScorers(),
+        serializedScorers,
       },
       {
         onSuccess: (response) => {
@@ -190,13 +207,13 @@ export const RunEvaluationButton = ({ experimentId }: { experimentId: string }) 
         onCancel={isSubmitting ? undefined : closeAndResetSelections}
       >
         <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.lg }}>
-          {submitError && (
+          {submissionError && (
             <Alert
               componentId="mlflow.eval-runs.start-run-modal.error"
               type="error"
-              message={submitError.message}
+              message={submissionError.message}
               closable
-              onClose={resetSubmit}
+              onClose={clearSubmissionError}
             />
           )}
           <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/hooks/useInvokeGenAIEvaluation.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/hooks/useInvokeGenAIEvaluation.ts
@@ -1,0 +1,28 @@
+import { useMutation } from '@databricks/web-shared/query-client';
+import { fetchAPI, getAjaxUrl } from '../../../../common/utils/FetchUtils';
+
+interface InvokeGenAIEvaluationParams {
+  experimentId: string;
+  traceIds: string[];
+  serializedScorers: string[];
+}
+
+interface InvokeGenAIEvaluationResponse {
+  job_id: string;
+  run_id: string;
+}
+
+export const useInvokeGenAIEvaluation = () =>
+  useMutation<InvokeGenAIEvaluationResponse, Error, InvokeGenAIEvaluationParams>({
+    mutationFn: async ({ experimentId, traceIds, serializedScorers }) => {
+      const response = await fetchAPI(getAjaxUrl('ajax-api/3.0/mlflow/genai/evaluate/invoke'), {
+        method: 'POST',
+        body: {
+          experiment_id: experimentId,
+          trace_ids: traceIds,
+          serialized_scorers: serializedScorers,
+        },
+      });
+      return response as InvokeGenAIEvaluationResponse;
+    },
+  });

--- a/tests/genai/evaluate/test_job.py
+++ b/tests/genai/evaluate/test_job.py
@@ -168,7 +168,7 @@ def test_invoke_genai_evaluate_job_propagates_username_via_env(monkeypatch):
         mock.patch("mlflow.genai.evaluation.job.MlflowClient", return_value=mock_client),
         mock.patch("mlflow.genai.evaluation.job.Scorer.model_validate_json"),
         mock.patch("mlflow.start_run"),
-        mock.patch("mlflow.genai.evaluate", side_effect=_capture_env),
+        mock.patch("mlflow.genai.evaluate", side_effect=_capture_env) as mock_evaluate,
     ):
         invoke_genai_evaluate_job(
             trace_ids=["trace-1"],
@@ -177,6 +177,7 @@ def test_invoke_genai_evaluate_job_propagates_username_via_env(monkeypatch):
             username="alice",
         )
 
+        mock_evaluate.assert_called_once()
         assert captured_env["MLFLOW_TRACKING_USERNAME"] == "alice"
 
 
@@ -190,7 +191,7 @@ def test_invoke_genai_evaluate_job_skips_username_propagation_when_none(monkeypa
         mock.patch("mlflow.genai.evaluation.job.MlflowClient", return_value=mock_client),
         mock.patch("mlflow.genai.evaluation.job.Scorer.model_validate_json"),
         mock.patch("mlflow.start_run"),
-        mock.patch("mlflow.genai.evaluate"),
+        mock.patch("mlflow.genai.evaluate") as mock_evaluate,
     ):
         invoke_genai_evaluate_job(
             trace_ids=["trace-1"],
@@ -199,4 +200,5 @@ def test_invoke_genai_evaluate_job_skips_username_propagation_when_none(monkeypa
             username=None,
         )
 
+        mock_evaluate.assert_called_once()
         assert os.environ["MLFLOW_TRACKING_USERNAME"] == "unchanged"


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/23781/files) to review incremental changes.
- [stack/run-eval-changes](https://github.com/mlflow/mlflow/pull/23735) [[Files changed](https://github.com/mlflow/mlflow/pull/23735/files)] [MERGED]
  - [stack/run-eval-dynamic-traces-snippet](https://github.com/mlflow/mlflow/pull/23737) [[Files changed](https://github.com/mlflow/mlflow/pull/23737/files)] [MERGED]
    - [stack/run-eval-traces-eval](https://github.com/mlflow/mlflow/pull/23758) [[Files changed](https://github.com/mlflow/mlflow/pull/23758/files)] [MERGED]
      - [stack/run-eval-traces-handler](https://github.com/mlflow/mlflow/pull/23779) [[Files changed](https://github.com/mlflow/mlflow/pull/23779/files)] [MERGED]
        - [**stack/run-eval-traces-fe-be-wiring**](https://github.com/mlflow/mlflow/pull/23781) [[Files changed](https://github.com/mlflow/mlflow/pull/23781/files)]

---------
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

This PR adds the FE wiring to the "Run Eval" button to the new `/mlflow/genai/evaluate/invoke` handler which will trigger a new evaluations directly from the UI.

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

https://github.com/user-attachments/assets/77ef1a83-3b53-490f-9817-fc89d9355d2f

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

Users are now able to trigger an evaluation run on their existing traces directly from the "Evaluations Run" page when they have no existing eval runs yet

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
