### PR TITLE
Warn when distributed tracing spans are dropped by an unsupported backend

### DIFF
--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -50,6 +50,13 @@ class MlflowV3SpanExporter(SpanExporter):
         # if log_spans() raises NotImplementedError or returns a 501.
         self._store_supports_log_spans = True
 
+        # Whether we have already warned that cross-process distributed tracing is not
+        # functional because the backend does not support span-level (OTLP) ingestion.
+        # Spans created in a remote process can only be delivered via log_spans(), so when
+        # the backend lacks that support they are dropped. We surface a single, actionable
+        # warning instead of silently discarding them (see _log_spans).
+        self._warned_distributed_tracing_unsupported = False
+
         # Root spans deferred when background thread spans are still running at export time.
         # Keyed by OTel trace ID; popped and exported once all spans in the trace have ended.
         # Protected by _deferred_lock because SimpleSpanProcessor calls export() from the
@@ -68,6 +75,10 @@ class MlflowV3SpanExporter(SpanExporter):
 
         if self._store_supports_log_spans:
             self._export_spans_incrementally(spans)
+        elif not self._warned_distributed_tracing_unsupported and self._has_remote_trace_spans(
+            spans
+        ):
+            self._warn_distributed_tracing_unsupported()
 
         self._export_traces(spans)
 
@@ -86,22 +97,25 @@ class MlflowV3SpanExporter(SpanExporter):
             )
             return
 
-        mlflow_spans_by_experiment = self._collect_mlflow_spans_for_export(spans)
+        mlflow_spans_by_experiment, remote_experiment_ids = self._collect_mlflow_spans_for_export(
+            spans
+        )
         for experiment_id, spans_to_log in mlflow_spans_by_experiment.items():
+            is_remote_trace = experiment_id in remote_experiment_ids
             if self._should_log_async():
                 self._async_queue.put(
                     task=Task(
                         handler=self._log_spans,
-                        args=(experiment_id, spans_to_log),
+                        args=(experiment_id, spans_to_log, is_remote_trace),
                         error_msg="Failed to log spans to the trace server.",
                     )
                 )
             else:
-                self._log_spans(experiment_id, spans_to_log)
+                self._log_spans(experiment_id, spans_to_log, is_remote_trace)
 
     def _collect_mlflow_spans_for_export(
         self, spans: Sequence[ReadableSpan]
-    ) -> dict[str, list[Span]]:
+    ) -> tuple[dict[str, list[Span]], set[str]]:
         """
         Collect MLflow spans from ReadableSpans for export, grouped by experiment_id.
 
@@ -113,10 +127,15 @@ class MlflowV3SpanExporter(SpanExporter):
             spans: Sequence of ReadableSpan objects.
 
         Returns:
-            Dictionary mapping experiment_id to list of MLflow Span objects.
+            A tuple ``(spans_by_experiment, remote_experiment_ids)`` where
+            ``spans_by_experiment`` maps experiment_id to its list of MLflow Span objects, and
+            ``remote_experiment_ids`` is the subset of those experiment_ids that contain spans
+            belonging to a remote (distributed) trace. Spans of a remote trace can only reach
+            the backend via log_spans(), so this is used to warn when that path is unavailable.
         """
         manager = InMemoryTraceManager.get_instance()
         spans_by_experiment = defaultdict(list)
+        remote_experiment_ids: set[str] = set()
 
         for span in spans:
             mlflow_trace_id = manager.get_mlflow_trace_id_from_otel_id(span.context.trace_id)
@@ -128,7 +147,10 @@ class MlflowV3SpanExporter(SpanExporter):
                 continue
             # Get experiment_id from trace info (resolved at on_start time in the
             # originating thread) to survive BatchSpanProcessor thread hops.
+            is_remote_trace = False
             with manager.get_trace(mlflow_trace_id) as trace:
+                if trace is not None:
+                    is_remote_trace = trace.is_remote_trace
                 try:
                     experiment_id = trace.info.experiment_id if trace else None
                 except AttributeError:
@@ -137,8 +159,10 @@ class MlflowV3SpanExporter(SpanExporter):
             if experiment_id is None:
                 experiment_id = get_experiment_id_for_trace(span)
             spans_by_experiment[experiment_id].append(mlflow_span)
+            if is_remote_trace:
+                remote_experiment_ids.add(experiment_id)
 
-        return spans_by_experiment
+        return spans_by_experiment, remote_experiment_ids
 
     def _export_traces(self, spans: Sequence[ReadableSpan]) -> None:
         """
@@ -211,20 +235,30 @@ class MlflowV3SpanExporter(SpanExporter):
         else:
             self._log_trace(trace, prompts=manager_trace.prompts)
 
-    def _log_spans(self, experiment_id: str, spans: list[Span]) -> None:
+    def _log_spans(
+        self, experiment_id: str, spans: list[Span], is_remote_trace: bool = False
+    ) -> None:
         """
         Helper method to log spans with error handling.
 
         Args:
             experiment_id: The experiment ID to log spans to.
             spans: List of spans to log.
