### PR TITLE
Add a "View review queue" link to the traces-added toast

### DIFF
--- a/mlflow/server/js/src/common/utils/Utils.tsx
+++ b/mlflow/server/js/src/common/utils/Utils.tsx
@@ -67,13 +67,15 @@ class Utils {
   }
 
   /**
-   * Displays the info notification in the UI.
+   * Displays the info notification in the UI. `style` is forwarded to the
+   * underlying notification (e.g. to widen it past the default fixed width so
+   * single-line content doesn't wrap).
    */
-  static displayGlobalInfoNotification(content: any, duration?: any) {
+  static displayGlobalInfoNotification(content: any, duration?: any, style?: any) {
     if (!Utils.#notificationsApi) {
       return;
     }
-    (Utils.#notificationsApi as any).info({ message: content, duration: duration });
+    (Utils.#notificationsApi as any).info({ message: content, duration: duration, style: style });
   }
 
   static runNameTag = 'mlflow.runName';

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueModal.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueModal.test.tsx
@@ -1,0 +1,110 @@
+import { describe, jest, it, expect, beforeEach } from '@jest/globals';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { DesignSystemProvider } from '@databricks/design-system';
+import { IntlProvider } from '@databricks/i18n';
+
+import { AddToReviewQueueModal } from './AddToReviewQueueModal';
+import Utils from '../../../common/utils/Utils';
+import { generatePath } from '../../../common/utils/RoutingUtils';
+import { RoutePaths } from '../../routes';
+
+jest.mock('../../../account/hooks', () => ({
+  useIsAuthAvailable: () => false,
+  useCurrentUserIsAdmin: () => false,
+  useCurrentUserIsWorkspaceAdmin: () => false,
+}));
+jest.mock('./hooks/useReviewer', () => ({ useReviewer: () => 'default', DEFAULT_REVIEWER: 'default' }));
+jest.mock('./hooks/useCanManageReviews', () => ({ useCanManageReviews: () => false }));
+jest.mock('./CreateReviewQueueModal', () => ({ CreateReviewQueueModal: () => null }));
+
+const mockAddItems = jest.fn<(...args: any[]) => Promise<any>>();
+jest.mock('./hooks/useAddItemsToReviewQueueMutation', () => ({
+  useAddItemsToReviewQueueMutation: () => ({
+    addItemsToReviewQueueAsync: mockAddItems,
+    isAddingItems: false,
+    error: null,
+    reset: jest.fn(),
+  }),
+}));
+
+const mockGetOrCreateUserQueue = jest.fn<(...args: any[]) => Promise<any>>();
+jest.mock('./hooks/useGetOrCreateUserQueueMutation', () => ({
+  useGetOrCreateUserQueueMutation: () => ({
+    getOrCreateUserQueueAsync: mockGetOrCreateUserQueue,
+    isResolvingUserQueue: false,
+    error: null,
+    reset: jest.fn(),
+  }),
+}));
+
+jest.mock('./hooks/useAssignableUsersQuery', () => ({
+  useAssignableUsersQuery: () => ({ users: [], isLoading: false }),
+}));
+jest.mock('./hooks/useListReviewQueuesQuery', () => ({
+  useListReviewQueuesQuery: () => ({ reviewQueues: [], isLoading: false, error: null }),
+}));
+// One experiment question, so the (no-auth) default queue is assignable.
+jest.mock('../../components/label-schemas', () => ({
+  useListLabelSchemasQuery: () => ({
+    labelSchemas: [{ schema_id: 's1', name: 'Q1', type: 'FEEDBACK', input: { text: {} } }],
+    isLoading: false,
+  }),
+  LabelSchemaFormModal: () => null,
+}));
+
+const renderModal = () =>
+  render(
+    <IntlProvider locale="en">
+      <DesignSystemProvider>
+        <AddToReviewQueueModal
+          experimentId="exp-1"
+          visible
+          setVisible={jest.fn()}
+          selectedTraceInfos={[{ trace_id: 'tr-1' } as any]}
+        />
+      </DesignSystemProvider>
+    </IntlProvider>,
+  );
+
+describe('AddToReviewQueueModal', () => {
+  beforeEach(() => {
+    mockAddItems.mockReset();
+    mockAddItems.mockResolvedValue({});
+    mockGetOrCreateUserQueue.mockReset();
+    mockGetOrCreateUserQueue.mockResolvedValue({ review_queue: { queue_id: 'rq-default' } });
+    jest.spyOn(Utils, 'displayGlobalInfoNotification').mockImplementation(() => {});
+  });
+
+  it('routes the traces and shows a confirmation toast when a destination is selected', async () => {
+    renderModal();
+
+    // Open the destination picker and select the (no-auth) default queue.
+    fireEvent.click(screen.getByRole('combobox'));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Default queue' }));
+
+    // Confirm.
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+    await waitFor(() => expect(mockAddItems).toHaveBeenCalledWith({ queue_id: 'rq-default', item_ids: ['tr-1'] }));
+    expect(Utils.displayGlobalInfoNotification).toHaveBeenCalledTimes(1);
+
+    const [toastNode, , style] = jest.mocked(Utils.displayGlobalInfoNotification).mock.calls[0];
+    // The toast widens past the default fixed width so the link stays on one line.
+    expect(style).toEqual({ width: 'auto' });
+    // The toast embeds a Link pointing at the experiment's review-queue page.
+    const findLinkTarget = (node: any): string | undefined => {
+      if (!node || typeof node !== 'object') return undefined;
+      if (node.props?.to) return node.props.to;
+      for (const child of React.Children.toArray(node.props?.children)) {
+        const target = findLinkTarget(child);
+        if (target) return target;
+      }
+      return undefined;
+    };
+    expect(findLinkTarget(toastNode)).toBe(
+      generatePath(RoutePaths.experimentPageTabReviewQueue, { experimentId: 'exp-1' }),
+    );
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueModal.tsx
@@ -22,6 +22,8 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import { LabelSchemaFormModal, useListLabelSchemasQuery } from '../../components/label-schemas';
 import { useCurrentUserIsAdmin, useCurrentUserIsWorkspaceAdmin, useIsAuthAvailable } from '../../../account/hooks';
 import Utils from '../../../common/utils/Utils';
+import { generatePath, Link } from '../../../common/utils/RoutingUtils';
+import { RoutePaths } from '../../routes';
 import { CreateReviewQueueModal } from './CreateReviewQueueModal';
 import { getQueueAssignability } from './queueAssignability';
 import { sameUser } from './queuePermissions';
@@ -242,15 +244,30 @@ export const AddToReviewQueueModal = ({
     const queueIds = Array.from(new Set([...selectedQueueIds, ...resolvedDefaultQueueIds, ...resolvedUserQueueIds]));
     await Promise.all(queueIds.map((queue_id) => addItemsToReviewQueueAsync({ queue_id, item_ids: itemIds })));
     // Confirm the add with a global toast — it must be global to survive this
-    // modal unmounting on close.
+    // modal unmounting on close. The notification holder renders inside the
+    // router, so a <Link> resolves correctly for any deployment. The message
+    // text is pre-built via `intl`. `white-space: nowrap` + the notification's
+    // `width: 'auto'` keep it on one line (widening past the default fixed
+    // width) instead of wrapping.
+    const reviewQueuePath = generatePath(RoutePaths.experimentPageTabReviewQueue, { experimentId });
     Utils.displayGlobalInfoNotification(
-      intl.formatMessage(
-        {
-          defaultMessage: 'Added {count, plural, one {# trace} other {# traces}} to review',
-          description: 'Add to review queue: success toast after traces are added',
-        },
-        { count: itemIds.length },
-      ),
+      <span css={{ whiteSpace: 'nowrap' }}>
+        {intl.formatMessage(
+          {
+            defaultMessage: 'Added {count, plural, one {# trace} other {# traces}} to review.',
+            description: 'Add to review queue: success toast after traces are added',
+          },
+          { count: itemIds.length },
+        )}{' '}
+        <Link componentId={`${CID}.toast-view-queue`} to={reviewQueuePath}>
+          {intl.formatMessage({
+            defaultMessage: 'View review queue',
+            description: 'Add to review queue: success toast link to the review queue page',
+          })}
+        </Link>
+      </span>,
+      undefined,
+      { width: 'auto' },
     );
     handleClose();
   };

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -4275,6 +4275,10 @@
     "defaultMessage": "Artifact evaluation",
     "description": "A tooltip for the view mode switcher in the experiment view, corresponding to artifact evaluation view"
   },
+  "LWkwgO": {
+    "defaultMessage": "Added {count, plural, one {# trace} other {# traces}} to review.",
+    "description": "Add to review queue: success toast after traces are added"
+  },
   "LXz6c5": {
     "defaultMessage": "This setting enables UI telemetry data collection. Learn more about what types of data are collected in our {documentation}.",
     "description": "Enable telemetry settings description"
@@ -4426,10 +4430,6 @@
   "MP+H1B": {
     "defaultMessage": "No webhooks configured. Create one to get started. <link>Learn more about webhooks.</link>",
     "description": "Empty state for webhooks list"
-  },
-  "MP8Hv3": {
-    "defaultMessage": "Added {count, plural, one {# trace} other {# traces}} to review",
-    "description": "Add to review queue: success toast after traces are added"
   },
   "MQ4Voz": {
     "defaultMessage": "{count, plural, one {Input} other {Inputs}}",
@@ -10342,6 +10342,10 @@
   "pzL5+U": {
     "defaultMessage": "Tracing",
     "description": "Feature card title for tracing"
+  },
+  "q/lZfS": {
+    "defaultMessage": "View review queue",
+    "description": "Add to review queue: success toast link to the review queue page"
   },
   "q/zoT3": {
     "defaultMessage": "Tokens",


### PR DESCRIPTION
### Related Issues/PRs

Relates to the OSS review-queue review UI.

### What changes are proposed in this pull request?

After flagging traces for review, the success toast links to the experiment's Review tab so the reviewer can jump straight to the queue. The link uses the workspace-aware `Link` (which preserves the active workspace and resolves correctly under any router/basename), and the toast stays on one line (`white-space: nowrap` plus the notification's `width: 'auto'`, via a small backward-compatible `style` argument on the shared `displayGlobalInfoNotification`). Adds an `AddToReviewQueueModal` unit test covering the confirm-and-toast flow.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.
