### PR TITLE
Preserve OTel resource attributes during OTLP trace ingestion

### DIFF
--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -5,6 +5,7 @@ import logging
 from functools import cached_property
 from typing import Any, Union
 
+from opentelemetry.proto.resource.v1.resource_pb2 import Resource as OTelProtoResource
 from opentelemetry.proto.trace.v1.trace_pb2 import Span as OTelProtoSpan
 from opentelemetry.proto.trace.v1.trace_pb2 import Status as OTelProtoStatus
 from opentelemetry.sdk.resources import Resource as _OTelResource
@@ -456,10 +457,11 @@ class Span:
     @classmethod
     def from_otel_proto(
         cls,
-        otel_proto_span,
+        otel_proto_span: OTelProtoSpan,
         location_id: str | None = None,
         *,
         preserve_request_id: bool = False,
+        resource: OTelProtoResource | None = None,
     ) -> "Span":
         """
         Create a Span from an OpenTelemetry protobuf span.
@@ -499,6 +501,17 @@ class Span:
             if location_id
             else generate_mlflow_trace_id_from_otel_trace_id(trace_id)
         )
+
+        # Convert proto Resource to OTel SDK Resource if provided.
+        # We avoid _OTelResource.create() which has significant overhead from
+        # environment variable reads (see https://github.com/mlflow/mlflow/issues/15625).
+        if resource is not None and resource.attributes:
+            resource_attrs = {
+                attr.key: _decode_otel_proto_anyvalue(attr.value) for attr in resource.attributes
+            }
+            otel_resource = _OTelResource(resource_attrs)
+        else:
+            otel_resource = _OTelResource.get_empty()
 
         links = []
         if location_id:
@@ -541,7 +554,7 @@ class Span:
                 )
                 for event in otel_proto_span.events
             ],
-            resource=_OTelResource.get_empty(),
+            resource=otel_resource,
         )
 
         span = cls(otel_span)

--- a/mlflow/server/otel_api.py
+++ b/mlflow/server/otel_api.py
@@ -180,10 +180,11 @@ async def export_traces(
                     service_names.add(resource_service_name)
                 break
 
+        resource = resource_span.resource
         for scope_span in resource_span.scope_spans:
             for otel_proto_span in scope_span.spans:
                 try:
-                    mlflow_span = Span.from_otel_proto(otel_proto_span)
+                    mlflow_span = Span.from_otel_proto(otel_proto_span, resource=resource)
 
                     # Propagate service.name onto root spans so it's visible
                     # in the UI. Per the OTel resource spec, resource attrs

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -5322,6 +5322,10 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                     for key, value in resource.attributes.items():
                         if not isinstance(value, str):
                             continue
+                        # Skip OTel SDK internal metadata attributes — these are
+                        # auto-added by the SDK and not user-meaningful resource info.
+                        if key.startswith("telemetry.sdk."):
+                            continue
                         # SqlTraceTag column limits: key=String(250), value=String(8000)
                         if len(key) <= 250 and len(value) <= 8000:
                             session.merge(

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -5293,6 +5293,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             # span writes, including span-only changes that did not update trace_info, commit
             # atomically with the new DB-backed payload generation.
             for trace_id in all_trace_ids:
+                agg = trace_aggregates[trace_id]
                 session.merge(
                     SqlTraceTag(
                         request_id=trace_id,
@@ -5300,15 +5301,13 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                         value=SpansLocation.TRACKING_STORE.value,
                     )
                 )
-                # Restore user-defined tags carried via mlflow.traceTag.* attributes on the root
-                # span (set by OtelSpanProcessor when the trace was exported over OTLP).
-                for tag_key, tag_value in agg.trace_tags.items():
-                    session.merge(SqlTraceTag(request_id=trace_id, key=tag_key, value=tag_value))
 
                 # Persist OTel resource attributes (e.g., service.name) as trace tags so
                 # they are visible in the UI and available for filtering. Resource is attached
                 # to every span produced from the same OTLP ResourceSpans block; use any span
                 # in this trace so multi-trace batches are handled correctly.
+                # These are written first so that user-defined trace tags (below) take
+                # precedence over resource attributes on key collision.
                 resource = next(
                     (
                         getattr(span._span, "resource", None)
@@ -5320,21 +5319,26 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 )
                 if resource is not None:
                     for key, value in resource.attributes.items():
-                        if not isinstance(value, str):
-                            continue
                         # Skip OTel SDK internal metadata attributes — these are
                         # auto-added by the SDK and not user-meaningful resource info.
                         if key.startswith("telemetry.sdk."):
                             continue
+                        str_value = str(value) if not isinstance(value, str) else value
                         # SqlTraceTag column limits: key=String(250), value=String(8000)
-                        if len(key) <= 250 and len(value) <= 8000:
+                        if len(key) <= 250 and len(str_value) <= 8000:
                             session.merge(
                                 SqlTraceTag(
                                     request_id=trace_id,
                                     key=key,
-                                    value=value,
+                                    value=str_value,
                                 )
                             )
+
+                # Restore user-defined tags carried via mlflow.traceTag.* attributes on the root
+                # span (set by OtelSpanProcessor when the trace was exported over OTLP).
+                # Written after resource attributes so user tags take precedence on collision.
+                for tag_key, tag_value in agg.trace_tags.items():
+                    session.merge(SqlTraceTag(request_id=trace_id, key=tag_key, value=tag_value))
 
         return spans
 

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -5310,29 +5310,35 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 # precedence over resource attributes on key collision.
                 resource = next(
                     (
-                        getattr(span._span, "resource", None)
+                        r
                         for span in spans_by_trace[trace_id]
-                        if getattr(span._span, "resource", None) is not None
-                        and getattr(span._span, "resource", None).attributes
+                        if (r := getattr(span._span, "resource", None)) is not None
+                        and r.attributes
                     ),
                     None,
                 )
                 if resource is not None:
                     for key, value in resource.attributes.items():
-                        # Skip OTel SDK internal metadata attributes — these are
-                        # auto-added by the SDK and not user-meaningful resource info.
-                        if key.startswith("telemetry.sdk."):
+                        # Skip OTel SDK internal metadata and the reserved mlflow.*
+                        # namespace so a client cannot clobber bookkeeping tags
+                        # (e.g. SPANS_LOCATION) via resource attributes.
+                        if key.startswith(("telemetry.sdk.", "mlflow.")):
                             continue
                         str_value = str(value) if not isinstance(value, str) else value
                         # SqlTraceTag column limits: key=String(250), value=String(8000)
-                        if len(key) <= 250 and len(str_value) <= 8000:
-                            session.merge(
-                                SqlTraceTag(
-                                    request_id=trace_id,
-                                    key=key,
-                                    value=str_value,
-                                )
+                        if len(key) > 250 or len(str_value) > 8000:
+                            _logger.debug(
+                                "Dropping resource attribute %r: exceeds trace tag column limits",
+                                key,
                             )
+                            continue
+                        session.merge(
+                            SqlTraceTag(
+                                request_id=trace_id,
+                                key=key,
+                                value=str_value,
+                            )
+                        )
 
                 # Restore user-defined tags carried via mlflow.traceTag.* attributes on the root
                 # span (set by OtelSpanProcessor when the trace was exported over OTLP).

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -5312,8 +5312,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                     (
                         r
                         for span in spans_by_trace[trace_id]
-                        if (r := getattr(span._span, "resource", None)) is not None
-                        and r.attributes
+                        if (r := getattr(span._span, "resource", None)) is not None and r.attributes
                     ),
                     None,
                 )
@@ -5324,13 +5323,11 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                         # (e.g. SPANS_LOCATION) via resource attributes.
                         if key.startswith(("telemetry.sdk.", "mlflow.")):
                             continue
-                        str_value = str(value) if not isinstance(value, str) else value
-                        # SqlTraceTag column limits: key=String(250), value=String(8000)
-                        if len(key) > 250 or len(str_value) > 8000:
-                            _logger.debug(
-                                "Dropping resource attribute %r: exceeds trace tag column limits",
-                                key,
-                            )
+                        str_value = value if isinstance(value, str) else json.dumps(value)
+                        try:
+                            key, str_value = _validate_trace_tag(key, str_value)
+                        except Exception:
+                            _logger.debug("Skipping invalid resource attribute %r", key)
                             continue
                         session.merge(
                             SqlTraceTag(

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -5305,6 +5305,33 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 for tag_key, tag_value in agg.trace_tags.items():
                     session.merge(SqlTraceTag(request_id=trace_id, key=tag_key, value=tag_value))
 
+                # Persist OTel resource attributes (e.g., service.name) as trace tags so
+                # they are visible in the UI and available for filtering. Resource is attached
+                # to every span produced from the same OTLP ResourceSpans block; use any span
+                # in this trace so multi-trace batches are handled correctly.
+                resource = next(
+                    (
+                        getattr(span._span, "resource", None)
+                        for span in spans_by_trace[trace_id]
+                        if getattr(span._span, "resource", None) is not None
+                        and getattr(span._span, "resource", None).attributes
+                    ),
+                    None,
+                )
+                if resource is not None:
+                    for key, value in resource.attributes.items():
+                        if not isinstance(value, str):
+                            continue
+                        # SqlTraceTag column limits: key=String(250), value=String(8000)
+                        if len(key) <= 250 and len(value) <= 8000:
+                            session.merge(
+                                SqlTraceTag(
+                                    request_id=trace_id,
+                                    key=key,
+                                    value=value,
+                                )
+                            )
+
         return spans
 
     def _update_trace_info_attributes(

--- a/tests/entities/test_span.py
+++ b/tests/entities/test_span.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import opentelemetry.trace as trace_api
 import pytest
+from opentelemetry.proto.resource.v1.resource_pb2 import Resource as OTelProtoResource
 from opentelemetry.proto.trace.v1.trace_pb2 import Span as OTelProtoSpan
 from opentelemetry.proto.trace.v1.trace_pb2 import Status as OTelProtoStatus
 from opentelemetry.sdk.resources import Resource as OTelResource
@@ -500,11 +501,59 @@ def test_span_from_otel_proto_conversion():
     assert mlflow_span.events[0].timestamp == 1500000000
     assert mlflow_span.events[0].attributes["event_data"] == "event_value"
 
+    # Verify resource is empty when none is provided
+    assert len(mlflow_span._span.resource.attributes) == 0
+
     # Verify links use v3 format when no location_id
     assert len(mlflow_span.links) == 1
     assert mlflow_span.links[0].trace_id == "tr-aabbccddeeff00112233445566778899"
     assert mlflow_span.links[0].span_id == "1122334455667788"
     assert mlflow_span.links[0].attributes == {"rel": "causal"}
+
+
+def test_span_from_otel_proto_with_resource():
+    otel_proto = OTelProtoSpan()
+    otel_proto.trace_id = bytes.fromhex("12345678901234567890123456789012")
+    otel_proto.span_id = bytes.fromhex("1234567890123456")
+    otel_proto.name = "span_with_resource"
+    otel_proto.start_time_unix_nano = 1000000000
+    otel_proto.end_time_unix_nano = 2000000000
+
+    # Build a proto Resource with typical OTel resource attributes
+    resource = OTelProtoResource()
+    for key, value in [
+        ("service.name", "my-app"),
+        ("telemetry.sdk.language", "java"),
+        ("telemetry.sdk.name", "opentelemetry"),
+        ("telemetry.sdk.version", "1.40.0"),
+    ]:
+        attr = resource.attributes.add()
+        attr.key = key
+        _set_otel_proto_anyvalue(attr.value, value)
+
+    mlflow_span = Span.from_otel_proto(otel_proto, resource=resource)
+
+    assert mlflow_span.name == "span_with_resource"
+    res_attrs = dict(mlflow_span._span.resource.attributes)
+    assert res_attrs["service.name"] == "my-app"
+    assert res_attrs["telemetry.sdk.language"] == "java"
+    assert res_attrs["telemetry.sdk.name"] == "opentelemetry"
+    assert res_attrs["telemetry.sdk.version"] == "1.40.0"
+
+
+def test_span_from_otel_proto_with_empty_resource():
+    otel_proto = OTelProtoSpan()
+    otel_proto.trace_id = bytes.fromhex("12345678901234567890123456789012")
+    otel_proto.span_id = bytes.fromhex("1234567890123456")
+    otel_proto.name = "span_empty_resource"
+    otel_proto.start_time_unix_nano = 1000000000
+    otel_proto.end_time_unix_nano = 2000000000
+
+    # An empty proto Resource (no attributes)
+    resource = OTelProtoResource()
+    mlflow_span = Span.from_otel_proto(otel_proto, resource=resource)
+
+    assert len(mlflow_span._span.resource.attributes) == 0
 
 
 def test_span_from_otel_proto_with_location():

--- a/tests/server/test_otel_api.py
+++ b/tests/server/test_otel_api.py
@@ -8,14 +8,20 @@ from mlflow.entities import Workspace
 from mlflow.environment_variables import MLFLOW_ENABLE_WORKSPACES
 from mlflow.server.fastapi_app import add_fastapi_workspace_middleware
 from mlflow.server.otel_api import otel_router
-from mlflow.tracing.utils.otlp import OTLP_TRACES_PATH
+from mlflow.tracing.utils.otlp import OTLP_TRACES_PATH, _set_otel_proto_anyvalue
 from mlflow.utils import workspace_context
 from mlflow.utils.workspace_utils import WORKSPACE_HEADER_NAME
 
 
-def _build_otlp_payload():
+def _build_otlp_payload(resource_attrs=None):
     request = ExportTraceServiceRequest()
-    span = request.resource_spans.add().scope_spans.add().spans.add()
+    resource_span = request.resource_spans.add()
+    if resource_attrs:
+        for key, value in resource_attrs.items():
+            attr = resource_span.resource.attributes.add()
+            attr.key = key
+            _set_otel_proto_anyvalue(attr.value, value)
+    span = resource_span.scope_spans.add().spans.add()
     span.trace_id = b"\x00" * 16
     span.span_id = b"\x01" * 8
     span.name = "span"
@@ -264,3 +270,43 @@ def test_otlp_conversion_error(monkeypatch):
     )
     assert response.status_code == 422
     assert "Cannot convert OpenTelemetry span" in response.json()["detail"]
+
+
+def test_otlp_resource_attributes_preserved(monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "false")
+
+    class DummyTrackingStore:
+        def __init__(self):
+            self.logged_spans = []
+
+        def log_spans(self, experiment_id, spans):
+            self.logged_spans.extend(spans)
+
+    tracking_store = DummyTrackingStore()
+    monkeypatch.setattr(
+        "mlflow.server.otel_api._get_tracking_store",
+        lambda: tracking_store,
+    )
+
+    client = _make_test_client()
+    resource_attrs = {
+        "service.name": "my-service",
+        "telemetry.sdk.language": "python",
+        "telemetry.sdk.name": "opentelemetry",
+    }
+    response = client.post(
+        OTLP_TRACES_PATH,
+        data=_build_otlp_payload(resource_attrs=resource_attrs),
+        headers={
+            "Content-Type": "application/x-protobuf",
+            "X-MLflow-Experiment-Id": "42",
+        },
+    )
+
+    assert response.status_code == 200
+    assert len(tracking_store.logged_spans) == 1
+    span = tracking_store.logged_spans[0]
+    res = dict(span._span.resource.attributes)
+    assert res["service.name"] == "my-service"
+    assert res["telemetry.sdk.language"] == "python"
+    assert res["telemetry.sdk.name"] == "opentelemetry"

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
@@ -3413,6 +3413,8 @@ def test_log_spans_persists_resource_attributes_as_tags(store: SqlAlchemyStore):
         # telemetry.sdk.* should be filtered out
         "telemetry.sdk.language": "python",
         "telemetry.sdk.name": "opentelemetry",
+        # mlflow.* namespace should be filtered out to prevent clobbering reserved tags
+        "mlflow.evil": "should-be-dropped",
         # non-string value should be converted to str
         "process.pid": 12345,
     })
@@ -3457,6 +3459,8 @@ def test_log_spans_persists_resource_attributes_as_tags(store: SqlAlchemyStore):
     # telemetry.sdk.* should be filtered out
     assert "telemetry.sdk.language" not in tags
     assert "telemetry.sdk.name" not in tags
+    # mlflow.* namespace should be filtered out
+    assert "mlflow.evil" not in tags
 
 
 def test_log_spans_resource_tags_do_not_overwrite_user_tags(store: SqlAlchemyStore):

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
@@ -3415,8 +3415,10 @@ def test_log_spans_persists_resource_attributes_as_tags(store: SqlAlchemyStore):
         "telemetry.sdk.name": "opentelemetry",
         # mlflow.* namespace should be filtered out to prevent clobbering reserved tags
         "mlflow.evil": "should-be-dropped",
-        # non-string value should be converted to str
+        # non-string values should be serialized via json.dumps
         "process.pid": 12345,
+        "k8s.pod.ready": True,
+        "host.cpu.count": 4.0,
     })
 
     span = create_mlflow_span(
@@ -3454,8 +3456,10 @@ def test_log_spans_persists_resource_attributes_as_tags(store: SqlAlchemyStore):
     assert tags["service.name"] == "my-service"
     assert tags["deployment.environment"] == "staging"
     assert tags["host.arch"] == "amd64"
-    # Non-string values should be converted
+    # Non-string values should be serialized via json.dumps
     assert tags["process.pid"] == "12345"
+    assert tags["k8s.pod.ready"] == "true"  # json.dumps lowercases booleans
+    assert tags["host.cpu.count"] == "4.0"
     # telemetry.sdk.* should be filtered out
     assert "telemetry.sdk.language" not in tags
     assert "telemetry.sdk.name" not in tags

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
@@ -56,6 +56,7 @@ from mlflow.store.tracking.dbmodels.models import (
     SqlSpanMetrics,
     SqlTraceInfo,
     SqlTraceMetrics,
+    SqlTraceTag,
 )
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore, _TraceArchiveCandidate
 from mlflow.store.workspace.abstract_store import ResolvedTraceArchivalConfig
@@ -3400,6 +3401,104 @@ def test_log_spans_multiple_traces(store: SqlAlchemyStore):
 
         span_row2 = session.query(SqlSpan).filter_by(trace_id="tr-multi-2").one()
         assert span_row2.name == "span_trace2"
+
+
+def test_log_spans_persists_resource_attributes_as_tags(store: SqlAlchemyStore):
+    experiment_id = store.create_experiment("test_resource_attrs")
+
+    resource = _OTelResource(
+        {
+            "service.name": "my-service",
+            "deployment.environment": "staging",
+            "host.arch": "amd64",
+            # telemetry.sdk.* should be filtered out
+            "telemetry.sdk.language": "python",
+            "telemetry.sdk.name": "opentelemetry",
+            # non-string value should be converted to str
+            "process.pid": 12345,
+        }
+    )
+
+    span = create_mlflow_span(
+        OTelReadableSpan(
+            name="span_with_resource",
+            context=trace_api.SpanContext(
+                trace_id=99999,
+                span_id=111,
+                is_remote=False,
+                trace_flags=trace_api.TraceFlags(1),
+            ),
+            parent=None,
+            attributes={
+                "mlflow.traceRequestId": json.dumps("tr-resource-test"),
+            },
+            start_time=1000000000,
+            end_time=2000000000,
+            resource=resource,
+        ),
+        "tr-resource-test",
+    )
+
+    store.log_spans(experiment_id, [span])
+
+    with store.ManagedSessionMaker() as session:
+        tags = {
+            row.key: row.value
+            for row in session.query(SqlTraceTag)
+            .filter(SqlTraceTag.request_id == "tr-resource-test")
+            .all()
+        }
+
+    # Resource attributes should be persisted
+    assert tags["service.name"] == "my-service"
+    assert tags["deployment.environment"] == "staging"
+    assert tags["host.arch"] == "amd64"
+    # Non-string values should be converted
+    assert tags["process.pid"] == "12345"
+    # telemetry.sdk.* should be filtered out
+    assert "telemetry.sdk.language" not in tags
+    assert "telemetry.sdk.name" not in tags
+
+
+def test_log_spans_resource_tags_do_not_overwrite_user_tags(store: SqlAlchemyStore):
+    experiment_id = store.create_experiment("test_resource_tag_priority")
+
+    resource = _OTelResource({"service.name": "from-resource"})
+
+    span = create_mlflow_span(
+        OTelReadableSpan(
+            name="span_tag_priority",
+            context=trace_api.SpanContext(
+                trace_id=88888,
+                span_id=111,
+                is_remote=False,
+                trace_flags=trace_api.TraceFlags(1),
+            ),
+            parent=None,
+            attributes={
+                "mlflow.traceRequestId": json.dumps("tr-tag-priority"),
+                # User-defined trace tag via mlflow.traceTag.* attribute
+                f"{SpanAttributeKey.TRACE_TAG_PREFIX}service.name": json.dumps("from-user"),
+            },
+            start_time=1000000000,
+            end_time=2000000000,
+            resource=resource,
+        ),
+        "tr-tag-priority",
+    )
+
+    store.log_spans(experiment_id, [span])
+
+    with store.ManagedSessionMaker() as session:
+        tags = {
+            row.key: row.value
+            for row in session.query(SqlTraceTag)
+            .filter(SqlTraceTag.request_id == "tr-tag-priority")
+            .all()
+        }
+
+    # User-defined tag should take precedence over resource attribute
+    assert tags["service.name"] == "from-user"
 
 
 def test_log_spans_persists_links(store: SqlAlchemyStore):

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
@@ -3406,18 +3406,16 @@ def test_log_spans_multiple_traces(store: SqlAlchemyStore):
 def test_log_spans_persists_resource_attributes_as_tags(store: SqlAlchemyStore):
     experiment_id = store.create_experiment("test_resource_attrs")
 
-    resource = _OTelResource(
-        {
-            "service.name": "my-service",
-            "deployment.environment": "staging",
-            "host.arch": "amd64",
-            # telemetry.sdk.* should be filtered out
-            "telemetry.sdk.language": "python",
-            "telemetry.sdk.name": "opentelemetry",
-            # non-string value should be converted to str
-            "process.pid": 12345,
-        }
-    )
+    resource = _OTelResource({
+        "service.name": "my-service",
+        "deployment.environment": "staging",
+        "host.arch": "amd64",
+        # telemetry.sdk.* should be filtered out
+        "telemetry.sdk.language": "python",
+        "telemetry.sdk.name": "opentelemetry",
+        # non-string value should be converted to str
+        "process.pid": 12345,
+    })
 
     span = create_mlflow_span(
         OTelReadableSpan(
@@ -3444,7 +3442,8 @@ def test_log_spans_persists_resource_attributes_as_tags(store: SqlAlchemyStore):
     with store.ManagedSessionMaker() as session:
         tags = {
             row.key: row.value
-            for row in session.query(SqlTraceTag)
+            for row in session
+            .query(SqlTraceTag)
             .filter(SqlTraceTag.request_id == "tr-resource-test")
             .all()
         }
@@ -3492,7 +3491,8 @@ def test_log_spans_resource_tags_do_not_overwrite_user_tags(store: SqlAlchemySto
     with store.ManagedSessionMaker() as session:
         tags = {
             row.key: row.value
-            for row in session.query(SqlTraceTag)
+            for row in session
+            .query(SqlTraceTag)
             .filter(SqlTraceTag.request_id == "tr-tag-priority")
             .all()
         }


### PR DESCRIPTION
### Related Issues/PRs

Closes #22121

Supersedes #22199 (authored by @sukhdeepg)

### What changes are proposed in this pull request?

When ingesting traces via the OTLP endpoint (`/v1/traces`), OTel **Resource attributes** (such as `service.name`, `telemetry.sdk.language`, `telemetry.sdk.name`) were completely discarded. This PR preserves them by:

1. **`mlflow/server/otel_api.py`**: Reading `resource_span.resource` and passing it to `Span.from_otel_proto()`
2. **`mlflow/entities/span.py`**: Accepting the proto Resource in `from_otel_proto()`, decoding its attributes, and storing them on the underlying `OTelReadableSpan` (instead of hardcoding an empty resource)
3. **`mlflow/store/tracking/sqlalchemy_store.py`**: Persisting resource attributes as trace tags (`SqlTraceTag`) so they are visible in the UI and available for filtering

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

**New tests added:**
- `test_span_from_otel_proto_with_resource`: verifies resource attributes are preserved on the span
- `test_span_from_otel_proto_with_empty_resource`: verifies empty resource is handled gracefully
- `test_otlp_resource_attributes_preserved`: verifies the full OTLP endpoint flow passes resource through

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. OTel resource attributes (e.g., `service.name`, `telemetry.sdk.language`) sent via the OTLP endpoint are now preserved as trace tags, making them visible in the MLflow UI and available for filtering.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release