### PR TITLE
Collapse the duplicate review-queue delete permission into `canManageQueue`

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ExperimentReviewQueuePage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ExperimentReviewQueuePage.tsx
@@ -22,7 +22,7 @@ import { useListReviewQueuesQuery } from './hooks/useListReviewQueuesQuery';
 import { useRemoveItemsFromReviewQueueMutation } from './hooks/useRemoveItemsFromReviewQueueMutation';
 import { DEFAULT_REVIEWER, displayUser, useReviewer } from './hooks/useReviewer';
 import { useSetReviewQueueItemStatusMutation } from './hooks/useSetReviewQueueItemStatusMutation';
-import { canDeleteQueue, canManageQueue } from './queuePermissions';
+import { canManageQueue } from './queuePermissions';
 import type { ReviewQueueItem, ReviewStatus } from './types';
 
 /**
@@ -98,15 +98,11 @@ const ExperimentReviewQueuePage = () => {
     () => (confirmDeleteQueueId ? (reviewQueues.find((q) => q.queue_id === confirmDeleteQueueId) ?? null) : null),
     [reviewQueues, confirmDeleteQueueId],
   );
-  // Whether the reviewer may manage the selected queue (remove traces) — a
-  // CUSTOM queue they created, or any on a no-auth server.
+  // Whether the reviewer may manage the selected queue — removing traces and
+  // the right-pane gear (manage settings / delete) share one permission: a
+  // CUSTOM queue they created, or any on a no-auth server (never USER queues).
   const canManageSelectedQueue = selectedQueue
     ? canManageQueue(selectedQueue, reviewer, authAvailable, canManage)
-    : false;
-  // Whether the right-pane gear (manage settings / delete) shows — editable
-  // custom queues only (never USER queues).
-  const canEditSelectedQueue = selectedQueue
-    ? canDeleteQueue(selectedQueue, reviewer, authAvailable, canManage)
     : false;
 
   const handleDeleteQueue = (queueId: string) =>
@@ -291,8 +287,8 @@ const ExperimentReviewQueuePage = () => {
         }
         isRemovingItems={isRemovingItems}
         // Gear menu (manage / delete) only for editable non-default custom queues.
-        onManageQueue={canEditSelectedQueue ? () => setEditingQueueId(selectedQueue.queue_id) : undefined}
-        onDeleteQueue={canEditSelectedQueue ? () => setConfirmDeleteQueueId(selectedQueue.queue_id) : undefined}
+        onManageQueue={canManageSelectedQueue ? () => setEditingQueueId(selectedQueue.queue_id) : undefined}
+        onDeleteQueue={canManageSelectedQueue ? () => setConfirmDeleteQueueId(selectedQueue.queue_id) : undefined}
       />
     );
   }

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/queuePermissions.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/queuePermissions.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from '@jest/globals';
 
-import { canDeleteQueue, canManageQueue, sameUser } from './queuePermissions';
+import { canManageQueue, sameUser } from './queuePermissions';
 import type { ReviewQueue } from './types';
 
 const queue = (overrides: Partial<ReviewQueue> = {}): ReviewQueue => ({
@@ -47,16 +47,5 @@ describe('canManageQueue', () => {
 
   it('requires review-management permission', () => {
     expect(canManageQueue(queue({ created_by: 'alice' }), 'alice', true, false)).toBe(false);
-  });
-});
-
-describe('canDeleteQueue', () => {
-  it('lets a manager delete a custom queue they can manage', () => {
-    expect(canDeleteQueue(queue({ created_by: 'alice' }), 'alice', true, true)).toBe(true);
-    expect(canDeleteQueue(queue({ created_by: 'someone-else' }), 'default', false, true)).toBe(true);
-  });
-
-  it('does not delete a queue the caller cannot manage', () => {
-    expect(canDeleteQueue(queue({ created_by: 'alice' }), 'bob', true, true)).toBe(false);
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/queuePermissions.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/queuePermissions.ts
@@ -17,14 +17,3 @@ export const canManageQueue = (
   authAvailable: boolean,
   canManage: boolean,
 ): boolean => canManage && queue.queue_type === 'CUSTOM' && (!authAvailable || sameUser(queue.created_by, reviewer));
-
-/**
- * Whether the current reviewer may delete a queue. Currently the same as
- * managing it (a distinct action, kept separate so the two can diverge).
- */
-export const canDeleteQueue = (
-  queue: ReviewQueue,
-  reviewer: string,
-  authAvailable: boolean,
-  canManage: boolean,
-): boolean => canManageQueue(queue, reviewer, authAvailable, canManage);


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23807

### What changes are proposed in this pull request?

Follow-up to a review comment on #23807. `canDeleteQueue` in `queuePermissions.ts` was an exact alias of `canManageQueue` — same four-argument signature, delegating straight through — and the review-queue page derived two identical flags from them (`canManageSelectedQueue` and `canEditSelectedQueue`).

This removes the `canDeleteQueue` alias, folds the gear-menu callbacks (`onManageQueue` / `onDeleteQueue`) onto the single `canManageSelectedQueue` flag, and drops the now-redundant test block. No behavior change — the two functions produced identical results for every input.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

`queuePermissions.test.ts` still covers `canManageQueue` and `sameUser`; the deleted block only re-asserted the alias.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.