### PR TITLE
[1/N] Support marking of Skill Spans in Claude Code Traces

### DIFF
--- a/libs/typescript/core/src/core/constants.ts
+++ b/libs/typescript/core/src/core/constants.ts
@@ -84,7 +84,9 @@ export const SpanAttributeKey = {
   // This attribute indicates which flavor/format generated the LLM span. This is
   // used by downstream (e.g., UI) to determine the message format for parsing.
   MESSAGE_FORMAT: 'mlflow.message.format',
-  // This attribute, if set, indicates that the tool call is a skill and the skill name is the value.
+  // Identifies the active skill scope for a span. Set on the Skill tool span itself and
+  // propagated to descendant LLM/TOOL/AGENT spans created within the skill body, so cost and
+  // latency can be attributed back to the originating skill.
   SKILL_NAME: 'mlflow.skill.name',
 };
 

--- a/libs/typescript/core/src/core/constants.ts
+++ b/libs/typescript/core/src/core/constants.ts
@@ -84,6 +84,8 @@ export const SpanAttributeKey = {
   // This attribute indicates which flavor/format generated the LLM span. This is
   // used by downstream (e.g., UI) to determine the message format for parsing.
   MESSAGE_FORMAT: 'mlflow.message.format',
+  // This attribute, if set, indicates that the tool call is a skill and the skill name is the value.
+  SKILL_NAME: 'mlflow.skill.name',
 };
 
 /**

--- a/libs/typescript/integrations/claude-code/src/liveTracing.ts
+++ b/libs/typescript/integrations/claude-code/src/liveTracing.ts
@@ -78,6 +78,7 @@ export interface SDKUserLike {
   type: 'user';
   message: { role: 'user'; content: string | ContentBlock[] };
   parent_tool_use_id?: string | null;
+  tool_use_result?: { commandName?: string };
 }
 
 export interface SDKResultLike {
@@ -264,6 +265,9 @@ export class LiveTracingContext {
             ? toolResult.content
             : JSON.stringify(toolResult.content);
         toolSpan.setStatus(SpanStatusCode.ERROR, errorText || 'Tool execution failed');
+      }
+      if (msg.tool_use_result?.commandName) {
+        toolSpan.setAttribute(SpanAttributeKey.SKILL_NAME, msg.tool_use_result.commandName);
       }
       toolSpan.end();
       this.openToolSpans.delete(toolUseId);

--- a/libs/typescript/integrations/claude-code/src/liveTracing.ts
+++ b/libs/typescript/integrations/claude-code/src/liveTracing.ts
@@ -74,11 +74,19 @@ export interface SDKAssistantLike {
   parent_tool_use_id?: string | null;
 }
 
+/**
+ * Minimal duck-type for SDK user messages. We deliberately under-declare vs
+ * the full SDKUserMessage (sdk.d.ts:3657-3676) — only the fields the live
+ * tracing path reads. Fields added here must reflect real wire properties.
+ */
 export interface SDKUserLike {
   type: 'user';
   message: { role: 'user'; content: string | ContentBlock[] };
   parent_tool_use_id?: string | null;
-  tool_use_result?: { commandName?: string };
+  tool_use_result?: { commandName?: string } | null;
+  origin?: { kind?: string }; // sdk.d.ts:3664; values from SDKMessageOrigin sdk.d.ts:3138-3151
+  isSynthetic?: boolean; // sdk.d.ts:3661
+  shouldQuery?: boolean; // sdk.d.ts:3669; false = don't trigger an assistant turn
 }
 
 export interface SDKResultLike {
@@ -101,6 +109,12 @@ export class LiveTracingContext {
   private model: string | undefined;
   private permissionMode: string | undefined;
   private claudeCodeVersion: string | undefined;
+  private activeSkillName: string | undefined;
+  // Tracks whether the previous user message carried a Skill tool_use_result so
+  // we can detect skill content injections (which always follow such a result
+  // and look structurally identical to a real user prompt). Mirrors the
+  // look-back used by findLastUserMessageIndex in transcript.ts:109-121.
+  private prevUserHadCommandName = false;
   private ended = false;
   private readonly spanOptions: unknown;
 
@@ -137,6 +151,7 @@ export class LiveTracingContext {
     this.model = msg.model ?? this.model;
     this.permissionMode = msg.permissionMode ?? this.permissionMode;
     this.claudeCodeVersion = msg.claude_code_version ?? this.claudeCodeVersion;
+    this.activeSkillName = undefined;
   }
 
   /**
@@ -164,6 +179,9 @@ export class LiveTracingContext {
           model,
           'mlflow.llm.model': model,
           [SpanAttributeKey.MESSAGE_FORMAT]: 'anthropic',
+          ...(this.activeSkillName
+            ? { [SpanAttributeKey.SKILL_NAME]: this.activeSkillName }
+            : {}),
         },
       });
       if (msg.message.usage) {
@@ -183,7 +201,13 @@ export class LiveTracingContext {
         spanType: SpanType.TOOL,
         parent: parentSpan,
         inputs: toolUse.input ?? {},
-        attributes: { tool_name: toolUse.name, tool_id: toolUse.id },
+        attributes: {
+          tool_name: toolUse.name,
+          tool_id: toolUse.id,
+          ...(this.activeSkillName
+            ? { [SpanAttributeKey.SKILL_NAME]: this.activeSkillName }
+            : {}),
+        },
       });
       this.openToolSpans.set(toolUse.id, toolSpan);
 
@@ -201,15 +225,83 @@ export class LiveTracingContext {
             description: toolUse.input?.description,
             subagent_type: subagentType,
           },
-          attributes: { subagent_type: subagentType },
+          attributes: {
+            subagent_type: subagentType,
+            ...(this.activeSkillName
+              ? { [SpanAttributeKey.SKILL_NAME]: this.activeSkillName }
+              : {}),
+          },
         });
         this.subagentSpans.set(toolUse.id, subagentSpan);
       }
     }
   }
 
+  /**
+   * Returns true if `msg` is a fresh, human-originated prompt — as opposed to
+   * a tool-result echo, sub-agent inner turn, skill content injection, or any
+   * other SDK-emitted non-prompt user-role message.
+   *
+   * Used to decide whether to clear `activeSkillName` so that work triggered
+   * by a *new* user prompt isn't mis-attributed to a previously active skill.
+   * Relevant to the AsyncIterable multi-prompt case: `query()` accepts
+   * `AsyncIterable<SDKUserMessage>`, which streams multiple prompts through
+   * a single LiveTracingContext. See
+   * https://docs.claude.com/en/api/agent-sdk/python.
+   *
+   * The check is layered: strong SDK-stamped signal first, then fallbacks for
+   * older SDK versions and programmatic emitters that may not set it.
+   *
+   * Wire-level field references from
+   * @anthropic-ai/claude-agent-sdk/sdk.d.ts (v0.2.0):
+   *   - SDKMessageOrigin: sdk.d.ts:3138-3151
+   *   - SDKUserMessage:   sdk.d.ts:3657-3676
+   *
+   * NOTE: we intentionally do NOT check for a leading `tool_result` block in
+   * `content` (as transcript.ts:130-137 does for the on-disk transcript)
+   * because in the live SDK stream tool-result echoes always carry
+   * `tool_use_result != null` (caught below). Verified by reading the SDK
+   * parser at @anthropic-ai/claude-agent-sdk/_internal/message_parser.py.
+   */
+  private isRealUserPrompt(msg: SDKUserLike): boolean {
+    // Strong signal: SDK-stamped origin (sdk.d.ts:3664).
+    if (msg.origin?.kind === 'human') {return true;}
+    if (msg.origin?.kind != null) {return false;}
+
+    // SDK metadata that explicitly says "not a real prompt".
+    if (msg.isSynthetic) {return false;}
+    if (msg.shouldQuery === false) {return false;}
+
+    // Fallback heuristics for older emitters with no `origin`.
+    if (msg.tool_use_result != null) {return false;}
+    if (msg.parent_tool_use_id != null) {return false;}
+
+    // Skill content injection: Claude Code injects the skill body as a `user`
+    // message immediately after a Skill tool_result. Structurally identical
+    // to a real prompt — only position distinguishes it. Mirrors the
+    // transcript-path heuristic at transcript.ts:109-121 and
+    // mlflow/claude_code/tracing.py:245-254.
+    if (this.prevUserHadCommandName) {return false;}
+
+    // Empty / whitespace-only string content is never a prompt.
+    if (typeof msg.message.content === 'string' && !msg.message.content.trim()) {
+      return false;
+    }
+
+    return true;
+  }
+
   /** Close any TOOL spans whose tool_use_id matches a tool_result block. */
   onUserMessage(msg: SDKUserLike): void {
+    // A new human prompt arriving mid-stream (e.g. AsyncIterable prompts to
+    // query()) means any previously active skill scope is over. Clear before
+    // updating `prevUserHadCommandName` so the next message sees the right
+    // look-back state.
+    if (this.isRealUserPrompt(msg)) {
+      this.activeSkillName = undefined;
+    }
+    this.prevUserHadCommandName = !!msg.tool_use_result?.commandName;
+
     const parentKey: ConversationKey = msg.parent_tool_use_id ?? null;
     const conversation = this.getConversation(parentKey);
     conversation.push({ role: 'user', content: msg.message.content });
@@ -268,6 +360,7 @@ export class LiveTracingContext {
       }
       if (msg.tool_use_result?.commandName) {
         toolSpan.setAttribute(SpanAttributeKey.SKILL_NAME, msg.tool_use_result.commandName);
+        this.activeSkillName = msg.tool_use_result.commandName;
       }
       toolSpan.end();
       this.openToolSpans.delete(toolUseId);

--- a/libs/typescript/integrations/claude-code/src/liveTracing.ts
+++ b/libs/typescript/integrations/claude-code/src/liveTracing.ts
@@ -183,9 +183,7 @@ export class LiveTracingContext {
           model,
           'mlflow.llm.model': model,
           [SpanAttributeKey.MESSAGE_FORMAT]: 'anthropic',
-          ...(this.activeSkillName
-            ? { [SpanAttributeKey.SKILL_NAME]: this.activeSkillName }
-            : {}),
+          ...(this.activeSkillName ? { [SpanAttributeKey.SKILL_NAME]: this.activeSkillName } : {}),
         },
       });
       if (msg.message.usage) {
@@ -208,9 +206,7 @@ export class LiveTracingContext {
         attributes: {
           tool_name: toolUse.name,
           tool_id: toolUse.id,
-          ...(this.activeSkillName
-            ? { [SpanAttributeKey.SKILL_NAME]: this.activeSkillName }
-            : {}),
+          ...(this.activeSkillName ? { [SpanAttributeKey.SKILL_NAME]: this.activeSkillName } : {}),
         },
       });
       this.openToolSpans.set(toolUse.id, toolSpan);
@@ -269,29 +265,47 @@ export class LiveTracingContext {
    */
   private isRealUserPrompt(msg: SDKUserLike): boolean {
     // Strong signal: SDK-stamped origin (sdk.d.ts:3664).
-    if (msg.origin?.kind === 'human') {return true;}
-    if (msg.origin?.kind != null) {return false;}
+    if (msg.origin?.kind === 'human') {
+      return true;
+    }
+    if (msg.origin?.kind != null) {
+      return false;
+    }
 
     // SDK metadata that explicitly says "not a real prompt".
-    if (msg.isSynthetic) {return false;}
-    if (msg.shouldQuery === false) {return false;}
+    if (msg.isSynthetic) {
+      return false;
+    }
+    if (msg.shouldQuery === false) {
+      return false;
+    }
 
     // Fallback heuristics for older emitters with no `origin`.
-    if (msg.tool_use_result != null) {return false;}
-    if (msg.parent_tool_use_id != null) {return false;}
+    if (msg.tool_use_result != null) {
+      return false;
+    }
+    if (msg.parent_tool_use_id != null) {
+      return false;
+    }
 
     // Skill content injection: Claude Code injects the skill body as a `user`
     // message immediately after a Skill tool_result. Structurally identical
     // to a real prompt — only position distinguishes it. Mirrors the
     // transcript-path heuristic at transcript.ts:109-121 and
     // mlflow/claude_code/tracing.py:245-254.
-    if (this.prevUserHadCommandName) {return false;}
+    if (this.prevUserHadCommandName) {
+      return false;
+    }
 
     // Empty / whitespace-only string content is never a prompt. Also treat
     // an empty content array as empty (no text or blocks to act on).
     const content = msg.message.content;
-    if (typeof content === 'string' && !content.trim()) {return false;}
-    if (Array.isArray(content) && content.length === 0) {return false;}
+    if (typeof content === 'string' && !content.trim()) {
+      return false;
+    }
+    if (Array.isArray(content) && content.length === 0) {
+      return false;
+    }
 
     return true;
   }
@@ -319,67 +333,65 @@ export class LiveTracingContext {
       }
 
       for (const block of content) {
-      if (
-        typeof block !== 'object' ||
-        block == null ||
-        !('type' in block) ||
-        block.type !== 'tool_result'
-      ) {
-        continue;
-      }
-      const toolResult = block as {
-        type: 'tool_result';
-        tool_use_id?: string;
-        content?: unknown;
-        is_error?: boolean;
-      };
-      const toolUseId = toolResult.tool_use_id;
-      if (!toolUseId) {
-        continue;
-      }
-
-      // If this tool result closes a Task/Agent call, finalize its sub-agent
-      // wrapper span first so it nests under the TOOL span correctly.
-      const subagentSpan = this.subagentSpans.get(toolUseId);
-      if (subagentSpan) {
-        const lastText = this.lastAssistantText.get(toolUseId);
-        if (lastText) {
-          subagentSpan.setOutputs({ response: lastText });
+        if (
+          typeof block !== 'object' ||
+          block == null ||
+          !('type' in block) ||
+          block.type !== 'tool_result'
+        ) {
+          continue;
         }
-        subagentSpan.end();
-        this.subagentSpans.delete(toolUseId);
-        this.conversations.delete(toolUseId);
-        this.lastAssistantText.delete(toolUseId);
-      }
+        const toolResult = block as {
+          type: 'tool_result';
+          tool_use_id?: string;
+          content?: unknown;
+          is_error?: boolean;
+        };
+        const toolUseId = toolResult.tool_use_id;
+        if (!toolUseId) {
+          continue;
+        }
 
-      const toolSpan = this.openToolSpans.get(toolUseId);
-      if (!toolSpan) {
-        continue;
-      }
+        // If this tool result closes a Task/Agent call, finalize its sub-agent
+        // wrapper span first so it nests under the TOOL span correctly.
+        const subagentSpan = this.subagentSpans.get(toolUseId);
+        if (subagentSpan) {
+          const lastText = this.lastAssistantText.get(toolUseId);
+          if (lastText) {
+            subagentSpan.setOutputs({ response: lastText });
+          }
+          subagentSpan.end();
+          this.subagentSpans.delete(toolUseId);
+          this.conversations.delete(toolUseId);
+          this.lastAssistantText.delete(toolUseId);
+        }
 
-      toolSpan.setOutputs({ result: toolResult.content ?? '' });
-      if (toolResult.is_error) {
-        const errorText =
-          typeof toolResult.content === 'string'
-            ? toolResult.content
-            : JSON.stringify(toolResult.content);
-        toolSpan.setStatus(SpanStatusCode.ERROR, errorText || 'Tool execution failed');
-      }
-      // Always stamp the Skill TOOL span with its own commandName for
-      // identification (failed Skills are still attributable).
-      // Propagation:
-      //   - success: activeSkillName = commandName (child spans inherit)
-      //   - failure: activeSkillName = undefined (prior skill must not leak
-      //     into recovery spans, and the failed skill never injected its body
-      //     so it shouldn't propagate either)
-      if (msg.tool_use_result?.commandName) {
-        toolSpan.setAttribute(SpanAttributeKey.SKILL_NAME, msg.tool_use_result.commandName);
-        this.activeSkillName = toolResult.is_error
-          ? undefined
-          : msg.tool_use_result.commandName;
-      }
-      toolSpan.end();
-      this.openToolSpans.delete(toolUseId);
+        const toolSpan = this.openToolSpans.get(toolUseId);
+        if (!toolSpan) {
+          continue;
+        }
+
+        toolSpan.setOutputs({ result: toolResult.content ?? '' });
+        if (toolResult.is_error) {
+          const errorText =
+            typeof toolResult.content === 'string'
+              ? toolResult.content
+              : JSON.stringify(toolResult.content);
+          toolSpan.setStatus(SpanStatusCode.ERROR, errorText || 'Tool execution failed');
+        }
+        // Always stamp the Skill TOOL span with its own commandName for
+        // identification (failed Skills are still attributable).
+        // Propagation:
+        //   - success: activeSkillName = commandName (child spans inherit)
+        //   - failure: activeSkillName = undefined (prior skill must not leak
+        //     into recovery spans, and the failed skill never injected its body
+        //     so it shouldn't propagate either)
+        if (msg.tool_use_result?.commandName) {
+          toolSpan.setAttribute(SpanAttributeKey.SKILL_NAME, msg.tool_use_result.commandName);
+          this.activeSkillName = toolResult.is_error ? undefined : msg.tool_use_result.commandName;
+        }
+        toolSpan.end();
+        this.openToolSpans.delete(toolUseId);
       }
     } finally {
       this.prevUserHadCommandName = hadCommandName;

--- a/libs/typescript/integrations/claude-code/src/liveTracing.ts
+++ b/libs/typescript/integrations/claude-code/src/liveTracing.ts
@@ -151,7 +151,11 @@ export class LiveTracingContext {
     this.model = msg.model ?? this.model;
     this.permissionMode = msg.permissionMode ?? this.permissionMode;
     this.claudeCodeVersion = msg.claude_code_version ?? this.claudeCodeVersion;
+    // Reset both skill-scope state fields together: clearing activeSkillName
+    // without also clearing prevUserHadCommandName would leave the next user
+    // message classified as a skill body injection.
     this.activeSkillName = undefined;
+    this.prevUserHadCommandName = false;
   }
 
   /**
@@ -283,10 +287,11 @@ export class LiveTracingContext {
     // mlflow/claude_code/tracing.py:245-254.
     if (this.prevUserHadCommandName) {return false;}
 
-    // Empty / whitespace-only string content is never a prompt.
-    if (typeof msg.message.content === 'string' && !msg.message.content.trim()) {
-      return false;
-    }
+    // Empty / whitespace-only string content is never a prompt. Also treat
+    // an empty content array as empty (no text or blocks to act on).
+    const content = msg.message.content;
+    if (typeof content === 'string' && !content.trim()) {return false;}
+    if (Array.isArray(content) && content.length === 0) {return false;}
 
     return true;
   }
@@ -294,24 +299,26 @@ export class LiveTracingContext {
   /** Close any TOOL spans whose tool_use_id matches a tool_result block. */
   onUserMessage(msg: SDKUserLike): void {
     // A new human prompt arriving mid-stream (e.g. AsyncIterable prompts to
-    // query()) means any previously active skill scope is over. Clear before
-    // updating `prevUserHadCommandName` so the next message sees the right
-    // look-back state.
-    if (this.isRealUserPrompt(msg)) {
-      this.activeSkillName = undefined;
-    }
-    this.prevUserHadCommandName = !!msg.tool_use_result?.commandName;
+    // query()) means any previously active skill scope is over. Read
+    // hadCommandName from this message up-front, but defer mutating
+    // prevUserHadCommandName until after the tool-result loop runs so an
+    // exception there can't leave the look-back state inconsistent.
+    const hadCommandName = !!msg.tool_use_result?.commandName;
+    try {
+      if (this.isRealUserPrompt(msg)) {
+        this.activeSkillName = undefined;
+      }
 
-    const parentKey: ConversationKey = msg.parent_tool_use_id ?? null;
-    const conversation = this.getConversation(parentKey);
-    conversation.push({ role: 'user', content: msg.message.content });
+      const parentKey: ConversationKey = msg.parent_tool_use_id ?? null;
+      const conversation = this.getConversation(parentKey);
+      conversation.push({ role: 'user', content: msg.message.content });
 
-    const content = msg.message.content;
-    if (!Array.isArray(content)) {
-      return;
-    }
+      const content = msg.message.content;
+      if (!Array.isArray(content)) {
+        return;
+      }
 
-    for (const block of content) {
+      for (const block of content) {
       if (
         typeof block !== 'object' ||
         block == null ||
@@ -358,12 +365,21 @@ export class LiveTracingContext {
             : JSON.stringify(toolResult.content);
         toolSpan.setStatus(SpanStatusCode.ERROR, errorText || 'Tool execution failed');
       }
+      // A failed Skill never injected its body, so subsequent spans should
+      // NOT inherit its name (would inflate cost attribution). We still
+      // stamp the Skill TOOL span itself with its own commandName for
+      // identification — only the propagation to `activeSkillName` is gated.
       if (msg.tool_use_result?.commandName) {
         toolSpan.setAttribute(SpanAttributeKey.SKILL_NAME, msg.tool_use_result.commandName);
-        this.activeSkillName = msg.tool_use_result.commandName;
+        if (!toolResult.is_error) {
+          this.activeSkillName = msg.tool_use_result.commandName;
+        }
       }
       toolSpan.end();
       this.openToolSpans.delete(toolUseId);
+      }
+    } finally {
+      this.prevUserHadCommandName = hadCommandName;
     }
   }
 

--- a/libs/typescript/integrations/claude-code/src/liveTracing.ts
+++ b/libs/typescript/integrations/claude-code/src/liveTracing.ts
@@ -365,15 +365,18 @@ export class LiveTracingContext {
             : JSON.stringify(toolResult.content);
         toolSpan.setStatus(SpanStatusCode.ERROR, errorText || 'Tool execution failed');
       }
-      // A failed Skill never injected its body, so subsequent spans should
-      // NOT inherit its name (would inflate cost attribution). We still
-      // stamp the Skill TOOL span itself with its own commandName for
-      // identification — only the propagation to `activeSkillName` is gated.
+      // Always stamp the Skill TOOL span with its own commandName for
+      // identification (failed Skills are still attributable).
+      // Propagation:
+      //   - success: activeSkillName = commandName (child spans inherit)
+      //   - failure: activeSkillName = undefined (prior skill must not leak
+      //     into recovery spans, and the failed skill never injected its body
+      //     so it shouldn't propagate either)
       if (msg.tool_use_result?.commandName) {
         toolSpan.setAttribute(SpanAttributeKey.SKILL_NAME, msg.tool_use_result.commandName);
-        if (!toolResult.is_error) {
-          this.activeSkillName = msg.tool_use_result.commandName;
-        }
+        this.activeSkillName = toolResult.is_error
+          ? undefined
+          : msg.tool_use_result.commandName;
       }
       toolSpan.end();
       this.openToolSpans.delete(toolUseId);

--- a/libs/typescript/integrations/claude-code/src/tracing.ts
+++ b/libs/typescript/integrations/claude-code/src/tracing.ts
@@ -411,10 +411,19 @@ function createLlmAndToolSpans(
         const toolName = toolUse.name ?? 'unknown';
         const commandName = toolResultInfo?.commandName;
 
-        // A failed Skill never injected its body, so subsequent spans should
-        // NOT inherit its name (would inflate cost attribution).
-        if (commandName && !toolResultInfo?.isError) {
-          activeSkillName = commandName;
+        // Stamp the Skill's own TOOL span with its own commandName for
+        // identification (failed Skills are still attributable).
+        // Propagation:
+        //   - success: activeSkillName = commandName (child spans inherit)
+        //   - failure: activeSkillName = undefined (prior skill must not leak
+        //     into recovery spans, and the failed skill itself never injected
+        //     its body so it shouldn't propagate either)
+        let spanSkillName: string | undefined;
+        if (commandName) {
+          spanSkillName = commandName;
+          activeSkillName = toolResultInfo?.isError ? undefined : commandName;
+        } else {
+          spanSkillName = activeSkillName;
         }
 
         const toolSpan = startSpan({
@@ -426,7 +435,7 @@ function createLlmAndToolSpans(
           attributes: {
             tool_name: toolName,
             tool_id: toolUseId,
-            ...(activeSkillName ? { [SpanAttributeKey.SKILL_NAME]: activeSkillName } : {}),
+            ...(spanSkillName ? { [SpanAttributeKey.SKILL_NAME]: spanSkillName } : {}),
           },
         });
 

--- a/libs/typescript/integrations/claude-code/src/tracing.ts
+++ b/libs/typescript/integrations/claude-code/src/tracing.ts
@@ -341,6 +341,7 @@ function createLlmAndToolSpans(
   transcriptPath?: string,
 ): void {
   const subagentGroups = collectSubagentGroups(transcript, startIdx);
+  let activeSkillName: string | undefined = undefined;
 
   for (let i = startIdx; i < transcript.length; i++) {
     const entry = transcript[i];
@@ -382,6 +383,7 @@ function createLlmAndToolSpans(
           model,
           'mlflow.llm.model': model,
           [SpanAttributeKey.MESSAGE_FORMAT]: 'anthropic',
+          ...(activeSkillName ? { [SpanAttributeKey.SKILL_NAME]: activeSkillName } : {}),
         },
       });
 
@@ -409,6 +411,10 @@ function createLlmAndToolSpans(
         const toolName = toolUse.name ?? 'unknown';
         const commandName = toolResultInfo?.commandName;
 
+        if (commandName) {
+          activeSkillName = commandName;
+        }
+
         const toolSpan = startSpan({
           name: `tool_${toolName}`,
           parent: parentSpan,
@@ -418,7 +424,7 @@ function createLlmAndToolSpans(
           attributes: {
             tool_name: toolName,
             tool_id: toolUseId,
-            ...(commandName && { [SpanAttributeKey.SKILL_NAME]: commandName }),
+            ...(activeSkillName ? { [SpanAttributeKey.SKILL_NAME]: activeSkillName } : {}),
           },
         });
 

--- a/libs/typescript/integrations/claude-code/src/tracing.ts
+++ b/libs/typescript/integrations/claude-code/src/tracing.ts
@@ -99,11 +99,13 @@ function findToolResults(
       // Check both entry-level and content-level toolUseResult for agentId
       const partToolUseResult = toolResult.toolUseResult ?? {};
       const agentId = entryToolUseResult.agentId ?? partToolUseResult.agentId;
+      const commandName = entryToolUseResult.commandName;
 
       results[toolUseId] = {
         content: toolResult.content ?? '',
         isError: toolResult.is_error ?? false,
         agentId,
+        ...(commandName && { commandName }),
       };
     }
   }
@@ -405,6 +407,7 @@ function createLlmAndToolSpans(
         const toolResultInfo = toolResults[toolUseId];
         const toolResult = toolResultInfo?.content ?? 'No result found';
         const toolName = toolUse.name ?? 'unknown';
+        const commandName = toolResultInfo?.commandName;
 
         const toolSpan = startSpan({
           name: `tool_${toolName}`,
@@ -415,6 +418,7 @@ function createLlmAndToolSpans(
           attributes: {
             tool_name: toolName,
             tool_id: toolUseId,
+            ...(commandName && { [SpanAttributeKey.SKILL_NAME]: commandName }),
           },
         });
 

--- a/libs/typescript/integrations/claude-code/src/tracing.ts
+++ b/libs/typescript/integrations/claude-code/src/tracing.ts
@@ -411,7 +411,9 @@ function createLlmAndToolSpans(
         const toolName = toolUse.name ?? 'unknown';
         const commandName = toolResultInfo?.commandName;
 
-        if (commandName) {
+        // A failed Skill never injected its body, so subsequent spans should
+        // NOT inherit its name (would inflate cost attribution).
+        if (commandName && !toolResultInfo?.isError) {
           activeSkillName = commandName;
         }
 

--- a/libs/typescript/integrations/claude-code/src/types.ts
+++ b/libs/typescript/integrations/claude-code/src/types.ts
@@ -112,6 +112,7 @@ export interface ToolResultInfo {
   content: string;
   isError: boolean;
   agentId?: string;
+  commandName?: string;
 }
 
 export interface SubagentGroup {

--- a/libs/typescript/integrations/claude-code/tests/liveTracing.test.ts
+++ b/libs/typescript/integrations/claude-code/tests/liveTracing.test.ts
@@ -110,18 +110,23 @@ const textMsg = (text: string) =>
 const toolResultMsg = (
   toolUseId: string,
   resultContent: string,
-  opts: { commandName?: string } = {},
+  opts: { commandName?: string; isError?: boolean } = {},
 ) => ({
   type: 'user' as const,
   parent_tool_use_id: null,
   message: {
     role: 'user' as const,
     content: [
-      { type: 'tool_result' as const, tool_use_id: toolUseId, content: resultContent },
+      {
+        type: 'tool_result' as const,
+        tool_use_id: toolUseId,
+        content: resultContent,
+        ...(opts.isError ? { is_error: true } : {}),
+      },
     ],
   },
   ...(opts.commandName
-    ? { tool_use_result: { success: true, commandName: opts.commandName } }
+    ? { tool_use_result: { success: !opts.isError, commandName: opts.commandName } }
     : {}),
 });
 
@@ -266,6 +271,84 @@ describe('LiveTracingContext — isRealUserPrompt clears skill scope', () => {
     ctx.onAssistantMessage(textMsg('inside other skill'));
 
     expect(llmSpans().slice(-1)[0].attributes[SKILL_NAME]).toBe('other-skill');
+  });
+});
+
+describe('LiveTracingContext — failed Skill should not propagate', () => {
+  beforeEach(() => resetMocks());
+
+  it('does NOT propagate skill name to subsequent spans when the Skill tool_result is_error=true', () => {
+    const ctx = new LiveTracingContext('start');
+    ctx.onAssistantMessage(toolUseMsg('skill_failed', 'Skill'));
+    ctx.onUserMessage(
+      toolResultMsg('skill_failed', 'launch failed', {
+        commandName: 'broken-skill',
+        isError: true,
+      }),
+    );
+    ctx.onAssistantMessage(textMsg('recovering after failure'));
+
+    // The Skill TOOL span itself is still stamped with its commandName for
+    // identification ("which skill failed?").
+    expect(findByToolId('skill_failed')?.attributes[SKILL_NAME]).toBe('broken-skill');
+    // But subsequent spans must NOT inherit the failed skill's name.
+    expect(llmSpans().slice(-1)[0].attributes[SKILL_NAME]).toBeUndefined();
+  });
+
+  it('successful skill after a failed one still propagates correctly', () => {
+    const ctx = new LiveTracingContext('start');
+    ctx.onAssistantMessage(toolUseMsg('skill_failed', 'Skill'));
+    ctx.onUserMessage(
+      toolResultMsg('skill_failed', 'failed', {
+        commandName: 'broken-skill',
+        isError: true,
+      }),
+    );
+    ctx.onAssistantMessage(toolUseMsg('skill_ok', 'Skill'));
+    ctx.onUserMessage(toolResultMsg('skill_ok', 'launched', { commandName: 'good-skill' }));
+    ctx.onAssistantMessage(textMsg('inside good skill'));
+
+    expect(llmSpans().slice(-1)[0].attributes[SKILL_NAME]).toBe('good-skill');
+  });
+});
+
+describe('LiveTracingContext — onSystemInit resets all skill-scope state', () => {
+  beforeEach(() => resetMocks());
+
+  it('clears prevUserHadCommandName in addition to activeSkillName', () => {
+    const ctx = new LiveTracingContext('start');
+    ctx.onAssistantMessage(toolUseMsg('skill_1', 'Skill'));
+    ctx.onUserMessage(toolResultMsg('skill_1', 'launched', { commandName: 'my-skill' }));
+    // Now prevUserHadCommandName=true, activeSkillName='my-skill'.
+    ctx.onSystemInit({ type: 'system', subtype: 'init' } as any);
+    // A plain user prompt right after init must NOT be misclassified as a
+    // skill body injection — both state fields must be reset.
+    ctx.onUserMessage({
+      type: 'user',
+      message: { role: 'user', content: 'fresh prompt' },
+    } as any);
+    ctx.onAssistantMessage(textMsg('responding fresh'));
+
+    expect(llmSpans().slice(-1)[0].attributes[SKILL_NAME]).toBeUndefined();
+  });
+});
+
+describe('LiveTracingContext — isRealUserPrompt empty content handling', () => {
+  beforeEach(() => resetMocks());
+
+  it('does NOT treat empty content array as a real prompt (preserves skill scope)', () => {
+    const ctx = new LiveTracingContext('start');
+    ctx.onAssistantMessage(toolUseMsg('skill_1', 'Skill'));
+    ctx.onUserMessage(toolResultMsg('skill_1', 'launched', { commandName: 'my-skill' }));
+    // An empty-array content message should not be classified as a real
+    // user prompt — i.e., it should not clear active skill scope.
+    ctx.onUserMessage({
+      type: 'user',
+      message: { role: 'user', content: [] },
+    } as any);
+    ctx.onAssistantMessage(textMsg('still in skill'));
+
+    expect(llmSpans().slice(-1)[0].attributes[SKILL_NAME]).toBe('my-skill');
   });
 });
 

--- a/libs/typescript/integrations/claude-code/tests/liveTracing.test.ts
+++ b/libs/typescript/integrations/claude-code/tests/liveTracing.test.ts
@@ -430,7 +430,7 @@ describe('LiveTracingContext — nested skills (KNOWN LIMITATION)', () => {
       type: 'user',
       parent_tool_use_id: null,
       message: { role: 'user', content: [{ type: 'text', text: 'A body' }] },
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
     ctx.onAssistantMessage(textMsg('A reasoning'));
 
@@ -441,7 +441,7 @@ describe('LiveTracingContext — nested skills (KNOWN LIMITATION)', () => {
       type: 'user',
       parent_tool_use_id: null,
       message: { role: 'user', content: [{ type: 'text', text: 'B body' }] },
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
     ctx.onAssistantMessage(textMsg('B reasoning'));
 
@@ -452,7 +452,7 @@ describe('LiveTracingContext — nested skills (KNOWN LIMITATION)', () => {
       type: 'user',
       parent_tool_use_id: null,
       message: { role: 'user', content: [{ type: 'text', text: 'C body' }] },
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
     ctx.onAssistantMessage(textMsg('C reasoning (deepest)'));
 
@@ -472,9 +472,7 @@ describe('LiveTracingContext — nested skills (KNOWN LIMITATION)', () => {
     expect(findByToolId('tc')?.attributes[SKILL_NAME]).toBe('skill-C');
 
     const llmByText = (text: string) =>
-      llmSpans().find((s) =>
-        JSON.stringify(s.outputs?.content ?? '').includes(text),
-      );
+      llmSpans().find((s) => JSON.stringify(s.outputs?.content ?? '').includes(text));
 
     // Inside-A reasoning: tagged skill-A (correct).
     expect(llmByText('A reasoning')?.attributes[SKILL_NAME]).toBe('skill-A');

--- a/libs/typescript/integrations/claude-code/tests/liveTracing.test.ts
+++ b/libs/typescript/integrations/claude-code/tests/liveTracing.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Unit tests for LiveTracingContext — exercise the streaming-path skill-scope
+ * state machine directly. Mocks @mlflow/core so spans are captured in-memory
+ * rather than shipped to a tracking server.
+ *
+ * Counterpart to tracedClaudeAgent.test.ts (which spins up a real server).
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+interface MockSpan {
+  name: string;
+  spanType: string;
+  inputs: any;
+  outputs: any;
+  attributes: Record<string, any>;
+  parentId: string | null;
+  ended: boolean;
+}
+
+const mockSpans: MockSpan[] = [];
+let spanCounter = 0;
+
+function resetMocks() {
+  mockSpans.length = 0;
+  spanCounter = 0;
+}
+
+jest.mock('@mlflow/core', () => ({
+  startSpan: jest.fn((opts: any) => {
+    spanCounter += 1;
+    const span: MockSpan = {
+      name: opts.name,
+      spanType: opts.spanType ?? 'UNKNOWN',
+      inputs: opts.inputs ?? {},
+      outputs: {},
+      attributes: { ...(opts.attributes ?? {}) },
+      parentId: opts.parent ? (opts.parent as { spanId: string }).spanId : null,
+      ended: false,
+    };
+    const handle: any = {
+      spanId: `span-${spanCounter}`,
+      setAttribute: jest.fn((k: string, v: any) => {
+        span.attributes[k] = v;
+      }),
+      setOutputs: jest.fn((o: any) => {
+        span.outputs = o;
+      }),
+      setStatus: jest.fn(),
+      setInputs: jest.fn(),
+      end: jest.fn(() => {
+        span.ended = true;
+      }),
+    };
+    mockSpans.push(span);
+    return handle;
+  }),
+  flushTraces: jest.fn().mockResolvedValue(undefined),
+  SpanType: { LLM: 'LLM', TOOL: 'TOOL', AGENT: 'AGENT', CHAIN: 'CHAIN', UNKNOWN: 'UNKNOWN' },
+  SpanAttributeKey: {
+    TOKEN_USAGE: 'mlflow.chat.tokenUsage',
+    MESSAGE_FORMAT: 'mlflow.message.format',
+    SKILL_NAME: 'mlflow.skill.name',
+  },
+  SpanStatusCode: { OK: 'OK', ERROR: 'ERROR', UNSET: 'UNSET' },
+  TraceMetadataKey: {
+    TRACE_SESSION: 'mlflow.trace.session',
+    TRACE_USER: 'mlflow.trace.user',
+  },
+  InMemoryTraceManager: {
+    getInstance: jest.fn(() => ({
+      getTrace: jest.fn(() => ({ info: { traceMetadata: {} } })),
+    })),
+  },
+}));
+
+import { LiveTracingContext } from '../src/liveTracing';
+
+const SKILL_NAME = 'mlflow.skill.name';
+const skillSpans = () => mockSpans.filter((s) => s.attributes[SKILL_NAME]);
+const findByToolId = (id: string) =>
+  mockSpans.find((s) => s.spanType === 'TOOL' && s.attributes.tool_id === id);
+const llmSpans = () => mockSpans.filter((s) => s.spanType === 'LLM');
+
+// Helper: assistant message that calls a single tool by id+name.
+const toolUseMsg = (id: string, name: string, input: any = {}) =>
+  ({
+    type: 'assistant' as const,
+    parent_tool_use_id: null,
+    message: {
+      role: 'assistant' as const,
+      model: 'claude-test',
+      content: [{ type: 'tool_use' as const, id, name, input }],
+    },
+  }) as any;
+
+// Helper: assistant message containing only text — produces an LLM span.
+const textMsg = (text: string) =>
+  ({
+    type: 'assistant' as const,
+    parent_tool_use_id: null,
+    message: {
+      role: 'assistant' as const,
+      model: 'claude-test',
+      content: [{ type: 'text' as const, text }],
+    },
+  }) as any;
+
+// Helper: user tool_result message; opts can attach tool_use_result for skills.
+const toolResultMsg = (
+  toolUseId: string,
+  resultContent: string,
+  opts: { commandName?: string } = {},
+) => ({
+  type: 'user' as const,
+  parent_tool_use_id: null,
+  message: {
+    role: 'user' as const,
+    content: [
+      { type: 'tool_result' as const, tool_use_id: toolUseId, content: resultContent },
+    ],
+  },
+  ...(opts.commandName
+    ? { tool_use_result: { success: true, commandName: opts.commandName } }
+    : {}),
+});
+
+// Helper: a plain text user prompt (multi-prompt AsyncIterable scenario).
+const userPromptMsg = (text: string, extra: Record<string, unknown> = {}) => ({
+  type: 'user' as const,
+  parent_tool_use_id: null,
+  message: { role: 'user' as const, content: text },
+  ...extra,
+});
+
+describe('LiveTracingContext — skill scope propagation', () => {
+  beforeEach(() => resetMocks());
+
+  it('stamps SKILL_NAME on the Skill TOOL span itself when commandName arrives', () => {
+    const ctx = new LiveTracingContext('do the thing');
+    ctx.onAssistantMessage(toolUseMsg('skill_1', 'Skill', { skill: 'my-skill' }));
+    ctx.onUserMessage(toolResultMsg('skill_1', 'launched', { commandName: 'my-skill' }));
+
+    expect(findByToolId('skill_1')?.attributes[SKILL_NAME]).toBe('my-skill');
+  });
+
+  it('propagates SKILL_NAME to child LLM spans emitted after the skill', () => {
+    const ctx = new LiveTracingContext('do the thing');
+    ctx.onAssistantMessage(toolUseMsg('skill_1', 'Skill'));
+    ctx.onUserMessage(toolResultMsg('skill_1', 'launched', { commandName: 'my-skill' }));
+    ctx.onAssistantMessage(textMsg('Working inside the skill.'));
+
+    const taggedLlm = llmSpans().filter((s) => s.attributes[SKILL_NAME] === 'my-skill');
+    expect(taggedLlm).toHaveLength(1);
+  });
+
+  it('propagates SKILL_NAME to child TOOL spans emitted after the skill', () => {
+    const ctx = new LiveTracingContext('do the thing');
+    ctx.onAssistantMessage(toolUseMsg('skill_1', 'Skill'));
+    ctx.onUserMessage(toolResultMsg('skill_1', 'launched', { commandName: 'my-skill' }));
+    ctx.onAssistantMessage(toolUseMsg('bash_1', 'Bash'));
+
+    expect(findByToolId('bash_1')?.attributes[SKILL_NAME]).toBe('my-skill');
+  });
+
+  it('does NOT tag spans created before any skill was invoked', () => {
+    const ctx = new LiveTracingContext('do the thing');
+    ctx.onAssistantMessage(toolUseMsg('bash_pre', 'Bash'));
+    ctx.onUserMessage(toolResultMsg('bash_pre', 'ok'));
+
+    expect(findByToolId('bash_pre')?.attributes[SKILL_NAME]).toBeUndefined();
+  });
+});
+
+describe('LiveTracingContext — isRealUserPrompt clears skill scope', () => {
+  beforeEach(() => resetMocks());
+
+  function buildContextWithActiveSkill() {
+    const ctx = new LiveTracingContext('start');
+    ctx.onAssistantMessage(toolUseMsg('skill_1', 'Skill'));
+    ctx.onUserMessage(toolResultMsg('skill_1', 'launched', { commandName: 'my-skill' }));
+    return ctx;
+  }
+
+  it('clears scope when origin.kind === "human" arrives mid-stream (AsyncIterable case)', () => {
+    const ctx = buildContextWithActiveSkill();
+    ctx.onUserMessage(userPromptMsg('a new prompt', { origin: { kind: 'human' } }));
+    ctx.onAssistantMessage(textMsg('after the new prompt'));
+
+    const afterPromptLlm = llmSpans().slice(-1)[0];
+    expect(afterPromptLlm.attributes[SKILL_NAME]).toBeUndefined();
+  });
+
+  it('clears scope on a plain user prompt when origin is absent (older SDK fallback)', () => {
+    // After the skill finishes, there's intervening assistant work (a Bash
+    // call + its tool_result) before the user types a new prompt. The Bash
+    // tool_result has no commandName so prevUserHadCommandName resets to
+    // false, letting the next plain user prompt be recognized as real.
+    const ctx = buildContextWithActiveSkill();
+    ctx.onAssistantMessage(toolUseMsg('bash_inside', 'Bash'));
+    ctx.onUserMessage(toolResultMsg('bash_inside', 'ok'));
+    ctx.onUserMessage(userPromptMsg('another prompt'));
+    ctx.onAssistantMessage(textMsg('plain'));
+
+    expect(llmSpans().slice(-1)[0].attributes[SKILL_NAME]).toBeUndefined();
+  });
+
+  it('does NOT clear on tool_result echoes (tool_use_result set)', () => {
+    const ctx = buildContextWithActiveSkill();
+    ctx.onAssistantMessage(toolUseMsg('bash_1', 'Bash'));
+    ctx.onUserMessage(toolResultMsg('bash_1', 'ok'));
+    ctx.onAssistantMessage(textMsg('still in skill'));
+
+    expect(llmSpans().slice(-1)[0].attributes[SKILL_NAME]).toBe('my-skill');
+  });
+
+  it('does NOT clear on skill content injection (msg right after Skill tool_result)', () => {
+    // Skill content injections look like a plain text user msg but always
+    // follow a tool_result with commandName. prevUserHadCommandName catches it.
+    const ctx = buildContextWithActiveSkill();
+    ctx.onUserMessage(userPromptMsg('Base directory for this skill: /path...'));
+    ctx.onAssistantMessage(textMsg('reading skill body'));
+
+    expect(llmSpans().slice(-1)[0].attributes[SKILL_NAME]).toBe('my-skill');
+  });
+
+  it('does NOT clear on sub-agent (parent_tool_use_id set)', () => {
+    const ctx = buildContextWithActiveSkill();
+    ctx.onUserMessage({
+      ...userPromptMsg('subagent inner'),
+      parent_tool_use_id: 'some_parent',
+    });
+    ctx.onAssistantMessage(textMsg('inside subagent'));
+
+    expect(llmSpans().slice(-1)[0].attributes[SKILL_NAME]).toBe('my-skill');
+  });
+
+  it('does NOT clear on non-human origin (e.g. coordinator)', () => {
+    const ctx = buildContextWithActiveSkill();
+    ctx.onUserMessage(userPromptMsg('coordinator msg', { origin: { kind: 'coordinator' } }));
+    ctx.onAssistantMessage(textMsg('still in skill'));
+
+    expect(llmSpans().slice(-1)[0].attributes[SKILL_NAME]).toBe('my-skill');
+  });
+
+  it('does NOT clear on isSynthetic messages', () => {
+    const ctx = buildContextWithActiveSkill();
+    ctx.onUserMessage(userPromptMsg('synthetic', { isSynthetic: true }));
+    ctx.onAssistantMessage(textMsg('still in skill'));
+
+    expect(llmSpans().slice(-1)[0].attributes[SKILL_NAME]).toBe('my-skill');
+  });
+
+  it('does NOT clear on shouldQuery=false', () => {
+    const ctx = buildContextWithActiveSkill();
+    ctx.onUserMessage(userPromptMsg('appended', { shouldQuery: false }));
+    ctx.onAssistantMessage(textMsg('still in skill'));
+
+    expect(llmSpans().slice(-1)[0].attributes[SKILL_NAME]).toBe('my-skill');
+  });
+
+  it('most-recent-skill wins when a second skill is invoked', () => {
+    const ctx = buildContextWithActiveSkill();
+    ctx.onAssistantMessage(toolUseMsg('skill_2', 'Skill'));
+    ctx.onUserMessage(toolResultMsg('skill_2', 'launched', { commandName: 'other-skill' }));
+    ctx.onAssistantMessage(textMsg('inside other skill'));
+
+    expect(llmSpans().slice(-1)[0].attributes[SKILL_NAME]).toBe('other-skill');
+  });
+});
+
+afterAll(() => expect(skillSpans().length).toBeGreaterThan(0)); // smoke: tests actually exercised the attribute

--- a/libs/typescript/integrations/claude-code/tests/liveTracing.test.ts
+++ b/libs/typescript/integrations/claude-code/tests/liveTracing.test.ts
@@ -310,6 +310,24 @@ describe('LiveTracingContext — failed Skill should not propagate', () => {
 
     expect(llmSpans().slice(-1)[0].attributes[SKILL_NAME]).toBe('good-skill');
   });
+
+  it('a failed Skill clears the prior skill scope (no leak to recovery spans)', () => {
+    // Skill A succeeds, then Skill B fails. Recovery work after B must NOT
+    // inherit Skill A's name (M2).
+    const ctx = new LiveTracingContext('start');
+    ctx.onAssistantMessage(toolUseMsg('skill_a', 'Skill'));
+    ctx.onUserMessage(toolResultMsg('skill_a', 'launched', { commandName: 'skill-a' }));
+    ctx.onAssistantMessage(toolUseMsg('skill_b', 'Skill'));
+    ctx.onUserMessage(
+      toolResultMsg('skill_b', 'failed', { commandName: 'skill-b', isError: true }),
+    );
+    ctx.onAssistantMessage(textMsg('recovering'));
+
+    expect(findByToolId('skill_a')?.attributes[SKILL_NAME]).toBe('skill-a');
+    expect(findByToolId('skill_b')?.attributes[SKILL_NAME]).toBe('skill-b');
+    // Recovery LLM span must NOT carry skill-a (the prior skill).
+    expect(llmSpans().slice(-1)[0].attributes[SKILL_NAME]).toBeUndefined();
+  });
 });
 
 describe('LiveTracingContext — onSystemInit resets all skill-scope state', () => {

--- a/libs/typescript/integrations/claude-code/tests/liveTracing.test.ts
+++ b/libs/typescript/integrations/claude-code/tests/liveTracing.test.ts
@@ -35,7 +35,7 @@
  * stay wire-format-accurate; treat those as the canonical reference shape.
  */
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return */
 
 interface MockSpan {
   name: string;

--- a/libs/typescript/integrations/claude-code/tests/liveTracing.test.ts
+++ b/libs/typescript/integrations/claude-code/tests/liveTracing.test.ts
@@ -4,6 +4,35 @@
  * rather than shipped to a tracking server.
  *
  * Counterpart to tracedClaudeAgent.test.ts (which spins up a real server).
+ *
+ * ----------------------------------------------------------------------------
+ * Canonical Skill wire format (shared with the Python and TS-transcript tests)
+ * ----------------------------------------------------------------------------
+ *
+ * When the user invokes a Skill, the Claude Code CLI emits TWO distinct
+ * user-role stream events on the happy path:
+ *
+ *   [assistant] tool_use(id=X, name="Skill", input={skill: "<name>"})
+ *   [user]      tool_result(tool_use_id=X)            ← success result
+ *                 + tool_use_result.commandName = "<name>"
+ *                 + tool_use_result.success    = true
+ *   [user]      text "<skill body>"                   ← synthetic body injection
+ *   [assistant] ... continuation (work inside the skill body) ...
+ *
+ * At the API layer the SDK merges the two user entries into one message with
+ * two content blocks; at the stream layer they remain two consecutive user
+ * events. The `prevUserHadCommandName` look-back exists to handle exactly
+ * that two-event pattern without clobbering the active skill scope.
+ *
+ * On the FAILED path (is_error=true), the CLI does NOT emit a body injection
+ * (the skill never boots), so failed fixtures stop at the tool_result and
+ * the assistant's next event is recovery work.
+ *
+ * Most tests below deliberately use the minimal sequence needed to drive one
+ * state-machine transition — adding the body-injection user event is a no-op
+ * for many of them and was elided for clarity. The integration-style
+ * propagation tests at the top of the file DO include the body injection to
+ * stay wire-format-accurate; treat those as the canonical reference shape.
  */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -153,6 +182,8 @@ describe('LiveTracingContext — skill scope propagation', () => {
     const ctx = new LiveTracingContext('do the thing');
     ctx.onAssistantMessage(toolUseMsg('skill_1', 'Skill'));
     ctx.onUserMessage(toolResultMsg('skill_1', 'launched', { commandName: 'my-skill' }));
+    // Synthetic body injection — canonical happy-path wire shape.
+    ctx.onUserMessage(userPromptMsg('<my-skill body>'));
     ctx.onAssistantMessage(textMsg('Working inside the skill.'));
 
     const taggedLlm = llmSpans().filter((s) => s.attributes[SKILL_NAME] === 'my-skill');
@@ -163,6 +194,8 @@ describe('LiveTracingContext — skill scope propagation', () => {
     const ctx = new LiveTracingContext('do the thing');
     ctx.onAssistantMessage(toolUseMsg('skill_1', 'Skill'));
     ctx.onUserMessage(toolResultMsg('skill_1', 'launched', { commandName: 'my-skill' }));
+    // Synthetic body injection — canonical happy-path wire shape.
+    ctx.onUserMessage(userPromptMsg('<my-skill body>'));
     ctx.onAssistantMessage(toolUseMsg('bash_1', 'Bash'));
 
     expect(findByToolId('bash_1')?.attributes[SKILL_NAME]).toBe('my-skill');
@@ -313,7 +346,7 @@ describe('LiveTracingContext — failed Skill should not propagate', () => {
 
   it('a failed Skill clears the prior skill scope (no leak to recovery spans)', () => {
     // Skill A succeeds, then Skill B fails. Recovery work after B must NOT
-    // inherit Skill A's name (M2).
+    // inherit Skill A's name.
     const ctx = new LiveTracingContext('start');
     ctx.onAssistantMessage(toolUseMsg('skill_a', 'Skill'));
     ctx.onUserMessage(toolResultMsg('skill_a', 'launched', { commandName: 'skill-a' }));
@@ -367,6 +400,94 @@ describe('LiveTracingContext — isRealUserPrompt empty content handling', () =>
     ctx.onAssistantMessage(textMsg('still in skill'));
 
     expect(llmSpans().slice(-1)[0].attributes[SKILL_NAME]).toBe('my-skill');
+  });
+});
+
+describe('LiveTracingContext — nested skills (KNOWN LIMITATION)', () => {
+  beforeEach(() => resetMocks());
+
+  // KNOWN LIMITATION (documented): The single-slot state machine doesn't
+  // preserve the outer skill's scope across nested invocations.
+  //
+  // Ideal attribution: the user invoked skill-A, so every span produced
+  // while A is running — including B's TOOL span, C's TOOL span, and all of
+  // B/C's reasoning LLMs — should be tagged skill-A. B and C are
+  // implementation details of A. Actual behavior: each nested Skill
+  // overwrites the active scope, so B's work is tagged skill-B, C's work
+  // skill-C, and the trailing unwind LLMs keep skill-C because there's no
+  // stack to pop.
+  //
+  // Set a breakpoint in `liveTracing.ts` at the `this.activeSkillName = ...`
+  // assignment (around line 377) to step through this.
+  it('nested skill overwrites the outer skill scope', () => {
+    const ctx = new LiveTracingContext('start');
+
+    // Skill A invoked.
+    ctx.onAssistantMessage(toolUseMsg('ta', 'Skill', { skill: 'A' }));
+    ctx.onUserMessage(toolResultMsg('ta', 'launch A', { commandName: 'skill-A' }));
+    // A body injection — must NOT clear scope (caught by prevUserHadCommandName).
+    ctx.onUserMessage({
+      type: 'user',
+      parent_tool_use_id: null,
+      message: { role: 'user', content: [{ type: 'text', text: 'A body' }] },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    ctx.onAssistantMessage(textMsg('A reasoning'));
+
+    // Skill B invoked from within A.
+    ctx.onAssistantMessage(toolUseMsg('tb', 'Skill', { skill: 'B' }));
+    ctx.onUserMessage(toolResultMsg('tb', 'launch B', { commandName: 'skill-B' }));
+    ctx.onUserMessage({
+      type: 'user',
+      parent_tool_use_id: null,
+      message: { role: 'user', content: [{ type: 'text', text: 'B body' }] },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    ctx.onAssistantMessage(textMsg('B reasoning'));
+
+    // Skill C invoked from within B (deepest).
+    ctx.onAssistantMessage(toolUseMsg('tc', 'Skill', { skill: 'C' }));
+    ctx.onUserMessage(toolResultMsg('tc', 'launch C', { commandName: 'skill-C' }));
+    ctx.onUserMessage({
+      type: 'user',
+      parent_tool_use_id: null,
+      message: { role: 'user', content: [{ type: 'text', text: 'C body' }] },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    ctx.onAssistantMessage(textMsg('C reasoning (deepest)'));
+
+    // Unwind: C finishes, control returns to B → A → user. The semantic
+    // skill scope should pop on each, but the state machine has no stack.
+    ctx.onAssistantMessage(textMsg('back to B'));
+    ctx.onAssistantMessage(textMsg('back to A'));
+    ctx.onAssistantMessage(textMsg('final reply'));
+
+    // Each Skill's OWN TOOL span IS stamped with its own commandName via the
+    // own-span pass. Ideally tb/tc would also report skill-A (the outer
+    // scope), but the single slot can only hold one value.
+    expect(findByToolId('ta')?.attributes[SKILL_NAME]).toBe('skill-A');
+    // ↓ THE LIMITATION (own-span): tb/tc tagged with themselves; the outer
+    //   skill-A scope is lost. Ideally both would be skill-A.
+    expect(findByToolId('tb')?.attributes[SKILL_NAME]).toBe('skill-B');
+    expect(findByToolId('tc')?.attributes[SKILL_NAME]).toBe('skill-C');
+
+    const llmByText = (text: string) =>
+      llmSpans().find((s) =>
+        JSON.stringify(s.outputs?.content ?? '').includes(text),
+      );
+
+    // Inside-A reasoning: tagged skill-A (correct).
+    expect(llmByText('A reasoning')?.attributes[SKILL_NAME]).toBe('skill-A');
+
+    // ↓ THE LIMITATION (propagation): once a nested skill is invoked, the
+    //   slot is overwritten and all descendants get the inner skill's name.
+    //   Ideally every LLM below should still be tagged skill-A — A is the
+    //   user-invoked skill and B/C are implementation details of A.
+    expect(llmByText('B reasoning')?.attributes[SKILL_NAME]).toBe('skill-B');
+    expect(llmByText('C reasoning (deepest)')?.attributes[SKILL_NAME]).toBe('skill-C');
+    expect(llmByText('back to B')?.attributes[SKILL_NAME]).toBe('skill-C');
+    expect(llmByText('back to A')?.attributes[SKILL_NAME]).toBe('skill-C');
+    expect(llmByText('final reply')?.attributes[SKILL_NAME]).toBe('skill-C');
   });
 });
 

--- a/libs/typescript/integrations/claude-code/tests/tracing.test.ts
+++ b/libs/typescript/integrations/claude-code/tests/tracing.test.ts
@@ -705,12 +705,114 @@ describe('processTranscript', () => {
     it('does NOT propagate when the Skill tool_result is_error=true', async () => {
       await writeAndProcess(buildSkillTranscript({ isError: true }));
 
+      // The failed Skill's OWN span IS stamped with its commandName (M1) so
+      // operators can attribute the failure to a specific skill.
+      expect(findByToolId('skill_tool')?.attributes['mlflow.skill.name']).toBe('my-skill');
+
       // Post-skill spans must NOT inherit the failed skill name.
       const llmSpans = getSpansByType('LLM');
       for (const s of llmSpans) {
         expect(s.attributes['mlflow.skill.name']).toBeUndefined();
       }
       expect(findByToolId('child_bash')?.attributes['mlflow.skill.name']).toBeUndefined();
+    });
+
+    it('a failed Skill clears the prior skill scope (no leak to recovery spans)', async () => {
+      // Skill A succeeds, then Skill B fails. Recovery work after B must NOT
+      // inherit Skill A's name (M2).
+      const transcript = [
+        {
+          type: 'user',
+          message: { role: 'user', content: 'do' },
+          timestamp: '2025-01-15T10:00:00.000Z',
+        },
+        {
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [
+              { type: 'tool_use', id: 'skill_a', name: 'Skill', input: { skill: 'skill-a' } },
+            ],
+          },
+          timestamp: '2025-01-15T10:00:01.000Z',
+        },
+        {
+          type: 'user',
+          toolUseResult: { success: true, commandName: 'skill-a' },
+          message: {
+            role: 'user',
+            content: [{ type: 'tool_result', tool_use_id: 'skill_a', content: 'launched' }],
+          },
+          timestamp: '2025-01-15T10:00:02.000Z',
+        },
+        {
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [
+              { type: 'tool_use', id: 'skill_b', name: 'Skill', input: { skill: 'skill-b' } },
+            ],
+          },
+          timestamp: '2025-01-15T10:00:03.000Z',
+        },
+        {
+          type: 'user',
+          toolUseResult: { success: false, commandName: 'skill-b' },
+          message: {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: 'skill_b',
+                content: 'failed',
+                is_error: true,
+              },
+            ],
+          },
+          timestamp: '2025-01-15T10:00:04.000Z',
+        },
+        {
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'recovering' }],
+            model: 'claude-test',
+          },
+          timestamp: '2025-01-15T10:00:05.000Z',
+        },
+        {
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [
+              { type: 'tool_use', id: 'recovery_bash', name: 'Bash', input: {} },
+            ],
+          },
+          timestamp: '2025-01-15T10:00:06.000Z',
+        },
+        {
+          type: 'user',
+          message: {
+            role: 'user',
+            content: [
+              { type: 'tool_result', tool_use_id: 'recovery_bash', content: 'ok' },
+            ],
+          },
+          timestamp: '2025-01-15T10:00:07.000Z',
+        },
+      ];
+
+      await writeAndProcess(transcript);
+
+      expect(findByToolId('skill_a')?.attributes['mlflow.skill.name']).toBe('skill-a');
+      expect(findByToolId('skill_b')?.attributes['mlflow.skill.name']).toBe('skill-b');
+
+      // Recovery LLM must NOT carry skill-a (or skill-b).
+      const llmSpans = getSpansByType('LLM');
+      for (const s of llmSpans) {
+        expect(s.attributes['mlflow.skill.name']).toBeUndefined();
+      }
+      expect(findByToolId('recovery_bash')?.attributes['mlflow.skill.name']).toBeUndefined();
     });
   });
 });

--- a/libs/typescript/integrations/claude-code/tests/tracing.test.ts
+++ b/libs/typescript/integrations/claude-code/tests/tracing.test.ts
@@ -574,9 +574,33 @@ describe('processTranscript', () => {
   // --------------------------------------------------------------------------
   // Skill propagation (createLlmAndToolSpans + findToolResults)
   // --------------------------------------------------------------------------
+  //
+  // Canonical Skill wire format (shared with the Python tests and the TS-live
+  // tests). When the user invokes a Skill, the Claude Code CLI writes TWO
+  // distinct user-role JSONL entries on the happy path:
+  //
+  //   [assistant] tool_use(id=X, name="Skill", ...)
+  //   [user]      tool_result(tool_use_id=X)           ← success result
+  //                 + toolUseResult.commandName = "<name>"
+  //                 + toolUseResult.success    = true
+  //   [user]      text "<skill body>"                  ← synthetic body injection
+  //   [assistant] ... continuation (work inside the skill body) ...
+  //
+  // At the API layer the SDK merges the two user entries into one message
+  // with two content blocks; at the transcript layer they remain two
+  // consecutive user entries, which is what the fixtures below reflect.
+  //
+  // On the FAILED path (is_error=true), the CLI does NOT emit a body
+  // injection (the skill never boots), so failed fixtures stop at the
+  // tool_result and the assistant's next event is recovery work.
+  //
+  // Keep new fixtures in this shape — happy paths always include the body
+  // injection entry, failed paths never do.
 
   describe('skill propagation', () => {
-    function buildSkillTranscript(opts: { isError?: boolean } = {}) {
+    // Happy-path transcript: pre-skill bash, successful skill, body injection,
+    // post-skill body (LLM + child bash) — all post-skill spans inherit.
+    function buildHappySkillTranscript() {
       return [
         {
           type: 'user',
@@ -588,9 +612,7 @@ describe('processTranscript', () => {
           type: 'assistant',
           message: {
             role: 'assistant',
-            content: [
-              { type: 'tool_use', id: 'pre_bash', name: 'Bash', input: {} },
-            ],
+            content: [{ type: 'tool_use', id: 'pre_bash', name: 'Bash', input: {} }],
           },
           timestamp: '2025-01-15T10:00:01.000Z',
         },
@@ -608,33 +630,32 @@ describe('processTranscript', () => {
           message: {
             role: 'assistant',
             content: [
-              {
-                type: 'tool_use',
-                id: 'skill_tool',
-                name: 'Skill',
-                input: { skill: 'my-skill' },
-              },
+              { type: 'tool_use', id: 'skill_tool', name: 'Skill', input: { skill: 'my-skill' } },
             ],
           },
           timestamp: '2025-01-15T10:00:03.000Z',
         },
         {
           type: 'user',
-          toolUseResult: { success: !opts.isError, commandName: 'my-skill' },
+          toolUseResult: { success: true, commandName: 'my-skill' },
           message: {
             role: 'user',
             content: [
-              {
-                type: 'tool_result',
-                tool_use_id: 'skill_tool',
-                content: 'launched',
-                ...(opts.isError ? { is_error: true } : {}),
-              },
+              { type: 'tool_result', tool_use_id: 'skill_tool', content: 'launched' },
             ],
           },
           timestamp: '2025-01-15T10:00:04.000Z',
         },
-        // Post-skill LLM turn — should inherit (only if skill succeeded).
+        // Synthetic body injection emitted by the CLI on the happy path.
+        {
+          type: 'user',
+          message: {
+            role: 'user',
+            content: [{ type: 'text', text: '<my-skill body>' }],
+          },
+          timestamp: '2025-01-15T10:00:04.500Z',
+        },
+        // Post-skill LLM turn — runs inside the skill body, should inherit.
         {
           type: 'assistant',
           message: {
@@ -644,14 +665,12 @@ describe('processTranscript', () => {
           },
           timestamp: '2025-01-15T10:00:05.000Z',
         },
-        // Post-skill bash — should also inherit (only if skill succeeded).
+        // Post-skill bash — also runs inside the skill body, should inherit.
         {
           type: 'assistant',
           message: {
             role: 'assistant',
-            content: [
-              { type: 'tool_use', id: 'child_bash', name: 'Bash', input: {} },
-            ],
+            content: [{ type: 'tool_use', id: 'child_bash', name: 'Bash', input: {} }],
           },
           timestamp: '2025-01-15T10:00:06.000Z',
         },
@@ -662,6 +681,73 @@ describe('processTranscript', () => {
             content: [{ type: 'tool_result', tool_use_id: 'child_bash', content: 'done' }],
           },
           timestamp: '2025-01-15T10:00:07.000Z',
+        },
+      ];
+    }
+
+    // Failed-skill transcript: skill fails to load (is_error=true). Realistic
+    // continuation: no body injection, assistant emits recovery text instead
+    // of "inside the skill", then attempts a recovery tool call.
+    function buildFailedSkillTranscript() {
+      return [
+        {
+          type: 'user',
+          message: { role: 'user', content: 'do the thing' },
+          timestamp: '2025-01-15T10:00:00.000Z',
+        },
+        // Skill invocation that will fail.
+        {
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [
+              { type: 'tool_use', id: 'skill_tool', name: 'Skill', input: { skill: 'my-skill' } },
+            ],
+          },
+          timestamp: '2025-01-15T10:00:01.000Z',
+        },
+        {
+          type: 'user',
+          toolUseResult: { success: false, commandName: 'my-skill' },
+          message: {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: 'skill_tool',
+                content: 'Skill failed to launch',
+                is_error: true,
+              },
+            ],
+          },
+          timestamp: '2025-01-15T10:00:02.000Z',
+        },
+        // Recovery LLM — must NOT inherit the failed skill name.
+        {
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'The skill failed; trying a different approach.' }],
+            model: 'claude-test',
+          },
+          timestamp: '2025-01-15T10:00:03.000Z',
+        },
+        // Recovery bash — must also NOT inherit.
+        {
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'tool_use', id: 'recovery_bash', name: 'Bash', input: {} }],
+          },
+          timestamp: '2025-01-15T10:00:04.000Z',
+        },
+        {
+          type: 'user',
+          message: {
+            role: 'user',
+            content: [{ type: 'tool_result', tool_use_id: 'recovery_bash', content: 'ok' }],
+          },
+          timestamp: '2025-01-15T10:00:05.000Z',
         },
       ];
     }
@@ -677,12 +763,12 @@ describe('processTranscript', () => {
       getSpans().find((s) => s.spanType === 'TOOL' && s.attributes.tool_id === id);
 
     it('stamps SKILL_NAME on the Skill TOOL span itself', async () => {
-      await writeAndProcess(buildSkillTranscript());
+      await writeAndProcess(buildHappySkillTranscript());
       expect(findByToolId('skill_tool')?.attributes['mlflow.skill.name']).toBe('my-skill');
     });
 
     it('propagates SKILL_NAME to post-skill LLM spans', async () => {
-      await writeAndProcess(buildSkillTranscript());
+      await writeAndProcess(buildHappySkillTranscript());
       const llmSpans = getSpansByType('LLM');
       const tagged = llmSpans.filter(
         (s) => s.attributes['mlflow.skill.name'] === 'my-skill',
@@ -691,35 +777,35 @@ describe('processTranscript', () => {
     });
 
     it('propagates SKILL_NAME to post-skill child TOOL spans', async () => {
-      await writeAndProcess(buildSkillTranscript());
+      await writeAndProcess(buildHappySkillTranscript());
       expect(findByToolId('child_bash')?.attributes['mlflow.skill.name']).toBe('my-skill');
     });
 
     it('does NOT tag pre-skill TOOL spans', async () => {
-      await writeAndProcess(buildSkillTranscript());
+      await writeAndProcess(buildHappySkillTranscript());
       const preBash = findByToolId('pre_bash');
       expect(preBash).toBeDefined();
       expect(preBash?.attributes['mlflow.skill.name']).toBeUndefined();
     });
 
     it('does NOT propagate when the Skill tool_result is_error=true', async () => {
-      await writeAndProcess(buildSkillTranscript({ isError: true }));
+      await writeAndProcess(buildFailedSkillTranscript());
 
-      // The failed Skill's OWN span IS stamped with its commandName (M1) so
+      // The failed Skill's OWN span IS stamped with its commandName so
       // operators can attribute the failure to a specific skill.
       expect(findByToolId('skill_tool')?.attributes['mlflow.skill.name']).toBe('my-skill');
 
-      // Post-skill spans must NOT inherit the failed skill name.
+      // Recovery spans must NOT inherit the failed skill name.
       const llmSpans = getSpansByType('LLM');
       for (const s of llmSpans) {
         expect(s.attributes['mlflow.skill.name']).toBeUndefined();
       }
-      expect(findByToolId('child_bash')?.attributes['mlflow.skill.name']).toBeUndefined();
+      expect(findByToolId('recovery_bash')?.attributes['mlflow.skill.name']).toBeUndefined();
     });
 
     it('a failed Skill clears the prior skill scope (no leak to recovery spans)', async () => {
       // Skill A succeeds, then Skill B fails. Recovery work after B must NOT
-      // inherit Skill A's name (M2).
+      // inherit Skill A's name.
       const transcript = [
         {
           type: 'user',
@@ -744,6 +830,15 @@ describe('processTranscript', () => {
             content: [{ type: 'tool_result', tool_use_id: 'skill_a', content: 'launched' }],
           },
           timestamp: '2025-01-15T10:00:02.000Z',
+        },
+        // Synthetic body injection for skill-a's happy-path boot.
+        {
+          type: 'user',
+          message: {
+            role: 'user',
+            content: [{ type: 'text', text: '<skill-a body>' }],
+          },
+          timestamp: '2025-01-15T10:00:02.500Z',
         },
         {
           type: 'assistant',

--- a/libs/typescript/integrations/claude-code/tests/tracing.test.ts
+++ b/libs/typescript/integrations/claude-code/tests/tracing.test.ts
@@ -87,6 +87,7 @@ jest.mock('@mlflow/core', () => {
     SpanAttributeKey: {
       TOKEN_USAGE: 'mlflow.chat.tokenUsage',
       MESSAGE_FORMAT: 'mlflow.message.format',
+      SKILL_NAME: 'mlflow.skill.name',
     },
     TraceMetadataKey: {
       TRACE_SESSION: 'mlflow.trace.session',
@@ -567,6 +568,149 @@ describe('processTranscript', () => {
       const steerMessages = inputMessages.filter((m) => m.content === 'also tell me about Java');
       expect(steerMessages).toHaveLength(1);
       expect(steerMessages[0].role).toBe('user');
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Skill propagation (createLlmAndToolSpans + findToolResults)
+  // --------------------------------------------------------------------------
+
+  describe('skill propagation', () => {
+    function buildSkillTranscript(opts: { isError?: boolean } = {}) {
+      return [
+        {
+          type: 'user',
+          message: { role: 'user', content: 'do the thing' },
+          timestamp: '2025-01-15T10:00:00.000Z',
+        },
+        // Pre-skill bash — must NOT be tagged with the skill name.
+        {
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [
+              { type: 'tool_use', id: 'pre_bash', name: 'Bash', input: {} },
+            ],
+          },
+          timestamp: '2025-01-15T10:00:01.000Z',
+        },
+        {
+          type: 'user',
+          message: {
+            role: 'user',
+            content: [{ type: 'tool_result', tool_use_id: 'pre_bash', content: 'ok' }],
+          },
+          timestamp: '2025-01-15T10:00:02.000Z',
+        },
+        // Skill invocation.
+        {
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool_use',
+                id: 'skill_tool',
+                name: 'Skill',
+                input: { skill: 'my-skill' },
+              },
+            ],
+          },
+          timestamp: '2025-01-15T10:00:03.000Z',
+        },
+        {
+          type: 'user',
+          toolUseResult: { success: !opts.isError, commandName: 'my-skill' },
+          message: {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: 'skill_tool',
+                content: 'launched',
+                ...(opts.isError ? { is_error: true } : {}),
+              },
+            ],
+          },
+          timestamp: '2025-01-15T10:00:04.000Z',
+        },
+        // Post-skill LLM turn — should inherit (only if skill succeeded).
+        {
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'inside the skill' }],
+            model: 'claude-test',
+          },
+          timestamp: '2025-01-15T10:00:05.000Z',
+        },
+        // Post-skill bash — should also inherit (only if skill succeeded).
+        {
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [
+              { type: 'tool_use', id: 'child_bash', name: 'Bash', input: {} },
+            ],
+          },
+          timestamp: '2025-01-15T10:00:06.000Z',
+        },
+        {
+          type: 'user',
+          message: {
+            role: 'user',
+            content: [{ type: 'tool_result', tool_use_id: 'child_bash', content: 'done' }],
+          },
+          timestamp: '2025-01-15T10:00:07.000Z',
+        },
+      ];
+    }
+
+    async function writeAndProcess(entries: any[]): Promise<void> {
+      const tmpDir = mkdtempSync(resolve(tmpdir(), 'cc-skill-'));
+      const file = resolve(tmpDir, 't.jsonl');
+      writeFileSync(file, entries.map((e) => JSON.stringify(e)).join('\n') + '\n');
+      await processTranscript(file, `sess-${Date.now()}`);
+    }
+
+    const findByToolId = (id: string) =>
+      getSpans().find((s) => s.spanType === 'TOOL' && s.attributes.tool_id === id);
+
+    it('stamps SKILL_NAME on the Skill TOOL span itself', async () => {
+      await writeAndProcess(buildSkillTranscript());
+      expect(findByToolId('skill_tool')?.attributes['mlflow.skill.name']).toBe('my-skill');
+    });
+
+    it('propagates SKILL_NAME to post-skill LLM spans', async () => {
+      await writeAndProcess(buildSkillTranscript());
+      const llmSpans = getSpansByType('LLM');
+      const tagged = llmSpans.filter(
+        (s) => s.attributes['mlflow.skill.name'] === 'my-skill',
+      );
+      expect(tagged.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('propagates SKILL_NAME to post-skill child TOOL spans', async () => {
+      await writeAndProcess(buildSkillTranscript());
+      expect(findByToolId('child_bash')?.attributes['mlflow.skill.name']).toBe('my-skill');
+    });
+
+    it('does NOT tag pre-skill TOOL spans', async () => {
+      await writeAndProcess(buildSkillTranscript());
+      const preBash = findByToolId('pre_bash');
+      expect(preBash).toBeDefined();
+      expect(preBash?.attributes['mlflow.skill.name']).toBeUndefined();
+    });
+
+    it('does NOT propagate when the Skill tool_result is_error=true', async () => {
+      await writeAndProcess(buildSkillTranscript({ isError: true }));
+
+      // Post-skill spans must NOT inherit the failed skill name.
+      const llmSpans = getSpansByType('LLM');
+      for (const s of llmSpans) {
+        expect(s.attributes['mlflow.skill.name']).toBeUndefined();
+      }
+      expect(findByToolId('child_bash')?.attributes['mlflow.skill.name']).toBeUndefined();
     });
   });
 });

--- a/libs/typescript/integrations/claude-code/tests/tracing.test.ts
+++ b/libs/typescript/integrations/claude-code/tests/tracing.test.ts
@@ -640,9 +640,7 @@ describe('processTranscript', () => {
           toolUseResult: { success: true, commandName: 'my-skill' },
           message: {
             role: 'user',
-            content: [
-              { type: 'tool_result', tool_use_id: 'skill_tool', content: 'launched' },
-            ],
+            content: [{ type: 'tool_result', tool_use_id: 'skill_tool', content: 'launched' }],
           },
           timestamp: '2025-01-15T10:00:04.000Z',
         },
@@ -770,9 +768,7 @@ describe('processTranscript', () => {
     it('propagates SKILL_NAME to post-skill LLM spans', async () => {
       await writeAndProcess(buildHappySkillTranscript());
       const llmSpans = getSpansByType('LLM');
-      const tagged = llmSpans.filter(
-        (s) => s.attributes['mlflow.skill.name'] === 'my-skill',
-      );
+      const tagged = llmSpans.filter((s) => s.attributes['mlflow.skill.name'] === 'my-skill');
       expect(tagged.length).toBeGreaterThanOrEqual(1);
     });
 
@@ -879,9 +875,7 @@ describe('processTranscript', () => {
           type: 'assistant',
           message: {
             role: 'assistant',
-            content: [
-              { type: 'tool_use', id: 'recovery_bash', name: 'Bash', input: {} },
-            ],
+            content: [{ type: 'tool_use', id: 'recovery_bash', name: 'Bash', input: {} }],
           },
           timestamp: '2025-01-15T10:00:06.000Z',
         },
@@ -889,9 +883,7 @@ describe('processTranscript', () => {
           type: 'user',
           message: {
             role: 'user',
-            content: [
-              { type: 'tool_result', tool_use_id: 'recovery_bash', content: 'ok' },
-            ],
+            content: [{ type: 'tool_result', tool_use_id: 'recovery_bash', content: 'ok' }],
           },
           timestamp: '2025-01-15T10:00:07.000Z',
         },

--- a/mlflow/claude_code/tracing.py
+++ b/mlflow/claude_code/tracing.py
@@ -770,7 +770,15 @@ def _is_real_sdk_user_prompt(messages: list[Any], idx: int) -> bool:
     # injecting the skill's prompt body — keep skill scope, don't reset it.
     if idx > 0:
         prev_tur = getattr(messages[idx - 1], "tool_use_result", None)
-        if isinstance(prev_tur, dict) and prev_tur.get("commandName"):
+        # The SDK types tool_use_result as a dict today, but tolerate a future
+        # typed object so a skill body injection is never misread as a real
+        # prompt (which would clear skill scope mid-skill).
+        command_name = (
+            prev_tur.get("commandName")
+            if isinstance(prev_tur, dict)
+            else getattr(prev_tur, "commandName", None)
+        )
+        if command_name:
             return False
 
     return True
@@ -901,11 +909,14 @@ def _create_sdk_child_spans(
 
                 # Stamp the Skill's own TOOL span with its own commandName for
                 # identification (failed Skills are still attributable).
+                # Gate on tool_block.name: commandName is message-level metadata,
+                # so if results are ever batched it must only mark the Skill
+                # block, not co-resident non-skill results.
                 # Propagation:
                 #   - success: active_skill_name = commandName (child spans inherit)
                 #   - failure: active_skill_name = None (prior skill must not
                 #     leak into recovery spans)
-                if tool_result and tool_result.command_name:
+                if tool_result and tool_result.command_name and tool_block.name == "Skill":
                     span_skill_name = tool_result.command_name
                     active_skill_name = (
                         tool_result.command_name if not tool_result.is_error else None

--- a/mlflow/claude_code/tracing.py
+++ b/mlflow/claude_code/tracing.py
@@ -57,6 +57,15 @@ CLAUDE_TRACING_LEVEL = logging.WARNING - 5
 
 
 # ============================================================================
+# CONSTANTS
+# ============================================================================
+@dataclasses.dataclass
+class ToolUseResult:
+    content: Any
+    command_name: str | None
+
+
+# ============================================================================
 # LOGGING AND SETUP
 # ============================================================================
 
@@ -293,7 +302,9 @@ def _extract_content_and_tools(content: list[dict[str, Any]]) -> tuple[str, list
     return text_content, tool_uses
 
 
-def _find_tool_results(transcript: list[dict[str, Any]], start_idx: int) -> dict[str, Any]:
+def _find_tool_results(
+    transcript: list[dict[str, Any]], start_idx: int
+) -> dict[str, ToolUseResult]:
     """Find tool results following the current assistant response.
 
     Returns a mapping from tool_use_id to tool result content.
@@ -307,6 +318,7 @@ def _find_tool_results(transcript: list[dict[str, Any]], start_idx: int) -> dict
             continue
 
         msg = entry.get(MESSAGE_FIELD_MESSAGE, {})
+        command_name = msg.get(MESSAGE_FIELD_COMMAND_NAME, None)
         content = msg.get(MESSAGE_FIELD_CONTENT, [])
 
         if isinstance(content, list):
@@ -318,7 +330,9 @@ def _find_tool_results(transcript: list[dict[str, Any]], start_idx: int) -> dict
                     tool_use_id = part.get("tool_use_id")
                     result_content = part.get("content", "")
                     if tool_use_id:
-                        tool_results[tool_use_id] = result_content
+                        tool_results[tool_use_id] = ToolUseResult(
+                            content=result_content, command_name=command_name
+                        )
 
         # Stop looking once we hit the next assistant response
         if entry.get(MESSAGE_FIELD_TYPE) == MESSAGE_TYPE_ASSISTANT:
@@ -484,7 +498,7 @@ def _create_llm_and_tool_spans(
             for idx, tool_use in enumerate(tool_uses):
                 tool_start_ns = timestamp_ns + (idx * tool_duration_ns)
                 tool_use_id = tool_use.get("id", "")
-                tool_result = tool_results.get(tool_use_id, "No result found")
+                tool_result = tool_results.get(tool_use_id, None)
 
                 tool_span = mlflow.start_span_no_context(
                     name=f"tool_{tool_use.get('name', 'unknown')}",
@@ -495,10 +509,17 @@ def _create_llm_and_tool_spans(
                     attributes={
                         "tool_name": tool_use.get("name", "unknown"),
                         "tool_id": tool_use_id,
+                        **(
+                            {SpanAttributeKey.SKILL_NAME: tool_result.command_name}
+                            if tool_result and tool_result.command_name
+                            else {}
+                        ),
                     },
                 )
 
-                tool_span.set_outputs({"result": tool_result})
+                tool_span.set_outputs({
+                    "result": tool_result.content if tool_result else "No result found"
+                })
                 tool_span.end(end_time_ns=tool_start_ns + tool_duration_ns)
 
 
@@ -690,7 +711,7 @@ def _find_sdk_user_prompt(messages: list[Any]) -> str | None:
     return None
 
 
-def _build_tool_result_map(messages: list[Any]) -> dict[str, str]:
+def _build_tool_result_map(messages: list[Any]) -> dict[str, ToolUseResult]:
     """Map tool_use_id to its result content so tool spans can show outputs."""
     from claude_agent_sdk.types import ToolResultBlock, UserMessage
 
@@ -699,10 +720,13 @@ def _build_tool_result_map(messages: list[Any]) -> dict[str, str]:
         if isinstance(msg, UserMessage) and isinstance(msg.content, list):
             for block in msg.content:
                 if isinstance(block, ToolResultBlock):
+                    command_name = block.input.get("commandName", None)
                     result = block.content
                     if isinstance(result, list):
                         result = str(result)
-                    tool_result_map[block.tool_use_id] = result or ""
+                    tool_result_map[block.tool_use_id] = ToolUseResult(
+                        content=result or "", command_name=command_name
+                    )
     return tool_result_map
 
 
@@ -748,7 +772,7 @@ def _serialize_sdk_message(msg) -> dict[str, Any] | None:
 def _create_sdk_child_spans(
     messages: list[Any],
     parent_span,
-    tool_result_map: dict[str, str],
+    tool_result_map: dict[str, ToolUseResult],
 ) -> str | None:
     """Create LLM and tool child spans under ``parent_span`` from SDK messages."""
     from claude_agent_sdk.types import AssistantMessage, TextBlock, ToolUseBlock
@@ -796,7 +820,14 @@ def _create_sdk_child_spans(
                     inputs=tool_block.input,
                     attributes={"tool_name": tool_block.name, "tool_id": tool_block.id},
                 )
-                tool_span.set_outputs({"result": tool_result_map.get(tool_block.id, "")})
+                tool_result = tool_result_map.get(tool_block.id)
+                tool_span.set_outputs({
+                    "result": tool_result.content if tool_result else "No result found"
+                })
+                if tool_result and tool_result.command_name:
+                    tool_span.set_attributes({
+                        SpanAttributeKey.SKILL_NAME: tool_result.command_name
+                    })
                 tool_span.end()
 
         if anthropic_msg := _serialize_sdk_message(msg):

--- a/mlflow/claude_code/tracing.py
+++ b/mlflow/claude_code/tracing.py
@@ -897,32 +897,40 @@ def _create_sdk_child_spans(
                 continue
 
             for tool_block in tool_blocks:
+                tool_result = tool_result_map.get(tool_block.id)
+
+                # Stamp the Skill's own TOOL span with its own commandName for
+                # identification (failed Skills are still attributable).
+                # Propagation:
+                #   - success: active_skill_name = commandName (child spans inherit)
+                #   - failure: active_skill_name = None (prior skill must not
+                #     leak into recovery spans)
+                if tool_result and tool_result.command_name:
+                    span_skill_name = tool_result.command_name
+                    active_skill_name = (
+                        tool_result.command_name if not tool_result.is_error else None
+                    )
+                else:
+                    span_skill_name = active_skill_name
+
                 tool_span = mlflow.start_span_no_context(
                     name=f"tool_{tool_block.name}",
                     parent_span=parent_span,
                     span_type=SpanType.TOOL,
                     inputs=tool_block.input,
-                    attributes={"tool_name": tool_block.name, "tool_id": tool_block.id},
+                    attributes={
+                        "tool_name": tool_block.name,
+                        "tool_id": tool_block.id,
+                        **(
+                            {SpanAttributeKey.SKILL_NAME: span_skill_name}
+                            if span_skill_name
+                            else {}
+                        ),
+                    },
                 )
-                tool_result = tool_result_map.get(tool_block.id)
                 tool_span.set_outputs({
                     "result": tool_result.content if tool_result else "No result found"
                 })
-                # Stamp the Skill's own TOOL span with its own commandName for
-                # identification (failed Skills are still attributable).
-                # Propagation:
-                #   - success: active_skill_name = commandName
-                #   - failure: active_skill_name = None (prior skill must not
-                #     leak into recovery spans)
-                if tool_result and tool_result.command_name:
-                    tool_span.set_attributes({
-                        SpanAttributeKey.SKILL_NAME: tool_result.command_name
-                    })
-                    active_skill_name = (
-                        tool_result.command_name if not tool_result.is_error else None
-                    )
-                elif active_skill_name:
-                    tool_span.set_attributes({SpanAttributeKey.SKILL_NAME: active_skill_name})
                 tool_span.end()
 
         if anthropic_msg := _serialize_sdk_message(msg):

--- a/mlflow/claude_code/tracing.py
+++ b/mlflow/claude_code/tracing.py
@@ -318,7 +318,12 @@ def _find_tool_results(
             continue
 
         msg = entry.get(MESSAGE_FIELD_MESSAGE, {})
-        command_name = msg.get(MESSAGE_FIELD_COMMAND_NAME, None)
+        tool_use_result = entry.get(MESSAGE_FIELD_TOOL_USE_RESULT)
+        command_name = (
+            tool_use_result.get(MESSAGE_FIELD_COMMAND_NAME)
+            if isinstance(tool_use_result, dict)
+            else None
+        )
         content = msg.get(MESSAGE_FIELD_CONTENT, [])
 
         if isinstance(content, list):
@@ -728,12 +733,19 @@ def _build_tool_result_map(messages: list[Any]) -> dict[str, ToolUseResult]:
     """Map tool_use_id to its result content so tool spans can show outputs."""
     from claude_agent_sdk.types import ToolResultBlock, UserMessage
 
-    tool_result_map: dict[str, str] = {}
+    tool_result_map: dict[str, ToolUseResult] = {}
     for msg in messages:
         if isinstance(msg, UserMessage) and isinstance(msg.content, list):
+            # Skill metadata lives on the UserMessage's tool_use_result dict
+            # (verified via the SDK at claude_agent_sdk/types.py:1021 and the
+            # CLI stream-json wire format). It is NOT on ToolResultBlock.
+            command_name = (
+                msg.tool_use_result.get("commandName")
+                if isinstance(msg.tool_use_result, dict)
+                else None
+            )
             for block in msg.content:
                 if isinstance(block, ToolResultBlock):
-                    command_name = block.input.get("commandName", None)
                     result = block.content
                     if isinstance(result, list):
                         result = str(result)

--- a/mlflow/claude_code/tracing.py
+++ b/mlflow/claude_code/tracing.py
@@ -63,6 +63,7 @@ CLAUDE_TRACING_LEVEL = logging.WARNING - 5
 class ToolUseResult:
     content: Any
     command_name: str | None
+    is_error: bool = False
 
 
 # ============================================================================
@@ -334,9 +335,12 @@ def _find_tool_results(
                 ):
                     tool_use_id = part.get("tool_use_id")
                     result_content = part.get("content", "")
+                    is_error = bool(part.get("is_error", False))
                     if tool_use_id:
                         tool_results[tool_use_id] = ToolUseResult(
-                            content=result_content, command_name=command_name
+                            content=result_content,
+                            command_name=command_name,
+                            is_error=is_error,
                         )
 
         # Stop looking once we hit the next assistant response
@@ -515,7 +519,9 @@ def _create_llm_and_tool_spans(
                 tool_use_id = tool_use.get("id", "")
                 tool_result = tool_results.get(tool_use_id, None)
 
-                if tool_result and tool_result.command_name:
+                # A failed Skill never injected its body, so subsequent spans
+                # should NOT inherit its name (would inflate cost attribution).
+                if tool_result and tool_result.command_name and not tool_result.is_error:
                     active_skill_name = tool_result.command_name
 
                 tool_span = mlflow.start_span_no_context(
@@ -739,10 +745,11 @@ def _build_tool_result_map(messages: list[Any]) -> dict[str, ToolUseResult]:
             # Skill metadata lives on the UserMessage's tool_use_result dict
             # (verified via the SDK at claude_agent_sdk/types.py:1021 and the
             # CLI stream-json wire format). It is NOT on ToolResultBlock.
+            # Use getattr to stay compatible with older SDK versions that
+            # predate the field.
+            tool_use_result = getattr(msg, "tool_use_result", None)
             command_name = (
-                msg.tool_use_result.get("commandName")
-                if isinstance(msg.tool_use_result, dict)
-                else None
+                tool_use_result.get("commandName") if isinstance(tool_use_result, dict) else None
             )
             for block in msg.content:
                 if isinstance(block, ToolResultBlock):
@@ -750,7 +757,9 @@ def _build_tool_result_map(messages: list[Any]) -> dict[str, ToolUseResult]:
                     if isinstance(result, list):
                         result = str(result)
                     tool_result_map[block.tool_use_id] = ToolUseResult(
-                        content=result or "", command_name=command_name
+                        content=result or "",
+                        command_name=command_name,
+                        is_error=bool(getattr(block, "is_error", False)),
                     )
     return tool_result_map
 
@@ -855,7 +864,9 @@ def _create_sdk_child_spans(
                 tool_span.set_outputs({
                     "result": tool_result.content if tool_result else "No result found"
                 })
-                if tool_result and tool_result.command_name:
+                # A failed Skill never injected its body, so subsequent spans
+                # should NOT inherit its name (would inflate cost attribution).
+                if tool_result and tool_result.command_name and not tool_result.is_error:
                     active_skill_name = tool_result.command_name
                 if active_skill_name:
                     tool_span.set_attributes({SpanAttributeKey.SKILL_NAME: active_skill_name})

--- a/mlflow/claude_code/tracing.py
+++ b/mlflow/claude_code/tracing.py
@@ -519,10 +519,20 @@ def _create_llm_and_tool_spans(
                 tool_use_id = tool_use.get("id", "")
                 tool_result = tool_results.get(tool_use_id, None)
 
-                # A failed Skill never injected its body, so subsequent spans
-                # should NOT inherit its name (would inflate cost attribution).
-                if tool_result and tool_result.command_name and not tool_result.is_error:
-                    active_skill_name = tool_result.command_name
+                # Stamp the Skill's own TOOL span with its own commandName for
+                # identification (so a failed Skill is still attributable).
+                # Propagation rules:
+                #   - success: active_skill_name = commandName (child spans inherit)
+                #   - failure: active_skill_name = None (prior skill must not leak
+                #     into recovery spans, and the failed skill itself never
+                #     injected its body so it shouldn't propagate either)
+                if tool_result and tool_result.command_name:
+                    span_skill_name = tool_result.command_name
+                    active_skill_name = (
+                        tool_result.command_name if not tool_result.is_error else None
+                    )
+                else:
+                    span_skill_name = active_skill_name
 
                 tool_span = mlflow.start_span_no_context(
                     name=f"tool_{tool_use.get('name', 'unknown')}",
@@ -534,8 +544,8 @@ def _create_llm_and_tool_spans(
                         "tool_name": tool_use.get("name", "unknown"),
                         "tool_id": tool_use_id,
                         **(
-                            {SpanAttributeKey.SKILL_NAME: active_skill_name}
-                            if active_skill_name
+                            {SpanAttributeKey.SKILL_NAME: span_skill_name}
+                            if span_skill_name
                             else {}
                         ),
                     },
@@ -735,6 +745,37 @@ def _find_sdk_user_prompt(messages: list[Any]) -> str | None:
     return None
 
 
+def _is_real_sdk_user_prompt(messages: list[Any], idx: int) -> bool:
+    """True when messages[idx] is a fresh user prompt — not a tool-result echo,
+    not a skill body injection, not empty. Used to scope skill-name propagation
+    so a skill from a prior turn doesn't leak into a subsequent prompt's spans.
+    """
+    from claude_agent_sdk.types import TextBlock, UserMessage
+
+    msg = messages[idx]
+    if not isinstance(msg, UserMessage) or msg.tool_use_result is not None:
+        return False
+
+    content = msg.content
+    if isinstance(content, str):
+        text = content
+    elif isinstance(content, list):
+        text = "\n".join(b.text for b in content if isinstance(b, TextBlock))
+    else:
+        return False
+    if not text.strip():
+        return False
+
+    # A user message immediately following a Skill tool-result is the CLI
+    # injecting the skill's prompt body — keep skill scope, don't reset it.
+    if idx > 0:
+        prev_tur = getattr(messages[idx - 1], "tool_use_result", None)
+        if isinstance(prev_tur, dict) and prev_tur.get("commandName"):
+            return False
+
+    return True
+
+
 def _build_tool_result_map(messages: list[Any]) -> dict[str, ToolUseResult]:
     """Map tool_use_id to its result content so tool spans can show outputs."""
     from claude_agent_sdk.types import ToolResultBlock, UserMessage
@@ -815,7 +856,10 @@ def _create_sdk_child_spans(
     pending_messages: list[dict[str, Any]] = []
     active_skill_name: str | None = None
 
-    for msg in messages:
+    for idx, msg in enumerate(messages):
+        if _is_real_sdk_user_prompt(messages, idx):
+            active_skill_name = None
+
         if isinstance(msg, AssistantMessage) and msg.content:
             text_blocks = [block for block in msg.content if isinstance(block, TextBlock)]
             tool_blocks = [block for block in msg.content if isinstance(block, ToolUseBlock)]
@@ -864,11 +908,20 @@ def _create_sdk_child_spans(
                 tool_span.set_outputs({
                     "result": tool_result.content if tool_result else "No result found"
                 })
-                # A failed Skill never injected its body, so subsequent spans
-                # should NOT inherit its name (would inflate cost attribution).
-                if tool_result and tool_result.command_name and not tool_result.is_error:
-                    active_skill_name = tool_result.command_name
-                if active_skill_name:
+                # Stamp the Skill's own TOOL span with its own commandName for
+                # identification (failed Skills are still attributable).
+                # Propagation:
+                #   - success: active_skill_name = commandName
+                #   - failure: active_skill_name = None (prior skill must not
+                #     leak into recovery spans)
+                if tool_result and tool_result.command_name:
+                    tool_span.set_attributes({
+                        SpanAttributeKey.SKILL_NAME: tool_result.command_name
+                    })
+                    active_skill_name = (
+                        tool_result.command_name if not tool_result.is_error else None
+                    )
+                elif active_skill_name:
                     tool_span.set_attributes({SpanAttributeKey.SKILL_NAME: active_skill_name})
                 tool_span.end()
 

--- a/mlflow/claude_code/tracing.py
+++ b/mlflow/claude_code/tracing.py
@@ -439,6 +439,11 @@ def _create_llm_and_tool_spans(
     parent_span, transcript: list[dict[str, Any]], start_idx: int
 ) -> None:
     """Create LLM and tool spans for assistant responses with proper timing."""
+
+    # Keeps track of the active skill name as all child spans of active skills
+    # need to be tagged for cost attribution purposes
+    active_skill_name: str | None = None
+
     for i in range(start_idx, len(transcript)):
         entry = transcript[i]
         if entry.get(MESSAGE_FIELD_TYPE) != MESSAGE_TYPE_ASSISTANT:
@@ -476,6 +481,11 @@ def _create_llm_and_tool_spans(
                 attributes={
                     "model": msg.get("model", "unknown"),
                     SpanAttributeKey.MESSAGE_FORMAT: "anthropic",
+                    **(
+                        {SpanAttributeKey.SKILL_NAME: active_skill_name}
+                        if active_skill_name
+                        else {}
+                    ),
                 },
             )
 
@@ -500,6 +510,9 @@ def _create_llm_and_tool_spans(
                 tool_use_id = tool_use.get("id", "")
                 tool_result = tool_results.get(tool_use_id, None)
 
+                if tool_result and tool_result.command_name:
+                    active_skill_name = tool_result.command_name
+
                 tool_span = mlflow.start_span_no_context(
                     name=f"tool_{tool_use.get('name', 'unknown')}",
                     parent_span=parent_span,
@@ -510,8 +523,8 @@ def _create_llm_and_tool_spans(
                         "tool_name": tool_use.get("name", "unknown"),
                         "tool_id": tool_use_id,
                         **(
-                            {SpanAttributeKey.SKILL_NAME: tool_result.command_name}
-                            if tool_result and tool_result.command_name
+                            {SpanAttributeKey.SKILL_NAME: active_skill_name}
+                            if active_skill_name
                             else {}
                         ),
                     },
@@ -779,6 +792,7 @@ def _create_sdk_child_spans(
 
     final_response = None
     pending_messages: list[dict[str, Any]] = []
+    active_skill_name: str | None = None
 
     for msg in messages:
         if isinstance(msg, AssistantMessage) and msg.content:
@@ -801,6 +815,11 @@ def _create_sdk_child_spans(
                     attributes={
                         "model": getattr(msg, "model", "unknown"),
                         SpanAttributeKey.MESSAGE_FORMAT: "anthropic",
+                        **(
+                            {SpanAttributeKey.SKILL_NAME: active_skill_name}
+                            if active_skill_name
+                            else {}
+                        ),
                     },
                 )
                 llm_span.set_outputs({
@@ -825,9 +844,9 @@ def _create_sdk_child_spans(
                     "result": tool_result.content if tool_result else "No result found"
                 })
                 if tool_result and tool_result.command_name:
-                    tool_span.set_attributes({
-                        SpanAttributeKey.SKILL_NAME: tool_result.command_name
-                    })
+                    active_skill_name = tool_result.command_name
+                if active_skill_name:
+                    tool_span.set_attributes({SpanAttributeKey.SKILL_NAME: active_skill_name})
                 tool_span.end()
 
         if anthropic_msg := _serialize_sdk_message(msg):

--- a/mlflow/claude_code/tracing.py
+++ b/mlflow/claude_code/tracing.py
@@ -57,7 +57,7 @@ CLAUDE_TRACING_LEVEL = logging.WARNING - 5
 
 
 # ============================================================================
-# CONSTANTS
+# TYPES
 # ============================================================================
 @dataclasses.dataclass
 class ToolUseResult:
@@ -731,7 +731,7 @@ def _find_sdk_user_prompt(messages: list[Any]) -> str | None:
     from claude_agent_sdk.types import TextBlock, UserMessage
 
     for msg in messages:
-        if not isinstance(msg, UserMessage) or msg.tool_use_result is not None:
+        if not isinstance(msg, UserMessage) or getattr(msg, "tool_use_result", None) is not None:
             continue
         content = msg.content
         if isinstance(content, str):
@@ -753,7 +753,7 @@ def _is_real_sdk_user_prompt(messages: list[Any], idx: int) -> bool:
     from claude_agent_sdk.types import TextBlock, UserMessage
 
     msg = messages[idx]
-    if not isinstance(msg, UserMessage) or msg.tool_use_result is not None:
+    if not isinstance(msg, UserMessage) or getattr(msg, "tool_use_result", None) is not None:
         return False
 
     content = msg.content

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -4994,10 +4994,11 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
 
                 content_json = json.dumps(span_dict, cls=TraceJSONEncoder)
 
-                # Prepare dimension attributes with model name and provider if available
+                # Prepare dimension attributes with model name, provider and skill name if available
                 dimension_attribute_keys = [
                     SpanAttributeKey.MODEL,
                     SpanAttributeKey.MODEL_PROVIDER,
+                    SpanAttributeKey.SKILL_NAME,
                 ]
                 dimension_attributes = {}
                 for key in dimension_attribute_keys:

--- a/mlflow/store/tracking/utils/sql_trace_metrics_utils.py
+++ b/mlflow/store/tracking/utils/sql_trace_metrics_utils.py
@@ -107,10 +107,13 @@ SPANS_METRICS_CONFIGS: dict[SpanMetricKey, TraceMetricsConfig] = {
     ),
     SpanMetricKey.LATENCY: TraceMetricsConfig(
         aggregation_types={AggregationType.AVG, AggregationType.PERCENTILE},
+        # No SPAN_SKILL_NAME: per-span latency averaged across a skill's spans
+        # blends fast tool spans with slow LLM spans, so it reflects span mix
+        # rather than skill speed. Skill wall-clock duration is a separate
+        # scope-level aggregation (needs a per-invocation id) — revisit then.
         dimensions={
             SpanMetricDimensionKey.SPAN_NAME,
             SpanMetricDimensionKey.SPAN_STATUS,
-            SpanMetricDimensionKey.SPAN_SKILL_NAME,
         },
     ),
     SpanMetricKey.INPUT_COST: TraceMetricsConfig(

--- a/mlflow/store/tracking/utils/sql_trace_metrics_utils.py
+++ b/mlflow/store/tracking/utils/sql_trace_metrics_utils.py
@@ -102,17 +102,23 @@ SPANS_METRICS_CONFIGS: dict[SpanMetricKey, TraceMetricsConfig] = {
             SpanMetricDimensionKey.SPAN_STATUS,
             SpanMetricDimensionKey.SPAN_MODEL_NAME,
             SpanMetricDimensionKey.SPAN_MODEL_PROVIDER,
+            SpanMetricDimensionKey.SPAN_SKILL_NAME,
         },
     ),
     SpanMetricKey.LATENCY: TraceMetricsConfig(
         aggregation_types={AggregationType.AVG, AggregationType.PERCENTILE},
-        dimensions={SpanMetricDimensionKey.SPAN_NAME, SpanMetricDimensionKey.SPAN_STATUS},
+        dimensions={
+            SpanMetricDimensionKey.SPAN_NAME,
+            SpanMetricDimensionKey.SPAN_STATUS,
+            SpanMetricDimensionKey.SPAN_SKILL_NAME,
+        },
     ),
     SpanMetricKey.INPUT_COST: TraceMetricsConfig(
         aggregation_types={AggregationType.SUM, AggregationType.AVG, AggregationType.PERCENTILE},
         dimensions={
             SpanMetricDimensionKey.SPAN_MODEL_NAME,
             SpanMetricDimensionKey.SPAN_MODEL_PROVIDER,
+            SpanMetricDimensionKey.SPAN_SKILL_NAME,
         },
     ),
     SpanMetricKey.OUTPUT_COST: TraceMetricsConfig(
@@ -120,6 +126,7 @@ SPANS_METRICS_CONFIGS: dict[SpanMetricKey, TraceMetricsConfig] = {
         dimensions={
             SpanMetricDimensionKey.SPAN_MODEL_NAME,
             SpanMetricDimensionKey.SPAN_MODEL_PROVIDER,
+            SpanMetricDimensionKey.SPAN_SKILL_NAME,
         },
     ),
     SpanMetricKey.TOTAL_COST: TraceMetricsConfig(
@@ -127,6 +134,7 @@ SPANS_METRICS_CONFIGS: dict[SpanMetricKey, TraceMetricsConfig] = {
         dimensions={
             SpanMetricDimensionKey.SPAN_MODEL_NAME,
             SpanMetricDimensionKey.SPAN_MODEL_PROVIDER,
+            SpanMetricDimensionKey.SPAN_SKILL_NAME,
         },
     ),
 }
@@ -439,6 +447,12 @@ def _apply_dimension_to_query(
                         db_type,
                         SpanAttributeKey.MODEL_PROVIDER,
                         SpanMetricDimensionKey.SPAN_MODEL_PROVIDER,
+                    )
+                case SpanMetricDimensionKey.SPAN_SKILL_NAME:
+                    return query, _get_json_dimension_column(
+                        db_type,
+                        SpanAttributeKey.SKILL_NAME,
+                        SpanMetricDimensionKey.SPAN_SKILL_NAME,
                     )
         case MetricViewType.ASSESSMENTS:
             match dimension:

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -143,7 +143,9 @@ class SpanAttributeKey:
     # survive OTLP export and can be restored to SqlTraceTag rows on the server side.
     # Each attribute is keyed as "mlflow.traceTag.<tag_key>" with the plain string value.
     TRACE_TAG_PREFIX = "mlflow.traceTag."
-    # This attribute, if set, indicates that tool call is a skill and the skill name is the value.
+    # Identifies the active skill scope for a span. Set on the Skill tool span itself and
+    # propagated to descendant LLM/TOOL/AGENT spans created within the skill body, so cost and
+    # latency can be attributed back to the originating skill.
     SKILL_NAME = "mlflow.skill.name"
 
 

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -143,6 +143,8 @@ class SpanAttributeKey:
     # survive OTLP export and can be restored to SqlTraceTag rows on the server side.
     # Each attribute is keyed as "mlflow.traceTag.<tag_key>" with the plain string value.
     TRACE_TAG_PREFIX = "mlflow.traceTag."
+    # This attribute, if set, indicates that tool call is a skill and the skill name is the value.
+    SKILL_NAME = "mlflow.skill.name"
 
 
 class TraceExperimentTagKey:
@@ -278,6 +280,7 @@ class SpanMetricDimensionKey:
     SPAN_STATUS = "span_status"
     SPAN_MODEL_NAME = "span_model_name"
     SPAN_MODEL_PROVIDER = "span_model_provider"
+    SPAN_SKILL_NAME = "span_skill_name"
 
 
 class AssessmentMetricKey:

--- a/tests/claude_code/test_autolog.py
+++ b/tests/claude_code/test_autolog.py
@@ -124,6 +124,63 @@ async def test_query_captures_async_generator_prompt():
 
 
 @pytest.mark.asyncio
+async def test_async_iterable_multi_prompt_captures_all_user_messages():
+    """Covers the autolog `hasattr(prompt, "__aiter__")` branch — verifies
+    that a streaming prompt yielding multiple dict-shaped user items causes
+    each to be captured as a UserMessage in the cumulative messages list
+    that gets handed to process_sdk_messages.
+
+    The live-SDK equivalent test was blocked by the SDK's bidirectional
+    streaming protocol; this unit test isolates the only AsyncIterable-
+    specific code path (the capturing_prompt wrapper).
+    """
+    mock_self = MagicMock()
+
+    async def fake_query(prompt, *args, **kwargs):
+        async for _ in prompt:
+            pass
+
+    mock_self.query = fake_query
+
+    response_messages = [
+        AssistantMessage(content=[TextBlock(text="ok")], model="claude-sonnet-4-20250514"),
+        ResultMessage(
+            subtype="success",
+            duration_ms=100,
+            duration_api_ms=80,
+            is_error=False,
+            num_turns=2,
+            session_id="async-multi",
+        ),
+    ]
+    _patch_sdk_init(mock_self, response_messages)
+
+    async def prompt_generator():
+        yield {"type": "user", "message": {"role": "user", "content": "first prompt"}}
+        yield {"type": "user", "message": {"role": "user", "content": "second prompt"}}
+        # Non-user items must be passed through but not captured.
+        yield {"type": "system", "message": {"foo": "bar"}}
+        # Empty content must not be captured.
+        yield {"type": "user", "message": {"role": "user", "content": "   "}}
+        # Non-string content must not be captured.
+        yield {"type": "user", "message": {"role": "user", "content": ["block"]}}
+
+    with (
+        patch("mlflow.utils.autologging_utils.autologging_is_disabled", return_value=False),
+        patch("mlflow.claude_code.tracing.process_sdk_messages") as mock_process,
+    ):
+        await mock_self.query(prompt_generator())
+        [msg async for msg in mock_self.receive_response()]
+
+    mock_process.assert_called_once()
+    called_messages = mock_process.call_args[0][0]
+    user_messages = [m for m in called_messages if isinstance(m, UserMessage)]
+    assert len(user_messages) == 2
+    assert user_messages[0].content == "first prompt"
+    assert user_messages[1].content == "second prompt"
+
+
+@pytest.mark.asyncio
 async def test_receive_response_skips_when_autologging_disabled():
     mock_self = MagicMock()
     _patch_sdk_init(mock_self, ["msg1", "msg2"])

--- a/tests/claude_code/test_tracing.py
+++ b/tests/claude_code/test_tracing.py
@@ -908,6 +908,38 @@ def test_process_transcript_includes_steer_messages(tmp_path):
 # ============================================================================
 # SKILL ATTRIBUTE PROPAGATION TESTS
 # ============================================================================
+#
+# Canonical Skill wire format (used by every test below).
+#
+# When the user invokes a Skill, the Claude Code CLI emits TWO distinct
+# user-role stream entries on the happy path:
+#
+#   [assistant] tool_use(id=X, name="Skill", input={"skill": "<name>"})
+#   [user]      tool_result(tool_use_id=X)               ← success result
+#                 + toolUseResult.commandName = "<name>"
+#                 + toolUseResult.success    = True
+#   [user]      text "<skill body>"                      ← synthetic body injection
+#   [assistant] ... continuation (work inside the skill body) ...
+#
+# At the API layer the SDK merges the two user entries into one message with
+# two content blocks (tool_result + text) before sending. At the stream/
+# transcript layer they remain as two consecutive user entries, which is what
+# this file's test fixtures should reflect.
+#
+# On the FAILED path (is_error=True), the CLI does NOT emit a body injection
+# — the skill never bootstraps — so the failed fixtures stop at the
+# tool_result and the assistant's next turn is recovery work:
+#
+#   [assistant] tool_use(id=X, name="Skill", ...)
+#   [user]      tool_result(tool_use_id=X, is_error=True)
+#                 + toolUseResult.commandName = "<name>"
+#                 + toolUseResult.success    = False
+#   [assistant] "recovering..."                          ← NO body injection
+#
+# Tests below follow this convention. If you're adding a new happy-path
+# skill test and the body-injection user entry seems redundant for your
+# assertion, add it anyway — keeping every fixture wire-format-accurate
+# saves the next contributor from wondering whether they or the test is wrong.
 
 
 def _skill_transcript_with_child_work() -> list[dict[Any, Any]]:
@@ -970,6 +1002,12 @@ def _skill_transcript_with_child_work() -> list[dict[Any, Any]]:
                 ],
             },
             "timestamp": "2025-01-15T10:00:04.000Z",
+        },
+        # Synthetic body injection emitted by the CLI on the happy path.
+        {
+            "type": "user",
+            "message": {"role": "user", "content": [{"type": "text", "text": "<my-skill body>"}]},
+            "timestamp": "2025-01-15T10:00:04.500Z",
         },
         # Child LLM turn after the skill — should inherit the skill name.
         {
@@ -1052,6 +1090,8 @@ def test_process_sdk_messages_propagates_skill_to_child_spans():
             content=[ToolResultBlock(tool_use_id="skill_tool", content="Launching skill")],
             tool_use_result={"success": True, "commandName": "my-skill"},
         ),
+        # Synthetic body injection emitted by the CLI on the happy path.
+        UserMessage(content="<my-skill body>", tool_use_result=None),
         # Child LLM turn — should inherit.
         AssistantMessage(
             content=[TextBlock(text="Thinking inside the skill.")],
@@ -1176,7 +1216,7 @@ def test_process_transcript_failed_skill_does_not_propagate(tmp_path):
     assert trace is not None
     spans = list(trace.search_spans())
 
-    # The failed Skill's OWN span IS stamped with its commandName (M1) so
+    # The failed Skill's OWN span IS stamped with its commandName so
     # operators can attribute the failure to a specific skill.
     skill_spans = [s for s in spans if s.attributes.get("tool_id") == "skill_tool"]
     assert len(skill_spans) == 1
@@ -1221,7 +1261,7 @@ def test_process_sdk_messages_failed_skill_does_not_propagate():
     assert trace is not None
     spans = list(trace.search_spans())
 
-    # The failed Skill's OWN span IS stamped with its commandName (M1).
+    # The failed Skill's OWN span IS stamped with its commandName.
     skill_spans = [s for s in spans if s.attributes.get("tool_id") == "skill_tool"]
     assert len(skill_spans) == 1
     assert skill_spans[0].get_attribute(SpanAttributeKey.SKILL_NAME) == "broken"
@@ -1264,6 +1304,8 @@ def test_process_sdk_messages_skill_does_not_bleed_across_user_prompts():
             content=[ToolResultBlock(tool_use_id="skill_tool", content="Launching")],
             tool_use_result={"success": True, "commandName": "prd-writer"},
         ),
+        # Synthetic body injection emitted by the CLI on the happy path.
+        UserMessage(content="<prd-writer body>", tool_use_result=None),
         AssistantMessage(
             content=[TextBlock(text="PRD body produced under the skill.")],
             model="claude-sonnet-4-20250514",
@@ -1405,6 +1447,12 @@ def _skill_transcript_with_prior_skill_then_failed_skill() -> list[dict[Any, Any
             },
             "timestamp": "2025-01-15T10:00:02.000Z",
         },
+        # Synthetic body injection for skill-a's happy-path boot.
+        {
+            "type": "user",
+            "message": {"role": "user", "content": [{"type": "text", "text": "<skill-a body>"}]},
+            "timestamp": "2025-01-15T10:00:02.500Z",
+        },
         # Skill B — fails.
         {
             "type": "assistant",
@@ -1486,12 +1534,12 @@ def test_process_transcript_failed_skill_clears_prior_skill_scope(tmp_path):
     assert len(skill_a) == 1
     assert skill_a[0].get_attribute(SpanAttributeKey.SKILL_NAME) == "skill-a"
 
-    # Skill B's own span carries skill-b (M1).
+    # Skill B's own span carries skill-b.
     skill_b = [s for s in spans if s.attributes.get("tool_id") == "skill_b"]
     assert len(skill_b) == 1
     assert skill_b[0].get_attribute(SpanAttributeKey.SKILL_NAME) == "skill-b"
 
-    # Recovery work after the failure must NOT inherit either skill name (M2).
+    # Recovery work after the failure must NOT inherit either skill name.
     recovery_llm = [s for s in spans if s.span_type == SpanType.LLM]
     assert len(recovery_llm) == 1
     assert recovery_llm[0].get_attribute(SpanAttributeKey.SKILL_NAME) is None
@@ -1513,6 +1561,8 @@ def test_process_sdk_messages_failed_skill_clears_prior_skill_scope():
             content=[ToolResultBlock(tool_use_id="skill_a", content="launched")],
             tool_use_result={"success": True, "commandName": "skill-a"},
         ),
+        # Synthetic body injection for skill-a's happy-path boot.
+        UserMessage(content="<skill-a body>", tool_use_result=None),
         # Skill B — fails.
         AssistantMessage(
             content=[ToolUseBlock(id="skill_b", name="Skill", input={"skill": "skill-b"})],
@@ -1561,3 +1611,221 @@ def test_process_sdk_messages_failed_skill_clears_prior_skill_scope():
     recovery_bash = [s for s in spans if s.attributes.get("tool_id") == "recovery_bash"]
     assert len(recovery_bash) == 1
     assert recovery_bash[0].get_attribute(SpanAttributeKey.SKILL_NAME) is None
+
+
+def _nested_skill_transcript() -> list[dict[Any, Any]]:
+    """3-level nesting: Skill A's body invokes Skill B; B's body invokes Skill C.
+
+    The user-invoked skill is A. Ideally every span produced while A is running
+    (including B's and C's own TOOL spans and the LLM reasoning under them)
+    should be attributed to skill-A — B and C are implementation details of A.
+    The single-slot state machine doesn't preserve that outer scope, which is
+    what this test documents.
+    """
+    return [
+        {
+            "type": "user",
+            "message": {"role": "user", "content": "use skill A"},
+            "timestamp": "2026-06-05T10:00:00Z",
+        },
+        # Skill A
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "ta", "name": "Skill", "input": {"skill": "A"}}
+                ],
+            },
+            "timestamp": "2026-06-05T10:00:01Z",
+        },
+        {
+            "type": "user",
+            "toolUseResult": {"success": True, "commandName": "skill-A"},
+            "message": {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "ta", "content": "launch A"}],
+            },
+            "timestamp": "2026-06-05T10:00:02Z",
+        },
+        # A's body injection
+        {
+            "type": "user",
+            "message": {"role": "user", "content": [{"type": "text", "text": "A body"}]},
+            "timestamp": "2026-06-05T10:00:03Z",
+        },
+        # A reasoning
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "A reasoning"}],
+            },
+            "timestamp": "2026-06-05T10:00:04Z",
+        },
+        # Skill B (invoked from inside A)
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "tb", "name": "Skill", "input": {"skill": "B"}}
+                ],
+            },
+            "timestamp": "2026-06-05T10:00:05Z",
+        },
+        {
+            "type": "user",
+            "toolUseResult": {"success": True, "commandName": "skill-B"},
+            "message": {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "tb", "content": "launch B"}],
+            },
+            "timestamp": "2026-06-05T10:00:06Z",
+        },
+        # B's body injection
+        {
+            "type": "user",
+            "message": {"role": "user", "content": [{"type": "text", "text": "B body"}]},
+            "timestamp": "2026-06-05T10:00:07Z",
+        },
+        # B reasoning
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "B reasoning"}],
+            },
+            "timestamp": "2026-06-05T10:00:08Z",
+        },
+        # Skill C (invoked from inside B)
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "tc", "name": "Skill", "input": {"skill": "C"}}
+                ],
+            },
+            "timestamp": "2026-06-05T10:00:09Z",
+        },
+        {
+            "type": "user",
+            "toolUseResult": {"success": True, "commandName": "skill-C"},
+            "message": {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "tc", "content": "launch C"}],
+            },
+            "timestamp": "2026-06-05T10:00:10Z",
+        },
+        # C's body injection
+        {
+            "type": "user",
+            "message": {"role": "user", "content": [{"type": "text", "text": "C body"}]},
+            "timestamp": "2026-06-05T10:00:11Z",
+        },
+        # Deepest: C reasoning
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "C reasoning (deepest)"}],
+            },
+            "timestamp": "2026-06-05T10:00:12Z",
+        },
+        # Unwinding: C done, back to B's continuation (semantically)
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "back to B"}],
+            },
+            "timestamp": "2026-06-05T10:00:13Z",
+        },
+        # Unwinding: B done, back to A
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "back to A"}],
+            },
+            "timestamp": "2026-06-05T10:00:14Z",
+        },
+        # Unwinding: A done, final reply to user
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "final reply"}],
+            },
+            "timestamp": "2026-06-05T10:00:15Z",
+        },
+    ]
+
+
+def test_process_transcript_nested_skills_outer_scope_lost(tmp_path):
+    """KNOWN LIMITATION (documented): The single-slot state machine doesn't
+    preserve the outer skill's scope across nested invocations.
+
+    Ideal attribution: the user invoked skill-A, so every span produced while
+    A is running — B's TOOL span, C's TOOL span, and all of B/C's reasoning
+    LLMs — should be tagged skill-A. B and C are implementation details of A.
+
+    Actual behavior: each nested Skill overwrites the active scope, so B's
+    work is tagged skill-B, C's work is tagged skill-C, and the trailing
+    unwind LLMs keep skill-C because there's no stack to pop.
+
+    Set a breakpoint in `_create_llm_and_tool_spans` at the
+    `active_skill_name = ...` assignment to step through this.
+    """
+    transcript_path = tmp_path / "nested.jsonl"
+    transcript_path.write_text("\n".join(json.dumps(e) for e in _nested_skill_transcript()) + "\n")
+
+    trace = process_transcript(str(transcript_path), "nested-skill-test")
+    assert trace is not None
+    spans = list(trace.search_spans())
+
+    # Each Skill's OWN TOOL span is stamped with its own commandName via the
+    # own-span pass (identification). Ideally these should also report skill-A
+    # as the outer scope, but the single slot can only hold one value.
+    assert (
+        next(s for s in spans if s.attributes.get("tool_id") == "ta").get_attribute(
+            SpanAttributeKey.SKILL_NAME
+        )
+        == "skill-A"
+    )
+    # ↓ THE LIMITATION (own-span): tb/tc are tagged with themselves; the outer
+    #   skill-A scope is lost. Ideally both would be skill-A.
+    assert (
+        next(s for s in spans if s.attributes.get("tool_id") == "tb").get_attribute(
+            SpanAttributeKey.SKILL_NAME
+        )
+        == "skill-B"
+    )
+    assert (
+        next(s for s in spans if s.attributes.get("tool_id") == "tc").get_attribute(
+            SpanAttributeKey.SKILL_NAME
+        )
+        == "skill-C"
+    )
+
+    # LLM spans, ordered by their text content (proxy for chronological order).
+    def llm_with_text(text: str):
+        return next(
+            s
+            for s in spans
+            if s.span_type == SpanType.LLM and text in str(s.outputs.get("content", ""))
+        )
+
+    # Inside-A reasoning: tagged skill-A (correct).
+    assert llm_with_text("A reasoning").get_attribute(SpanAttributeKey.SKILL_NAME) == "skill-A"
+
+    # ↓ THE LIMITATION (propagation): once a nested skill is invoked, the slot
+    #   is overwritten and all descendants get the inner skill's name. Ideally
+    #   every LLM below should still be tagged skill-A — A is the user-invoked
+    #   skill and B/C are implementation details of A.
+    assert llm_with_text("B reasoning").get_attribute(SpanAttributeKey.SKILL_NAME) == "skill-B"
+    assert llm_with_text("C reasoning").get_attribute(SpanAttributeKey.SKILL_NAME) == "skill-C"
+    assert llm_with_text("back to B").get_attribute(SpanAttributeKey.SKILL_NAME) == "skill-C"
+    assert llm_with_text("back to A").get_attribute(SpanAttributeKey.SKILL_NAME) == "skill-C"
+    assert llm_with_text("final reply").get_attribute(SpanAttributeKey.SKILL_NAME) == "skill-C"

--- a/tests/claude_code/test_tracing.py
+++ b/tests/claude_code/test_tracing.py
@@ -2,6 +2,7 @@ import importlib
 import json
 import logging
 from pathlib import Path
+from typing import Any
 
 import pytest
 from claude_agent_sdk.types import (
@@ -902,4 +903,194 @@ def test_process_transcript_includes_steer_messages(tmp_path):
     input_messages = second_llm.inputs["messages"]
     steer_messages = [m for m in input_messages if m.get("content") == "also tell me about Java"]
     assert len(steer_messages) == 1
-    assert steer_messages[0]["role"] == "user"
+
+
+# ============================================================================
+# SKILL ATTRIBUTE PROPAGATION TESTS
+# ============================================================================
+
+
+def _skill_transcript_with_child_work() -> list[dict[Any, Any]]:
+    """Transcript where a Skill invocation is followed by a child LLM turn and
+    a child Bash tool call — both should inherit mlflow.skill.name = "my-skill".
+
+    A pre-skill Bash call is included to verify it is NOT tagged (it happened
+    before the skill was invoked).
+    """
+    return [
+        {
+            "type": "user",
+            "message": {"role": "user", "content": "Do the thing."},
+            "timestamp": "2025-01-15T10:00:00.000Z",
+        },
+        # Pre-skill tool call — must NOT inherit the skill name.
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "id": "pre_bash", "name": "Bash", "input": {}}],
+            },
+            "timestamp": "2025-01-15T10:00:01.000Z",
+        },
+        {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "pre_bash", "content": "ok"}],
+            },
+            "timestamp": "2025-01-15T10:00:02.000Z",
+        },
+        # Skill invocation.
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "skill_tool",
+                        "name": "Skill",
+                        "input": {"skill": "my-skill"},
+                    }
+                ],
+            },
+            "timestamp": "2025-01-15T10:00:03.000Z",
+        },
+        {
+            "type": "user",
+            "toolUseResult": {"success": True, "commandName": "my-skill"},
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "skill_tool",
+                        "content": "Launching skill",
+                    }
+                ],
+            },
+            "timestamp": "2025-01-15T10:00:04.000Z",
+        },
+        # Child LLM turn after the skill — should inherit the skill name.
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Thinking inside the skill."}],
+                "model": "claude-sonnet-4-20250514",
+            },
+            "timestamp": "2025-01-15T10:00:05.000Z",
+        },
+        # Child tool call after the skill — should also inherit the skill name.
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "id": "child_bash", "name": "Bash", "input": {}}],
+            },
+            "timestamp": "2025-01-15T10:00:06.000Z",
+        },
+        {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "child_bash", "content": "done"}
+                ],
+            },
+            "timestamp": "2025-01-15T10:00:07.000Z",
+        },
+    ]
+
+
+def test_process_transcript_propagates_skill_to_child_spans(tmp_path):
+    transcript_path = tmp_path / "skill_transcript.jsonl"
+    transcript_path.write_text(
+        "\n".join(json.dumps(e) for e in _skill_transcript_with_child_work()) + "\n"
+    )
+
+    trace = process_transcript(str(transcript_path), "skill-prop-session")
+    assert trace is not None
+
+    spans = list(trace.search_spans())
+
+    # Pre-skill Bash is NOT tagged.
+    pre_bash = [s for s in spans if s.attributes.get("tool_id") == "pre_bash"]
+    assert len(pre_bash) == 1
+    assert pre_bash[0].get_attribute(SpanAttributeKey.SKILL_NAME) is None
+
+    # Skill TOOL span is tagged with its own command name.
+    skill_spans = [s for s in spans if s.attributes.get("tool_id") == "skill_tool"]
+    assert len(skill_spans) == 1
+    assert skill_spans[0].get_attribute(SpanAttributeKey.SKILL_NAME) == "my-skill"
+
+    # Post-skill LLM span inherits the skill name.
+    post_skill_llm = [
+        s
+        for s in spans
+        if s.span_type == SpanType.LLM
+        and s.outputs.get("content", [{}])[0].get("text") == "Thinking inside the skill."
+    ]
+    assert len(post_skill_llm) == 1
+    assert post_skill_llm[0].get_attribute(SpanAttributeKey.SKILL_NAME) == "my-skill"
+
+    # Child Bash tool inherits the skill name.
+    child_bash = [s for s in spans if s.attributes.get("tool_id") == "child_bash"]
+    assert len(child_bash) == 1
+    assert child_bash[0].get_attribute(SpanAttributeKey.SKILL_NAME) == "my-skill"
+
+
+def test_process_sdk_messages_propagates_skill_to_child_spans():
+    messages = [
+        UserMessage(content="Do the thing."),
+        # Skill invocation.
+        AssistantMessage(
+            content=[ToolUseBlock(id="skill_tool", name="Skill", input={"skill": "my-skill"})],
+            model="claude-sonnet-4-20250514",
+        ),
+        UserMessage(
+            content=[ToolResultBlock(tool_use_id="skill_tool", content="Launching skill")],
+            tool_use_result={"success": True, "commandName": "my-skill"},
+        ),
+        # Child LLM turn — should inherit.
+        AssistantMessage(
+            content=[TextBlock(text="Thinking inside the skill.")],
+            model="claude-sonnet-4-20250514",
+        ),
+        # Child Bash tool — should inherit.
+        AssistantMessage(
+            content=[ToolUseBlock(id="child_bash", name="Bash", input={})],
+            model="claude-sonnet-4-20250514",
+        ),
+        UserMessage(content=[ToolResultBlock(tool_use_id="child_bash", content="done")]),
+        ResultMessage(
+            subtype="success",
+            duration_ms=1000,
+            duration_api_ms=800,
+            is_error=False,
+            num_turns=3,
+            session_id="sdk-skill-prop",
+        ),
+    ]
+
+    trace = process_sdk_messages(messages, "sdk-skill-prop")
+    assert trace is not None
+
+    spans = list(trace.search_spans())
+
+    skill_spans = [s for s in spans if s.attributes.get("tool_id") == "skill_tool"]
+    assert len(skill_spans) == 1
+    assert skill_spans[0].get_attribute(SpanAttributeKey.SKILL_NAME) == "my-skill"
+
+    post_skill_llm = [
+        s
+        for s in spans
+        if s.span_type == SpanType.LLM
+        and "Thinking inside the skill." in str(s.outputs.get("content", ""))
+    ]
+    assert len(post_skill_llm) == 1
+    assert post_skill_llm[0].get_attribute(SpanAttributeKey.SKILL_NAME) == "my-skill"
+
+    child_bash = [s for s in spans if s.attributes.get("tool_id") == "child_bash"]
+    assert len(child_bash) == 1
+    assert child_bash[0].get_attribute(SpanAttributeKey.SKILL_NAME) == "my-skill"

--- a/tests/claude_code/test_tracing.py
+++ b/tests/claude_code/test_tracing.py
@@ -1272,12 +1272,10 @@ def test_process_sdk_messages_failed_skill_does_not_propagate():
     assert post_llm[0].get_attribute(SpanAttributeKey.SKILL_NAME) is None
 
 
-def test_build_tool_result_map_tolerates_missing_tool_use_result_attr():
-    # Older claude_agent_sdk versions did not expose UserMessage.tool_use_result.
-    # _build_tool_result_map uses getattr with a default so the function is
-    # safe regardless of whether the attribute exists on the class. We can't
-    # easily strip the attribute from the real UserMessage dataclass, so this
-    # test verifies the explicit-None case (the bulk of the real-world risk).
+def test_build_tool_result_map_handles_none_tool_use_result():
+    # When UserMessage.tool_use_result is None (the common case for non-Skill
+    # tool calls), _build_tool_result_map should still emit an entry with
+    # command_name=None and is_error=False.
     from mlflow.claude_code.tracing import _build_tool_result_map
 
     msg = UserMessage(

--- a/tests/claude_code/test_tracing.py
+++ b/tests/claude_code/test_tracing.py
@@ -1094,3 +1094,146 @@ def test_process_sdk_messages_propagates_skill_to_child_spans():
     child_bash = [s for s in spans if s.attributes.get("tool_id") == "child_bash"]
     assert len(child_bash) == 1
     assert child_bash[0].get_attribute(SpanAttributeKey.SKILL_NAME) == "my-skill"
+
+
+def _skill_transcript_with_failed_skill() -> list[dict[Any, Any]]:
+    """Transcript where a Skill invocation fails (is_error=True). Subsequent
+    spans should NOT inherit the skill name — a failed skill never injected
+    its body, so attributing later work to it inflates cost.
+    """
+    return [
+        {
+            "type": "user",
+            "message": {"role": "user", "content": "Do the thing."},
+            "timestamp": "2025-01-15T10:00:00.000Z",
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "skill_tool",
+                        "name": "Skill",
+                        "input": {"skill": "broken-skill"},
+                    }
+                ],
+            },
+            "timestamp": "2025-01-15T10:00:01.000Z",
+        },
+        {
+            "type": "user",
+            "toolUseResult": {"success": False, "commandName": "broken-skill"},
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "skill_tool",
+                        "content": "Skill failed to launch",
+                        "is_error": True,
+                    }
+                ],
+            },
+            "timestamp": "2025-01-15T10:00:02.000Z",
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "I'll try a different approach."}],
+                "model": "claude-sonnet-4-20250514",
+            },
+            "timestamp": "2025-01-15T10:00:03.000Z",
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "id": "post_bash", "name": "Bash", "input": {}}],
+            },
+            "timestamp": "2025-01-15T10:00:04.000Z",
+        },
+        {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "post_bash", "content": "ok"}],
+            },
+            "timestamp": "2025-01-15T10:00:05.000Z",
+        },
+    ]
+
+
+def test_process_transcript_failed_skill_does_not_propagate(tmp_path):
+    transcript_path = tmp_path / "failed_skill_transcript.jsonl"
+    transcript_path.write_text(
+        "\n".join(json.dumps(e) for e in _skill_transcript_with_failed_skill()) + "\n"
+    )
+
+    trace = process_transcript(str(transcript_path), "failed-skill-session")
+    assert trace is not None
+    spans = list(trace.search_spans())
+
+    # Post-skill LLM and tool spans must NOT be tagged with broken-skill.
+    post_llm = [s for s in spans if s.span_type == SpanType.LLM]
+    for s in post_llm:
+        assert s.get_attribute(SpanAttributeKey.SKILL_NAME) is None
+
+    post_bash = [s for s in spans if s.attributes.get("tool_id") == "post_bash"]
+    assert len(post_bash) == 1
+    assert post_bash[0].get_attribute(SpanAttributeKey.SKILL_NAME) is None
+
+
+def test_process_sdk_messages_failed_skill_does_not_propagate():
+    messages = [
+        UserMessage(content="Do the thing."),
+        AssistantMessage(
+            content=[ToolUseBlock(id="skill_tool", name="Skill", input={"skill": "broken"})],
+            model="claude-sonnet-4-20250514",
+        ),
+        UserMessage(
+            content=[ToolResultBlock(tool_use_id="skill_tool", content="failed", is_error=True)],
+            tool_use_result={"success": False, "commandName": "broken"},
+        ),
+        AssistantMessage(
+            content=[TextBlock(text="trying again")],
+            model="claude-sonnet-4-20250514",
+        ),
+        ResultMessage(
+            subtype="success",
+            duration_ms=100,
+            duration_api_ms=80,
+            is_error=False,
+            num_turns=2,
+            session_id="failed-sdk-skill",
+        ),
+    ]
+
+    trace = process_sdk_messages(messages, "failed-sdk-skill")
+    assert trace is not None
+    spans = list(trace.search_spans())
+
+    # Post-failure LLM span must NOT be tagged with the failed skill name.
+    post_llm = [s for s in spans if s.span_type == SpanType.LLM]
+    assert len(post_llm) == 1
+    assert post_llm[0].get_attribute(SpanAttributeKey.SKILL_NAME) is None
+
+
+def test_build_tool_result_map_tolerates_missing_tool_use_result_attr():
+    # Older claude_agent_sdk versions did not expose UserMessage.tool_use_result.
+    # _build_tool_result_map uses getattr with a default so the function is
+    # safe regardless of whether the attribute exists on the class. We can't
+    # easily strip the attribute from the real UserMessage dataclass, so this
+    # test verifies the explicit-None case (the bulk of the real-world risk).
+    from mlflow.claude_code.tracing import _build_tool_result_map
+
+    msg = UserMessage(
+        content=[ToolResultBlock(tool_use_id="t1", content="ok")],
+        tool_use_result=None,
+    )
+    result = _build_tool_result_map([msg])
+    assert "t1" in result
+    assert result["t1"].command_name is None
+    assert result["t1"].is_error is False

--- a/tests/claude_code/test_tracing.py
+++ b/tests/claude_code/test_tracing.py
@@ -1176,6 +1176,12 @@ def test_process_transcript_failed_skill_does_not_propagate(tmp_path):
     assert trace is not None
     spans = list(trace.search_spans())
 
+    # The failed Skill's OWN span IS stamped with its commandName (M1) so
+    # operators can attribute the failure to a specific skill.
+    skill_spans = [s for s in spans if s.attributes.get("tool_id") == "skill_tool"]
+    assert len(skill_spans) == 1
+    assert skill_spans[0].get_attribute(SpanAttributeKey.SKILL_NAME) == "broken-skill"
+
     # Post-skill LLM and tool spans must NOT be tagged with broken-skill.
     post_llm = [s for s in spans if s.span_type == SpanType.LLM]
     for s in post_llm:
@@ -1215,6 +1221,11 @@ def test_process_sdk_messages_failed_skill_does_not_propagate():
     assert trace is not None
     spans = list(trace.search_spans())
 
+    # The failed Skill's OWN span IS stamped with its commandName (M1).
+    skill_spans = [s for s in spans if s.attributes.get("tool_id") == "skill_tool"]
+    assert len(skill_spans) == 1
+    assert skill_spans[0].get_attribute(SpanAttributeKey.SKILL_NAME) == "broken"
+
     # Post-failure LLM span must NOT be tagged with the failed skill name.
     post_llm = [s for s in spans if s.span_type == SpanType.LLM]
     assert len(post_llm) == 1
@@ -1237,3 +1248,316 @@ def test_build_tool_result_map_tolerates_missing_tool_use_result_attr():
     assert "t1" in result
     assert result["t1"].command_name is None
     assert result["t1"].is_error is False
+
+
+def test_process_sdk_messages_skill_does_not_bleed_across_user_prompts():
+    # ClaudeSDKClient autolog accumulates messages across query() calls and
+    # invokes process_sdk_messages with the full list. Turn 1 uses a Skill;
+    # Turn 2 is unrelated. The Skill must NOT tag Turn 2's spans.
+    messages = [
+        UserMessage(content="Turn 1: write a PRD."),
+        AssistantMessage(
+            content=[ToolUseBlock(id="skill_tool", name="Skill", input={"skill": "prd-writer"})],
+            model="claude-sonnet-4-20250514",
+        ),
+        UserMessage(
+            content=[ToolResultBlock(tool_use_id="skill_tool", content="Launching")],
+            tool_use_result={"success": True, "commandName": "prd-writer"},
+        ),
+        AssistantMessage(
+            content=[TextBlock(text="PRD body produced under the skill.")],
+            model="claude-sonnet-4-20250514",
+        ),
+        # Turn 2: fresh user prompt, no skill. The skill scope must reset here.
+        UserMessage(content="Turn 2: refactor my code."),
+        AssistantMessage(
+            content=[TextBlock(text="Refactoring (unrelated to the skill).")],
+            model="claude-sonnet-4-20250514",
+        ),
+        AssistantMessage(
+            content=[ToolUseBlock(id="turn2_bash", name="Bash", input={})],
+            model="claude-sonnet-4-20250514",
+        ),
+        UserMessage(content=[ToolResultBlock(tool_use_id="turn2_bash", content="ok")]),
+        ResultMessage(
+            subtype="success",
+            duration_ms=100,
+            duration_api_ms=80,
+            is_error=False,
+            num_turns=4,
+            session_id="multi-turn-skill",
+        ),
+    ]
+
+    trace = process_sdk_messages(messages, "multi-turn-skill")
+    assert trace is not None
+    spans = list(trace.search_spans())
+
+    # Turn 1 LLM (inside skill scope) IS tagged.
+    turn1_llm = [
+        s
+        for s in spans
+        if s.span_type == SpanType.LLM
+        and "PRD body produced under the skill." in str(s.outputs.get("content", ""))
+    ]
+    assert len(turn1_llm) == 1
+    assert turn1_llm[0].get_attribute(SpanAttributeKey.SKILL_NAME) == "prd-writer"
+
+    # Turn 2 LLM is NOT tagged — skill scope was cleared at the new user prompt.
+    turn2_llm = [
+        s
+        for s in spans
+        if s.span_type == SpanType.LLM
+        and "Refactoring (unrelated to the skill)." in str(s.outputs.get("content", ""))
+    ]
+    assert len(turn2_llm) == 1
+    assert turn2_llm[0].get_attribute(SpanAttributeKey.SKILL_NAME) is None
+
+    # Turn 2 child TOOL is NOT tagged either.
+    turn2_bash = [s for s in spans if s.attributes.get("tool_id") == "turn2_bash"]
+    assert len(turn2_bash) == 1
+    assert turn2_bash[0].get_attribute(SpanAttributeKey.SKILL_NAME) is None
+
+
+def test_process_sdk_messages_skill_body_injection_does_not_reset_scope():
+    # If the SDK ever surfaces a skill-body injection as a UserMessage with
+    # tool_use_result=None immediately after the Skill tool-result, the reset
+    # logic must NOT clear active_skill_name — the prior message's commandName
+    # marks it as a skill body, not a fresh user prompt.
+    messages = [
+        UserMessage(content="Run the skill."),
+        AssistantMessage(
+            content=[ToolUseBlock(id="skill_tool", name="Skill", input={"skill": "my-skill"})],
+            model="claude-sonnet-4-20250514",
+        ),
+        UserMessage(
+            content=[ToolResultBlock(tool_use_id="skill_tool", content="Launching")],
+            tool_use_result={"success": True, "commandName": "my-skill"},
+        ),
+        # Injected skill body — looks like a fresh prompt but must NOT reset.
+        UserMessage(content="<the skill's prompt body>", tool_use_result=None),
+        AssistantMessage(
+            content=[TextBlock(text="Skill body output.")],
+            model="claude-sonnet-4-20250514",
+        ),
+        ResultMessage(
+            subtype="success",
+            duration_ms=100,
+            duration_api_ms=80,
+            is_error=False,
+            num_turns=2,
+            session_id="skill-body-injection",
+        ),
+    ]
+
+    trace = process_sdk_messages(messages, "skill-body-injection")
+    assert trace is not None
+    spans = list(trace.search_spans())
+
+    body_llm = [
+        s
+        for s in spans
+        if s.span_type == SpanType.LLM and "Skill body output." in str(s.outputs.get("content", ""))
+    ]
+    assert len(body_llm) == 1
+    assert body_llm[0].get_attribute(SpanAttributeKey.SKILL_NAME) == "my-skill"
+
+
+def _skill_transcript_with_prior_skill_then_failed_skill() -> list[dict[Any, Any]]:
+    """Successful skill A → failed skill B → recovery work. The recovery
+    spans must NOT carry skill A's name; the failed skill B IS stamped on its
+    own span.
+    """
+    return [
+        {
+            "type": "user",
+            "message": {"role": "user", "content": "Do the thing."},
+            "timestamp": "2025-01-15T10:00:00.000Z",
+        },
+        # Skill A — succeeds.
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "skill_a",
+                        "name": "Skill",
+                        "input": {"skill": "skill-a"},
+                    }
+                ],
+            },
+            "timestamp": "2025-01-15T10:00:01.000Z",
+        },
+        {
+            "type": "user",
+            "toolUseResult": {"success": True, "commandName": "skill-a"},
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "skill_a",
+                        "content": "Skill A launched",
+                    }
+                ],
+            },
+            "timestamp": "2025-01-15T10:00:02.000Z",
+        },
+        # Skill B — fails.
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "skill_b",
+                        "name": "Skill",
+                        "input": {"skill": "skill-b"},
+                    }
+                ],
+            },
+            "timestamp": "2025-01-15T10:00:03.000Z",
+        },
+        {
+            "type": "user",
+            "toolUseResult": {"success": False, "commandName": "skill-b"},
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "skill_b",
+                        "content": "Skill B failed",
+                        "is_error": True,
+                    }
+                ],
+            },
+            "timestamp": "2025-01-15T10:00:04.000Z",
+        },
+        # Recovery LLM + tool — must NOT inherit skill-a.
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "recovering"}],
+                "model": "claude-sonnet-4-20250514",
+            },
+            "timestamp": "2025-01-15T10:00:05.000Z",
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "recovery_bash", "name": "Bash", "input": {}}
+                ],
+            },
+            "timestamp": "2025-01-15T10:00:06.000Z",
+        },
+        {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "recovery_bash", "content": "ok"}
+                ],
+            },
+            "timestamp": "2025-01-15T10:00:07.000Z",
+        },
+    ]
+
+
+def test_process_transcript_failed_skill_clears_prior_skill_scope(tmp_path):
+    transcript_path = tmp_path / "prior_then_failed.jsonl"
+    transcript_path.write_text(
+        "\n".join(json.dumps(e) for e in _skill_transcript_with_prior_skill_then_failed_skill())
+        + "\n"
+    )
+
+    trace = process_transcript(str(transcript_path), "prior-then-failed")
+    assert trace is not None
+    spans = list(trace.search_spans())
+
+    # Skill A's own span carries skill-a.
+    skill_a = [s for s in spans if s.attributes.get("tool_id") == "skill_a"]
+    assert len(skill_a) == 1
+    assert skill_a[0].get_attribute(SpanAttributeKey.SKILL_NAME) == "skill-a"
+
+    # Skill B's own span carries skill-b (M1).
+    skill_b = [s for s in spans if s.attributes.get("tool_id") == "skill_b"]
+    assert len(skill_b) == 1
+    assert skill_b[0].get_attribute(SpanAttributeKey.SKILL_NAME) == "skill-b"
+
+    # Recovery work after the failure must NOT inherit either skill name (M2).
+    recovery_llm = [s for s in spans if s.span_type == SpanType.LLM]
+    assert len(recovery_llm) == 1
+    assert recovery_llm[0].get_attribute(SpanAttributeKey.SKILL_NAME) is None
+
+    recovery_bash = [s for s in spans if s.attributes.get("tool_id") == "recovery_bash"]
+    assert len(recovery_bash) == 1
+    assert recovery_bash[0].get_attribute(SpanAttributeKey.SKILL_NAME) is None
+
+
+def test_process_sdk_messages_failed_skill_clears_prior_skill_scope():
+    messages = [
+        UserMessage(content="Do the thing."),
+        # Skill A — succeeds.
+        AssistantMessage(
+            content=[ToolUseBlock(id="skill_a", name="Skill", input={"skill": "skill-a"})],
+            model="claude-sonnet-4-20250514",
+        ),
+        UserMessage(
+            content=[ToolResultBlock(tool_use_id="skill_a", content="launched")],
+            tool_use_result={"success": True, "commandName": "skill-a"},
+        ),
+        # Skill B — fails.
+        AssistantMessage(
+            content=[ToolUseBlock(id="skill_b", name="Skill", input={"skill": "skill-b"})],
+            model="claude-sonnet-4-20250514",
+        ),
+        UserMessage(
+            content=[ToolResultBlock(tool_use_id="skill_b", content="failed", is_error=True)],
+            tool_use_result={"success": False, "commandName": "skill-b"},
+        ),
+        # Recovery LLM + Bash. Must NOT inherit skill-a.
+        AssistantMessage(
+            content=[TextBlock(text="recovering")],
+            model="claude-sonnet-4-20250514",
+        ),
+        AssistantMessage(
+            content=[ToolUseBlock(id="recovery_bash", name="Bash", input={})],
+            model="claude-sonnet-4-20250514",
+        ),
+        UserMessage(content=[ToolResultBlock(tool_use_id="recovery_bash", content="ok")]),
+        ResultMessage(
+            subtype="success",
+            duration_ms=100,
+            duration_api_ms=80,
+            is_error=False,
+            num_turns=3,
+            session_id="prior-then-failed-sdk",
+        ),
+    ]
+
+    trace = process_sdk_messages(messages, "prior-then-failed-sdk")
+    assert trace is not None
+    spans = list(trace.search_spans())
+
+    skill_a = [s for s in spans if s.attributes.get("tool_id") == "skill_a"]
+    assert len(skill_a) == 1
+    assert skill_a[0].get_attribute(SpanAttributeKey.SKILL_NAME) == "skill-a"
+
+    skill_b = [s for s in spans if s.attributes.get("tool_id") == "skill_b"]
+    assert len(skill_b) == 1
+    assert skill_b[0].get_attribute(SpanAttributeKey.SKILL_NAME) == "skill-b"
+
+    recovery_llm = [s for s in spans if s.span_type == SpanType.LLM]
+    assert len(recovery_llm) == 1
+    assert recovery_llm[0].get_attribute(SpanAttributeKey.SKILL_NAME) is None
+
+    recovery_bash = [s for s in spans if s.attributes.get("tool_id") == "recovery_bash"]
+    assert len(recovery_bash) == 1
+    assert recovery_bash[0].get_attribute(SpanAttributeKey.SKILL_NAME) is None

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_query_trace_metrics.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_query_trace_metrics.py
@@ -4983,3 +4983,89 @@ def test_query_span_metrics_count_by_span_status_and_model_provider(store: SqlAl
         },
         "values": {"COUNT": 2},
     }
+
+
+def test_query_span_metrics_cost_by_skill_name(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("test_span_cost_by_skill_name")
+
+    trace_info = TraceInfo(
+        trace_id="trace1",
+        trace_location=trace_location.TraceLocation.from_experiment_id(exp_id),
+        request_time=get_current_time_millis(),
+        execution_duration=100,
+        state=TraceStatus.OK,
+        tags={TraceTagKey.TRACE_NAME: "test_trace"},
+    )
+    store.start_trace(trace_info)
+
+    spans = [
+        create_test_span(
+            "trace1",
+            "gpt4_call_1",
+            span_id=1,
+            span_type="LLM",
+            start_ns=1000000000,
+            attributes={
+                SpanAttributeKey.LLM_COST: {
+                    "input_cost": 0.01,
+                    "output_cost": 0.02,
+                    "total_cost": 0.03,
+                },
+                SpanAttributeKey.MODEL: "gpt-4",
+                SpanAttributeKey.SKILL_NAME: "skill1",
+            },
+        ),
+        create_test_span(
+            "trace1",
+            "gpt4_call_2",
+            span_id=2,
+            span_type="LLM",
+            start_ns=1100000000,
+            attributes={
+                SpanAttributeKey.LLM_COST: {
+                    "input_cost": 0.01,
+                    "output_cost": 0.02,
+                    "total_cost": 0.03,
+                },
+                SpanAttributeKey.MODEL: "gpt-4",
+                SpanAttributeKey.SKILL_NAME: "skill1",
+            },
+        ),
+        create_test_span(
+            "trace1",
+            "claude_call",
+            span_id=3,
+            span_type="LLM",
+            start_ns=1200000000,
+            attributes={
+                SpanAttributeKey.LLM_COST: {
+                    "input_cost": 0.005,
+                    "output_cost": 0.015,
+                    "total_cost": 0.02,
+                },
+                SpanAttributeKey.MODEL: "claude-3",
+                SpanAttributeKey.SKILL_NAME: "skill2",
+            },
+        ),
+    ]
+    store.log_spans(exp_id, spans)
+
+    result = store.query_trace_metrics(
+        experiment_ids=[exp_id],
+        view_type=MetricViewType.SPANS,
+        metric_name=SpanMetricKey.TOTAL_COST,
+        aggregations=[MetricAggregation(aggregation_type=AggregationType.SUM)],
+        dimensions=[SpanMetricDimensionKey.SPAN_SKILL_NAME],
+    )
+
+    assert len(result) == 2
+    assert asdict(result[0]) == {
+        "metric_name": SpanMetricKey.TOTAL_COST,
+        "dimensions": {SpanMetricDimensionKey.SPAN_SKILL_NAME: "skill1"},
+        "values": {"SUM": 0.06},
+    }
+    assert asdict(result[1]) == {
+        "metric_name": SpanMetricKey.TOTAL_COST,
+        "dimensions": {SpanMetricDimensionKey.SPAN_SKILL_NAME: "skill2"},
+        "values": {"SUM": 0.02},
+    }

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
@@ -4780,6 +4780,7 @@ def test_log_spans_creates_span_metrics(store: SqlAlchemyStore) -> None:
         }),
         SpanAttributeKey.MODEL: json.dumps("gpt-4-turbo"),
         SpanAttributeKey.MODEL_PROVIDER: json.dumps("openai"),
+        SpanAttributeKey.SKILL_NAME: json.dumps("skill1"),
     }
     span = create_mlflow_span(otel_span, trace_id, "LLM")
     store.log_spans(experiment_id, [span])
@@ -4808,6 +4809,7 @@ def test_log_spans_creates_span_metrics(store: SqlAlchemyStore) -> None:
         )
         assert sql_span.dimension_attributes[SpanAttributeKey.MODEL] == "gpt-4-turbo"
         assert sql_span.dimension_attributes[SpanAttributeKey.MODEL_PROVIDER] == "openai"
+        assert sql_span.dimension_attributes[SpanAttributeKey.SKILL_NAME] == "skill1"
 
 
 def test_log_spans_updates_trace_metrics_incrementally(store: SqlAlchemyStore) -> None:


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

NA

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

I do apologise for the long PR, but most of it are tests.

To help reviewing the non-test code easily, I recommend using the "Hide Whitespace" feature.
<img width="577" height="504" alt="Screenshot 2026-06-05 at 1 26 17 PM" src="https://github.com/user-attachments/assets/47bb17b1-ef29-4cde-b8ee-1cd46b29daa0" />

This PR proposes changes to support insights into skills on the MLFLow UI.

Currently, MLFlow supports insights into Tools via its `overview/tool-calls` view. However, MLFlow does not distinguish between Tools and Skills. All Skills are marked as Tools.

For Claude code specifically, there is a `commandName` field that is populated if something uses a skill

From the MLFLow layer, this PR offers a way to distinguish between Skills and Tools via the addition of a new SpanAttribute called a skill name. If a Tool call has this set, it must be a Skill. We use the presence of the `commandName` field to indicate if something is a field or not.

We are then able to add this new Span Attribute to the existing dimension columns, enabling the frontend to perform some aggregation based logic for the view.

The goal is to allow users to evaluate their performance of their skills based on some aggregate level metrics, such as average/min/max latency or token cost. I will follow up here with another PR for frontend changes

However, one thing to note is that to figure out the cost of a skill, we have to take into account the subsequent LLM call as well, because the tool span itself doesn't contain information around token cost that we need. Therefore, we also need to add support in the TS and the Python client code to support this.

There are 3 paths we support right now:
1. Transcript based, these are fired off from the Stop hooks and hence should only contain one message from user, due to `find_last_user_message_index`. (`tracing.py`, `tracing.ts`)
2. Python SDK , fires off a list of messages attached to the SDK client, may contain multiple message from user (`tracing.py`)
3. Live Tracing, live tracing, requires us to store state to figure out when to append the Span Attribute to the child span as well. (`liveTracing.ts`)

This PR also adds support for MLFlow to support tagging child spans of a Skill call. However, the current approach doesn't cover all cases, such as if the user make parallel skill calls. This can be handled as a follow up item as I am assuming that it does not happen too often. Also nested skill calls follow are tagged with the most recent skill call. Concretely, if I have skill A which calls skill B which then calls skill C, these 3 skill calls are tagged with different skill names instead of all being tagged with Skill A. Implementing this is possible, but requires us to store a more complex state, as we currently assume that each skill tool call is only followed up by one User Message ran by the skill. 


Risk of this PR:
* The main risk of this PR is that if we wrongly interpret the Claude response format/conventions and tag the spans incorrectly, the skills information displayed will be incorrect.
* However, the changes made are strictly additive and only used by one chart in the frontend, which will be implemented in the next PR. 



### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

Manual testing involved having creating transcripts and having Claude parse the transcripts in order to figure out the response type, as `toolUseResult` was not heavily documented in official docs. 

Claude also generated some testing scripts to test the live tracing and the Python SDK routes. 

Manual testing covered four scenarios across both languages, driven against real Claude Code sessions where possible:

| # | Scenario | Path | Driver | What was verified |
|---|---|---|---|---|
| 1 | Happy-path Skill invocation | PY transcript | Real captured `verify-skill-tiny` JSONL from `~/.claude/projects/`, replayed via `process_transcript` | Skill TOOL span stamped; subsequent LLM tagged via propagation |
| 2 | Failed Skill | PY transcript | Derived from scenario 1 (real happy-path mutated: `is_error=true`, synthetic recovery turns) — Claude refuses to invoke unknown skills so a real failed session can't be captured cleanly | Failed Skill's own TOOL span stamped (so operators can see which skill failed); recovery LLM + Bash untagged (no leak) |
| 3 | Multi-turn live SDK | PY SDK live | Real two-turn `ClaudeSDKClient` session — turn 1 invokes `verify-skill-tiny`, turn 2 asks an unrelated question | Turn-1 Skill propagates to its body LLM; turn-2 LLM **not** tagged (cross-prompt bleed prevented) |
| 4 | Multi-turn live AsyncIterable | TS live | Real two-prompt `createTracedQuery` driven by an async generator with a 25 s gap | Same as scenario 3 — propagation within the skill, clean tail after the next prompt |



#### Unit Test review helper

Reviewing unit tests is hard, so I got Claude to generate a HTML file that should hopefully make it easier to understand what the unit tests are asserting

[state-machine-viz.html](https://github.com/user-attachments/files/28629341/state-machine-viz.html)


### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

MLFlow experiment overview now allows users to view performance of their skills, in addition to existing support for tool calls

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

