### PR TITLE
Handle empty model_id in UC model version copy

### DIFF
--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -892,7 +892,7 @@ class UcModelRegistryStore(BaseRestStore):
                     shutil.rmtree(local_model_dir)
 
     def _get_logged_model_from_model_id(self, model_id) -> LoggedModel | None:
-        if model_id is None:
+        if model_id in (None, ""):
             return None
         try:
             return mlflow.get_logged_model(model_id)

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -979,6 +979,11 @@ def test_get_logged_model_from_model_id_returns_none_for_none_input(store):
     assert result is None
 
 
+def test_get_logged_model_from_model_id_returns_none_for_empty_string_input(store):
+    result = store._get_logged_model_from_model_id("")
+    assert result is None
+
+
 def test_get_logged_model_from_model_id_reraises_other_exceptions(store):
     with mock.patch(
         "mlflow.get_logged_model",
@@ -1028,6 +1033,51 @@ def test_create_model_version_succeeds_when_logged_model_not_found(store, local_
         mock.patch.dict("sys.modules", {"boto3": {}}),
     ):
         store.create_model_version(name=model_name, source=source, model_id="nonexistent_model_id")
+        _assert_create_model_version_endpoints_called(
+            request_mock=request_mock,
+            name=model_name,
+            source=source,
+            version=version,
+            model_id=None,
+        )
+
+
+def test_create_model_version_succeeds_when_model_id_is_empty_string(store, local_model_dir):
+    access_key_id = "fake-key"
+    secret_access_key = "secret-key"
+    session_token = "session-token"
+    aws_temp_creds = TemporaryCredentials(
+        aws_temp_credentials=AwsCredentials(
+            access_key_id=access_key_id,
+            secret_access_key=secret_access_key,
+            session_token=session_token,
+        )
+    )
+    storage_location = "s3://blah"
+    source = str(local_model_dir)
+    model_name = "model_1"
+    version = "1"
+    mock_artifact_repo = mock.MagicMock(autospec=OptimizedS3ArtifactRepository)
+    with (
+        mock.patch("mlflow.get_logged_model") as mock_get_logged_model,
+        mock.patch(
+            "mlflow.utils.rest_utils.http_request",
+            side_effect=get_request_mock(
+                name=model_name,
+                version=version,
+                temp_credentials=aws_temp_creds,
+                storage_location=storage_location,
+                source=source,
+            ),
+        ) as request_mock,
+        mock.patch(
+            "mlflow.store.artifact.optimized_s3_artifact_repo.OptimizedS3ArtifactRepository",
+            return_value=mock_artifact_repo,
+        ),
+        mock.patch.dict("sys.modules", {"boto3": {}}),
+    ):
+        store.create_model_version(name=model_name, source=source, model_id="")
+        mock_get_logged_model.assert_not_called()
         _assert_create_model_version_endpoints_called(
             request_mock=request_mock,
             name=model_name,


### PR DESCRIPTION
### Related Issues/PRs

Closes #22012

### What changes are proposed in this pull request?

This PR fixes Unity Catalog model version creation when `model_id` is an empty string during model version copy flows.

Previously, `_get_logged_model_from_model_id()` only treated `None` as an absent model ID. When `model_id=""`, the code attempted to call `mlflow.get_logged_model("")`, which caused validation failures instead of treating the value as missing.

This change updates the Unity Catalog registry store to treat an empty string `model_id` the same as `None` and adds regression coverage for that behavior.

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests

Manual verification:
- Ran `python -m pytest tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py -k "empty_string or logged_model_not_found or returns_none_for_none_input"`
- Verified these tests pass:
  - `test_get_logged_model_from_model_id_returns_none_for_none_input`
  - `test_get_logged_model_from_model_id_returns_none_for_empty_string_input`
  - `test_create_model_version_succeeds_when_logged_model_not_found`
  - `test_create_model_version_succeeds_when_model_id_is_empty_string`

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixes a Unity Catalog model registry edge case where copying or creating model versions with an empty `model_id` could fail instead of treating the value as absent.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release