### PR TITLE
Optimize local artifact uploads with atomic rename

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -315,9 +315,11 @@ from mlflow.server.workspace_helpers import (
     _get_workspace_store,
 )
 from mlflow.store.artifact.artifact_repo import (
+    ARTIFACT_STREAM_CHUNK_SIZE,
     MultipartDownloadMixin,
     MultipartUploadMixin,
     PresignedUploadMixin,
+    StreamUploadMixin,
 )
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.store.db.db_types import DATABASE_ENGINES
@@ -414,8 +416,6 @@ _artifact_repo = None
 STATIC_PREFIX_ENV_VAR = "_MLFLOW_STATIC_PREFIX"
 MAX_RUNS_GET_METRIC_HISTORY_BULK = 100
 MAX_RESULTS_PER_RUN = 2500
-# Chunk size for streaming artifact uploads and downloads (1 MB)
-ARTIFACT_STREAM_CHUNK_SIZE = 1024 * 1024
 
 
 class TrackingStoreRegistryWrapper(TrackingStoreRegistry):
@@ -3578,14 +3578,17 @@ def _upload_artifact(artifact_path):
     artifact_path = validate_path_is_safe(artifact_path)
     artifact_path = _get_workspace_scoped_repo_path_if_enabled(artifact_path)
     head, tail = posixpath.split(artifact_path)
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        tmp_path = os.path.join(tmp_dir, tail)
-        with open(tmp_path, "wb") as f:
-            while chunk := request.stream.read(ARTIFACT_STREAM_CHUNK_SIZE):
-                f.write(chunk)
+    artifact_repo = _get_artifact_repo_mlflow_artifacts()
 
-        artifact_repo = _get_artifact_repo_mlflow_artifacts()
-        artifact_repo.log_artifact(tmp_path, artifact_path=head or None)
+    if isinstance(artifact_repo, StreamUploadMixin):
+        artifact_repo.log_artifact_from_stream(request.stream, tail, artifact_path=head or None)
+    else:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = os.path.join(tmp_dir, tail)
+            with open(tmp_path, "wb") as f:
+                while chunk := request.stream.read(ARTIFACT_STREAM_CHUNK_SIZE):
+                    f.write(chunk)
+            artifact_repo.log_artifact(tmp_path, artifact_path=head or None)
 
     return _wrap_response(UploadArtifact.Response())
 

