### PR TITLE
[bugfix] Fix Experiments empty-state when tag filter is active

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.test.tsx
@@ -24,7 +24,6 @@ jest.mock('./experiment-page/hooks/useUpdateExperimentTags', () => ({
 
 jest.mock('./experiment-page/hooks/useTagsFilter', () => ({
   useTagsFilter: jest.fn(),
-  ExperimentListViewTagsFilter: () => null,
 }));
 
 const mountComponent = (props: { experiments: any[]; tagsFilter?: any[] }) => {

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.test.tsx
@@ -11,6 +11,7 @@ import Fixtures from '../utils/test-utils/Fixtures';
 import { DesignSystemProvider } from '@databricks/design-system';
 import { useExperimentListQuery } from './experiment-page/hooks/useExperimentListQuery';
 import { useUpdateExperimentTags } from './experiment-page/hooks/useUpdateExperimentTags';
+import { useTagsFilter } from './experiment-page/hooks/useTagsFilter';
 
 jest.mock('./experiment-page/hooks/useExperimentListQuery', () => ({
   useExperimentListQuery: jest.fn(),
@@ -21,7 +22,12 @@ jest.mock('./experiment-page/hooks/useUpdateExperimentTags', () => ({
   useUpdateExperimentTags: jest.fn(),
 }));
 
-const mountComponent = (props: any) => {
+jest.mock('./experiment-page/hooks/useTagsFilter', () => ({
+  useTagsFilter: jest.fn(),
+  ExperimentListViewTagsFilter: () => null,
+}));
+
+const mountComponent = (props: { experiments: any[]; tagsFilter?: any[] }) => {
   const mockStore = configureStore([thunk, promiseMiddleware()]);
 
   jest.mocked(useExperimentListQuery).mockImplementation(() => ({
@@ -47,6 +53,13 @@ const mountComponent = (props: any) => {
     isLoading: false,
     EditTagsModal: <span />,
     showEditExperimentTagsModal: jest.fn(),
+  });
+
+  jest.mocked(useTagsFilter).mockReturnValue({
+    tagsFilter: props.tagsFilter ?? [],
+    setTagsFilter: jest.fn(),
+    isTagsFilterOpen: false,
+    setIsTagsFilterOpen: jest.fn(),
   });
 
   return renderWithIntl(
@@ -90,4 +103,37 @@ test('paginated list should not render everything when there are many experiment
   });
   const selected = screen.getAllByTestId('experiment-list-item');
   expect(selected.length).toBeLessThan(keys.length);
+});
+
+test('should show "No experiments found" when tags filter is active and experiments list is empty', () => {
+  mountComponent({
+    experiments: [],
+    tagsFilter: [{ key: 'team', operator: 'IS', value: 'ml' }],
+  });
+
+  expect(screen.getByText('No experiments found')).toBeInTheDocument();
+  expect(screen.queryByText('Create your first experiment')).not.toBeInTheDocument();
+});
+
+test('Tag filter button shows active filter count when filters are applied', () => {
+  mountComponent({
+    experiments: [],
+    tagsFilter: [
+      { key: 'team', operator: 'IS', value: 'alpha' },
+      { key: 'project', operator: 'IS', value: 'nlp' },
+    ],
+  });
+
+  expect(screen.getByRole('button', { name: /Tag · 2/ })).toBeInTheDocument();
+});
+
+test('Tag filter button shows no count when no filters are applied', () => {
+  mountComponent({
+    experiments: [],
+    tagsFilter: [],
+  });
+
+  const tagButton = screen.getByRole('button', { name: /^Tag$/ });
+  expect(tagButton).toBeInTheDocument();
+  expect(tagButton).not.toHaveTextContent('·');
 });

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.tsx
@@ -206,8 +206,9 @@ export const ExperimentListView = () => {
                 type={tagsFilter.length > 0 ? 'primary' : undefined}
               >
                 <FormattedMessage
-                  defaultMessage="Tag"
-                  description="Button to open the tags filter popover in the experiments page"
+                  defaultMessage="Tag{count, plural, =0 {} other { · #}}"
+                  description="Button to open the tags filter popover in the experiments page. Shows an interpunct (·) followed by the count of active tag filters when any are applied."
+                  values={{ count: tagsFilter.length }}
                 />
               </Button>
             </Popover.Trigger>
@@ -219,7 +220,7 @@ export const ExperimentListView = () => {
         <ExperimentListTable
           experiments={experiments}
           isLoading={isLoading}
-          isFiltered={Boolean(searchFilter)}
+          isFiltered={Boolean(searchFilter) || tagsFilter.length > 0}
           rowSelection={rowSelection}
           setRowSelection={setRowSelection}
           cursorPaginationProps={{

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -471,6 +471,10 @@
     "defaultMessage": "MLflow documentation",
     "description": "Link to tracing documentation"
   },
+  "0W7Pi4": {
+    "defaultMessage": "Tag{count, plural, =0 {} other { · #}}",
+    "description": "Button to open the tags filter popover in the experiments page. Shows an interpunct (·) followed by the count of active tag filters when any are applied."
+  },
   "0WzWvy": {
     "defaultMessage": "Issues detected on the trace by automatic issue detection",
     "description": "Tooltip description for the Issues column in the traces table"
@@ -3954,10 +3958,6 @@
   "KcGozs": {
     "defaultMessage": "Endpoint:",
     "description": "Endpoint selector label"
-  },
-  "KcnW3U": {
-    "defaultMessage": "Tag",
-    "description": "Button to open the tags filter popover in the experiments page"
   },
   "KdsrPi": {
     "defaultMessage": "Assessments",


### PR DESCRIPTION

<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fixes bug recorded in a user interview

[bugfix]

The `isFiltered` prop passed to `ExperimentListTable` only considered the search filter, so an active tag filter with no results showed the zero-state ("Create your first experiment") instead of "No experiments found", making the page look broken to users whose workspace did have experiments.

[UI/UX fix]

Also pair the blue/primary button state with a count badge ("Tag · N") to fix the color-only signaling for active tag filters since this may be hard for users with colour blindness. We could make it even more obvious to the user, but I didn't want to make two big a change. Happy to change this as well, we could use a more aggressive colour other than blue to make it clear that a tag filter is being applied. 



### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
**Before (see bug when we apply filter)**



https://github.com/user-attachments/assets/d753d13a-7ec4-47da-b4fd-8f192fbe9008



**After, note that it shows empty experiments which is correct plus the tag filter also shows how many filters are applied**

https://github.com/user-attachments/assets/29724d37-a68c-4e3d-aaef-1f4bb0e1357b



### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

Fixed a bug where tag filters with no results encouraged users to create a new experiment

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
