### PR TITLE
Install Codex/OpenCode skills at `.agents/skills`

### DIFF
--- a/mlflow/agent/agents.py
+++ b/mlflow/agent/agents.py
@@ -38,13 +38,13 @@ AGENTS: dict[AgentName, AgentTool] = {
         name="codex",
         display_name="OpenAI Codex",
         binary="codex",
-        skills_dir=".codex/skills",
+        skills_dir=".agents/skills",
     ),
     "opencode": AgentTool(
         name="opencode",
         display_name="OpenCode",
         binary="opencode",
-        skills_dir=".opencode/skills",
+        skills_dir=".agents/skills",
         interactive_args=("--prompt",),
     ),
 }

--- a/mlflow/server/js/src/assistant/setup/SetupStepProject.tsx
+++ b/mlflow/server/js/src/assistant/setup/SetupStepProject.tsx
@@ -34,7 +34,7 @@ interface SetupStepProjectProps {
 
 const PROVIDER_SKILLS_DIR = {
   claude_code: '.claude/skills',
-  codex: '.codex/skills',
+  codex: '.agents/skills',
 } satisfies Record<string, string>;
 
 // Only Claude Code actually loads skills at runtime; other providers ignore

--- a/tests/agent/test_cli.py
+++ b/tests/agent/test_cli.py
@@ -53,8 +53,8 @@ def test_setup_user_provided_uri(tmp_git_repo: Path):
     ("agent", "binary", "skills_dir"),
     [
         ("claude", "/usr/local/bin/claude", ".claude/skills"),
-        ("codex", "/usr/local/bin/codex", ".codex/skills"),
-        ("opencode", "/usr/local/bin/opencode", ".opencode/skills"),
+        ("codex", "/usr/local/bin/codex", ".agents/skills"),
+        ("opencode", "/usr/local/bin/opencode", ".agents/skills"),
     ],
 )
 def test_setup_renders_per_agent_skills_dir(


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

Switch the Codex and OpenCode skills directories in `mlflow agent setup` from `.codex/skills` / `.opencode/skills` to the shared `.agents/skills` path.

Codex only scans `.agents/skills` (per [Codex docs](https://developers.openai.com/codex/skills)), so the old `.codex/skills` install was silently ignored. OpenCode reads `.agents/skills` too, so both providers now share one path. Claude Code is unchanged (`.claude/skills`).

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`mlflow agent setup --agent codex` now installs skills to `.agents/skills`, the only path Codex actually scans.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release