### PR TITLE
Add run switcher with multi-run metric overlay to the run page

### DIFF
--- a/.github/actions/check-component-ids/componentId-registry.js
+++ b/.github/actions/check-component-ids/componentId-registry.js
@@ -1718,6 +1718,14 @@ module.exports = {
   "mlflow.run.row_actions.visibility.tooltip": "",
 
   // -- mlflow.run-page --
+  "mlflow.run-page.run-switcher.clear-compare": "",
+  "mlflow.run-page.run-switcher.compare-btn": "",
+  "mlflow.run-page.run-switcher.compare-tooltip": "",
+  "mlflow.run-page.run-switcher.item": "",
+  "mlflow.run-page.run-switcher.loading": "",
+  "mlflow.run-page.run-switcher.no-results": "",
+  "mlflow.run-page.run-switcher.search": "",
+  "mlflow.run-page.run-switcher.trigger": "",
   "mlflow.run-page.view-mode-switch": "",
 
   // -- mlflow.run-view --

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunPage.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunPage.test.tsx
@@ -1,4 +1,4 @@
-import { jest, describe, beforeEach, test, expect } from '@jest/globals';
+import { jest, describe, afterEach, beforeEach, test, expect } from '@jest/globals';
 import { MockedReduxStoreProvider } from '../../../common/utils/TestUtils';
 import { renderWithIntl, screen, waitFor, within } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
 import { getExperimentApi, getRunApi, updateRunApi } from '../../actions';
@@ -12,6 +12,7 @@ import type { RunInfoEntity } from '../../types';
 import userEvent from '@testing-library/user-event';
 import { ErrorWrapper } from '../../../common/utils/ErrorWrapper';
 import { TestApolloProvider } from '../../../common/utils/TestApolloProvider';
+import { MlflowService } from '../../sdk/MlflowService';
 import {
   shouldEnableGraphQLRunDetailsPage,
   shouldUseGetLoggedModelsBatchAPI,
@@ -177,6 +178,155 @@ describe('RunPage (legacy redux + REST API)', () => {
 
     await waitFor(() => {
       expect(screen.getByText(/Run ID test-run-uuid does not exist/)).toBeInTheDocument();
+    });
+  });
+
+  describe('comparison run management', () => {
+    const createRunEntity = (runUuid: string, runName: string) => ({
+      info: {
+        runUuid,
+        runName,
+        experimentId: testExperimentId,
+        artifactUri: '',
+        endTime: 0,
+        lifecycleStage: 'active',
+        startTime: 0,
+        status: 'FINISHED' as const,
+      },
+      data: { metrics: [], params: [], tags: [] },
+    });
+
+    const mountOnMetricsTab = () => {
+      const state: DeepPartial<ReduxState> = {
+        entities: {
+          runInfosByUuid: { [testRunUuid]: testRunInfo },
+          experimentsById: {
+            [testExperimentId]: { experimentId: testExperimentId, name: 'Test experiment' },
+          },
+          tagsByRunUuid: { [testRunUuid]: {} },
+          latestMetricsByRunUuid: {},
+          runDatasetsByUuid: {},
+          paramsByRunUuid: {},
+          modelVersionsByRunUuid: {},
+          artifactRootUriByRunUuid: {},
+          imagesByRunUuid: {},
+          sampledMetricsByRunUuid: {},
+        },
+        apis: {
+          experiment_request: { active: false },
+          run_request: { active: false },
+        },
+      };
+
+      const queryClient = new QueryClient();
+
+      return renderWithIntl(
+        <TestApolloProvider>
+          <DesignSystemProvider>
+            <QueryClientProvider client={queryClient}>
+              <MockedReduxStoreProvider state={state}>
+                <TestRouter
+                  initialEntries={[`/experiment/${testExperimentId}/run/${testRunUuid}/model-metrics`]}
+                  routes={[testRoute(<RunPage />, '/experiment/:experimentId/run/:runUuid/*')]}
+                />
+              </MockedReduxStoreProvider>
+            </QueryClientProvider>
+          </DesignSystemProvider>
+        </TestApolloProvider>,
+      );
+    };
+
+    const openSwitcher = async () => {
+      await waitFor(() => expect(screen.getByRole('button', { name: 'Switch run' })).toBeInTheDocument());
+      await userEvent.click(screen.getByRole('button', { name: 'Switch run' }));
+      await screen.findByPlaceholderText('Search runs');
+    };
+
+    beforeEach(() => {
+      jest.spyOn(MlflowService, 'searchRuns').mockResolvedValue({ runs: [] });
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    test('adds a comparison run and shows its name in the header label', async () => {
+      jest.spyOn(MlflowService, 'searchRuns').mockResolvedValueOnce({
+        runs: [createRunEntity('run-2', 'Run Two')],
+      });
+
+      mountOnMetricsTab();
+      await openSwitcher();
+
+      await userEvent.click(within(screen.getByRole('menuitemcheckbox', { name: /Run Two/ })).getByRole('button'));
+
+      // Close dropdown so "Run Two" only appears in the label, not the run list
+      await userEvent.click(screen.getByRole('button', { name: 'Switch run' }));
+      await waitFor(() => expect(screen.queryByPlaceholderText('Search runs')).not.toBeInTheDocument());
+
+      expect(screen.getByText('vs')).toBeInTheDocument();
+      expect(screen.getByText('Run Two')).toBeInTheDocument();
+    });
+
+    test('clicking compare on an active comparison run removes it', async () => {
+      jest.spyOn(MlflowService, 'searchRuns').mockResolvedValueOnce({
+        runs: [createRunEntity('run-2', 'Run Two')],
+      });
+
+      mountOnMetricsTab();
+      await openSwitcher();
+
+      // Add Run Two
+      await userEvent.click(within(screen.getByRole('menuitemcheckbox', { name: /Run Two/ })).getByRole('button'));
+      await waitFor(() => expect(screen.getByText('vs')).toBeInTheDocument());
+
+      // Toggle off — button is now primary (close icon), click it again
+      await userEvent.click(within(screen.getByRole('menuitemcheckbox', { name: /Run Two/ })).getByRole('button'));
+
+      await waitFor(() => expect(screen.queryByText('vs')).not.toBeInTheDocument());
+    });
+
+    test('caps comparison at 5 runs and disables further additions', async () => {
+      jest.spyOn(MlflowService, 'searchRuns').mockResolvedValueOnce({
+        runs: [
+          createRunEntity('run-2', 'Run Two'),
+          createRunEntity('run-3', 'Run Three'),
+          createRunEntity('run-4', 'Run Four'),
+          createRunEntity('run-5', 'Run Five'),
+          createRunEntity('run-6', 'Run Six'),
+          createRunEntity('run-7', 'Run Seven'),
+        ],
+      });
+
+      mountOnMetricsTab();
+      await openSwitcher();
+
+      for (const name of ['Run Two', 'Run Three', 'Run Four', 'Run Five', 'Run Six']) {
+        await userEvent.click(
+          within(screen.getByRole('menuitemcheckbox', { name: new RegExp(name) })).getByRole('button'),
+        );
+      }
+
+      await waitFor(() => expect(screen.getByText('5 runs')).toBeInTheDocument());
+      expect(within(screen.getByRole('menuitemcheckbox', { name: /Run Seven/ })).getByRole('button')).toBeDisabled();
+    });
+
+    test('clear button resets all comparison runs', async () => {
+      jest.spyOn(MlflowService, 'searchRuns').mockResolvedValueOnce({
+        runs: [createRunEntity('run-2', 'Run Two'), createRunEntity('run-3', 'Run Three')],
+      });
+
+      mountOnMetricsTab();
+      await openSwitcher();
+
+      await userEvent.click(within(screen.getByRole('menuitemcheckbox', { name: /Run Two/ })).getByRole('button'));
+      await userEvent.click(within(screen.getByRole('menuitemcheckbox', { name: /Run Three/ })).getByRole('button'));
+
+      await waitFor(() => expect(screen.getByText('2 runs')).toBeInTheDocument());
+
+      await userEvent.click(screen.getByRole('button', { name: 'Clear comparison' }));
+
+      await waitFor(() => expect(screen.queryByText('vs')).not.toBeInTheDocument());
     });
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunPage.tsx
@@ -8,7 +8,7 @@ import {
 } from '@databricks/design-system';
 import { useSelector } from 'react-redux';
 import invariant from 'invariant';
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useState, useCallback } from 'react';
 
 import { PageContainer } from '../../../common/components/PageContainer';
 import { useNavigate, useParams } from '../../../common/utils/RoutingUtils';
@@ -42,6 +42,7 @@ import { useLoggedModelsForExperimentRun } from '../experiment-page/hooks/useLog
 import { useLoggedModelsForExperimentRunV2 } from '../experiment-page/hooks/useLoggedModelsForExperimentRunV2';
 import { useExperimentKind } from '../../utils/ExperimentKindUtils';
 import type { KeyValueEntity } from '../../../common/types';
+import type { RunEntity } from '../../types';
 
 const RunPageLoadingState = () => (
   <PageContainer>
@@ -83,6 +84,19 @@ export const RunPage = (props: RunPageProps) => {
   const { theme } = useDesignSystemTheme();
   const [renameModalVisible, setRenameModalVisible] = useState(false);
   const [deleteModalVisible, setDeleteModalVisible] = useState(false);
+  const [comparisonRuns, setComparisonRuns] = useState<RunEntity[]>([]);
+
+  const handleToggleCompareRun = useCallback((run: RunEntity) => {
+    setComparisonRuns((prev) =>
+      prev.some((r) => r.info.runUuid === run.info.runUuid)
+        ? prev.filter((r) => r.info.runUuid !== run.info.runUuid)
+        : prev.length < 5
+          ? [...prev, run]
+          : prev,
+    );
+  }, []);
+
+  const handleClearComparisons = useCallback(() => setComparisonRuns([]), []);
 
   invariant(runUuid, '[RunPage] Run UUID route param not provided');
   invariant(experimentId, '[RunPage] Experiment ID route param not provided');
@@ -130,6 +144,9 @@ export const RunPage = (props: RunPageProps) => {
   );
 
   const activeTab = useRunViewActiveTab();
+
+  const supportsComparison =
+    activeTab === RunPageTabName.MODEL_METRIC_CHARTS || activeTab === RunPageTabName.SYSTEM_METRIC_CHARTS;
 
   const isUsingGetLoggedModelsApi = shouldUseGetLoggedModelsBatchAPI();
 
@@ -179,6 +196,7 @@ export const RunPage = (props: RunPageProps) => {
             latestMetrics={latestMetrics}
             tags={tags}
             params={params}
+            comparisonRuns={comparisonRuns}
           />
         );
 
@@ -192,6 +210,7 @@ export const RunPage = (props: RunPageProps) => {
             latestMetrics={latestMetrics}
             tags={tags}
             params={params}
+            comparisonRuns={comparisonRuns}
           />
         );
       case RunPageTabName.EVALUATIONS:
@@ -323,6 +342,11 @@ export const RunPage = (props: RunPageProps) => {
           isLoading={loading || isLoadingLoggedModels}
           customBreadcrumbs={customBreadcrumbs}
           tabSwitchProps={tabSwitchProps}
+          activeTab={activeTab}
+          comparisonRuns={comparisonRuns}
+          onCompareRun={handleToggleCompareRun}
+          onClearComparisons={handleClearComparisons}
+          supportsComparison={supportsComparison}
         />
         {/* Scroll tab contents independently within own container */}
         <div css={{ flex: 1, overflow: 'auto', marginBottom: theme.spacing.sm, display: 'flex' }}>

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunSwitcherDropdown.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunSwitcherDropdown.test.tsx
@@ -1,0 +1,229 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { renderWithIntl, screen, within, cleanup, waitFor } from '../../../common/utils/TestUtils.react18';
+import { MemoryRouter } from '../../../common/utils/RoutingUtils';
+import { DesignSystemProvider } from '@databricks/design-system';
+import userEvent from '@testing-library/user-event';
+import { RunSwitcherDropdown } from './RunSwitcherDropdown';
+import { MlflowService } from '../../sdk/MlflowService';
+import type { RunEntity } from '../../types';
+import Routes from '../../routes';
+
+jest.mock('../../sdk/MlflowService', () => ({
+  MlflowService: {
+    searchRuns: jest.fn(),
+  },
+}));
+
+const mockNavigate = jest.fn();
+jest.mock('../../../common/utils/RoutingUtils', () => ({
+  ...jest.requireActual<typeof import('../../../common/utils/RoutingUtils')>('../../../common/utils/RoutingUtils'),
+  useNavigate: () => mockNavigate,
+}));
+
+const createRun = (runUuid: string, runName: string): RunEntity => ({
+  info: {
+    runUuid,
+    runName,
+    experimentId: 'exp-id',
+    artifactUri: '',
+    endTime: 0,
+    lifecycleStage: 'active',
+    startTime: 0,
+    status: 'FINISHED',
+  },
+  data: { metrics: [], params: [], tags: [] },
+});
+
+interface RenderProps {
+  comparisonRunUuids?: string[];
+  onCompareRun?: (run: RunEntity) => void;
+  onClearComparisons?: () => void;
+}
+
+const renderComponent = (props: RenderProps = {}) =>
+  renderWithIntl(
+    <MemoryRouter>
+      <DesignSystemProvider>
+        <RunSwitcherDropdown experimentId="exp-id" currentRunUuid="run-1" activeTab="model-metrics" {...props} />
+      </DesignSystemProvider>
+    </MemoryRouter>,
+  );
+
+const openDropdown = async () => {
+  await userEvent.click(screen.getByRole('button', { name: 'Switch run' }));
+  await screen.findByPlaceholderText('Search runs');
+};
+
+describe('RunSwitcherDropdown', () => {
+  beforeEach(() => {
+    jest.mocked(MlflowService.searchRuns).mockReset();
+    mockNavigate.mockClear();
+  });
+
+  test('renders the trigger button', () => {
+    renderComponent();
+    expect(screen.getByRole('button', { name: 'Switch run' })).toBeInTheDocument();
+  });
+
+  test('fetches runs from the experiment on first open and displays them', async () => {
+    jest.mocked(MlflowService.searchRuns).mockResolvedValueOnce({
+      runs: [createRun('run-1', 'Run 1'), createRun('run-2', 'Run 2')],
+    });
+
+    renderComponent();
+    await openDropdown();
+
+    expect(MlflowService.searchRuns).toHaveBeenCalledWith({
+      experiment_ids: ['exp-id'],
+      max_results: 200,
+    });
+    expect(screen.getByText('Run 1')).toBeInTheDocument();
+    expect(screen.getByText('Run 2')).toBeInTheDocument();
+  });
+
+  test('does not re-fetch when opened a second time', async () => {
+    jest.mocked(MlflowService.searchRuns).mockResolvedValueOnce({
+      runs: [createRun('run-1', 'Run 1')],
+    });
+
+    renderComponent();
+    await openDropdown();
+
+    // Close by clicking the trigger again (Escape is swallowed by the search input's onKeyDown)
+    await userEvent.click(screen.getByRole('button', { name: 'Switch run' }));
+    await waitFor(() => expect(screen.queryByPlaceholderText('Search runs')).not.toBeInTheDocument());
+
+    await openDropdown();
+
+    expect(jest.mocked(MlflowService.searchRuns)).toHaveBeenCalledTimes(1);
+  });
+
+  test('shows loading state while runs are being fetched', async () => {
+    jest.mocked(MlflowService.searchRuns).mockImplementationOnce(() => new Promise(() => {}));
+    renderComponent();
+    await openDropdown();
+    expect(screen.getByText('Loading…')).toBeInTheDocument();
+  });
+
+  test('shows empty list when the fetch fails', async () => {
+    jest.mocked(MlflowService.searchRuns).mockRejectedValueOnce(new Error('Network error'));
+    renderComponent();
+    await openDropdown();
+    await waitFor(() => expect(screen.getByText('No runs found')).toBeInTheDocument());
+  });
+
+  test('filters the run list by search input and shows "No runs found" when nothing matches', async () => {
+    jest.mocked(MlflowService.searchRuns).mockResolvedValueOnce({
+      runs: [createRun('run-1', 'Alpha run'), createRun('run-2', 'Beta run'), createRun('run-3', 'Gamma run')],
+    });
+
+    renderComponent();
+    await openDropdown();
+
+    await userEvent.type(screen.getByPlaceholderText('Search runs'), 'Alpha');
+
+    expect(screen.getByText('Alpha run')).toBeInTheDocument();
+    expect(screen.queryByText('Beta run')).not.toBeInTheDocument();
+    expect(screen.queryByText('Gamma run')).not.toBeInTheDocument();
+
+    await userEvent.clear(screen.getByPlaceholderText('Search runs'));
+    await userEvent.type(screen.getByPlaceholderText('Search runs'), 'zzz-no-match');
+
+    expect(screen.getByText('No runs found')).toBeInTheDocument();
+  });
+
+  test('navigates to the selected run keeping the active tab', async () => {
+    jest.mocked(MlflowService.searchRuns).mockResolvedValueOnce({
+      runs: [createRun('run-1', 'Run 1'), createRun('run-2', 'Run 2')],
+    });
+
+    renderComponent();
+    await openDropdown();
+
+    await userEvent.click(screen.getByText('Run 2'));
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.getRunPageTabRoute('exp-id', 'run-2', 'model-metrics'));
+  });
+
+  test('shows compare button for non-current runs only when onCompareRun is provided', async () => {
+    jest.mocked(MlflowService.searchRuns).mockResolvedValueOnce({
+      runs: [createRun('run-1', 'Run 1'), createRun('run-2', 'Run 2'), createRun('run-3', 'Run 3')],
+    });
+
+    renderComponent({ onCompareRun: jest.fn() });
+    await openDropdown();
+
+    const run1Item = screen.getByRole('menuitemcheckbox', { name: /Run 1/ });
+    const run2Item = screen.getByRole('menuitemcheckbox', { name: /Run 2/ });
+
+    // Current run has no compare button; non-current runs do
+    expect(within(run1Item).queryByRole('button')).not.toBeInTheDocument();
+    expect(within(run2Item).getByRole('button')).toBeInTheDocument();
+  });
+
+  test('clicking the compare button calls onCompareRun without triggering navigation', async () => {
+    const onCompareRun = jest.fn();
+    jest.mocked(MlflowService.searchRuns).mockResolvedValueOnce({
+      runs: [createRun('run-1', 'Run 1'), createRun('run-2', 'Run 2')],
+    });
+
+    renderComponent({ onCompareRun });
+    await openDropdown();
+
+    const run2Item = screen.getByRole('menuitemcheckbox', { name: /Run 2/ });
+    await userEvent.click(within(run2Item).getByRole('button'));
+
+    expect(onCompareRun).toHaveBeenCalledWith(createRun('run-2', 'Run 2'));
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  test('disables compare button at the 5-run cap but not for runs already in comparison', async () => {
+    jest.mocked(MlflowService.searchRuns).mockResolvedValueOnce({
+      runs: [
+        createRun('run-1', 'Run 1'),
+        createRun('run-2', 'Run 2'),
+        createRun('run-3', 'Run 3'),
+        createRun('run-4', 'Run 4'),
+        createRun('run-5', 'Run 5'),
+        createRun('run-6', 'Run 6'),
+        createRun('run-7', 'Run 7'),
+      ],
+    });
+
+    renderComponent({
+      onCompareRun: jest.fn(),
+      comparisonRunUuids: ['run-2', 'run-3', 'run-4', 'run-5', 'run-6'],
+    });
+    await openDropdown();
+
+    // run-7 is not in comparison and cap is reached — should be disabled
+    expect(within(screen.getByRole('menuitemcheckbox', { name: /Run 7/ })).getByRole('button')).toBeDisabled();
+    // run-2 is already pinned — can still be toggled off
+    expect(within(screen.getByRole('menuitemcheckbox', { name: /Run 2/ })).getByRole('button')).not.toBeDisabled();
+  });
+
+  test('renders comparison label as UUID for one run, count for multiple, and hidden when empty', () => {
+    // Single comparison: shows UUID as fallback before runs are loaded
+    renderComponent({ comparisonRunUuids: ['run-2'], onClearComparisons: jest.fn() });
+    expect(screen.getByText('vs')).toBeInTheDocument();
+    expect(screen.getByText('run-2')).toBeInTheDocument();
+    cleanup();
+
+    // Multiple comparisons: shows count
+    renderComponent({ comparisonRunUuids: ['run-2', 'run-3'], onClearComparisons: jest.fn() });
+    expect(screen.getByText('vs')).toBeInTheDocument();
+    expect(screen.getByText('2 runs')).toBeInTheDocument();
+    cleanup();
+
+    // No comparisons: label is absent
+    renderComponent();
+    expect(screen.queryByText('vs')).not.toBeInTheDocument();
+  });
+
+  test('calls onClearComparisons when the clear button is clicked', async () => {
+    const onClearComparisons = jest.fn();
+    renderComponent({ comparisonRunUuids: ['run-2'], onClearComparisons });
+    await userEvent.click(screen.getByRole('button', { name: 'Clear comparison' }));
+    expect(onClearComparisons).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunSwitcherDropdown.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunSwitcherDropdown.tsx
@@ -1,0 +1,227 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  BarChartIcon,
+  Button,
+  ChevronDownIcon,
+  CloseIcon,
+  DropdownMenu,
+  Input,
+  SearchIcon,
+  Tooltip,
+  Typography,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
+import { useNavigate } from '../../../common/utils/RoutingUtils';
+import Routes from '../../routes';
+import { MlflowService } from '../../sdk/MlflowService';
+import type { RunEntity } from '../../types';
+
+const MAX_VISIBLE_RUNS = 25;
+
+const RunSwitcherBody = ({
+  runs,
+  loading,
+  currentRunUuid,
+  comparisonRunUuids,
+  onSelect,
+  onCompareRun,
+}: {
+  runs: RunEntity[];
+  loading: boolean;
+  currentRunUuid: string;
+  comparisonRunUuids?: string[];
+  onSelect: (runUuid: string) => void;
+  onCompareRun?: (run: RunEntity) => void;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const inputRef = useRef<React.ComponentRef<typeof Input>>(null);
+  const firstItemRef = useRef<HTMLDivElement>(null);
+  const [filter, setFilter] = useState('');
+
+  const filteredRuns = useMemo(
+    () => runs.filter((r) => r.info.runName?.toLowerCase().includes(filter.toLowerCase())).slice(0, MAX_VISIBLE_RUNS),
+    [runs, filter],
+  );
+
+  useEffect(() => {
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+    });
+  }, []);
+
+  return (
+    <>
+      <div css={{ padding: `${theme.spacing.sm}px ${theme.spacing.sm}px`, width: '100%' }}>
+        <Input
+          componentId="mlflow.run-page.run-switcher.search"
+          prefix={<SearchIcon />}
+          value={filter}
+          type="search"
+          onChange={(e) => setFilter(e.target.value)}
+          placeholder="Search runs"
+          autoFocus
+          ref={inputRef}
+          onKeyDown={(e) => {
+            if (e.key === 'ArrowDown' || e.key === 'Tab') {
+              firstItemRef.current?.focus();
+              return;
+            }
+            e.stopPropagation();
+          }}
+        />
+      </div>
+      <DropdownMenu.Group css={{ maxHeight: 300, overflowY: 'auto' }}>
+        {loading && (
+          <DropdownMenu.Item componentId="mlflow.run-page.run-switcher.loading" disabled>
+            Loading…
+          </DropdownMenu.Item>
+        )}
+        {!loading &&
+          filteredRuns.map((run, index) => {
+            const isCurrentRun = run.info.runUuid === currentRunUuid;
+            const isComparisonRun = comparisonRunUuids?.includes(run.info.runUuid) ?? false;
+            const atMax = (comparisonRunUuids?.length ?? 0) >= 5;
+            return (
+              <DropdownMenu.CheckboxItem
+                componentId="mlflow.run-page.run-switcher.item"
+                key={run.info.runUuid}
+                checked={isCurrentRun}
+                onClick={() => onSelect(run.info.runUuid)}
+                ref={index === 0 ? firstItemRef : undefined}
+              >
+                <DropdownMenu.ItemIndicator />
+                <span css={{ flex: 1 }}>{run.info.runName || run.info.runUuid}</span>
+                {onCompareRun && !isCurrentRun && (
+                  <Tooltip
+                    componentId="mlflow.run-page.run-switcher.compare-tooltip"
+                    side="right"
+                    content={
+                      isComparisonRun
+                        ? 'Remove comparison'
+                        : atMax
+                          ? 'Maximum 5 comparisons reached'
+                          : 'Overlay metrics'
+                    }
+                  >
+                    <Button
+                      componentId="mlflow.run-page.run-switcher.compare-btn"
+                      size="small"
+                      type={isComparisonRun ? 'primary' : 'tertiary'}
+                      disabled={!isComparisonRun && atMax}
+                      icon={isComparisonRun ? <CloseIcon /> : <BarChartIcon />}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onCompareRun(run);
+                      }}
+                    />
+                  </Tooltip>
+                )}
+              </DropdownMenu.CheckboxItem>
+            );
+          })}
+        {!loading && filteredRuns.length === 0 && (
+          <DropdownMenu.Item componentId="mlflow.run-page.run-switcher.no-results" disabled>
+            No runs found
+          </DropdownMenu.Item>
+        )}
+      </DropdownMenu.Group>
+    </>
+  );
+};
+
+export const RunSwitcherDropdown = ({
+  experimentId,
+  currentRunUuid,
+  activeTab,
+  comparisonRunUuids,
+  onCompareRun,
+  onClearComparisons,
+}: {
+  experimentId: string;
+  currentRunUuid: string;
+  activeTab: string;
+  comparisonRunUuids?: string[];
+  onCompareRun?: (run: RunEntity) => void;
+  onClearComparisons?: () => void;
+}) => {
+  const navigate = useNavigate();
+  const { theme } = useDesignSystemTheme();
+  const [open, setOpen] = useState(false);
+  const [runs, setRuns] = useState<RunEntity[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [hasFetched, setHasFetched] = useState(false);
+
+  const comparisonLabel = useMemo(() => {
+    if (!comparisonRunUuids?.length) return null;
+    if (comparisonRunUuids.length === 1) {
+      return runs.find((r) => r.info.runUuid === comparisonRunUuids[0])?.info.runName ?? comparisonRunUuids[0];
+    }
+    return `${comparisonRunUuids.length} runs`;
+  }, [runs, comparisonRunUuids]);
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (nextOpen && !hasFetched) {
+      setLoading(true);
+      MlflowService.searchRuns({ experiment_ids: [experimentId], max_results: 200 })
+        .then((response) => {
+          setRuns(response.runs ?? []);
+        })
+        .catch(() => {
+          setRuns([]);
+        })
+        .finally(() => {
+          setLoading(false);
+          setHasFetched(true);
+        });
+    }
+  };
+
+  const handleSelect = (runUuid: string) => {
+    setOpen(false);
+    navigate(Routes.getRunPageTabRoute(experimentId, runUuid, activeTab));
+  };
+
+  return (
+    <span css={{ display: 'inline-flex', alignItems: 'center', gap: theme.spacing.xs }}>
+      <DropdownMenu.Root open={open} onOpenChange={handleOpenChange} modal={false}>
+        <DropdownMenu.Trigger asChild>
+          <Button
+            componentId="mlflow.run-page.run-switcher.trigger"
+            size="small"
+            icon={<ChevronDownIcon />}
+            aria-label="Switch run"
+          />
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content minWidth={260}>
+          <RunSwitcherBody
+            runs={runs}
+            loading={loading}
+            currentRunUuid={currentRunUuid}
+            comparisonRunUuids={comparisonRunUuids}
+            onSelect={handleSelect}
+            onCompareRun={onCompareRun}
+          />
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
+      {comparisonLabel && onClearComparisons && (
+        <span css={{ display: 'inline-flex', alignItems: 'center', gap: theme.spacing.xs }}>
+          <Typography.Text color="secondary" size="sm">
+            vs
+          </Typography.Text>
+          <Typography.Text size="sm" bold>
+            {comparisonLabel}
+          </Typography.Text>
+          <Button
+            componentId="mlflow.run-page.run-switcher.clear-compare"
+            size="small"
+            type="tertiary"
+            icon={<CloseIcon />}
+            onClick={onClearComparisons}
+            aria-label="Clear comparison"
+          />
+        </span>
+      )}
+    </span>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeader.intg.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeader.intg.test.tsx
@@ -1,5 +1,8 @@
-import { jest, describe, it, expect } from '@jest/globals';
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { render, screen } from '@testing-library/react';
+import { within } from '../../../common/utils/TestUtils.react18';
+import userEvent from '@testing-library/user-event';
+import { MlflowService } from '../../sdk/MlflowService';
 import { IntlProvider } from 'react-intl';
 import { QueryClient, QueryClientProvider } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
 import { DesignSystemProvider } from '@databricks/design-system';
@@ -9,6 +12,12 @@ import { EXPERIMENT_KIND_TAG_KEY } from '../../utils/ExperimentKindUtils';
 import { TestRouter, testRoute, waitForRoutesToBeRendered } from '@mlflow/mlflow/src/common/utils/RoutingTestUtils';
 import Routes from '../../routes';
 import { prefixRouteWithWorkspace } from '@mlflow/mlflow/src/workspaces/utils/WorkspaceUtils';
+
+jest.mock('../../sdk/MlflowService', () => ({
+  MlflowService: {
+    searchRuns: jest.fn(),
+  },
+}));
 
 jest.mock('../../../common/utils/FeatureUtils', () => ({
   shouldEnableExperimentPageHeaderV2: () => true,
@@ -22,6 +31,10 @@ describe('RunViewHeader - integration test', () => {
   const testRunUuid = 'test-run-uuid';
   const testExperimentId = 'test-experiment-id';
   const testRunName = 'Test Run';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
   const renderTestComponent = (props: any) => {
     const defaultProps = {
@@ -144,5 +157,52 @@ describe('RunViewHeader - integration test', () => {
       Routes.getExperimentPageTabRoute(testExperimentId, ExperimentPageTabName.Runs),
     );
     expect(experimentLink.getAttribute('href')).toBe(expectedPath);
+  });
+
+  it('renders the run switcher trigger button when activeTab is provided', async () => {
+    renderTestComponent({ activeTab: 'model-metrics' });
+
+    await waitForRoutesToBeRendered();
+
+    expect(screen.getByRole('button', { name: 'Switch run' })).toBeInTheDocument();
+  });
+
+  it('does not render the run switcher trigger button when activeTab is not provided', async () => {
+    renderTestComponent({});
+
+    await waitForRoutesToBeRendered();
+
+    expect(screen.queryByRole('button', { name: 'Switch run' })).not.toBeInTheDocument();
+  });
+
+  it('hides compare buttons when supportsComparison is false even when onCompareRun is provided', async () => {
+    jest.mocked(MlflowService.searchRuns).mockResolvedValueOnce({
+      runs: [
+        {
+          info: {
+            runUuid: 'run-2',
+            runName: 'Run Two',
+            experimentId: testExperimentId,
+            artifactUri: '',
+            endTime: 0,
+            lifecycleStage: 'active',
+            startTime: 0,
+            status: 'FINISHED',
+          },
+          data: { metrics: [], params: [], tags: [] },
+        },
+      ],
+    } as any);
+
+    renderTestComponent({
+      activeTab: 'overview',
+      supportsComparison: false,
+      onCompareRun: jest.fn(),
+    });
+
+    await waitForRoutesToBeRendered();
+    await userEvent.click(screen.getByRole('button', { name: 'Switch run' }));
+    const run2Item = await screen.findByRole('menuitemcheckbox', { name: /Run Two/ });
+    expect(within(run2Item).queryByRole('button')).not.toBeInTheDocument();
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeader.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeader.tsx
@@ -2,9 +2,10 @@ import { FormattedMessage } from 'react-intl';
 import { Link } from '../../../common/utils/RoutingUtils';
 import { OverflowMenu, PageHeader } from '../../../shared/building_blocks/PageHeader';
 import Routes, { PageId as ExperimentTrackingPageId } from '../../routes';
-import type { ExperimentEntity } from '../../types';
+import type { ExperimentEntity, RunEntity } from '../../types';
 import type { KeyValueEntity } from '../../../common/types';
 import { RunViewModeSwitch, type RunViewModeSwitchProps } from './RunViewModeSwitch';
+import { RunSwitcherDropdown } from './RunSwitcherDropdown';
 import Utils from '../../../common/utils/Utils';
 import { RunViewHeaderRegisterModelButton } from './RunViewHeaderRegisterModelButton';
 import type { UseGetRunQueryResponseExperiment, UseGetRunQueryResponseOutputs } from './hooks/useGetRunQuery';
@@ -53,6 +54,11 @@ export interface RunViewHeaderProps {
   customBreadcrumbs?: ReactNode[];
   /** Props to pass to RunViewModeSwitch for custom tab configuration */
   tabSwitchProps?: Omit<RunViewModeSwitchProps, 'runTags'>;
+  activeTab?: string;
+  comparisonRuns?: RunEntity[];
+  onCompareRun?: (run: RunEntity) => void;
+  onClearComparisons?: () => void;
+  supportsComparison?: boolean;
 }
 
 /**
@@ -74,6 +80,11 @@ export const RunViewHeader = ({
   isLoading,
   customBreadcrumbs,
   tabSwitchProps,
+  activeTab,
+  comparisonRuns,
+  onCompareRun,
+  onClearComparisons,
+  supportsComparison,
 }: RunViewHeaderProps) => {
   const { theme } = useDesignSystemTheme();
   const experimentKind = useExperimentKind(experiment.tags);
@@ -191,6 +202,16 @@ export const RunViewHeader = ({
           <span css={{ display: 'inline-flex', alignItems: 'center', gap: theme.spacing.sm }}>
             <RunViewHeaderIcon />
             <span data-testid="runs-header">{runDisplayName}</span>
+            {activeTab !== undefined && experiment.experimentId && (
+              <RunSwitcherDropdown
+                experimentId={experiment.experimentId}
+                currentRunUuid={runUuid}
+                activeTab={activeTab}
+                comparisonRunUuids={supportsComparison ? comparisonRuns?.map((r) => r.info.runUuid) : undefined}
+                onCompareRun={supportsComparison ? onCompareRun : undefined}
+                onClearComparisons={supportsComparison ? onClearComparisons : undefined}
+              />
+            )}
           </span>
         }
         breadcrumbs={breadcrumbs}

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewMetricCharts.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewMetricCharts.test.tsx
@@ -8,7 +8,7 @@ import { ReduxState } from '../../../redux-types';
 import { type RunsChartsBarChartCardProps } from '../runs-charts/components/cards/RunsChartsBarChartCard';
 import type { RunsChartsLineChartCardProps } from '../runs-charts/components/cards/RunsChartsLineChartCard';
 import userEvent from '@testing-library/user-event';
-import type { MetricEntitiesByName } from '../../types';
+import type { MetricEntitiesByName, RunEntity } from '../../types';
 import type { KeyValueEntity } from '../../../common/types';
 import { DesignSystemProvider } from '@databricks/design-system';
 import { MlflowService } from '../../sdk/MlflowService';
@@ -16,13 +16,19 @@ import { LOG_IMAGE_TAG_INDICATOR } from '../../constants';
 
 // Mock plot components, as they are not relevant to this test and would hog a lot of resources
 jest.mock('../runs-charts/components/cards/RunsChartsBarChartCard', () => ({
-  RunsChartsBarChartCard: ({ config }: RunsChartsBarChartCardProps) => (
-    <div data-testid="test-bar-plot">Bar plot for {config.metricKey}</div>
+  RunsChartsBarChartCard: ({ config, chartRunData }: RunsChartsBarChartCardProps) => (
+    <div data-testid="test-bar-plot" data-run-count={chartRunData?.length}>
+      Bar plot for {config.metricKey}
+    </div>
   ),
 }));
 jest.mock('../runs-charts/components/cards/RunsChartsLineChartCard', () => ({
-  RunsChartsLineChartCard: ({ config }: RunsChartsLineChartCardProps) => {
-    return <div data-testid="test-line-plot">Line plot for {config.metricKey}</div>;
+  RunsChartsLineChartCard: ({ config, chartRunData }: RunsChartsLineChartCardProps) => {
+    return (
+      <div data-testid="test-line-plot" data-run-count={chartRunData?.length}>
+        Line plot for {config.metricKey}
+      </div>
+    );
   },
 }));
 
@@ -71,17 +77,26 @@ describe('RunViewMetricCharts', () => {
     metricKeys = testMetricKeys,
     metrics = testMetrics,
     tags = {},
+    comparisonRuns,
   }: {
     mode?: 'model' | 'system';
     metricKeys?: string[];
     metrics?: MetricEntitiesByName;
     tags?: Record<string, KeyValueEntity>;
+    comparisonRuns?: RunEntity[];
   } = {}) => {
     const runInfo = {
       runUuid: testRunUuid,
     } as any;
     return render(
-      <RunViewMetricCharts runInfo={runInfo} metricKeys={metricKeys} mode={mode} latestMetrics={metrics} tags={tags} />,
+      <RunViewMetricCharts
+        runInfo={runInfo}
+        metricKeys={metricKeys}
+        mode={mode}
+        latestMetrics={metrics}
+        tags={tags}
+        comparisonRuns={comparisonRuns}
+      />,
       {
         wrapper: ({ children }) => (
           <DesignSystemProvider>
@@ -233,5 +248,29 @@ describe('RunViewMetricCharts', () => {
     });
 
     expect(MlflowService.listArtifacts).toHaveBeenCalledWith({ path: 'images', run_uuid: 'test_run_uuid' });
+  });
+
+  it('passes primary run and all comparison runs to chart cards', async () => {
+    const comparisonRuns: RunEntity[] = [
+      {
+        info: {
+          runUuid: 'cmp-1',
+          runName: 'Comparison Run',
+          experimentId: 'exp-1',
+          artifactUri: '',
+          endTime: 0,
+          lifecycleStage: 'active',
+          startTime: 0,
+          status: 'FINISHED',
+        },
+        data: { metrics: [], params: [], tags: [] },
+      },
+    ];
+
+    renderComponent({ metricKeys: ['metric_1'], metrics: testMetrics, comparisonRuns });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('test-bar-plot')).toHaveAttribute('data-run-count', '2');
+    });
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewMetricCharts.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewMetricCharts.tsx
@@ -1,11 +1,11 @@
 import { TableSkeleton, ToggleButton, useDesignSystemTheme } from '@databricks/design-system';
-import { compact, mapValues, values } from 'lodash';
+import { compact, keyBy, mapValues, values } from 'lodash';
 import type { ReactNode } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
 import type { ReduxState } from '../../../redux-types';
-import type { MetricEntitiesByName, RunInfoEntity } from '../../types';
+import type { MetricEntitiesByName, RunEntity, RunInfoEntity } from '../../types';
 import type { KeyValueEntity } from '../../../common/types';
 
 import { RunsChartsTooltipWrapper } from '../runs-charts/hooks/useRunsChartsTooltip';
@@ -45,6 +45,8 @@ import {
   useNodeLevelMetricsFilterState,
 } from './node-level-metric-charts/contexts/NodeLevelMetricsFilterContext';
 
+const COMPARISON_RUN_COLORS = ['#E88B48', '#3E9C4B', '#9B59B6', '#E74C3C', '#1ABC9C'];
+
 interface RunViewMetricChartsProps {
   metricKeys: string[];
   runInfo: RunInfoEntity | UseGetRunQueryResponseRunInfo;
@@ -56,6 +58,7 @@ interface RunViewMetricChartsProps {
   latestMetrics?: MetricEntitiesByName;
   tags?: Record<string, KeyValueEntity>;
   params?: Record<string, KeyValueEntity>;
+  comparisonRuns?: RunEntity[];
 }
 
 /**
@@ -70,6 +73,7 @@ const RunViewMetricChartsImpl = ({
   latestMetrics = {},
   params = {},
   tags = {},
+  comparisonRuns,
 }: RunViewMetricChartsProps & {
   chartUIState: ExperimentRunsChartsUIConfiguration;
   updateChartsUIState: (
@@ -134,23 +138,37 @@ const RunViewMetricChartsImpl = ({
     setConfiguredCardConfig(null);
   };
 
-  // Create a single run data object to be used in charts
-  const chartData: RunsChartsRunData[] = useMemo(
-    () => [
-      {
-        displayName: runInfo.runName ?? '',
-        metrics: latestMetrics,
-        params,
-        tags,
-        images: imagesByRunUuid[runInfo.runUuid ?? ''] || {},
-        metricHistory: {},
-        uuid: runInfo.runUuid ?? '',
-        color: theme.colors.primary,
-        runInfo,
-      },
-    ],
-    [runInfo, latestMetrics, params, tags, imagesByRunUuid, theme],
-  );
+  const chartData: RunsChartsRunData[] = useMemo(() => {
+    const primaryEntry: RunsChartsRunData = {
+      displayName: runInfo.runName ?? '',
+      metrics: latestMetrics,
+      params,
+      tags,
+      images: imagesByRunUuid[runInfo.runUuid ?? ''] || {},
+      metricsHistory: {},
+      uuid: runInfo.runUuid ?? '',
+      color: theme.colors.primary,
+      runInfo,
+    };
+
+    if (!comparisonRuns?.length) {
+      return [primaryEntry];
+    }
+
+    const comparisonEntries: RunsChartsRunData[] = comparisonRuns.map((run, index) => ({
+      uuid: run.info.runUuid,
+      displayName: run.info.runName ?? run.info.runUuid,
+      runInfo: run.info,
+      metrics: keyBy(run.data.metrics, 'key') as MetricEntitiesByName,
+      params: keyBy(run.data.params, 'key'),
+      tags: keyBy(run.data.tags, 'key'),
+      images: {},
+      color: COMPARISON_RUN_COLORS[index % COMPARISON_RUN_COLORS.length],
+      metricsHistory: {},
+    }));
+
+    return [primaryEntry, ...comparisonEntries];
+  }, [runInfo, latestMetrics, params, tags, imagesByRunUuid, theme, comparisonRuns]);
 
   const allMetricKeys = useMemo(() => Object.keys(latestMetrics), [latestMetrics]);
 


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #16668

### What changes are proposed in this pull request?

Previously, navigating between runs required going back to the experiment page. This change adds a chevron button next to the run name that opens a searchable dropdown listing all runs in the experiment, enabling direct navigation without leaving the run view.

On the Model Metrics and System Metrics tabs, each run in the dropdown can be toggled as a comparison overlay. Up to 5 comparison runs are supported simultaneously, each rendered in a distinct color. A header badge tracks active comparisons ("vs Alpha" or "vs 3 runs") with a one-click clear button. Compare controls are hidden on Overview, Traces, and Artifacts tabs where metric charts are not present.

Example: while viewing a run's model metrics, a user can add two other runs as overlays to compare loss curves side-by-side without leaving the page.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Users can now switch between runs and compare run metrics through the dropdown available next to the run name.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
