### PR TITLE
Improve Google ADK scorers doc page

### DIFF
--- a/docs/docs/genai/eval-monitor/scorers/third-party/google-adk.mdx
+++ b/docs/docs/genai/eval-monitor/scorers/third-party/google-adk.mdx
@@ -12,8 +12,12 @@ import { Bot, GitBranch, Shield } from "lucide-react";
 Google ADK scorers require the `google-adk` package:
 
 ```bash
-pip install google-adk
+pip install "mlflow>=3.13" "google-adk"
 ```
+
+MLflow 3.11 added `ToolTrajectory` and `ResponseMatch`. MLflow 3.13 added the three LLM-judge scorers (`ResponseEvaluation`, `Safety`, `Hallucination`). Install MLflow 3.13 or later for the full set.
+
+If you're also tracing your agent, see the [Google ADK tracing integration](/genai/tracing/integrations/listing/google-adk) for one-line auto-tracing setup. The deterministic scorers on this page read tool calls directly from those traces.
 
 ## Quick Start
 
@@ -97,12 +101,22 @@ LLM judge scorers use a Gemini model to grade the agent's response:
 | <APILink fn="mlflow.genai.scorers.google_adk.Hallucination">Hallucination</APILink>           | Is the agent's response factually grounded (not hallucinated)?     | [Link](https://google.github.io/adk-docs/evaluate/) |
 
 :::note
-LLM judge scorers require a model that ADK's `LlmRegistry` can resolve, such as `gemini-2.5-flash`. MLflow model URIs like `databricks` or `openai:/gpt-4o` are not supported by these scorers.
+LLM judge scorers require a model that ADK's `LlmRegistry` can resolve, such as `gemini-2.5-flash`. MLflow model URIs like `databricks` or `openai:/gpt-4o` aren't supported here, because ADK's evaluators wire directly into Google's model registry. If you need an OpenAI, Anthropic, or Databricks judge backend, the [TruLens](/genai/eval-monitor/scorers/third-party/trulens) and [DeepEval](/genai/eval-monitor/scorers/third-party/deepeval) integrations cover the broader provider set.
 :::
 
 :::caution
 `ResponseEvaluation` and `Hallucination` call the Gemini Developer API and accept a `GEMINI_API_KEY` or `GOOGLE_API_KEY` plus `GOOGLE_GENAI_USE_VERTEXAI=false`. `Safety` is routed by ADK through the Vertex AI Evaluation Service (`_SingleTurnVertexAiEvalFacade`) and requires Google Cloud project credentials (`GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, and `gcloud auth application-default login` or a service account). When auth is missing, scorers return a `Feedback` with an `error` field rather than raising, so evaluation runs can continue and surface the misconfiguration per-sample.
 :::
+
+## How Tool Calls Are Resolved
+
+`ToolTrajectory` needs both the expected tool calls (from `expectations["expected_tool_calls"]`) and the actual tool calls the agent made. It resolves the actual calls in this order:
+
+1. **`expectations["actual_tool_calls"]` when present.** Useful for offline evaluation where you've captured tool calls as data, or for synthetic test cases.
+2. **`TOOL` spans on the MLflow trace.** When no explicit override is provided, the scorer walks the trace and reads tool calls from spans tagged as `TOOL`. This is the path for live evaluations that use `mlflow.genai.evaluate(predict_fn=...)` or pass a trace directly.
+3. **Empty list.** If neither is available, the scorer compares the expected list against an empty actual list, which results in a 0.0 score for non-empty expectations.
+
+Returned tool call dicts have `name` and `args` keys, matching the shape used under `expectations["expected_tool_calls"]`. This keeps the same call format consistent across offline data and live trace extraction.
 
 ## Creating Scorers by Name
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22299, relates to #22496

Follow-up doc-only improvements to the Google ADK scorers page that landed across #22299 (deterministic scorers) and #22496 (LLM judges).

### What changes are proposed in this pull request?

Five small improvements to \`docs/docs/genai/eval-monitor/scorers/third-party/google-adk.mdx\`:

1. Pin \`mlflow>=3.13\` in the pip install line so users running the full scorer set don't hit import errors on older versions.
2. Note which scorers shipped in 3.11 vs 3.13 so users on 3.11 know what's available.
3. Cross-link to the existing Google ADK tracing integration page. Users reading the eval-monitor page often don't know auto-tracing is one line away on the tracing page, and the deterministic scorers depend on those traces.
4. Cross-link to TruLens and DeepEval from the LLM judge note. ADK's evaluators wire directly into Google's LlmRegistry so MLflow model URIs like \`databricks\` and \`openai:/gpt-4o\` aren't supported; readers asking "how do I use a non-Gemini judge?" now have a path.
5. Add a \"How Tool Calls Are Resolved\" section explaining the \`expectations[\"actual_tool_calls\"]\` override and the trace TOOL spans fallback. This was the most common confusion point during the blog draft review.

No code or API changes. Doc-only.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

\`\`\`
cd docs && npm run prettier:check  # passes
cd docs && npm run eslint           # passes
\`\`\`

Verified all code references against the merged source in \`mlflow/genai/scorers/google_adk/\` on master: \`ToolTrajectory\`, \`ResponseMatch\`, \`ResponseEvaluation\`, \`Safety\`, \`Hallucination\`, \`_DEFAULT_JUDGE_MODEL = \"gemini-2.5-flash\"\`, \`_DEFAULT_JUDGE_SAMPLES = 5\`, \`Safety\` raise-on-kwargs behavior, and the trace TOOL span extraction path in \`utils.py:_extract_actual_tool_calls\`.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

(This PR IS the documentation update.)

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The Google ADK scorers documentation page now shows the right minimum MLflow version, cross-links to the ADK tracing integration and to TruLens/DeepEval for non-Gemini judges, and explains how tool calls are resolved from the MLflow trace.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] \`area/docs\`: MLflow documentation pages

<a name=\"release-note-category\"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] \`rn/documentation\` - A user-facing documentation change worth mentioning in the release notes

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release