### PR TITLE
Fix `--print` example in `mlflow agent setup` help text

### DIFF
--- a/mlflow/agent/setup/cli.py
+++ b/mlflow/agent/setup/cli.py
@@ -188,7 +188,7 @@ def _run_setup(
     default=False,
     help=(
         "Print the composed task prompt to stdout and skip launching the agent. "
-        "Capture it for a custom invocation, e.g. "
+        "Capture the prompt for a custom invocation, e.g. "
         '`claude --dangerously-skip-permissions "$(mlflow agent setup --agent claude --print)"`.'
     ),
 )

--- a/mlflow/agent/setup/cli.py
+++ b/mlflow/agent/setup/cli.py
@@ -188,8 +188,8 @@ def _run_setup(
     default=False,
     help=(
         "Print the composed task prompt to stdout and skip launching the agent. "
-        "Lets you pipe into a custom invocation, e.g. "
-        "`mlflow agent setup --print | claude --permission-mode auto`."
+        "Capture it for a custom invocation, e.g. "
+        '`claude --dangerously-skip-permissions "$(mlflow agent setup --agent claude --print)"`.'
     ),
 )
 def setup(

--- a/mlflow/agent/setup/cli.py
+++ b/mlflow/agent/setup/cli.py
@@ -187,8 +187,8 @@ def _run_setup(
     is_flag=True,
     default=False,
     help=(
-        "Print the composed task prompt to stdout instead of launching the agent, so it can "
-        "be passed to a custom invocation, e.g. "
+        "Print the composed task prompt to stdout and exit without launching the agent. "
+        "Useful for piping it into a custom invocation, e.g. "
         '`claude --permission-mode auto "$(mlflow agent setup --agent claude --print)"`.'
     ),
 )

--- a/mlflow/agent/setup/cli.py
+++ b/mlflow/agent/setup/cli.py
@@ -187,8 +187,8 @@ def _run_setup(
     is_flag=True,
     default=False,
     help=(
-        "Print the composed task prompt to stdout and skip launching the agent. "
-        "Capture the prompt for a custom invocation, e.g. "
+        "Print the composed task prompt to stdout instead of launching the agent, so it can "
+        "be passed to a custom invocation, e.g. "
         '`claude --permission-mode auto "$(mlflow agent setup --agent claude --print)"`.'
     ),
 )

--- a/mlflow/agent/setup/cli.py
+++ b/mlflow/agent/setup/cli.py
@@ -188,7 +188,7 @@ def _run_setup(
     default=False,
     help=(
         "Print the composed task prompt to stdout and exit without launching the agent. "
-        "Useful for piping it into a custom invocation, e.g. "
+        "Useful for piping the prompt into a custom invocation, e.g. "
         '`claude --permission-mode auto "$(mlflow agent setup --agent claude --print)"`.'
     ),
 )

--- a/mlflow/agent/setup/cli.py
+++ b/mlflow/agent/setup/cli.py
@@ -189,7 +189,7 @@ def _run_setup(
     help=(
         "Print the composed task prompt to stdout and skip launching the agent. "
         "Capture the prompt for a custom invocation, e.g. "
-        '`claude --dangerously-skip-permissions "$(mlflow agent setup --agent claude --print)"`.'
+        '`claude --permission-mode auto "$(mlflow agent setup --agent claude --print)"`.'
     ),
 )
 def setup(


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23783

### What changes are proposed in this pull request?

The `--print` option's help text advertises this pattern:

```
mlflow agent setup --print | claude --permission-mode auto
```

This does not work in practice. Claude Code has a 3-second stdin inactivity timeout (added in claude-code v2.1.79 to fix `tail -f | claude -p` hangs). The interactive setup prompts take longer than 3 seconds to drive, so by the time the user finishes picking options, claude has already printed `Warning: no stdin data received in 3s, proceeding without it` and launched without the composed prompt.

Switch the example to command substitution. The prompt is captured to stdout and passed to claude as a positional argument, sidestepping the stdin timeout. The interactive setup prompts continue to work because they go to stderr, which isn't captured.

```
claude --dangerously-skip-permissions "$(mlflow agent setup --agent claude --print)"
```

Upstream tracking issue for the timeout: anthropics/claude-code#60998.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Manual verification: ran `claude --dangerously-skip-permissions "$(mlflow agent setup --agent claude --print)"` end-to-end on a small test app; the prompt was delivered correctly and the agent instrumented the app, installed MLflow, started the tracking server, and logged a real trace.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)