### PR TITLE
Include `skills_installed` in `AgentSetupEvent` telemetry

### DIFF
--- a/mlflow/agent/setup/cli.py
+++ b/mlflow/agent/setup/cli.py
@@ -106,7 +106,6 @@ def setup(
         raise click.ClickException("`mlflow agent setup` must be run inside a git working tree.")
 
     agent = _choose_agent(agent_name)
-    _record_event(AgentSetupEvent, {"agent": agent.name, "print_prompt": print_prompt})
 
     skills_dest = repo_root / agent.skills_dir
     skills_installed = click.confirm(
@@ -117,6 +116,14 @@ def setup(
         ),
         default=True,
         err=True,
+    )
+    _record_event(
+        AgentSetupEvent,
+        {
+            "agent": agent.name,
+            "print_prompt": print_prompt,
+            "skills_installed": skills_installed,
+        },
     )
     if skills_installed:
         installed = install_skills(skills_dest)

--- a/mlflow/agent/setup/cli.py
+++ b/mlflow/agent/setup/cli.py
@@ -122,7 +122,7 @@ def setup(
         {
             "agent": agent.name,
             "print_prompt": print_prompt,
-            "skills_installed": skills_installed,
+            "skills_install_confirmed": skills_installed,
         },
     )
     if skills_installed:

--- a/tests/agent/test_cli.py
+++ b/tests/agent/test_cli.py
@@ -62,10 +62,12 @@ def test_setup_declined_skills_uses_bundled_path(tmp_git_repo: Path):
 
 
 @pytest.mark.parametrize(
-    ("skills_input", "skills_installed"),
+    ("skills_input", "skills_install_confirmed"),
     [("y", True), ("n", False)],
 )
-def test_setup_records_telemetry(tmp_git_repo: Path, skills_input: str, skills_installed: bool):
+def test_setup_records_telemetry(
+    tmp_git_repo: Path, skills_input: str, skills_install_confirmed: bool
+):
     with (
         mock.patch("mlflow.agent.agents.shutil.which", return_value="/usr/local/bin/claude"),
         mock.patch("mlflow.agent.setup.cli._record_event") as mock_record,
@@ -81,7 +83,7 @@ def test_setup_records_telemetry(tmp_git_repo: Path, skills_input: str, skills_i
     assert payload == {
         "agent": "claude",
         "print_prompt": True,
-        "skills_installed": skills_installed,
+        "skills_install_confirmed": skills_install_confirmed,
     }
 
 

--- a/tests/agent/test_cli.py
+++ b/tests/agent/test_cli.py
@@ -61,6 +61,30 @@ def test_setup_declined_skills_uses_bundled_path(tmp_git_repo: Path):
     mock_which.assert_called()
 
 
+@pytest.mark.parametrize(
+    ("skills_input", "skills_installed"),
+    [("y", True), ("n", False)],
+)
+def test_setup_records_telemetry(tmp_git_repo: Path, skills_input: str, skills_installed: bool):
+    with (
+        mock.patch("mlflow.agent.agents.shutil.which", return_value="/usr/local/bin/claude"),
+        mock.patch("mlflow.agent.setup.cli._record_event") as mock_record,
+    ):
+        result = CliRunner().invoke(
+            setup,
+            ["--agent", "claude", "--print"],
+            input=f"{skills_input}\nhttp://localhost:5001\n",
+        )
+    assert result.exit_code == 0, result.stderr
+    mock_record.assert_called_once()
+    _event, payload = mock_record.call_args.args
+    assert payload == {
+        "agent": "claude",
+        "print_prompt": True,
+        "skills_installed": skills_installed,
+    }
+
+
 def test_setup_requested_agent_not_installed(tmp_git_repo: Path):
     with mock.patch("mlflow.agent.agents.shutil.which", return_value=None) as mock_which:
         result = CliRunner().invoke(setup, ["--agent", "claude", "--print"])

--- a/tests/agent/test_cli.py
+++ b/tests/agent/test_cli.py
@@ -8,6 +8,7 @@ import pytest
 from click.testing import CliRunner
 
 from mlflow.agent.setup.cli import setup
+from mlflow.telemetry.events import AgentSetupEvent
 
 
 @pytest.fixture
@@ -69,7 +70,9 @@ def test_setup_records_telemetry(
     tmp_git_repo: Path, skills_input: str, skills_install_confirmed: bool
 ):
     with (
-        mock.patch("mlflow.agent.agents.shutil.which", return_value="/usr/local/bin/claude"),
+        mock.patch(
+            "mlflow.agent.agents.shutil.which", return_value="/usr/local/bin/claude"
+        ) as mock_which,
         mock.patch("mlflow.agent.setup.cli._record_event") as mock_record,
     ):
         result = CliRunner().invoke(
@@ -78,13 +81,15 @@ def test_setup_records_telemetry(
             input=f"{skills_input}\nhttp://localhost:5001\n",
         )
     assert result.exit_code == 0, result.stderr
-    mock_record.assert_called_once()
-    _event, payload = mock_record.call_args.args
-    assert payload == {
-        "agent": "claude",
-        "print_prompt": True,
-        "skills_install_confirmed": skills_install_confirmed,
-    }
+    mock_which.assert_called()
+    mock_record.assert_called_once_with(
+        AgentSetupEvent,
+        {
+            "agent": "claude",
+            "print_prompt": True,
+            "skills_install_confirmed": skills_install_confirmed,
+        },
+    )
 
 
 def test_setup_requested_agent_not_installed(tmp_git_repo: Path):


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23595

### What changes are proposed in this pull request?

Adds the user's response to the skill-install prompt as a `skills_installed` field in the `AgentSetupEvent` telemetry payload emitted by `mlflow agent setup`. This lets us see how often users opt out of skill installation, which informs whether the prompt's default and copy are working well.

The `_record_event` call was moved to after the `click.confirm` so the flag is available.

### How is this PR tested?

- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)