### PR TITLE
Fix undefined generate_response in tracing docs

### DIFF
--- a/docs/docs/genai/tracing/quickstart/index.mdx
+++ b/docs/docs/genai/tracing/quickstart/index.mdx
@@ -210,7 +210,7 @@ Many LLM applications and AI agents maintain multi-turn conversations with users
         )
 
         # Your chat logic here
-        return generate_response(message)
+        return f"Echo: {message[-1]['content'] if message else ''}"
     ```
 
   </TabItem>

--- a/docs/docs/genai/tracing/track-users-sessions/index.mdx
+++ b/docs/docs/genai/tracing/track-users-sessions/index.mdx
@@ -69,7 +69,7 @@ To record user and session information within a function you control, use the <A
         mlflow.update_current_trace(session_id=session_id, user=user_id)
 
         # Your chat logic here
-        return generate_response(message)
+        return f"Echo: {message[-1]['content'] if message else ''}"
     ```
 
   </TabItem>


### PR DESCRIPTION
### Related Issues/PRs

Closes #23805

### What changes are proposed in this pull request?

This PR fixes two tracing documentation examples that call `generate_response(message)` without defining or importing it.

The undefined call appears in:
- `docs/docs/genai/tracing/quickstart/index.mdx`
- `docs/docs/genai/tracing/track-users-sessions/index.mdx`

To make both snippets runnable as written, this PR replaces the undefined call with a simple self-contained placeholder response:

```python
return f"Echo: {message[-1]['content'] if message else ''}"
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Manual verification:
- Confirmed both example snippets no longer reference an undefined function.
- Confirmed the replacement keeps the examples self-contained and runnable as documentation snippets.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release