### PR TITLE
Support common RETRIEVER chunk content fields

### DIFF
--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -814,11 +814,34 @@ def _get_top_level_retrieval_spans(trace: Trace) -> list[Span]:
     return top_level_retrieval_spans
 
 
+_RETRIEVER_DOCUMENT_CONTENT_KEYS = ("page_content", "content", "text")
+_RETRIEVER_DOCUMENT_METADATA_KEYS = ("metadata",)
+
+
 def _parse_chunk(chunk: Any) -> dict[str, Any] | None:
     if not isinstance(chunk, dict):
         return None
 
-    doc = {"content": chunk.get("page_content")}
+    content_key = next(
+        (key for key in _RETRIEVER_DOCUMENT_CONTENT_KEYS if key in chunk),
+        None,
+    )
+    content = chunk.get(content_key) if content_key is not None else None
+
+    if content_key is None:
+        # Many retriever libraries store source/citation details under metadata.
+        # Avoid warning for metadata-only chunks, but warn when other fields are
+        # present because they may contain text under an unsupported key.
+        non_metadata_keys = set(chunk) - set(_RETRIEVER_DOCUMENT_METADATA_KEYS)
+        if non_metadata_keys:
+            _logger.warning(
+                "RETRIEVER span document does not contain any recognized text field. "
+                "Expected one of %s. Found fields: %s",
+                list(_RETRIEVER_DOCUMENT_CONTENT_KEYS),
+                sorted(chunk.keys()),
+            )
+
+    doc = {"content": content}
     if doc_uri := chunk.get("metadata", {}).get("doc_uri"):
         doc["doc_uri"] = doc_uri
     return doc

--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -816,6 +816,7 @@ def _get_top_level_retrieval_spans(trace: Trace) -> list[Span]:
 
 _RETRIEVER_DOCUMENT_CONTENT_KEYS = ("page_content", "content", "text")
 _RETRIEVER_DOCUMENT_METADATA_KEYS = ("metadata",)
+_WARNED_RETRIEVER_DOCUMENT_KEY_SETS: set[frozenset[str]] = set()
 
 
 def _parse_chunk(chunk: Any) -> dict[str, Any] | None:
@@ -834,15 +835,20 @@ def _parse_chunk(chunk: Any) -> dict[str, Any] | None:
         # present because they may contain text under an unsupported key.
         non_metadata_keys = set(chunk) - set(_RETRIEVER_DOCUMENT_METADATA_KEYS)
         if non_metadata_keys:
-            _logger.warning(
-                "RETRIEVER span document does not contain any recognized text field. "
-                "Expected one of %s. Found fields: %s",
-                list(_RETRIEVER_DOCUMENT_CONTENT_KEYS),
-                sorted(chunk.keys()),
-            )
+            key_set = frozenset(chunk.keys())
+            if key_set not in _WARNED_RETRIEVER_DOCUMENT_KEY_SETS:
+                _WARNED_RETRIEVER_DOCUMENT_KEY_SETS.add(key_set)
+                _logger.warning(
+                    "RETRIEVER span document does not contain any recognized text field. "
+                    "Expected one of %s. Found fields: %s",
+                    list(_RETRIEVER_DOCUMENT_CONTENT_KEYS),
+                    sorted(map(str, chunk.keys())),
+                )
 
+    metadata = chunk.get("metadata")
+    metadata = metadata if isinstance(metadata, dict) else {}
     doc = {"content": content}
-    if doc_uri := chunk.get("metadata", {}).get("doc_uri"):
+    if doc_uri := metadata.get("doc_uri"):
         doc["doc_uri"] = doc_uri
     return doc
 

--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -4,6 +4,8 @@ import inspect
 import json
 import logging
 import math
+import threading
+from collections import OrderedDict
 from typing import TYPE_CHECKING, Any, Callable
 
 from cachetools.func import cached
@@ -816,7 +818,22 @@ def _get_top_level_retrieval_spans(trace: Trace) -> list[Span]:
 
 _RETRIEVER_DOCUMENT_CONTENT_KEYS = ("page_content", "content", "text")
 _RETRIEVER_DOCUMENT_METADATA_KEYS = ("metadata",)
