### PR TITLE
Size review-queue progress-bar segments with flex instead of `width%` + margin

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/SegmentedProgressBar.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/SegmentedProgressBar.tsx
@@ -20,20 +20,25 @@ export const SegmentedProgressBar = ({ items, className }: { items: ProgressBarI
   }
 
   return (
-    <div css={{ display: 'flex', alignItems: 'center', height: '100%' }} className={className}>
+    // `gap` handles the hairline spacing between segments (only between, never
+    // before the first or after the last), and `flex: 1` lets the segments
+    // share the row equally. This keeps the total width at exactly 100% — unlike
+    // width% + right margin, which sums past 100% and can overflow.
+    <div
+      css={{ display: 'flex', alignItems: 'center', height: '100%', gap: theme.spacing.xs / 2 }}
+      className={className}
+    >
       {items.map((item, index) => (
         <div
           key={index}
           css={{
-            width: `${100 / items.length}%`,
+            flex: 1,
             height: '100%',
             backgroundColor: item.color,
             borderTopLeftRadius: index === 0 ? radius : 0,
             borderBottomLeftRadius: index === 0 ? radius : 0,
             borderTopRightRadius: index === items.length - 1 ? radius : 0,
             borderBottomRightRadius: index === items.length - 1 ? radius : 0,
-            // Hairline gap between segments (no gap after the last one).
-            marginRight: index === items.length - 1 ? 0 : theme.spacing.xs / 2,
           }}
         />
       ))}


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23807

### What changes are proposed in this pull request?

Follow-up to a review comment on #23807. Each `SegmentedProgressBar` segment set `width: ${100 / items.length}%` and also applied a right margin between segments, so the segment widths plus the inter-segment margins summed to more than 100% — which can cause subtle horizontal overflow / layout jitter in a constrained container.

This switches the spacing to `gap` on the flex container (applied only between segments, never before the first or after the last) and sizes each segment with `flex: 1`, so the row always totals exactly 100% regardless of segment count. No visual change in the normal case.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

`SegmentedProgressBar.test.tsx` passes unchanged.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.