### PR TITLE
fix: prevent 'Table already exists' error during db upgrade (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,7 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    InitialBase.metadata.create_all(engine, checkfirst=True)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When running `mlflow db upgrade` after updating MLflow from 3.7.0 to 3.8.x, the upgrade fails with:
```
pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")
```

This happens because `_initialize_tables` calls `InitialBase.metadata.create_all(engine)` which tries to create all tables defined in the initial schema without checking if they already exist. On upgrade, the 'secrets' table may already exist from a previous version, causing the error.

## Fix
Added `checkfirst=True` to the `create_all` call so that SQLAlchemy only creates tables that don't already exist. This is a safe change because:
- For fresh databases: all tables are created (none exist yet)
- For existing databases: only missing tables are created, preventing duplication errors
- The subsequent `_upgrade_db` call still applies any pending Alembic migrations correctly

Closes #19943