-_WARNED_RETRIEVER_DOCUMENT_KEY_SETS: set[frozenset[str]] = set()
+_MAX_RETRIEVER_DOCUMENT_WARNING_KEY_SETS = 128
+_WARNED_RETRIEVER_DOCUMENT_KEY_SETS: OrderedDict[frozenset[str], None] = OrderedDict()
+_WARNED_RETRIEVER_DOCUMENT_KEY_SETS_LOCK = threading.Lock()
+
+
+def _should_warn_for_retriever_document_key_set(key_set: frozenset[str]) -> bool:
+    with _WARNED_RETRIEVER_DOCUMENT_KEY_SETS_LOCK:
+        if key_set in _WARNED_RETRIEVER_DOCUMENT_KEY_SETS:
+            _WARNED_RETRIEVER_DOCUMENT_KEY_SETS.move_to_end(key_set)
+            return False
+
+        _WARNED_RETRIEVER_DOCUMENT_KEY_SETS[key_set] = None
+        if len(_WARNED_RETRIEVER_DOCUMENT_KEY_SETS) > _MAX_RETRIEVER_DOCUMENT_WARNING_KEY_SETS:
+            _WARNED_RETRIEVER_DOCUMENT_KEY_SETS.popitem(last=False)
+
+        return True
 
 
 def _parse_chunk(chunk: Any) -> dict[str, Any] | None:
@@ -835,14 +852,13 @@ def _parse_chunk(chunk: Any) -> dict[str, Any] | None:
         # present because they may contain text under an unsupported key.
         non_metadata_keys = set(chunk) - set(_RETRIEVER_DOCUMENT_METADATA_KEYS)
         if non_metadata_keys:
-            key_set = frozenset(chunk.keys())
-            if key_set not in _WARNED_RETRIEVER_DOCUMENT_KEY_SETS:
-                _WARNED_RETRIEVER_DOCUMENT_KEY_SETS.add(key_set)
+            key_set = frozenset(map(str, chunk.keys()))
+            if _should_warn_for_retriever_document_key_set(key_set):
                 _logger.warning(
                     "RETRIEVER span document does not contain any recognized text field. "
                     "Expected one of %s. Found fields: %s",
                     list(_RETRIEVER_DOCUMENT_CONTENT_KEYS),
-                    sorted(map(str, chunk.keys())),
+                    sorted(key_set),
                 )
 
     metadata = chunk.get("metadata")

--- a/tests/genai/utils/test_trace_utils.py
+++ b/tests/genai/utils/test_trace_utils.py
@@ -23,6 +23,7 @@ from mlflow.genai.scorers.base import scorer
 from mlflow.genai.utils.trace_utils import (
     _does_store_support_trace_linking,
     _extract_tool_name_from_span,
+    _parse_chunk,
     _should_keep_trace,
     _try_extract_available_tools_with_llm,
     clean_up_extra_traces,
@@ -645,6 +646,95 @@ def test_parse_outputs_to_str(output_data, expected):
 )
 def test_is_none_or_nan(input_value, expected):
     assert is_none_or_nan(input_value) == expected
