### PR TITLE
Cache `install-bin` tool binaries in `Lint` workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -76,6 +76,15 @@ jobs:
           path: .mypy_cache
           key: mypy-${{ matrix.os }}-${{ hashFiles('uv.lock', 'pyproject.toml') }}
           restore-keys: mypy-${{ matrix.os }}-
+      - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: |
+            bin/*
+            !bin/install.py
+            !bin/README.md
+            !bin/.gitignore
+          key: install-bin-${{ matrix.os }}-${{ hashFiles('bin/install.py') }}
+          restore-keys: install-bin-${{ matrix.os }}-
       - name: Install pre-commit hooks
         run: |
           uv run --no-sync pre-commit install --install-hooks

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -67,16 +67,19 @@ jobs:
       - name: Install Python dependencies
         run: |
           uv sync --locked --only-group lint --only-group pytest
-      - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      - name: Cache action pins
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: .cache/action-pins.json
           key: action-pins-${{ hashFiles('dev/check_actions.py') }}
-      - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      - name: Cache mypy
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: .mypy_cache
           key: mypy-${{ matrix.os }}-${{ hashFiles('uv.lock', 'pyproject.toml') }}
           restore-keys: mypy-${{ matrix.os }}-
-      - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      - name: Cache install-bin tools
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: |
             bin/*


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Cache the tool binaries downloaded by `bin/install.py` (`taplo`, `typos`, `conftest`, `regal`, `buf`, `rg`) between `Lint` runs. The `install-bin` pre-commit hook re-runs each time but skips the network when the binaries are already present and version-matched.

The cache key includes `hashFiles('bin/install.py')`, so any version bump invalidates the cache. `restore-keys` provides a fallback to a stale cache: any binary whose version no longer matches gets re-downloaded, so a partial-hit cache is safe.

This also makes lint resilient to transient GitHub release CDN outages (e.g. incident [m7n7sm0sr1pz](https://www.githubstatus.com/incidents/m7n7sm0sr1pz)) once the cache is warm.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)