### PR TITLE
Drop infeasible "Don't crash without the tracking server" rule from `instrument.md`

### DIFF
--- a/mlflow/agent/setup/templates/instrument.md
+++ b/mlflow/agent/setup/templates/instrument.md
@@ -53,4 +53,3 @@ Summarize:
 - MLflow version installed
 - Files modified
 - Trace URL (required)
-- Whether the app still works without the tracking server reachable

--- a/mlflow/agent/setup/templates/instrument.md
+++ b/mlflow/agent/setup/templates/instrument.md
@@ -9,11 +9,6 @@ You are being launched by `mlflow agent setup` in repo `{{ repo_root }}`.
   ask the user which to instrument before starting.
 - **Install the latest MLflow.** Use the project's package manager's normal
   install. Do not hard-pin the version unless the user asks.
-- **Don't crash without the tracking server.** If {{ tracking_uri }} is
-  unreachable at runtime, traces should fail silently — the app must still
-  work. To verify quickly without waiting on long client timeouts, run the
-  app with `MLFLOW_HTTP_REQUEST_TIMEOUT=5` and an unreachable URI (e.g.
-  `MLFLOW_TRACKING_URI=http://localhost:1`).
 - **Do not add eval code** unless explicitly requested.
 - **If MLflow is already installed and configured, do not duplicate work.**
   Note the existing setup in the final summary.
@@ -36,7 +31,11 @@ Before writing any code:
 - Run the application end-to-end via its normal entry point.
 - Confirm at least one trace is emitted to {{ tracking_uri }}.
 - Confirm no runtime errors.
-- Confirm the app still runs if the tracking server is unreachable.
+
+If MLflow calls hang during verification (e.g. because the tracking server is
+slow or unreachable), set `MLFLOW_HTTP_REQUEST_MAX_RETRIES=0` and
+`MLFLOW_HTTP_REQUEST_TIMEOUT=5` to fail fast instead of waiting through the
+default retries.
 
 If you don't know how to run the app, ask the user and wait for a response
 before proceeding.


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23595

### What changes are proposed in this pull request?

The `mlflow agent setup` instrument prompt asked the agent to ensure the
instrumented app keeps running when the tracking server is unreachable, but
`mlflow.set_experiment(...)` makes a real REST call (`get_experiment_by_name`)
and raises `MlflowException` on failure. With default retries (7 × backoff
factor 2 × 120s timeout) the agent's verify step also hangs for several
minutes before crashing, so an honest agent could not satisfy the rule.

This PR:

- Removes the unsatisfiable "Don't crash without the tracking server" hard
  rule and the matching Step 4 verify bullet.
- Adds a fast-fail hint pointing at `MLFLOW_HTTP_REQUEST_MAX_RETRIES=0` and
  `MLFLOW_HTTP_REQUEST_TIMEOUT=5` so an agent that hits a slow/unreachable
  tracking server during verification fails immediately instead of sitting
  through the default backoff.

### How is this PR tested?

- [x] Existing unit/integration tests

`uv run --frozen pytest tests/agent` passes (26 tests).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)