### PR TITLE
Always record `AgentSetupEvent` telemetry

### DIFF
--- a/mlflow/agent/setup/cli.py
+++ b/mlflow/agent/setup/cli.py
@@ -76,7 +76,8 @@ def _run_setup(
     agent_name: AgentName | None,
     print_prompt: bool,
     payload: dict[str, Any],
-) -> int:
+) -> tuple[list[str], Path] | None:
+    """Run the interactive setup flow and return the agent launch command, or None for --print."""
     repo_root = _git_root(Path.cwd())
     if repo_root is None:
         raise click.ClickException("`mlflow agent setup` must be run inside a git working tree.")
@@ -133,14 +134,12 @@ def _run_setup(
 
     if print_prompt:
         click.echo(prompt)
-        return 0
+        return None
 
     cmd = [agent.binary, *agent.interactive_args, prompt]
     click.echo(err=True)
     click.secho(f"Launching {agent.display_name}...", fg="cyan", err=True)
-    # Inherit stdio so the agent's TUI takes over until the user exits.
-    result = subprocess.run(cmd, cwd=repo_root)
-    return result.returncode
+    return cmd, repo_root
 
 
 @click.command("setup")
@@ -180,9 +179,17 @@ def setup(
         "skills_install_confirmed": None,
     }
     try:
-        exit_code = _run_setup(agent_name, print_prompt, payload)
-        success = exit_code == 0
+        launch = _run_setup(agent_name, print_prompt, payload)
+        success = True
     finally:
+        # Record before handing off to the agent's TUI so a force-aborted session
+        # (kill -9, terminal closed) doesn't drop the setup event.
         _record_event(AgentSetupEvent, payload, success=success)
 
-    sys.exit(exit_code)
+    if launch is None:
+        return
+
+    cmd, cwd = launch
+    # Inherit stdio so the agent's TUI takes over until the user exits.
+    result = subprocess.run(cmd, cwd=cwd)
+    sys.exit(result.returncode)

--- a/mlflow/agent/setup/cli.py
+++ b/mlflow/agent/setup/cli.py
@@ -181,7 +181,7 @@ def setup(
     }
     try:
         exit_code = _run_setup(agent_name, print_prompt, payload)
-        success = True
+        success = exit_code == 0
     finally:
         _record_event(AgentSetupEvent, payload, success=success)
 

--- a/mlflow/agent/setup/cli.py
+++ b/mlflow/agent/setup/cli.py
@@ -4,6 +4,7 @@ import socket
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
 import click
 
@@ -74,7 +75,7 @@ def _choose_agent(preferred: AgentName | None) -> AgentTool:
 def _run_setup(
     agent_name: AgentName | None,
     print_prompt: bool,
-    payload,
+    payload: dict[str, Any],
 ) -> int:
     repo_root = _git_root(Path.cwd())
     if repo_root is None:

--- a/mlflow/agent/setup/cli.py
+++ b/mlflow/agent/setup/cli.py
@@ -71,41 +71,17 @@ def _choose_agent(preferred: AgentName | None) -> AgentTool:
             return installed[choice - 1]
 
 
-@click.command("setup")
-@click.option(
-    "--agent",
-    "agent_name",
-    type=click.Choice(sorted(AGENTS)),
-    default=None,
-    help="Coding agent to set up. If omitted, picks from installed agents.",
-)
-@click.option(
-    "--print",
-    "print_prompt",
-    is_flag=True,
-    default=False,
-    help=(
-        "Print the composed task prompt to stdout and skip launching the agent. "
-        "Lets you pipe into a custom invocation, e.g. "
-        "`mlflow agent setup --print | claude --permission-mode auto`."
-    ),
-)
-def setup(
+def _run_setup(
     agent_name: AgentName | None,
     print_prompt: bool,
-):
-    """[Experimental] Install MLflow skills and launch a coding agent to instrument this repo."""
-    click.secho(
-        "[Experimental] `mlflow agent setup` is experimental and may change without notice.",
-        fg="yellow",
-        err=True,
-    )
-
+    payload,
+) -> int:
     repo_root = _git_root(Path.cwd())
     if repo_root is None:
         raise click.ClickException("`mlflow agent setup` must be run inside a git working tree.")
 
     agent = _choose_agent(agent_name)
+    payload["agent"] = agent.name
 
     skills_dest = repo_root / agent.skills_dir
     skills_installed = click.confirm(
@@ -117,14 +93,7 @@ def setup(
         default=True,
         err=True,
     )
-    _record_event(
-        AgentSetupEvent,
-        {
-            "agent": agent.name,
-            "print_prompt": print_prompt,
-            "skills_install_confirmed": skills_installed,
-        },
-    )
+    payload["skills_install_confirmed"] = skills_installed
     if skills_installed:
         installed = install_skills(skills_dest)
         click.secho(
@@ -163,11 +132,56 @@ def setup(
 
     if print_prompt:
         click.echo(prompt)
-        return
+        return 0
 
     cmd = [agent.binary, *agent.interactive_args, prompt]
     click.echo(err=True)
     click.secho(f"Launching {agent.display_name}...", fg="cyan", err=True)
     # Inherit stdio so the agent's TUI takes over until the user exits.
     result = subprocess.run(cmd, cwd=repo_root)
-    sys.exit(result.returncode)
+    return result.returncode
+
+
+@click.command("setup")
+@click.option(
+    "--agent",
+    "agent_name",
+    type=click.Choice(sorted(AGENTS)),
+    default=None,
+    help="Coding agent to set up. If omitted, picks from installed agents.",
+)
+@click.option(
+    "--print",
+    "print_prompt",
+    is_flag=True,
+    default=False,
+    help=(
+        "Print the composed task prompt to stdout and skip launching the agent. "
+        "Lets you pipe into a custom invocation, e.g. "
+        "`mlflow agent setup --print | claude --permission-mode auto`."
+    ),
+)
+def setup(
+    agent_name: AgentName | None,
+    print_prompt: bool,
+):
+    """[Experimental] Install MLflow skills and launch a coding agent to instrument this repo."""
+    click.secho(
+        "[Experimental] `mlflow agent setup` is experimental and may change without notice.",
+        fg="yellow",
+        err=True,
+    )
+
+    success = False
+    payload = {
+        "agent": None,
+        "print_prompt": print_prompt,
+        "skills_install_confirmed": None,
+    }
+    try:
+        exit_code = _run_setup(agent_name, print_prompt, payload)
+        success = True
+    finally:
+        _record_event(AgentSetupEvent, payload, success=success)
+
+    sys.exit(exit_code)

--- a/tests/agent/test_cli.py
+++ b/tests/agent/test_cli.py
@@ -4,6 +4,7 @@ import subprocess
 from pathlib import Path
 from unittest import mock
 
+import click
 import pytest
 from click.testing import CliRunner
 
@@ -105,5 +106,24 @@ def test_setup_requested_agent_not_installed(tmp_git_repo: Path):
     mock_record.assert_called_once_with(
         AgentSetupEvent,
         {"agent": None, "print_prompt": True, "skills_install_confirmed": None},
+        success=False,
+    )
+
+
+def test_setup_records_failure_on_abort(tmp_git_repo: Path):
+    with (
+        mock.patch(
+            "mlflow.agent.agents.shutil.which", return_value="/usr/local/bin/claude"
+        ) as mock_which,
+        mock.patch("mlflow.agent.setup.cli.click.confirm", side_effect=click.Abort) as mock_confirm,
+        mock.patch("mlflow.agent.setup.cli._record_event") as mock_record,
+    ):
+        result = CliRunner().invoke(setup, ["--agent", "claude", "--print"])
+    assert result.exit_code != 0
+    mock_which.assert_called()
+    mock_confirm.assert_called_once()
+    mock_record.assert_called_once_with(
+        AgentSetupEvent,
+        {"agent": "claude", "print_prompt": True, "skills_install_confirmed": None},
         success=False,
     )

--- a/tests/agent/test_cli.py
+++ b/tests/agent/test_cli.py
@@ -89,12 +89,21 @@ def test_setup_records_telemetry(
             "print_prompt": True,
             "skills_install_confirmed": skills_install_confirmed,
         },
+        success=True,
     )
 
 
 def test_setup_requested_agent_not_installed(tmp_git_repo: Path):
-    with mock.patch("mlflow.agent.agents.shutil.which", return_value=None) as mock_which:
+    with (
+        mock.patch("mlflow.agent.agents.shutil.which", return_value=None) as mock_which,
+        mock.patch("mlflow.agent.setup.cli._record_event") as mock_record,
+    ):
         result = CliRunner().invoke(setup, ["--agent", "claude", "--print"])
     assert result.exit_code != 0
     assert "not found on PATH" in result.stderr
     mock_which.assert_called()
+    mock_record.assert_called_once_with(
+        AgentSetupEvent,
+        {"agent": None, "print_prompt": True, "skills_install_confirmed": None},
+        success=False,
+    )


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23796

### What changes are proposed in this pull request?

`mlflow agent setup` previously only recorded telemetry on the successful-completion path. That means runs that bailed out early (no agent CLI installed, run outside a git tree, user Ctrl+C'd the install prompt, etc.) were invisible, so we couldn't measure how often users start the flow but don't complete it.

This wraps the main flow in a `try/finally` so the event always fires, and uses the existing `success` parameter on `_record_event` to distinguish completed runs from abandoned ones. Payload fields default to `None` and get populated as state becomes known, so a failure before the install prompt still records a meaningful event.

The main flow is also extracted into `_run_setup` so the click handler stays focused on the telemetry/exit wrapping.

### How is this PR tested?

- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)