### PR TITLE
Fix `gh pr create` failure in `update-model-catalog` workflow

### DIFF
--- a/.github/workflows/update-model-catalog.yml
+++ b/.github/workflows/update-model-catalog.yml
@@ -87,12 +87,11 @@ jobs:
             echo "number=$existing_pr" >> "$GITHUB_OUTPUT"
             echo "is_new_pr=false" >> "$GITHUB_OUTPUT"
           else
-            pr_number=$(gh pr create \
+            pr_url=$(gh pr create \
               --title "Update model catalog from upstream sources" \
               --body "Daily refresh of model pricing and context window data from LiteLLM, transformed to MLflow-native schema." \
-              --reviewer "TomeHirata" \
-              --json number --jq '.number')
-            echo "number=$pr_number" >> "$GITHUB_OUTPUT"
+              --reviewer "TomeHirata")
+            echo "number=${pr_url##*/}" >> "$GITHUB_OUTPUT"
             echo "is_new_pr=true" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23727

### What changes are proposed in this pull request?

`gh pr create` does not accept `--json`/`--jq` flags, so the [`update-model-catalog`](https://github.com/mlflow/mlflow/actions/workflows/update-model-catalog.yml) workflow has been failing whenever it actually has to open a new PR — the latent bug, introduced in #23727, was first exposed on 2026-06-08 once the previous PR auto-merged and the catalog had upstream changes again. Capture the PR URL that `gh pr create` prints and derive the number from its trailing path segment instead.

### How is this PR tested?

- [x] Manual tests

Inspected the `gh pr create` help output to confirm the supported flags, and verified `${pr_url##*/}` returns the PR number from a `https://github.com/mlflow/mlflow/pull/NNN` URL. The full path will be exercised by the next scheduled run.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)