### PR TITLE
fix: support content and text fields in retrieval chunk parsing

### DIFF
--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -814,11 +814,21 @@ def _get_top_level_retrieval_spans(trace: Trace) -> list[Span]:
     return top_level_retrieval_spans
 
 
+_CHUNK_TEXT_FIELDS = ("page_content", "content", "text")
+
+
 def _parse_chunk(chunk: Any) -> dict[str, Any] | None:
     if not isinstance(chunk, dict):
         return None
 
-    doc = {"content": chunk.get("page_content")}
+    text = next((chunk[f] for f in _CHUNK_TEXT_FIELDS if f in chunk), None)
+    if text is None:
+        _logger.warning(
+            "Retriever documents contain no recognized text field "
+            f"({', '.join(_CHUNK_TEXT_FIELDS)}). The document will be treated as having no "
+            "content. Consider using one of the supported field names."
+        )
+    doc = {"content": text}
     if doc_uri := chunk.get("metadata", {}).get("doc_uri"):
         doc["doc_uri"] = doc_uri
     return doc

--- a/tests/genai/utils/test_trace_utils.py
+++ b/tests/genai/utils/test_trace_utils.py
@@ -23,6 +23,7 @@ from mlflow.genai.scorers.base import scorer
 from mlflow.genai.utils.trace_utils import (
     _does_store_support_trace_linking,
     _extract_tool_name_from_span,
+    _parse_chunk,
     _should_keep_trace,
     _try_extract_available_tools_with_llm,
     clean_up_extra_traces,
@@ -1616,3 +1617,54 @@ def test_evaluate_with_trace_column_preserves_traces():
     remaining_traces = get_traces()
     remaining_trace_ids = {t.info.trace_id for t in remaining_traces}
     assert original_trace_id in remaining_trace_ids
+
+
+# -- _parse_chunk --------------------------------------------------------------
+
+def test_parse_chunk_page_content():
+    chunk = {"page_content": "VPN instructions", "metadata": {"doc_uri": "http://example.com"}}
+    result = _parse_chunk(chunk)
+    assert result == {"content": "VPN instructions", "doc_uri": "http://example.com"}
+
+
+def test_parse_chunk_content_field():
+    chunk = {"content": "Install Cisco AnyConnect"}
+    result = _parse_chunk(chunk)
+    assert result == {"content": "Install Cisco AnyConnect"}
+
+
+def test_parse_chunk_text_field():
+    chunk = {"text": "Reset your password"}
+    result = _parse_chunk(chunk)
+    assert result == {"content": "Reset your password"}
+
+
+def test_parse_chunk_page_content_takes_priority_over_content():
+    chunk = {"page_content": "primary", "content": "secondary"}
+    result = _parse_chunk(chunk)
+    assert result == {"content": "primary"}
+
+
+def test_parse_chunk_no_recognized_field_warns():
+    from unittest.mock import patch
+
+    from mlflow.genai.utils import trace_utils
+
+    chunk = {"body": "some text"}
+    with patch.object(trace_utils._logger, "warning") as mock_warn:
+        result = _parse_chunk(chunk)
+    assert result == {"content": None}
+    mock_warn.assert_called_once()
+    assert "no recognized text field" in mock_warn.call_args[0][0].lower()
+
+
+def test_parse_chunk_non_dict_returns_none():
+    assert _parse_chunk("plain string") is None
+    assert _parse_chunk(["a", "b"]) is None
+    assert _parse_chunk(None) is None
+
+
+def test_parse_chunk_preserves_doc_uri_with_content_field():
+    chunk = {"content": "some doc", "metadata": {"doc_uri": "s3://bucket/file"}}
+    result = _parse_chunk(chunk)
+    assert result == {"content": "some doc", "doc_uri": "s3://bucket/file"}


### PR DESCRIPTION
Fixes #23817

_parse_chunk previously only read `page_content`, causing documents that use `content` or `text` as their text field (DSPy, manual retrievers, some CrewAI integrations) to be silently converted to `{"content": None}`. This made RetrievalGroundedness incorrectly score valid retrievals as ungrounded.

Changes:
- Try fields in order: `page_content` → `content` → `text`
- Emit a WARNING when none of the recognized fields are present, instead of silently returning None content

Added unit tests covering all three field names, priority ordering, the warning path, non-dict inputs, and doc_uri preservation.

<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [ ] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
