### PR TITLE
Support 'latest' alias in MCPAccessBinding creation and resolution

### DIFF
--- a/mlflow/store/tracking/mcp_server_registry/abstract_mixin.py
+++ b/mlflow/store/tracking/mcp_server_registry/abstract_mixin.py
@@ -170,14 +170,22 @@ class MCPServerRegistryMixin:
     def get_latest_mcp_server_version(self, name: str) -> MCPServerVersion:
         """Retrieve the latest version of an MCP server.
 
-        Uses the pinned latest_version if set, otherwise falls back to the
-        most recently created non-draft version.
+        If latest_version is explicitly pinned, resolves to that version only.
+        A stale pin (version no longer exists or is deleted) raises
+        RESOURCE_DOES_NOT_EXIST rather than silently falling back.
+
+        If latest_version is unset, falls back to the most recently created
+        non-draft, non-deleted version.
 
         Args:
             name: Server name.
 
         Returns:
             The latest MCPServerVersion entity.
+
+        Raises:
+            MlflowException: If the pinned version is stale or no eligible
+                version exists.
         """
         raise NotImplementedError(self.__class__.__name__)
 

--- a/mlflow/store/tracking/mcp_server_registry/sqlalchemy_mixin.py
+++ b/mlflow/store/tracking/mcp_server_registry/sqlalchemy_mixin.py
@@ -359,7 +359,20 @@ class SqlAlchemyMCPServerRegistryMixin:
                 error_code=RESOURCE_DOES_NOT_EXIST,
             )
 
