### PR TITLE
Fix undefined generate_response in tracing docs examples

### DIFF
--- a/docs/docs/genai/tracing/quickstart/index.mdx
+++ b/docs/docs/genai/tracing/quickstart/index.mdx
@@ -210,7 +210,7 @@ Many LLM applications and AI agents maintain multi-turn conversations with users
         )
 
         # Your chat logic here
-        return generate_response(message)
+        return f"Echo: {message[-1]['content'] if message else ''}"
     ```
 
   </TabItem>

--- a/docs/docs/genai/tracing/track-users-sessions/index.mdx
+++ b/docs/docs/genai/tracing/track-users-sessions/index.mdx
@@ -69,7 +69,7 @@ To record user and session information within a function you control, use the <A
         mlflow.update_current_trace(session_id=session_id, user=user_id)
 
         # Your chat logic here
-        return generate_response(message)
+        return f"Echo: {message[-1]['content'] if message else ''}"
     ```
 
   </TabItem>


### PR DESCRIPTION
### Related Issues/PRs

Closes #23805

### What changes are proposed in this pull request?

This PR fixes two tracing documentation examples that call `generate_response(message)` without defining or importing it.

The undefined call appears in:
- `docs/docs/genai/tracing/quickstart/index.mdx`
- `docs/docs/genai/tracing/track-users-sessions/index.mdx`

To make both snippets runnable as written, this PR replaces the undefined call with a simple self-contained placeholder response:

```python
return f"Echo: {message[-1]['content'] if message else ''}"