### PR TITLE
Add cached token pricing to Databricks model catalog

### DIFF
--- a/mlflow/utils/model_catalog/databricks.json
+++ b/mlflow/utils/model_catalog/databricks.json
@@ -29,13 +29,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 2.99999,
-        "output_per_million_tokens": 15.00002
+        "output_per_million_tokens": 15.00002,
+        "cache_write_per_million_tokens": 3.74999,
+        "cache_read_per_million_tokens": 0.3
       },
       "capabilities": {
         "function_calling": true,
         "vision": false,
         "reasoning": true,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-04-24"
@@ -49,13 +51,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 1.00002,
-        "output_per_million_tokens": 5.00003
+        "output_per_million_tokens": 5.00003,
+        "cache_write_per_million_tokens": 1.25002,
+        "cache_read_per_million_tokens": 0.1
       },
       "capabilities": {
         "function_calling": true,
         "vision": false,
         "reasoning": true,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-20"
@@ -69,13 +73,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 15.00002,
-        "output_per_million_tokens": 75.00003
+        "output_per_million_tokens": 75.00003,
+        "cache_write_per_million_tokens": 18.75003,
+        "cache_read_per_million_tokens": 1.5
       },
       "capabilities": {
         "function_calling": true,
         "vision": false,
         "reasoning": true,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-20"
@@ -89,13 +95,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 15.00002,
-        "output_per_million_tokens": 75.00003
+        "output_per_million_tokens": 75.00003,
+        "cache_write_per_million_tokens": 18.75003,
+        "cache_read_per_million_tokens": 1.5
       },
       "capabilities": {
         "function_calling": true,
         "vision": false,
         "reasoning": true,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-20"
@@ -109,13 +117,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 5.00003,
-        "output_per_million_tokens": 25.00001
+        "output_per_million_tokens": 25.00001,
+        "cache_write_per_million_tokens": 6.25004,
+        "cache_read_per_million_tokens": 0.5
       },
       "capabilities": {
         "function_calling": true,
         "vision": false,
         "reasoning": true,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-20"
@@ -129,13 +139,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 5.00003,
-        "output_per_million_tokens": 25.00001
+        "output_per_million_tokens": 25.00001,
+        "cache_write_per_million_tokens": 6.25004,
+        "cache_read_per_million_tokens": 0.5
       },
       "capabilities": {
         "function_calling": true,
         "vision": false,
         "reasoning": true,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-20"
@@ -149,13 +161,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 5.00003,
-        "output_per_million_tokens": 25.00001
+        "output_per_million_tokens": 25.00001,
+        "cache_write_per_million_tokens": 6.25004,
+        "cache_read_per_million_tokens": 0.5
       },
       "capabilities": {
         "function_calling": true,
         "vision": false,
         "reasoning": true,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-20"
@@ -169,13 +183,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 5.00003,
-        "output_per_million_tokens": 25.00001
+        "output_per_million_tokens": 25.00001,
+        "cache_write_per_million_tokens": 6.25004,
+        "cache_read_per_million_tokens": 0.5
       },
       "capabilities": {
         "function_calling": true,
         "vision": false,
         "reasoning": true,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-20"
@@ -189,13 +205,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 5.00003,
-        "output_per_million_tokens": 25.00001
+        "output_per_million_tokens": 25.00001,
+        "cache_write_per_million_tokens": 6.25004,
+        "cache_read_per_million_tokens": 0.5
       },
       "capabilities": {
         "function_calling": true,
         "vision": false,
         "reasoning": true,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-20"
@@ -209,13 +227,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 2.99999,
-        "output_per_million_tokens": 15.00002
+        "output_per_million_tokens": 15.00002,
+        "cache_write_per_million_tokens": 3.74999,
+        "cache_read_per_million_tokens": 0.3
       },
       "capabilities": {
         "function_calling": true,
         "vision": false,
         "reasoning": true,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-20"
@@ -229,13 +249,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 2.99999,
-        "output_per_million_tokens": 15.00002
+        "output_per_million_tokens": 15.00002,
+        "cache_write_per_million_tokens": 3.74999,
+        "cache_read_per_million_tokens": 0.3
       },
       "capabilities": {
         "function_calling": true,
         "vision": false,
         "reasoning": true,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-20"
@@ -249,13 +271,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 2.99999,
-        "output_per_million_tokens": 15.00002
+        "output_per_million_tokens": 15.00002,
+        "cache_write_per_million_tokens": 3.74999,
+        "cache_read_per_million_tokens": 0.3
       },
       "capabilities": {
         "function_calling": true,
         "vision": false,
         "reasoning": true,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-20"
@@ -269,13 +293,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 2.99999,
-        "output_per_million_tokens": 15.00002
+        "output_per_million_tokens": 15.00002,
+        "cache_write_per_million_tokens": 3.74999,
+        "cache_read_per_million_tokens": 0.3
       },
       "capabilities": {
         "function_calling": true,
         "vision": false,
         "reasoning": true,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-20"
@@ -289,13 +315,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 2.99999,
-        "output_per_million_tokens": 15.00002
+        "output_per_million_tokens": 15.00002,
+        "cache_write_per_million_tokens": 3.74999,
+        "cache_read_per_million_tokens": 0.3
       },
       "capabilities": {
         "function_calling": true,
         "vision": false,
         "reasoning": true,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-20"
@@ -309,13 +337,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 0.30002,
-        "output_per_million_tokens": 2.49998
+        "output_per_million_tokens": 2.49998,
+        "cache_write_per_million_tokens": 0.30002,
+        "cache_read_per_million_tokens": 0.03
       },
       "capabilities": {
         "function_calling": true,
         "vision": false,
         "reasoning": false,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-21"
@@ -329,13 +359,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 1.24999,
-        "output_per_million_tokens": 9.99999
+        "output_per_million_tokens": 9.99999,
+        "cache_write_per_million_tokens": 1.24999,
+        "cache_read_per_million_tokens": 0.125
       },
       "capabilities": {
         "function_calling": true,
         "vision": false,
         "reasoning": false,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-21"
@@ -349,13 +381,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 0.31248,
-        "output_per_million_tokens": 1.87502
+        "output_per_million_tokens": 1.87502,
+        "cache_write_per_million_tokens": 0.31248,
+        "cache_read_per_million_tokens": 0.03125
       },
       "capabilities": {
         "function_calling": true,
         "vision": false,
         "reasoning": false,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-20"
@@ -369,13 +403,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 2.49998,
-        "output_per_million_tokens": 15.00002
+        "output_per_million_tokens": 15.00002,
+        "cache_write_per_million_tokens": 2.49998,
+        "cache_read_per_million_tokens": 0.25
       },
       "capabilities": {
         "function_calling": true,
         "vision": false,
         "reasoning": true,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-20"
@@ -389,13 +425,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 1.87502,
-        "output_per_million_tokens": 11.24998
+        "output_per_million_tokens": 11.24998,
+        "cache_write_per_million_tokens": 1.87502,
+        "cache_read_per_million_tokens": 0.1875
       },
       "capabilities": {
         "function_calling": true,
         "vision": false,
         "reasoning": true,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-20"
@@ -409,13 +447,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 0.62503,
-        "output_per_million_tokens": 3.74997
+        "output_per_million_tokens": 3.74997,
+        "cache_write_per_million_tokens": 0.62503,
+        "cache_read_per_million_tokens": 0.0625
       },
       "capabilities": {
         "function_calling": true,
         "vision": false,
         "reasoning": false,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-20"
@@ -429,13 +469,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 2.49998,
-        "output_per_million_tokens": 15.00002
+        "output_per_million_tokens": 15.00002,
+        "cache_write_per_million_tokens": 2.49998,
+        "cache_read_per_million_tokens": 0.25
       },
       "capabilities": {
         "function_calling": true,
         "vision": false,
         "reasoning": true,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-20"
@@ -469,13 +511,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 1.24999,
-        "output_per_million_tokens": 9.99999
+        "output_per_million_tokens": 9.99999,
+        "cache_write_per_million_tokens": 1.24999,
+        "cache_read_per_million_tokens": 0.125
       },
       "capabilities": {
         "function_calling": false,
         "vision": false,
         "reasoning": false,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-21"
@@ -489,13 +533,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 1.24999,
-        "output_per_million_tokens": 9.99999
+        "output_per_million_tokens": 9.99999,
+        "cache_write_per_million_tokens": 1.24999,
+        "cache_read_per_million_tokens": 0.125
       },
       "capabilities": {
         "function_calling": false,
         "vision": false,
         "reasoning": false,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-21"
@@ -509,13 +555,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 1.24999,
-        "output_per_million_tokens": 9.99999
+        "output_per_million_tokens": 9.99999,
+        "cache_write_per_million_tokens": 1.24999,
+        "cache_read_per_million_tokens": 0.125
       },
       "capabilities": {
         "function_calling": false,
         "vision": false,
         "reasoning": false,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-20"
@@ -529,13 +577,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 0.24997,
-        "output_per_million_tokens": 1.99997
+        "output_per_million_tokens": 1.99997,
+        "cache_write_per_million_tokens": 0.24997,
+        "cache_read_per_million_tokens": 0.025
       },
       "capabilities": {
         "function_calling": false,
         "vision": false,
         "reasoning": false,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-20"
@@ -549,13 +599,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 1.75,
-        "output_per_million_tokens": 14.0
+        "output_per_million_tokens": 14.0,
+        "cache_write_per_million_tokens": 1.75,
+        "cache_read_per_million_tokens": 0.175
       },
       "capabilities": {
         "function_calling": false,
         "vision": false,
         "reasoning": false,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-20"
@@ -569,13 +621,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 1.75,
-        "output_per_million_tokens": 14.0
+        "output_per_million_tokens": 14.0,
+        "cache_write_per_million_tokens": 1.75,
+        "cache_read_per_million_tokens": 0.175
       },
       "capabilities": {
         "function_calling": false,
         "vision": false,
         "reasoning": false,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-20"
@@ -589,13 +643,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 1.75,
-        "output_per_million_tokens": 14.0
+        "output_per_million_tokens": 14.0,
+        "cache_write_per_million_tokens": 1.75,
+        "cache_read_per_million_tokens": 0.175
       },
       "capabilities": {
         "function_calling": false,
         "vision": false,
         "reasoning": false,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-20"
@@ -609,13 +665,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 2.49998,
-        "output_per_million_tokens": 15.00002
+        "output_per_million_tokens": 15.00002,
+        "cache_write_per_million_tokens": 2.49998,
+        "cache_read_per_million_tokens": 0.25
       },
       "capabilities": {
         "function_calling": false,
         "vision": false,
         "reasoning": true,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-20"
@@ -629,13 +687,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 0.74998,
-        "output_per_million_tokens": 4.50002
+        "output_per_million_tokens": 4.50002,
+        "cache_write_per_million_tokens": 0.74998,
+        "cache_read_per_million_tokens": 0.075
       },
       "capabilities": {
         "function_calling": false,
         "vision": false,
         "reasoning": true,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-20"
@@ -649,13 +709,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 0.19999,
-        "output_per_million_tokens": 1.24999
+        "output_per_million_tokens": 1.24999,
+        "cache_write_per_million_tokens": 0.19999,
+        "cache_read_per_million_tokens": 0.02
       },
       "capabilities": {
         "function_calling": false,
         "vision": false,
         "reasoning": true,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-20"
@@ -669,13 +731,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 5.00003,
-        "output_per_million_tokens": 30.00003
+        "output_per_million_tokens": 30.00003,
+        "cache_write_per_million_tokens": 5.00003,
+        "cache_read_per_million_tokens": 0.5
       },
       "capabilities": {
         "function_calling": false,
         "vision": false,
         "reasoning": false,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-20"
@@ -689,13 +753,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 30.00003,
-        "output_per_million_tokens": 180.00003
+        "output_per_million_tokens": 180.00003,
+        "cache_write_per_million_tokens": 30.00003,
+        "cache_read_per_million_tokens": 3.0
       },
       "capabilities": {
         "function_calling": false,
         "vision": false,
         "reasoning": true,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-20"
@@ -709,13 +775,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 0.24997,
-        "output_per_million_tokens": 1.99997
+        "output_per_million_tokens": 1.99997,
+        "cache_write_per_million_tokens": 0.24997,
+        "cache_read_per_million_tokens": 0.025
       },
       "capabilities": {
         "function_calling": false,
         "vision": false,
         "reasoning": false,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-21"
@@ -729,13 +797,15 @@
       },
       "pricing": {
         "input_per_million_tokens": 0.04998,
-        "output_per_million_tokens": 0.39998
+        "output_per_million_tokens": 0.39998,
+        "cache_write_per_million_tokens": 0.04998,
+        "cache_read_per_million_tokens": 0.005
       },
       "capabilities": {
         "function_calling": false,
         "vision": false,
         "reasoning": false,
-        "prompt_caching": false,
+        "prompt_caching": true,
         "response_schema": false
       },
       "last_updated_at": "2026-05-21"


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Add `cache_write_per_million_tokens` and `cache_read_per_million_tokens` pricing fields to all proprietary Databricks-hosted models in the model catalog, and enable the `prompt_caching` capability flag.

Pricing ratios sourced from the [Databricks Proprietary Foundation Model Serving pricing page](https://www.databricks.com/product/pricing/proprietary-foundation-model-serving):

| Provider | Cache Write | Cache Read |
|----------|------------|------------|
| Anthropic (Claude) | 1.25x input | 0.1x input |
| OpenAI (GPT-5) | 1.0x input | 0.1x input |
| Google (Gemini) | 1.0x input | 0.1x input |

Models updated:
- All `databricks-claude-*` models
- All `databricks-gpt-5*` models (excluding GPT-OSS open-source models)
- All `databricks-gemini-*` models

Open-source models (Llama, Gemma, GPT-OSS, Qwen, Mixtral, MPT) and embedding models are unchanged.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Verified programmatically that all proprietary models have cache pricing fields and `prompt_caching: true`, while open-source/embedding models remain unchanged.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Add cached token pricing data for Databricks-hosted proprietary models (Claude, GPT-5, Gemini) to the bundled model catalog, enabling accurate cost tracking for prompt-cached requests.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Claude.