### PR TITLE
Trim redundant emphasis from agent instrument template

### DIFF
--- a/mlflow/agent/setup/templates/instrument.md
+++ b/mlflow/agent/setup/templates/instrument.md
@@ -42,7 +42,8 @@ before proceeding.
 ### 5. Report the trace URL
 
 After the app run, capture the experiment / trace URL printed by MLflow or
-constructable from the tracking URI + experiment ID.
+constructable from the tracking URI + experiment ID. Include this URL in the
+Final Summary below so the user can open the trace.
 
 ### 6. Final Summary
 

--- a/mlflow/agent/setup/templates/instrument.md
+++ b/mlflow/agent/setup/templates/instrument.md
@@ -20,13 +20,12 @@ Before writing any code:
 
 1. Create a **checklist** from the steps below.
 2. Execute each step in order.
-3. Do not skip steps.
 
 ## Steps
 
 {{ language_steps }}
 
-### 4. Verify installation (MANDATORY)
+### 4. Verify installation
 
 - Run the application end-to-end via its normal entry point.
 - Confirm at least one trace is emitted to {{ tracking_uri }}.
@@ -40,11 +39,10 @@ default retries.
 If you don't know how to run the app, ask the user and wait for a response
 before proceeding.
 
-### 5. Report the trace URL (CRITICAL)
+### 5. Report the trace URL
 
 After the app run, capture the experiment / trace URL printed by MLflow or
-constructable from the tracking URI + experiment ID. This URL must appear in
-the final summary so the user can open it in the MLflow UI.
+constructable from the tracking URI + experiment ID.
 
 ### 6. Final Summary
 
@@ -52,4 +50,4 @@ Summarize:
 
 - MLflow version installed
 - Files modified
-- Trace URL (required)
+- Trace URL


### PR DESCRIPTION
### Related Issues/PRs

Relates to #

### What changes are proposed in this pull request?

Tidies `mlflow/agent/setup/templates/instrument.md`:

- Drops the `(MANDATORY)` / `(CRITICAL)` qualifiers on step headings.
- Removes "Do not skip steps." (redundant with "Execute each step in order").
- Removes the duplicated "must appear in the final summary" sentence in step 5 and the "(required)" qualifier in step 6, since step 6 already lists the Trace URL as a summary item.

No behavioral change — instructions are unchanged in substance.

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)