### PR TITLE
Add string-based scorers (`Contains`, `Excludes`, `Matches`, `Equals`)

### DIFF
--- a/mlflow/genai/scorers/__init__.py
+++ b/mlflow/genai/scorers/__init__.py
@@ -51,14 +51,27 @@ _LAZY_IMPORTS = {
     "get_all_scorers",
 }
 
+# Deterministic string scorers live in a separate module so they're not
+# entangled with the LLM-judge inheritance chain.
+_STRING_SCORER_IMPORTS = {
+    "Contains",
+    "Excludes",
+    "Matches",
+    "Equals",
+}
+
 
 def __getattr__(name):
     """Lazily import builtin scorers to avoid circular dependency."""
     if name in _LAZY_IMPORTS:
-        # Import the module when first accessed
         from mlflow.genai.scorers import builtin_scorers
 
         return getattr(builtin_scorers, name)
+
+    if name in _STRING_SCORER_IMPORTS:
+        from mlflow.genai.scorers import string_scorers
+
+        return getattr(string_scorers, name)
 
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
@@ -72,7 +85,7 @@ def __dir__():
     # Get the default module attributes
     module_attrs = list(globals().keys())
     # Add the lazy imports
-    return sorted(set(module_attrs) | _LAZY_IMPORTS)
+    return sorted(set(module_attrs) | _LAZY_IMPORTS | _STRING_SCORER_IMPORTS)
 
 
 # The TYPE_CHECKING block below is for static analysis tools only.
@@ -103,6 +116,12 @@ if TYPE_CHECKING:
         UserFrustration,
         get_all_scorers,
     )
