### PR TITLE
Honor `OPENAI_BASE_URL` env var in OpenAI provider config

### DIFF
--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -352,7 +352,13 @@ def _get_provider_instance(
             )
         config = OpenAIConfig(
             openai_api_key=os.environ["OPENAI_API_KEY"],
-            openai_api_base=os.environ.get("OPENAI_API_BASE"),
+            # Honor the OpenAI SDK's standard ``OPENAI_BASE_URL`` in addition to
+            # MLflow's historical ``OPENAI_API_BASE``. Without this, pointing the
+            # openai provider at an OpenAI-compatible endpoint (e.g. Databricks
+            # FMAPI) the SDK way is silently ignored and requests fall back to
+            # api.openai.com.
+            openai_api_base=os.environ.get("OPENAI_API_BASE")
+            or os.environ.get("OPENAI_BASE_URL"),
         )
         return OpenAIProvider(_get_route_config(config))
 

--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -352,13 +352,9 @@ def _get_provider_instance(
             )
         config = OpenAIConfig(
             openai_api_key=os.environ["OPENAI_API_KEY"],
-            # Honor the OpenAI SDK's standard ``OPENAI_BASE_URL`` in addition to
-            # MLflow's historical ``OPENAI_API_BASE``. Without this, pointing the
-            # openai provider at an OpenAI-compatible endpoint (e.g. Databricks
-            # FMAPI) the SDK way is silently ignored and requests fall back to
-            # api.openai.com.
-            openai_api_base=os.environ.get("OPENAI_API_BASE")
-            or os.environ.get("OPENAI_BASE_URL"),
+            openai_api_base=v
+            if (v := os.environ.get("OPENAI_API_BASE")) is not None
+            else os.environ.get("OPENAI_BASE_URL"),
         )
         return OpenAIProvider(_get_route_config(config))
 

--- a/tests/metrics/genai/test_model_utils.py
+++ b/tests/metrics/genai/test_model_utils.py
@@ -147,9 +147,6 @@ def test_score_model_openai_with_custom_header_and_proxy_url(set_envs):
 
 
 def test_score_model_openai_honors_openai_base_url(set_envs, monkeypatch):
-    # OPENAI_BASE_URL is the OpenAI SDK's standard env var. The openai provider
-    # must honor it (not silently fall back to api.openai.com) so that
-    # OpenAI-compatible endpoints (e.g. Databricks FMAPI) can be used as judges.
     monkeypatch.delenv("OPENAI_API_BASE", raising=False)
     monkeypatch.setenv("OPENAI_BASE_URL", "https://my-host/serving-endpoints/v1")
     with mock.patch(
@@ -157,9 +154,14 @@ def test_score_model_openai_honors_openai_base_url(set_envs, monkeypatch):
     ) as mock_post:
         score_model_on_payload("openai:/gpt-4o-mini", "my prompt", {"temperature": 0.1})
 
-        assert (
-            mock_post.call_args.kwargs["endpoint"]
-            == "https://my-host/serving-endpoints/v1/chat/completions"
+        mock_post.assert_called_once_with(
+            endpoint="https://my-host/serving-endpoints/v1/chat/completions",
+            headers={"authorization": "Bearer test"},
+            payload={
+                "messages": [{"role": "user", "content": "my prompt"}],
+                "model": "gpt-4o-mini",
+                "temperature": 0.1,
+            },
         )
 
 
@@ -171,8 +173,14 @@ def test_score_model_openai_api_base_takes_precedence_over_base_url(set_envs, mo
     ) as mock_post:
         score_model_on_payload("openai:/gpt-4o-mini", "my prompt", {"temperature": 0.1})
 
-        assert (
-            mock_post.call_args.kwargs["endpoint"] == "https://api-base/v1/chat/completions"
+        mock_post.assert_called_once_with(
+            endpoint="https://api-base/v1/chat/completions",
+            headers={"authorization": "Bearer test"},
+            payload={
+                "messages": [{"role": "user", "content": "my prompt"}],
+                "model": "gpt-4o-mini",
+                "temperature": 0.1,
+            },
         )
 
 

--- a/tests/metrics/genai/test_model_utils.py
+++ b/tests/metrics/genai/test_model_utils.py
@@ -146,6 +146,36 @@ def test_score_model_openai_with_custom_header_and_proxy_url(set_envs):
         )
 
 
+def test_score_model_openai_honors_openai_base_url(set_envs, monkeypatch):
+    # OPENAI_BASE_URL is the OpenAI SDK's standard env var. The openai provider
+    # must honor it (not silently fall back to api.openai.com) so that
+    # OpenAI-compatible endpoints (e.g. Databricks FMAPI) can be used as judges.
+    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://my-host/serving-endpoints/v1")
+    with mock.patch(
+        "mlflow.metrics.genai.model_utils._send_request", return_value=_OAI_RESPONSE
+    ) as mock_post:
+        score_model_on_payload("openai:/gpt-4o-mini", "my prompt", {"temperature": 0.1})
+
+        assert (
+            mock_post.call_args.kwargs["endpoint"]
+            == "https://my-host/serving-endpoints/v1/chat/completions"
+        )
+
+
+def test_score_model_openai_api_base_takes_precedence_over_base_url(set_envs, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_BASE", "https://api-base/v1")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://base-url/v1")
+    with mock.patch(
+        "mlflow.metrics.genai.model_utils._send_request", return_value=_OAI_RESPONSE
+    ) as mock_post:
+        score_model_on_payload("openai:/gpt-4o-mini", "my prompt", {"temperature": 0.1})
+
+        assert (
+            mock_post.call_args.kwargs["endpoint"] == "https://api-base/v1/chat/completions"
+        )
+
+
 def test_openai_other_error(set_envs):
     with mock.patch(
         "mlflow.metrics.genai.model_utils._send_request",


### PR DESCRIPTION
### Related Issues/PRs

(Fixing a bug I encountered while running demo)

### What changes are proposed in this pull request?

The OpenAI Python SDK uses `OPENAI_BASE_URL` as its standard environment variable for overriding the API base URL. MLflow's OpenAI provider currently only reads the historical `OPENAI_API_BASE` env var when constructing `OpenAIConfig`, which means setting `OPENAI_BASE_URL` to point at an OpenAI-compatible endpoint (e.g., Databricks FMAPI) is silently ignored - requests fall back to `api.openai.com`.

This PR adds a fallback so that `OPENAI_BASE_URL` is honored when `OPENAI_API_BASE` is not set. `OPENAI_API_BASE` still takes precedence for backward compatibility.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Two new tests in `tests/metrics/genai/test_model_utils.py`:
- `test_score_model_openai_honors_openai_base_url` - verifies requests go to the URL in `OPENAI_BASE_URL` when `OPENAI_API_BASE` is unset
- `test_score_model_openai_api_base_takes_precedence_over_base_url` - verifies `OPENAI_API_BASE` wins when both are set

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The OpenAI provider now honors the `OPENAI_BASE_URL` environment variable (the OpenAI SDK's standard env var) in addition to MLflow's historical `OPENAI_API_BASE`. This lets users point the OpenAI provider at OpenAI-compatible endpoints without switching env var names.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release