### PR TITLE
Gate review-queue write stamping until the reviewer identity resolves

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueModal.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueModal.test.tsx
@@ -15,7 +15,12 @@ jest.mock('../../../account/hooks', () => ({
   useCurrentUserIsAdmin: () => false,
   useCurrentUserIsWorkspaceAdmin: () => false,
 }));
-jest.mock('./hooks/useReviewer', () => ({ useReviewer: () => 'default', DEFAULT_REVIEWER: 'default' }));
+let mockReviewerResolved = true;
+jest.mock('./hooks/useReviewer', () => ({
+  useReviewer: () => 'default',
+  DEFAULT_REVIEWER: 'default',
+  useIsReviewerResolved: () => mockReviewerResolved,
+}));
 jest.mock('./hooks/useCanManageReviews', () => ({ useCanManageReviews: () => false }));
 jest.mock('./CreateReviewQueueModal', () => ({ CreateReviewQueueModal: () => null }));
 
@@ -70,6 +75,7 @@ const renderModal = () =>
 
 describe('AddToReviewQueueModal', () => {
   beforeEach(() => {
+    mockReviewerResolved = true;
     mockAddItems.mockReset();
     mockAddItems.mockResolvedValue({});
     mockGetOrCreateUserQueue.mockReset();
@@ -106,5 +112,17 @@ describe('AddToReviewQueueModal', () => {
     expect(findLinkTarget(toastNode)).toBe(
       generatePath(RoutePaths.experimentPageTabReviewQueue, { experimentId: 'exp-1' }),
     );
+  });
+
+  it('keeps Add disabled until the reviewer identity is resolved', () => {
+    mockReviewerResolved = false;
+    renderModal();
+
+    fireEvent.click(screen.getByRole('combobox'));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Default queue' }));
+
+    // A destination is selected, but the reviewer is still loading, so the write
+    // (which stamps created_by) must not be allowed yet.
+    expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled();
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueModal.tsx
@@ -31,7 +31,7 @@ import { useAddItemsToReviewQueueMutation } from './hooks/useAddItemsToReviewQue
 import { useAssignableUsersQuery } from './hooks/useAssignableUsersQuery';
 import { useGetOrCreateUserQueueMutation } from './hooks/useGetOrCreateUserQueueMutation';
 import { useListReviewQueuesQuery } from './hooks/useListReviewQueuesQuery';
-import { DEFAULT_REVIEWER, useReviewer } from './hooks/useReviewer';
+import { DEFAULT_REVIEWER, useIsReviewerResolved, useReviewer } from './hooks/useReviewer';
 import type { ReviewQueue } from './types';
 
 const CID = 'mlflow.experiment-review-queue.add-to-queue';
@@ -71,6 +71,8 @@ export const AddToReviewQueueModal = ({
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
   const reviewer = useReviewer();
+  // Don't let a write stamp `created_by` until the reviewer identity is settled.
+  const reviewerResolved = useIsReviewerResolved();
   const authAvailable = useIsAuthAvailable();
   const isAdmin = useCurrentUserIsAdmin();
   const isWorkspaceAdmin = useCurrentUserIsWorkspaceAdmin();
@@ -160,7 +162,7 @@ export const AddToReviewQueueModal = ({
 
   const actionError = addError ?? resolveError;
   const isWorking = isAddingItems || isResolvingUserQueue;
-  const canAdd = selectedCount > 0 && itemIds.length > 0 && !isWorking;
+  const canAdd = selectedCount > 0 && itemIds.length > 0 && !isWorking && reviewerResolved;
 
   const triggerValue = useMemo(
     () =>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/CreateReviewQueueModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/CreateReviewQueueModal.tsx
@@ -22,7 +22,7 @@ import { LabelSchemaInputRenderer, useListLabelSchemasQuery } from '../../compon
 import { QuestionChecklistCombobox } from './QuestionChecklistCombobox';
 import { useIsAuthAvailable } from '../../../account/hooks';
 import { useCreateReviewQueueMutation } from './hooks/useCreateReviewQueueMutation';
-import { useReviewer } from './hooks/useReviewer';
+import { useIsReviewerResolved, useReviewer } from './hooks/useReviewer';
 import type { ReviewQueue } from './types';
 
 const CID = 'mlflow.experiment-review-queue.create-queue';
@@ -47,6 +47,8 @@ export const CreateReviewQueueModal = ({
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
   const createdBy = useReviewer();
+  // Don't let the create stamp `created_by` until the reviewer identity is settled.
+  const reviewerResolved = useIsReviewerResolved();
   const authAvailable = useIsAuthAvailable();
   const { labelSchemas, isLoading } = useListLabelSchemasQuery({ experimentId });
   const { createReviewQueueAsync, isCreatingQueue, error } = useCreateReviewQueueMutation();
@@ -109,7 +111,7 @@ export const CreateReviewQueueModal = ({
   const removeReviewerAt = (index: number) => setReviewers((prev) => prev.filter((_, i) => i !== index));
 
   const trimmedName = name.trim();
-  const canSubmit = trimmedName.length > 0 && checkedIds.size > 0 && !isCreatingQueue;
+  const canSubmit = trimmedName.length > 0 && checkedIds.size > 0 && !isCreatingQueue && reviewerResolved;
 
   // Keep the questions dropdown above this modal — otherwise it opens behind the
   // modal when launched over a trace-detail drawer. `zIndexBase` is the drawer's

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ExperimentReviewQueuePage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ExperimentReviewQueuePage.tsx
@@ -20,7 +20,7 @@ import { useGetOrCreateUserQueueMutation } from './hooks/useGetOrCreateUserQueue
 import { useListReviewQueueItemsQuery } from './hooks/useListReviewQueueItemsQuery';
 import { useListReviewQueuesQuery } from './hooks/useListReviewQueuesQuery';
 import { useRemoveItemsFromReviewQueueMutation } from './hooks/useRemoveItemsFromReviewQueueMutation';
-import { DEFAULT_REVIEWER, displayUser, useReviewer } from './hooks/useReviewer';
+import { DEFAULT_REVIEWER, displayUser, useIsReviewerResolved, useReviewer } from './hooks/useReviewer';
 import { useSetReviewQueueItemStatusMutation } from './hooks/useSetReviewQueueItemStatusMutation';
 import { canDeleteQueue, canManageQueue } from './queuePermissions';
 import type { ReviewQueueItem, ReviewStatus } from './types';
@@ -40,6 +40,9 @@ const ExperimentReviewQueuePage = () => {
   const intl = useIntl();
   const { experimentId } = useParams<{ experimentId: string }>();
   const reviewer = useReviewer();
+  // Completion stamps `completed_by` with the reviewer, so block it until the
+  // identity is settled (an in-flight /users/current load reads as `default`).
+  const reviewerResolved = useIsReviewerResolved();
   const authAvailable = useIsAuthAvailable();
   // Gate management controls (create / edit / delete queue, edit questions) on
   // EDIT+; reviewing stays available to everyone assigned. See useCanManageReviews.
@@ -264,7 +267,9 @@ const ExperimentReviewQueuePage = () => {
         items={orderedTraces}
         schemas={questionSchemas}
         completedBy={reviewer}
-        isSettingStatus={isSettingStatus}
+        // Treat an unresolved reviewer like an in-flight write so the complete /
+        // decline controls stay disabled until `completed_by` is trustworthy.
+        isSettingStatus={isSettingStatus || !reviewerResolved}
         onBack={() => setOpenItemId(null)}
         onSelect={(itemId) => setOpenItemId(itemId)}
         onSetStatus={setOpenStatus}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/hooks/useReviewer.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/hooks/useReviewer.ts
@@ -28,3 +28,17 @@ export const useReviewer = (): string => {
   const { data: currentUser } = useCurrentUserQuery();
   return currentUser?.user?.username || DEFAULT_REVIEWER;
 };
+
+/**
+ * Whether the reviewer identity returned by `useReviewer` is settled. While
+ * `/users/current` is still loading on an authenticated server, `useReviewer`
+ * falls back to the reserved `default` user — indistinguishable from a genuine
+ * no-auth server. Stamping a write (`created_by` / `completed_by`) in that
+ * window would mis-attribute it to `default`, so callers gate those actions on
+ * this. Once the query settles the reviewer is correct on both auth (real
+ * username) and no-auth (`default`) servers.
+ */
+export const useIsReviewerResolved = (): boolean => {
+  const { isLoading } = useCurrentUserQuery();
+  return !isLoading;
+};


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23807

### What changes are proposed in this pull request?

Follow-up to a review comment on the review-queue stack. `useReviewer` returns `currentUser?.user?.username || DEFAULT_REVIEWER`, so while `/users/current` is still loading on an authenticated server it momentarily resolves to the reserved `default` user — indistinguishable from a genuine no-auth server. A write fired in that brief window would stamp `created_by` / `completed_by` as `default` instead of the real reviewer.

This adds `useIsReviewerResolved` (true once the current-user query settles) and gates the stamping actions on it:
- "Add to review queue" confirm button (`created_by` on the resolved user queues).
- "Create review queue" confirm button (`created_by`).
- Focused-review complete / decline controls (`completed_by`), by treating an unresolved reviewer like an in-flight status write.

Once the query resolves, the reviewer is correct on both authenticated (real username) and no-auth (`default`) servers, so the gate is a no-op in the common case. This is a client-side attribution fix only; server-side authorization is independent and does not trust these fields.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added a test asserting the "Add" button stays disabled while the reviewer identity is unresolved.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.