### PR TITLE
Fix AI Gateway SSE large-frame read limit

### DIFF
--- a/mlflow/gateway/providers/utils.py
+++ b/mlflow/gateway/providers/utils.py
@@ -26,7 +26,9 @@ async def _aiohttp_post(headers: dict[str, str], base_url: str, path: str, paylo
     request_headers = {k: v for k, v in headers.items() if k.lower() != "accept-encoding"}
     request_headers["Accept-Encoding"] = SUPPORTED_ACCEPT_ENCODING
     url = append_to_uri_path(base_url, path)
-    async with aiohttp.ClientSession(headers=request_headers) as session:
+    async with aiohttp.ClientSession(
+        headers=request_headers, read_bufsize=2**20
+    ) as session:
         timeout = aiohttp.ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get())
         async with session.post(url, json=payload, timeout=timeout) as response:
             yield response

--- a/tests/gateway/providers/test_provider_utils.py
+++ b/tests/gateway/providers/test_provider_utils.py
@@ -77,6 +77,21 @@ async def test_aiohttp_post_uses_timeout_from_env_var(monkeypatch):
     assert mock_client.post.call_args.kwargs["timeout"].total == 2
 
 
+@pytest.mark.asyncio
+async def test_aiohttp_post_sets_read_bufsize_for_large_sse_lines():
+    mock_client = mock_http_client(MockAsyncResponse({}))
+    with mock.patch("aiohttp.ClientSession", return_value=mock_client) as mock_session_cls:
+        async with _aiohttp_post(
+            headers={"Authorization": "Bearer key"},
+            base_url="https://api.example.com",
+            path="/v1/chat",
+            payload={"model": "x"},
+        ):
+            pass
+
+    assert mock_session_cls.call_args.kwargs["read_bufsize"] == 2**20
+
+
 @pytest.mark.parametrize(
     ("base_url", "expected"),
     [


### PR DESCRIPTION
### Related Issues/PRs

Closes #23865

### What changes are proposed in this pull request?

This PR updates the AI Gateway provider HTTP client configuration to prevent streaming failures on large SSE frames:

- Set `read_bufsize=2**20` on `aiohttp.ClientSession` in `mlflow/gateway/providers/utils.py`.
- Add a focused unit test that asserts `_aiohttp_post` configures `read_bufsize` for large SSE line handling.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added test:
- `tests/gateway/providers/test_provider_utils.py::test_aiohttp_post_sets_read_bufsize_for_large_sse_lines`

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Prevents MLflow AI Gateway streaming requests from failing with `Got more than 131072 bytes when reading` when providers emit large single SSE `data:` frames.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
