### PR TITLE
Add support for `setPendingPrompt` for MLFlow AI assistant

### DIFF
--- a/mlflow/server/js/src/assistant/AssistantChatPanel.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.test.tsx
@@ -17,6 +17,9 @@ beforeAll(() => {
 
 const mockSendMessage = jest.fn();
 const mockCancelSession = jest.fn();
+const mockClearPendingPrompt = jest.fn();
+let mockSetupComplete = true;
+let mockPendingPrompt: string | null = null;
 
 jest.mock('./AssistantContext', () => ({
   useAssistant: () => ({
@@ -27,12 +30,15 @@ jest.mock('./AssistantContext', () => ({
     error: null,
     currentStatus: null,
     activeTools: [],
-    setupComplete: true,
+    setupComplete: mockSetupComplete,
     isLoadingConfig: false,
     isLocalServer: true,
+    pendingPrompt: mockPendingPrompt,
     openPanel: jest.fn(),
     closePanel: jest.fn(),
     sendMessage: mockSendMessage,
+    prefillPrompt: jest.fn(),
+    clearPendingPrompt: mockClearPendingPrompt,
     regenerateLastMessage: jest.fn(),
     reset: jest.fn(),
     cancelSession: mockCancelSession,
@@ -63,8 +69,54 @@ describe('AssistantChatPanel', () => {
   beforeEach(() => {
     mockSendMessage.mockClear();
     mockCancelSession.mockClear();
+    mockClearPendingPrompt.mockClear();
+    mockSetupComplete = true;
+    mockPendingPrompt = null;
     mockLogTelemetryEvent = jest.fn();
     jest.mocked(useLogTelemetryEvent).mockReturnValue(mockLogTelemetryEvent);
+  });
+
+  test('when setup is NOT complete, the panel shows the "Get Started" setup prompt and no chat input', () => {
+    mockSetupComplete = false;
+    renderChatPanel();
+
+    // The user is asked to set up the assistant ...
+    expect(screen.getByRole('button', { name: 'Get Started' })).toBeInTheDocument();
+    // ... and the chat input isn't mounted yet, so a queued prompt waits on the context.
+    expect(screen.queryByPlaceholderText('Ask a question...')).not.toBeInTheDocument();
+  });
+
+  test('a queued pendingPrompt is dropped into the input once chat appears, then cleared', async () => {
+    mockPendingPrompt = 'SEED';
+    renderChatPanel();
+
+    const textarea = await screen.findByDisplayValue('SEED');
+    expect(textarea.tagName).toBe('TEXTAREA');
+    expect(mockClearPendingPrompt).toHaveBeenCalledTimes(1);
+  });
+
+  // Not set up → complete setup WITHOUT closing → prompt prefilled.
+  test('seed waits while setup is incomplete, then prefills the input after setup completes', async () => {
+    mockSetupComplete = false;
+    mockPendingPrompt = 'SEED';
+    const { rerender } = renderChatPanel();
+
+    // Setup prompt is shown; no input yet; the seed has NOT been consumed.
+    expect(screen.getByRole('button', { name: 'Get Started' })).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('Ask a question...')).not.toBeInTheDocument();
+    expect(mockClearPendingPrompt).not.toHaveBeenCalled();
+
+    // Setup completes (provider selected) — ChatPanelContent mounts and consumes the seed.
+    mockSetupComplete = true;
+    rerender(
+      <DesignSystemProvider>
+        <AssistantChatPanel />
+      </DesignSystemProvider>,
+    );
+
+    const textarea = await screen.findByDisplayValue('SEED');
+    expect(textarea.tagName).toBe('TEXTAREA');
+    expect(mockClearPendingPrompt).toHaveBeenCalledTimes(1);
   });
 
   test('renders a textarea for chat input', () => {

--- a/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
@@ -264,8 +264,17 @@ const PromptSuggestions = ({ onSelect }: { onSelect: (prompt: string) => void })
  */
 const ChatPanelContent = () => {
   const { theme } = useDesignSystemTheme();
-  const { messages, isStreaming, error, activeTools, sendMessage, regenerateLastMessage, cancelSession } =
-    useAssistant();
+  const {
+    messages,
+    isStreaming,
+    error,
+    activeTools,
+    sendMessage,
+    regenerateLastMessage,
+    cancelSession,
+    pendingPrompt,
+    clearPendingPrompt,
+  } = useAssistant();
   const logTelemetryEvent = useLogTelemetryEvent();
   const viewId = useMemo(() => uuidv4(), []);
 
@@ -286,6 +295,16 @@ const ChatPanelContent = () => {
       textarea.style.height = `${textarea.scrollHeight}px`;
     }
   }, [inputValue]);
+
+  // Consume a prompt queued by an onboarding card. This component only mounts once setup is
+  // complete, so a prompt queued during the setup wizard lands here on first mount.
+  useEffect(() => {
+    if (pendingPrompt != null) {
+      setInputValue(pendingPrompt);
+      clearPendingPrompt();
+      textareaRef.current?.focus();
+    }
+  }, [pendingPrompt, clearPendingPrompt]);
 
   const handleSend = useCallback(() => {
     if (inputValue.trim() && !isStreaming) {

--- a/mlflow/server/js/src/assistant/AssistantContext.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.test.tsx
@@ -1,0 +1,164 @@
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+import { renderHook, act, cleanup } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import { AssistantProvider, useAssistant } from './AssistantContext';
+import * as AssistantService from './AssistantService';
+import type { SendMessageStreamCallbacks } from './AssistantService';
+
+jest.mock('./AssistantService', () => ({
+  __esModule: true,
+  sendMessageStream: jest.fn(),
+  getConfig: jest.fn(),
+  cancelSession: jest.fn(),
+}));
+
+const mockSendMessageStream = jest.mocked(AssistantService.sendMessageStream);
+const mockGetConfig = jest.mocked(AssistantService.getConfig);
+
+// A fake EventSource — the real one is created inside sendMessageStream, which we mock,
+// so the context only ever calls .close() on what we hand back here.
+let fakeEventSource: { close: jest.Mock };
+// Capture the callbacks the context passes in so a test can simulate the backend streaming.
+let capturedCallbacks: SendMessageStreamCallbacks | undefined;
+
+const wrapper = ({ children }: { children: ReactNode }) => <AssistantProvider>{children}</AssistantProvider>;
+
+// Render and flush the mount-time refreshConfig() promise so its state update lands inside act().
+const renderAssistant = async () => {
+  const utils = renderHook(() => useAssistant(), { wrapper });
+  await act(async () => {});
+  return utils;
+};
+
+beforeEach(() => {
+  fakeEventSource = { close: jest.fn() };
+  capturedCallbacks = undefined;
+  mockGetConfig.mockResolvedValue({ providers: {}, projects: {} });
+  mockSendMessageStream.mockImplementation(async (_req, callbacks) => {
+    capturedCallbacks = callbacks;
+    return { eventSource: fakeEventSource as unknown as EventSource };
+  });
+  // Control rAF so a scheduled flush stays pending until we assert on it.
+  jest.spyOn(window, 'requestAnimationFrame').mockReturnValue(777 as unknown as number);
+  jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  cleanup();
+  jest.restoreAllMocks();
+  jest.clearAllMocks();
+});
+
+describe('AssistantContext — reset() tears down the active stream', () => {
+  it('closes the active EventSource when reset() is called mid-stream', async () => {
+    const { result } = await renderAssistant();
+
+    // Start a stream via the public sendMessage path (no session yet → startChat).
+    await act(async () => {
+      result.current.sendMessage('hello');
+    });
+    expect(fakeEventSource.close).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(fakeEventSource.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels a pending animation frame when reset() is called', async () => {
+    const { result } = await renderAssistant();
+
+    await act(async () => {
+      result.current.sendMessage('hello');
+    });
+
+    // Simulate a token arriving — this schedules a rAF flush (id 777).
+    act(() => {
+      capturedCallbacks?.onMessage('partial token');
+    });
+    expect(window.requestAnimationFrame).toHaveBeenCalled();
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(window.cancelAnimationFrame).toHaveBeenCalledWith(777);
+  });
+
+  it('clears the session so the next turn starts fresh', async () => {
+    const { result } = await renderAssistant();
+
+    await act(async () => {
+      result.current.sendMessage('hello');
+    });
+    act(() => {
+      capturedCallbacks?.onSessionId?.('session-OLD');
+    });
+    expect(result.current.sessionId).toBe('session-OLD');
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.sessionId).toBeNull();
+    expect(result.current.messages).toHaveLength(0);
+  });
+});
+
+describe('AssistantContext — pendingPrompt seed', () => {
+  it('prefillPrompt sets pendingPrompt and clearPendingPrompt nulls it', async () => {
+    const { result } = await renderAssistant();
+    expect(result.current.pendingPrompt).toBeNull();
+
+    act(() => {
+      result.current.prefillPrompt('SEED');
+    });
+    expect(result.current.pendingPrompt).toBe('SEED');
+
+    act(() => {
+      result.current.clearPendingPrompt();
+    });
+    expect(result.current.pendingPrompt).toBeNull();
+  });
+
+  it('closePanel clears a queued pendingPrompt (abandon ⇒ no stale inject later)', async () => {
+    const { result } = await renderAssistant();
+
+    act(() => {
+      result.current.prefillPrompt('SEED');
+    });
+    expect(result.current.pendingPrompt).toBe('SEED');
+
+    act(() => {
+      result.current.closePanel();
+    });
+    expect(result.current.pendingPrompt).toBeNull();
+  });
+
+  // completing setup must NOT drop a queued prompt, so it can be
+  // consumed once the chat input appears post-setup.
+  it('keeps pendingPrompt across completeSetup() (seed survives the setup wizard)', async () => {
+    const { result } = await renderAssistant();
+
+    act(() => {
+      result.current.prefillPrompt('SEED');
+    });
+    expect(result.current.pendingPrompt).toBe('SEED');
+
+    // completeSetup() re-fetches config; mirror a finished wizard where a provider is selected
+    // so setupComplete stays true after the refresh lands.
+    mockGetConfig.mockResolvedValue({
+      providers: { anthropic: { model: 'm', selected: true, permissions: {} } },
+      projects: {},
+    } as unknown as Awaited<ReturnType<typeof AssistantService.getConfig>>);
+
+    await act(async () => {
+      result.current.completeSetup();
+    });
+
+    expect(result.current.setupComplete).toBe(true);
+    expect(result.current.pendingPrompt).toBe('SEED');
+  });
+});

--- a/mlflow/server/js/src/assistant/AssistantContext.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.test.tsx
@@ -107,6 +107,102 @@ describe('AssistantContext — reset() tears down the active stream', () => {
   });
 });
 
+describe('AssistantContext — reset() during the in-flight send window', () => {
+  // Drive sendMessageStream with a deferred promise so reset() can run while the POST is still
+  // pending — the exact window where the captured token is invalidated before the stream attaches.
+  const deferSend = () => {
+    let resolveSend!: (result: { eventSource: EventSource | null }) => void;
+    mockSendMessageStream.mockImplementation((_req, callbacks) => {
+      capturedCallbacks = callbacks;
+      return new Promise((resolve) => {
+        resolveSend = resolve;
+      });
+    });
+    return { resolve: () => resolveSend({ eventSource: fakeEventSource as unknown as EventSource }) };
+  };
+
+  it('ignores a stale onSessionId fired after reset() (no session revival)', async () => {
+    const { result } = await renderAssistant();
+    deferSend();
+
+    // Start the send but leave the POST pending (do not await it).
+    act(() => {
+      result.current.sendMessage('hello');
+    });
+
+    act(() => {
+      result.current.reset();
+    });
+
+    // The backend reply lands after reset — the guarded callback must no-op.
+    act(() => {
+      capturedCallbacks?.onSessionId?.('session-OLD');
+    });
+
+    expect(result.current.sessionId).toBeNull();
+  });
+
+  it('closes the late-resolved EventSource instead of storing it', async () => {
+    const { result } = await renderAssistant();
+    const send = deferSend();
+
+    act(() => {
+      result.current.sendMessage('hello');
+    });
+    act(() => {
+      result.current.reset();
+    });
+
+    // POST resolves after reset: the post-await guard closes the orphaned stream.
+    await act(async () => {
+      send.resolve();
+    });
+    expect(fakeEventSource.close).toHaveBeenCalledTimes(1);
+
+    // A second reset() must not close it again — proving it was never stored in eventSourceRef.
+    act(() => {
+      result.current.reset();
+    });
+    expect(fakeEventSource.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes a regenerate stream orphaned by reset() during its in-flight window', async () => {
+    const { result } = await renderAssistant();
+
+    // Seed a completed turn so regenerateLastMessage has a user message to replay.
+    const firstSend = deferSend();
+    act(() => {
+      result.current.sendMessage('hello');
+    });
+    await act(async () => {
+      firstSend.resolve();
+    });
+    act(() => {
+      capturedCallbacks?.onSessionId?.('session-1');
+      capturedCallbacks?.onDone();
+    });
+    expect(result.current.isStreaming).toBe(false);
+    fakeEventSource.close.mockClear();
+
+    // Regenerate, but leave its POST pending, then reset before it attaches.
+    const regen = deferSend();
+    act(() => {
+      result.current.regenerateLastMessage();
+    });
+    act(() => {
+      result.current.reset();
+    });
+
+    await act(async () => {
+      regen.resolve();
+    });
+
+    // The orphaned regenerate stream is closed by the guard, and the session stays cleared.
+    expect(fakeEventSource.close).toHaveBeenCalledTimes(1);
+    expect(result.current.sessionId).toBeNull();
+  });
+});
+
 describe('AssistantContext — pendingPrompt seed', () => {
   it('prefillPrompt sets pendingPrompt and clearPendingPrompt nulls it', async () => {
     const { result } = await renderAssistant();

--- a/mlflow/server/js/src/assistant/AssistantContext.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.tsx
@@ -47,6 +47,9 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
   const [setupComplete, setSetupComplete] = useState(false);
   const [isLoadingConfig, setIsLoadingConfig] = useState(true);
 
+  // A prompt queued by an onboarding card to seed the chat input the next time it's visible.
+  const [pendingPrompt, setPendingPrompt] = useState<string | null>(null);
+
   // Use ref to track current streaming message
   const streamingMessageRef = useRef<string>('');
 
@@ -191,13 +194,30 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
 
   const closePanel = useCallback(() => {
     setIsPanelOpen(false);
+    // Drop any queued prompt — closing the panel is an abandon, so a stale seed shouldn't
+    // inject into an unrelated chat opened later.
+    setPendingPrompt(null);
   }, [setIsPanelOpen]);
 
+  const prefillPrompt = useCallback((prompt: string) => setPendingPrompt(prompt), []);
+  const clearPendingPrompt = useCallback(() => setPendingPrompt(null), []);
+
   const reset = useCallback(() => {
+    // Tear down any active stream so its callbacks can't leak into the reset state
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+      eventSourceRef.current = null;
+    }
+    if (rafPendingRef.current !== null) {
+      cancelAnimationFrame(rafPendingRef.current);
+      rafPendingRef.current = null;
+    }
     setSessionId(null);
     setMessages([]);
     setIsStreaming(false);
     setError(null);
+    setCurrentStatus(null);
+    setActiveTools([]);
     streamingMessageRef.current = '';
   }, []);
 
@@ -457,10 +477,13 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
     setupComplete,
     isLoadingConfig,
     isLocalServer,
+    pendingPrompt,
     // Actions
     openPanel,
     closePanel,
     sendMessage: handleSendMessage,
+    prefillPrompt,
+    clearPendingPrompt,
     regenerateLastMessage,
     reset,
     cancelSession: handleCancelSession,
@@ -483,9 +506,12 @@ const disabledAssistantContext: AssistantAgentContextType = {
   setupComplete: false,
   isLoadingConfig: false,
   isLocalServer: false,
+  pendingPrompt: null,
   openPanel: () => {},
   closePanel: () => {},
   sendMessage: () => {},
+  prefillPrompt: () => {},
+  clearPendingPrompt: () => {},
   regenerateLastMessage: () => {},
   reset: () => {},
   cancelSession: () => {},

--- a/mlflow/server/js/src/assistant/AssistantContext.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.tsx
@@ -6,11 +6,37 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 
 import type { AssistantAgentContextType, ChatMessage, ToolUseInfo } from './types';
-import { cancelSession as cancelSessionApi, sendMessageStream, getConfig } from './AssistantService';
+import {
+  cancelSession as cancelSessionApi,
+  sendMessageStream,
+  getConfig,
+  type SendMessageStreamCallbacks,
+  type SendMessageStreamResult,
+} from './AssistantService';
 import { useLocalStorage } from '@databricks/web-shared/hooks';
 import { useAssistantPageContextActions } from './AssistantPageContext';
 
 const AssistantReactContext = createContext<AssistantAgentContextType | null>(null);
+
+/**
+ * Wrap every stream callback so it no-ops once the originating send is stale (the user reset or
+ * cancelled while the POST was still in flight). Guards the whole object generically rather than
+ * each callback by hand, so callbacks added later are covered automatically.
+ */
+const withGuard = (isCurrent: () => boolean, callbacks: SendMessageStreamCallbacks): SendMessageStreamCallbacks =>
+  Object.fromEntries(
+    Object.entries(callbacks).map(([key, fn]) => [
+      key,
+      typeof fn === 'function'
+        ? (...args: unknown[]) => {
+            if (isCurrent()) {
+              fn(...args);
+            }
+          }
+        : fn,
+    ]),
+    // Object.fromEntries widens to { [k: string]: ... }; the shape is unchanged so the cast is safe.
+  ) as SendMessageStreamCallbacks;
 
 /**
  * Check if the server is running locally (localhost or 127.0.0.1).
@@ -58,6 +84,11 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
 
   // Use ref to track active EventSource for cancellation
   const eventSourceRef = useRef<EventSource | null>(null);
+
+  // Identity token for the in-flight send. Each send captures its own token; reset()/cancel set
+  // this to null, which invalidates a send still awaiting its POST so its callbacks (fired from
+  // inside the service) and its late-attached EventSource can't leak into the reset state.
+  const activeRequestRef = useRef<symbol | null>(null);
 
   // Throttle streaming updates to avoid overwhelming React with re-renders
   const rafPendingRef = useRef<number | null>(null);
@@ -143,6 +174,8 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
   // Cancel pending RAF and close EventSource on unmount
   useEffect(() => {
     return () => {
+      // Invalidate any in-flight send so any POST cleans up the stream on unmount
+      activeRequestRef.current = null;
       if (rafPendingRef.current !== null) {
         cancelAnimationFrame(rafPendingRef.current);
         rafPendingRef.current = null;
@@ -203,6 +236,9 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
   const clearPendingPrompt = useCallback(() => setPendingPrompt(null), []);
 
   const reset = useCallback(() => {
+    // Invalidate any in-flight send still awaiting its POST: its captured token no longer matches,
+    // so its guarded callbacks no-op and its EventSource is closed when the await resolves.
+    activeRequestRef.current = null;
     // Tear down any active stream so its callbacks can't leak into the reset state
     if (eventSourceRef.current) {
       eventSourceRef.current.close();
@@ -221,8 +257,30 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
     streamingMessageRef.current = '';
   }, []);
 
+  // Begin a new in-flight send: stamp a fresh token in closure,
+  // return a checker for whether this send is
+  // still the active one (i.e. not superseded by a reset/cancel that ran during its POST).
+  const beginRequest = useCallback(() => {
+    const token = Symbol();
+    activeRequestRef.current = token;
+    return () => activeRequestRef.current === token;
+  }, []);
+
+  // Store the resolved stream if its send is still current, otherwise close the orphan. Returns
+  // whether it was attached
+  const attachStreamIfCurrent = useCallback((isCurrent: () => boolean, result: SendMessageStreamResult): boolean => {
+    if (!isCurrent()) {
+      result.eventSource?.close();
+      return false;
+    }
+    eventSourceRef.current = result.eventSource;
+    return true;
+  }, []);
+
   const startChat = useCallback(
     async (prompt?: string) => {
+      const isCurrent = beginRequest();
+
       setError(null);
       setIsStreaming(true);
 
@@ -261,7 +319,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
             experiment_id: pageContext['experimentId'] as string | undefined,
             context: pageContext,
           },
-          {
+          withGuard(isCurrent, {
             onMessage: appendToStreamingMessage,
             onError: handleStreamError,
             onDone: finalizeStreamingMessage,
@@ -269,15 +327,22 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
             onSessionId: handleSessionId,
             onToolUse: handleToolUse,
             onInterrupted: handleInterrupted,
-          },
+          }),
         );
-        eventSourceRef.current = result.eventSource;
+        if (!attachStreamIfCurrent(isCurrent, result)) {
+          return;
+        }
       } catch (err) {
+        if (!isCurrent()) {
+          return;
+        }
         handleStreamError(err instanceof Error ? err.message : 'Failed to start chat');
       }
     },
     [
       sessionId,
+      beginRequest,
+      attachStreamIfCurrent,
       getPageContext,
       appendToStreamingMessage,
       handleStreamError,
@@ -295,6 +360,8 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
         startChat(message);
         return;
       }
+
+      const isCurrent = beginRequest();
 
       setError(null);
       setIsStreaming(true);
@@ -332,7 +399,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
           experiment_id: pageContext['experimentId'] as string | undefined,
           context: pageContext,
         },
-        {
+        withGuard(isCurrent, {
           onMessage: appendToStreamingMessage,
           onError: handleStreamError,
           onDone: finalizeStreamingMessage,
@@ -340,13 +407,15 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
           onSessionId: handleSessionId,
           onToolUse: handleToolUse,
           onInterrupted: handleInterrupted,
-        },
+        }),
       );
-      eventSourceRef.current = result.eventSource;
+      attachStreamIfCurrent(isCurrent, result);
     },
     [
       sessionId,
       startChat,
+      beginRequest,
+      attachStreamIfCurrent,
       getPageContext,
       appendToStreamingMessage,
       handleStreamError,
@@ -360,6 +429,9 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
 
   const handleCancelSession = useCallback(() => {
     if (!sessionId || !isStreaming) return;
+
+    // Invalidate any in-flight send so a stream still awaiting its POST can't attach after cancel.
+    activeRequestRef.current = null;
 
     // Close EventSource immediately to stop receiving data
     if (eventSourceRef.current) {
@@ -389,7 +461,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
     streamingMessageRef.current = '';
   }, [sessionId, isStreaming]);
 
-  const regenerateLastMessage = useCallback(() => {
+  const regenerateLastMessage = useCallback(async () => {
     // Prevent regeneration while already streaming
     if (isStreaming) {
       return;
@@ -400,6 +472,8 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
     if (lastUserMessageIndex === -1) {
       return; // No user message to regenerate from
     }
+
+    const isCurrent = beginRequest();
 
     const userMessageContent = messages[lastUserMessageIndex].content;
 
@@ -434,14 +508,14 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
 
     // Re-send the last user message
     const pageContext = getPageContext();
-    sendMessageStream(
+    const result = await sendMessageStream(
       {
         session_id: sessionId ?? undefined,
         message: userMessageContent,
         experiment_id: pageContext['experimentId'] as string | undefined,
         context: pageContext,
       },
-      {
+      withGuard(isCurrent, {
         onMessage: appendToStreamingMessage,
         onError: handleStreamError,
         onDone: finalizeStreamingMessage,
@@ -449,12 +523,15 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
         onSessionId: handleSessionId,
         onToolUse: handleToolUse,
         onInterrupted: handleInterrupted,
-      },
+      }),
     );
+    attachStreamIfCurrent(isCurrent, result);
   }, [
     messages,
     sessionId,
     isStreaming,
+    beginRequest,
+    attachStreamIfCurrent,
     getPageContext,
     appendToStreamingMessage,
     handleStreamError,

--- a/mlflow/server/js/src/assistant/types.ts
+++ b/mlflow/server/js/src/assistant/types.ts
@@ -74,6 +74,8 @@ export interface AssistantAgentState {
   isLoadingConfig: boolean;
   /** Whether the server is running locally (localhost) */
   isLocalServer: boolean;
+  /** A prompt queued to seed the chat input the next time it becomes visible (null when none) */
+  pendingPrompt: string | null;
 }
 
 export interface AssistantAgentActions {
@@ -83,6 +85,10 @@ export interface AssistantAgentActions {
   closePanel: () => void;
   /** Send a message to Assistant */
   sendMessage: (message: string) => void;
+  /** Queue a prompt to seed the chat input the next time it's visible (survives the setup wizard) */
+  prefillPrompt: (prompt: string) => void;
+  /** Clear any queued prompt */
+  clearPendingPrompt: () => void;
   /** Regenerate the last assistant response */
   regenerateLastMessage: () => void;
   /** Reset the conversation */

--- a/mlflow/server/js/src/experiment-tracking/components/onboarding/AgentActionCard.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/onboarding/AgentActionCard.test.tsx
@@ -6,7 +6,7 @@ import userEvent from '@testing-library/user-event';
 import { AgentActionCard } from './AgentActionCard';
 
 const mockOpenPanel = jest.fn();
-const mockSendMessage = jest.fn();
+const mockPrefillPrompt = jest.fn();
 let mockSetupComplete = true;
 let mockIsLocalServer = true;
 
@@ -14,8 +14,12 @@ jest.mock('../../../assistant', () => ({
   __esModule: true,
   useAssistant: () => ({
     openPanel: mockOpenPanel,
-    sendMessage: mockSendMessage,
+    sendMessage: jest.fn(),
+    prefillPrompt: mockPrefillPrompt,
+    clearPendingPrompt: jest.fn(),
+    reset: jest.fn(),
     setupComplete: mockSetupComplete,
+    pendingPrompt: null,
     isPanelOpen: false,
     sessionId: null,
     messages: [],
@@ -27,7 +31,6 @@ jest.mock('../../../assistant', () => ({
     isLocalServer: mockIsLocalServer,
     closePanel: jest.fn(),
     regenerateLastMessage: jest.fn(),
-    reset: jest.fn(),
     cancelSession: jest.fn(),
     refreshConfig: jest.fn(),
     completeSetup: jest.fn(),
@@ -52,7 +55,7 @@ const renderCard = (props: Partial<React.ComponentProps<typeof AgentActionCard>>
 
 beforeEach(() => {
   mockOpenPanel.mockClear();
-  mockSendMessage.mockClear();
+  mockPrefillPrompt.mockClear();
   mockSetupComplete = true;
   mockIsLocalServer = true;
 });
@@ -99,7 +102,7 @@ describe('AgentActionCard', () => {
     expect(screen.getByRole('tab', { name: /One-line setup/ })).toBeInTheDocument();
   });
 
-  it('clicking "Open assistant" with setup complete calls openPanel and sendMessage with the assistant prompt', async () => {
+  it('clicking "Open assistant" opens the panel and prefills the chat input with the prompt', async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
     renderCard();
 
@@ -107,11 +110,11 @@ describe('AgentActionCard', () => {
     await user.click(screen.getByRole('button', { name: /Open assistant/ }));
 
     expect(mockOpenPanel).toHaveBeenCalledTimes(1);
-    expect(mockSendMessage).toHaveBeenCalledTimes(1);
-    expect(mockSendMessage).toHaveBeenCalledWith('ASSISTANT_PROMPT_BODY');
+    expect(mockPrefillPrompt).toHaveBeenCalledTimes(1);
+    expect(mockPrefillPrompt).toHaveBeenCalledWith('ASSISTANT_PROMPT_BODY');
   });
 
-  it('clicking "Open assistant" with setup NOT complete opens the panel but drops the prompt (known follow-up)', async () => {
+  it('still prefills the prompt when setup is NOT complete (seed waits on the context through setup)', async () => {
     mockSetupComplete = false;
     const user = userEvent.setup({ pointerEventsCheck: 0 });
     renderCard();
@@ -120,7 +123,7 @@ describe('AgentActionCard', () => {
     await user.click(screen.getByRole('button', { name: /Open assistant/ }));
 
     expect(mockOpenPanel).toHaveBeenCalledTimes(1);
-    expect(mockSendMessage).not.toHaveBeenCalled();
+    expect(mockPrefillPrompt).toHaveBeenCalledWith('ASSISTANT_PROMPT_BODY');
   });
 
   it('renders extraTabs after the built-in tabs and shows their content when selected', async () => {

--- a/mlflow/server/js/src/experiment-tracking/components/onboarding/AgentActionCard.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/onboarding/AgentActionCard.tsx
@@ -56,19 +56,17 @@ export const AgentActionCard = ({
   onActiveTabChange?: (tab: string) => void;
 }) => {
   const { theme } = useDesignSystemTheme();
-  const { openPanel, sendMessage, setupComplete, isLocalServer } = useAssistant();
+  const { openPanel, prefillPrompt, isLocalServer } = useAssistant();
   const defaultTab: TabKey = showAgentSetupTab ? 'agent-setup' : 'copy-prompt';
+  // Typed as string, not TabKey, because extraTabs contribute arbitrary string values to the
+  // tab space (Tabs.Root.onValueChange hands back a plain string).
   const [activeTab, setActiveTab] = useState<string>(defaultTab);
 
+  // Open the panel and drop the prompt into the chat input for the user to review and send.
+  // The seed lives on the context, so it survives the setup wizard if setup isn't done yet.
   const handleAssistantClick = () => {
     openPanel();
-    // TODO(joshuawong-db follow-up): if setup isn't complete, the prompt is silently dropped.
-    // Once the setup wizard finishes the user has to retype it. Plumb a queueMessage()
-    // through AssistantContext to defer the send until setupComplete flips true, and
-    // fix the stale-sessionId closure inside startChat at the same time.
-    if (setupComplete) {
-      sendMessage(assistantPrompt);
-    }
+    prefillPrompt(assistantPrompt);
   };
 
   return (

--- a/mlflow/server/js/src/experiment-tracking/components/onboarding/AgentActionCard.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/onboarding/AgentActionCard.tsx
@@ -272,7 +272,7 @@ export const AgentActionCard = ({
           <Tabs.Content value="assistant" css={{ paddingTop: 0 }}>
             <Typography.Text color="secondary" css={{ fontSize: 13, display: 'block', marginBottom: theme.spacing.sm }}>
               <FormattedMessage
-                defaultMessage="Opens the MLflow assistant in this browser and starts the conversation."
+                defaultMessage="Opens the MLflow assistant in the browser with a suggested prompt."
                 description="Description above the MLflow assistant button in the agent action card"
               />
             </Typography.Text>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/EvalRunsEmptyStateCard.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/EvalRunsEmptyStateCard.test.tsx
@@ -19,13 +19,17 @@ const mockTraceMetricsCount = (count: number) =>
   });
 
 const mockOpenPanel = jest.fn();
-const mockSendMessage = jest.fn();
+const mockPrefillPrompt = jest.fn();
 
 jest.mock('@mlflow/mlflow/src/assistant', () => ({
   __esModule: true,
   useAssistant: () => ({
     openPanel: mockOpenPanel,
-    sendMessage: mockSendMessage,
+    sendMessage: jest.fn(),
+    prefillPrompt: mockPrefillPrompt,
+    clearPendingPrompt: jest.fn(),
+    pendingPrompt: null,
+    reset: jest.fn(),
     setupComplete: true,
     isPanelOpen: false,
     sessionId: null,
@@ -38,7 +42,6 @@ jest.mock('@mlflow/mlflow/src/assistant', () => ({
     isLocalServer: true,
     closePanel: jest.fn(),
     regenerateLastMessage: jest.fn(),
-    reset: jest.fn(),
     cancelSession: jest.fn(),
     refreshConfig: jest.fn(),
     completeSetup: jest.fn(),
@@ -68,7 +71,7 @@ const renderCard = () =>
 
 beforeEach(() => {
   mockOpenPanel.mockClear();
-  mockSendMessage.mockClear();
+  mockPrefillPrompt.mockClear();
   mockUseTraceMetricsQuery.mockReset();
   mockTraceMetricsCount(5); // default: experiment has traces
 });
@@ -93,7 +96,7 @@ describe('EvalRunsEmptyStateCard', () => {
     expect(screen.getByTestId('assistant-sparkle-icon')).toBeInTheDocument();
   });
 
-  it('clicking "Open assistant" calls openPanel and sendMessage with the eval assistant prompt', async () => {
+  it('clicking "Open assistant" opens the panel and prefills the chat input with the eval prompt', async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
     renderCard();
 
@@ -101,8 +104,8 @@ describe('EvalRunsEmptyStateCard', () => {
     await user.click(screen.getByRole('button', { name: /Open assistant/ }));
 
     expect(mockOpenPanel).toHaveBeenCalledTimes(1);
-    expect(mockSendMessage).toHaveBeenCalledTimes(1);
-    expect(mockSendMessage.mock.calls[0][0]).toContain('Target experiment ID: 42');
+    expect(mockPrefillPrompt).toHaveBeenCalledTimes(1);
+    expect(mockPrefillPrompt.mock.calls[0][0]).toContain('Target experiment ID: 42');
   });
 
   it('renders the trace-based snippet when the experiment has traces', async () => {

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -5691,10 +5691,6 @@
     "defaultMessage": "Select a workspace to start experiments",
     "description": "Home page workspaces section subtitle"
   },
-  "SSxRdM": {
-    "defaultMessage": "Opens the MLflow assistant in this browser and starts the conversation.",
-    "description": "Description above the MLflow assistant button in the agent action card"
-  },
   "STEhnv": {
     "defaultMessage": "Description",
     "description": "Header for the description column in the experiments table"
@@ -12126,6 +12122,10 @@
   "yjerKR": {
     "defaultMessage": "<link>Version {versionNumber}</link>",
     "description": "Link to model version in the model version table"
+  },
+  "ylLjh0": {
+    "defaultMessage": "Opens the MLflow assistant in the browser with a suggested prompt.",
+    "description": "Description above the MLflow assistant button in the agent action card"
   },
   "yltiK8": {
     "defaultMessage": "No prompts match your search",


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?


This is a followup from https://github.com/mlflow/mlflow/pull/23834.

This PR adds support for adding pending messages to the Assistant Chat Panel. This will be used by the "Open Assistant" button used for LLM onboarding. 

Previously, clicking the button always sent the message directly to the agent. However, I found this disruptive

<img width="1382" height="932" alt="Assistant" src="https://github.com/user-attachments/assets/51318ea8-2752-4203-bb5d-02148d97564a" />

For the user, there are only two obvious entry points to the assistant. Of which, the "Open Assistant" button is more obvious since its at the centre of the screen. If we send a message everytime they click this, it might pollute their chat history.

Therefore, I think prefilling the input box is a friendlier alternative. Users can decide what to do with the prefilled chat input.

The chat window will also survive `reset()`.

This PR can be reviewed commit by commit.

The second commit deals with improving correctness issues that automated review brought up.

The Assistant works using a Streaming Event Source -> Streaming Message Buffer -> Flush to UI. The changes help to ensure that on reset and close, that old Streaming Event Sources and Request Animation Frames are cleared. It also adds a `activeRequestRef` to track the active session at that time. This helps with the scenario where we POST a new message but a reset() is called before the response returns. In such a scenario, we want to discard the returned result, so we use a `withGuard` function to discard all results whose ref doesn't match the current `activeRequestRef`


<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->




https://github.com/user-attachments/assets/4adea31b-5397-4dba-870d-e30b5fefc0fc





### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