+            is_remote_trace: Whether these spans belong to a remote (distributed) trace. Such
+                spans can only be delivered to the backend via log_spans(), so if the backend
+                does not support it they are dropped and we surface a clear, one-time warning.
         """
         try:
             self._client.log_spans(experiment_id, spans)
         except NotImplementedError:
-            # Silently skip if the store doesn't support log_spans. This is expected for stores that
-            # don't implement span-level logging, and we don't want to spam warnings for every span.
+            # The store doesn't support log_spans. This is expected for stores that don't
+            # implement span-level logging, and we don't want to spam warnings for every span.
+            # For local (non-remote) traces this is harmless because the full trace is still
+            # exported via start_trace, but for remote traces these spans are the only carrier,
+            # so warn that distributed tracing is not functional with this backend.
             self._store_supports_log_spans = False
+            if is_remote_trace:
+                self._warn_distributed_tracing_unsupported()
         except RestException as e:
             # When the FileStore is behind the tracking server, it returns 501 exception.
             # However, the OTLP endpoint returns general HTTP error, not MlflowException, which does
@@ -232,10 +266,43 @@ class MlflowV3SpanExporter(SpanExporter):
             # we need to check the message to handle this case.
             if "REST OTLP span logging is not supported" in e.message:
                 self._store_supports_log_spans = False
+                if is_remote_trace:
+                    self._warn_distributed_tracing_unsupported()
             else:
                 _logger.debug(f"Failed to log span to MLflow backend: {e}")
         except Exception as e:
             _logger.debug(f"Failed to log span to MLflow backend: {e}")
+
+    def _has_remote_trace_spans(self, spans: Sequence[ReadableSpan]) -> bool:
+        """Return True if any of the given spans belong to a remote (distributed) trace."""
+        manager = InMemoryTraceManager.get_instance()
+        for span in spans:
+            mlflow_trace_id = manager.get_mlflow_trace_id_from_otel_id(span.context.trace_id)
+            if mlflow_trace_id is None:
+                continue
+            with manager.get_trace(mlflow_trace_id) as trace:
+                if trace is not None and trace.is_remote_trace:
+                    return True
+        return False
+
+    def _warn_distributed_tracing_unsupported(self) -> None:
+        """Emit a single, actionable warning that distributed tracing is not supported.
+
+        Spans created in a remote process are delivered to the backend only via the
+        span-level (OTLP) ingestion API. When the tracking backend does not support it,
+        those spans are dropped, which otherwise fails silently.
+        """
+        if self._warned_distributed_tracing_unsupported:
+            return
+        self._warned_distributed_tracing_unsupported = True
+        _logger.warning(
+            "Spans created in a remote process could not be logged because the current "
+            "MLflow tracking backend does not support span-level (OTLP) ingestion. "
+            "Cross-process distributed tracing requires an MLflow tracking server (version "
+            "3.4 or newer) backed by a SQL store. As a result, traces from the remote "
+            "service will not be linked into the distributed trace. See "
+            "https://mlflow.org/docs/latest/genai/tracing/ for supported backends."
+        )
 
     def _log_trace(self, trace: Trace, prompts: Sequence[PromptVersion]) -> None:
         """

--- a/tests/tracing/export/test_mlflow_v3_exporter.py
+++ b/tests/tracing/export/test_mlflow_v3_exporter.py
@@ -758,3 +758,101 @@ def test_deferred_root_span_export(monkeypatch):
         exporter.export([child_otel_span_closed])
         mock_start_trace.assert_called_once()
         mock_upload_trace_data.assert_called_once()