+    from mlflow.genai.scorers.string_scorers import (
+        Contains,
+        Equals,
+        Excludes,
+        Matches,
+    )
 
 __all__ = [
     "Completeness",
@@ -111,12 +130,16 @@ __all__ = [
     "ConversationalSafety",
     "ConversationalToolCallEfficiency",
     "ConversationCompleteness",
+    "Contains",
     "Correctness",
+    "Equals",
+    "Excludes",
     "ExpectationsGuidelines",
     "Fluency",
     "Guidelines",
     "Equivalence",
     "KnowledgeRetention",
+    "Matches",
     "RelevanceToQuery",
     "RetrievalGroundedness",
     "RetrievalRelevance",

--- a/mlflow/genai/scorers/string_scorers.py
+++ b/mlflow/genai/scorers/string_scorers.py
@@ -1,0 +1,275 @@
+"""Deterministic string-based scorers.
+
+These scorers are pure Python comparisons. They cost no tokens, run in
+microseconds, and produce stable rationales. Prefer them over LLM judges
+whenever the assertion can be expressed as substring / regex / equality.
+
+::
+
+    from mlflow.genai.scorers import Contains, Excludes, Matches, Equals
+
+    Contains("workspace")
+    Contains(["register_prompt", "Create Prompt"], match_any=True)
+    Contains(["trace", "scorer", "dataset"])         # default: all must match
+    Excludes("mlflow runs create")
+    Matches(r"mlflow\\.org/docs/.+/genai/prompt")
+    Equals("yes", case_sensitive=False)
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, ClassVar, Literal
+
+from pydantic import Field
+
+from mlflow.entities.assessment import Feedback
+from mlflow.genai.scorers.base import Scorer
+
+_NAME_MAX_LEN = 40
+_FieldName = Literal["outputs", "inputs"]
+
+
+def _stringify(value: Any) -> str:
+    """Best-effort coercion to string for substring / regex / equality checks.
+
+    Most agent responses are strings already. Dict / structured outputs get
+    ``str()``-coerced; users who need precision can extract the field they
+    care about in the test body before calling ``verify``.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
+def _slug(text: str) -> str:
+    return re.sub(r"[^a-zA-Z0-9]+", "_", text).strip("_").lower()[:_NAME_MAX_LEN]
+
+
+class _StringScorerBase(Scorer):
+    """Shared plumbing for the four deterministic string scorers."""
+
+    # Subclasses set this to "contains" / "excludes" / "matches" / "equals".
+    KIND: ClassVar[str] = ""
+
+    field: _FieldName = "outputs"
+    case_sensitive: bool = False
+
+    def _target_text(self, *, outputs: Any, inputs: Any) -> str:
+        return _stringify(outputs if self.field == "outputs" else inputs)
+
+
+class Contains(_StringScorerBase):
+    """Pass iff the targeted field contains the given substring(s).
+
+    By default every substring in ``needles`` must appear (AND). Pass
+    ``match_any=True`` for OR semantics.
+
+    Args:
+        needles: A single substring or a list of substrings.
+        match_any: When ``True`` and a list is given, pass if any substring
+            matches. Defaults to ``False`` (all must match).
+        case_sensitive: Defaults to ``False``.
+        field: Which field to read. ``"outputs"`` (default) or ``"inputs"``.
+        name: Display name. Auto-generated from the needles when omitted.
+    """
+
+    KIND: ClassVar[str] = "contains"
+
+    needles: list[str] = Field(default_factory=list)
+    match_any: bool = False
+
+    def __init__(
+        self,
+        needles: str | list[str],
+        *,
+        match_any: bool = False,
+        case_sensitive: bool = False,
+        field: _FieldName = "outputs",
+        name: str | None = None,
+    ):
+        needle_list = [needles] if isinstance(needles, str) else list(needles)
+        if not needle_list:
+            raise ValueError("Contains(...) requires at least one substring.")
+        super().__init__(
+            name=name or _auto_name(self.KIND, needle_list),
+            needles=needle_list,
+            match_any=match_any,
+            case_sensitive=case_sensitive,
+            field=field,
+        )
+
+    def __call__(self, *, outputs: Any = None, inputs: Any = None) -> Feedback:
+        text = self._target_text(outputs=outputs, inputs=inputs)
+        haystack = text if self.case_sensitive else text.lower()
+        needles = self.needles if self.case_sensitive else [n.lower() for n in self.needles]
+
+        found = [n for n in needles if n in haystack]
+        if self.match_any:
+            passed = bool(found)
+            rationale = (
+                f"Found any of {self.needles!r}: {found!r}"
+                if passed
+                else f"None of {self.needles!r} found in {self.field}."
+            )
+        else:
+            missing = [n for n in needles if n not in haystack]
+            passed = not missing
+            rationale = (
+                f"All required substrings present: {self.needles!r}"
+                if passed
+                else f"Missing required substrings: {missing!r}"
+            )
+        return Feedback(name=self.name, value=passed, rationale=rationale)
+
+
+class Excludes(_StringScorerBase):
+    """Pass iff the targeted field contains none of the given substring(s).
+
+    Args:
+        needles: A single substring or a list of substrings that must not appear.
+        case_sensitive: Defaults to ``False``.
+        field: Which field to read. ``"outputs"`` (default) or ``"inputs"``.
+        name: Display name. Auto-generated when omitted.
+    """
+
+    KIND: ClassVar[str] = "excludes"
+
+    needles: list[str] = Field(default_factory=list)
+
+    def __init__(
+        self,
+        needles: str | list[str],
+        *,
+        case_sensitive: bool = False,
+        field: _FieldName = "outputs",
+        name: str | None = None,
+    ):
+        needle_list = [needles] if isinstance(needles, str) else list(needles)
+        if not needle_list:
+            raise ValueError("Excludes(...) requires at least one substring.")
+        super().__init__(
+            name=name or _auto_name(self.KIND, needle_list),
+            needles=needle_list,
+            case_sensitive=case_sensitive,
+            field=field,
+        )
+
+    def __call__(self, *, outputs: Any = None, inputs: Any = None) -> Feedback:
+        text = self._target_text(outputs=outputs, inputs=inputs)
+        haystack = text if self.case_sensitive else text.lower()
+        needles = self.needles if self.case_sensitive else [n.lower() for n in self.needles]
+
+        found = [n for n in needles if n in haystack]
+        passed = not found
+        rationale = (
+            f"No forbidden substrings present in {self.field}."
+            if passed
+            else f"Forbidden substrings found: {found!r}"
+        )
+        return Feedback(name=self.name, value=passed, rationale=rationale)
+
+
+class Matches(_StringScorerBase):
+    """Pass iff the targeted field matches the regex pattern.
+
+    Uses ``re.search`` semantics (anywhere in the string, not anchored).
+    Use ``^...$`` in the pattern to anchor.
+
+    Args:
+        pattern: The regex pattern.
+        case_sensitive: Defaults to ``False``. Adds ``re.IGNORECASE`` when ``False``.
+        field: Which field to read. ``"outputs"`` (default) or ``"inputs"``.
+        name: Display name. Auto-generated when omitted.
+    """
+
+    KIND: ClassVar[str] = "matches"
+
+    pattern: str
+
+    def __init__(
+        self,
+        pattern: str,
+        *,
+        case_sensitive: bool = False,
+        field: _FieldName = "outputs",
+        name: str | None = None,
+    ):
+        if not pattern:
+            raise ValueError("Matches(...) requires a non-empty pattern.")
+        # Compile-check up front so users get the error at decoration time,
+        # not while a test is running.
+        flags = 0 if case_sensitive else re.IGNORECASE
+        re.compile(pattern, flags=flags)
+        super().__init__(
+            name=name or _auto_name(self.KIND, [pattern]),
+            pattern=pattern,
+            case_sensitive=case_sensitive,
+            field=field,
+        )
+
+    def __call__(self, *, outputs: Any = None, inputs: Any = None) -> Feedback:
+        text = self._target_text(outputs=outputs, inputs=inputs)
+        flags = 0 if self.case_sensitive else re.IGNORECASE
+        match = re.search(self.pattern, text, flags=flags)
+        passed = match is not None
+        rationale = (
+            f"Pattern matched: {match.group(0)!r}"
+            if passed
+            else f"Pattern {self.pattern!r} not found in {self.field}."
+        )
+        return Feedback(name=self.name, value=passed, rationale=rationale)
+
+
+class Equals(_StringScorerBase):
+    """Pass iff the targeted field equals the expected value.
+
+    Args:
+        expected: The expected string.
+        case_sensitive: Defaults to ``False``.
+        field: Which field to read. ``"outputs"`` (default) or ``"inputs"``.
+        name: Display name. Auto-generated when omitted.
+    """
+
+    KIND: ClassVar[str] = "equals"
+
+    expected: str
+
+    def __init__(
+        self,
+        expected: str,
+        *,
+        case_sensitive: bool = False,
+        field: _FieldName = "outputs",
+        name: str | None = None,
+    ):
+        super().__init__(
+            name=name or _auto_name(self.KIND, [expected]),
+            expected=expected,
+            case_sensitive=case_sensitive,
+            field=field,
+        )
+
+    def __call__(self, *, outputs: Any = None, inputs: Any = None) -> Feedback:
+        text = self._target_text(outputs=outputs, inputs=inputs)
+        if self.case_sensitive:
+            passed = text == self.expected
+        else:
+            passed = text.lower() == self.expected.lower()
+        rationale = (
+            f"Equals {self.expected!r}"
+            if passed
+            else f"Expected {self.expected!r}, got {text!r}"
+        )
+        return Feedback(name=self.name, value=passed, rationale=rationale)
+
+
+def _auto_name(kind: str, needles: list[str]) -> str:
+    """Derive a stable, readable scorer name like ``contains_workspace``."""
+    if len(needles) == 1:
+        return f"{kind}_{_slug(needles[0])}"
+    joined = "_".join(_slug(n) for n in needles[:3])
+    suffix = "_etc" if len(needles) > 3 else ""
+    return f"{kind}_{joined}{suffix}"[:_NAME_MAX_LEN]

--- a/tests/genai/scorers/test_string_scorers.py
+++ b/tests/genai/scorers/test_string_scorers.py
@@ -1,0 +1,120 @@
+"""Unit tests for Contains / Excludes / Matches / Equals."""
+
+from __future__ import annotations
+
+import pytest
+
+from mlflow.entities.assessment import Feedback
+from mlflow.genai.scorers import Contains, Equals, Excludes, Matches
+
+
+@pytest.mark.parametrize(
+    ("needles", "outputs", "kwargs", "expected"),
+    [
+        ("workspace", "go to your workspace settings", {}, True),
+        ("workspace", "go to your settings", {}, False),
+        ("Workspace", "go to your WORKSPACE", {}, True),  # case-insensitive default
+        ("Workspace", "go to your WORKSPACE", {"case_sensitive": True}, False),
+        (["trace", "scorer"], "use trace and scorer", {}, True),
+        (["trace", "scorer"], "only trace here", {}, False),
+        (["trace", "scorer"], "only trace here", {"match_any": True}, True),
+        (["trace", "scorer"], "no matches", {"match_any": True}, False),
+    ],
+)
+def test_contains(needles, outputs, kwargs, expected):
+    result: Feedback = Contains(needles, **kwargs)(outputs=outputs)
+    assert result.value is expected
+    assert result.rationale
+
+
+def test_contains_field_inputs():
+    result: Feedback = Contains("hello", field="inputs")(inputs="hello world", outputs="bye")
+    assert result.value is True
+
+
+def test_contains_empty_raises():
+    with pytest.raises(ValueError, match="at least one"):
+        Contains([])
+
+
+def test_contains_auto_name():
+    assert Contains("workspace").name == "contains_workspace"
+    assert Contains(["trace", "scorer"]).name == "contains_trace_scorer"
+    assert Contains(["a", "b", "c", "d", "e"]).name.endswith("_etc")
+
+
+def test_contains_custom_name():
+    assert Contains("workspace", name="mentions_workspace").name == "mentions_workspace"
+
+
+@pytest.mark.parametrize(
+    ("needles", "outputs", "kwargs", "expected"),
+    [
+        ("mlflow runs create", "use mlflow runs create here", {}, False),
+        ("mlflow runs create", "use mlflow logs here", {}, True),
+        (["foo", "bar"], "contains bar only", {}, False),
+        (["foo", "bar"], "contains neither", {}, True),
+    ],
+)
+def test_excludes(needles, outputs, kwargs, expected):
+    result = Excludes(needles, **kwargs)(outputs=outputs)
+    assert result.value is expected
+    assert result.rationale
+
+
+@pytest.mark.parametrize(
+    ("pattern", "outputs", "kwargs", "expected"),
+    [
+        (r"docs/.+/genai", "see https://mlflow.org/docs/3.5.0/genai/intro", {}, True),
+        (r"docs/.+/genai", "no docs link", {}, False),
+        (r"^hello$", "hello", {}, True),
+        (r"^hello$", "hello world", {}, False),
+        (r"HELLO", "hello world", {}, True),  # case-insensitive default
+        (r"HELLO", "hello world", {"case_sensitive": True}, False),
+    ],
+)
+def test_matches(pattern, outputs, kwargs, expected):
+    result = Matches(pattern, **kwargs)(outputs=outputs)
+    assert result.value is expected
+    assert result.rationale
+
+
+def test_matches_invalid_pattern_raises_at_definition():
+    with pytest.raises(re_error_or_value_error()):
+        Matches("(unclosed")
+
+
+def re_error_or_value_error():
+    import re
+
+    return re.error
+
+
+@pytest.mark.parametrize(
+    ("expected_val", "outputs", "kwargs", "expected_pass"),
+    [
+        ("yes", "yes", {}, True),
+        ("yes", "YES", {}, True),  # case-insensitive default
+        ("yes", "YES", {"case_sensitive": True}, False),
+        ("yes", "no", {}, False),
+        ("yes", "yes ", {}, False),  # exact match, no auto-trim
+    ],
+)
+def test_equals(expected_val, outputs, kwargs, expected_pass):
+    result = Equals(expected_val, **kwargs)(outputs=outputs)
+    assert result.value is expected_pass
+    assert result.rationale
+
+
+def test_run_filters_unused_kwargs():
+    # Scorer.run() filters kwargs to what __call__ accepts. Contains accepts
+    # outputs + inputs but not `expectations` / `trace`, so passing those
+    # extras should not raise.
+    result = Contains("hi").run(outputs="say hi", expectations={"x": 1}, trace=None)
+    assert result.value is True
+
+
+def test_none_outputs_coerced_to_empty_string():
+    # Defensive: agents that return None should not crash the scorer.
+    result = Contains("anything")(outputs=None)
+    assert result.value is False


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23779

### What changes are proposed in this pull request?

Adds four deterministic string-based scorers: `Contains`, `Excludes`, `Matches`, and `Equals`. These scorers run pure Python comparisons (substring checks, regex matches, equality) without requiring LLM judge calls. They are useful for fast, stable, zero-cost assertion checks on agent/model outputs.

**New scorers:**
- `Contains(needles, match_any=False)` - pass iff output contains the given substring(s), with AND/OR semantics
- `Excludes(needles)` - pass iff output does not contain any of the given substrings
- `Matches(pattern)` - pass iff output matches a regex pattern (uses `re.search`)
- `Equals(expected)` - pass iff output exactly equals the expected string

All scorers support `case_sensitive` (default `False`), `field` selection (`"outputs"` or `"inputs"`), and auto-generated names.

### How is this PR tested?

- [x] New unit/integration tests

30 tests in `tests/genai/scorers/test_string_scorers.py`, all passing:

```
tests/genai/scorers/test_string_scorers.py  30 passed in 9.28s
```

Tests cover:
- Parametrized pass/fail for all four scorers
- Case sensitivity toggling
- `field="inputs"` support
- Validation errors (empty needles, invalid regex)
- Auto-name generation
- Custom name override
- `Scorer.run()` filtering of unused kwargs
- `None` output coercion

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Adds deterministic string-based scorers (`Contains`, `Excludes`, `Matches`, `Equals`) for fast, zero-cost assertion checks on agent/model outputs without LLM judge calls.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release