### PR TITLE
Add Databricks workspace support to `mlflow agent setup`

### DIFF
--- a/mlflow/agent/setup/cli.py
+++ b/mlflow/agent/setup/cli.py
@@ -100,7 +100,8 @@ def _run_setup(
 
     tracking_uri_input = click.prompt(
         click.style(
-            "Tracking URI (leave empty to let the agent start a local server)",
+            "Tracking URI (leave empty to let the agent start a local server, "
+            "or 'databricks' for a Databricks workspace)",
             fg="cyan",
             bold=True,
         ),
@@ -108,9 +109,24 @@ def _run_setup(
         show_default=False,
         err=True,
     ).strip()
+    experiment_path: str | None = None
     if tracking_uri_input:
         tracking_uri = tracking_uri_input
         local_server_port: int | None = None
+        if tracking_uri == "databricks":
+            experiment_path = click.prompt(
+                click.style(
+                    "Workspace experiment path (e.g. /Users/you@example.com/my-app)",
+                    fg="cyan",
+                    bold=True,
+                ),
+                err=True,
+            ).strip()
+            if not experiment_path.startswith("/"):
+                raise click.ClickException(
+                    "Databricks experiment path must start with '/' "
+                    "(e.g. /Users/you@example.com/my-app)."
+                )
     else:
         local_server_port = _find_available_port()
         tracking_uri = f"http://127.0.0.1:{local_server_port}"
@@ -121,6 +137,7 @@ def _run_setup(
         agent,
         tracking_uri,
         local_server_port=local_server_port,
+        experiment_path=experiment_path,
         skills_installed=skills_installed,
     )
 

--- a/mlflow/agent/setup/prompt.py
+++ b/mlflow/agent/setup/prompt.py
@@ -34,6 +34,7 @@ def build_prompt(
     tracking_uri: str,
     *,
     local_server_port: int | None = None,
+    experiment_path: str | None = None,
     skills_installed: bool = True,
 ) -> str:
     """Compose the first user message handed to the agent.
@@ -46,6 +47,10 @@ def build_prompt(
     When ``local_server_port`` is not ``None``, the CLI picked it and built
     ``tracking_uri = http://127.0.0.1:<port>``; the agent is instructed to
     start a local MLflow server on that port.
+
+    When ``tracking_uri == "databricks"``, ``experiment_path`` is the
+    workspace experiment path (e.g. ``/Users/<email>/<name>``) and the
+    Databricks-specific setup block is injected.
 
     When ``skills_installed`` is ``False``, ``{{ skills_dir }}`` is
     redirected to the bundled skill location inside the MLflow install so
@@ -78,6 +83,14 @@ def build_prompt(
             _read_template("local-server.md"),
             tracking_uri=tracking_uri,
             port=str(local_server_port),
+        )
+    elif tracking_uri == "databricks":
+        if not experiment_path:
+            raise ValueError("experiment_path is required when tracking_uri is 'databricks'.")
+        server_setup = _render(
+            _read_template("databricks.md"),
+            tracking_uri=tracking_uri,
+            experiment_path=experiment_path,
         )
     else:
         server_setup = ""

--- a/mlflow/agent/setup/templates/databricks.md
+++ b/mlflow/agent/setup/templates/databricks.md
@@ -1,0 +1,62 @@
+### Configure the Databricks workspace
+
+You're sending traces to a Databricks workspace (`MLFLOW_TRACKING_URI={{ tracking_uri }}`).
+
+Before instrumenting the app, verify that Databricks auth is configured.
+The Databricks SDK resolves credentials from env vars, `~/.databrickscfg`
+profiles, OAuth, and other sources, so don't hard-require any specific env
+var: just confirm the SDK can authenticate.
+
+```python
+from databricks.sdk import WorkspaceClient
+
+WorkspaceClient().current_user.me()
+```
+
+If that call raises, stop and ask the user to configure auth (for example via `databricks auth login`, a `~/.databrickscfg` profile, or by exporting `DATABRICKS_HOST` and `DATABRICKS_TOKEN`). Never write secrets into files in the repo.
+
+Pin the active experiment to the workspace path picked at setup time
+(tracking URI itself is wired in step 2 below, so don't repeat that here):
+
+```python
+import mlflow
+
+mlflow.set_experiment("{{ experiment_path }}")
+```
+
+The path must be a workspace path such as `/Users/<email>/<name>` or
+`/Shared/<team>/<name>`. MLflow creates it on first use.
+
+**Optional: store traces in Unity Catalog.** If the user wants traces backed
+by a UC Delta table (requires `mlflow>=3.11` and a SQL warehouse), ask for
+the catalog, schema, table prefix, and SQL warehouse ID, then:
+
+```python
+import mlflow
+from mlflow.entities.trace_location import UnityCatalog
+
+mlflow.set_experiment(
+    experiment_name="{{ experiment_path }}",
+    trace_location=UnityCatalog(
+        catalog_name="<catalog>",
+        schema_name="<schema>",
+        table_prefix="<prefix>",
+    ),
+)
+```
+
+Skip this block entirely if the user does not ask for UC-backed traces.
+
+#### References
+
+If anything in this section is ambiguous, consult the authoritative Databricks
+docs before guessing:
+
+- MLflow tracing from a local IDE:
+  https://docs.databricks.com/aws/en/mlflow3/genai/getting-started/tracing/tracing-ide
+- Storing traces in Unity Catalog:
+  https://docs.databricks.com/aws/en/mlflow3/genai/tracing/trace-unity-catalog
+- Workspace experiment paths:
+  https://docs.databricks.com/aws/en/mlflow/experiments
+- Databricks SDK authentication:
+  https://docs.databricks.com/aws/en/dev-tools/auth/index.html

--- a/tests/agent/test_cli.py
+++ b/tests/agent/test_cli.py
@@ -206,3 +206,36 @@ def test_setup_records_failure_on_abort(tmp_git_repo: Path):
         {"agent": "claude", "print_prompt": True, "skills_install_confirmed": None},
         success=False,
     )
+
+
+def test_setup_databricks_prompts_for_workspace_path(tmp_git_repo: Path):
+    with mock.patch(
+        "mlflow.agent.agents.shutil.which", return_value="/usr/local/bin/claude"
+    ) as mock_which:
+        result = CliRunner().invoke(
+            setup,
+            ["--agent", "claude", "--print"],
+            input="1\ndatabricks\n/Users/me@example.com/my-app\n",
+        )
+    assert result.exit_code == 0, result.stderr
+    assert "Workspace experiment path" in result.stderr
+    assert "Configure the Databricks workspace" in result.stdout
+    assert "MLFLOW_TRACKING_URI=databricks" in result.stdout
+    assert "WorkspaceClient().current_user.me()" in result.stdout
+    assert 'mlflow.set_experiment("/Users/me@example.com/my-app")' in result.stdout
+    assert "Start a local MLflow tracking server" not in result.stdout
+    mock_which.assert_called()
+
+
+def test_setup_databricks_rejects_non_absolute_experiment_path(tmp_git_repo: Path):
+    with mock.patch(
+        "mlflow.agent.agents.shutil.which", return_value="/usr/local/bin/claude"
+    ) as mock_which:
+        result = CliRunner().invoke(
+            setup,
+            ["--agent", "claude", "--print"],
+            input="1\ndatabricks\nmy-app\n",
+        )
+    assert result.exit_code != 0
+    assert "must start with '/'" in result.stderr
+    mock_which.assert_called()

--- a/tests/agent/test_prompt.py
+++ b/tests/agent/test_prompt.py
@@ -30,10 +30,10 @@ def test_render_raises_on_missing_key():
 
 
 def test_build_prompt_with_user_uri_omits_local_server_section(tmp_path: Path):
-    out = build_prompt(tmp_path, AGENTS["claude"], "databricks")
+    out = build_prompt(tmp_path, AGENTS["claude"], "http://remote:5000")
     assert "Start a local MLflow tracking server" not in out
-    assert "MLFLOW_TRACKING_URI=databricks" in out
-    assert 'mlflow.set_tracking_uri("databricks")' in out
+    assert "MLFLOW_TRACKING_URI=http://remote:5000" in out
+    assert 'mlflow.set_tracking_uri("http://remote:5000")' in out
 
 
 def test_build_prompt_with_local_server_port_bakes_url(tmp_path: Path):
@@ -49,13 +49,13 @@ def test_build_prompt_with_local_server_port_bakes_url(tmp_path: Path):
 
 
 def test_build_prompt_skills_installed_uses_agent_skills_dir(tmp_path: Path):
-    out = build_prompt(tmp_path, AGENTS["claude"], "databricks", skills_installed=True)
+    out = build_prompt(tmp_path, AGENTS["claude"], "http://remote:5000", skills_installed=True)
     assert "has been installed at `.claude/skills/`" in out
     assert "are already installed; do not\n  overwrite them." in out
 
 
 def test_build_prompt_skills_declined_uses_bundled_path(tmp_path: Path):
-    out = build_prompt(tmp_path, AGENTS["claude"], "databricks", skills_installed=False)
+    out = build_prompt(tmp_path, AGENTS["claude"], "http://remote:5000", skills_installed=False)
     assert "bundled at" in out
     assert "/mlflow/assistant/skills" in out
     assert "are already installed; do not\n  overwrite them." not in out
@@ -63,13 +63,18 @@ def test_build_prompt_skills_declined_uses_bundled_path(tmp_path: Path):
 
 @pytest.mark.parametrize("skills_installed", [True, False])
 @pytest.mark.parametrize(
-    ("tracking_uri", "local_server_port"),
-    [("databricks", None), ("http://127.0.0.1:5050", 5050)],
+    ("tracking_uri", "local_server_port", "experiment_path"),
+    [
+        ("databricks", None, "/Users/me@example.com/my-app"),
+        ("http://127.0.0.1:5050", 5050, None),
+        ("http://some-remote:5000", None, None),
+    ],
 )
 def test_build_prompt_renders_all_placeholders(
     tmp_path: Path,
     tracking_uri: str,
     local_server_port: int | None,
+    experiment_path: str | None,
     skills_installed: bool,
 ):
     out = build_prompt(
@@ -77,7 +82,32 @@ def test_build_prompt_renders_all_placeholders(
         AGENTS["claude"],
         tracking_uri,
         local_server_port=local_server_port,
+        experiment_path=experiment_path,
         skills_installed=skills_installed,
     )
     assert "{{" not in out
     assert "}}" not in out
+
+
+def test_build_prompt_databricks_injects_workspace_section(tmp_path: Path):
+    out = build_prompt(
+        tmp_path,
+        AGENTS["claude"],
+        "databricks",
+        experiment_path="/Users/me@example.com/my-app",
+    )
+    assert "Configure the Databricks workspace" in out
+    assert "WorkspaceClient().current_user.me()" in out
+    assert 'mlflow.set_experiment("/Users/me@example.com/my-app")' in out
+    assert "Start a local MLflow tracking server" not in out
+
+
+def test_build_prompt_databricks_without_experiment_path_raises(tmp_path: Path):
+    with pytest.raises(ValueError, match="experiment_path is required"):
+        build_prompt(tmp_path, AGENTS["claude"], "databricks")
+
+
+def test_build_prompt_with_user_uri_omits_databricks_section(tmp_path: Path):
+    out = build_prompt(tmp_path, AGENTS["claude"], "http://127.0.0.1:5001")
+    assert "Configure the Databricks workspace" not in out
+    assert "WorkspaceClient" not in out


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23783

### What changes are proposed in this pull request?

Adds a Databricks workspace flow to `mlflow agent setup`. When a user enters `databricks` as their tracking URI, the CLI prompts for a workspace experiment path (e.g. `/Users/you@example.com/my-app`) and generates a Databricks-specific setup prompt that includes:

- `MLFLOW_TRACKING_URI=databricks` configuration
- Workspace credential setup via `databricks-sdk`
- Experiment path validation (must start with `/`)
- A new `databricks.md` template with Databricks-specific instructions

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

New tests in `tests/agent/test_cli.py`:
- `test_setup_databricks_prompts_for_workspace_path` - verifies the interactive Databricks flow end-to-end
- `test_setup_databricks_rejects_non_absolute_experiment_path` - validates path must start with `/`

New tests in `tests/agent/test_prompt.py`:
- `test_build_prompt_databricks_injects_workspace_section` - verifies the Databricks template is injected into the prompt
- `test_build_prompt_databricks_without_experiment_path_raises` - error when experiment_path is missing for databricks URI
- `test_build_prompt_with_user_uri_omits_databricks_section` - Databricks section not included for non-databricks URIs
- Parametrized `test_build_prompt_renders_all_placeholders` extended with databricks cases

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. `mlflow agent setup` now supports Databricks workspaces as a tracking backend. When users enter `databricks` as the tracking URI, they are prompted for a workspace experiment path and receive Databricks-specific setup instructions.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release