### PR TITLE
Add `mlflow skills view/list` CLI

### DIFF
--- a/mlflow/assistant/skill_installer.py
+++ b/mlflow/assistant/skill_installer.py
@@ -8,6 +8,7 @@ which points to the https://github.com/mlflow/skills repository.
 import shutil
 from dataclasses import dataclass
 from importlib import resources
+from importlib.abc import Traversable
 from pathlib import Path
 
 from mlflow.ai_commands.ai_command_utils import parse_frontmatter
@@ -20,7 +21,7 @@ SKILLS_PACKAGE = "mlflow.assistant.skills"
 class BundledSkill:
     name: str
     description: str
-    path: Path
+    path: Traversable
 
 
 def _find_skill_directories(path: Path) -> list[Path]:
@@ -48,15 +49,14 @@ def list_bundled_skills() -> list[BundledSkill]:
         skill_manifest = item.joinpath(SKILL_MANIFEST_FILE)
         if not skill_manifest.is_file():
             continue
-        with resources.as_file(skill_manifest) as manifest_path:
-            metadata, _ = parse_frontmatter(manifest_path.read_text(encoding="utf-8"))
-            skills.append(
-                BundledSkill(
-                    name=metadata.get("name") or manifest_path.parent.name,
-                    description=metadata.get("description") or "",
-                    path=manifest_path.parent,
-                )
+        metadata, _ = parse_frontmatter(skill_manifest.read_text(encoding="utf-8"))
+        skills.append(
+            BundledSkill(
+                name=metadata.get("name") or item.name,
+                description=metadata.get("description") or "",
+                path=item,
             )
+        )
     return sorted(skills, key=lambda skill: skill.name)
 
 

--- a/mlflow/assistant/skill_installer.py
+++ b/mlflow/assistant/skill_installer.py
@@ -33,10 +33,14 @@ def list_bundled_skills() -> list[BundledSkill]:
     Skills live in the ``mlflow.assistant.skills`` package.
 
     Returns:
-        Skills sorted by name. Empty when the submodule is not checked out
-        (e.g. a development clone without ``git submodule update --init``).
+        Skills sorted by name. Empty when the package is not importable or the
+        submodule is not checked out (e.g. a development clone without
+        ``git submodule update --init``).
     """
-    skills_pkg = resources.files(SKILLS_PACKAGE)
+    try:
+        skills_pkg = resources.files(SKILLS_PACKAGE)
+    except ModuleNotFoundError:
+        return []
     skills = []
     for item in skills_pkg.iterdir():
         if not item.is_dir():

--- a/mlflow/assistant/skill_installer.py
+++ b/mlflow/assistant/skill_installer.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from mlflow.ai_commands.ai_command_utils import parse_frontmatter
 
 SKILL_MANIFEST_FILE = "SKILL.md"
+SKILLS_PACKAGE = "mlflow.assistant.skills"
 
 
 @dataclass
@@ -29,15 +30,13 @@ def _find_skill_directories(path: Path) -> list[Path]:
 def list_bundled_skills() -> list[BundledSkill]:
     """List the MLflow skills bundled with this installation.
 
-    Skills live in the ``mlflow.assistant.skills`` package, populated from the
-    https://github.com/mlflow/skills submodule at build time. Reading from the
-    installed package means this works offline and never touches the network.
+    Skills live in the ``mlflow.assistant.skills`` package.
 
     Returns:
         Skills sorted by name. Empty when the submodule is not checked out
         (e.g. a development clone without ``git submodule update --init``).
     """
-    skills_pkg = resources.files("mlflow.assistant.skills")
+    skills_pkg = resources.files(SKILLS_PACKAGE)
     skills = []
     for item in skills_pkg.iterdir():
         if not item.is_dir():
@@ -68,7 +67,7 @@ def install_skills(destination_path: Path) -> list[str]:
         A list of installed skill names.
     """
     destination_dir = destination_path.expanduser()
-    skills_pkg = resources.files("mlflow.assistant.skills")
+    skills_pkg = resources.files(SKILLS_PACKAGE)
     installed_skills = []
 
     for item in skills_pkg.iterdir():

--- a/mlflow/assistant/skill_installer.py
+++ b/mlflow/assistant/skill_installer.py
@@ -6,14 +6,68 @@ which points to the https://github.com/mlflow/skills repository.
 """
 
 import shutil
+from dataclasses import dataclass
 from importlib import resources
 from pathlib import Path
+
+import yaml
 
 SKILL_MANIFEST_FILE = "SKILL.md"
 
 
+@dataclass
+class BundledSkill:
+    name: str
+    description: str
+    path: Path
+
+
 def _find_skill_directories(path: Path) -> list[Path]:
     return [item.parent for item in path.rglob(SKILL_MANIFEST_FILE)]
+
+
+def _parse_skill_manifest(text: str) -> dict[str, str]:
+    """Parse the YAML frontmatter of a ``SKILL.md`` file.
+
+    Returns an empty dict when no frontmatter block is present.
+    """
+    match text.split("---", 2):
+        case ["", frontmatter, _]:
+            data = yaml.safe_load(frontmatter)
+            return data if isinstance(data, dict) else {}
+        case _:
+            return {}
+
+
+def list_bundled_skills() -> list[BundledSkill]:
+    """List the MLflow skills bundled with this installation.
+
+    Skills live in the ``mlflow.assistant.skills`` package, populated from the
+    https://github.com/mlflow/skills submodule at build time. Reading from the
+    installed package means this works offline and never touches the network.
+
+    Returns:
+        Skills sorted by name. Empty when the submodule is not checked out
+        (e.g. a development clone without ``git submodule update --init``).
+    """
+    skills_pkg = resources.files("mlflow.assistant.skills")
+    skills = []
+    for item in skills_pkg.iterdir():
+        if not item.is_dir():
+            continue
+        skill_manifest = item.joinpath(SKILL_MANIFEST_FILE)
+        if not skill_manifest.is_file():
+            continue
+        with resources.as_file(skill_manifest) as manifest_path:
+            metadata = _parse_skill_manifest(manifest_path.read_text(encoding="utf-8"))
+            skills.append(
+                BundledSkill(
+                    name=metadata.get("name") or manifest_path.parent.name,
+                    description=metadata.get("description", ""),
+                    path=manifest_path.parent,
+                )
+            )
+    return sorted(skills, key=lambda skill: skill.name)
 
 
 def install_skills(destination_path: Path) -> list[str]:

--- a/mlflow/assistant/skill_installer.py
+++ b/mlflow/assistant/skill_installer.py
@@ -53,7 +53,7 @@ def list_bundled_skills() -> list[BundledSkill]:
             skills.append(
                 BundledSkill(
                     name=metadata.get("name") or manifest_path.parent.name,
-                    description=metadata.get("description", ""),
+                    description=metadata.get("description") or "",
                     path=manifest_path.parent,
                 )
             )

--- a/mlflow/assistant/skill_installer.py
+++ b/mlflow/assistant/skill_installer.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from importlib import resources
 from pathlib import Path
 
-import yaml
+from mlflow.ai_commands.ai_command_utils import parse_frontmatter
 
 SKILL_MANIFEST_FILE = "SKILL.md"
 
@@ -24,19 +24,6 @@ class BundledSkill:
 
 def _find_skill_directories(path: Path) -> list[Path]:
     return [item.parent for item in path.rglob(SKILL_MANIFEST_FILE)]
-
-
-def _parse_skill_manifest(text: str) -> dict[str, str]:
-    """Parse the YAML frontmatter of a ``SKILL.md`` file.
-
-    Returns an empty dict when no frontmatter block is present.
-    """
-    match text.split("---", 2):
-        case ["", frontmatter, _]:
-            data = yaml.safe_load(frontmatter)
-            return data if isinstance(data, dict) else {}
-        case _:
-            return {}
 
 
 def list_bundled_skills() -> list[BundledSkill]:
@@ -59,7 +46,7 @@ def list_bundled_skills() -> list[BundledSkill]:
         if not skill_manifest.is_file():
             continue
         with resources.as_file(skill_manifest) as manifest_path:
-            metadata = _parse_skill_manifest(manifest_path.read_text(encoding="utf-8"))
+            metadata, _ = parse_frontmatter(manifest_path.read_text(encoding="utf-8"))
             skills.append(
                 BundledSkill(
                     name=metadata.get("name") or manifest_path.parent.name,

--- a/mlflow/cli/__init__.py
+++ b/mlflow/cli/__init__.py
@@ -1353,9 +1353,12 @@ from mlflow.cli.demo import demo
 cli.add_command(demo)
 
 # Add skills CLI command
-from mlflow.cli import skills
+try:
+    from mlflow.cli import skills
 
-cli.add_command(skills.commands)
+    cli.add_command(skills.commands)
+except ImportError:
+    pass
 
 # Add AI commands CLI
 cli.add_command(ai_commands.commands)

--- a/mlflow/cli/__init__.py
+++ b/mlflow/cli/__init__.py
@@ -1352,6 +1352,11 @@ from mlflow.cli.demo import demo
 
 cli.add_command(demo)
 
+# Add skills CLI command
+from mlflow.cli import skills
+
+cli.add_command(skills.commands)
+
 # Add AI commands CLI
 cli.add_command(ai_commands.commands)
 

--- a/mlflow/cli/skills.py
+++ b/mlflow/cli/skills.py
@@ -22,7 +22,7 @@ def list_command():
         click.secho(
             "No MLflow skills found in this installation.\n"
             "If you are working from a source checkout, fetch the skills submodule with:\n"
-            "    git submodule update --init mlflow/assistant/skills",
+            "    git submodule update --init --recursive",
             fg="yellow",
         )
         return

--- a/mlflow/cli/skills.py
+++ b/mlflow/cli/skills.py
@@ -5,9 +5,10 @@ import click
 from mlflow.assistant.skill_installer import BundledSkill, list_bundled_skills
 
 
-def _list_skill_details(skill: BundledSkill):
-    click.secho(skill.name, fg="cyan", bold=True)
-    click.secho(f"  {skill.path}", fg="cyan", dim=True)
+def _echo_skill_details(skill: BundledSkill):
+    skill_name_styled = click.style(skill.name, fg="cyan", bold=True)
+    skill_path_styled = click.style(f" ({skill.path})", fg="cyan")
+    click.echo(skill_name_styled + skill_path_styled)
     if skill.description:
         click.echo(f"  {skill.description}")
 
@@ -31,7 +32,7 @@ def list_command():
         return
 
     for skill in skills:
-        _list_skill_details(skill)
+        _echo_skill_details(skill)
 
 
 @commands.command("view")
@@ -42,4 +43,4 @@ def view_command(skill_name: str):
     target_skill = next((s for s in skills if s.name == skill_name), None)
     if not target_skill:
         raise click.ClickException(f"Skill {skill_name} not found.")
-    _list_skill_details(target_skill)
+    _echo_skill_details(target_skill)

--- a/mlflow/cli/skills.py
+++ b/mlflow/cli/skills.py
@@ -27,6 +27,3 @@ def list_command():
         click.secho(skill.name, fg="cyan", bold=True)
         if skill.description:
             click.echo(f"  {skill.description}")
-
-    click.echo()
-    click.secho(f"Skills directory: {skills[0].path.parent}", dim=True)

--- a/mlflow/cli/skills.py
+++ b/mlflow/cli/skills.py
@@ -2,7 +2,14 @@
 
 import click
 
-from mlflow.assistant.skill_installer import list_bundled_skills
+from mlflow.assistant.skill_installer import BundledSkill, list_bundled_skills
+
+
+def _list_skill_details(skill: BundledSkill):
+    click.secho(skill.name, fg="cyan", bold=True)
+    if skill.description:
+        click.echo(f"  {skill.description}")
+    click.secho(f"  {skill.path}", dim=True)
 
 
 @click.group("skills")
@@ -24,6 +31,16 @@ def list_command():
         return
 
     for skill in skills:
-        click.secho(skill.name, fg="cyan", bold=True)
-        if skill.description:
-            click.echo(f"  {skill.description}")
+        _list_skill_details(skill)
+
+
+@commands.command("view")
+@click.argument("skill_name", type=str)
+def view_command(skill_name: str):
+    """View the details of a MLflow skill."""
+    skills = list_bundled_skills()
+    target_skill = next((s for s in skills if s.name == skill_name), None)
+    if not target_skill:
+        click.secho(f"Skill {skill_name} not found.", fg="red")
+        return
+    _list_skill_details(target_skill)

--- a/mlflow/cli/skills.py
+++ b/mlflow/cli/skills.py
@@ -7,9 +7,9 @@ from mlflow.assistant.skill_installer import BundledSkill, list_bundled_skills
 
 def _list_skill_details(skill: BundledSkill):
     click.secho(skill.name, fg="cyan", bold=True)
+    click.secho(f"  {skill.path}", fg="cyan", dim=True)
     if skill.description:
         click.echo(f"  {skill.description}")
-    click.secho(f"  {skill.path}", dim=True)
 
 
 @click.group("skills")

--- a/mlflow/cli/skills.py
+++ b/mlflow/cli/skills.py
@@ -1,0 +1,36 @@
+"""CLI commands for inspecting MLflow Assistant skills."""
+
+import click
+
+from mlflow.assistant.skill_installer import list_bundled_skills
+
+
+@click.group("skills")
+def commands():
+    """Inspect the MLflow Assistant skills bundled with this installation."""
+
+
+@commands.command("list")
+def list_command():
+    """List the MLflow skills bundled with this installation.
+
+    Skills are read from the installed package, so this works offline without
+    cloning https://github.com/mlflow/skills.
+    """
+    skills = list_bundled_skills()
+    if not skills:
+        click.secho(
+            "No MLflow skills found in this installation.\n"
+            "If you are working from a source checkout, fetch the skills submodule with:\n"
+            "    git submodule update --init mlflow/assistant/skills",
+            fg="yellow",
+        )
+        return
+
+    for skill in skills:
+        click.secho(skill.name, fg="cyan", bold=True)
+        if skill.description:
+            click.echo(f"  {skill.description}")
+
+    click.echo()
+    click.secho(f"Skills directory: {skills[0].path.parent}", dim=True)

--- a/mlflow/cli/skills.py
+++ b/mlflow/cli/skills.py
@@ -7,7 +7,7 @@ from mlflow.assistant.skill_installer import list_bundled_skills
 
 @click.group("skills")
 def commands():
-    """Inspect the MLflow Assistant skills bundled with this installation."""
+    """Inspect the MLflow skills bundled with this installation."""
 
 
 @commands.command("list")

--- a/mlflow/cli/skills.py
+++ b/mlflow/cli/skills.py
@@ -12,11 +12,7 @@ def commands():
 
 @commands.command("list")
 def list_command():
-    """List the MLflow skills bundled with this installation.
-
-    Skills are read from the installed package, so this works offline without
-    cloning https://github.com/mlflow/skills.
-    """
+    """List the MLflow skills bundled with this installation."""
     skills = list_bundled_skills()
     if not skills:
         click.secho(

--- a/mlflow/cli/skills.py
+++ b/mlflow/cli/skills.py
@@ -37,10 +37,9 @@ def list_command():
 @commands.command("view")
 @click.argument("skill_name", type=str)
 def view_command(skill_name: str):
-    """View the details of a MLflow skill."""
+    """View the details of an MLflow skill."""
     skills = list_bundled_skills()
     target_skill = next((s for s in skills if s.name == skill_name), None)
     if not target_skill:
-        click.secho(f"Skill {skill_name} not found.", fg="red")
-        return
+        raise click.ClickException(f"Skill {skill_name} not found.")
     _list_skill_details(target_skill)

--- a/tests/assistant/test_skill_installer.py
+++ b/tests/assistant/test_skill_installer.py
@@ -1,4 +1,11 @@
-from mlflow.assistant.skill_installer import install_skills, list_installed_skills
+import pytest
+
+from mlflow.assistant.skill_installer import (
+    _parse_skill_manifest,
+    install_skills,
+    list_bundled_skills,
+    list_installed_skills,
+)
 
 
 def test_install_skills_copies_to_destination(tmp_path):
@@ -42,3 +49,26 @@ def test_list_installed_skills_nonexistent_path(tmp_path):
     nonexistent = tmp_path / "does-not-exist"
     skills = list_installed_skills(nonexistent)
     assert skills == []
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("---\nname: foo\ndescription: bar\n---\nbody", {"name": "foo", "description": "bar"}),
+        ("# No frontmatter\nbody", {}),
+        ("---\n---\nbody", {}),
+        ("---\nnot a mapping\n---\nbody", {}),
+    ],
+)
+def test_parse_skill_manifest(text, expected):
+    assert _parse_skill_manifest(text) == expected
+
+
+def test_list_bundled_skills():
+    skills = list_bundled_skills()
+
+    by_name = {skill.name: skill for skill in skills}
+    assert "agent-evaluation" in by_name
+    assert by_name["agent-evaluation"].description
+    assert (by_name["agent-evaluation"].path / "SKILL.md").is_file()
+    assert [skill.name for skill in skills] == sorted(skill.name for skill in skills)

--- a/tests/assistant/test_skill_installer.py
+++ b/tests/assistant/test_skill_installer.py
@@ -1,7 +1,4 @@
-import pytest
-
 from mlflow.assistant.skill_installer import (
-    _parse_skill_manifest,
     install_skills,
     list_bundled_skills,
     list_installed_skills,
@@ -49,19 +46,6 @@ def test_list_installed_skills_nonexistent_path(tmp_path):
     nonexistent = tmp_path / "does-not-exist"
     skills = list_installed_skills(nonexistent)
     assert skills == []
-
-
-@pytest.mark.parametrize(
-    ("text", "expected"),
-    [
-        ("---\nname: foo\ndescription: bar\n---\nbody", {"name": "foo", "description": "bar"}),
-        ("# No frontmatter\nbody", {}),
-        ("---\n---\nbody", {}),
-        ("---\nnot a mapping\n---\nbody", {}),
-    ],
-)
-def test_parse_skill_manifest(text, expected):
-    assert _parse_skill_manifest(text) == expected
 
 
 def test_list_bundled_skills():

--- a/tests/assistant/test_skill_installer.py
+++ b/tests/assistant/test_skill_installer.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from mlflow.assistant.skill_installer import (
     install_skills,
     list_bundled_skills,
@@ -46,6 +48,15 @@ def test_list_installed_skills_nonexistent_path(tmp_path):
     nonexistent = tmp_path / "does-not-exist"
     skills = list_installed_skills(nonexistent)
     assert skills == []
+
+
+def test_list_bundled_skills_returns_empty_when_package_missing():
+    with mock.patch(
+        "mlflow.assistant.skill_installer.resources.files",
+        side_effect=ModuleNotFoundError,
+    ) as mock_files:
+        assert list_bundled_skills() == []
+    mock_files.assert_called_once()
 
 
 def test_list_bundled_skills():

--- a/tests/cli/test_skills.py
+++ b/tests/cli/test_skills.py
@@ -25,6 +25,8 @@ def test_list_command_renders_skills(runner, monkeypatch):
     assert "alpha-skill" in result.output
     assert "Does alpha things." in result.output
     assert "beta-skill" in result.output
+    assert str(Path("/s/alpha")) in result.output
+    assert str(Path("/s/beta")) in result.output
 
 
 def test_list_command_handles_no_skills(runner, monkeypatch):
@@ -35,3 +37,40 @@ def test_list_command_handles_no_skills(runner, monkeypatch):
     assert result.exit_code == 0
     assert "No MLflow skills found" in result.output
     assert "git submodule update --init" in result.output
+
+
+def test_view_command_renders_skill(runner, monkeypatch):
+    skills = [
+        BundledSkill(name="alpha-skill", description="Does alpha things.", path=Path("/s/alpha")),
+        BundledSkill(name="beta-skill", description="Does beta things.", path=Path("/s/beta")),
+    ]
+    monkeypatch.setattr("mlflow.cli.skills.list_bundled_skills", lambda: skills)
+
+    result = runner.invoke(commands, ["view", "alpha-skill"])
+
+    assert result.exit_code == 0
+    assert "alpha-skill" in result.output
+    assert "Does alpha things." in result.output
+    assert str(Path("/s/alpha")) in result.output
+    assert "beta-skill" not in result.output
+
+
+def test_view_command_skill_not_found(runner, monkeypatch):
+    monkeypatch.setattr("mlflow.cli.skills.list_bundled_skills", lambda: [])
+
+    result = runner.invoke(commands, ["view", "missing-skill"])
+
+    assert result.exit_code == 0
+    assert "Skill missing-skill not found." in result.output
+
+
+def test_view_command_skill_without_description(runner, monkeypatch):
+    skills = [BundledSkill(name="alpha-skill", description="", path=Path("/s/alpha"))]
+    monkeypatch.setattr("mlflow.cli.skills.list_bundled_skills", lambda: skills)
+
+    result = runner.invoke(commands, ["view", "alpha-skill"])
+
+    assert result.exit_code == 0
+    assert "alpha-skill" in result.output
+    assert str(Path("/s/alpha")) in result.output
+    assert "\n  \n" not in result.output

--- a/tests/cli/test_skills.py
+++ b/tests/cli/test_skills.py
@@ -15,8 +15,7 @@ def runner():
 
 @pytest.fixture
 def mock_bundled_skills():
-    with mock.patch("mlflow.cli.skills.list_bundled_skills") as m:
-        m.return_value = []
+    with mock.patch("mlflow.cli.skills.list_bundled_skills", return_value=[]) as m:
         yield m
 
 

--- a/tests/cli/test_skills.py
+++ b/tests/cli/test_skills.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from mlflow.assistant.skill_installer import BundledSkill
+from mlflow.cli.skills import commands
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def test_list_command_renders_skills(runner, monkeypatch):
+    skills = [
+        BundledSkill(name="alpha-skill", description="Does alpha things.", path=Path("/s/alpha")),
+        BundledSkill(name="beta-skill", description="", path=Path("/s/beta")),
+    ]
+    monkeypatch.setattr("mlflow.cli.skills.list_bundled_skills", lambda: skills)
+
+    result = runner.invoke(commands, ["list"])
+
+    assert result.exit_code == 0
+    assert "alpha-skill" in result.output
+    assert "Does alpha things." in result.output
+    assert "beta-skill" in result.output
+    assert "Skills directory: /s" in result.output
+
+
+def test_list_command_handles_no_skills(runner, monkeypatch):
+    monkeypatch.setattr("mlflow.cli.skills.list_bundled_skills", lambda: [])
+
+    result = runner.invoke(commands, ["list"])
+
+    assert result.exit_code == 0
+    assert "No MLflow skills found" in result.output
+    assert "git submodule update --init" in result.output

--- a/tests/cli/test_skills.py
+++ b/tests/cli/test_skills.py
@@ -25,7 +25,6 @@ def test_list_command_renders_skills(runner, monkeypatch):
     assert "alpha-skill" in result.output
     assert "Does alpha things." in result.output
     assert "beta-skill" in result.output
-    assert "Skills directory: " in result.output
 
 
 def test_list_command_handles_no_skills(runner, monkeypatch):

--- a/tests/cli/test_skills.py
+++ b/tests/cli/test_skills.py
@@ -25,7 +25,7 @@ def test_list_command_renders_skills(runner, monkeypatch):
     assert "alpha-skill" in result.output
     assert "Does alpha things." in result.output
     assert "beta-skill" in result.output
-    assert "Skills directory: /s" in result.output
+    assert "Skills directory: " in result.output
 
 
 def test_list_command_handles_no_skills(runner, monkeypatch):

--- a/tests/cli/test_skills.py
+++ b/tests/cli/test_skills.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from unittest import mock
 
 import pytest
 from click.testing import CliRunner
@@ -12,12 +13,19 @@ def runner():
     return CliRunner()
 
 
-def test_list_command_renders_skills(runner, monkeypatch):
+@pytest.fixture
+def mock_bundled_skills():
+    with mock.patch("mlflow.cli.skills.list_bundled_skills") as m:
+        m.return_value = []
+        yield m
+
+
+def test_list_command_renders_skills(runner, mock_bundled_skills):
     skills = [
         BundledSkill(name="alpha-skill", description="Does alpha things.", path=Path("/s/alpha")),
         BundledSkill(name="beta-skill", description="", path=Path("/s/beta")),
     ]
-    monkeypatch.setattr("mlflow.cli.skills.list_bundled_skills", lambda: skills)
+    mock_bundled_skills.return_value = skills
 
     result = runner.invoke(commands, ["list"])
 
@@ -29,9 +37,7 @@ def test_list_command_renders_skills(runner, monkeypatch):
     assert str(Path("/s/beta")) in result.output
 
 
-def test_list_command_handles_no_skills(runner, monkeypatch):
-    monkeypatch.setattr("mlflow.cli.skills.list_bundled_skills", lambda: [])
-
+def test_list_command_handles_no_skills(runner, mock_bundled_skills):
     result = runner.invoke(commands, ["list"])
 
     assert result.exit_code == 0
@@ -39,12 +45,12 @@ def test_list_command_handles_no_skills(runner, monkeypatch):
     assert "git submodule update --init" in result.output
 
 
-def test_view_command_renders_skill(runner, monkeypatch):
+def test_view_command_renders_skill(runner, mock_bundled_skills):
     skills = [
         BundledSkill(name="alpha-skill", description="Does alpha things.", path=Path("/s/alpha")),
         BundledSkill(name="beta-skill", description="Does beta things.", path=Path("/s/beta")),
     ]
-    monkeypatch.setattr("mlflow.cli.skills.list_bundled_skills", lambda: skills)
+    mock_bundled_skills.return_value = skills
 
     result = runner.invoke(commands, ["view", "alpha-skill"])
 
@@ -55,18 +61,16 @@ def test_view_command_renders_skill(runner, monkeypatch):
     assert "beta-skill" not in result.output
 
 
-def test_view_command_skill_not_found(runner, monkeypatch):
-    monkeypatch.setattr("mlflow.cli.skills.list_bundled_skills", lambda: [])
-
+def test_view_command_skill_not_found(runner, mock_bundled_skills):
     result = runner.invoke(commands, ["view", "missing-skill"])
 
-    assert result.exit_code == 0
+    assert result.exit_code != 0
     assert "Skill missing-skill not found." in result.output
 
 
-def test_view_command_skill_without_description(runner, monkeypatch):
+def test_view_command_skill_without_description(runner, mock_bundled_skills):
     skills = [BundledSkill(name="alpha-skill", description="", path=Path("/s/alpha"))]
-    monkeypatch.setattr("mlflow.cli.skills.list_bundled_skills", lambda: skills)
+    mock_bundled_skills.return_value = skills
 
     result = runner.invoke(commands, ["view", "alpha-skill"])
 


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Not applicable

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

This is a follow-up from a comment: https://github.com/mlflow/mlflow/pull/23834#discussion_r3387467139

This PR introduces a new CLI command group called `mlflow skills`.

There are two commands, `mlflow skills list` which lists all available MLFlow skills that have been bundled locally.
The second is `mlflow skills view` which details the individual skill. The only difference is that `view` outputs only one skill compared to `list`

These can be used by LLMs locally.

I don't think we need to be concerned with the length of the output for now. I don't think its that long such that we will have concerns about context window pollution

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests


<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions
  - [x] Waiting for sphinx to regen docs

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Adds a new CLI command to support listing all MLFlow skills.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
