### PR TITLE
Fill in `skills_dir` and launch flags for `codex` and `opencode` agents

### DIFF
--- a/mlflow/agent/agents.py
+++ b/mlflow/agent/agents.py
@@ -20,7 +20,7 @@ class AgentTool:
     binary: str
     # Repo-relative directory where this agent reads SKILL.md from.
     skills_dir: str
-    # Extra args appended before the task prompt in interactive launch.
+    # Args inserted between the binary and the prompt at launch.
     interactive_args: tuple[str, ...] = ()
 
     def is_installed(self) -> bool:
@@ -33,29 +33,19 @@ AGENTS: dict[AgentName, AgentTool] = {
         display_name="Claude Code",
         binary="claude",
         skills_dir=".claude/skills",
-        interactive_args=(
-            "--permission-mode",
-            "acceptEdits",
-            "--disallowedTools",
-            "ExitPlanMode,EnterPlanMode",
-            # `--disallowedTools` is variadic; `--` ends option parsing so the
-            # prompt isn't consumed as another tool name.
-            "--",
-        ),
     ),
     "codex": AgentTool(
         name="codex",
         display_name="OpenAI Codex",
         binary="codex",
-        skills_dir=".agents/skills",  # TBD: confirm codex picks up `.agents/skills`
-        interactive_args=(),  # TBD: interactive launch flags for codex
+        skills_dir=".codex/skills",
     ),
     "opencode": AgentTool(
         name="opencode",
         display_name="OpenCode",
         binary="opencode",
-        skills_dir=".agents/skills",  # TBD: confirm opencode picks up `.agents/skills`
-        interactive_args=(),  # TBD: interactive launch flags for opencode
+        skills_dir=".opencode/skills",
+        interactive_args=("--prompt",),
     ),
 }
 

--- a/tests/agent/test_cli.py
+++ b/tests/agent/test_cli.py
@@ -80,22 +80,17 @@ def test_setup_renders_per_agent_skills_dir(
 def test_setup_launches_agent_with_correct_argv(
     tmp_git_repo: Path, agent: str, expected_args_before_prompt: list[str]
 ):
-    real_run = subprocess.run
-    captured: list[list[str]] = []
-
-    def fake_run(cmd, *args, **kwargs):
-        if cmd and cmd[0] == agent:
-            captured.append(cmd)
-            return subprocess.CompletedProcess(cmd, 0)
-        return real_run(cmd, *args, **kwargs)
-
     with (
         mock.patch("mlflow.agent.agents.shutil.which", return_value=f"/usr/local/bin/{agent}"),
-        mock.patch("mlflow.agent.setup.cli.subprocess.run", side_effect=fake_run),
+        mock.patch("mlflow.agent.setup.cli._git_root", return_value=tmp_git_repo),
+        mock.patch(
+            "mlflow.agent.setup.cli.subprocess.run",
+            return_value=subprocess.CompletedProcess([], 0),
+        ) as mock_run,
     ):
         CliRunner().invoke(setup, ["--agent", agent], input="y\nhttp://localhost:5001\n")
-    assert len(captured) == 1
-    cmd = captured[0]
+    mock_run.assert_called_once()
+    cmd = mock_run.call_args.args[0]
     assert cmd[:-1] == expected_args_before_prompt
     assert cmd[-1].startswith("# MLflow Tracing Setup")
 

--- a/tests/agent/test_cli.py
+++ b/tests/agent/test_cli.py
@@ -48,6 +48,58 @@ def test_setup_user_provided_uri(tmp_git_repo: Path):
     mock_which.assert_called()
 
 
+@pytest.mark.parametrize(
+    ("agent", "binary", "skills_dir"),
+    [
+        ("claude", "/usr/local/bin/claude", ".claude/skills"),
+        ("codex", "/usr/local/bin/codex", ".codex/skills"),
+        ("opencode", "/usr/local/bin/opencode", ".opencode/skills"),
+    ],
+)
+def test_setup_renders_per_agent_skills_dir(
+    tmp_git_repo: Path, agent: str, binary: str, skills_dir: str
+):
+    with mock.patch("mlflow.agent.agents.shutil.which", return_value=binary) as mock_which:
+        result = CliRunner().invoke(
+            setup, ["--agent", agent, "--print"], input="y\nhttp://localhost:5001\n"
+        )
+    assert result.exit_code == 0, result.stderr
+    assert f"Install MLflow skills at {skills_dir}/" in result.stderr
+    assert f"`{skills_dir}/`" in result.stdout
+    mock_which.assert_called()
+
+
+@pytest.mark.parametrize(
+    ("agent", "expected_args_before_prompt"),
+    [
+        ("claude", ["claude"]),
+        ("codex", ["codex"]),
+        ("opencode", ["opencode", "--prompt"]),
+    ],
+)
+def test_setup_launches_agent_with_correct_argv(
+    tmp_git_repo: Path, agent: str, expected_args_before_prompt: list[str]
+):
+    real_run = subprocess.run
+    captured: list[list[str]] = []
+
+    def fake_run(cmd, *args, **kwargs):
+        if cmd and cmd[0] == agent:
+            captured.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0)
+        return real_run(cmd, *args, **kwargs)
+
+    with (
+        mock.patch("mlflow.agent.agents.shutil.which", return_value=f"/usr/local/bin/{agent}"),
+        mock.patch("mlflow.agent.setup.cli.subprocess.run", side_effect=fake_run),
+    ):
+        CliRunner().invoke(setup, ["--agent", agent], input="y\nhttp://localhost:5001\n")
+    assert len(captured) == 1
+    cmd = captured[0]
+    assert cmd[:-1] == expected_args_before_prompt
+    assert cmd[-1].startswith("# MLflow Tracing Setup")
+
+
 def test_setup_declined_skills_uses_bundled_path(tmp_git_repo: Path):
     with mock.patch(
         "mlflow.agent.agents.shutil.which", return_value="/usr/local/bin/claude"


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23798

### What changes are proposed in this pull request?

Resolve the TBDs in `mlflow/agent/agents.py` for the two non-Claude coding agents:

- `codex`: `skills_dir` = `.codex/skills` (matches the project-level convention documented in the [Codex Skills](https://developers.openai.com/codex/skills) page).
- `opencode`: `skills_dir` = `.opencode/skills`, and `interactive_args = ("--prompt",)` because opencode's positional CLI slot is `[project]` (a directory path), so a long prompt passed positionally trips `ENAMETOOLONG`. The `--prompt` flag is documented in `opencode --help`.

Also drops `--permission-mode acceptEdits --disallowedTools ExitPlanMode,EnterPlanMode --` from the `claude` entry. We can't assume what the user prefers (they may have their own `settings.json` / permission setup for Claude), so it's safer to launch each agent with its default settings.

### How is this PR tested?

- [x] Manual tests

Drove both `mlflow agent setup --agent codex` and `mlflow agent setup --agent opencode` end-to-end and confirmed each agent launches its TUI and starts executing the setup prompt.

**codex demo:**

https://github.com/user-attachments/assets/4c5f575b-a87d-4387-9bf1-d035f7b2af64

**opencode demo:**

https://github.com/user-attachments/assets/060fc25f-3073-4c38-9fee-162cb08a2d8d

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)