+
+
+def test_parse_chunk_uses_page_content_by_default():
+    chunk = {
+        "page_content": "Page content text",
+        "metadata": {"doc_uri": "doc-1"},
+    }
+
+    assert _parse_chunk(chunk) == {
+        "content": "Page content text",
+        "doc_uri": "doc-1",
+    }
+
+
+def test_parse_chunk_falls_back_to_content_field():
+    chunk = {
+        "content": "Content text",
+        "metadata": {"doc_uri": "doc-1"},
+    }
+
+    assert _parse_chunk(chunk) == {
+        "content": "Content text",
+        "doc_uri": "doc-1",
+    }
+
+
+def test_parse_chunk_falls_back_to_text_field():
+    chunk = {
+        "text": "Text field content",
+        "metadata": {"doc_uri": "doc-1"},
+    }
+
+    assert _parse_chunk(chunk) == {
+        "content": "Text field content",
+        "doc_uri": "doc-1",
+    }
+
+
+def test_parse_chunk_prefers_page_content_over_aliases():
+    chunk = {
+        "page_content": "Preferred text",
+        "content": "Fallback content",
+        "text": "Fallback text",
+    }
+
+    assert _parse_chunk(chunk) == {"content": "Preferred text"}
+
+
+def test_parse_chunk_warns_for_unrecognized_text_field(monkeypatch):
+    logged_messages = []
+
+    monkeypatch.setattr(
+        "mlflow.genai.utils.trace_utils._logger.warning",
+        lambda message, *args: logged_messages.append(message % args),
+    )
+
+    chunk = {
+        "body": "Body text",
+        "metadata": {"doc_uri": "doc-1"},
+    }
+
+    parsed_chunk = _parse_chunk(chunk)
+
+    assert parsed_chunk == {"content": None, "doc_uri": "doc-1"}
+    assert len(logged_messages) == 1
+    assert "does not contain any recognized text field" in logged_messages[0]
+    assert "body" in logged_messages[0]
+
+
+def test_parse_chunk_does_not_warn_for_metadata_only_chunk(monkeypatch):
+    logged_messages = []
+
+    monkeypatch.setattr(
+        "mlflow.genai.utils.trace_utils._logger.warning",
+        lambda message, *args: logged_messages.append(message % args),
+    )
+
+    chunk = {
+        "metadata": {"doc_uri": "doc-1"},
+    }
+
+    parsed_chunk = _parse_chunk(chunk)
+
+    assert parsed_chunk == {"content": None, "doc_uri": "doc-1"}
+    assert logged_messages == []
+
+
+def test_parse_chunk_returns_none_for_non_dict_chunk():
+    assert _parse_chunk("not a chunk") is None
 
 
 def test_extract_expectations_from_trace_with_source_filter():

