### PR TITLE
Link review comment to the `review` job, not the workflow run

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -119,9 +119,16 @@ jobs:
           RUN_ATTEMPT: ${{ github.run_attempt }}
           PR_NUMBER: ${{ github.event.issue.number }}
         run: |
+          # first(...) // empty: pick exactly one id, or output nothing if no match.
           JOB_ID=$(gh api "repos/$REPO/actions/runs/$RUN_ID/attempts/$RUN_ATTEMPT/jobs" \
-            --jq '.jobs[] | select(.name == "review") | .id')
-          echo "JOB_RUN_URL=https://github.com/$REPO/actions/runs/$RUN_ID/job/$JOB_ID?pr=$PR_NUMBER" >> "$GITHUB_ENV"
+            --jq 'first(.jobs[] | select(.name == "review") | .id) // empty')
+          # Fall back to the workflow-run URL so downstream links are never malformed.
+          if [ -n "$JOB_ID" ]; then
+            JOB_RUN_URL="https://github.com/$REPO/actions/runs/$RUN_ID/job/$JOB_ID?pr=$PR_NUMBER"
+          else
+            JOB_RUN_URL="https://github.com/$REPO/actions/runs/$RUN_ID?pr=$PR_NUMBER"
+          fi
+          echo "JOB_RUN_URL=$JOB_RUN_URL" >> "$GITHUB_ENV"
       - name: React to comment
         if: github.event_name == 'issue_comment'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -107,8 +107,21 @@ jobs:
         with:
           client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-actions: read
           permission-contents: read
           permission-pull-requests: write
+      - name: Resolve job URL
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ steps.app-token-write.outputs.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          JOB_ID=$(gh api "repos/$REPO/actions/runs/$RUN_ID/attempts/$RUN_ATTEMPT/jobs" \
+            --jq '.jobs[] | select(.name == "review") | .id')
+          echo "JOB_RUN_URL=https://github.com/$REPO/actions/runs/$RUN_ID/job/$JOB_ID?pr=$PR_NUMBER" >> "$GITHUB_ENV"
       - name: React to comment
         if: github.event_name == 'issue_comment'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
@@ -117,8 +130,7 @@ jobs:
           retries: 3
           script: |
             const { comment } = context.payload;
-            const workflowUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}?pr=${context.issue.number}`;
-            const message = `🚀 [Review running...](${workflowUrl})`;
+            const message = `🚀 [Review running...](${process.env.JOB_RUN_URL})`;
             const updatedBody = `${comment.body}\n\n---\n\n${message}`;
 
             await github.rest.issues.updateComment({
@@ -305,11 +317,11 @@ jobs:
               }
             }
 
-            const workflowUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}?pr=${context.issue.number}`;
+            const jobRunUrl = process.env.JOB_RUN_URL;
             const failed = jobStatus !== 'success' || resultEvent?.is_error;
             const icon = failed ? '❌' : '✅';
             const verb = failed ? 'failed' : 'completed';
-            let resultLine = `${icon} [Review](${workflowUrl}) ${verb}`;
+            let resultLine = `${icon} [Review](${jobRunUrl}) ${verb}`;
 
             if (resultEvent) {
               const seconds = (resultEvent.duration_ms / 1000).toFixed(1);
@@ -323,7 +335,7 @@ jobs:
                 resultLine += `\n\nThe Claude API is overloaded. Check [status.claude.com](https://status.claude.com/) and retry.`;
               }
             } else if (failed) {
-              resultLine += `\n\nSee [workflow logs](${workflowUrl}) for details.`;
+              resultLine += `\n\nSee [workflow logs](${jobRunUrl}) for details.`;
             }
 
             console.log('Result line to post:', resultLine);


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

The `/review` workflow currently appends a link to the workflow-run overview page in the trigger comment, which forces the reader to click into the `review` job manually. This PR resolves the numeric job ID at runtime via the `actions/runs/{run_id}/attempts/{attempt}/jobs` API and points both the "Review running..." reaction and the final result line at the job page directly.

Why a separate `Resolve job URL` step (vs. computing the URL inline): GitHub doesn't expose the job ID in the `github` context, and the YAML-job-id shortcut (`/jobs/review`) actually 404s — I verified that against a real run before settling on the API lookup. To keep Claude's read-only token minimal, the lookup uses `app-token-write` instead, which gains a `permission-actions: read` scope.

I also tested the `gh api` call locally against a recent `review.yml` run to confirm the JSON shape and that the composed URL resolves with 200.

### How is this PR tested?

- [x] Manual tests

Reproduced the `gh api` call locally against a recent `review.yml` run; the resolved `…/job/<id>?pr=<n>` URL returns 200. The `pull_request` smoke trigger on this PR exercises the workflow up to the `Post review` step (gated off).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)