### PR TITLE
Parse `output_cost_per_video_per_second` from model catalog

### DIFF
--- a/dev/update_model_catalog.py
+++ b/dev/update_model_catalog.py
@@ -77,6 +77,7 @@ _MODALITY_CACHE_READ = re.compile(r"^cache_read_input_([a-z0-9_]+)_token_cost$")
 _MODALITY_CACHE_WRITE = re.compile(r"^cache_creation_input_([a-z0-9_]+)_token_cost$")
 _MODALITY_CACHE_READ_ALT = re.compile(r"^cache_read_input_token_cost_per_([a-z0-9_]+)_token$")
 _FLAT_INPUT_PER_SECOND = re.compile(r"^input_cost_per_([a-z]+)_per_second$")
+_FLAT_OUTPUT_PER_SECOND = re.compile(r"^output_cost_per_([a-z]+)_per_second$")
 _EXCLUDED_MODALITIES = {"reasoning"}
 
 
@@ -85,7 +86,8 @@ def _extract_modality_pricing(info: dict[str, Any]) -> dict[str, dict[str, float
 
     Keyed-per-token keys (e.g. input_cost_per_image_token) are scaled to per-million and
     stored under input_per_million_tokens for the modality.
-    Per-second rates (e.g. input_cost_per_video_per_second) are stored as input_per_second.
+    Per-second rates (e.g. input_cost_per_video_per_second, output_cost_per_video_per_second)
+    are stored as input_per_second / output_per_second.
     """
     modalities: dict[str, dict[str, float]] = {}
     for k, v in info.items():
@@ -120,6 +122,9 @@ def _extract_modality_pricing(info: dict[str, Any]) -> dict[str, dict[str, float
         elif m := _FLAT_INPUT_PER_SECOND.match(k):
             modality = m.group(1)
             modalities.setdefault(modality, {})["input_per_second"] = v
+        elif m := _FLAT_OUTPUT_PER_SECOND.match(k):
+            modality = m.group(1)
+            modalities.setdefault(modality, {})["output_per_second"] = v
 
     return modalities
 

--- a/mlflow/utils/model_catalog/azure.json
+++ b/mlflow/utils/model_catalog/azure.json
@@ -2804,6 +2804,13 @@
     },
     "sora-2": {
       "mode": "video_generation",
+      "pricing": {
+        "modality": {
+          "video": {
+            "output_per_second": 0.1
+          }
+        }
+      },
       "capabilities": {
         "function_calling": false,
         "vision": false,
@@ -2811,10 +2818,17 @@
         "prompt_caching": false,
         "response_schema": false
       },
-      "last_updated_at": "2026-05-28"
+      "last_updated_at": "2026-06-09"
     },
     "sora-2-pro": {
       "mode": "video_generation",
+      "pricing": {
+        "modality": {
+          "video": {
+            "output_per_second": 0.3
+          }
+        }
+      },
       "capabilities": {
         "function_calling": false,
         "vision": false,
@@ -2822,10 +2836,17 @@
         "prompt_caching": false,
         "response_schema": false
       },
-      "last_updated_at": "2026-05-28"
+      "last_updated_at": "2026-06-09"
     },
     "sora-2-pro-high-res": {
       "mode": "video_generation",
+      "pricing": {
+        "modality": {
+          "video": {
+            "output_per_second": 0.5
+          }
+        }
+      },
       "capabilities": {
         "function_calling": false,
         "vision": false,
@@ -2833,7 +2854,7 @@
         "prompt_caching": false,
         "response_schema": false
       },
-      "last_updated_at": "2026-05-28"
+      "last_updated_at": "2026-06-09"
     },
     "standard/1024-x-1024/dall-e-2": {
       "mode": "image_generation",

--- a/mlflow/utils/model_catalog/azure_ai.json
+++ b/mlflow/utils/model_catalog/azure_ai.json
@@ -1369,6 +1369,26 @@
       },
       "last_updated_at": "2026-04-24"
     },
+    "kimi-k2.6": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144,
+        "max_tokens": 262144
+      },
+      "pricing": {
+        "input_per_million_tokens": 0.95,
+        "output_per_million_tokens": 4.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      },
+      "last_updated_at": "2026-06-09"
+    },
     "ministral-3b": {
       "mode": "chat",
       "context_window": {

--- a/mlflow/utils/model_catalog/bedrock.json
+++ b/mlflow/utils/model_catalog/bedrock.json
@@ -4021,6 +4021,36 @@
       },
       "last_updated_at": "2026-06-01"
     },
+    "jp.anthropic.claude-opus-4-7": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 128000,
+        "max_tokens": 128000
+      },
+      "pricing": {
+        "input_per_million_tokens": 5.5,
+        "output_per_million_tokens": 27.5,
+        "cache_read_per_million_tokens": 0.55,
+        "cache_write_per_million_tokens": 6.875,
+        "tooling": {
+          "search_context_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+          },
+          "tool_use_system_prompt_tokens": 346
+        }
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "last_updated_at": "2026-06-09"
+    },
     "jp.anthropic.claude-sonnet-4-5-20250929-v1:0": {
       "mode": "chat",
       "context_window": {
@@ -6086,10 +6116,10 @@
         "max_tokens": 8192
       },
       "pricing": {
-        "input_per_million_tokens": 3.3,
-        "output_per_million_tokens": 16.5,
-        "cache_read_per_million_tokens": 0.33,
-        "cache_write_per_million_tokens": 4.125
+        "input_per_million_tokens": 3.6,
+        "output_per_million_tokens": 18.0,
+        "cache_read_per_million_tokens": 0.36,
+        "cache_write_per_million_tokens": 4.5
       },
       "capabilities": {
         "function_calling": true,
@@ -6098,7 +6128,7 @@
         "prompt_caching": true,
         "response_schema": true
       },
-      "last_updated_at": "2026-04-24"
+      "last_updated_at": "2026-06-09"
     },
     "us-gov-east-1/claude-sonnet-4-5-20250929-v1:0": {
       "mode": "chat",
@@ -6108,10 +6138,10 @@
         "max_tokens": 8192
       },
       "pricing": {
-        "input_per_million_tokens": 3.3,
-        "output_per_million_tokens": 16.5,
-        "cache_read_per_million_tokens": 0.33,
-        "cache_write_per_million_tokens": 4.125
+        "input_per_million_tokens": 3.6,
+        "output_per_million_tokens": 18.0,
+        "cache_read_per_million_tokens": 0.36,
+        "cache_write_per_million_tokens": 4.5
       },
       "capabilities": {
         "function_calling": true,
@@ -6120,7 +6150,7 @@
         "prompt_caching": true,
         "response_schema": true
       },
-      "last_updated_at": "2026-04-24"
+      "last_updated_at": "2026-06-09"
     },
     "us-gov-east-1/meta.llama3-70b-instruct-v1:0": {
       "mode": "chat",
@@ -6376,10 +6406,10 @@
         "max_tokens": 8192
       },
       "pricing": {
-        "input_per_million_tokens": 3.3,
-        "output_per_million_tokens": 16.5,
-        "cache_read_per_million_tokens": 0.33,
-        "cache_write_per_million_tokens": 4.125
+        "input_per_million_tokens": 3.6,
+        "output_per_million_tokens": 18.0,
+        "cache_read_per_million_tokens": 0.36,
+        "cache_write_per_million_tokens": 4.5
       },
       "capabilities": {
         "function_calling": true,
@@ -6388,7 +6418,7 @@
         "prompt_caching": true,
         "response_schema": true
       },
-      "last_updated_at": "2026-04-24"
+      "last_updated_at": "2026-06-09"
     },
     "us-gov-west-1/claude-sonnet-4-5-20250929-v1:0": {
       "mode": "chat",
@@ -6398,10 +6428,10 @@
         "max_tokens": 8192
       },
       "pricing": {
-        "input_per_million_tokens": 3.3,
-        "output_per_million_tokens": 16.5,
-        "cache_read_per_million_tokens": 0.33,
-        "cache_write_per_million_tokens": 4.125
+        "input_per_million_tokens": 3.6,
+        "output_per_million_tokens": 18.0,
+        "cache_read_per_million_tokens": 0.36,
+        "cache_write_per_million_tokens": 4.5
       },
       "capabilities": {
         "function_calling": true,
@@ -6410,7 +6440,7 @@
         "prompt_caching": true,
         "response_schema": true
       },
-      "last_updated_at": "2026-04-24"
+      "last_updated_at": "2026-06-09"
     },
     "us-gov-west-1/meta.llama3-70b-instruct-v1:0": {
       "mode": "chat",
@@ -6460,17 +6490,17 @@
         "max_tokens": 64000
       },
       "pricing": {
-        "input_per_million_tokens": 3.3,
-        "output_per_million_tokens": 16.5,
-        "cache_read_per_million_tokens": 0.33,
-        "cache_write_per_million_tokens": 4.125,
+        "input_per_million_tokens": 3.6,
+        "output_per_million_tokens": 18.0,
+        "cache_read_per_million_tokens": 0.36,
+        "cache_write_per_million_tokens": 4.5,
         "long_context": [
           {
             "threshold_tokens": 200000,
-            "input_per_million_tokens": 6.6,
-            "output_per_million_tokens": 24.75,
-            "cache_write_per_million_tokens": 8.25,
-            "cache_read_per_million_tokens": 0.66
+            "input_per_million_tokens": 7.2,
+            "output_per_million_tokens": 27.0,
+            "cache_write_per_million_tokens": 9.0,
+            "cache_read_per_million_tokens": 0.72
           }
         ]
       },
@@ -6481,7 +6511,7 @@
         "prompt_caching": true,
         "response_schema": true
       },
-      "last_updated_at": "2026-06-01"
+      "last_updated_at": "2026-06-09"
     },
     "us-west-1/meta.llama3-70b-instruct-v1:0": {
       "mode": "chat",

--- a/mlflow/utils/model_catalog/fal_ai.json
+++ b/mlflow/utils/model_catalog/fal_ai.json
@@ -67,6 +67,17 @@
       },
       "last_updated_at": "2026-05-28"
     },
+    "fal-ai/gemini-25-flash-image": {
+      "mode": "image_generation",
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      },
+      "last_updated_at": "2026-06-09"
+    },
     "fal-ai/ideogram/v3": {
       "mode": "image_generation",
       "capabilities": {
@@ -110,6 +121,17 @@
         "response_schema": false
       },
       "last_updated_at": "2026-05-28"
+    },
+    "fal-ai/nano-banana": {
+      "mode": "image_generation",
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      },
+      "last_updated_at": "2026-06-09"
     },
     "fal-ai/recraft/v3/text-to-image": {
       "mode": "image_generation",

--- a/mlflow/utils/model_catalog/gemini.json
+++ b/mlflow/utils/model_catalog/gemini.json
@@ -860,7 +860,7 @@
             "input_per_million_tokens": 1.0
           },
           "video": {
-            "input_per_second": 3.3333333333333335e-05
+            "input_per_second": 3.3333333333333335e-5
           }
         }
       },

--- a/mlflow/utils/model_catalog/gemini.json
+++ b/mlflow/utils/model_catalog/gemini.json
@@ -860,7 +860,7 @@
             "input_per_million_tokens": 1.0
           },
           "video": {
-            "input_per_second": 3.3333333333333335e-5
+            "input_per_second": 3.3333333333333335e-05
           }
         }
       },

--- a/mlflow/utils/model_catalog/inception.json
+++ b/mlflow/utils/model_catalog/inception.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "mercury-2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 50000,
+        "max_tokens": 50000
+      },
+      "pricing": {
+        "input_per_million_tokens": 0.25,
+        "output_per_million_tokens": 0.75,
+        "cache_read_per_million_tokens": 0.025
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "last_updated_at": "2026-06-09"
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/minimax.json
+++ b/mlflow/utils/model_catalog/minimax.json
@@ -105,6 +105,26 @@
         "response_schema": false
       },
       "last_updated_at": "2026-04-24"
+    },
+    "MiniMax-M3": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 512000,
+        "max_output": 128000
+      },
+      "pricing": {
+        "input_per_million_tokens": 0.6,
+        "output_per_million_tokens": 2.4,
+        "cache_read_per_million_tokens": 0.12
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      },
+      "last_updated_at": "2026-06-09"
     }
   }
 }

--- a/mlflow/utils/model_catalog/mistral.json
+++ b/mlflow/utils/model_catalog/mistral.json
@@ -497,6 +497,26 @@
       },
       "last_updated_at": "2026-05-27"
     },
+    "ministral-8b-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 262144,
+        "max_output": 262144,
+        "max_tokens": 262144
+      },
+      "pricing": {
+        "input_per_million_tokens": 0.15,
+        "output_per_million_tokens": 0.15
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      },
+      "last_updated_at": "2026-06-09"
+    },
     "mistral-embed": {
       "mode": "embedding",
       "context_window": {

--- a/mlflow/utils/model_catalog/moonshot.json
+++ b/mlflow/utils/model_catalog/moonshot.json
@@ -123,9 +123,9 @@
         "vision": true,
         "reasoning": true,
         "prompt_caching": false,
-        "response_schema": false
+        "response_schema": true
       },
-      "last_updated_at": "2026-04-24"
+      "last_updated_at": "2026-06-09"
     },
     "kimi-k2.6": {
       "mode": "chat",
@@ -144,9 +144,9 @@
         "vision": true,
         "reasoning": true,
         "prompt_caching": false,
-        "response_schema": false
+        "response_schema": true
       },
-      "last_updated_at": "2026-04-24"
+      "last_updated_at": "2026-06-09"
     },
     "kimi-latest": {
       "mode": "chat",
@@ -269,9 +269,9 @@
         "vision": false,
         "reasoning": false,
         "prompt_caching": false,
-        "response_schema": false
+        "response_schema": true
       },
-      "last_updated_at": "2026-04-24"
+      "last_updated_at": "2026-06-09"
     },
     "moonshot-v1-128k-0430": {
       "mode": "chat",
@@ -309,9 +309,9 @@
         "vision": true,
         "reasoning": false,
         "prompt_caching": false,
-        "response_schema": false
+        "response_schema": true
       },
-      "last_updated_at": "2026-04-24"
+      "last_updated_at": "2026-06-09"
     },
     "moonshot-v1-32k": {
       "mode": "chat",
@@ -329,9 +329,9 @@
         "vision": false,
         "reasoning": false,
         "prompt_caching": false,
-        "response_schema": false
+        "response_schema": true
       },
-      "last_updated_at": "2026-04-24"
+      "last_updated_at": "2026-06-09"
     },
     "moonshot-v1-32k-0430": {
       "mode": "chat",
@@ -369,9 +369,9 @@
         "vision": true,
         "reasoning": false,
         "prompt_caching": false,
-        "response_schema": false
+        "response_schema": true
       },
-      "last_updated_at": "2026-04-24"
+      "last_updated_at": "2026-06-09"
     },
     "moonshot-v1-8k": {
       "mode": "chat",
@@ -389,9 +389,9 @@
         "vision": false,
         "reasoning": false,
         "prompt_caching": false,
-        "response_schema": false
+        "response_schema": true
       },
-      "last_updated_at": "2026-04-24"
+      "last_updated_at": "2026-06-09"
     },
     "moonshot-v1-8k-0430": {
       "mode": "chat",
@@ -429,9 +429,9 @@
         "vision": true,
         "reasoning": false,
         "prompt_caching": false,
-        "response_schema": false
+        "response_schema": true
       },
-      "last_updated_at": "2026-04-24"
+      "last_updated_at": "2026-06-09"
     },
     "moonshot-v1-auto": {
       "mode": "chat",
@@ -449,9 +449,9 @@
         "vision": false,
         "reasoning": false,
         "prompt_caching": false,
-        "response_schema": false
+        "response_schema": true
       },
-      "last_updated_at": "2026-04-24"
+      "last_updated_at": "2026-06-09"
     }
   }
 }

--- a/mlflow/utils/model_catalog/openai.json
+++ b/mlflow/utils/model_catalog/openai.json
@@ -2711,6 +2711,13 @@
     },
     "sora-2": {
       "mode": "video_generation",
+      "pricing": {
+        "modality": {
+          "video": {
+            "output_per_second": 0.1
+          }
+        }
+      },
       "capabilities": {
         "function_calling": false,
         "vision": false,
@@ -2718,10 +2725,17 @@
         "prompt_caching": false,
         "response_schema": false
       },
-      "last_updated_at": "2026-05-28"
+      "last_updated_at": "2026-06-09"
     },
     "sora-2-pro": {
       "mode": "video_generation",
+      "pricing": {
+        "modality": {
+          "video": {
+            "output_per_second": 0.3
+          }
+        }
+      },
       "capabilities": {
         "function_calling": false,
         "vision": false,
@@ -2729,10 +2743,17 @@
         "prompt_caching": false,
         "response_schema": false
       },
-      "last_updated_at": "2026-05-28"
+      "last_updated_at": "2026-06-09"
     },
     "sora-2-pro-high-res": {
       "mode": "video_generation",
+      "pricing": {
+        "modality": {
+          "video": {
+            "output_per_second": 0.5
+          }
+        }
+      },
       "capabilities": {
         "function_calling": false,
         "vision": false,
@@ -2740,7 +2761,7 @@
         "prompt_caching": false,
         "response_schema": false
       },
-      "last_updated_at": "2026-05-28"
+      "last_updated_at": "2026-06-09"
     },
     "text-embedding-3-large": {
       "mode": "embedding",

--- a/mlflow/utils/model_catalog/runwayml.json
+++ b/mlflow/utils/model_catalog/runwayml.json
@@ -3,6 +3,13 @@
   "models": {
     "gen3a_turbo": {
       "mode": "video_generation",
+      "pricing": {
+        "modality": {
+          "video": {
+            "output_per_second": 0.05
+          }
+        }
+      },
       "capabilities": {
         "function_calling": false,
         "vision": false,
@@ -10,10 +17,17 @@
         "prompt_caching": false,
         "response_schema": false
       },
-      "last_updated_at": "2026-05-28"
+      "last_updated_at": "2026-06-09"
     },
     "gen4_aleph": {
       "mode": "video_generation",
+      "pricing": {
+        "modality": {
+          "video": {
+            "output_per_second": 0.15
+          }
+        }
+      },
       "capabilities": {
         "function_calling": false,
         "vision": false,
@@ -21,7 +35,7 @@
         "prompt_caching": false,
         "response_schema": false
       },
-      "last_updated_at": "2026-05-28"
+      "last_updated_at": "2026-06-09"
     },
     "gen4_image": {
       "mode": "image_generation",
@@ -47,6 +61,13 @@
     },
     "gen4_turbo": {
       "mode": "video_generation",
+      "pricing": {
+        "modality": {
+          "video": {
+            "output_per_second": 0.05
+          }
+        }
+      },
       "capabilities": {
         "function_calling": false,
         "vision": false,
@@ -54,7 +75,7 @@
         "prompt_caching": false,
         "response_schema": false
       },
-      "last_updated_at": "2026-05-28"
+      "last_updated_at": "2026-06-09"
     }
   }
 }

--- a/mlflow/utils/model_catalog/snowflake.json
+++ b/mlflow/utils/model_catalog/snowflake.json
@@ -4,25 +4,160 @@
     "claude-3-5-sonnet": {
       "mode": "chat",
       "context_window": {
-        "max_input": 18000,
-        "max_output": 8192,
-        "max_tokens": 8192
+        "max_input": 200000,
+        "max_output": 16384,
+        "max_tokens": 16384
+      },
+      "pricing": {
+        "input_per_million_tokens": 3.0,
+        "output_per_million_tokens": 15.0,
+        "cache_read_per_million_tokens": 0.3
       },
       "capabilities": {
-        "function_calling": false,
-        "vision": false,
+        "function_calling": true,
+        "vision": true,
         "reasoning": false,
-        "prompt_caching": false,
-        "response_schema": false
+        "prompt_caching": true,
+        "response_schema": true
       },
-      "last_updated_at": "2026-04-24"
+      "last_updated_at": "2026-06-09"
+    },
+    "claude-3-7-sonnet": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 16384,
+        "max_tokens": 16384
+      },
+      "pricing": {
+        "input_per_million_tokens": 3.0,
+        "output_per_million_tokens": 15.0,
+        "cache_read_per_million_tokens": 0.3
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "last_updated_at": "2026-06-09"
+    },
+    "claude-4-opus": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 16384,
+        "max_tokens": 16384
+      },
+      "pricing": {
+        "input_per_million_tokens": 5.0,
+        "output_per_million_tokens": 25.0,
+        "cache_read_per_million_tokens": 0.5
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "last_updated_at": "2026-06-09"
+    },
+    "claude-4-sonnet": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 16384,
+        "max_tokens": 16384
+      },
+      "pricing": {
+        "input_per_million_tokens": 3.0,
+        "output_per_million_tokens": 15.0,
+        "cache_read_per_million_tokens": 0.3
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "last_updated_at": "2026-06-09"
+    },
+    "claude-haiku-4-5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 16384,
+        "max_tokens": 16384
+      },
+      "pricing": {
+        "input_per_million_tokens": 1.0,
+        "output_per_million_tokens": 5.0,
+        "cache_read_per_million_tokens": 0.1
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "last_updated_at": "2026-06-09"
+    },
+    "claude-sonnet-4-5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 16384,
+        "max_tokens": 16384
+      },
+      "pricing": {
+        "input_per_million_tokens": 3.0,
+        "output_per_million_tokens": 15.0,
+        "cache_read_per_million_tokens": 0.3
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "last_updated_at": "2026-06-09"
+    },
+    "claude-sonnet-4-6": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 16384,
+        "max_tokens": 16384
+      },
+      "pricing": {
+        "input_per_million_tokens": 3.0,
+        "output_per_million_tokens": 15.0,
+        "cache_read_per_million_tokens": 0.3
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "last_updated_at": "2026-06-09"
     },
     "deepseek-r1": {
       "mode": "chat",
       "context_window": {
-        "max_input": 32768,
-        "max_output": 8192,
-        "max_tokens": 8192
+        "max_input": 128000,
+        "max_output": 16384,
+        "max_tokens": 16384
+      },
+      "pricing": {
+        "input_per_million_tokens": 1.35,
+        "output_per_million_tokens": 5.4
       },
       "capabilities": {
         "function_calling": false,
@@ -31,7 +166,7 @@
         "prompt_caching": false,
         "response_schema": false
       },
-      "last_updated_at": "2026-04-24"
+      "last_updated_at": "2026-06-09"
     },
     "gemma-7b": {
       "mode": "chat",
@@ -149,40 +284,52 @@
       "mode": "chat",
       "context_window": {
         "max_input": 128000,
-        "max_output": 8192,
-        "max_tokens": 8192
+        "max_output": 16384,
+        "max_tokens": 16384
+      },
+      "pricing": {
+        "input_per_million_tokens": 1.2,
+        "output_per_million_tokens": 1.2
       },
       "capabilities": {
-        "function_calling": false,
+        "function_calling": true,
         "vision": false,
         "reasoning": false,
         "prompt_caching": false,
         "response_schema": false
       },
-      "last_updated_at": "2026-04-24"
+      "last_updated_at": "2026-06-09"
     },
     "llama3.1-70b": {
       "mode": "chat",
       "context_window": {
         "max_input": 128000,
-        "max_output": 8192,
-        "max_tokens": 8192
+        "max_output": 16384,
+        "max_tokens": 16384
+      },
+      "pricing": {
+        "input_per_million_tokens": 0.72,
+        "output_per_million_tokens": 0.72
       },
       "capabilities": {
-        "function_calling": false,
+        "function_calling": true,
         "vision": false,
         "reasoning": false,
         "prompt_caching": false,
         "response_schema": false
       },
-      "last_updated_at": "2026-04-24"
+      "last_updated_at": "2026-06-09"
     },
     "llama3.1-8b": {
       "mode": "chat",
       "context_window": {
         "max_input": 128000,
-        "max_output": 8192,
-        "max_tokens": 8192
+        "max_output": 16384,
+        "max_tokens": 16384
+      },
+      "pricing": {
+        "input_per_million_tokens": 0.24,
+        "output_per_million_tokens": 0.24
       },
       "capabilities": {
         "function_calling": false,
@@ -191,7 +338,7 @@
         "prompt_caching": false,
         "response_schema": false
       },
-      "last_updated_at": "2026-04-24"
+      "last_updated_at": "2026-06-09"
     },
     "llama3.2-1b": {
       "mode": "chat",
@@ -229,17 +376,41 @@
       "mode": "chat",
       "context_window": {
         "max_input": 128000,
-        "max_output": 8192,
-        "max_tokens": 8192
+        "max_output": 16384,
+        "max_tokens": 16384
+      },
+      "pricing": {
+        "input_per_million_tokens": 0.72,
+        "output_per_million_tokens": 0.72
       },
       "capabilities": {
-        "function_calling": false,
+        "function_calling": true,
         "vision": false,
         "reasoning": false,
         "prompt_caching": false,
         "response_schema": false
       },
-      "last_updated_at": "2026-04-24"
+      "last_updated_at": "2026-06-09"
+    },
+    "llama4-maverick": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 16384,
+        "max_tokens": 16384
+      },
+      "pricing": {
+        "input_per_million_tokens": 0.24,
+        "output_per_million_tokens": 0.97
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      },
+      "last_updated_at": "2026-06-09"
     },
     "mistral-7b": {
       "mode": "chat",
@@ -277,17 +448,21 @@
       "mode": "chat",
       "context_window": {
         "max_input": 128000,
-        "max_output": 8192,
-        "max_tokens": 8192
+        "max_output": 16384,
+        "max_tokens": 16384
+      },
+      "pricing": {
+        "input_per_million_tokens": 2.0,
+        "output_per_million_tokens": 6.0
       },
       "capabilities": {
-        "function_calling": false,
+        "function_calling": true,
         "vision": false,
         "reasoning": false,
         "prompt_caching": false,
-        "response_schema": false
+        "response_schema": true
       },
-      "last_updated_at": "2026-04-24"
+      "last_updated_at": "2026-06-09"
     },
     "mixtral-8x7b": {
       "mode": "chat",
@@ -304,6 +479,88 @@
         "response_schema": false
       },
       "last_updated_at": "2026-04-24"
+    },
+    "openai-gpt-4.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 300000,
+        "max_output": 16384,
+        "max_tokens": 16384
+      },
+      "pricing": {
+        "input_per_million_tokens": 2.0,
+        "output_per_million_tokens": 8.0,
+        "cache_read_per_million_tokens": 0.5
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "last_updated_at": "2026-06-09"
+    },
+    "openai-gpt-5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 300000,
+        "max_output": 16384,
+        "max_tokens": 16384
+      },
+      "pricing": {
+        "input_per_million_tokens": 1.25,
+        "output_per_million_tokens": 10.0,
+        "cache_read_per_million_tokens": 0.125
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": true
+      },
+      "last_updated_at": "2026-06-09"
+    },
+    "openai-gpt-5-mini": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 16384,
+        "max_tokens": 16384
+      },
+      "pricing": {
+        "input_per_million_tokens": 0.3,
+        "output_per_million_tokens": 1.2
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      },
+      "last_updated_at": "2026-06-09"
+    },
+    "openai-gpt-5-nano": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 5000000,
+        "max_output": 16384,
+        "max_tokens": 16384
+      },
+      "pricing": {
+        "input_per_million_tokens": 0.15,
+        "output_per_million_tokens": 0.6
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": true
+      },
+      "last_updated_at": "2026-06-09"
     },
     "reka-core": {
       "mode": "chat",
@@ -353,6 +610,44 @@
       },
       "last_updated_at": "2026-04-24"
     },
+    "snowflake-arctic-embed-l-v2.0": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 8192,
+        "max_tokens": 8192
+      },
+      "pricing": {
+        "input_per_million_tokens": 0.07,
+        "output_per_million_tokens": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      },
+      "last_updated_at": "2026-06-09"
+    },
+    "snowflake-arctic-embed-m-v2.0": {
+      "mode": "embedding",
+      "context_window": {
+        "max_input": 8192,
+        "max_tokens": 8192
+      },
+      "pricing": {
+        "input_per_million_tokens": 0.07,
+        "output_per_million_tokens": 0.0
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      },
+      "last_updated_at": "2026-06-09"
+    },
     "snowflake-llama-3.1-405b": {
       "mode": "chat",
       "context_window": {
@@ -372,18 +667,22 @@
     "snowflake-llama-3.3-70b": {
       "mode": "chat",
       "context_window": {
-        "max_input": 8000,
-        "max_output": 8192,
-        "max_tokens": 8192
+        "max_input": 128000,
+        "max_output": 16384,
+        "max_tokens": 16384
+      },
+      "pricing": {
+        "input_per_million_tokens": 0.72,
+        "output_per_million_tokens": 0.72
       },
       "capabilities": {
-        "function_calling": false,
+        "function_calling": true,
         "vision": false,
         "reasoning": false,
         "prompt_caching": false,
         "response_schema": false
       },
-      "last_updated_at": "2026-04-24"
+      "last_updated_at": "2026-06-09"
     }
   }
 }

--- a/mlflow/utils/model_catalog/text-completion-inception.json
+++ b/mlflow/utils/model_catalog/text-completion-inception.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "mercury-edit-2": {
+      "mode": "completion",
+      "context_window": {
+        "max_input": 32000,
+        "max_output": 8192,
+        "max_tokens": 8192
+      },
+      "pricing": {
+        "input_per_million_tokens": 0.25,
+        "output_per_million_tokens": 0.75,
+        "cache_read_per_million_tokens": 0.025
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      },
+      "last_updated_at": "2026-06-09"
+    }
+  }
+}

--- a/mlflow/utils/model_catalog/vertex_ai.json
+++ b/mlflow/utils/model_catalog/vertex_ai.json
@@ -1931,6 +1931,26 @@
       },
       "last_updated_at": "2026-04-24"
     },
+    "google/gemma-4-26b-a4b-it-maas": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 128000,
+        "max_tokens": 128000
+      },
+      "pricing": {
+        "input_per_million_tokens": 0.15,
+        "output_per_million_tokens": 0.6
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      },
+      "last_updated_at": "2026-06-09"
+    },
     "imagegeneration@006": {
       "mode": "image_generation",
       "capabilities": {

--- a/mlflow/utils/providers.py
+++ b/mlflow/utils/providers.py
@@ -96,7 +96,11 @@ class CatalogLongContextTier(CatalogPricingTier, total=False):
 
 class CatalogPricingModality(TypedDict, total=False):
     input_per_million_tokens: float
+    output_per_million_tokens: float
+    cache_read_per_million_tokens: float
+    cache_write_per_million_tokens: float
     input_per_second: float
+    output_per_second: float
 
 
 class ModelInfo(TypedDict, total=False):

--- a/tests/dev/test_update_model_catalog.py
+++ b/tests/dev/test_update_model_catalog.py
@@ -218,10 +218,11 @@ def test_extract_modality_pricing_mixed():
     info = {
         "input_cost_per_audio_token": 7e-7,
         "input_cost_per_video_per_second": 0.0007,
+        "output_cost_per_video_per_second": 0.0014,
     }
     assert _extract_modality_pricing(info) == {
         "audio": {"input_per_million_tokens": 0.7},
-        "video": {"input_per_second": 0.0007},
+        "video": {"input_per_second": 0.0007, "output_per_second": 0.0014},
     }
 
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22121

### What changes are proposed in this pull request?

The model catalog update script parses `input_cost_per_video_per_second` from LiteLLM's pricing data but ignores the corresponding `output_cost_per_video_per_second` field. This PR adds a `_FLAT_OUTPUT_PER_SECOND` regex pattern to capture output per-second rates and stores them as `output_per_second` in the modality pricing dict.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Updated `test_extract_modality_pricing_mixed` to include `output_cost_per_video_per_second` and assert it is parsed as `output_per_second`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release