### PR TITLE
Run macOS lint job on push events to warm shared caches

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,11 +34,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        is-pull-request:
-          - ${{ github.event_name == 'pull_request' }}
+        run-macos:
+          - ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
         exclude:
           - os: macos-latest
-            is-pull-request: false
+            run-macos: false
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Run the macOS variant of the `lint` job on `push` events (master and `branch-X.Y`), not just on pull requests. The job already caches mypy and the `install-bin` tools, but those caches were never populated outside of PR runs. Branch-scoped caches built on master become the fallback that PR runs restore from, so warming them on push should cut macOS lint times for PRs.

The matrix variable was renamed from `is-pull-request` to `run-macos` to match its new meaning.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)