### PR TITLE
Mention `mlflow agent setup` in tracing quickstart

### DIFF
--- a/docs/docs/genai/tracing/quickstart/index.mdx
+++ b/docs/docs/genai/tracing/quickstart/index.mdx
@@ -19,6 +19,12 @@ Need help setting up tracing? Try [MLflow Assistant](/genai/getting-started/try-
 
 :::
 
+:::tip[CLI: `mlflow agent setup`]
+
+Want a coding agent to set up tracing for you? Run `mlflow agent setup` in your project to install MLflow skills and let your coding agent instrument your app.
+
+:::
+
 This quickstart guide will walk you through setting up a simple LLM application with MLflow Tracing. In less than 10 minutes, you'll enable tracing, run a basic application, and explore the generated traces in the MLflow UI.
 
 ## Prerequisites


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23845

### What changes are proposed in this pull request?

Adds a CLI tip alongside the existing MLflow Assistant tip at the top of the Tracing Quickstart so users who already work in a coding agent (Claude Code, Codex, etc.) can discover `mlflow agent setup` as the way to install MLflow skills and have the agent wire up tracing.

### How is this PR tested?

- [x] Manual tests

<img width="1280" height="720" alt="Tracing quickstart with new CLI tip" src="https://github.com/user-attachments/assets/a21dff5b-db11-4c6c-adc7-2f02e380acd3" />

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)