### PR TITLE
Restore `guardrails-ai` in genai OSS CI step

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -324,19 +324,17 @@ jobs:
           uv sync --extra genai
           # TODO: migrate mlflow/genai/scorers/phoenix to arize-phoenix-evals 3.x API
           # (removed HallucinationEvaluator/RelevanceEvaluator/etc. and LiteLLMModel)
-          # `guardrails-ai` is temporarily unavailable on PyPI; skip both the
-          # install and the corresponding tests until it is republished.
           # TODO: drop the langchain-community<0.4.2 pin once ragas releases a
           # fix for the removed `langchain_community.chat_models.vertexai`
           # import (0.4.2 dropped the shim).
           # https://github.com/vibrantlabsai/ragas/issues/2745
           uv pip install \
             -r requirements/test-requirements.txt \
-            deepeval ragas 'arize-phoenix-evals<3.0.0' 'langchain-community<0.4.2' trulens trulens-providers-litellm 'google-adk[gcp]'
+            deepeval ragas 'arize-phoenix-evals<3.0.0' 'langchain-community<0.4.2' trulens trulens-providers-litellm 'google-adk[gcp]' guardrails-ai
       - uses: ./.github/actions/show-versions
       - name: Run GenAI Tests (OSS)
         run: |
-          uv run --no-sync pytest tests/genai --ignore tests/genai/scorers/guardrails
+          uv run --no-sync pytest tests/genai
 
       - name: Run GenAI Tests (Databricks)
         run: |


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23227

### What changes are proposed in this pull request?

`guardrails-ai` is `active` on PyPI again (latest 0.10.0), so the temporary skip from #23227 can come off the genai OSS CI step:

- `.github/workflows/master.yml` — re-add `guardrails-ai` to the `uv pip install` line and drop `--ignore tests/genai/scorers/guardrails` from the OSS pytest invocation.
- The Databricks step keeps its own `--ignore` because that skip is driven by a separate `google-adk` / `opentelemetry-sdk` overlay issue, not the PyPI quarantine.

Verified status via PyPI simple API v1.4:

```
curl -s -H "Accept: application/vnd.pypi.simple.v1+json" https://pypi.org/simple/guardrails-ai/ \
  | python3 -c "import json,sys; print(json.load(sys.stdin)['project-status'])"
# {'status': 'active'}
```

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release