### PR TITLE
Cache pre-commit hook environments in the `Lint` workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -88,6 +88,12 @@ jobs:
             !bin/.gitignore
           key: install-bin-${{ matrix.os }}-${{ hashFiles('bin/install.py') }}
           restore-keys: install-bin-${{ matrix.os }}-
+      - name: Cache pre-commit hooks
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ matrix.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: pre-commit-${{ matrix.os }}-
       - name: Install pre-commit hooks
         run: |
           uv run --no-sync pre-commit install --install-hooks


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Every `Lint` run reinstalls every pre-commit hook environment from scratch (the `Installing environment for ...` lines in the log), which takes a couple of minutes — mostly for the prettier Node env. Cache `~/.cache/pre-commit` keyed on `.pre-commit-config.yaml` so unchanged configs skip the reinstall on subsequent runs.

### How is this PR tested?

- [x] Manual tests

Compared two runs of this PR's `Lint` workflow, "Install pre-commit hooks" step duration:

| Run | `lint` (ubuntu) | `lint-macos` |
|---|---|---|
| [Cold cache (attempt 1)](https://github.com/mlflow/mlflow/actions/runs/27188589362/attempts/1) | 12 s | 18 s |
| [Warm cache (attempt 2)](https://github.com/mlflow/mlflow/actions/runs/27188589362/attempts/2) | 1 s | 1 s |

Attempt 2 logged `Cache restored from key: pre-commit-ubuntu-latest-…` and no `Installing environment for …` lines.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)