### PR TITLE
Reword and i18n the Add-question (review question) form

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/label-schemas/LabelSchemaFormRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/label-schemas/LabelSchemaFormRenderer.tsx
@@ -11,7 +11,7 @@ import {
   Typography,
   useDesignSystemTheme,
 } from '@databricks/design-system';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import { Controller, type Control } from 'react-hook-form';
 import { useDrag, useDrop } from 'react-dnd';
 
@@ -45,6 +45,7 @@ const COMPONENT_PREFIX = 'mlflow.experiment-label-schemas.form';
 
 export const LabelSchemaFormRenderer = ({ control, isEdit, errors, watchedValues }: LabelSchemaFormRendererProps) => {
   const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
   const { inputKind } = watchedValues;
   return (
     <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
@@ -52,7 +53,7 @@ export const LabelSchemaFormRenderer = ({ control, isEdit, errors, watchedValues
         <Typography.Text color="error" css={{ marginBottom: -theme.spacing.sm }}>
           <FormattedMessage
             defaultMessage="Disabled fields are fixed after creation."
-            description="Label schema edit-mode notice explaining why some fields are disabled"
+            description="Review question edit-mode notice explaining why some fields are disabled"
           />
         </Typography.Text>
       )}
@@ -62,12 +63,12 @@ export const LabelSchemaFormRenderer = ({ control, isEdit, errors, watchedValues
           required
           infoPopoverContents={
             <FormattedMessage
-              defaultMessage="The prompt shown to the reviewer for this label."
-              description="Label schema name hint"
+              defaultMessage="The question shown to the reviewer."
+              description="Review question name hint"
             />
           }
         >
-          <FormattedMessage defaultMessage="Prompt to reviewer" description="Label schema name input" />
+          <FormattedMessage defaultMessage="Question for reviewer" description="Review question name input" />
         </FormUI.Label>
         <Controller
           name="name"
@@ -78,7 +79,10 @@ export const LabelSchemaFormRenderer = ({ control, isEdit, errors, watchedValues
               id={`${COMPONENT_PREFIX}.name`}
               {...field}
               disabled={isEdit}
-              placeholder="Is the answer correct?"
+              placeholder={intl.formatMessage({
+                defaultMessage: 'Is the answer correct?',
+                description: 'Review question name input placeholder',
+              })}
             />
           )}
         />
@@ -87,7 +91,7 @@ export const LabelSchemaFormRenderer = ({ control, isEdit, errors, watchedValues
 
       <div css={{ display: 'flex', flexDirection: 'column' }}>
         <FormUI.Label htmlFor={`${COMPONENT_PREFIX}.instruction`}>
-          <FormattedMessage defaultMessage="Instructions (optional)" description="Label schema instruction input" />
+          <FormattedMessage defaultMessage="Instructions (optional)" description="Review question instruction input" />
         </FormUI.Label>
         <Controller
           name="instruction"
@@ -98,7 +102,10 @@ export const LabelSchemaFormRenderer = ({ control, isEdit, errors, watchedValues
               id={`${COMPONENT_PREFIX}.instruction`}
               {...field}
               rows={3}
-              placeholder="Instructions for reviewers on how to complete this label"
+              placeholder={intl.formatMessage({
+                defaultMessage: 'Instructions for reviewers on how to answer this question',
+                description: 'Review question instruction input placeholder',
+              })}
             />
           )}
         />
@@ -109,8 +116,8 @@ export const LabelSchemaFormRenderer = ({ control, isEdit, errors, watchedValues
       <div css={{ display: 'flex', flexDirection: 'column' }}>
         <FormUI.Label htmlFor={`${COMPONENT_PREFIX}.type`} required>
           <FormattedMessage
-            defaultMessage="Label type"
-            description="Label schema feedback-vs-expectation selector label"
+            defaultMessage="Answer type"
+            description="Review question feedback-vs-expectation selector label"
           />
         </FormUI.Label>
         <Controller
@@ -125,8 +132,15 @@ export const LabelSchemaFormRenderer = ({ control, isEdit, errors, watchedValues
               onChange={(e) => field.onChange(e.target.value as LabelSchemaType)}
               disabled={isEdit}
             >
-              <Radio value="FEEDBACK">Feedback</Radio>
-              <Radio value="EXPECTATION">Expectation (ground truth)</Radio>
+              <Radio value="FEEDBACK">
+                <FormattedMessage defaultMessage="Feedback" description="Review question answer type: feedback" />
+              </Radio>
+              <Radio value="EXPECTATION">
+                <FormattedMessage
+                  defaultMessage="Expectation (ground truth)"
+                  description="Review question answer type: expectation"
+                />
+              </Radio>
             </Radio.Group>
           )}
         />
@@ -134,7 +148,7 @@ export const LabelSchemaFormRenderer = ({ control, isEdit, errors, watchedValues
 
       <div css={{ display: 'flex', flexDirection: 'column' }}>
         <FormUI.Label htmlFor={`${COMPONENT_PREFIX}.input-kind`} required>
-          <FormattedMessage defaultMessage="Input type" description="Label schema input variant selector" />
+          <FormattedMessage defaultMessage="Input type" description="Review question input variant selector" />
         </FormUI.Label>
         <Controller
           name="inputKind"
@@ -148,10 +162,18 @@ export const LabelSchemaFormRenderer = ({ control, isEdit, errors, watchedValues
               onChange={(e) => field.onChange(e.target.value as LabelSchemaInputKind)}
               disabled={isEdit}
             >
-              <Radio value="pass_fail">Pass / Fail</Radio>
-              <Radio value="categorical">Categorical</Radio>
-              <Radio value="numeric">Numeric</Radio>
-              <Radio value="text">Text</Radio>
+              <Radio value="pass_fail">
+                <FormattedMessage defaultMessage="Pass / Fail" description="Review question input type: pass/fail" />
+              </Radio>
+              <Radio value="categorical">
+                <FormattedMessage defaultMessage="Categorical" description="Review question input type: categorical" />
+              </Radio>
+              <Radio value="numeric">
+                <FormattedMessage defaultMessage="Numeric" description="Review question input type: numeric" />
+              </Radio>
+              <Radio value="text">
+                <FormattedMessage defaultMessage="Text" description="Review question input type: text" />
+              </Radio>
             </Radio.Group>
           )}
         />
@@ -186,7 +208,7 @@ export const LabelSchemaFormRenderer = ({ control, isEdit, errors, watchedValues
 
       <div css={{ display: 'flex', flexDirection: 'column' }}>
         <FormUI.Label htmlFor={`${COMPONENT_PREFIX}.enable-comment`}>
-          <FormattedMessage defaultMessage="Allow rationale" description="Label schema rationale section title" />
+          <FormattedMessage defaultMessage="Allow rationale" description="Review question rationale section title" />
         </FormUI.Label>
         <Controller
           name="enable_comment"
@@ -279,6 +301,7 @@ const DraggableOptionChip = ({
   onRemove: () => void;
 }) => {
   const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
   const ref = useRef<HTMLDivElement>(null);
   // Latest hovered edge, read at drop time (drop's closure mustn't go stale).
   const edgeRef = useRef<'before' | 'after'>('before');
@@ -360,7 +383,13 @@ const DraggableOptionChip = ({
       >
         <span
           ref={drag}
-          aria-label={`Drag to reorder ${option}`}
+          aria-label={intl.formatMessage(
+            {
+              defaultMessage: 'Drag to reorder {option}',
+              description: 'Categorical option chip: drag-handle accessibility label',
+            },
+            { option },
+          )}
           css={{
             display: 'inline-flex',
             alignItems: 'center',
@@ -390,6 +419,7 @@ const DraggableOptionChip = ({
  */
 const CategoricalOptionsEditor = ({ value, onChange }: { value: string[]; onChange: (next: string[]) => void }) => {
   const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
   const [draft, setDraft] = useState('');
   const atMax = value.length >= MAX_CATEGORICAL_OPTIONS;
 
@@ -435,7 +465,20 @@ const CategoricalOptionsEditor = ({ value, onChange }: { value: string[]; onChan
               addDraft();
             }
           }}
-          placeholder={atMax ? `Max ${MAX_CATEGORICAL_OPTIONS} options` : 'Add an option'}
+          placeholder={
+            atMax
+              ? intl.formatMessage(
+                  {
+                    defaultMessage: 'Max {max} options',
+                    description: 'Categorical options: placeholder when the option limit is reached',
+                  },
+                  { max: MAX_CATEGORICAL_OPTIONS },
+                )
+              : intl.formatMessage({
+                  defaultMessage: 'Add an option',
+                  description: 'Categorical options: add-option input placeholder',
+                })
+          }
           disabled={atMax}
           css={{ flex: 1 }}
         />
@@ -507,6 +550,7 @@ const CategoricalFields = ({ control, errors }: { control: Control<LabelSchemaFo
 
 const NumericFields = ({ control, errors }: { control: Control<LabelSchemaFormData>; errors: FormErrors }) => {
   const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
   // Min / max sit side-by-side (item 9) to save vertical space.
   return (
     <div css={{ display: 'flex', gap: theme.spacing.md }}>
@@ -531,7 +575,10 @@ const NumericFields = ({ control, errors }: { control: Control<LabelSchemaFormDa
               id={`${COMPONENT_PREFIX}.numeric.min`}
               type="number"
               {...field}
-              placeholder="No minimum"
+              placeholder={intl.formatMessage({
+                defaultMessage: 'No minimum',
+                description: 'Numeric question: min-value input placeholder when unbounded',
+              })}
             />
           )}
         />
@@ -550,7 +597,10 @@ const NumericFields = ({ control, errors }: { control: Control<LabelSchemaFormDa
               id={`${COMPONENT_PREFIX}.numeric.max`}
               type="number"
               {...field}
-              placeholder="No maximum"
+              placeholder={intl.formatMessage({
+                defaultMessage: 'No maximum',
+                description: 'Numeric question: max-value input placeholder when unbounded',
+              })}
             />
           )}
         />
@@ -562,6 +612,7 @@ const NumericFields = ({ control, errors }: { control: Control<LabelSchemaFormDa
 
 const TextFields = ({ control, errors }: { control: Control<LabelSchemaFormData>; errors: FormErrors }) => {
   const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
   return (
     <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
       <div css={{ display: 'flex', flexDirection: 'column' }}>
@@ -583,7 +634,10 @@ const TextFields = ({ control, errors }: { control: Control<LabelSchemaFormData>
               id={`${COMPONENT_PREFIX}.text.max-length`}
               type="number"
               {...field}
-              placeholder="No limit"
+              placeholder={intl.formatMessage({
+                defaultMessage: 'No limit',
+                description: 'Text question: max-length input placeholder when unbounded',
+              })}
             />
           )}
         />

--- a/mlflow/server/js/src/experiment-tracking/components/label-schemas/LabelSchemaPreview.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/label-schemas/LabelSchemaPreview.tsx
@@ -52,12 +52,12 @@ export const LabelSchemaPreview = ({ formData }: LabelSchemaPreviewProps) => {
       }}
     >
       <Typography.Text bold>
-        <FormattedMessage defaultMessage="Preview" description="Label schema preview panel header" />
+        <FormattedMessage defaultMessage="Preview" description="Review question preview panel header" />
       </Typography.Text>
       <Typography.Hint>
         <FormattedMessage
-          defaultMessage="How a reviewer sees the schema"
-          description="Label schema preview panel header subtitle"
+          defaultMessage="How a reviewer sees the question"
+          description="Review question preview panel header subtitle"
         />
       </Typography.Hint>
     </div>
@@ -108,13 +108,13 @@ export const LabelSchemaPreview = ({ formData }: LabelSchemaPreviewProps) => {
             title={
               <FormattedMessage
                 defaultMessage="Preview unavailable"
-                description="Label schema preview render-error empty title"
+                description="Review question preview render-error empty title"
               />
             }
             description={
               <FormattedMessage
-                defaultMessage="Continue editing the schema to see a preview."
-                description="Label schema preview render-error empty description"
+                defaultMessage="Continue editing the question to see a preview."
+                description="Review question preview render-error empty description"
               />
             }
           />
@@ -159,7 +159,7 @@ export const LabelSchemaPreview = ({ formData }: LabelSchemaPreviewProps) => {
             <Typography.Text color="secondary" css={{ fontStyle: 'italic' }}>
               <FormattedMessage
                 defaultMessage="(no name yet)"
-                description="Label schema preview placeholder for blank name"
+                description="Review question preview placeholder for blank name"
               />
             </Typography.Text>
           )}
@@ -190,7 +190,7 @@ export const LabelSchemaPreview = ({ formData }: LabelSchemaPreviewProps) => {
               css={{ marginTop: theme.spacing.sm }}
               placeholder={intl.formatMessage({
                 defaultMessage: 'Rationale (optional)',
-                description: 'Label schema preview free-form rationale placeholder',
+                description: 'Review question preview free-form rationale placeholder',
               })}
             />
           )}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ManageQuestionsModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ManageQuestionsModal.tsx
@@ -72,7 +72,7 @@ export const ManageQuestionsModal = ({ experimentId, onClose }: { experimentId: 
       >
         <Typography.Hint css={{ marginBottom: theme.spacing.md }}>
           <FormattedMessage
-            defaultMessage="Questions are the experiment's label schemas. Add a new one or click a question to edit it."
+            defaultMessage="Add a new question, or click a question to edit it."
             description="Manage review questions: explanatory hint"
           />
         </Typography.Hint>
@@ -157,9 +157,9 @@ export const ManageQuestionsModal = ({ experimentId, onClose }: { experimentId: 
                   )}
                   <Tag componentId={`${CID}.type-tag`} color={schema.type === 'EXPECTATION' ? 'turquoise' : 'lime'}>
                     {schema.type === 'EXPECTATION' ? (
-                      <FormattedMessage defaultMessage="Expectation" description="Label schema type: expectation" />
+                      <FormattedMessage defaultMessage="Expectation" description="Review question type: expectation" />
                     ) : (
-                      <FormattedMessage defaultMessage="Feedback" description="Label schema type: feedback" />
+                      <FormattedMessage defaultMessage="Feedback" description="Review question type: feedback" />
                     )}
                   </Tag>
                   <Button

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -27,6 +27,10 @@
     "defaultMessage": "Store it securely and restrict access to server administrators only.",
     "description": "AI Gateway setup guide > Passphrase warning security note"
   },
+  "+634bT": {
+    "defaultMessage": "Feedback",
+    "description": "Review question type: feedback"
+  },
   "+6406R": {
     "defaultMessage": "Name",
     "description": "Guardrail name label"
@@ -211,6 +215,10 @@
     "defaultMessage": "Does the app's response avoid harmful or toxic content?",
     "description": "Hint for Safety template"
   },
+  "/8w8Ea": {
+    "defaultMessage": "Pass / Fail",
+    "description": "Review question input type: pass/fail"
+  },
   "/Aup8Q": {
     "defaultMessage": "Request time",
     "description": "Column label for request time"
@@ -222,10 +230,6 @@
   "/CaNq/": {
     "defaultMessage": "A network error occurred.",
     "description": "Generic message for a network error"
-  },
-  "/CuPPV": {
-    "defaultMessage": "Rationale (optional)",
-    "description": "Label schema preview free-form rationale placeholder"
   },
   "/DcBLQ": {
     "defaultMessage": "role",
@@ -394,6 +398,10 @@
   "/yjgDc": {
     "defaultMessage": "{formattedAverage} (AVG)",
     "description": "Label showing the average value of numeric assessments"
+  },
+  "/zbm8T": {
+    "defaultMessage": "Continue editing the question to see a preview.",
+    "description": "Review question preview render-error empty description"
   },
   "0+djpP": {
     "defaultMessage": "or",
@@ -779,10 +787,6 @@
     "defaultMessage": "LLM judge",
     "description": "Section header for LLM judge selection"
   },
-  "26K5gq": {
-    "defaultMessage": "Prompt to reviewer",
-    "description": "Label schema name input"
-  },
   "26uApn": {
     "defaultMessage": "Trace archival retention updated",
     "description": "Partial save status message when experiment trace archival retention update succeeds"
@@ -1078,6 +1082,10 @@
   "3db93e": {
     "defaultMessage": "Failed to save the queue settings.",
     "description": "Queue settings: error alert title"
+  },
+  "3dtjfI": {
+    "defaultMessage": "No minimum",
+    "description": "Numeric question: min-value input placeholder when unbounded"
   },
   "3geT+I": {
     "defaultMessage": "Use the log artifact APIs to store file outputs from MLflow runs.",
@@ -2063,6 +2071,10 @@
     "defaultMessage": "Delete Model Version",
     "description": "Title text for model version deletion modal in model versions view page"
   },
+  "98al2/": {
+    "defaultMessage": "Instructions (optional)",
+    "description": "Review question instruction input"
+  },
   "98v9a0": {
     "defaultMessage": "The guidelines LLM judge determines whether the response adheres to the guidelines provided. All responses must adhere to guidelines.",
     "description": "Evaluation results > known type of evaluation result assessment > guidelines judge."
@@ -2515,6 +2527,10 @@
     "defaultMessage": "We support multiple experiment types, each with its own set of features. Please select the type you'd like to use. You can change this later if needed.",
     "description": "Popover message displayed when the experiment type could not not inferred"
   },
+  "BEG0mS": {
+    "defaultMessage": "(no name yet)",
+    "description": "Review question preview placeholder for blank name"
+  },
   "BEXAt0": {
     "defaultMessage": "(empty)",
     "description": "Placeholder for an empty JSON cell"
@@ -2670,6 +2686,10 @@
   "BwgPX0": {
     "defaultMessage": "Delete",
     "description": "Label for the delete prompt action on the registered prompt details page"
+  },
+  "BxZsWD": {
+    "defaultMessage": "Preview unavailable",
+    "description": "Review question preview render-error empty title"
   },
   "By4hRe": {
     "defaultMessage": "Are retrieved documents relevant to the user's request?",
@@ -3054,6 +3074,10 @@
   "EDWwN/": {
     "defaultMessage": "Compare",
     "description": "Compare button on run detail page"
+  },
+  "EE/OnY": {
+    "defaultMessage": "How a reviewer sees the question",
+    "description": "Review question preview panel header subtitle"
   },
   "EE7SQ0": {
     "defaultMessage": "Edit budget policy",
@@ -3515,10 +3539,6 @@
     "defaultMessage": "Detection progress",
     "description": "Issue detection progress > Title"
   },
-  "HJk2X8": {
-    "defaultMessage": "Preview",
-    "description": "Label schema preview panel header"
-  },
   "HLbyGb": {
     "defaultMessage": "Show more",
     "description": "Button text to show more description text for the entity"
@@ -3734,6 +3754,10 @@
   "IKx3DN": {
     "defaultMessage": "Predict on a Pandas DataFrame.",
     "description": "Code comment which states on how we can predict using pandas DataFrame"
+  },
+  "IMAf09": {
+    "defaultMessage": "No limit",
+    "description": "Text question: max-length input placeholder when unbounded"
   },
   "IMEGsC": {
     "defaultMessage": "Associated MLflow Run if the trace was generated within an MLflow run context",
@@ -4283,10 +4307,6 @@
     "defaultMessage": "Budgets",
     "description": "Budget policies page title"
   },
-  "La0EKA": {
-    "defaultMessage": "How a reviewer sees the schema",
-    "description": "Label schema preview panel header subtitle"
-  },
   "LajLDb": {
     "defaultMessage": "Move to top",
     "description": "Experiment page > compare runs tab > chart header > move to top option"
@@ -4527,6 +4547,10 @@
     "defaultMessage": "View all integrations",
     "description": "Link text directing users to additional tracing integrations"
   },
+  "Mr3+R5": {
+    "defaultMessage": "Expectation (ground truth)",
+    "description": "Review question answer type: expectation"
+  },
   "Mtj9Ay": {
     "defaultMessage": "Edit description",
     "description": "Run page > Overview > Description section > Edit button label"
@@ -4766,6 +4790,10 @@
   "O+hq1Q": {
     "defaultMessage": "Create Workspace",
     "description": "Title for create workspace modal"
+  },
+  "O1K7/e": {
+    "defaultMessage": "Feedback",
+    "description": "Review question answer type: feedback"
   },
   "O1rYVN": {
     "defaultMessage": "Load model as a Spark UDF. Override result_type if the model does not return double values.",
@@ -5231,6 +5259,10 @@
     "defaultMessage": "Use other parameters or disable run grouping to continue.",
     "description": "Experiment page > compare runs > parallel coordinates chart > unsupported string values warning > description"
   },
+  "QR5jwv": {
+    "defaultMessage": "Add an option",
+    "description": "Categorical options: add-option input placeholder"
+  },
   "QRnRh3": {
     "defaultMessage": "No experiments found",
     "description": "Label for the empty state in the experiments table when no experiments are found"
@@ -5370,6 +5402,10 @@
   "RDg+Pl": {
     "defaultMessage": "Time",
     "description": "Label for the time select dropdown for experiment runs view"
+  },
+  "REfKpP": {
+    "defaultMessage": "Question for reviewer",
+    "description": "Review question name input"
   },
   "RGKRP9": {
     "defaultMessage": "Feedback",
@@ -5607,6 +5643,10 @@
     "defaultMessage": "Create LLM judge",
     "description": "Title for new LLM judge modal"
   },
+  "SVXXp4": {
+    "defaultMessage": "Input type",
+    "description": "Review question input variant selector"
+  },
   "SZIwwQ": {
     "defaultMessage": "Flag for review",
     "description": "Button text for adding a trace to a review queue"
@@ -5626,6 +5666,10 @@
   "Sd7sQi": {
     "defaultMessage": "Traces are only available for experiment-scoped prompts.",
     "description": "Message when prompt is not experiment-scoped"
+  },
+  "SdwhGR": {
+    "defaultMessage": "No maximum",
+    "description": "Numeric question: max-value input placeholder when unbounded"
   },
   "Shv28w": {
     "defaultMessage": "Save",
@@ -6003,10 +6047,6 @@
     "defaultMessage": "Transition to",
     "description": "Text for transitioning a model version to a different stage under\n                 dropdown menu in model version page"
   },
-  "UiURN5": {
-    "defaultMessage": "Preview unavailable",
-    "description": "Label schema preview render-error empty title"
-  },
   "UkVgwL": {
     "defaultMessage": "Create endpoint",
     "description": "Page title for create endpoint"
@@ -6171,10 +6211,6 @@
     "defaultMessage": "Compare parameter importance",
     "description": "Experiment page > compare runs > parallel coordinates chart > chart not configured warning > title"
   },
-  "VSFnB3": {
-    "defaultMessage": "Continue editing the schema to see a preview.",
-    "description": "Label schema preview render-error empty description"
-  },
   "VSitCY": {
     "defaultMessage": "Top K",
     "description": "Label for top K input"
@@ -6335,6 +6371,10 @@
     "defaultMessage": "Page {page}",
     "description": "Current page indicator"
   },
+  "WEbu//": {
+    "defaultMessage": "The question shown to the reviewer.",
+    "description": "Review question name hint"
+  },
   "WFEeyZ": {
     "defaultMessage": "Cost: {input} in / {output} out",
     "description": "Model cost per token"
@@ -6443,10 +6483,6 @@
     "defaultMessage": "Violates guidelines",
     "description": "Evaluation results > guidelines assessment > negative value label. Displayed if evaluation result does not adhere to the guidelines."
   },
-  "Wne4Y/": {
-    "defaultMessage": "Disabled fields are fixed after creation.",
-    "description": "Label schema edit-mode notice explaining why some fields are disabled"
-  },
   "Wp1PWT": {
     "defaultMessage": "Failed to delete webhook",
     "description": "Generic error message informing the user that webhook deletion failed"
@@ -6458,6 +6494,10 @@
   "WpNCQl": {
     "defaultMessage": "No results",
     "description": "Experiment page > sort selector > no results after filtering"
+  },
+  "Wpwofy": {
+    "defaultMessage": "Max {max} options",
+    "description": "Categorical options: placeholder when the option limit is reached"
   },
   "Ws58cc": {
     "defaultMessage": "Groundedness",
@@ -7603,10 +7643,6 @@
     "defaultMessage": "Hide assessments",
     "description": "Tooltip for a button that closes the assessments pane"
   },
-  "cQVGtX": {
-    "defaultMessage": "Questions are the experiment's label schemas. Add a new one or click a question to edit it.",
-    "description": "Manage review questions: explanatory hint"
-  },
   "cRN9pa": {
     "defaultMessage": "Delete ({count})",
     "description": "Delete button in the V2 dataset records inline bulk-selection group"
@@ -7955,10 +7991,6 @@
     "defaultMessage": "Key",
     "description": "Tag key label in unified trace tag assignment modal"
   },
-  "eLkD+y": {
-    "defaultMessage": "The prompt shown to the reviewer for this label.",
-    "description": "Label schema name hint"
-  },
   "eNHVjy": {
     "defaultMessage": "Name is required",
     "description": "Form validation error message informing the user that the webhook name is required"
@@ -8034,10 +8066,6 @@
   "ecUdab": {
     "defaultMessage": "Usage",
     "description": "Label for the usage tab in the experiment overview page"
-  },
-  "ecj2Xt": {
-    "defaultMessage": "Feedback",
-    "description": "Label schema type: feedback"
   },
   "eeLqSn": {
     "defaultMessage": "Submit",
@@ -8122,6 +8150,10 @@
   "f4CfIz": {
     "defaultMessage": "(edited)",
     "description": "Link text in an edited assessment that allows the user to click to see the previous value"
+  },
+  "f6B8LJ": {
+    "defaultMessage": "Numeric",
+    "description": "Review question input type: numeric"
   },
   "fBB0xR": {
     "defaultMessage": "Assistant Not Available",
@@ -8419,6 +8451,10 @@
     "defaultMessage": "Create new workspace",
     "description": "Create workspace button"
   },
+  "gY9VVl": {
+    "defaultMessage": "Instructions for reviewers on how to answer this question",
+    "description": "Review question instruction input placeholder"
+  },
   "gYOuKs": {
     "defaultMessage": "Rationale",
     "description": "Label for the rationale of an expectation assessment"
@@ -8470,6 +8506,10 @@
   "gjMj0f": {
     "defaultMessage": "The SQL query timed out. Please retry, and if the problem persists, try selecting a larger SQL warehouse.",
     "description": "Traces empty state > SQL warehouse timeout error description with CTA to select larger warehouse"
+  },
+  "gkGvc6": {
+    "defaultMessage": "Add a new question, or click a question to edit it.",
+    "description": "Manage review questions: explanatory hint"
   },
   "glxGz2": {
     "defaultMessage": "Parallel coordinates chart does not support aggregated string values.",
@@ -8959,6 +8999,10 @@
     "defaultMessage": "Last Modified",
     "description": "Label name for the last modified time under details tab on the model view page"
   },
+  "j1ddWI": {
+    "defaultMessage": "Categorical",
+    "description": "Review question input type: categorical"
+  },
   "j25Ttg": {
     "defaultMessage": "Model metrics",
     "description": "Run details page > tab selector > Model metrics tab"
@@ -9075,10 +9119,6 @@
     "defaultMessage": "Models",
     "description": "Models column header"
   },
-  "jeaWWg": {
-    "defaultMessage": "Instructions (optional)",
-    "description": "Label schema instruction input"
-  },
   "jhgu6C": {
     "defaultMessage": "A unique identifier for the session or conversation for grouping traces",
     "description": "Tooltip description for the Session column in the traces table"
@@ -9127,6 +9167,10 @@
     "defaultMessage": "Cancel",
     "description": "Experiment page > artifact compare view > \"add new row\" modal cancel button label"
   },
+  "jyD5wg": {
+    "defaultMessage": "Is the answer correct?",
+    "description": "Review question name input placeholder"
+  },
   "jzNMBH": {
     "defaultMessage": "This key is currently in use. After deleting, you will need to attach a different API key to continue using the endpoints currently using this key.",
     "description": "Gateway > Delete API key modal > Warning about endpoints using this key"
@@ -9162,6 +9206,10 @@
   "k4F8aJ": {
     "defaultMessage": "Copy issue ID",
     "description": "Tooltip to copy issue ID"
+  },
+  "k4ulqN": {
+    "defaultMessage": "Drag to reorder {option}",
+    "description": "Categorical option chip: drag-handle accessibility label"
   },
   "k5kAB3": {
     "defaultMessage": "Rejected ({count})",
@@ -9635,10 +9683,6 @@
     "defaultMessage": "Linked prompts",
     "description": "Label for the linked prompts view tab in the model trace explorer"
   },
-  "mab+cP": {
-    "defaultMessage": "Expectation",
-    "description": "Label schema type: expectation"
-  },
   "mba0x8": {
     "defaultMessage": "Step 1: Define your judge function",
     "description": "Step 1 title for custom code judge creation"
@@ -9830,10 +9874,6 @@
   "nPHUYN": {
     "defaultMessage": "https://example.com/webhook",
     "description": "Webhook URL placeholder"
-  },
-  "nPOCQM": {
-    "defaultMessage": "Input type",
-    "description": "Label schema input variant selector"
   },
   "nPWZsh": {
     "defaultMessage": "Make sure that at least one experiment run is visible and available to compare",
@@ -10235,6 +10275,10 @@
     "defaultMessage": "Weight",
     "description": "Label for traffic split weight input"
   },
+  "pPo8Le": {
+    "defaultMessage": "Preview",
+    "description": "Review question preview panel header"
+  },
   "pT8+E7": {
     "defaultMessage": "Delete budget policy",
     "description": "Gateway > Budgets list > Delete budget policy button aria label"
@@ -10282,10 +10326,6 @@
   "pfyUes": {
     "defaultMessage": "See details",
     "description": "Evaluation review > assessments > see details button"
-  },
-  "pgksxr": {
-    "defaultMessage": "Allow rationale",
-    "description": "Label schema rationale section title"
   },
   "pjCmlG": {
     "defaultMessage": "Usage",
@@ -10510,6 +10550,10 @@
   "qvEOHi": {
     "defaultMessage": "MLflow collects usage data to improve the product. To confirm your preferences, please visit the settings page in the navigation sidebar. To learn more about what data is collected, please visit the <documentation>documentation</documentation>.",
     "description": "Telemetry alert description"
+  },
+  "qwSqlQ": {
+    "defaultMessage": "Rationale (optional)",
+    "description": "Review question preview free-form rationale placeholder"
   },
   "qz9XeG": {
     "defaultMessage": "Cancel",
@@ -10843,6 +10887,10 @@
     "defaultMessage": "Version {version}",
     "description": "Label for the version of a registered prompt in the registered prompts table"
   },
+  "sNSyZl": {
+    "defaultMessage": "Disabled fields are fixed after creation.",
+    "description": "Review question edit-mode notice explaining why some fields are disabled"
+  },
   "sOQcFW": {
     "defaultMessage": "None",
     "description": "Label for the button disabling grouping in the logged model list page"
@@ -10958,6 +11006,10 @@
   "t/59XU": {
     "defaultMessage": "Logs",
     "description": "Tab label for endpoint logs"
+  },
+  "t/acBz": {
+    "defaultMessage": "Allow rationale",
+    "description": "Review question rationale section title"
   },
   "t0Qkuc": {
     "defaultMessage": "Value",
@@ -11327,10 +11379,6 @@
     "defaultMessage": "Auto-create experiment",
     "description": "Placeholder for experiment selector when no experiment is selected"
   },
-  "vDnSXw": {
-    "defaultMessage": "Label type",
-    "description": "Label schema feedback-vs-expectation selector label"
-  },
   "vEuvEt": {
     "defaultMessage": "Show first 10",
     "description": "Menu option for showing only 10 first runs in the evaluation runs table"
@@ -11511,6 +11559,10 @@
     "defaultMessage": "Next",
     "description": "Next page button"
   },
+  "wEZrdF": {
+    "defaultMessage": "Text",
+    "description": "Review question input type: text"
+  },
   "wElRV+": {
     "defaultMessage": "Collapse graph",
     "description": "Tooltip for the button that collapses the graph view"
@@ -11687,6 +11739,10 @@
     "defaultMessage": "Reasoning",
     "description": "Label for the collapsible reasoning section in chat message"
   },
+  "xBIlD4": {
+    "defaultMessage": "Expectation",
+    "description": "Review question type: expectation"
+  },
   "xBVMQz": {
     "defaultMessage": "LLM",
     "description": "Example text snippet for LLM"
@@ -11782,6 +11838,10 @@
   "xgbeVS": {
     "defaultMessage": "Large",
     "description": "Large row size"
+  },
+  "xgh7nX": {
+    "defaultMessage": "Answer type",
+    "description": "Review question feedback-vs-expectation selector label"
   },
   "xgy7fN": {
     "defaultMessage": "Close notification",
@@ -12150,10 +12210,6 @@
   "zZlPwp": {
     "defaultMessage": "Categories",
     "description": "Run page > Overview > Issue categories being detected"
-  },
-  "zbAsb1": {
-    "defaultMessage": "(no name yet)",
-    "description": "Label schema preview placeholder for blank name"
   },
   "zcnCPF": {
     "defaultMessage": "Issues",


### PR DESCRIPTION
### Related Issues/PRs

Relates to the OSS review-queue review UI.

### What changes are proposed in this pull request?

Polish the add/edit review-question modal and its preview:

- **Reword** the reviewer-facing copy to consistently say "question" instead of "prompt", "schema", or "label": "Prompt to reviewer" -> "Question for reviewer", "Label type" -> "Answer type"; the preview and the questions-list hint no longer say "schema"; translator `description` notes updated to match.
- **i18n** the remaining raw-English strings so they go through `intl.formatMessage` / `FormattedMessage`: the name / instruction / numeric / text / categorical placeholders, the drag-to-reorder `aria-label`, and the answer-type / input-type radio labels. (The Pass/Fail default placeholders stay as value constants.)

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.
