### PR TITLE
docs: document MLFLOW_STATIC_PREFIX behavior change in migration guide

### DIFF
--- a/docs/docs/classic-ml/mlflow-3/index.mdx
+++ b/docs/docs/classic-ml/mlflow-3/index.mdx
@@ -189,7 +189,8 @@ mlflow.models.evaluate(
 
 ### Environment Variables
 
-`MLFLOW_GCS_DEFAULT_TIMEOUT` removed ([#15365](https://github.com/mlflow/mlflow/pull/15365)). Configure timeouts using standard GCS client library approaches.
+- `MLFLOW_GCS_DEFAULT_TIMEOUT` removed ([#15365](https://github.com/mlflow/mlflow/pull/15365)). Configure timeouts using standard GCS client library approaches.
+- **Static Prefix Behavior Change**: Since MLflow 3.12, the `--static-prefix` command-line option and `MLFLOW_STATIC_PREFIX` environment variable are consistently applied to both UI (AJAX API) routes and REST API (`/api/`) URLs ([#22159](https://github.com/mlflow/mlflow/pull/22159)). Previously, the static prefix only applied to UI/AJAX routes and static files. Setups using a reverse proxy or REST clients may need to adjust their routing rules to handle the prefix on REST API endpoints.
 
 ## Migration FAQs
 


### PR DESCRIPTION

### Related Issues/PRs
Closes #23808

### What changes are proposed in this pull request?
This PR updates the MLflow 3.0 migration guide (`docs/docs/classic-ml/mlflow-3/index.mdx`) to document the changes to the static prefix behavior. Since MLflow 3.12, the `--static-prefix` command-line option and `MLFLOW_STATIC_PREFIX` environment variable are consistently applied to both UI (AJAX API) routes and REST API (`/api/`) URLs.

### How is this PR tested?
- [x] Manual tests

### Does this PR require documentation update?
- [x] Yes. I've updated:
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?
- [x] No.

### Release Notes

#### Is this a user-facing change?
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Documented the consistent application of static prefix to REST API URLs in the MLflow 3 migration guide.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release