### PR TITLE
Fix AI Gateway SSE large-frame read limit

### DIFF
--- a/mlflow/gateway/providers/utils.py
+++ b/mlflow/gateway/providers/utils.py
@@ -26,7 +26,9 @@ async def _aiohttp_post(headers: dict[str, str], base_url: str, path: str, paylo
     request_headers = {k: v for k, v in headers.items() if k.lower() != "accept-encoding"}
     request_headers["Accept-Encoding"] = SUPPORTED_ACCEPT_ENCODING
     url = append_to_uri_path(base_url, path)
-    async with aiohttp.ClientSession(headers=request_headers) as session:
+    async with aiohttp.ClientSession(
+        headers=request_headers, read_bufsize=2**20
+    ) as session:
         timeout = aiohttp.ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get())
         async with session.post(url, json=payload, timeout=timeout) as response:
             yield response

--- a/mlflow/gateway/providers/utils.py
+++ b/mlflow/gateway/providers/utils.py
@@ -28,9 +28,7 @@ async def _aiohttp_post(headers: dict[str, str], base_url: str, path: str, paylo
     url = append_to_uri_path(base_url, path)
     # Raise the aiohttp stream read buffer to tolerate large SSE `data:` lines
     # emitted by some providers during streaming responses.
-    async with aiohttp.ClientSession(
-        headers=request_headers, read_bufsize=2**20
-    ) as session:
+    async with aiohttp.ClientSession(headers=request_headers, read_bufsize=2**20) as session:
         timeout = aiohttp.ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get())
         async with session.post(url, json=payload, timeout=timeout) as response:
             yield response

