### PR TITLE
Send `GH_TOKEN` when downloading tools in `bin/install.py`

### DIFF
--- a/.github/actions/update-requirements/action.yml
+++ b/.github/actions/update-requirements/action.yml
@@ -12,6 +12,8 @@ runs:
     - name: Update requirements
       id: update-requirements
       shell: bash --noprofile --norc -exo pipefail {0}
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         python bin/install.py
         python dev/update_requirements.py --requirements-yaml-location requirements

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -123,7 +123,9 @@ jobs:
       # ************************************************************************
       # pre-commit
       # ************************************************************************
-      - run: |
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
           uv run --only-group lint pre-commit install --install-hooks
           uv run --only-group lint pre-commit run install-bin -a -v
           uv run --only-group lint pre-commit run --all-files --color=always || true

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -29,6 +29,8 @@ jobs:
         run: |
           uv sync --only-group lint
       - name: pre-commit setup
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           uv run --only-group lint pre-commit install --install-hooks
           uv run --only-group lint pre-commit run install-bin -a -v

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -77,6 +77,8 @@ jobs:
           key: mypy-${{ matrix.os }}-${{ hashFiles('uv.lock', 'pyproject.toml') }}
           restore-keys: mypy-${{ matrix.os }}-
       - name: Install pre-commit hooks
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           uv run --no-sync pre-commit install --install-hooks
           uv run --no-sync pre-commit run install-bin -a -v

--- a/.github/workflows/update-model-catalog.yml
+++ b/.github/workflows/update-model-catalog.yml
@@ -44,6 +44,8 @@ jobs:
         run: uv run python dev/update_model_catalog.py
 
       - name: Run pre-commit on generated files
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           uv sync --locked --only-group lint
           uv run --no-sync pre-commit install --install-hooks

--- a/bin/install.py
+++ b/bin/install.py
@@ -7,6 +7,7 @@ import argparse
 import gzip
 import hashlib
 import http.client
+import os
 import platform
 import re
 import shutil
@@ -183,13 +184,22 @@ def get_platform_key() -> PlatformKey | None:
     return None
 
 
+def build_request(url: str) -> urllib.request.Request:
+    req = urllib.request.Request(url)
+    # Authenticated requests to github.com are routed differently and get higher
+    # rate limits, which helps when the anonymous release CDN is degraded.
+    if (token := os.environ.get("GH_TOKEN")) and "github.com" in url:
+        req.add_header("Authorization", f"Bearer {token}")
+    return req
+
+
 def urlopen_with_retry(
     url: str, max_retries: int = 7, base_delay: float = 1.0
 ) -> http.client.HTTPResponse:
     """Open a URL with retry logic for transient HTTP errors (e.g., 503)."""
     for attempt in range(max_retries):
         try:
-            return urllib.request.urlopen(url)
+            return urllib.request.urlopen(build_request(url))
         except HTTPError as e:
             if e.code in (502, 503, 504) and attempt < max_retries - 1:
                 delay = base_delay * (2**attempt)


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

`bin/install.py` downloads release assets from `github.com/.../releases/download/...` anonymously. During GitHub incidents (e.g. [m7n7sm0sr1pz](https://www.githubstatus.com/incidents/m7n7sm0sr1pz)) those anonymous requests get routed through degraded paths and return 504s through all retries, failing the `Install pre-commit hooks` step on the `Lint` job.

This PR threads `GH_TOKEN` (the workflow `GITHUB_TOKEN`) into the download path so requests are authenticated, which lands on the higher-rate-limit path and is more resilient during incidents. The header is only added when both the env var is set and the URL is on `github.com`, so local invocations and non-GitHub mirrors are unaffected.

Wired into every workflow step that runs `install-bin` or `bin/install.py`: `lint.yml`, `autoformat.yml`, `copilot-setup-steps.yml`, `update-model-catalog.yml`, and the `update-requirements` composite action.

### How is this PR tested?

- [x] Manual tests

Verified locally that `build_request()` attaches `Authorization: Bearer ...` only when `GH_TOKEN` is set *and* the URL is on `github.com`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)