--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -9,7 +9,7 @@ from abc import ABC, ABCMeta, abstractmethod
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, BinaryIO
 
 from mlflow.entities.file_info import FileInfo
 from mlflow.entities.multipart_upload import (
@@ -49,6 +49,8 @@ assert _NUM_MAX_THREADS_PER_CPU > 0
 # Default number of CPUs to assume on the machine if unavailable to fetch it using os.cpu_count()
 _NUM_DEFAULT_CPUS = _NUM_MAX_THREADS // _NUM_MAX_THREADS_PER_CPU
 _logger = logging.getLogger(__name__)
+# Chunk size for streaming artifact uploads and downloads (1 MB).
+ARTIFACT_STREAM_CHUNK_SIZE = 1024 * 1024
 
 
 def _truncate_error(err: str, max_length: int = 10_000) -> str:
@@ -641,6 +643,32 @@ class PresignedUploadMixin(ABC):
 
         Returns:
             CreatePresignedUploadResponse with presigned_url and headers.
+        """
+
+
+class StreamUploadMixin(ABC):
+    """
+    Mixin that defines the API for artifact repositories that support streaming
+    uploads directly from a binary stream, avoiding an intermediate temp-file copy
+    in the server handler.
+    """
+
+    @abstractmethod
+    def log_artifact_from_stream(
+        self,
+        stream: BinaryIO,
+        artifact_file_name: str,
+        artifact_path: str | None = None,
+    ) -> None:
+        """
+        Log artifact contents from a binary stream.
+
+        Args:
+            stream: Readable binary stream containing the artifact contents.
+            artifact_file_name: Artifact filename to log. Any directory components are
+                ignored; use ``artifact_path`` to specify the destination directory.
+            artifact_path: Directory within the run's artifact directory in which to log
+                the artifact.
         """
 
 

--- a/mlflow/store/artifact/local_artifact_repo.py
+++ b/mlflow/store/artifact/local_artifact_repo.py
@@ -1,11 +1,16 @@
 import os
 import shutil
-from typing import Any
+import tempfile
+import threading
+from contextlib import suppress
+from typing import Any, BinaryIO, Callable
 
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
 from mlflow.store.artifact.artifact_repo import (
+    ARTIFACT_STREAM_CHUNK_SIZE,
     ArtifactRepository,
+    StreamUploadMixin,
     try_read_trace_data,
     verify_artifact_path,
 )
@@ -20,8 +25,30 @@ from mlflow.utils.file_utils import (
 )
 from mlflow.utils.uri import validate_path_is_safe, validate_path_within_directory
 
+_TEMP_ARTIFACT_PREFIX = ".artifact.uploading."
+_UMASK_LOCK = threading.Lock()
 
-class LocalArtifactRepository(ArtifactRepository):
+
+def _set_default_file_mode(file_path: str) -> None:
+    """Set file permissions to match the default mode produced by ``open()``."""
+    if os.name == "nt":
+        return
+
+    with _UMASK_LOCK:
+        current_umask = os.umask(0)
+        os.umask(current_umask)
+    os.chmod(file_path, 0o666 & ~current_umask)
+
+
+def _verify_artifact_file_name(artifact_file_name: str) -> None:
+    if os.path.basename(artifact_file_name).startswith(_TEMP_ARTIFACT_PREFIX):
+        raise MlflowException.invalid_parameter_value(
+            f"Invalid artifact file name: '{artifact_file_name}'. "
+            f"Artifact names starting with '{_TEMP_ARTIFACT_PREFIX}' are reserved."
+        )
+
+
+class LocalArtifactRepository(ArtifactRepository, StreamUploadMixin):
     """Stores artifacts as files in a local directory."""
 
     def __init__(
@@ -45,7 +72,7 @@ class LocalArtifactRepository(ArtifactRepository):
             )
         return os.path.abspath(local_artifact_path)
 
-    def log_artifact(self, local_file, artifact_path=None):
+    def _get_or_create_artifact_dir(self, artifact_path: str | None = None) -> str:
         verify_artifact_path(artifact_path)
         # NOTE: The artifact_path is expected to be in posix format.
         # Posix paths work fine on windows but just in case we normalize it here.
@@ -55,12 +82,88 @@ class LocalArtifactRepository(ArtifactRepository):
         artifact_dir = (
             os.path.join(self.artifact_dir, artifact_path) if artifact_path else self.artifact_dir
         )
+        validate_path_within_directory(self.artifact_dir, artifact_dir)
         if not os.path.exists(artifact_dir):
             mkdir(artifact_dir)
+        return artifact_dir
+
+    def _get_destination_artifact_path(
+        self, artifact_file_name: str, artifact_path: str | None = None
+    ) -> tuple[str, str]:
+        artifact_dir = self._get_or_create_artifact_dir(artifact_path)
+        _verify_artifact_file_name(artifact_file_name)
+        destination_file_path = os.path.join(artifact_dir, os.path.basename(artifact_file_name))
+        validate_path_within_directory(self.artifact_dir, destination_file_path)
+        return artifact_dir, destination_file_path
+
+    def _write_to_destination_path(
+        self,
+        artifact_file_name: str,
+        writer: Callable[[BinaryIO], None],
+        artifact_path: str | None = None,
+        finalize_temp_path: Callable[[str], None] | None = None,
+    ) -> None:
+        artifact_dir, destination_file_path = self._get_destination_artifact_path(
+            artifact_file_name, artifact_path
+        )
+        # Write to a hidden temp file in the destination directory, then atomically
+        # replace the target path so readers never see a partially-written artifact.
+        temp_file_descriptor, temp_file_path = tempfile.mkstemp(
+            dir=artifact_dir, prefix=_TEMP_ARTIFACT_PREFIX
+        )
+        published = False
         try:
-            shutil.copy2(local_file, os.path.join(artifact_dir, os.path.basename(local_file)))
-        except shutil.SameFileError:
+            temp_file = os.fdopen(temp_file_descriptor, "wb")
+            temp_file_descriptor = None
+            with temp_file:
+                writer(temp_file)
+            if finalize_temp_path is not None:
+                finalize_temp_path(temp_file_path)
+            os.replace(temp_file_path, destination_file_path)
+            published = True
+        finally:
+            if temp_file_descriptor is not None:
+                os.close(temp_file_descriptor)
+            if not published:
+                with suppress(FileNotFoundError):
+                    os.remove(temp_file_path)
+
+    def log_artifact(self, local_file, artifact_path=None):
+        _, destination_file_path = self._get_destination_artifact_path(local_file, artifact_path)
+        try:
+            if os.path.samefile(local_file, destination_file_path):
+                return
+        except FileNotFoundError:
             pass
+
+        def _write_file(temp_file: BinaryIO) -> None:
+            with open(local_file, "rb") as local_artifact_file:
+                shutil.copyfileobj(
+                    local_artifact_file, temp_file, length=ARTIFACT_STREAM_CHUNK_SIZE
+                )
+
+        self._write_to_destination_path(
+            local_file,
+            _write_file,
+            artifact_path,
+            finalize_temp_path=lambda temp_file_path: shutil.copystat(local_file, temp_file_path),
+        )
+
+    def log_artifact_from_stream(
+        self,
+        stream: BinaryIO,
+        artifact_file_name: str,
+        artifact_path: str | None = None,
+    ) -> None:
+        def _write_stream(temp_file: BinaryIO) -> None:
+            shutil.copyfileobj(stream, temp_file, length=ARTIFACT_STREAM_CHUNK_SIZE)
+
+        self._write_to_destination_path(
+            artifact_file_name,
+            _write_stream,
+            artifact_path,
+            finalize_temp_path=_set_default_file_mode,
+        )
 
     def _is_directory(self, artifact_path):
         # NOTE: The path is expected to be in posix format.
@@ -70,16 +173,7 @@ class LocalArtifactRepository(ArtifactRepository):
         return os.path.isdir(list_dir)
 
     def log_artifacts(self, local_dir, artifact_path=None):
-        verify_artifact_path(artifact_path)
-        # NOTE: The artifact_path is expected to be in posix format.
-        # Posix paths work fine on windows but just in case we normalize it here.
-        if artifact_path:
-            artifact_path = os.path.normpath(artifact_path)
-        artifact_dir = (
-            os.path.join(self.artifact_dir, artifact_path) if artifact_path else self.artifact_dir
-        )
-        if not os.path.exists(artifact_dir):
-            mkdir(artifact_dir)
+        artifact_dir = self._get_or_create_artifact_dir(artifact_path)
         shutil_copytree_without_file_permissions(local_dir, artifact_dir)
 
     def download_artifacts(self, artifact_path, dst_path=None):
@@ -113,6 +207,7 @@ class LocalArtifactRepository(ArtifactRepository):
                     f, relative_path_to_artifact_path(os.path.relpath(f, self.artifact_dir))
                 )
                 for f in artifact_files
+                if not os.path.basename(f).startswith(_TEMP_ARTIFACT_PREFIX)
             ]
             return sorted(infos, key=lambda f: f.path)
         else:

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 import uuid
 from typing import NamedTuple
@@ -239,19 +240,41 @@ def test_log_artifact_windows_path_with_hostname(text_artifact):
         "test_exp_d", experiment_test_1_artifact_location
     )
     with mlflow.start_run(experiment_id=experiment_test_1_id) as run:
+        artifact_dir = rf"{experiment_test_1_artifact_location}\{run.info.run_id}\artifacts"
+        temp_artifact_path = rf"{artifact_dir}\.artifact.uploading.mock"
+        destination_artifact_path = rf"{artifact_dir}\{text_artifact.artifact_name}"
+        real_exists = os.path.exists
+
+        def _exists(path):
+            if os.path.normcase(path) == os.path.normcase(artifact_dir):
+                return mkdir_mock.called
+            return real_exists(path)
+
+        fdopen_mock = mock.MagicMock()
+        fdopen_mock.__enter__.return_value = fdopen_mock
         with (
-            mock.patch("shutil.copy2") as copyfile_mock,
-            mock.patch("os.path.exists", return_value=True) as exists_mock,
+            mock.patch("shutil.copyfileobj") as copyfileobj_mock,
+            mock.patch(
+                "mlflow.store.artifact.local_artifact_repo.os.path.exists", side_effect=_exists
+            ),
+            mock.patch("mlflow.store.artifact.local_artifact_repo.mkdir") as mkdir_mock,
+            mock.patch(
+                "mlflow.store.artifact.local_artifact_repo.tempfile.mkstemp",
+                return_value=(123, temp_artifact_path),
+            ) as mkstemp_mock,
+            mock.patch(
+                "mlflow.store.artifact.local_artifact_repo.os.fdopen", return_value=fdopen_mock
+            ) as fdopen_fn_mock,
+            mock.patch("mlflow.store.artifact.local_artifact_repo.os.replace") as replace_mock,
+            mock.patch("mlflow.store.artifact.local_artifact_repo.shutil.copystat"),
         ):
             mlflow.log_artifact(text_artifact.artifact_path)
-            exists_mock.assert_called_once()
-            copyfile_mock.assert_called_once_with(
-                text_artifact.artifact_path,
-                (
-                    rf"{experiment_test_1_artifact_location}\{run.info.run_id}"
-                    rf"\artifacts\{text_artifact.artifact_name}"
-                ),
-            )
+            mkdir_mock.assert_called_once_with(artifact_dir)
+            mkstemp_mock.assert_called_once_with(dir=artifact_dir, prefix=".artifact.uploading.")
+            fdopen_fn_mock.assert_called_once_with(123, "wb")
+            copyfileobj_mock.assert_called_once()
+            assert copyfileobj_mock.call_args.args[1] is fdopen_mock
+            replace_mock.assert_called_once_with(temp_artifact_path, destination_artifact_path)
 
 
 def test_list_artifacts_with_artifact_uri(run_with_artifacts):

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -227,6 +227,7 @@ from mlflow.server.handlers import (
     _update_model_version,
     _update_registered_model,
     _update_review_queue,
+    _upload_artifact,
     _upsert_dataset_records_handler,
     _validate_source_run,
     catch_mlflow_exception,
@@ -240,6 +241,7 @@ from mlflow.server.handlers import (
     upload_artifact_handler,
 )
 from mlflow.store._unity_catalog.registry.rest_store import UcModelRegistryStore
+from mlflow.store.artifact.artifact_repo import ArtifactRepository
 from mlflow.store.artifact.azure_blob_artifact_repo import AzureBlobArtifactRepository
 from mlflow.store.artifact.local_artifact_repo import LocalArtifactRepository
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
@@ -4106,6 +4108,50 @@ def test_download_artifact_uses_local_path_fast_path(enable_serve_artifacts, tmp
     mock_artifact_repo.get_local_path.assert_called_once_with(artifact_path)
     mock_artifact_repo.download_artifacts.assert_not_called()
     mock_tmp_dir.assert_not_called()
+
+
+def test_upload_artifact_uses_stream_upload_when_mixin_supported(enable_serve_artifacts):
+    artifact_path = "nested/model.pkl"
+    test_data = b"streamed artifact"
+
+    with (
+        app.test_request_context(
+            method="PUT", data=test_data, content_type="application/octet-stream"
+        ),
+        mock.patch("mlflow.server.handlers._get_artifact_repo_mlflow_artifacts") as mock_repo,
+    ):
+        mock_artifact_repo = mock.MagicMock(spec=LocalArtifactRepository)
+        mock_repo.return_value = mock_artifact_repo
+
+        response = _upload_artifact(artifact_path)
+
+    mock_artifact_repo.log_artifact_from_stream.assert_called_once()
+    args, kwargs = mock_artifact_repo.log_artifact_from_stream.call_args
+    assert args[1] == "model.pkl"
+    assert kwargs["artifact_path"] == "nested"
+    assert response.status_code == 200
+
+
+def test_upload_artifact_falls_back_to_log_artifact_without_mixin(enable_serve_artifacts):
+    artifact_path = "nested/model.pkl"
+    test_data = b"streamed artifact"
+
+    with (
+        app.test_request_context(
+            method="PUT", data=test_data, content_type="application/octet-stream"
+        ),
+        mock.patch("mlflow.server.handlers._get_artifact_repo_mlflow_artifacts") as mock_repo,
+    ):
+        mock_artifact_repo = mock.MagicMock(spec=ArtifactRepository)
+        mock_repo.return_value = mock_artifact_repo
+
+        response = _upload_artifact(artifact_path)
+
+    mock_artifact_repo.log_artifact.assert_called_once()
+    args, kwargs = mock_artifact_repo.log_artifact.call_args
+    assert args[0].endswith("model.pkl")
+    assert kwargs["artifact_path"] == "nested"
+    assert response.status_code == 200
 
 
 def test_download_artifact_streams_in_chunks(enable_serve_artifacts, tmp_path):

--- a/tests/store/artifact/test_local_artifact_repo.py
+++ b/tests/store/artifact/test_local_artifact_repo.py
@@ -1,7 +1,10 @@
+import io
 import json
 import os
 import pathlib
 import posixpath
+import stat
+from unittest import mock
 
 import pytest
 from opentelemetry.sdk.trace import ReadableSpan as OTelReadableSpan
@@ -57,6 +60,23 @@ def test_log_artifacts(local_artifact_repo, local_artifact_root):
     assert artifact_dst_path != artifact_src_path
     with open(artifact_dst_path) as f:
         assert f.read() == artifact_text
+
+
+def test_log_artifact_preserves_source_file_mtime(local_artifact_repo, local_artifact_root):
+    artifact_rel_path = "test.txt"
+    artifact_text = "hello world!"
+    requested_mtime_ns = 1_700_000_000_123_456_789
+
+    with TempDir() as src_dir:
+        artifact_src_path = src_dir.path(artifact_rel_path)
+        with open(artifact_src_path, "w") as f:
+            f.write(artifact_text)
+        os.utime(artifact_src_path, ns=(requested_mtime_ns, requested_mtime_ns))
+        expected_mtime_ns = os.stat(artifact_src_path).st_mtime_ns
+        local_artifact_repo.log_artifact(artifact_src_path)
+
+    artifact_dst_path = os.path.join(local_artifact_root, artifact_rel_path)
+    assert os.stat(artifact_dst_path).st_mtime_ns == expected_mtime_ns
 
 
 @pytest.mark.parametrize("dst_path", [None, "dest"])
@@ -202,6 +222,121 @@ def test_hidden_files_are_logged_correctly(local_artifact_repo):
         local_artifact_repo.log_artifact(hidden_file)
         with open(local_artifact_repo.download_artifacts(".mystery")) as f:
             assert f.read() == "42"
+
+
+def test_log_artifact_is_noop_when_source_matches_destination(
+    local_artifact_repo, local_artifact_root
+):
+    artifact_path = os.path.join(local_artifact_root, "test.txt")
+    with open(artifact_path, "w") as f:
+        f.write("artifact")
+
+    with mock.patch.object(local_artifact_repo, "_write_to_destination_path") as write_mock:
+        local_artifact_repo.log_artifact(artifact_path)
+
+    write_mock.assert_not_called()
+
+
+def test_log_artifact_rejects_internal_temp_file_prefix(local_artifact_repo):
+    with TempDir() as local_dir:
+        local_path = local_dir.path(".artifact.uploading.mock")
+        with open(local_path, "w") as f:
+            f.write("artifact")
+
+        with pytest.raises(MlflowException, match="Artifact names starting with"):
+            local_artifact_repo.log_artifact(local_path)
+
+
+def test_log_artifact_from_stream_writes_file_atomically(local_artifact_repo):
+    artifact_contents = b"hello world!"
+
+    local_artifact_repo.log_artifact_from_stream(
+        io.BytesIO(artifact_contents),
+        "test.txt",
+        artifact_path="nested",
+    )
+
+    artifact_dir = pathlib.Path(local_artifact_repo.artifact_dir) / "nested"
+    assert (artifact_dir / "test.txt").read_bytes() == artifact_contents
+    assert list(artifact_dir.glob(".artifact.uploading.*")) == []
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX-only permission semantics")
+def test_log_artifact_from_stream_preserves_default_file_mode(local_artifact_repo):
+    artifact_contents = b"hello world!"
+    artifact_dir = pathlib.Path(local_artifact_repo.artifact_dir) / "nested"
+    artifact_dir.mkdir()
+
+    reference_path = artifact_dir / "reference.txt"
+    with open(reference_path, "wb"):
+        pass
+    expected_mode = stat.S_IMODE(reference_path.stat().st_mode)
+    reference_path.unlink()
+
+    local_artifact_repo.log_artifact_from_stream(
+        io.BytesIO(artifact_contents),
+        "test.txt",
+        artifact_path="nested",
+    )
+
+    final_path = artifact_dir / "test.txt"
+    assert stat.S_IMODE(final_path.stat().st_mode) == expected_mode
+
+
+def test_log_artifact_from_stream_cleans_up_temp_file_on_failure(local_artifact_repo):
+    artifact_dir = pathlib.Path(local_artifact_repo.artifact_dir) / "nested"
+    artifact_dir.mkdir()
+    final_path = artifact_dir / "test.txt"
+    final_path.write_bytes(b"existing-content")
+
+    class FailingStream:
+        def __init__(self):
+            self._chunks = iter([b"new-content", RuntimeError("stream failed")])
+
+        def read(self, _size: int) -> bytes:
+            chunk = next(self._chunks, b"")
+            if isinstance(chunk, Exception):
+                raise chunk
+            return chunk
+
+    with pytest.raises(RuntimeError, match="stream failed"):
+        local_artifact_repo.log_artifact_from_stream(
+            FailingStream(),
+            "test.txt",
+            artifact_path="nested",
+        )
+
+    assert final_path.read_bytes() == b"existing-content"
+    assert list(artifact_dir.glob(".artifact.uploading.*")) == []
+
+
+def test_log_artifact_from_stream_closes_fd_when_fdopen_fails(local_artifact_repo):
+    artifact_dir = pathlib.Path(local_artifact_repo.artifact_dir) / "nested"
+    artifact_dir.mkdir()
+    temp_artifact_path = artifact_dir / ".artifact.uploading.mock"
+    temp_artifact_path.touch()
+
+    with (
+        mock.patch(
+            "mlflow.store.artifact.local_artifact_repo.tempfile.mkstemp",
+            return_value=(123, str(temp_artifact_path)),
+        ),
+        mock.patch(
+            "mlflow.store.artifact.local_artifact_repo.os.fdopen",
+            side_effect=OSError("fdopen failed"),
+        ),
+        mock.patch("mlflow.store.artifact.local_artifact_repo.os.close") as close_mock,
+        mock.patch("mlflow.store.artifact.local_artifact_repo.os.remove") as remove_mock,
+    ):
+        with pytest.raises(OSError, match="fdopen failed"):
+            local_artifact_repo.log_artifact_from_stream(
+                io.BytesIO(b"hello world!"),
+                "test.txt",
+                artifact_path="nested",
+            )
+
+    close_mock.assert_called_once_with(123)
+    remove_mock.assert_called_once_with(str(temp_artifact_path))
 
 
 def test_delete_artifacts_folder(local_artifact_repo):


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #23787 

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
This updates filesystem-backed artifact uploads to stream through `ArtifactRepository.log_artifact_from_stream()`.

`LocalArtifactRepository` now writes uploads to a hidden temp file in the destination directory and atomically installs the final artifact with `os.replace()`, while other backends keep the existing default behavior.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
