### PR TITLE
fix: prevent database upgrade failure due to already-existing tables (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -86,7 +86,12 @@ def _is_empty_database(engine):
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
     InitialBase.metadata.create_all(engine)
-    _upgrade_db(engine)
+    # After creating initial tables, stamp the database with the latest revision
+    # to prevent Alembic from trying to apply historical migrations that would
+    # attempt to create already-existing tables.
+    from alembic.command import stamp
+    config = _get_alembic_config(engine.url)
+    stamp(config, revision="head")
 
 
 def _safe_initialize_tables(engine: sqlalchemy.engine.Engine) -> None:


### PR DESCRIPTION
## What
After upgrading to MLflow 3.8.x, running `mlflow db upgrade` fails with `Table 'secrets' already exists` when the database already contains a partial migration set.

The issue is that `_initialize_tables()` attempts to create all initial tables (including the `secrets` table) using `InitialBase.metadata.create_all()`, but some of those tables may already exist from a previous migration. `create_all` uses `checkfirst=True` by default, but the error still occurs because of a race condition or because the migration is applied without stamping the latest revision.

## Fix
After `InitialBase.metadata.create_all()` succeeds, we now stamp the database with the Alembic `head` revision. This ensures that Alembic will not attempt to re-apply any migrations that correspond to tables already created by the initial models, preventing the duplicate table error.

Additionally, this approach ensures that the database schema version is correctly tracked by Alembic from that point forward.

Closes #19943