### PR TITLE
Fix `llama_index` streaming traces stuck `IN_PROGRESS` with dropped metadata on `llama-index-core` >= 0.14.22

### DIFF
--- a/mlflow/llama_index/tracer.py
+++ b/mlflow/llama_index/tracer.py
@@ -249,6 +249,17 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
                     # We still need to detach the span from the context, otherwise it will
                     # be considered as "active"
                     detach_span_from_context(token)
+                    # For StreamingResponse wrappers, also resolve the span when the
+                    # user-facing generator is exhausted. Some flows (e.g. chat-based
+                    # response synthesis in llama-index-core >= 0.14.22) fire the LLM end
+                    # event and resolve the inner span *before* these enclosing spans
+                    # register, so the event-driven upward walk in resolve() never reaches
+                    # them. Tying resolution to generator exhaustion makes it independent of
+                    # event/registration ordering, and is idempotent with resolve().
+                    if isinstance(result, (StreamingResponse, AsyncStreamingResponse)):
+                        result.response_gen = self._wrap_stream_for_exhaustion(
+                            result.response_gen, span
+                        )
                 else:
                     # If the span is not pended successfully, end it immediately
                     _end_span(span=span, outputs=result, token=token)
@@ -285,6 +296,43 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
         """End the pending streaming span(s)"""
         self._stream_resolver.resolve(span, event)
         self._pending_spans.pop(event.span_id, None)
+
+    def _wrap_stream_for_exhaustion(self, response_gen, span: LiveSpan):
+        """Wrap a StreamingResponse generator so the pending span is resolved when the
+        generator is exhausted (or closed), independent of LLM end-event ordering. The
+        streamed text chunks are accumulated and recorded as the span output.
+        """
+        handler = self
+
+        if inspect.isasyncgen(response_gen):
+
+            async def _async_wrapper():
+                chunks = []
+                try:
+                    async for item in response_gen:
+                        if isinstance(item, str):
+                            chunks.append(item)
+                        yield item
+                finally:
+                    handler._end_pending_stream_span_on_exhaustion(span, "".join(chunks) or None)
+
+            return _async_wrapper()
+
+        def _wrapper():
+            chunks = []
+            try:
+                for item in response_gen:
+                    if isinstance(item, str):
+                        chunks.append(item)
+                    yield item
+            finally:
+                handler._end_pending_stream_span_on_exhaustion(span, "".join(chunks) or None)
+
+        return _wrapper()
+
+    def _end_pending_stream_span_on_exhaustion(self, span: LiveSpan, outputs=None):
+        for ended_id in self._stream_resolver.resolve_exhausted(span, outputs):
+            self._pending_spans.pop(ended_id, None)
 
     def prepare_to_drop_span(self, id_: str, err: Exception | None, **kwargs) -> _LlamaSpan:
         """Logic for handling errors during the model execution."""
@@ -654,3 +702,40 @@ class StreamResolver:
                 # as token stream can be modified by callers. However, it is technically
                 # challenging to track the modified stream across multiple spans.
                 _end_span(span=span, status=status, outputs=output_text)
+
+    def resolve_exhausted(self, span: LiveSpan, outputs=None) -> list[str]:
+        """Resolve a pending stream span and its still-pending ancestors when the
+        user-facing response generator is exhausted.
+
+        Used for flows where the LLM end event resolved the inner span *before* these
+        enclosing StreamingResponse spans registered (e.g. chat-based response synthesis
+        in llama-index-core >= 0.14.22), so the event-driven `resolve()` upward walk never
+        reached them. Idempotent: spans already resolved by an end event are skipped.
+
+        Returns the span ids that were ended.
+        """
+        entry = self._span_id_to_span_and_gen.pop(span.span_id, None)
+        if entry is None:
+            return []
+        trace_id = span.trace_id
+        span, _ = entry
+        _end_span(span=span, status=SpanStatusCode.OK, outputs=outputs)
+        ended = [span.span_id]
+        # Resolve the still-pending ancestors that share the (now-exhausted) stream.
+        while span.parent_id in self._span_id_to_span_and_gen:
+            if span_and_stream := self._span_id_to_span_and_gen.pop(span.parent_id, None):
+                span, _ = span_and_stream
+                _end_span(span=span, status=SpanStatusCode.OK, outputs=outputs)
+                ended.append(span.span_id)
+        # Resolve any other still-pending spans of the same trace. On
+        # llama-index-core >= 0.14.22, intermediate generator spans (e.g.
+        # CompactAndRefine.get_response) can also register after their LLM child's end
+        # event fired, leaving them open. While such spans stay open, the trace's
+        # full-info export stays deferred and trace-level metadata (inputs/outputs,
+        # model id) is dropped. The user-facing stream is exhausted, so the trace is done.
+        for pending_id, (pending_span, _) in list(self._span_id_to_span_and_gen.items()):
+            if pending_span.trace_id == trace_id:
+                self._span_id_to_span_and_gen.pop(pending_id, None)
+                _end_span(span=pending_span, status=SpanStatusCode.OK)
+                ended.append(pending_id)
+        return ended


### PR DESCRIPTION
> **Draft** — scoped to the `llama_index` flavor only (no core tracing changes). Posting for `llama_index` integration review.

### Related Issues/PRs

Relates to the failing scheduled cross-version `Cross version tests` (llama_index autologging) job on `mlflow/dev`.

### What changes are proposed in this pull request?

On `llama-index-core >= 0.14.22`, chat-based response synthesis fires the LLM end event and resolves the inner span **before** the enclosing `StreamingResponse` spans (and intermediate generator spans such as `CompactAndRefine.get_response`) register. The event-driven upward walk in `StreamResolver.resolve()` then never reaches those spans, so for streaming queries:

- the streaming spans stay `IN_PROGRESS` (the trace status never becomes `OK`), and
- because spans stay open, the trace's full-info export remains deferred and **all trace-level `request_metadata` is dropped** (inputs/outputs, model id, schema, etc.).

This adds an order-independent resolution path in the `llama_index` tracer: a pending `StreamingResponse` span is resolved when its user-facing response generator is exhausted (accumulating the streamed text as the span output), and any other still-pending spans of the same trace are swept closed. It is idempotent with the existing event-driven resolution, so it is a no-op on versions where the end event already resolves the spans. Contained to `mlflow/llama_index/tracer.py`; no core tracing changes.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Bisected the regression to `llama-index-core` 0.14.22 (0.14.21 passes). With this change, on **0.14.22** the previously-failing `tests/llama_index/test_llama_index_tracer.py::test_trace_query_engine[False-True]` and `tests/llama_index/test_llama_index_autolog.py::test_autolog_link_traces_to_loaded_model_index_query[True]` both pass; on **0.14.21** results are unchanged (no regression). Full `test_llama_index_tracer.py` + `test_llama_index_autolog.py` suites pass on both versions.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fixes `llama_index` autolog streaming traces being recorded as incomplete (status `IN_PROGRESS`, missing metadata) on `llama-index-core >= 0.14.22`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release