### PR TITLE
Show add-endpoint button in Playground endpoint selector

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/playground/components/PlaygroundTopBar.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/components/PlaygroundTopBar.test.tsx
@@ -9,15 +9,20 @@ jest.mock('../../../components/EndpointSelector', () => ({
   EndpointSelector: ({
     currentEndpointName,
     onEndpointSelect,
+    showCreateButton,
   }: {
     currentEndpointName?: string;
     onEndpointSelect: (name: string) => void;
+    showCreateButton?: boolean;
   }) => (
-    <input
-      data-testid="endpoint-selector-test-input"
-      value={currentEndpointName ?? ''}
-      onChange={(event) => onEndpointSelect(event.target.value)}
-    />
+    <>
+      <input
+        data-testid="endpoint-selector-test-input"
+        value={currentEndpointName ?? ''}
+        onChange={(event) => onEndpointSelect(event.target.value)}
+      />
+      {showCreateButton && <div data-testid="endpoint-selector-create-button-enabled" />}
+    </>
   ),
 }));
 
@@ -71,5 +76,10 @@ describe('PlaygroundTopBar', () => {
     const { onOpenRegistry } = renderTopBar();
     await userEvent.click(screen.getByRole('button', { name: /load prompt from registry/i }));
     expect(onOpenRegistry).toHaveBeenCalledTimes(1);
+  });
+
+  it('enables the create-endpoint button on the endpoint selector', () => {
+    renderTopBar();
+    expect(screen.getByTestId('endpoint-selector-create-button-enabled')).toBeInTheDocument();
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/components/PlaygroundTopBar.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/components/PlaygroundTopBar.tsx
@@ -61,7 +61,7 @@ export const PlaygroundTopBar = ({
         componentIdPrefix="mlflow.playground.endpoint-selector"
         currentEndpointName={endpointName}
         onEndpointSelect={onEndpointSelect}
-        showCreateButton={false}
+        showCreateButton
         triggerMaxWidth={400}
       />
       <ParametersButton


### PR DESCRIPTION
### Related Issues/PRs

Relates to ML-66430

Part of the Playground work tracked in #22778.

### What changes are proposed in this pull request?

When the Playground has no AI Gateway endpoint configured, the endpoint selector dropdown showed only the design system's default "No results found" text, leaving users with no clear next step.

This enables the **existing** inline create flow on the Playground's `EndpointSelector` by setting `showCreateButton`. The selector already supports a "Create new endpoint" footer button (used by the scorers and evaluation flows) that opens `CreateEndpointModal`; on success it refetches the endpoint list, auto-selects the new endpoint, and keeps the user in the Playground. The Playground previously opted out via `showCreateButton={false}`.

The change is a single prop on `PlaygroundTopBar.tsx`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

Existing `PlaygroundTopBar` tests pass; type-check and lint are clean.

#### Before
<img width="2914" height="1126" alt="image" src="https://github.com/user-attachments/assets/934c57ee-3aee-45cf-8694-4fd8be61aa7b" />

#### After
https://github.com/user-attachments/assets/aa54d824-6b7c-41dd-960a-bcc6f920996b

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The Playground endpoint selector now lets users create an AI Gateway endpoint inline when none is configured.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.