### PR TITLE
fix: handle table already exists in db initialization (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,9 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    # Use checkfirst=True to avoid 'table already exists' errors
+    # when called on a database that has partial tables.
+    InitialBase.metadata.create_all(engine, checkfirst=True)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When upgrading from 3.7.0 to 3.8.x, the `mlflow db upgrade` command fails with "Table 'secrets' already exists" because `_initialize_tables` calls `create_all` without `checkfirst=True`, and the 'secrets' table already exists in the database.

## Fix
Added `checkfirst=True` to the `InitialBase.metadata.create_all(engine)` call in `_initialize_tables`. This tells SQLAlchemy to skip creation of tables that already exist, preventing the duplicate table error.

Closes #19943