### PR TITLE
Allow `claude-fable-5` in review workflow and install latest Claude CLI

### DIFF
--- a/.claude/scripts/install-claude.sh
+++ b/.claude/scripts/install-claude.sh
@@ -13,7 +13,7 @@ fi
 DOWNLOAD_URL="https://downloads.claude.ai/claude-code-releases"
 PLATFORM="linux-x64"
 
-VERSION="$(curl -fsSL --retry 3 --retry-delay 2 "$DOWNLOAD_URL/stable")"
+VERSION="$(curl -fsSL --retry 3 --retry-delay 2 "$DOWNLOAD_URL/latest")"
 CHECKSUM="$(curl -fsSL --retry 3 --retry-delay 2 "$DOWNLOAD_URL/$VERSION/manifest.json" \
   | jq -r ".platforms[\"$PLATFORM\"].checksum")"
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -177,9 +177,11 @@ jobs:
           import sys
 
           MODEL_CHOICES = [
+              "fable",
               "opus",
               "sonnet",
               "haiku",
+              "claude-fable-5",
               "claude-opus-4-7",
               "claude-sonnet-4-6",
               "claude-haiku-4-5",


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Enable reviewing PRs with [Claude Fable 5](https://www.anthropic.com/news/claude-fable-5-mythos-5), Anthropic's newest model tier:

- Add `fable` / `claude-fable-5` to the model choices accepted by `/review -m ...` in `.github/workflows/review.yml`. Defaults are unchanged.
- Change `.claude/scripts/install-claude.sh` to install the `latest` Claude CLI release instead of `stable`, so the CI binary picks up support for newly released models without waiting for the stable channel.

### How is this PR tested?

- [x] Manual tests

Will trigger `/review -m fable` on this PR after filing it.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)