### PR TITLE
Drop the redundant Close button from the Review questions modal

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ManageQuestionsModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ManageQuestionsModal.tsx
@@ -60,12 +60,10 @@ export const ManageQuestionsModal = ({ experimentId, onClose }: { experimentId: 
         onCancel={onClose}
         title={<FormattedMessage defaultMessage="Review questions" description="Manage review questions modal title" />}
         footer={
-          <div css={{ display: 'flex', justifyContent: 'space-between' }}>
+          <div css={{ display: 'flex', justifyContent: 'flex-end' }}>
+            {/* No explicit Close button — the modal's top-right "X" (onCancel) closes it. */}
             <Button componentId={`${CID}.add`} icon={<PlusIcon />} onClick={openCreate}>
               <FormattedMessage defaultMessage="Add question" description="Manage review questions: add button" />
-            </Button>
-            <Button componentId={`${CID}.close`} onClick={onClose}>
-              <FormattedMessage defaultMessage="Close" description="Manage review questions: close button" />
             </Button>
           </div>
         }

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -11539,10 +11539,6 @@
     "defaultMessage": "Toggle visibility of evaluation runs",
     "description": "Evaluation runs table > toggle visibility of runs > accessible label"
   },
-  "wKYkfj": {
-    "defaultMessage": "Close",
-    "description": "Manage review questions: close button"
-  },
   "wLoYcw": {
     "defaultMessage": "Duplicate ({count})",
     "description": "Gateway > Endpoints list > Duplicate button with count"


### PR DESCRIPTION
### Related Issues/PRs

Relates to the OSS review-queue review UI.

### What changes are proposed in this pull request?

The "Review questions" modal's top-right `X` already closes it (`onCancel`), so the footer "Close" button was redundant. Keep just the "Add question" action, right-aligned in the footer.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.
