### PR TITLE
Pin `llama-index>=0.12.38` in `extra-ml-requirements.txt`

### DIFF
--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -57,7 +57,10 @@ openai
 tiktoken
 tenacity
 # Required by mlflow.llama_index
-llama_index
+# Floor matches the supported minimum in mlflow/ml-package-versions.yml. Without it, a
+# transitive conflict in the combined ML env silently backtracks llama-index to an
+# unsupported 0.10.x (pydantic v1 models), which crashes Settings serialization.
+llama-index>=0.12.38
 # Required for an agent example of mlflow.llama_index
 llama-index-agent-openai
 # Required by mlflow.langchain


### PR DESCRIPTION
### Related Issues/PRs

Relates to the failing scheduled `Examples` job on `mlflow/dev` (the `examples/llama_index/simple_index.py` example).

### What changes are proposed in this pull request?

The `llama_index` entry in `requirements/extra-ml-requirements.txt` was unpinned. In the combined ML environment, the dependency resolver backtracks it to an unsupported 0.10.x release, whose LLM objects are pydantic v1 models (`__fields__`, no class-level `model_fields`). That makes `mlflow.llama_index.log_model` -> `serialize_objects.py` crash with `AttributeError: '<LLM>' object has no attribute 'model_fields'`.

This pins a floor of `>=0.12.38` -- matching the supported minimum already declared in `ml-package-versions.yml` -- so a native-pydantic-v2 llama-index is installed and the existing serialization code works.

### How is this PR tested?

- [x] Manual tests

Resolving the combined `extra-ml-requirements.txt`:
- Unpinned -> `llama-index 0.10.68` (+ `llama-index-legacy`), reproducing the crash.
- Pinned `>=0.12.38` -> resolves cleanly to `llama-index 0.12.52` (native pydantic v2); the existing serialization code works, no conflicts.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release