### PR TITLE
fix: prevent 'table already exists' error during database upgrade (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,10 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    # Use create_all only for fresh databases to avoid "table already exists" errors on upgrade.
+    # If tables already exist (e.g. from a partial upgrade), Alembic will handle the rest.
+    if not _all_tables_exist(engine):
+        InitialBase.metadata.create_all(engine)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
Running `mlflow db upgrade` from 3.7.0 to 3.8.x fails with `pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")` when the secrets table already exists from a previous migration but the database is not fully up-to-date.

## Root Cause
`_initialize_tables` calls `InitialBase.metadata.create_all(engine)` unconditionally, which attempts to create all tables again. While this works on SQLite (which supports `CREATE TABLE IF NOT EXISTS`), MySQL raises an error if the table already exists. This happens when a previous Alembic migration has already created the `secrets` table, but the overall database schema is not yet at the latest revision, so `_initialize_tables` is invoked again.

## Fix
Check if all expected tables already exist before calling `create_all`. If they do, skip the direct table creation and proceed directly to `_upgrade_db`, letting Alembic handle the rest of the migration steps. This prevents the duplicate table creation error while still ensuring the schema is fully upgraded.

Closes #19943