### PR TITLE
Add `MLFLOW_GENAI_JUDGE_DEFAULT_MODEL` environment variable

### DIFF
--- a/docs/docs/genai/eval-monitor/scorers/index.mdx
+++ b/docs/docs/genai/eval-monitor/scorers/index.mdx
@@ -76,7 +76,7 @@ For a list of supported models, see [selecting judge models](/genai/eval-monitor
 
 :::tip Set a default judge model globally
 
-To avoid passing `model` to every scorer, set the `MLFLOW_GENAI_JUDGE_DEFAULT_MODEL` environment variable. All built-in judges and scorers will use that model when no explicit `model` argument is provided.
+Set the `MLFLOW_GENAI_JUDGE_DEFAULT_MODEL` environment variable to change the default judge model, instead of specifying `model` on each scorer individually. All built-in judges and scorers fall back to this model when no explicit `model` argument is provided.
 
 ```bash
 export MLFLOW_GENAI_JUDGE_DEFAULT_MODEL="openai:/gpt-5-mini"

--- a/docs/docs/genai/eval-monitor/scorers/index.mdx
+++ b/docs/docs/genai/eval-monitor/scorers/index.mdx
@@ -74,6 +74,16 @@ Correctness(model="openai:/gpt-5-mini")
 
 For a list of supported models, see [selecting judge models](/genai/eval-monitor/scorers/llm-judge/custom-judges/#selecting-judge-models).
 
+:::tip Set a default judge model globally
+
+To avoid passing `model` to every scorer, set the `MLFLOW_GENAI_JUDGE_DEFAULT_MODEL` environment variable. All built-in judges and scorers will use that model when no explicit `model` argument is provided.
+
+```bash
+export MLFLOW_GENAI_JUDGE_DEFAULT_MODEL="openai:/gpt-5-mini"
+```
+
+:::
+
 ## What Judges you should use?
 
 MLflow provides different types of judges to address different evaluation needs:

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -841,7 +841,7 @@ MLFLOW_GENAI_OPTIMIZE_MAX_WORKERS = _EnvironmentVariable(
 #: ``Guidelines``, ``Safety``) when no ``model`` is passed explicitly. When unset,
 #: MLflow falls back to the Databricks managed judge on Databricks tracking URIs
 #: and ``openai:/gpt-4.1-mini`` otherwise. Set this to point every default judge
-#: at a single model URI, e.g. ``openai:/databricks-gpt-5``. (default: unset)
+#: at a single model URI, e.g. ``openai:/gpt-5-mini``. (default: unset)
 MLFLOW_GENAI_JUDGE_DEFAULT_MODEL = _EnvironmentVariable(
     "MLFLOW_GENAI_JUDGE_DEFAULT_MODEL", str, None
 )

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -837,6 +837,15 @@ MLFLOW_GENAI_OPTIMIZE_MAX_WORKERS = _EnvironmentVariable(
     "MLFLOW_GENAI_OPTIMIZE_MAX_WORKERS", int, 8
 )
 
+#: Default LLM judge model URI used by built-in judges and scorers (e.g.
+#: ``Guidelines``, ``Safety``) when no ``model`` is passed explicitly. When unset,
+#: MLflow falls back to the Databricks managed judge on Databricks tracking URIs
+#: and ``openai:/gpt-4.1-mini`` otherwise. Set this to point every default judge
+#: at a single model URI, e.g. ``openai:/databricks-gpt-5``. (default: unset)
+MLFLOW_GENAI_JUDGE_DEFAULT_MODEL = _EnvironmentVariable(
+    "MLFLOW_GENAI_JUDGE_DEFAULT_MODEL", str, None
+)
+
 
 #: Skip trace validation during GenAI evaluation. By default (False), MLflow will validate if
 #: the given predict function generates a valid trace, and otherwise wraps it with @mlflow.trace

--- a/mlflow/genai/judges/builtin.py
+++ b/mlflow/genai/judges/builtin.py
@@ -19,9 +19,11 @@ _MODEL_API_DOC = {
 `"anthropic:/claude-3.5-sonnet-20240620"`. MLflow natively supports
 `["openai", "anthropic", "bedrock", "mistral"]`, and more providers are supported
 through `LiteLLM <https://docs.litellm.ai/docs/providers>`_.
-Default model depends on the tracking URI setup:
+Default model depends on the ``MLFLOW_GENAI_JUDGE_DEFAULT_MODEL`` environment
+variable and the tracking URI setup:
 
-* Databricks: `databricks`
+* If ``MLFLOW_GENAI_JUDGE_DEFAULT_MODEL`` is set, that value is used.
+* Databricks tracking URI: `databricks`
 * Otherwise: `openai:/gpt-4.1-mini`.
 """,
 }

--- a/mlflow/genai/judges/utils/__init__.py
+++ b/mlflow/genai/judges/utils/__init__.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:
     from mlflow.genai.judges.base import AlignmentOptimizer
 
 import mlflow
+from mlflow.environment_variables import MLFLOW_GENAI_JUDGE_DEFAULT_MODEL
 from mlflow.genai.judges.adapters.databricks_managed_judge_adapter import (
     call_chat_completions,
 )
@@ -32,6 +33,8 @@ from mlflow.utils.uri import is_databricks_uri
 
 
 def get_default_model() -> str:
+    if override := MLFLOW_GENAI_JUDGE_DEFAULT_MODEL.get():
+        return override
     if is_databricks_uri(mlflow.get_tracking_uri()):
         return _DATABRICKS_DEFAULT_JUDGE_MODEL
     else:

--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -21,7 +21,7 @@ from mlflow.environment_variables import (
 )
 from mlflow.exceptions import MlflowException
 from mlflow.genai.discovery.constants import DEFAULT_TOP_N_SLOWEST_SPANS
-from mlflow.genai.judges.utils import get_chat_completions_with_structured_output
+from mlflow.genai.judges.utils import get_chat_completions_with_structured_output, get_default_model
 from mlflow.genai.utils.data_validation import check_model_prediction
 from mlflow.genai.utils.prompts.available_tools_extraction import (
     get_available_tools_extraction_prompts,
@@ -1168,8 +1168,6 @@ def _try_extract_available_tools_with_llm(
         List of ChatTool objects extracted by the LLM, or empty list if extraction fails.
     """
     if model is None:
-        from mlflow.genai.judges.utils import get_default_model
-
         model = get_default_model()
 
     try:

--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -21,7 +21,6 @@ from mlflow.environment_variables import (
 )
 from mlflow.exceptions import MlflowException
 from mlflow.genai.discovery.constants import DEFAULT_TOP_N_SLOWEST_SPANS
-from mlflow.genai.judges.constants import _DATABRICKS_DEFAULT_JUDGE_MODEL
 from mlflow.genai.judges.utils import get_chat_completions_with_structured_output
 from mlflow.genai.utils.data_validation import check_model_prediction
 from mlflow.genai.utils.prompts.available_tools_extraction import (
@@ -1169,10 +1168,9 @@ def _try_extract_available_tools_with_llm(
         List of ChatTool objects extracted by the LLM, or empty list if extraction fails.
     """
     if model is None:
-        if is_databricks_uri(mlflow.get_tracking_uri()):
-            model = _DATABRICKS_DEFAULT_JUDGE_MODEL
-        else:
-            model = "openai:/gpt-4.1-mini"
+        from mlflow.genai.judges.utils import get_default_model
+
+        model = get_default_model()
 
     try:
         from mlflow.types.chat import (

--- a/tests/genai/judges/utils/test_get_default_model.py
+++ b/tests/genai/judges/utils/test_get_default_model.py
@@ -8,6 +8,8 @@ from mlflow.genai.judges.utils import get_default_model
     [
         ("openai:/gpt-5", "databricks", "openai:/gpt-5"),
         ("anthropic:/claude-4", "http://localhost:5000", "anthropic:/claude-4"),
+        ("", "databricks", "databricks"),
+        ("", "http://localhost:5000", "openai:/gpt-4.1-mini"),
         (None, "databricks", "databricks"),
         (None, "http://localhost:5000", "openai:/gpt-4.1-mini"),
     ],

--- a/tests/genai/judges/utils/test_get_default_model.py
+++ b/tests/genai/judges/utils/test_get_default_model.py
@@ -1,0 +1,25 @@
+import pytest
+
+from mlflow.genai.judges.utils import get_default_model
+
+
+@pytest.mark.parametrize(
+    ("env_value", "tracking_uri", "expected"),
+    [
+        ("openai:/gpt-5", "databricks", "openai:/gpt-5"),
+        ("anthropic:/claude-4", "http://localhost:5000", "anthropic:/claude-4"),
+        (None, "databricks", "databricks"),
+        (None, "http://localhost:5000", "openai:/gpt-4.1-mini"),
+    ],
+)
+def test_get_default_model(monkeypatch, env_value, tracking_uri, expected):
+    if env_value is not None:
+        monkeypatch.setenv("MLFLOW_GENAI_JUDGE_DEFAULT_MODEL", env_value)
+    else:
+        monkeypatch.delenv("MLFLOW_GENAI_JUDGE_DEFAULT_MODEL", raising=False)
+    monkeypatch.setattr("mlflow.genai.judges.utils.mlflow.get_tracking_uri", lambda: tracking_uri)
+    monkeypatch.setattr(
+        "mlflow.genai.judges.utils.is_databricks_uri",
+        lambda uri: uri == "databricks",
+    )
+    assert get_default_model() == expected

--- a/tests/genai/judges/utils/test_get_default_model.py
+++ b/tests/genai/judges/utils/test_get_default_model.py
@@ -20,8 +20,4 @@ def test_get_default_model(monkeypatch, env_value, tracking_uri, expected):
     else:
         monkeypatch.delenv("MLFLOW_GENAI_JUDGE_DEFAULT_MODEL", raising=False)
     monkeypatch.setattr("mlflow.genai.judges.utils.mlflow.get_tracking_uri", lambda: tracking_uri)
-    monkeypatch.setattr(
-        "mlflow.genai.judges.utils.is_databricks_uri",
-        lambda uri: uri == "databricks",
-    )
     assert get_default_model() == expected


### PR DESCRIPTION
### Related Issues/PRs

(Fixing a papercut I encountered while running demo)

### What changes are proposed in this pull request?

Adds a new `MLFLOW_GENAI_JUDGE_DEFAULT_MODEL` environment variable that overrides the default LLM judge model used by all built-in judges and scorers (`Guidelines`, `Safety`, `Correctness`, etc.).

If we don't have this, users need to specify judge model for every scorer instance, which is tedius.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

All 188 tests in `tests/genai/judges/test_make_judge.py` pass.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added `MLFLOW_GENAI_JUDGE_DEFAULT_MODEL` environment variable to override the default model used by all built-in GenAI judges and scorers. When set, judges use the specified model URI instead of the default, allowing users to route all judge traffic to a specific endpoint without code changes.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release