--- a/mlflow/gateway/providers/utils.py
+++ b/mlflow/gateway/providers/utils.py
@@ -26,6 +26,8 @@ async def _aiohttp_post(headers: dict[str, str], base_url: str, path: str, paylo
     request_headers = {k: v for k, v in headers.items() if k.lower() != "accept-encoding"}
     request_headers["Accept-Encoding"] = SUPPORTED_ACCEPT_ENCODING
     url = append_to_uri_path(base_url, path)
+    # Raise the aiohttp stream read buffer to tolerate large SSE `data:` lines
+    # emitted by some providers during streaming responses.
     async with aiohttp.ClientSession(
         headers=request_headers, read_bufsize=2**20
     ) as session:

--- a/pyproject.release.toml
+++ b/pyproject.release.toml
@@ -31,7 +31,7 @@ dependencies = [
   "mlflow-tracing==3.13.1.dev0",
   "Flask-CORS<7",
   "Flask<4",
-  "aiohttp<4",
+  "aiohttp<4,>=3.7.0",
   "alembic<2,!=1.10.0",
   "cryptography<49,>=43.0.0",
   "docker<8,>=4.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ requires-python = ">=3.10"
 dependencies = [
   "Flask-CORS<7",
   "Flask<4",
-  "aiohttp<4",
+  "aiohttp<4,>=3.7.0",
   "alembic<2,!=1.10.0",
   "cachetools<8,>=5.0.0",
   "click<9,>=7.0",

--- a/requirements/core-requirements.yaml
+++ b/requirements/core-requirements.yaml
@@ -83,4 +83,5 @@ huey:
 
 aiohttp:
   pip_release: aiohttp
+  minimum: "3.7.0"
   max_major_version: 3

--- a/tests/gateway/providers/test_anthropic.py
+++ b/tests/gateway/providers/test_anthropic.py
@@ -970,7 +970,7 @@ async def test_passthrough_anthropic_messages():
     captured_session_headers = {}
     mock_session_client = mock_http_client(MockAsyncResponse(resp))
 
-    def mock_client_session(headers=None):
+    def mock_client_session(headers=None, **kwargs):
         captured_session_headers.update(headers or {})
         return mock_session_client
 
@@ -1027,7 +1027,7 @@ async def test_passthrough_anthropic_messages_streaming():
     captured_session_headers = {}
     mock_session_client = mock_http_client(MockAsyncStreamingResponse(resp))
 
-    def mock_client_session(headers=None):
+    def mock_client_session(headers=None, **kwargs):
         captured_session_headers.update(headers or {})
         return mock_session_client
 
@@ -1084,7 +1084,7 @@ async def test_proxy_anthropic_non_streaming():
     captured_session_headers = {}
     mock_session_client = mock_http_client(MockAsyncResponse(resp))
 
-    def mock_client_session(headers=None):
+    def mock_client_session(headers=None, **kwargs):
         captured_session_headers.update(headers or {})
         return mock_session_client
 
@@ -1122,7 +1122,7 @@ async def test_proxy_anthropic_streaming():
         MockAsyncStreamingResponse(resp, headers={"Content-Type": "text/event-stream"})
     )
 
-    def mock_client_session(headers=None):
+    def mock_client_session(headers=None, **kwargs):
         captured_session_headers.update(headers or {})
         return mock_session_client
 
@@ -1202,7 +1202,7 @@ async def test_chat_with_structured_output():
     captured_session_headers = {}
     mock_session_client = mock_http_client(MockAsyncResponse(resp))
 
-    def mock_client_session(headers=None):
+    def mock_client_session(headers=None, **kwargs):
         captured_session_headers.update(headers or {})
         return mock_session_client
 

--- a/tests/gateway/providers/test_gemini.py
+++ b/tests/gateway/providers/test_gemini.py
@@ -1110,7 +1110,7 @@ async def test_passthrough_gemini_generate_content():
     captured_session_headers = {}
     mock_session_client = mock_http_client(MockAsyncResponse(resp))
 
-    def mock_client_session(headers=None):
+    def mock_client_session(headers=None, **kwargs):
         captured_session_headers.update(headers or {})
         return mock_session_client
 
@@ -1161,7 +1161,7 @@ async def test_passthrough_gemini_stream_generate_content():
     captured_session_headers = {}
     mock_session_client = mock_http_client(MockAsyncStreamingResponse(resp))
 
-    def mock_client_session(headers=None):
+    def mock_client_session(headers=None, **kwargs):
         captured_session_headers.update(headers or {})
         return mock_session_client
 

--- a/tests/gateway/providers/test_openai_compatible.py
+++ b/tests/gateway/providers/test_openai_compatible.py
@@ -336,7 +336,7 @@ async def test_proxy_propagates_headers():
     mock_client = mock_http_client(MockAsyncResponse(_chat_response()))
     captured_headers = {}
 
-    def mock_client_session(headers=None):
+    def mock_client_session(headers=None, **kwargs):
         captured_headers.update(headers or {})
         return mock_client
 

--- a/tests/gateway/providers/test_provider_utils.py
+++ b/tests/gateway/providers/test_provider_utils.py
@@ -77,6 +77,21 @@ async def test_aiohttp_post_uses_timeout_from_env_var(monkeypatch):
     assert mock_client.post.call_args.kwargs["timeout"].total == 2
 
 
+@pytest.mark.asyncio
+async def test_aiohttp_post_sets_read_bufsize_for_large_sse_lines():
+    mock_client = mock_http_client(MockAsyncResponse({}))
+    with mock.patch("aiohttp.ClientSession", return_value=mock_client) as mock_session_cls:
+        async with _aiohttp_post(
+            headers={"Authorization": "Bearer key"},
+            base_url="https://api.example.com",
+            path="/v1/chat",
+            payload={"model": "x"},
+        ):
+            pass
+
+    assert mock_session_cls.call_args.kwargs["read_bufsize"] == 2**20
+
+
 @pytest.mark.parametrize(
     ("base_url", "expected"),
     [

--- a/uv.lock
+++ b/uv.lock
@@ -4146,7 +4146,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiohttp", specifier = "<4" },
+    { name = "aiohttp", specifier = ">=3.7.0,<4" },
     { name = "alembic", specifier = "!=1.10.0,<2" },
     { name = "aliyunstoreplugin", marker = "extra == 'aliyun-oss'" },
     { name = "azure-identity", marker = "extra == 'azure'", specifier = ">=1.6.1" },


### PR DESCRIPTION
### Related Issues/PRs

Closes #23865

### What changes are proposed in this pull request?

This PR updates the AI Gateway provider HTTP client configuration to prevent streaming failures on large SSE frames:

- Set `read_bufsize=2**20` on `aiohttp.ClientSession` in `mlflow/gateway/providers/utils.py`.
- Add a focused unit test that asserts `_aiohttp_post` configures `read_bufsize` for large SSE line handling.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added test:
- `tests/gateway/providers/test_provider_utils.py::test_aiohttp_post_sets_read_bufsize_for_large_sse_lines`

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Prevents MLflow AI Gateway streaming requests from failing with `Got more than 131072 bytes when reading` when providers emit large single SSE `data:` frames.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
