### PR TITLE
Surface every per-destination failure when adding traces to review queues

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueModal.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueModal.test.tsx
@@ -151,6 +151,9 @@ describe('AddToReviewQueueModal', () => {
 
     expect(await screen.findByText('Attach failed')).toBeInTheDocument();
     expect(Utils.displayGlobalInfoNotification).not.toHaveBeenCalled();
+    // The modal stays open and Add is re-enabled (isSubmitting cleared in
+    // `finally`), so the reviewer can retry without reopening.
+    expect(screen.getByRole('button', { name: 'Add' })).toBeEnabled();
   });
 
   it('surfaces a partial attach failure while still issuing the successful attach', async () => {
@@ -167,9 +170,29 @@ describe('AddToReviewQueueModal', () => {
 
     // The failing destination surfaces an error...
     expect(await screen.findByText('Attach failed for rq-custom')).toBeInTheDocument();
-    // ...the successful attach was still issued (allSettled doesn't abort it)...
+    // ...both attaches were still issued in the same batch (allSettled doesn't
+    // abort the successful one when a sibling rejects)...
+    expect(mockAddItems).toHaveBeenCalledTimes(2);
     expect(mockAddItems).toHaveBeenCalledWith({ queue_id: 'rq-default', item_ids: ['tr-1'] });
+    expect(mockAddItems).toHaveBeenCalledWith({ queue_id: 'rq-custom', item_ids: ['tr-1'] });
     // ...and no success toast fires while any destination failed.
+    expect(Utils.displayGlobalInfoNotification).not.toHaveBeenCalled();
+  });
+
+  it('aborts the whole add (including selected CUSTOM queues) when a destination resolution fails', async () => {
+    // A user-queue resolution failure aborts before any attach, so the
+    // independently-selected CUSTOM queue is intentionally NOT attached either.
+    mockGetOrCreateUserQueue.mockRejectedValue(new Error('Queue resolution failed'));
+    renderModal();
+
+    fireEvent.click(screen.getByRole('combobox'));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Default queue' }));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Relevance' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+    expect(await screen.findByText('Queue resolution failed')).toBeInTheDocument();
+    // No attach is issued at all — not even for the CUSTOM queue that resolved fine.
+    expect(mockAddItems).not.toHaveBeenCalled();
     expect(Utils.displayGlobalInfoNotification).not.toHaveBeenCalled();
   });
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueModal.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueModal.test.tsx
@@ -42,8 +42,16 @@ jest.mock('./hooks/useGetOrCreateUserQueueMutation', () => ({
 jest.mock('./hooks/useAssignableUsersQuery', () => ({
   useAssignableUsersQuery: () => ({ users: [], isLoading: false }),
 }));
+// One assignable CUSTOM queue (its schema_id resolves against the experiment
+// schema below), so tests can route to it alongside the no-auth default queue.
 jest.mock('./hooks/useListReviewQueuesQuery', () => ({
-  useListReviewQueuesQuery: () => ({ reviewQueues: [], isLoading: false, error: null }),
+  useListReviewQueuesQuery: () => ({
+    reviewQueues: [
+      { queue_id: 'rq-custom', queue_type: 'CUSTOM', name: 'Relevance', created_by: 'default', schema_ids: ['s1'] },
+    ],
+    isLoading: false,
+    error: null,
+  }),
 }));
 // One experiment question, so the (no-auth) default queue is assignable.
 jest.mock('../../components/label-schemas', () => ({
@@ -74,7 +82,10 @@ describe('AddToReviewQueueModal', () => {
     mockAddItems.mockResolvedValue({});
     mockGetOrCreateUserQueue.mockReset();
     mockGetOrCreateUserQueue.mockResolvedValue({ review_queue: { queue_id: 'rq-default' } });
-    jest.spyOn(Utils, 'displayGlobalInfoNotification').mockImplementation(() => {});
+    jest
+      .spyOn(Utils, 'displayGlobalInfoNotification')
+      .mockReset()
+      .mockImplementation(() => {});
   });
 
   it('routes the traces and shows a confirmation toast when a destination is selected', async () => {
@@ -106,5 +117,53 @@ describe('AddToReviewQueueModal', () => {
     expect(findLinkTarget(toastNode)).toBe(
       generatePath(RoutePaths.experimentPageTabReviewQueue, { experimentId: 'exp-1' }),
     );
+  });
+
+  it('surfaces a failed destination resolution instead of swallowing it', async () => {
+    mockGetOrCreateUserQueue.mockRejectedValue(new Error('Queue resolution failed'));
+    renderModal();
+
+    fireEvent.click(screen.getByRole('combobox'));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Default queue' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+    // The batch failure surfaces in the modal; traces are not added and no
+    // success toast fires.
+    expect(await screen.findByText('Queue resolution failed')).toBeInTheDocument();
+    expect(mockAddItems).not.toHaveBeenCalled();
+    expect(Utils.displayGlobalInfoNotification).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a failed trace attach instead of swallowing it', async () => {
+    // Resolution succeeds; the attach step is the one that rejects.
+    mockAddItems.mockRejectedValue(new Error('Attach failed'));
+    renderModal();
+
+    fireEvent.click(screen.getByRole('combobox'));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Default queue' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+    expect(await screen.findByText('Attach failed')).toBeInTheDocument();
+    expect(Utils.displayGlobalInfoNotification).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a partial attach failure while still issuing the successful attach', async () => {
+    // Two destinations: the default queue succeeds, the custom queue rejects.
+    mockAddItems.mockImplementation((arg: any) =>
+      arg.queue_id === 'rq-custom' ? Promise.reject(new Error('Attach failed for rq-custom')) : Promise.resolve({}),
+    );
+    renderModal();
+
+    fireEvent.click(screen.getByRole('combobox'));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Default queue' }));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Relevance' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+    // The failing destination surfaces an error...
+    expect(await screen.findByText('Attach failed for rq-custom')).toBeInTheDocument();
+    // ...the successful attach was still issued (allSettled doesn't abort it)...
+    expect(mockAddItems).toHaveBeenCalledWith({ queue_id: 'rq-default', item_ids: ['tr-1'] });
+    // ...and no success toast fires while any destination failed.
+    expect(Utils.displayGlobalInfoNotification).not.toHaveBeenCalled();
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueModal.tsx
@@ -536,8 +536,11 @@ export const AddToReviewQueueModal = ({
               componentId={`${CID}.error`}
               type="error"
               closable={false}
+              // Neutral title: the failure can come from the destination
+              // resolution step or the attach step; the specific cause is in
+              // `submitError` (the description).
               message={intl.formatMessage({
-                defaultMessage: 'Failed to add traces to the review queue.',
+                defaultMessage: 'Something went wrong',
                 description: 'Add to review queue: error alert title',
               })}
               description={submitError}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueModal.tsx
@@ -112,6 +112,11 @@ export const AddToReviewQueueModal = ({
   // `error` slot only retains the last-settled call and a mid-batch failure
   // would be lost. `handleAdd` collects every failure from the batch instead.
   const [submitError, setSubmitError] = useState<string | null>(null);
+  // Tracks the whole add operation locally. The mutation hooks' `isLoading`
+  // reflects only their last-settled call (same shared-instance issue as their
+  // `error` slot), so it can flip false mid-batch and momentarily re-enable
+  // Add; this flag stays true for the entire batch to block a double-submit.
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const itemIds = useMemo(
     () => selectedTraceInfos.map((info) => info.trace_id).filter((id): id is string => Boolean(id)),
@@ -164,7 +169,7 @@ export const AddToReviewQueueModal = ({
   const defaultQueueChecked = !authAvailable && defaultQueueSelected && inheritAllAssignable;
   const selectedCount = (defaultQueueChecked ? 1 : 0) + selectedQueueIds.size + selectedUsers.size;
 
-  const isWorking = isAddingItems || isResolvingUserQueue;
+  const isWorking = isAddingItems || isResolvingUserQueue || isSubmitting;
   const canAdd = selectedCount > 0 && itemIds.length > 0 && !isWorking && reviewerResolved;
 
   const triggerValue = useMemo(
@@ -213,6 +218,7 @@ export const AddToReviewQueueModal = ({
     setCreateOpen(false);
     setAddQuestionOpen(false);
     setSubmitError(null);
+    setIsSubmitting(false);
     resetAdd();
     resetResolve();
     setVisible(false);
@@ -226,75 +232,85 @@ export const AddToReviewQueueModal = ({
     if (!canAdd) {
       return;
     }
+    // Block re-entry for the whole batch (the mutation hooks' isLoading can't —
+    // see the `isSubmitting` declaration); cleared in `finally` on every path.
+    setIsSubmitting(true);
     setSubmitError(null);
-    // Fallback so a failure whose message is blank still surfaces something.
-    const genericError = intl.formatMessage({
-      defaultMessage: 'Something went wrong. Please try again.',
-      description: 'Add to review queue: fallback error when a failure carries no message',
-    });
-    // Resolve every USER-queue destination to a queue id: the no-auth catch-all
-    // (the reserved `default` user queue) and each selected user's personal
-    // queue, all via get-or-create. `allSettled` so one failure doesn't hide the
-    // others; we collect every rejection rather than relying on the mutation's
-    // single shared `error` slot, which only keeps the last-settled call.
-    const usersToResolve = [...(defaultQueueChecked ? [DEFAULT_REVIEWER] : []), ...selectedUsers];
-    const resolved = await Promise.allSettled(
-      usersToResolve.map((user) =>
-        getOrCreateUserQueueAsync({ experiment_id: experimentId, user, created_by: reviewer }).then(
-          (res) => res.review_queue.queue_id,
+    try {
+      // Fallback so a failure whose message is blank still surfaces something.
+      const genericError = intl.formatMessage({
+        defaultMessage: 'Please try again.',
+        description: 'Add to review queue: fallback error detail when a failure carries no message',
+      });
+      // Resolve every USER-queue destination to a queue id: the no-auth catch-all
+      // (the reserved `default` user queue) and each selected user's personal
+      // queue, all via get-or-create. `allSettled` so one failure doesn't hide the
+      // others; we collect every rejection rather than relying on the mutation's
+      // single shared `error` slot, which only keeps the last-settled call.
+      const usersToResolve = [...(defaultQueueChecked ? [DEFAULT_REVIEWER] : []), ...selectedUsers];
+      const resolved = await Promise.allSettled(
+        usersToResolve.map((user) =>
+          getOrCreateUserQueueAsync({ experiment_id: experimentId, user, created_by: reviewer }).then(
+            (res) => res.review_queue.queue_id,
+          ),
         ),
-      ),
-    );
-    // Gate on the rejection count (not the joined message, which can be empty),
-    // and narrow the fulfilled results by status rather than casting.
-    const resolveRejections = resolved.filter((r): r is PromiseRejectedResult => r.status === 'rejected');
-    if (resolveRejections.length > 0) {
-      setSubmitError(collectRejectionMessages(resolveRejections) || genericError);
-      return;
+      );
+      // Gate on the rejection count (not the joined message, which can be empty),
+      // and narrow the fulfilled results by status rather than casting. A failed
+      // resolution aborts the whole add (including selected CUSTOM queues): a
+      // requested destination we can't even resolve fails the operation visibly,
+      // and the idempotent attach makes a corrected retry safe.
+      const resolveRejections = resolved.filter((r): r is PromiseRejectedResult => r.status === 'rejected');
+      if (resolveRejections.length > 0) {
+        setSubmitError(collectRejectionMessages(resolveRejections) || genericError);
+        return;
+      }
+      const resolvedQueueIds = resolved
+        .filter((r): r is PromiseFulfilledResult<string> => r.status === 'fulfilled')
+        .map((r) => r.value);
+      // Attach the traces to every distinct destination, again accumulating every
+      // failure. Re-attaching is idempotent server-side (an already-attached item
+      // is a no-op that keeps its status), so retrying after a partial failure
+      // safely re-sends to the destinations that already succeeded.
+      const queueIds = Array.from(new Set([...selectedQueueIds, ...resolvedQueueIds]));
+      const added = await Promise.allSettled(
+        queueIds.map((queue_id) => addItemsToReviewQueueAsync({ queue_id, item_ids: itemIds })),
+      );
+      const addRejections = added.filter((r): r is PromiseRejectedResult => r.status === 'rejected');
+      if (addRejections.length > 0) {
+        setSubmitError(collectRejectionMessages(addRejections) || genericError);
+        return;
+      }
+      // Confirm the add with a global toast — it must be global to survive this
+      // modal unmounting on close. The notification holder renders inside the
+      // router, so a <Link> resolves correctly for any deployment. The message
+      // text is pre-built via `intl`. `white-space: nowrap` + the notification's
+      // `width: 'auto'` keep it on one line (widening past the default fixed
+      // width) instead of wrapping.
+      const reviewQueuePath = generatePath(RoutePaths.experimentPageTabReviewQueue, { experimentId });
+      Utils.displayGlobalInfoNotification(
+        <span css={{ whiteSpace: 'nowrap' }}>
+          {intl.formatMessage(
+            {
+              defaultMessage: 'Added {count, plural, one {# trace} other {# traces}} to review.',
+              description: 'Add to review queue: success toast after traces are added',
+            },
+            { count: itemIds.length },
+          )}{' '}
+          <Link componentId={`${CID}.toast-view-queue`} to={reviewQueuePath}>
+            {intl.formatMessage({
+              defaultMessage: 'View review queue',
+              description: 'Add to review queue: success toast link to the review queue page',
+            })}
+          </Link>
+        </span>,
+        undefined,
+        { width: 'auto' },
+      );
+      handleClose();
+    } finally {
+      setIsSubmitting(false);
     }
-    const resolvedQueueIds = resolved
-      .filter((r): r is PromiseFulfilledResult<string> => r.status === 'fulfilled')
-      .map((r) => r.value);
-    // Attach the traces to every distinct destination, again accumulating every
-    // failure. Re-attaching is idempotent server-side (an already-attached item
-    // is a no-op that keeps its status), so retrying after a partial failure
-    // safely re-sends to the destinations that already succeeded.
-    const queueIds = Array.from(new Set([...selectedQueueIds, ...resolvedQueueIds]));
-    const added = await Promise.allSettled(
-      queueIds.map((queue_id) => addItemsToReviewQueueAsync({ queue_id, item_ids: itemIds })),
-    );
-    const addRejections = added.filter((r): r is PromiseRejectedResult => r.status === 'rejected');
-    if (addRejections.length > 0) {
-      setSubmitError(collectRejectionMessages(addRejections) || genericError);
-      return;
-    }
-    // Confirm the add with a global toast — it must be global to survive this
-    // modal unmounting on close. The notification holder renders inside the
-    // router, so a <Link> resolves correctly for any deployment. The message
-    // text is pre-built via `intl`. `white-space: nowrap` + the notification's
-    // `width: 'auto'` keep it on one line (widening past the default fixed
-    // width) instead of wrapping.
-    const reviewQueuePath = generatePath(RoutePaths.experimentPageTabReviewQueue, { experimentId });
-    Utils.displayGlobalInfoNotification(
-      <span css={{ whiteSpace: 'nowrap' }}>
-        {intl.formatMessage(
-          {
-            defaultMessage: 'Added {count, plural, one {# trace} other {# traces}} to review.',
-            description: 'Add to review queue: success toast after traces are added',
-          },
-          { count: itemIds.length },
-        )}{' '}
-        <Link componentId={`${CID}.toast-view-queue`} to={reviewQueuePath}>
-          {intl.formatMessage({
-            defaultMessage: 'View review queue',
-            description: 'Add to review queue: success toast link to the review queue page',
-          })}
-        </Link>
-      </span>,
-      undefined,
-      { width: 'auto' },
-    );
-    handleClose();
   };
 
   const reasonText = (reason: ReturnType<typeof getQueueAssignability>['reason']) => {
@@ -540,7 +556,7 @@ export const AddToReviewQueueModal = ({
               // resolution step or the attach step; the specific cause is in
               // `submitError` (the description).
               message={intl.formatMessage({
-                defaultMessage: 'Something went wrong',
+                defaultMessage: 'Something went wrong.',
                 description: 'Add to review queue: error alert title',
               })}
               description={submitError}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueModal.tsx
@@ -36,6 +36,15 @@ import type { ReviewQueue } from './types';
 
 const CID = 'mlflow.experiment-review-queue.add-to-queue';
 
+// Distinct, non-empty error messages from a batch of rejected promises, joined
+// for display. May be empty if every rejection carried a blank message, so
+// callers must decide whether the batch failed from the rejection count, not
+// from this string.
+const collectRejectionMessages = (rejections: PromiseRejectedResult[]): string =>
+  Array.from(
+    new Set(rejections.map((r) => (r.reason instanceof Error ? r.reason.message : String(r.reason))).filter(Boolean)),
+  ).join('; ');
+
 // Custom queues shown before the reviewer searches; the rest are reachable by
 // name through the dropdown's search box.
 const COLLAPSED_QUEUE_COUNT = 3;
@@ -94,18 +103,13 @@ export const AddToReviewQueueModal = ({
   } = useListReviewQueuesQuery({ experimentId, enabled: visible });
   const { labelSchemas } = useListLabelSchemasQuery({ experimentId, enabled: visible });
   const { users, isLoading: usersLoading } = useAssignableUsersQuery({ enabled: visible && canListUsers });
-  const {
-    addItemsToReviewQueueAsync,
-    isAddingItems,
-    error: addError,
-    reset: resetAdd,
-  } = useAddItemsToReviewQueueMutation();
-  const {
-    getOrCreateUserQueueAsync,
-    isResolvingUserQueue,
-    error: resolveError,
-    reset: resetResolve,
-  } = useGetOrCreateUserQueueMutation();
+  const { addItemsToReviewQueueAsync, isAddingItems, reset: resetAdd } = useAddItemsToReviewQueueMutation();
+  const { getOrCreateUserQueueAsync, isResolvingUserQueue, reset: resetResolve } = useGetOrCreateUserQueueMutation();
+  // Errors are tracked locally rather than read off the mutation hooks: a single
+  // `useMutation` instance is reused across every per-destination call, so its
+  // `error` slot only retains the last-settled call and a mid-batch failure
+  // would be lost. `handleAdd` collects every failure from the batch instead.
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
   const itemIds = useMemo(
     () => selectedTraceInfos.map((info) => info.trace_id).filter((id): id is string => Boolean(id)),
@@ -158,7 +162,6 @@ export const AddToReviewQueueModal = ({
   const defaultQueueChecked = !authAvailable && defaultQueueSelected && inheritAllAssignable;
   const selectedCount = (defaultQueueChecked ? 1 : 0) + selectedQueueIds.size + selectedUsers.size;
 
-  const actionError = addError ?? resolveError;
   const isWorking = isAddingItems || isResolvingUserQueue;
   const canAdd = selectedCount > 0 && itemIds.length > 0 && !isWorking;
 
@@ -207,6 +210,7 @@ export const AddToReviewQueueModal = ({
     setSelectedUsers(new Set());
     setCreateOpen(false);
     setAddQuestionOpen(false);
+    setSubmitError(null);
     resetAdd();
     resetResolve();
     setVisible(false);
@@ -220,29 +224,48 @@ export const AddToReviewQueueModal = ({
     if (!canAdd) {
       return;
     }
-    // The no-auth catch-all is the reserved `default` user queue, resolved via
-    // get-or-create just like each selected user's personal queue. Then attach
-    // the traces to every distinct destination.
-    const resolvedDefaultQueueIds = defaultQueueChecked
-      ? [
-          (
-            await getOrCreateUserQueueAsync({
-              experiment_id: experimentId,
-              user: DEFAULT_REVIEWER,
-              created_by: reviewer,
-            })
-          ).review_queue.queue_id,
-        ]
-      : [];
-    const resolvedUserQueueIds = await Promise.all(
-      [...selectedUsers].map((user) =>
+    setSubmitError(null);
+    // Fallback so a failure whose message is blank still surfaces something.
+    const genericError = intl.formatMessage({
+      defaultMessage: 'Something went wrong. Please try again.',
+      description: 'Add to review queue: fallback error when a failure carries no message',
+    });
+    // Resolve every USER-queue destination to a queue id: the no-auth catch-all
+    // (the reserved `default` user queue) and each selected user's personal
+    // queue, all via get-or-create. `allSettled` so one failure doesn't hide the
+    // others; we collect every rejection rather than relying on the mutation's
+    // single shared `error` slot, which only keeps the last-settled call.
+    const usersToResolve = [...(defaultQueueChecked ? [DEFAULT_REVIEWER] : []), ...selectedUsers];
+    const resolved = await Promise.allSettled(
+      usersToResolve.map((user) =>
         getOrCreateUserQueueAsync({ experiment_id: experimentId, user, created_by: reviewer }).then(
           (res) => res.review_queue.queue_id,
         ),
       ),
     );
-    const queueIds = Array.from(new Set([...selectedQueueIds, ...resolvedDefaultQueueIds, ...resolvedUserQueueIds]));
-    await Promise.all(queueIds.map((queue_id) => addItemsToReviewQueueAsync({ queue_id, item_ids: itemIds })));
+    // Gate on the rejection count (not the joined message, which can be empty),
+    // and narrow the fulfilled results by status rather than casting.
+    const resolveRejections = resolved.filter((r): r is PromiseRejectedResult => r.status === 'rejected');
+    if (resolveRejections.length > 0) {
+      setSubmitError(collectRejectionMessages(resolveRejections) || genericError);
+      return;
+    }
+    const resolvedQueueIds = resolved
+      .filter((r): r is PromiseFulfilledResult<string> => r.status === 'fulfilled')
+      .map((r) => r.value);
+    // Attach the traces to every distinct destination, again accumulating every
+    // failure. Re-attaching is idempotent server-side (an already-attached item
+    // is a no-op that keeps its status), so retrying after a partial failure
+    // safely re-sends to the destinations that already succeeded.
+    const queueIds = Array.from(new Set([...selectedQueueIds, ...resolvedQueueIds]));
+    const added = await Promise.allSettled(
+      queueIds.map((queue_id) => addItemsToReviewQueueAsync({ queue_id, item_ids: itemIds })),
+    );
+    const addRejections = added.filter((r): r is PromiseRejectedResult => r.status === 'rejected');
+    if (addRejections.length > 0) {
+      setSubmitError(collectRejectionMessages(addRejections) || genericError);
+      return;
+    }
     // Confirm the add with a global toast — it must be global to survive this
     // modal unmounting on close. The notification holder renders inside the
     // router, so a <Link> resolves correctly for any deployment. The message
@@ -506,7 +529,7 @@ export const AddToReviewQueueModal = ({
             </Typography.Link>
           </div>
 
-          {actionError && (
+          {submitError && (
             <Alert
               componentId={`${CID}.error`}
               type="error"
@@ -515,7 +538,7 @@ export const AddToReviewQueueModal = ({
                 defaultMessage: 'Failed to add traces to the review queue.',
                 description: 'Add to review queue: error alert title',
               })}
-              description={actionError.message}
+              description={submitError}
             />
           )}
         </div>

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -4419,6 +4419,10 @@
     "defaultMessage": "You cannot delete your own account.",
     "description": "Tooltip explaining why the row checkbox is disabled for the current user"
   },
+  "M9u8y0": {
+    "defaultMessage": "Something went wrong. Please try again.",
+    "description": "Add to review queue: fallback error when a failure carries no message"
+  },
   "MB3kda": {
     "defaultMessage": "{pendingCount} pending {pendingCount, plural, =1 {change} other {changes}}",
     "description": "Evaluation review > assessments > pending entries counter"

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -2767,6 +2767,10 @@
     "defaultMessage": "Create and manage judges",
     "description": "Title for the empty state of the judges page"
   },
+  "CSee+U": {
+    "defaultMessage": "Please try again.",
+    "description": "Add to review queue: fallback error detail when a failure carries no message"
+  },
   "CTEh+b": {
     "defaultMessage": "Cancel",
     "description": "Experiment page > new run modal > \"cancel\" button label"
@@ -4415,10 +4419,6 @@
     "defaultMessage": "You cannot delete your own account.",
     "description": "Tooltip explaining why the row checkbox is disabled for the current user"
   },
-  "M9u8y0": {
-    "defaultMessage": "Something went wrong. Please try again.",
-    "description": "Add to review queue: fallback error when a failure carries no message"
-  },
   "MB3kda": {
     "defaultMessage": "{pendingCount} pending {pendingCount, plural, =1 {change} other {changes}}",
     "description": "Evaluation review > assessments > pending entries counter"
@@ -5238,10 +5238,6 @@
   "QJEOCL": {
     "defaultMessage": "Select review queues",
     "description": "Add to review queue: destination dropdown placeholder"
-  },
-  "QJyy17": {
-    "defaultMessage": "Something went wrong",
-    "description": "Add to review queue: error alert title"
   },
   "QK/Qyx": {
     "defaultMessage": "Total",
@@ -6910,6 +6906,10 @@
   "Z+tEhr": {
     "defaultMessage": "Compare selected runs",
     "description": "Tooltip for the compare button when enabled"
+  },
+  "Z/7Ru5": {
+    "defaultMessage": "Something went wrong.",
+    "description": "Add to review queue: error alert title"
   },
   "Z/CtWD": {
     "defaultMessage": "Safety",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -3499,10 +3499,6 @@
     "defaultMessage": "Select a Provider",
     "description": "Modal title for provider selection"
   },
-  "H1F4hJ": {
-    "defaultMessage": "Failed to add traces to the review queue.",
-    "description": "Add to review queue: error alert title"
-  },
   "H2UIIZ": {
     "defaultMessage": "null",
     "description": "Null value in the evaluations table."
@@ -5242,6 +5238,10 @@
   "QJEOCL": {
     "defaultMessage": "Select review queues",
     "description": "Add to review queue: destination dropdown placeholder"
+  },
+  "QJyy17": {
+    "defaultMessage": "Something went wrong",
+    "description": "Add to review queue: error alert title"
   },
   "QK/Qyx": {
     "defaultMessage": "Total",


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23807

### What changes are proposed in this pull request?

Follow-up to a review comment on #23807. When routing traces, `AddToReviewQueueModal` resolves each destination (the no-auth default queue and each selected user's personal queue) and then attaches the traces, in both cases firing many calls through a single `useMutation` instance per step. The displayed error was read off that hook's shared `error` slot, and react-query overwrites the slot on every call — so if a mid-batch call failed but a later one settled, the failure was silently swallowed (the modal could even close as if it succeeded).

This change:
- Runs both batches (queue resolution, item attach) through `Promise.allSettled` and collects every rejection into a local `submitError` state, joining distinct messages.
- Surfaces the error in the existing alert and only fires the success toast / closes the modal when the whole batch succeeds.
- Drops the now-unused `error` reads from the two mutation hooks.

As a side benefit, the old `Promise.all` could reject out of the click handler with no `catch` (an unhandled rejection); `allSettled` removes that path.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added a test asserting a failed destination resolution surfaces the error and does not add traces or fire the success toast.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.