+
+
+def test_remote_trace_warns_once_when_backend_does_not_support_span_logging(monkeypatch):
+    """Regression test for #23778.
+
+    Spans created in a remote process are delivered to the backend only via log_spans().
+    When the backend does not support span-level (OTLP) ingestion (as with some managed
+    MLflow backends, e.g. AWS SageMaker AI), those spans are dropped. This previously failed
+    silently; the exporter must now surface a single, actionable warning.
+    """
+    monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_TRACE_LOGGING", "false")
+
+    now_ns = int(time.time() * 1e9)
+    otel_trace_id = 0xABCDEF
+    otel_span = create_mock_otel_span(
+        name="remote-child",
+        trace_id=otel_trace_id,
+        span_id=2,
+        parent_id=1,
+        start_time=now_ns,
+        end_time=now_ns,
+    )
+    trace_id = generate_trace_id_v3(otel_span)
+    span = LiveSpan(otel_span, trace_id)
+
+    trace_manager = InMemoryTraceManager.get_instance()
+    trace_info = create_test_trace_info(trace_id, _EXPERIMENT_ID)
+    trace_manager.register_trace(otel_trace_id, trace_info, is_remote_trace=True)
+    trace_manager.register_span(span)
+
+    with (
+        mock.patch(
+            "mlflow.tracing.client.TracingClient.log_spans",
+            side_effect=NotImplementedError,
+        ),
+        mock.patch("mlflow.tracing.export.mlflow_v3._logger") as mock_logger,
+    ):
+        exporter = MlflowV3SpanExporter()
+        # Export twice to verify the warning is emitted only once.
+        exporter.export([otel_span])
+        exporter.export([otel_span])
+
+    assert exporter._store_supports_log_spans is False
+    assert exporter._warned_distributed_tracing_unsupported is True
+    warning_calls = [
+        c for c in mock_logger.warning.call_args_list if "distributed tracing" in c.args[0].lower()
+    ]
+    assert len(warning_calls) == 1
+    assert "does not support span-level" in warning_calls[0].args[0]
+
+
+def test_local_trace_does_not_warn_when_backend_does_not_support_span_logging(monkeypatch):
+    """A local (non-distributed) trace must not trigger the distributed-tracing warning.
+
+    For local traces the full trace is still exported via start_trace + artifact upload, so a
+    log_spans() failure is harmless and warning would be misleading noise.
+    """
+    monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_TRACE_LOGGING", "false")
+
+    now_ns = int(time.time() * 1e9)
+    otel_trace_id = 0xBADF00D
+    otel_span = create_mock_otel_span(
+        name="root",
+        trace_id=otel_trace_id,
+        span_id=1,
+        parent_id=None,
+        start_time=now_ns,
+        end_time=now_ns,
+    )
+    trace_id = generate_trace_id_v3(otel_span)
+    span = LiveSpan(otel_span, trace_id)
+
+    trace_manager = InMemoryTraceManager.get_instance()
+    trace_info = create_test_trace_info(trace_id, _EXPERIMENT_ID)
+    trace_manager.register_trace(otel_trace_id, trace_info)  # local trace (not remote)
+    trace_manager.register_span(span)
+
+    with (
+        mock.patch(
+            "mlflow.tracing.client.TracingClient.log_spans",
+            side_effect=NotImplementedError,
+        ),
+        mock.patch(
+            "mlflow.tracing.client.TracingClient.start_trace",
+            return_value=trace_info,
+        ),
+        mock.patch("mlflow.tracing.client.TracingClient._upload_trace_data", return_value=None),
+        mock.patch("mlflow.tracing.export.mlflow_v3._logger") as mock_logger,
+    ):
+        exporter = MlflowV3SpanExporter()
+        exporter.export([otel_span])
+
+    assert exporter._store_supports_log_spans is False
+    assert exporter._warned_distributed_tracing_unsupported is False
+    warning_calls = [
+        c for c in mock_logger.warning.call_args_list if "distributed tracing" in c.args[0].lower()
+    ]
+    assert warning_calls == []


### PR DESCRIPTION
### Related Issues/PRs

Closes #23778

### What changes are proposed in this pull request?

Cross-process distributed tracing was failing silently against backends that do not support span-level (OTLP) ingestion, such as some managed MLflow backends (the linked issue reports AWS SageMaker AI MLflow). The same application works against a local OSS MLflow with a SQL backend and silently logs nothing against the managed backend.

Root cause: spans created in a remote process (under the context propagated via the `traceparent` header) always have a parent span, so they are never root spans. The full-trace export path skips non-root spans (`if span._parent is not None: continue` in `_export_traces`), which means those spans can only reach the backend through the span-level `log_spans` (OTLP) API. When the backend does not implement that API, `log_spans` raises `NotImplementedError` (or the server returns 501), and `MlflowV3SpanExporter._log_spans` caught it and silently set `_store_supports_log_spans = False`, dropping the spans. The one existing warning for this situation lives in `_do_export_trace`, which only runs for root spans, so it never fires for remote child spans.

This PR surfaces a single, actionable warning when remote (distributed) spans are dropped because the backend does not support span logging. It is intentionally gated to remote traces: for ordinary local traces a `log_spans` failure is harmless because the full trace is still exported via `start_trace` plus artifact upload, so warning there would be misleading noise.

Note: actually ingesting remote spans on such a backend still requires that backend to implement the OTLP span-logging endpoint, which is outside the scope of OSS MLflow. This change makes the failure visible and actionable instead of silent.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added `test_remote_trace_warns_once_when_backend_does_not_support_span_logging` (warns exactly once for remote spans when `log_spans` is unsupported) and `test_local_trace_does_not_warn_when_backend_does_not_support_span_logging` (no warning for a local trace in the same situation). Existing `tests/tracing/test_distributed.py` and `tests/tracing/export/test_mlflow_v3_exporter.py` continue to pass.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the MLflow Skills repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

MLflow now emits a clear warning when spans from a remote process in a distributed trace are dropped because the tracking backend does not support span-level (OTLP) ingestion, instead of failing silently.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