--- a/tests/genai/utils/test_trace_utils.py
+++ b/tests/genai/utils/test_trace_utils.py
@@ -21,6 +21,7 @@ from mlflow.genai.evaluation.entities import EvalItem
 from mlflow.genai.evaluation.utils import is_none_or_nan
 from mlflow.genai.scorers.base import scorer
 from mlflow.genai.utils.trace_utils import (
+    _WARNED_RETRIEVER_DOCUMENT_KEY_SETS,
     _does_store_support_trace_linking,
     _extract_tool_name_from_span,
     _parse_chunk,
@@ -648,6 +649,41 @@ def test_is_none_or_nan(input_value, expected):
     assert is_none_or_nan(input_value) == expected
 
 
+def test_parse_chunk_preserves_empty_page_content():
+    assert _parse_chunk({"page_content": ""}) == {"content": ""}
+
+
+def test_parse_chunk_non_dict_metadata_does_not_drop_valid_content():
+    assert _parse_chunk({"page_content": "text", "metadata": "bad metadata"}) == {"content": "text"}
+
+
+def test_parse_chunk_page_content_none_beats_populated_aliases():
+    chunk = {
+        "page_content": None,
+        "content": "Fallback content",
+        "text": "Fallback text",
+    }
+
+    assert _parse_chunk(chunk) == {"content": None}
+
+
+def test_parse_chunk_warns_once_per_unrecognized_key_set(monkeypatch):
+    _WARNED_RETRIEVER_DOCUMENT_KEY_SETS.clear()
+    logged_messages = []
+
+    monkeypatch.setattr(
+        "mlflow.genai.utils.trace_utils._logger.warning",
+        lambda message, *args: logged_messages.append(message % args),
+    )
+
+    _parse_chunk({"body": "Body text", "metadata": {"doc_uri": "doc-1"}})
+    _parse_chunk({"body": "Another body text", "metadata": {"doc_uri": "doc-2"}})
+
+    assert len(logged_messages) == 1
+    assert "does not contain any recognized text field" in logged_messages[0]
+    assert "body" in logged_messages[0]
+
+
 def test_parse_chunk_uses_page_content_by_default():
     chunk = {
         "page_content": "Page content text",
@@ -695,6 +731,7 @@ def test_parse_chunk_prefers_page_content_over_aliases():
 
 
 def test_parse_chunk_warns_for_unrecognized_text_field(monkeypatch):
+    _WARNED_RETRIEVER_DOCUMENT_KEY_SETS.clear()
     logged_messages = []
 
     monkeypatch.setattr(
@@ -716,6 +753,7 @@ def test_parse_chunk_warns_for_unrecognized_text_field(monkeypatch):
 
 
 def test_parse_chunk_does_not_warn_for_metadata_only_chunk(monkeypatch):
+    _WARNED_RETRIEVER_DOCUMENT_KEY_SETS.clear()
     logged_messages = []
 
     monkeypatch.setattr(

--- a/tests/genai/utils/test_trace_utils.py
+++ b/tests/genai/utils/test_trace_utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+from collections import OrderedDict
 from typing import Any
 from unittest import mock
 
@@ -21,7 +22,6 @@ from mlflow.genai.evaluation.entities import EvalItem
 from mlflow.genai.evaluation.utils import is_none_or_nan
 from mlflow.genai.scorers.base import scorer
 from mlflow.genai.utils.trace_utils import (
-    _WARNED_RETRIEVER_DOCUMENT_KEY_SETS,
     _does_store_support_trace_linking,
     _extract_tool_name_from_span,
     _parse_chunk,
@@ -667,8 +667,15 @@ def test_parse_chunk_page_content_none_beats_populated_aliases():
     assert _parse_chunk(chunk) == {"content": None}
 
 
+def _reset_retriever_document_warning_cache(monkeypatch):
+    monkeypatch.setattr(
+        "mlflow.genai.utils.trace_utils._WARNED_RETRIEVER_DOCUMENT_KEY_SETS",
+        OrderedDict(),
+    )
+
+
 def test_parse_chunk_warns_once_per_unrecognized_key_set(monkeypatch):
-    _WARNED_RETRIEVER_DOCUMENT_KEY_SETS.clear()
+    _reset_retriever_document_warning_cache(monkeypatch)
     logged_messages = []
 
     monkeypatch.setattr(
@@ -731,7 +738,7 @@ def test_parse_chunk_prefers_page_content_over_aliases():
 
 
 def test_parse_chunk_warns_for_unrecognized_text_field(monkeypatch):
-    _WARNED_RETRIEVER_DOCUMENT_KEY_SETS.clear()
+    _reset_retriever_document_warning_cache(monkeypatch)
     logged_messages = []
 
     monkeypatch.setattr(
@@ -753,7 +760,7 @@ def test_parse_chunk_warns_for_unrecognized_text_field(monkeypatch):
 
 
 def test_parse_chunk_does_not_warn_for_metadata_only_chunk(monkeypatch):
-    _WARNED_RETRIEVER_DOCUMENT_KEY_SETS.clear()
+    _reset_retriever_document_warning_cache(monkeypatch)
     logged_messages = []
 
     monkeypatch.setattr(


### PR DESCRIPTION
### Related Issues/PRs

Addresses the consumer-side `_parse_chunk` part of #23817.

### What changes are proposed in this pull request?

This PR updates `RETRIEVER` chunk parsing to recognize common flat text fields in addition to `page_content`.

Changes:

- Preserve existing `page_content` behavior and priority.
- Fall back to `content` and `text` for common retriever output shapes.
- Emit a warning when a non-metadata-only chunk has no recognized text field.
- Add regression tests for aliases, field priority, warning behavior, metadata-only chunks, and non-dict chunks.

Note: nested OpenInference/OTel document shapes are being handled separately in #23818.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Tested with:
```
pytest tests/genai/utils/test_trace_utils.py -k "parse_chunk" -x
ruff check mlflow/genai/utils/trace_utils.py tests/genai/utils/test_trace_utils.py --fix
ruff format mlflow/genai/utils/trace_utils.py tests/genai/utils/test_trace_utils.py
pre-commit run --files \
  mlflow/genai/utils/trace_utils.py \
  tests/genai/utils/test_trace_utils.py
```

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`RETRIEVER` span document parsing now recognizes common flat text fields (`content` and `text`) in addition to `page_content`, and warns when a non-metadata-only document chunk has no recognized text field.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release