### PR TITLE
Raise minimum dependency floors to address known CVEs

### DIFF
--- a/dev/pyproject.py
+++ b/dev/pyproject.py
@@ -364,7 +364,7 @@ def build(package_type: PackageType) -> None:
                 "gateway": gateways_requirements,
                 "genai": genai_requirements,
                 # click 8.3.0 causes MLflow MCP server to fail: https://github.com/mlflow/mlflow/issues/18747
-                "mcp": ["fastmcp<4,>=2.7.0", "click!=8.3.0"],
+                "mcp": ["fastmcp<4,>=3.2.0", "click!=8.3.0"],
                 "azure": [
                     # Required to log artifacts and models to Azure Blob Storage
                     "azure-storage-blob>=12",

--- a/libs/skinny/pyproject.toml
+++ b/libs/skinny/pyproject.toml
@@ -30,17 +30,17 @@ dependencies = [
   "cloudpickle<4",
   "databricks-sdk<1,>=0.20.0",
   "fastapi<1",
-  "gitpython<4,>=3.1.9",
+  "gitpython<4,>=3.1.47",
   "importlib_metadata<10,>=3.7.0,!=4.7.0",
   "opentelemetry-api<3,>=1.9.0",
   "opentelemetry-proto<3,>=1.9.0",
   "opentelemetry-sdk<3,>=1.9.0",
   "packaging<27",
-  "protobuf<8,>=3.12.0",
+  "protobuf<8,>=6.33.5",
   "pydantic<3,>=2.0.0",
-  "python-dotenv<2,>=0.19.0",
+  "python-dotenv<2,>=1.2.2",
   "pyyaml<7,>=5.1",
-  "requests<3,>=2.17.3",
+  "requests<3,>=2.33.0",
   "sqlparse<1,>=0.4.0",
   "starlette<2",
   "typing-extensions<5,>=4.0.0",
@@ -89,7 +89,7 @@ genai = [
   "uvicorn[standard]<1",
   "watchfiles<2",
 ]
-mcp = ["fastmcp<4,>=2.7.0", "click!=8.3.0"]
+mcp = ["fastmcp<4,>=3.2.0", "click!=8.3.0"]
 azure = ["azure-storage-blob>=12", "azure-identity>=1.6.1"]
 sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]

--- a/libs/tracing/pyproject.toml
+++ b/libs/tracing/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "opentelemetry-proto<3,>=1.9.0",
   "opentelemetry-sdk<3,>=1.9.0",
   "packaging<27",
-  "protobuf<8,>=3.12.0",
+  "protobuf<8,>=6.33.5",
   "pydantic<3,>=2.0.0",
 ]
 [[project.maintainers]]

--- a/pyproject.release.toml
+++ b/pyproject.release.toml
@@ -91,7 +91,7 @@ genai = [
   "uvicorn[standard]<1",
   "watchfiles<2",
 ]
-mcp = ["fastmcp<4,>=2.7.0", "click!=8.3.0"]
+mcp = ["fastmcp<4,>=3.2.0", "click!=8.3.0"]
 azure = ["azure-storage-blob>=12", "azure-identity>=1.6.1"]
 sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "databricks-sdk<1,>=0.20.0",
   "docker<8,>=4.0.0",
   "fastapi<1",
-  "gitpython<4,>=3.1.9",
+  "gitpython<4,>=3.1.47",
   "graphene<4",
   "gunicorn<27; platform_system != 'Windows'",
   "huey<4,>=2.5.4",
@@ -50,12 +50,12 @@ dependencies = [
   "opentelemetry-sdk<3,>=1.9.0",
   "packaging<27",
   "pandas<3",
-  "protobuf<8,>=3.12.0",
+  "protobuf<8,>=6.33.5",
   "pyarrow<25,>=4.0.0",
   "pydantic<3,>=2.0.0",
-  "python-dotenv<2,>=0.19.0",
+  "python-dotenv<2,>=1.2.2",
   "pyyaml<7,>=5.1",
-  "requests<3,>=2.17.3",
+  "requests<3,>=2.33.0",
   "scikit-learn<2",
   "scipy<2",
   "skops<1",
@@ -109,7 +109,7 @@ genai = [
   "uvicorn[standard]<1",
   "watchfiles<2",
 ]
-mcp = ["fastmcp<4,>=2.7.0", "click!=8.3.0"]
+mcp = ["fastmcp<4,>=3.2.0", "click!=8.3.0"]
 azure = ["azure-storage-blob>=12", "azure-identity>=1.6.1"]
 sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]

--- a/requirements/skinny-requirements.yaml
+++ b/requirements/skinny-requirements.yaml
@@ -15,12 +15,12 @@ cloudpickle:
 
 python-dotenv:
   pip_release: python-dotenv
-  minimum: "0.19.0"
+  minimum: "1.2.2"
   max_major_version: 1
 
 gitpython:
   pip_release: gitpython
-  minimum: "3.1.9"
+  minimum: "3.1.47"
   max_major_version: 3
 
 pyyaml:
@@ -30,12 +30,12 @@ pyyaml:
 
 protobuf:
   pip_release: protobuf
-  minimum: "3.12.0"
+  minimum: "6.33.5"
   max_major_version: 7
 
 requests:
   pip_release: requests
-  minimum: "2.17.3"
+  minimum: "2.33.0"
   max_major_version: 2
 
 packaging:

--- a/requirements/tracing-requirements.yaml
+++ b/requirements/tracing-requirements.yaml
@@ -6,7 +6,7 @@
 
 protobuf:
   pip_release: protobuf
-  minimum: "3.12.0"
+  minimum: "6.33.5"
   max_major_version: 7
 
 packaging:


### PR DESCRIPTION
## Summary

Fixes #23061 by raising the minimum supported versions of dependencies with known security issues.

Updated minimum versions:

- `gitpython` to `>=3.1.47`
- `python-dotenv` to `>=1.2.2`
- `protobuf` to `>=6.33.5`
- `requests` to `>=2.33.0`
- `fastmcp` to `>=3.2.0`

## Changes

- Updated dependency floors in `requirements/skinny-requirements.yaml`
- Updated the tracing dependency floor in `requirements/tracing-requirements.yaml`
- Updated generated dependency declarations in:
  - `dev/pyproject.py`
  - `pyproject.toml`
  - `pyproject.release.toml`
  - `libs/skinny/pyproject.toml`
  - `libs/tracing/pyproject.toml`

## Testing

- Not run locally