### PR TITLE
Fix `_stop_listen_for_spark_activity` hanging indefinitely on CLOSE_WAIT socket

### DIFF
--- a/mlflow/spark/autologging.py
+++ b/mlflow/spark/autologging.py
@@ -24,6 +24,11 @@ _SPARK_TABLE_INFO_TAG_NAME = "sparkDatasourceInfo"
 
 _logger = logging.getLogger(__name__)
 _lock = threading.Lock()
+
+# Upper bound on how long to wait for the py4j callback server to shut down before
+# abandoning it. A CLOSE_WAIT socket makes shutdown_callback_server() block forever, so
+# we cap the wait and let the daemon thread (and the OS) reclaim the socket on exit.
+_CALLBACK_SERVER_SHUTDOWN_TIMEOUT_SECONDS = 60.0
 _table_infos = []
 _spark_table_info_listener = None
 
@@ -110,10 +115,28 @@ def _set_run_tag(run_id, path, version, data_format):
 
 def _stop_listen_for_spark_activity(spark_context):
     gw = spark_context._gateway
-    try:
-        gw.shutdown_callback_server()
-    except Exception as e:
-        _logger.warning("Failed to shut down Spark callback server for autologging: %s", e)
+
+    def _shutdown():
+        try:
+            gw.shutdown_callback_server()
+        except Exception as e:
+            _logger.warning("Failed to shut down Spark callback server for autologging: %s", e)
+
+    # Run the shutdown in a daemon thread and bound the wait. On a CLOSE_WAIT socket
+    # shutdown_callback_server() never returns and raises no exception, which would hang
+    # spark.stop() forever. Abandoning the thread is safe: the callback server is started
+    # with daemonize=True, so the OS reclaims the socket when the process exits.
+    t = threading.Thread(
+        target=_shutdown, name="mlflow-spark-callback-server-shutdown", daemon=True
+    )
+    t.start()
+    t.join(timeout=_CALLBACK_SERVER_SHUTDOWN_TIMEOUT_SECONDS)
+    if t.is_alive():
+        _logger.warning(
+            "shutdown_callback_server() did not complete within %.0f s "
+            "(likely a CLOSE_WAIT socket); abandoning to allow process exit.",
+            _CALLBACK_SERVER_SHUTDOWN_TIMEOUT_SECONDS,
+        )
 
 
 def _listen_for_spark_activity(spark_context):

--- a/tests/spark/test_spark_autologging_stop.py
+++ b/tests/spark/test_spark_autologging_stop.py
@@ -1,0 +1,104 @@
+import logging
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import mlflow.spark.autologging as autologging_module
+from mlflow.spark.autologging import _stop_listen_for_spark_activity
+
+
+@pytest.fixture
+def autolog_caplog(caplog):
+    # The "mlflow" logger sets propagate=False, so caplog's root handler does not see
+    # records. Attach caplog's handler directly to the autologging logger.
+    logger = logging.getLogger("mlflow.spark.autologging")
+    logger.addHandler(caplog.handler)
+    try:
+        with caplog.at_level(logging.WARNING, logger="mlflow.spark.autologging"):
+            yield caplog
+    finally:
+        logger.removeHandler(caplog.handler)
+
+
+def _make_spark_context(shutdown_side_effect=None):
+    gw = MagicMock()
+    if shutdown_side_effect is not None:
+        gw.shutdown_callback_server.side_effect = shutdown_side_effect
+    sc = MagicMock()
+    sc._gateway = gw
+    return sc
+
+
+def test_fast_shutdown_returns_without_warning(autolog_caplog):
+    sc = _make_spark_context()
+    _stop_listen_for_spark_activity(sc)
+    sc._gateway.shutdown_callback_server.assert_called_once()
+    assert not any("did not complete" in r.message for r in autolog_caplog.records)
+
+
+def test_hanging_shutdown_times_out_and_logs_warning(autolog_caplog):
+    hang = threading.Event()
+
+    def _hang():
+        hang.wait()
+
+    sc = _make_spark_context(shutdown_side_effect=_hang)
+    try:
+        with patch.object(autologging_module, "_CALLBACK_SERVER_SHUTDOWN_TIMEOUT_SECONDS", 0.2):
+            _stop_listen_for_spark_activity(sc)
+        warnings = [r for r in autolog_caplog.records if "did not complete" in r.message]
+        assert len(warnings) == 1
+        assert "CLOSE_WAIT" in warnings[0].message
+    finally:
+        hang.set()
+
+
+def test_hanging_shutdown_does_not_block_caller():
+    hang = threading.Event()
+
+    def _hang():
+        hang.wait()
+
+    sc = _make_spark_context(shutdown_side_effect=_hang)
+    try:
+        with patch.object(autologging_module, "_CALLBACK_SERVER_SHUTDOWN_TIMEOUT_SECONDS", 0.2):
+            start = time.monotonic()
+            _stop_listen_for_spark_activity(sc)
+            elapsed = time.monotonic() - start
+        assert elapsed < 2.0
+    finally:
+        hang.set()
+
+
+def test_exception_during_shutdown_logs_error_not_timeout(autolog_caplog):
+    sc = _make_spark_context(shutdown_side_effect=Exception("connection reset"))
+    with patch.object(autologging_module, "_CALLBACK_SERVER_SHUTDOWN_TIMEOUT_SECONDS", 0.2):
+        _stop_listen_for_spark_activity(sc)
+    error_warnings = [r for r in autolog_caplog.records if "Failed to shut down" in r.message]
+    assert len(error_warnings) == 1
+    assert "connection reset" in error_warnings[0].message
+    assert not any("did not complete" in r.message for r in autolog_caplog.records)
+
+
+def test_shutdown_thread_is_daemon():
+    created_threads = []
+    original_init = threading.Thread.__init__
+
+    def capturing_init(self, *args, **kwargs):
+        original_init(self, *args, **kwargs)
+        created_threads.append(self)
+
+    hang = threading.Event()
+    sc = _make_spark_context(shutdown_side_effect=lambda: hang.wait())
+    try:
+        with (
+            patch.object(threading.Thread, "__init__", capturing_init),
+            patch.object(autologging_module, "_CALLBACK_SERVER_SHUTDOWN_TIMEOUT_SECONDS", 0.1),
+        ):
+            _stop_listen_for_spark_activity(sc)
+        assert created_threads
+        assert all(t.daemon for t in created_threads)
+    finally:
+        hang.set()


