### PR TITLE
[Tracing] Reassemble OpenInference retriever documents into span outputs on OTel ingest

### DIFF
--- a/mlflow/tracing/otel/translation/__init__.py
+++ b/mlflow/tracing/otel/translation/__init__.py
@@ -89,10 +89,16 @@ def translate_span_when_storing(span: Span) -> dict[str, Any]:
     ):
         attributes[SpanAttributeKey.INPUTS] = input_value
 
-    if SpanAttributeKey.OUTPUTS not in attributes and (
-        output_value := _get_output_value(attributes, events)
-    ):
-        attributes[SpanAttributeKey.OUTPUTS] = output_value
+    if SpanAttributeKey.OUTPUTS not in attributes:
+        # For retriever spans, prefer the structured per-document attributes (e.g. OpenInference's
+        # retrieval.documents.*) over the generic output.value blob, so retrieval-grounded scorers
+        # receive a list of documents instead of an opaque string.
+        span_type_raw = attributes.get(SpanAttributeKey.SPAN_TYPE)
+        span_type = try_json_loads(span_type_raw) if span_type_raw else None
+        if span_type == SpanType.RETRIEVER and (documents := _get_retrieval_documents(attributes)):
+            attributes[SpanAttributeKey.OUTPUTS] = documents
+        elif output_value := _get_output_value(attributes, events):
+            attributes[SpanAttributeKey.OUTPUTS] = output_value
 
     # Translate token usage
     if SpanAttributeKey.CHAT_USAGE not in attributes and (
@@ -264,6 +270,18 @@ def _get_output_value(
             if hasattr(translator, "get_output_value_from_events"):
                 if value := translator.get_output_value_from_events(events):
                     return value
+
+
+def _get_retrieval_documents(attributes: dict[str, Any]) -> Any:
+    """
+    Reassemble a retriever span's documents from convention-specific indexed attributes
+    (e.g. OpenInference's ``retrieval.documents.*``). Returns a JSON-serialized list of
+    document dicts, or None if no translator recognizes the attributes.
+    """
+    for translator in _TRANSLATORS:
+        if value := translator.get_retrieval_documents(attributes):
+            return value
+    return None
 
 
 def _get_message_format(attributes: dict[str, Any]) -> str | None:

--- a/mlflow/tracing/otel/translation/base.py
+++ b/mlflow/tracing/otel/translation/base.py
@@ -184,6 +184,23 @@ class OtelSchemaTranslator:
         """
         return self.get_attribute_value(attributes, self.OUTPUT_VALUE_KEYS)
 
+    def get_retrieval_documents(self, attributes: dict[str, Any]) -> Any:
+        """
+        Reassemble retrieved documents for a RETRIEVER span from convention-specific
+        attributes into the MLflow ``Document`` shape consumed by retrieval-grounded scorers.
+
+        Most conventions express a retriever's output only as a single ``output.value`` blob,
+        which is handled by ``get_output_value``; this hook is for conventions (e.g. OpenInference)
+        that emit the documents as separate indexed attributes. Returns ``None`` by default.
+
+        Args:
+            attributes: Dictionary of span attributes
+
+        Returns:
+            A JSON-serialized list of document dicts, or None if not applicable.
+        """
+        return None
+
     def get_tool_definitions(self, attributes: dict[str, Any]) -> Any:
         """
         Get tool definitions from OTEL attributes.

--- a/mlflow/tracing/otel/translation/open_inference.py
+++ b/mlflow/tracing/otel/translation/open_inference.py
@@ -4,8 +4,13 @@ Translation utilities for OpenInference semantic conventions.
 Reference: https://github.com/Arize-ai/openinference/blob/main/python/openinference-semantic-conventions/
 """
 
+import json
+import re
+from typing import Any
+
 from mlflow.entities.span import SpanType
 from mlflow.tracing.otel.translation.base import OtelSchemaTranslator
+from mlflow.tracing.utils import dump_span_attribute_value
 
 
 class OpenInferenceTranslator(OtelSchemaTranslator):
@@ -50,3 +55,67 @@ class OpenInferenceTranslator(OtelSchemaTranslator):
     MODEL_NAME_KEYS = ["llm.model_name", "embedding.model_name"]
     # https://github.com/Arize-ai/openinference/blob/c80c81b8d6fa564598bd359cdd7313f4472ceca8/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py#L49
     LLM_PROVIDER_KEY = "llm.provider"
+
+    # A retriever span's documents are emitted as flattened, indexed attributes
+    # ``retrieval.documents.{i}.document.{content|id|score|metadata}`` (from the
+    # SpanAttributes.RETRIEVAL_DOCUMENTS + DocumentAttributes conventions), not a single value.
+    # Reference: https://github.com/Arize-ai/openinference/blob/main/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py
+    _RETRIEVAL_DOCUMENT_ATTRIBUTE = re.compile(
+        r"^retrieval\.documents\.(\d+)\.document\.(content|id|score|metadata)$"
+    )
+
+    def get_retrieval_documents(self, attributes: dict[str, Any]) -> Any:
+        """
+        Reassemble OpenInference retriever documents into MLflow ``Document``-shaped dicts.
+
+        OpenInference flattens each retrieved document into ``retrieval.documents.{i}.document.*``
+        attributes. Without this, only the span-level ``output.value`` blob is captured, so
+        ``extract_retrieval_context_from_trace`` finds no per-document text and retrieval-grounded
+        scorers silently see empty context.
+        """
+        documents_by_index: dict[int, dict[str, Any]] = {}
+        for key, value in attributes.items():
+            if match := self._RETRIEVAL_DOCUMENT_ATTRIBUTE.match(key):
+                index, field = int(match.group(1)), match.group(2)
+                documents_by_index.setdefault(index, {})[field] = self._try_decode_if_json(value)
+
+        if not documents_by_index:
+            return None
+
+        documents = []
+        for index in sorted(documents_by_index):
+            fields = documents_by_index[index]
+            content = fields.get("content")
+            if not isinstance(content, str):
+                # ``document.content`` is spec'd as a plain string; coerce defensively so a
+                # non-string never reaches the scorers that string-join the context.
+                content = "" if content is None else str(content)
+            metadata = self._coerce_document_metadata(fields.get("metadata"))
+            if (score := fields.get("score")) is not None:
+                # MLflow's Document has no score field; preserve it under metadata. The dedicated
+                # ``document.score`` attribute is authoritative and wins over any metadata["score"].
+                metadata = {**metadata, "score": score}
+            documents.append({
+                "page_content": content,
+                "id": fields.get("id"),
+                "metadata": metadata,
+            })
+        # Use MLflow's canonical span-attribute serializer (TraceJSONEncoder) rather than a raw
+        # ``json.dumps``: ``document.metadata`` may carry non-JSON-native values, and this keeps
+        # serialization consistent with how every other OUTPUTS attribute is stored and read back.
+        return dump_span_attribute_value(documents)
+
+    @staticmethod
+    def _coerce_document_metadata(value: Any) -> dict[str, Any]:
+        # ``document.metadata`` is spec'd as a JSON-string dict; tolerate already-decoded dicts
+        # and malformed/non-dict payloads (return ``{}`` rather than raising).
+        if isinstance(value, dict):
+            return value
+        if isinstance(value, str) and value:
+            try:
+                loaded = json.loads(value)
+            except (json.JSONDecodeError, ValueError):
+                return {}
+            if isinstance(loaded, dict):
+                return loaded
+        return {}

--- a/mlflow/tracing/otel/translation/open_inference.py
+++ b/mlflow/tracing/otel/translation/open_inference.py
@@ -76,7 +76,8 @@ class OpenInferenceTranslator(OtelSchemaTranslator):
         documents_by_index: dict[int, dict[str, Any]] = {}
         for key, value in attributes.items():
             if match := self._RETRIEVAL_DOCUMENT_ATTRIBUTE.match(key):
-                index, field = int(match.group(1)), match.group(2)
+                index = int(match.group(1))
+                field = match.group(2)
                 documents_by_index.setdefault(index, {})[field] = self._try_decode_if_json(value)
 
         if not documents_by_index:

--- a/tests/tracing/otel/test_span_translation.py
+++ b/tests/tracing/otel/test_span_translation.py
@@ -512,6 +512,77 @@ def test_translate_outputs_for_spans_traceloop(output_key: str, output_value: An
     assert result["attributes"][SpanAttributeKey.OUTPUTS] == json.dumps(output_value)
 
 
+def _openinference_retriever_span(attributes: dict[str, Any]) -> mock.Mock:
+    span = mock.Mock(spec=Span)
+    span.parent_id = "parent_123"
+    span.to_dict.return_value = {
+        "attributes": {
+            OpenInferenceTranslator.SPAN_KIND_ATTRIBUTE_KEY: "RETRIEVER",
+            **attributes,
+        }
+    }
+    return span
+
+
+def test_translate_openinference_retrieval_documents():
+    span = _openinference_retriever_span({
+        "retrieval.documents.0.document.content": json.dumps("doc zero text"),
+        "retrieval.documents.0.document.id": json.dumps("id0"),
+        "retrieval.documents.0.document.metadata": json.dumps('{"doc_uri": "u0"}'),
+        "retrieval.documents.0.document.score": json.dumps(0.9),
+        "retrieval.documents.1.document.content": json.dumps("doc one text"),
+    })
+
+    result = translate_span_when_storing(span)
+
+    assert json.loads(result["attributes"][SpanAttributeKey.OUTPUTS]) == [
+        {"page_content": "doc zero text", "id": "id0", "metadata": {"doc_uri": "u0", "score": 0.9}},
+        {"page_content": "doc one text", "id": None, "metadata": {}},
+    ]
+
+
+def test_translate_openinference_retrieval_prefers_documents_over_output_value():
+    span = _openinference_retriever_span({
+        "retrieval.documents.0.document.content": json.dumps("real chunk text"),
+        # OpenInference retriever spans ALSO set output.value; the structured docs win.
+        "output.value": json.dumps({"documents": ["opaque blob"]}),
+    })
+
+    result = translate_span_when_storing(span)
+
+    assert json.loads(result["attributes"][SpanAttributeKey.OUTPUTS]) == [
+        {"page_content": "real chunk text", "id": None, "metadata": {}},
+    ]
+
+
+def test_translate_openinference_retrieval_sparse_indices_preserve_order():
+    span = _openinference_retriever_span({
+        "retrieval.documents.2.document.content": json.dumps("third"),
+        "retrieval.documents.0.document.content": json.dumps("first"),
+    })
+
+    result = translate_span_when_storing(span)
+
+    docs = json.loads(result["attributes"][SpanAttributeKey.OUTPUTS])
+    assert [d["page_content"] for d in docs] == ["first", "third"]
+
+
+def test_translate_non_retriever_openinference_still_uses_output_value():
+    # A non-retriever OpenInference span must be unaffected: output.value still wins.
+    span = mock.Mock(spec=Span)
+    span.parent_id = "parent_123"
+    span.to_dict.return_value = {
+        "attributes": {
+            OpenInferenceTranslator.SPAN_KIND_ATTRIBUTE_KEY: "LLM",
+            OpenInferenceTranslator.OUTPUT_VALUE_KEYS[0]: json.dumps("llm output"),
+        }
+    }
+
+    result = translate_span_when_storing(span)
+
+    assert result["attributes"][SpanAttributeKey.OUTPUTS] == json.dumps("llm output")
+
+
 @pytest.mark.parametrize(
     (
         "parent_id",


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23817

### What changes are proposed in this pull request?

When a trace using the OpenInference convention is imported over OTLP, a retriever span carries its results as flattened, indexed attributes — `retrieval.documents.{i}.document.{content|id|score|metadata}` — alongside a span-level `output.value` JSON blob. The OTel translation layer only mapped the span type and read `output.value` for the span's outputs, so the per-document attributes were dropped.

As a result `extract_retrieval_context_from_trace` finds no documents, and retrieval-grounded scorers (`RetrievalGroundedness`, `RetrievalRelevance`) run against empty context. This is the ingest-side half of #23817.

This PR:

- Adds a `get_retrieval_documents(attributes)` hook to `OtelSchemaTranslator` that returns `None` by default, so existing translators are unaffected.
- Overrides it in `OpenInferenceTranslator` to regroup the `retrieval.documents.{i}.document.*` attributes by index into an ordered list of MLflow `Document`-shaped dicts (`page_content` / `id` / `metadata`). `document.score` is preserved under `metadata` (the `Document` dataclass has no score field), and `document.metadata` (a JSON-string dict per the spec) is parsed defensively, degrading malformed payloads to `{}` rather than raising.
- In `translate_span_when_storing`, for spans resolved to `RETRIEVER` the reassembled documents take precedence over the generic `output.value`. Non-retriever spans, and retriever spans from conventions without this hook, are unchanged.

The emitted shape matches what native MLflow retriever spans already produce, so the trace UI's retriever renderer (which reads `document.page_content` / `document.metadata`) and the grounding scorers consume it without changes.

**Behavior change:** for OpenInference retriever spans, the stored span output now holds the structured document list instead of the `output.value` blob (OpenInference sets both). That is the shape the trace UI's retriever renderer already expects, but it does change the stored output for OTel-imported retriever traces, so flagging it.

Out of scope: reranker spans (a different attribute prefix, `reranker.{input,output}_documents.*`) and the consumer-side `_parse_chunk` field handling for #23817.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New tests in `tests/tracing/otel/test_span_translation.py`: document reassembly and index ordering; `score` surfaced under `metadata`; `metadata` JSON-string parsing; sparse/non-contiguous indices (`0`, `2`) ordered correctly; `output.value` ignored when indexed documents are present; non-retriever spans still use `output.value`. `ruff check` and `ruff format --check` are clean on the touched files.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

OpenInference retriever documents imported over OTel are now reassembled into the retriever span's outputs, so retrieval-grounded scorers (`RetrievalGroundedness`, `RetrievalRelevance`) evaluate against the actual retrieved context instead of an empty one.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