-        sv = (
+        sv = self._latest_eligible_version_query(session, server_name).first()
+        if not sv:
+            raise MlflowException(
+                f"No eligible latest version found for MCP server '{server_name}'",
+                error_code=RESOURCE_DOES_NOT_EXIST,
+            )
+        return sv
+
+    def get_latest_mcp_server_version(self, name: str) -> MCPServerVersion:
+        with self.ManagedSessionMaker() as session:
+            return self._resolve_latest_version_orm(session, name).to_mlflow_entity()
+
+    def _latest_eligible_version_query(self, session, server_name: str):
+        return (
             self
             ._mcp_server_version_query(session)
             .filter(
@@ -373,33 +386,11 @@ class SqlAlchemyMCPServerRegistryMixin:
                 SqlMCPServerVersion.created_at.desc(),
                 SqlMCPServerVersion.version.desc(),
             )
-            .first()
         )
-        if not sv:
-            raise MlflowException(
-                f"No eligible latest version found for MCP server '{server_name}'",
-                error_code=RESOURCE_DOES_NOT_EXIST,
-            )
-        return sv
-
-    def get_latest_mcp_server_version(self, name: str) -> MCPServerVersion:
-        with self.ManagedSessionMaker() as session:
-            return self._resolve_latest_version_orm(session, name).to_mlflow_entity()
 
     def _delete_latest_alias_bindings_if_unresolvable(self, session, server_name: str) -> None:
         """Delete "latest" bindings when no eligible target version remains."""
-        remaining_versions = (
-            self
-            ._get_query(session, SqlMCPServerVersion)
-            .filter(
-                SqlMCPServerVersion.name == server_name,
-                SqlMCPServerVersion.status.notin_([
-                    MCPStatus.DRAFT.value,
-                    MCPStatus.DELETED.value,
-                ]),
-            )
-            .first()
-        )
+        remaining_versions = self._latest_eligible_version_query(session, server_name).first()
         if not remaining_versions:
             (
                 self

--- a/mlflow/store/tracking/mcp_server_registry/sqlalchemy_mixin.py
+++ b/mlflow/store/tracking/mcp_server_registry/sqlalchemy_mixin.py
@@ -327,46 +327,64 @@ class SqlAlchemyMCPServerRegistryMixin:
                 )
             return self.get_mcp_server_version(name, alias_row.version)
 
-    def get_latest_mcp_server_version(self, name: str) -> MCPServerVersion:
-        with self.ManagedSessionMaker() as session:
-            server = self._get_entity_or_raise(session, SqlMCPServer, {"name": name}, "MCPServer")
-            if server.latest_version:
-                sv = (
-                    self
-                    ._mcp_server_version_query(session)
-                    .filter(
-                        SqlMCPServerVersion.name == name,
-                        SqlMCPServerVersion.version == server.latest_version,
-                    )
-                    .one_or_none()
-                )
-                if sv:
-                    return sv.to_mlflow_entity()
+    def _resolve_latest_version_orm(self, session, server_name: str) -> SqlMCPServerVersion:
+        """Resolve 'latest' to a SqlMCPServerVersion within an existing session.
 
+        If latest_version is explicitly pinned, resolve to that version only —
+        a stale pin resolves to an error rather than silently falling back to
+        the next candidate (matching resolved_status_expression / with_resolved_latest
+        SQL-level behavior).
+
+        If latest_version is unset, falls back to the most recent non-DRAFT/non-DELETED
+        version (matching _latest_candidates_query ordering for consistency).
+        """
+        server = self._get_entity_or_raise(
+            session, SqlMCPServer, {"name": server_name}, "MCPServer"
+        )
+        if server.latest_version:
             sv = (
                 self
                 ._mcp_server_version_query(session)
                 .filter(
-                    SqlMCPServerVersion.name == name,
-                    SqlMCPServerVersion.status.notin_([
-                        MCPStatus.DRAFT.value,
-                        MCPStatus.DELETED.value,
-                    ]),
+                    SqlMCPServerVersion.name == server_name,
+                    SqlMCPServerVersion.version == server.latest_version,
                 )
-                # Match _latest_candidates_query ordering so same-timestamp
-                # versions resolve consistently.
-                .order_by(
-                    SqlMCPServerVersion.created_at.desc(),
-                    SqlMCPServerVersion.version.desc(),
-                )
-                .first()
+                .one_or_none()
             )
-            if not sv:
-                raise MlflowException(
-                    f"No eligible latest version found for MCP server '{name}'",
-                    error_code=RESOURCE_DOES_NOT_EXIST,
-                )
-            return sv.to_mlflow_entity()
+            if sv:
+                return sv
+            raise MlflowException(
+                f"Pinned latest_version '{server.latest_version}' not found "
+                f"for MCP server '{server_name}'",
+                error_code=RESOURCE_DOES_NOT_EXIST,
+            )
+
+        sv = (
+            self
+            ._mcp_server_version_query(session)
+            .filter(
+                SqlMCPServerVersion.name == server_name,
+                SqlMCPServerVersion.status.notin_([
+                    MCPStatus.DRAFT.value,
+                    MCPStatus.DELETED.value,
+                ]),
+            )
+            .order_by(
+                SqlMCPServerVersion.created_at.desc(),
+                SqlMCPServerVersion.version.desc(),
+            )
+            .first()
+        )
+        if not sv:
+            raise MlflowException(
+                f"No eligible latest version found for MCP server '{server_name}'",
+                error_code=RESOURCE_DOES_NOT_EXIST,
+            )
+        return sv
+
+    def get_latest_mcp_server_version(self, name: str) -> MCPServerVersion:
+        with self.ManagedSessionMaker() as session:
+            return self._resolve_latest_version_orm(session, name).to_mlflow_entity()
 
     def search_mcp_server_versions(
         self,
@@ -481,6 +499,10 @@ class SqlAlchemyMCPServerRegistryMixin:
         server_name: str,
         server_alias: str,
     ) -> SqlMCPServerVersion:
+        if server_alias == "latest":
+            return self._resolve_latest_version_orm(session, server_name)
+
+        # Handle stored aliases
         row = (
             self
             ._get_query(session, SqlMCPServerAlias)
@@ -976,6 +998,11 @@ def _resolved_binding_targets_subquery(
             stmt = stmt.where(SqlMCPAccessBinding.server_name == server_name)
         return stmt
 
+    # All branches include a defensive `status != DELETED` filter on the final
+    # SqlMCPServerVersion join. Under normal operation deleted versions cannot
+    # appear here (delete_mcp_server_version cascade-deletes affected bindings
+    # and clears latest_version pins), but the filter keeps the branches
+    # consistent and guards against data-integrity edge cases.
     direct_stmt = _apply_common_filters(
         sa
         .select(
@@ -1001,7 +1028,8 @@ def _resolved_binding_targets_subquery(
     if server_version is not None:
         direct_stmt = direct_stmt.where(SqlMCPAccessBinding.server_version == server_version)
 
-    alias_stmt = _apply_common_filters(
+    # Stored aliases (non-"latest")
+    stored_alias_stmt = _apply_common_filters(
         sa
         .select(
             SqlMCPAccessBinding.binding_id.label("binding_id"),
@@ -1029,21 +1057,88 @@ def _resolved_binding_targets_subquery(
                 SqlMCPServerVersion.status != MCPStatus.DELETED.value,
             ),
         )
-        .where(SqlMCPAccessBinding.server_alias.is_not(None))
+        .where(
+            SqlMCPAccessBinding.server_alias.is_not(None),
+            SqlMCPAccessBinding.server_alias != "latest",
+        )
     )
-    if server_alias is not None:
-        alias_stmt = alias_stmt.where(SqlMCPAccessBinding.server_alias == server_alias)
+    if server_alias is not None and server_alias != "latest":
+        stored_alias_stmt = stored_alias_stmt.where(
+            SqlMCPAccessBinding.server_alias == server_alias
+        )
+
+    # "latest" alias resolution
+    pinned_version = sa.orm.aliased(SqlMCPServerVersion, name="pinned_latest")
+    latest_candidates = SqlMCPServer._latest_candidates_query().subquery("latest_candidates")
+    latest_alias_stmt = _apply_common_filters(
+        sa
+        .select(
+            SqlMCPAccessBinding.binding_id.label("binding_id"),
+            SqlMCPAccessBinding.workspace.label("binding_workspace"),
+            SqlMCPAccessBinding.server_name.label("binding_server_name"),
+            SqlMCPServerVersion.workspace.label("resolved_workspace"),
+            SqlMCPServerVersion.name.label("resolved_name"),
+            SqlMCPServerVersion.version.label("resolved_version"),
+        )
+        .select_from(SqlMCPAccessBinding)
+        .join(
+            SqlMCPServer,
+            sa.and_(
+                SqlMCPAccessBinding.workspace == SqlMCPServer.workspace,
+                SqlMCPAccessBinding.server_name == SqlMCPServer.name,
+            ),
+        )
+        .outerjoin(
+            pinned_version,
+            sa.and_(
+                pinned_version.workspace == SqlMCPServer.workspace,
+                pinned_version.name == SqlMCPServer.name,
+                pinned_version.version == SqlMCPServer.latest_version,
+            ),
+        )
+        .outerjoin(
+            latest_candidates,
+            sa.and_(
+                latest_candidates.c.workspace == SqlMCPServer.workspace,
+                latest_candidates.c.name == SqlMCPServer.name,
+                latest_candidates.c.row_num == 1,
+            ),
+        )
+        .join(
+            SqlMCPServerVersion,
+            sa.and_(
+                SqlMCPServerVersion.workspace == SqlMCPAccessBinding.workspace,
+                SqlMCPServerVersion.name == SqlMCPAccessBinding.server_name,
+                SqlMCPServerVersion.version
+                == sa.case(
+                    (SqlMCPServer.latest_version.is_not(None), pinned_version.version),
+                    else_=latest_candidates.c.version,
+                ),
+                SqlMCPServerVersion.status != MCPStatus.DELETED.value,
+            ),
+        )
+        .where(SqlMCPAccessBinding.server_alias == "latest")
+    )
 
     branches = []
+
     if server_alias is None:
         branches.append(direct_stmt)
+
     if server_version is None:
-        branches.append(alias_stmt)
+        if server_alias is None:
+            branches.append(stored_alias_stmt)
+            branches.append(latest_alias_stmt)
+        elif server_alias == "latest":
+            branches.append(latest_alias_stmt)
+        else:
+            branches.append(stored_alias_stmt)
 
     if not branches:
         return direct_stmt.where(sa.false()).subquery("resolved_binding_targets")
 
-    stmt = branches[0] if len(branches) == 1 else branches[0].union_all(branches[1])
+    # Use sa.union_all to combine multiple branches
+    stmt = branches[0] if len(branches) == 1 else sa.union_all(*branches)
     return stmt.subquery("resolved_binding_targets")
 
 

--- a/mlflow/store/tracking/mcp_server_registry/sqlalchemy_mixin.py
+++ b/mlflow/store/tracking/mcp_server_registry/sqlalchemy_mixin.py
@@ -386,6 +386,31 @@ class SqlAlchemyMCPServerRegistryMixin:
         with self.ManagedSessionMaker() as session:
             return self._resolve_latest_version_orm(session, name).to_mlflow_entity()
 
+    def _delete_latest_alias_bindings_if_unresolvable(self, session, server_name: str) -> None:
+        """Delete "latest" bindings when no eligible target version remains."""
+        remaining_versions = (
+            self
+            ._get_query(session, SqlMCPServerVersion)
+            .filter(
+                SqlMCPServerVersion.name == server_name,
+                SqlMCPServerVersion.status.notin_([
+                    MCPStatus.DRAFT.value,
+                    MCPStatus.DELETED.value,
+                ]),
+            )
+            .first()
+        )
+        if not remaining_versions:
+            (
+                self
+                ._get_query(session, SqlMCPAccessBinding)
+                .filter(
+                    SqlMCPAccessBinding.server_name == server_name,
+                    SqlMCPAccessBinding.server_alias == "latest",
+                )
+                .delete(synchronize_session=False)
+            )
+
     def search_mcp_server_versions(
         self,
         name: str,
@@ -436,6 +461,8 @@ class SqlAlchemyMCPServerRegistryMixin:
             sv.last_updated_at = get_current_time_millis()
             session.add(sv)
             session.flush()
+            if status == MCPStatus.DRAFT:
+                self._delete_latest_alias_bindings_if_unresolvable(session, name)
             return sv.to_mlflow_entity()
 
     def delete_mcp_server_version(self, name: str, version: str) -> None:
@@ -490,31 +517,7 @@ class SqlAlchemyMCPServerRegistryMixin:
             sv.status = MCPStatus.DELETED.value
             sv.last_updated_at = get_current_time_millis()
             session.flush()
-
-            # If no eligible versions remain for "latest" resolution, clean up
-            # bindings that use server_alias="latest"
-            remaining_versions = (
-                self
-                ._get_query(session, SqlMCPServerVersion)
-                .filter(
-                    SqlMCPServerVersion.name == name,
-                    SqlMCPServerVersion.status.notin_([
-                        MCPStatus.DRAFT.value,
-                        MCPStatus.DELETED.value,
-                    ]),
-                )
-                .first()
-            )
-            if not remaining_versions:
-                (
-                    self
-                    ._get_query(session, SqlMCPAccessBinding)
-                    .filter(
-                        SqlMCPAccessBinding.server_name == name,
-                        SqlMCPAccessBinding.server_alias == "latest",
-                    )
-                    .delete(synchronize_session=False)
-                )
+            self._delete_latest_alias_bindings_if_unresolvable(session, name)
 
     # --- MCPAccessBinding operations ---
 

--- a/mlflow/store/tracking/mcp_server_registry/sqlalchemy_mixin.py
+++ b/mlflow/store/tracking/mcp_server_registry/sqlalchemy_mixin.py
@@ -491,6 +491,31 @@ class SqlAlchemyMCPServerRegistryMixin:
             sv.last_updated_at = get_current_time_millis()
             session.flush()
 
+            # If no eligible versions remain for "latest" resolution, clean up
+            # bindings that use server_alias="latest"
+            remaining_versions = (
+                self
+                ._get_query(session, SqlMCPServerVersion)
+                .filter(
+                    SqlMCPServerVersion.name == name,
+                    SqlMCPServerVersion.status.notin_([
+                        MCPStatus.DRAFT.value,
+                        MCPStatus.DELETED.value,
+                    ]),
+                )
+                .first()
+            )
+            if not remaining_versions:
+                (
+                    self
+                    ._get_query(session, SqlMCPAccessBinding)
+                    .filter(
+                        SqlMCPAccessBinding.server_name == name,
+                        SqlMCPAccessBinding.server_alias == "latest",
+                    )
+                    .delete(synchronize_session=False)
+                )
+
     # --- MCPAccessBinding operations ---
 
     def _get_alias_target_version_or_raise(
@@ -1003,139 +1028,161 @@ def _resolved_binding_targets_subquery(
     # appear here (delete_mcp_server_version cascade-deletes affected bindings
     # and clears latest_version pins), but the filter keeps the branches
     # consistent and guards against data-integrity edge cases.
-    direct_stmt = _apply_common_filters(
-        sa
-        .select(
-            SqlMCPAccessBinding.binding_id.label("binding_id"),
-            SqlMCPAccessBinding.workspace.label("binding_workspace"),
-            SqlMCPAccessBinding.server_name.label("binding_server_name"),
-            SqlMCPServerVersion.workspace.label("resolved_workspace"),
-            SqlMCPServerVersion.name.label("resolved_name"),
-            SqlMCPServerVersion.version.label("resolved_version"),
-        )
-        .select_from(SqlMCPAccessBinding)
-        .join(
-            SqlMCPServerVersion,
-            sa.and_(
-                SqlMCPAccessBinding.workspace == SqlMCPServerVersion.workspace,
-                SqlMCPAccessBinding.server_name == SqlMCPServerVersion.name,
-                SqlMCPAccessBinding.server_version == SqlMCPServerVersion.version,
-                SqlMCPServerVersion.status != MCPStatus.DELETED.value,
-            ),
-        )
-        .where(SqlMCPAccessBinding.server_version.is_not(None))
-    )
-    if server_version is not None:
-        direct_stmt = direct_stmt.where(SqlMCPAccessBinding.server_version == server_version)
-
-    # Stored aliases (non-"latest")
-    stored_alias_stmt = _apply_common_filters(
-        sa
-        .select(
-            SqlMCPAccessBinding.binding_id.label("binding_id"),
-            SqlMCPAccessBinding.workspace.label("binding_workspace"),
-            SqlMCPAccessBinding.server_name.label("binding_server_name"),
-            SqlMCPServerVersion.workspace.label("resolved_workspace"),
-            SqlMCPServerVersion.name.label("resolved_name"),
-            SqlMCPServerVersion.version.label("resolved_version"),
-        )
-        .select_from(SqlMCPAccessBinding)
-        .join(
-            alias_row,
-            sa.and_(
-                SqlMCPAccessBinding.workspace == alias_row.workspace,
-                SqlMCPAccessBinding.server_name == alias_row.name,
-                SqlMCPAccessBinding.server_alias == alias_row.alias,
-            ),
-        )
-        .join(
-            SqlMCPServerVersion,
-            sa.and_(
-                alias_row.workspace == SqlMCPServerVersion.workspace,
-                alias_row.name == SqlMCPServerVersion.name,
-                alias_row.version == SqlMCPServerVersion.version,
-                SqlMCPServerVersion.status != MCPStatus.DELETED.value,
-            ),
-        )
-        .where(
-            SqlMCPAccessBinding.server_alias.is_not(None),
-            SqlMCPAccessBinding.server_alias != "latest",
-        )
-    )
-    if server_alias is not None and server_alias != "latest":
-        stored_alias_stmt = stored_alias_stmt.where(
-            SqlMCPAccessBinding.server_alias == server_alias
-        )
-
-    # "latest" alias resolution
-    pinned_version = sa.orm.aliased(SqlMCPServerVersion, name="pinned_latest")
-    latest_candidates = SqlMCPServer._latest_candidates_query().subquery("latest_candidates")
-    latest_alias_stmt = _apply_common_filters(
-        sa
-        .select(
-            SqlMCPAccessBinding.binding_id.label("binding_id"),
-            SqlMCPAccessBinding.workspace.label("binding_workspace"),
-            SqlMCPAccessBinding.server_name.label("binding_server_name"),
-            SqlMCPServerVersion.workspace.label("resolved_workspace"),
-            SqlMCPServerVersion.name.label("resolved_name"),
-            SqlMCPServerVersion.version.label("resolved_version"),
-        )
-        .select_from(SqlMCPAccessBinding)
-        .join(
-            SqlMCPServer,
-            sa.and_(
-                SqlMCPAccessBinding.workspace == SqlMCPServer.workspace,
-                SqlMCPAccessBinding.server_name == SqlMCPServer.name,
-            ),
-        )
-        .outerjoin(
-            pinned_version,
-            sa.and_(
-                pinned_version.workspace == SqlMCPServer.workspace,
-                pinned_version.name == SqlMCPServer.name,
-                pinned_version.version == SqlMCPServer.latest_version,
-            ),
-        )
-        .outerjoin(
-            latest_candidates,
-            sa.and_(
-                latest_candidates.c.workspace == SqlMCPServer.workspace,
-                latest_candidates.c.name == SqlMCPServer.name,
-                latest_candidates.c.row_num == 1,
-            ),
-        )
-        .join(
-            SqlMCPServerVersion,
-            sa.and_(
-                SqlMCPServerVersion.workspace == SqlMCPAccessBinding.workspace,
-                SqlMCPServerVersion.name == SqlMCPAccessBinding.server_name,
-                SqlMCPServerVersion.version
-                == sa.case(
-                    (SqlMCPServer.latest_version.is_not(None), pinned_version.version),
-                    else_=latest_candidates.c.version,
-                ),
-                SqlMCPServerVersion.status != MCPStatus.DELETED.value,
-            ),
-        )
-        .where(SqlMCPAccessBinding.server_alias == "latest")
-    )
 
     branches = []
 
+    # Build only the query branches we'll actually need based on filter parameters
     if server_alias is None:
+        # Direct version bindings
+        direct_stmt = _apply_common_filters(
+            sa
+            .select(
+                SqlMCPAccessBinding.binding_id.label("binding_id"),
+                SqlMCPAccessBinding.workspace.label("binding_workspace"),
+                SqlMCPAccessBinding.server_name.label("binding_server_name"),
+                SqlMCPServerVersion.workspace.label("resolved_workspace"),
+                SqlMCPServerVersion.name.label("resolved_name"),
+                SqlMCPServerVersion.version.label("resolved_version"),
+            )
+            .select_from(SqlMCPAccessBinding)
+            .join(
+                SqlMCPServerVersion,
+                sa.and_(
+                    SqlMCPAccessBinding.workspace == SqlMCPServerVersion.workspace,
+                    SqlMCPAccessBinding.server_name == SqlMCPServerVersion.name,
+                    SqlMCPAccessBinding.server_version == SqlMCPServerVersion.version,
+                    SqlMCPServerVersion.status != MCPStatus.DELETED.value,
+                ),
+            )
+            .where(SqlMCPAccessBinding.server_version.is_not(None))
+        )
+        if server_version is not None:
+            direct_stmt = direct_stmt.where(SqlMCPAccessBinding.server_version == server_version)
         branches.append(direct_stmt)
 
     if server_version is None:
-        if server_alias is None:
-            branches.append(stored_alias_stmt)
-            branches.append(latest_alias_stmt)
-        elif server_alias == "latest":
-            branches.append(latest_alias_stmt)
-        else:
+        if server_alias is None or (server_alias is not None and server_alias != "latest"):
+            # Stored aliases (non-"latest")
+            stored_alias_stmt = _apply_common_filters(
+                sa
+                .select(
+                    SqlMCPAccessBinding.binding_id.label("binding_id"),
+                    SqlMCPAccessBinding.workspace.label("binding_workspace"),
+                    SqlMCPAccessBinding.server_name.label("binding_server_name"),
+                    SqlMCPServerVersion.workspace.label("resolved_workspace"),
+                    SqlMCPServerVersion.name.label("resolved_name"),
+                    SqlMCPServerVersion.version.label("resolved_version"),
+                )
+                .select_from(SqlMCPAccessBinding)
+                .join(
+                    alias_row,
+                    sa.and_(
+                        SqlMCPAccessBinding.workspace == alias_row.workspace,
+                        SqlMCPAccessBinding.server_name == alias_row.name,
+                        SqlMCPAccessBinding.server_alias == alias_row.alias,
+                    ),
+                )
+                .join(
+                    SqlMCPServerVersion,
+                    sa.and_(
+                        alias_row.workspace == SqlMCPServerVersion.workspace,
+                        alias_row.name == SqlMCPServerVersion.name,
+                        alias_row.version == SqlMCPServerVersion.version,
+                        SqlMCPServerVersion.status != MCPStatus.DELETED.value,
+                    ),
+                )
+                .where(
+                    SqlMCPAccessBinding.server_alias.is_not(None),
+                    SqlMCPAccessBinding.server_alias != "latest",
+                )
+            )
+            if server_alias is not None and server_alias != "latest":
+                stored_alias_stmt = stored_alias_stmt.where(
+                    SqlMCPAccessBinding.server_alias == server_alias
+                )
             branches.append(stored_alias_stmt)
 
+        if server_alias is None or server_alias == "latest":
+            # "latest" alias resolution - only construct when needed
+            pinned_version = sa.orm.aliased(SqlMCPServerVersion, name="pinned_latest")
+            latest_candidates = SqlMCPServer._latest_candidates_query().subquery(
+                "latest_candidates"
+            )
+            latest_alias_stmt = _apply_common_filters(
+                sa
+                .select(
+                    SqlMCPAccessBinding.binding_id.label("binding_id"),
+                    SqlMCPAccessBinding.workspace.label("binding_workspace"),
+                    SqlMCPAccessBinding.server_name.label("binding_server_name"),
+                    SqlMCPServerVersion.workspace.label("resolved_workspace"),
+                    SqlMCPServerVersion.name.label("resolved_name"),
+                    SqlMCPServerVersion.version.label("resolved_version"),
+                )
+                .select_from(SqlMCPAccessBinding)
+                .join(
+                    SqlMCPServer,
+                    sa.and_(
+                        SqlMCPAccessBinding.workspace == SqlMCPServer.workspace,
+                        SqlMCPAccessBinding.server_name == SqlMCPServer.name,
+                    ),
+                )
+                .outerjoin(
+                    pinned_version,
+                    sa.and_(
+                        pinned_version.workspace == SqlMCPServer.workspace,
+                        pinned_version.name == SqlMCPServer.name,
+                        pinned_version.version == SqlMCPServer.latest_version,
+                    ),
+                )
+                .outerjoin(
+                    latest_candidates,
+                    sa.and_(
+                        latest_candidates.c.workspace == SqlMCPServer.workspace,
+                        latest_candidates.c.name == SqlMCPServer.name,
+                        latest_candidates.c.row_num == 1,
+                    ),
+                )
+                .join(
+                    SqlMCPServerVersion,
+                    sa.and_(
+                        SqlMCPServerVersion.workspace == SqlMCPAccessBinding.workspace,
+                        SqlMCPServerVersion.name == SqlMCPAccessBinding.server_name,
+                        SqlMCPServerVersion.version
+                        == sa.case(
+                            (SqlMCPServer.latest_version.is_not(None), pinned_version.version),
+                            else_=latest_candidates.c.version,
+                        ),
+                        SqlMCPServerVersion.status != MCPStatus.DELETED.value,
+                    ),
+                )
+                .where(SqlMCPAccessBinding.server_alias == "latest")
+            )
+            branches.append(latest_alias_stmt)
+
     if not branches:
-        return direct_stmt.where(sa.false()).subquery("resolved_binding_targets")
+        # No valid query - return empty result set
+        empty_stmt = _apply_common_filters(
+            sa
+            .select(
+                SqlMCPAccessBinding.binding_id.label("binding_id"),
+                SqlMCPAccessBinding.workspace.label("binding_workspace"),
+                SqlMCPAccessBinding.server_name.label("binding_server_name"),
+                SqlMCPServerVersion.workspace.label("resolved_workspace"),
+                SqlMCPServerVersion.name.label("resolved_name"),
+                SqlMCPServerVersion.version.label("resolved_version"),
+            )
+            .select_from(SqlMCPAccessBinding)
+            .join(
+                SqlMCPServerVersion,
+                sa.and_(
+                    SqlMCPAccessBinding.workspace == SqlMCPServerVersion.workspace,
+                    SqlMCPAccessBinding.server_name == SqlMCPServerVersion.name,
+                    SqlMCPAccessBinding.server_version == SqlMCPServerVersion.version,
+                ),
+            )
+            .where(sa.false())
+        )
+        return empty_stmt.subquery("resolved_binding_targets")
 
     # Use sa.union_all to combine multiple branches
     stmt = branches[0] if len(branches) == 1 else sa.union_all(*branches)

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_mcp_server_registry.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_mcp_server_registry.py
@@ -1508,6 +1508,45 @@ def test_search_binding_latest_alias_stale_pin_omitted(store):
         store.get_mcp_access_binding("io.github.test/s", binding.binding_id)
 
 
+def test_update_last_eligible_version_to_draft_cleans_up_latest_alias_bindings(store):
+    store.create_mcp_server_version(
+        _server_json("io.github.test/s", "1.0"), status=MCPStatus.ACTIVE
+    )
+    binding = store.create_mcp_access_binding(
+        "io.github.test/s",
+        "https://latest.example.com",
+        server_alias="latest",
+    )
+
+    store.update_mcp_server_version("io.github.test/s", "1.0", status=MCPStatus.DRAFT)
+
+    assert store.search_mcp_access_bindings(server_name="io.github.test/s") == []
+    server = store.get_mcp_server("io.github.test/s")
+    assert server.access_bindings == []
+    with pytest.raises(MlflowException, match="not found"):
+        store.get_mcp_access_binding("io.github.test/s", binding.binding_id)
+
+
+def test_delete_last_eligible_version_cleans_up_latest_alias_bindings(store):
+    store.create_mcp_server_version(
+        _server_json("io.github.test/s", "1.0"), status=MCPStatus.ACTIVE
+    )
+    binding = store.create_mcp_access_binding(
+        "io.github.test/s",
+        "https://latest.example.com",
+        server_alias="latest",
+    )
+    store.update_mcp_server_version("io.github.test/s", "1.0", status=MCPStatus.DEPRECATED)
+
+    store.delete_mcp_server_version("io.github.test/s", "1.0")
+
+    assert store.search_mcp_access_bindings(server_name="io.github.test/s") == []
+    server = store.get_mcp_server("io.github.test/s")
+    assert server.access_bindings == []
+    with pytest.raises(MlflowException, match="not found"):
+        store.get_mcp_access_binding("io.github.test/s", binding.binding_id)
+
+
 def test_search_unfiltered_returns_all_binding_types(store):
     store.create_mcp_server_version(
         _server_json("io.github.test/s", "1.0"), status=MCPStatus.ACTIVE

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_mcp_server_registry.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_mcp_server_registry.py
@@ -1392,6 +1392,204 @@ def test_search_mcp_server_versions_order_by(store):
     assert versions == ["gamma", "beta", "alpha"]
 
 
+def test_create_mcp_access_binding_with_latest_alias(store):
+    # Create server with an active version
+    store.create_mcp_server_version(
+        _server_json("io.github.test/s", "1.0"), status=MCPStatus.ACTIVE
+    )
+
+    # Should be able to create a binding with server_alias="latest"
+    binding = store.create_mcp_access_binding(
+        "io.github.test/s",
+        "https://latest.example.com",
+        server_alias="latest",
+    )
+
+    # Verify the binding was created and resolves to the latest version
+    assert binding.server_alias == "latest"
+    assert binding.server_version is None
+    assert binding.resolved_version is not None
+    assert binding.resolved_version.version == "1.0"
+
+    # Create a newer version and verify "latest" now resolves to it
+    store.create_mcp_server_version(
+        _server_json("io.github.test/s", "2.0"), status=MCPStatus.ACTIVE
+    )
+
+    # Retrieve the binding again to check resolution
+    retrieved_binding = store.get_mcp_access_binding("io.github.test/s", binding.binding_id)
+    assert retrieved_binding.resolved_version.version == "2.0"
+
+
+def test_search_mcp_access_bindings_with_latest_alias(store):
+    store.create_mcp_server_version(
+        _server_json("io.github.test/s", "1.0"), status=MCPStatus.ACTIVE
+    )
+    store.create_mcp_access_binding(
+        "io.github.test/s",
+        "https://latest.example.com",
+        server_alias="latest",
+    )
+
+    # Search should find the binding and resolve its version
+    bindings = store.search_mcp_access_bindings(
+        server_name="io.github.test/s",
+        server_alias="latest",
+    )
+    assert len(bindings) == 1
+    assert bindings[0].server_alias == "latest"
+    assert bindings[0].resolved_version.version == "1.0"
+
+
+def test_get_latest_version_stale_pin_raises(store):
+    store.create_mcp_server_version(
+        _server_json("io.github.test/s", "1.0"), status=MCPStatus.ACTIVE
+    )
+    store.update_mcp_server("io.github.test/s", latest_version="1.0")
+
+    # Simulate stale pin by directly setting latest_version to a nonexistent version
+    from mlflow.store.tracking.dbmodels.models import SqlMCPServer
+
+    with store.ManagedSessionMaker(read_only=False) as session:
+        server = session.query(SqlMCPServer).filter(SqlMCPServer.name == "io.github.test/s").one()
+        server.latest_version = "gone"
+        session.flush()
+
+    with pytest.raises(MlflowException, match="Pinned latest_version 'gone' not found"):
+        store.get_latest_mcp_server_version("io.github.test/s")
+
+
+def test_create_binding_latest_alias_stale_pin_raises(store):
+    store.create_mcp_server_version(
+        _server_json("io.github.test/s", "1.0"), status=MCPStatus.ACTIVE
+    )
+
+    from mlflow.store.tracking.dbmodels.models import SqlMCPServer
+
+    with store.ManagedSessionMaker(read_only=False) as session:
+        server = session.query(SqlMCPServer).filter(SqlMCPServer.name == "io.github.test/s").one()
+        server.latest_version = "gone"
+        session.flush()
+
+    with pytest.raises(MlflowException, match="Pinned latest_version 'gone' not found"):
+        store.create_mcp_access_binding(
+            "io.github.test/s",
+            "https://latest.example.com",
+            server_alias="latest",
+        )
+
+
+def test_search_binding_latest_alias_stale_pin_omitted(store):
+    # Stale-pin bindings are silently omitted from search (SQL JOIN produces no
+    # rows); get_mcp_access_binding surfaces the error instead.
+    store.create_mcp_server_version(
+        _server_json("io.github.test/s", "1.0"), status=MCPStatus.ACTIVE
+    )
+    binding = store.create_mcp_access_binding(
+        "io.github.test/s",
+        "https://latest.example.com",
+        server_alias="latest",
+    )
+    assert binding.resolved_version.version == "1.0"
+
+    from mlflow.store.tracking.dbmodels.models import SqlMCPServer
+
+    with store.ManagedSessionMaker(read_only=False) as session:
+        server = session.query(SqlMCPServer).filter(SqlMCPServer.name == "io.github.test/s").one()
+        server.latest_version = "gone"
+        session.flush()
+
+    # Search silently omits unresolvable bindings
+    bindings = store.search_mcp_access_bindings(server_name="io.github.test/s")
+    assert len(bindings) == 0
+
+    # get_mcp_access_binding surfaces the error
+    with pytest.raises(MlflowException, match="not found"):
+        store.get_mcp_access_binding("io.github.test/s", binding.binding_id)
+
+
+def test_search_unfiltered_returns_all_binding_types(store):
+    store.create_mcp_server_version(
+        _server_json("io.github.test/s", "1.0"), status=MCPStatus.ACTIVE
+    )
+    store.set_mcp_server_alias("io.github.test/s", "prod", "1.0")
+
+    store.create_mcp_access_binding(
+        "io.github.test/s", "https://direct.example.com", server_version="1.0"
+    )
+    store.create_mcp_access_binding(
+        "io.github.test/s", "https://alias.example.com", server_alias="prod"
+    )
+    store.create_mcp_access_binding(
+        "io.github.test/s", "https://latest.example.com", server_alias="latest"
+    )
+
+    bindings = store.search_mcp_access_bindings(server_name="io.github.test/s")
+    assert len(bindings) == 3
+    urls = {b.endpoint_url for b in bindings}
+    assert urls == {
+        "https://direct.example.com",
+        "https://alias.example.com",
+        "https://latest.example.com",
+    }
+    for b in bindings:
+        assert b.resolved_version is not None
+        assert b.resolved_version.version == "1.0"
+
+
+def test_update_binding_to_latest_alias(store):
+    store.create_mcp_server_version(
+        _server_json("io.github.test/s", "1.0"), status=MCPStatus.ACTIVE
+    )
+    binding = store.create_mcp_access_binding(
+        "io.github.test/s", "https://example.com", server_version="1.0"
+    )
+    assert binding.server_version == "1.0"
+
+    updated = store.update_mcp_access_binding(
+        "io.github.test/s",
+        binding.binding_id,
+        server_alias="latest",
+    )
+    assert updated.server_alias == "latest"
+    assert updated.server_version is None
+    assert updated.resolved_version is not None
+    assert updated.resolved_version.version == "1.0"
+
+
+def test_get_mcp_server_includes_latest_alias_binding(store):
+    store.create_mcp_server_version(
+        _server_json("io.github.test/s", "1.0"), status=MCPStatus.ACTIVE
+    )
+    store.create_mcp_access_binding(
+        "io.github.test/s", "https://latest.example.com", server_alias="latest"
+    )
+    server = store.get_mcp_server("io.github.test/s")
+    assert len(server.access_bindings) == 1
+    b = server.access_bindings[0]
+    assert b.server_alias == "latest"
+    assert b.resolved_version is not None
+    assert b.resolved_version.version == "1.0"
+
+
+def test_search_mcp_servers_has_access_bindings_with_latest_alias(store):
+    store.create_mcp_server_version(
+        _server_json("io.github.test/s1", "1.0"), status=MCPStatus.ACTIVE
+    )
+    store.create_mcp_access_binding(
+        "io.github.test/s1", "https://latest.example.com", server_alias="latest"
+    )
+    store.create_mcp_server_version(
+        _server_json("io.github.test/s2", "1.0"), status=MCPStatus.ACTIVE
+    )
+
+    result = store.search_mcp_servers(filter_string="has_access_bindings = 'true'")
+    assert len(result) == 1
+    assert result[0].name == "io.github.test/s1"
+    assert len(result[0].access_bindings) == 1
+    assert result[0].access_bindings[0].resolved_version.version == "1.0"
+
+
 def test_deleted_versions_excluded_from_get(store):
     store.create_mcp_server_version(_server_json("io.github.test/s", "1.0"))
     store.delete_mcp_server_version("io.github.test/s", "1.0")


### PR DESCRIPTION
The reserved "latest" alias was never stored in mcp_server_aliases, so _get_alias_target_version_or_raise() and _resolved_binding_targets_subquery() both failed to resolve it. This caused binding creation with server_alias="latest" to raise, and existing "latest" bindings to never appear in search results.

Changes:
- Extract _resolve_latest_version_orm() as a shared helper for the "pinned or dynamic fallback" resolution pattern, used by both get_latest_mcp_server_version() and _get_alias_target_version_or_raise().
- Add "latest" short-circuit in _get_alias_target_version_or_raise() so binding creation validates via the shared resolver.
- Add a dedicated latest_alias_stmt branch in _resolved_binding_targets_subquery() that resolves "latest" at query time using the same pinned-or-candidate CASE pattern as SqlMCPServer.with_resolved_latest().
- A stale pin (latest_version set but version gone) now raises RESOURCE_DOES_NOT_EXIST rather than silently falling back, matching the SQL-level CASE (not COALESCE) semantics in resolved_status_expression() and with_resolved_latest().
- Simplify branch-selection logic in _resolved_binding_targets_subquery() to make mutual exclusivity of query branches clearer.

<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