### PR DESCRIPTION
### Related Issues/PRs

No existing issue — root cause is described below.

### What changes are proposed in this pull request?

When Spark datasource autologging is active, `spark.stop()` can hang forever in long-lived processes (interactive notebooks, REPL sessions).

**Root cause.** `spark.stop()` is patched by `patched_session_stop`, which calls `_stop_listen_for_spark_activity` before the real stop. That helper calls `gw.shutdown_callback_server()` with no timeout:

```python
def _stop_listen_for_spark_activity(spark_context):
    gw = spark_context._gateway
    try:
        gw.shutdown_callback_server()   # no timeout — blocks forever
    except Exception as e:
        _logger.warning("Failed to shut down Spark callback server for autologging: %s", e)
```

After a query completes, the JVM closes its end of the py4j callback TCP connection, leaving the socket in `CLOSE_WAIT`. `shutdown_callback_server()` internally calls `socket.close()`, which **blocks indefinitely** on a `CLOSE_WAIT` socket and raises no exception — so the `except` never fires and the real `SparkSession.stop()` is never reached. Short-lived apps are unaffected because the process exits and the OS reclaims the socket; long-lived processes hang permanently. `mlflow.spark.autolog(disable=True)` routes through the same helper and hits the same hang.

**Fix.** Run the shutdown in a daemon thread bounded by a configurable timeout, then abandon it on timeout (logging a warning). This is safe because the callback server is started with `daemonize=True`, so the OS reclaims the socket on process exit. The normal fast path and the quick-exception path are behaviorally unchanged; only the previously-infinite hang path now returns within the timeout.

```python
_CALLBACK_SERVER_SHUTDOWN_TIMEOUT_SECONDS = 60.0

def _stop_listen_for_spark_activity(spark_context):
    gw = spark_context._gateway

    def _shutdown():
        try:
            gw.shutdown_callback_server()
        except Exception as e:
            _logger.warning("Failed to shut down Spark callback server for autologging: %s", e)

    t = threading.Thread(
        target=_shutdown, name="mlflow-spark-callback-server-shutdown", daemon=True
    )
    t.start()
    t.join(timeout=_CALLBACK_SERVER_SHUTDOWN_TIMEOUT_SECONDS)
    if t.is_alive():
        _logger.warning(
            "shutdown_callback_server() did not complete within %.0f s "
            "(likely a CLOSE_WAIT socket); abandoning to allow process exit.",
            _CALLBACK_SERVER_SHUTDOWN_TIMEOUT_SECONDS,
        )
```

| Scenario | Before | After |
| --- | --- | --- |
| Clean shutdown | Returns immediately | Returns immediately (identical) |
| `shutdown_callback_server()` raises | Warning logged, returns | Warning logged, returns (identical) |
| `CLOSE_WAIT` hang | Blocks forever | Blocks at most 60s, warns, returns |

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New tests in `tests/spark/test_spark_autologging_stop.py` cover: fast shutdown logs no warning; a hanging shutdown times out and logs the warning; the caller is not blocked past the timeout; a quick exception logs the existing error (not a timeout); and the background thread is a daemon. Also manually verified on a long-lived interactive Spark session that `spark.stop()` and `autolog(disable=True)` return instead of hanging.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. `spark.stop()` (and `mlflow.spark.autolog(disable=True)`) no longer hang indefinitely when Spark autologging is active and the py4j callback server socket is in the `CLOSE_WAIT` state.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request was AI-assisted by Isaac.