### PR TITLE
Reword `--print` help to "passing" since example uses command substitution

### DIFF
--- a/mlflow/agent/setup/cli.py
+++ b/mlflow/agent/setup/cli.py
@@ -188,7 +188,7 @@ def _run_setup(
     default=False,
     help=(
         "Print the composed task prompt to stdout and exit without launching the agent. "
-        "Useful for piping the prompt into a custom invocation, e.g. "
+        "Useful for passing the prompt into a custom invocation, e.g. "
         '`claude --permission-mode auto "$(mlflow agent setup --agent claude --print)"`.'
     ),
 )


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23845

### What changes are proposed in this pull request?

The `--print` flag help text in `mlflow agent setup` described the use case as "piping the prompt", but the example uses shell command substitution (`$(...)`), not a pipe (`|`). Reword to "passing" to match the example.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release