### PR TITLE
Return 404 for missing Azure blob artifacts

### DIFF
--- a/mlflow/store/artifact/azure_blob_artifact_repo.py
+++ b/mlflow/store/artifact/azure_blob_artifact_repo.py
@@ -13,6 +13,7 @@ from mlflow.entities.multipart_upload import (
 )
 from mlflow.environment_variables import MLFLOW_ARTIFACT_UPLOAD_DOWNLOAD_TIMEOUT
 from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
 from mlflow.store.artifact.artifact_repo import ArtifactRepository, MultipartUploadMixin
 from mlflow.utils.credentials import get_default_host_creds
 
@@ -197,12 +198,20 @@ class AzureBlobArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         return sorted(infos, key=lambda f: f.path)
 
     def _download_file(self, remote_file_path, local_path):
+        from azure.core.exceptions import ResourceNotFoundError
+
         (container, _, remote_root_path, _) = self.parse_wasbs_uri(self.artifact_uri)
         container_client = self.client.get_container_client(container)
         remote_full_path = posixpath.join(remote_root_path, remote_file_path)
-        blob = container_client.download_blob(remote_full_path)
-        with open(local_path, "wb") as file:
-            blob.readinto(file)
+        try:
+            blob = container_client.download_blob(remote_full_path)
+            with open(local_path, "wb") as file:
+                blob.readinto(file)
+        except ResourceNotFoundError as e:
+            raise MlflowException(
+                f"No such file or directory: '{remote_full_path}'",
+                error_code=RESOURCE_DOES_NOT_EXIST,
+            ) from e
 
     def delete_artifacts(self, artifact_path=None):
         from azure.core.exceptions import ResourceNotFoundError

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -4042,7 +4042,7 @@ def test_download_artifact_streams_in_chunks(enable_serve_artifacts, tmp_path):
 
 
 def test_download_artifact_returns_404_for_missing_azure_blob(enable_serve_artifacts):
-ResourceNotFoundError = pytest.importorskip("azure.core.exceptions").ResourceNotFoundError
+    ResourceNotFoundError = pytest.importorskip("azure.core.exceptions").ResourceNotFoundError
 
     artifact_repo = AzureBlobArtifactRepository(
         "wasbs://container@account.blob.core.windows.net/root",

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -4064,9 +4064,7 @@ def test_download_artifact_returns_404_for_missing_azure_blob(enable_serve_artif
     artifact_repo.thread_pool.shutdown()
 
     assert response.status_code == 404
-    assert json.loads(response.get_data())["error_code"] == ErrorCode.Name(
-        RESOURCE_DOES_NOT_EXIST
-    )
+    assert json.loads(response.get_data())["error_code"] == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
 
 
 @pytest.mark.parametrize(

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -4041,6 +4041,34 @@ def test_download_artifact_streams_in_chunks(enable_serve_artifacts, tmp_path):
         assert streamed_data == test_data
 
 
+def test_download_artifact_returns_404_for_missing_azure_blob(enable_serve_artifacts):
+    from azure.core.exceptions import ResourceNotFoundError
+
+    artifact_repo = AzureBlobArtifactRepository(
+        "wasbs://container@account.blob.core.windows.net/root",
+        client=mock.MagicMock(),
+    )
+    artifact_repo.client.get_container_client().walk_blobs.return_value = []
+    artifact_repo.client.get_container_client().download_blob.side_effect = ResourceNotFoundError(
+        "Operation returned an invalid status: BlobNotFound"
+    )
+
+    with (
+        app.test_request_context(method="GET"),
+        mock.patch(
+            "mlflow.server.handlers._get_artifact_repo_mlflow_artifacts",
+            return_value=artifact_repo,
+        ),
+    ):
+        response = _download_artifact("missing.txt")
+    artifact_repo.thread_pool.shutdown()
+
+    assert response.status_code == 404
+    assert json.loads(response.get_data())["error_code"] == ErrorCode.Name(
+        RESOURCE_DOES_NOT_EXIST
+    )
+
+
 @pytest.mark.parametrize(
     ("file_path", "expected_simple", "expected_quoted"),
     [

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -4042,7 +4042,7 @@ def test_download_artifact_streams_in_chunks(enable_serve_artifacts, tmp_path):
 
 
 def test_download_artifact_returns_404_for_missing_azure_blob(enable_serve_artifacts):
-    from azure.core.exceptions import ResourceNotFoundError
+ResourceNotFoundError = pytest.importorskip("azure.core.exceptions").ResourceNotFoundError
 
     artifact_repo = AzureBlobArtifactRepository(
         "wasbs://container@account.blob.core.windows.net/root",


### PR DESCRIPTION
### Related Issues/PRs

Closes #23792

### What changes are proposed in this pull request?

Translate Azure Blob Storage artifact download `ResourceNotFoundError` / `BlobNotFound` into MLflow `RESOURCE_DOES_NOT_EXIST` in `AzureBlobArtifactRepository._download_file()`.

The proxied artifact handler already maps `RESOURCE_DOES_NOT_EXIST` to HTTP 404. This keeps missing or stale artifact URIs on the not-found path instead of returning HTTP 500 / `INTERNAL_ERROR`, which can look like a registry server failure.

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests

Manual verification:

- On upstream `master`, reproduced the baseline: a missing Azure blob artifact download returned HTTP 500 with `error_code: INTERNAL_ERROR`.
- Ran focused regression test:
  `UV_PYTHON_INSTALL_DIR=.uv/python UV_CACHE_DIR=.uv/cache uv run --frozen --group test --with httpx --with azure-storage-blob pytest tests/server/test_handlers.py::test_download_artifact_returns_404_for_missing_azure_blob`
- Ran targeted lint:
  `.venv/bin/ruff check mlflow/store/artifact/azure_blob_artifact_repo.py tests/server/test_handlers.py`
- Ran `git diff --check`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Missing Azure Blob Storage artifacts served through MLflow's proxied artifact endpoint now return HTTP 404 instead of HTTP 500.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
