### PR TITLE
Clean up review-queue items and assessment errors when a trace is deleted

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -4246,6 +4246,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                     .filter(SqlTraceInfo.request_id.in_(db_backed_trace_ids))
                     .delete(synchronize_session=False)
                 )
+                self._delete_review_queue_items_for_traces(session, db_backed_trace_ids)
 
         if not selected_archived_traces:
             return deleted_db_backed_count
@@ -4264,7 +4265,31 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 .filter(SqlTraceInfo.request_id.in_(deleted_archived_trace_ids))
                 .delete(synchronize_session=False)
             )
+            self._delete_review_queue_items_for_traces(session, deleted_archived_trace_ids)
         return deleted_db_backed_count + deleted_archived_count
+
+    def _delete_review_queue_items_for_traces(self, session: Session, trace_ids: list[str]) -> None:
+        """Remove review-queue items pointing at traces that are being deleted.
+
+        ``review_queue_items.item_id`` has no foreign key into ``trace_info`` (an
+        item can reference a trace, session, or span), so deleting a trace does
+        not cascade to its queue items. Without this cleanup the item lingers in
+        its queue and any review submitted for it fails on the assessments
+        foreign key (surfacing the raw SQL error to the reviewer).
+        """
+        from mlflow.genai.review_queues import ReviewItemType
+
+        if not trace_ids:
+            return
+        (
+            session
+            .query(SqlReviewQueueItem)
+            .filter(
+                SqlReviewQueueItem.item_type == ReviewItemType.TRACE.value,
+                SqlReviewQueueItem.item_id.in_(trace_ids),
+            )
+            .delete(synchronize_session=False)
+        )
 
     def _select_trace_ids_for_delete(
         self,
@@ -4407,6 +4432,17 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                     )
 
             session.add(sql_assessment)
+            # The only foreign key on ``assessments`` is ``trace_id`` -> ``trace_info``,
+            # so an IntegrityError here means the trace no longer exists (e.g. it was
+            # deleted while still attached to a review queue). Translate the raw SQL
+            # error into a clean "not found" instead of leaking it to the caller.
+            try:
+                session.flush()
+            except IntegrityError as e:
+                raise MlflowException(
+                    f"Trace with ID '{assessment.trace_id}' not found. It may have been deleted.",
+                    RESOURCE_DOES_NOT_EXIST,
+                ) from e
             return sql_assessment.to_mlflow_entity()
 
     def get_assessment(self, trace_id: str, assessment_id: str) -> Assessment:

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -90,6 +90,7 @@ from mlflow.genai.judges.instructions_judge import (
     EXPECTATIONS_FIELD,
     InstructionsJudge,
 )
+from mlflow.genai.review_queues import ReviewItemType
 from mlflow.genai.scorers.base import Scorer
 from mlflow.genai.scorers.online.entities import (
     CompletedSession,
@@ -4277,8 +4278,6 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         its queue and any review submitted for it fails on the assessments
         foreign key (surfacing the raw SQL error to the reviewer).
         """
-        from mlflow.genai.review_queues import ReviewItemType
-
         if not trace_ids:
             return
         (

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -90,7 +90,6 @@ from mlflow.genai.judges.instructions_judge import (
     EXPECTATIONS_FIELD,
     InstructionsJudge,
 )
-from mlflow.genai.review_queues import ReviewItemType
 from mlflow.genai.scorers.base import Scorer
 from mlflow.genai.scorers.online.entities import (
     CompletedSession,
@@ -4278,6 +4277,10 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         its queue and any review submitted for it fails on the assessments
         foreign key (surfacing the raw SQL error to the reviewer).
         """
+        # Lazy import: importing `mlflow.genai.review_queues` triggers the `mlflow.genai`
+        # package init, which can pull this module back in (see `dbmodels/models.py`).
+        from mlflow.genai.review_queues import ReviewItemType
+
         if not trace_ids:
             return
         (
@@ -4431,16 +4434,31 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                     )
 
             session.add(sql_assessment)
-            # The only foreign key on ``assessments`` is ``trace_id`` -> ``trace_info``,
-            # so an IntegrityError here means the trace no longer exists (e.g. it was
-            # deleted while still attached to a review queue). Translate the raw SQL
-            # error into a clean "not found" instead of leaking it to the caller.
+            # A missing trace (e.g. deleted while still attached to a review queue) trips the
+            # ``trace_id`` -> ``trace_info`` foreign key on flush. Rather than leak the raw SQL
+            # error, roll back and check whether the trace is actually gone: report a clean
+            # "not found" if so, otherwise a generic error (the IntegrityError could also come
+            # from another constraint, e.g. a caller-supplied duplicate ``assessment_id``).
             try:
                 session.flush()
             except IntegrityError as e:
+                session.rollback()
+                trace_exists = (
+                    session
+                    .query(SqlTraceInfo.request_id)
+                    .filter(SqlTraceInfo.request_id == assessment.trace_id)
+                    .first()
+                ) is not None
+                if not trace_exists:
+                    raise MlflowException(
+                        f"Trace with ID '{assessment.trace_id}' not found. "
+                        "It may have been deleted.",
+                        RESOURCE_DOES_NOT_EXIST,
+                    ) from e
                 raise MlflowException(
-                    f"Trace with ID '{assessment.trace_id}' not found. It may have been deleted.",
-                    RESOURCE_DOES_NOT_EXIST,
+                    f"Failed to create assessment for trace '{assessment.trace_id}' "
+                    "due to a constraint violation.",
+                    INTERNAL_ERROR,
                 ) from e
             return sql_assessment.to_mlflow_entity()
 

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_assessments.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_assessments.py
@@ -14,6 +14,7 @@ from mlflow.entities.assessment import ExpectationValue, FeedbackValue
 from mlflow.entities.trace_info import TraceInfo
 from mlflow.entities.trace_state import TraceState
 from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST, ErrorCode
 from mlflow.utils.time import get_current_time_millis
 
 pytestmark = pytest.mark.notrackingurimock
@@ -544,3 +545,21 @@ def test_start_trace_with_assessments_missing_trace_id(store):
     assert len(result.assessments) == 1
     assert result.assessments[0].trace_id == trace_id
     assert result.assessments[0].name == "test_feedback"
+
+
+def test_create_assessment_for_missing_trace_returns_not_found(store):
+    # A trace can be deleted while still referenced elsewhere (e.g. a review
+    # queue item). The assessment insert then fails the trace_id foreign key;
+    # the store must surface a clean "not found" rather than the raw SQL error.
+    feedback = Feedback(
+        trace_id="tr-does-not-exist",
+        name="quality",
+        value="looks good",
+        source=AssessmentSource(source_type=AssessmentSourceType.HUMAN, source_id="reviewer"),
+    )
+    with pytest.raises(MlflowException, match="not found") as exc:
+        store.create_assessment(feedback)
+    assert exc.value.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
+    message = str(exc.value)
+    assert "IntegrityError" not in message
+    assert "INSERT INTO" not in message

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_assessments.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_assessments.py
@@ -14,8 +14,10 @@ from mlflow.entities.assessment import ExpectationValue, FeedbackValue
 from mlflow.entities.trace_info import TraceInfo
 from mlflow.entities.trace_state import TraceState
 from mlflow.exceptions import MlflowException
-from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST, ErrorCode
+from mlflow.protos.databricks_pb2 import INTERNAL_ERROR, RESOURCE_DOES_NOT_EXIST, ErrorCode
 from mlflow.utils.time import get_current_time_millis
+
+from tests.store.tracking.sqlalchemy_store.conftest import _create_trace
 
 pytestmark = pytest.mark.notrackingurimock
 
@@ -547,12 +549,18 @@ def test_start_trace_with_assessments_missing_trace_id(store):
     assert result.assessments[0].name == "test_feedback"
 
 
-def test_create_assessment_for_missing_trace_returns_not_found(store):
-    # A trace can be deleted while still referenced elsewhere (e.g. a review
-    # queue item). The assessment insert then fails the trace_id foreign key;
-    # the store must surface a clean "not found" rather than the raw SQL error.
+def test_create_assessment_for_deleted_trace_returns_not_found(store):
+    # The actual repro: a trace that exists is deleted (e.g. while still attached to a
+    # review queue), then a review is submitted for it. The assessment insert trips the
+    # trace_id foreign key; the store must surface a clean "not found" rather than the raw
+    # SQL error. Runs in both fixture modes: workspace mode raises in
+    # `_validate_trace_accessible`; single-tenant mode hits the IntegrityError fallback.
+    exp_id = store.create_experiment("assess_deleted_trace")
+    _create_trace(store, "tr-doomed", experiment_id=exp_id)
+    store.delete_traces(exp_id, trace_ids=["tr-doomed"])
+
     feedback = Feedback(
-        trace_id="tr-does-not-exist",
+        trace_id="tr-doomed",
         name="quality",
         value="looks good",
         source=AssessmentSource(source_type=AssessmentSourceType.HUMAN, source_id="reviewer"),
@@ -561,5 +569,29 @@ def test_create_assessment_for_missing_trace_returns_not_found(store):
         store.create_assessment(feedback)
     assert exc.value.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
     message = str(exc.value)
+    assert "IntegrityError" not in message
+    assert "INSERT INTO" not in message
+
+
+def test_create_assessment_constraint_violation_is_not_reported_as_missing_trace(
+    store_and_trace_info,
+):
+    # An IntegrityError unrelated to the trace foreign key (here a duplicate
+    # assessment_id primary key, on a trace that exists) must not be mislabeled as
+    # "trace not found". It should raise a generic, non-SQL-leaking error instead.
+    store, trace_info = store_and_trace_info
+    source = AssessmentSource(source_type=AssessmentSourceType.HUMAN, source_id="reviewer")
+
+    first = Feedback(trace_id=trace_info.request_id, name="quality", value="a", source=source)
+    first.assessment_id = "a-duplicate-id"
+    store.create_assessment(first)
+
+    second = Feedback(trace_id=trace_info.request_id, name="quality", value="b", source=source)
+    second.assessment_id = "a-duplicate-id"
+    with pytest.raises(MlflowException, match="constraint violation") as exc:
+        store.create_assessment(second)
+    assert exc.value.error_code == ErrorCode.Name(INTERNAL_ERROR)
+    message = str(exc.value)
+    assert "not found" not in message
     assert "IntegrityError" not in message
     assert "INSERT INTO" not in message

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_review_queues.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_review_queues.py
@@ -730,7 +730,6 @@ def test_delete_trace_removes_items_from_every_queue(store):
 
 
 def test_delete_traces_by_timestamp_removes_review_queue_items(store):
-    # The timestamp-based delete path shares the same cleanup helper as the id-based one.
     exp_id = _create_experiments(store, "delete_trace_items_ts")
     _create_trace(store, "tr-old", experiment_id=exp_id, request_time=1000)
     queue = store.create_review_queue(exp_id, name="Q", queue_type="custom")

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_review_queues.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_review_queues.py
@@ -13,7 +13,7 @@ from mlflow.protos.databricks_pb2 import (
 )
 from mlflow.store.tracking.dbmodels.models import SqlReviewQueue
 
-from tests.store.tracking.sqlalchemy_store.conftest import _create_experiments
+from tests.store.tracking.sqlalchemy_store.conftest import _create_experiments, _create_trace
 
 pytestmark = pytest.mark.notrackingurimock
 
@@ -700,3 +700,35 @@ def test_create_custom_queue_rejects_default_name_case_insensitive(store, name):
     with pytest.raises(MlflowException, match="reserved queue name") as exc:
         store.create_review_queue(exp_id, name=name, queue_type="custom")
     _assert_error_code(exc, INVALID_PARAMETER_VALUE)
+
+
+# --------------------------------------------------------------------------
+# Trace deletion cleans up attached items
+# --------------------------------------------------------------------------
+
+
+def test_delete_trace_removes_its_review_queue_items(store):
+    exp_id = _create_experiments(store, "delete_trace_items")
+    _create_trace(store, "tr-keep", experiment_id=exp_id)
+    _create_trace(store, "tr-del", experiment_id=exp_id)
+    queue = store.create_review_queue(exp_id, name="Q", queue_type="custom")
+    store.add_items_to_review_queue(queue.queue_id, item_ids=["tr-keep", "tr-del"])
+
+    store.delete_traces(exp_id, trace_ids=["tr-del"])
+
+    remaining = {i.item_id for i in store.list_review_queue_items(queue.queue_id)}
+    assert remaining == {"tr-keep"}
+
+
+def test_delete_trace_removes_items_from_every_queue(store):
+    exp_id = _create_experiments(store, "delete_trace_items_multi")
+    _create_trace(store, "tr-del", experiment_id=exp_id)
+    q1 = store.create_review_queue(exp_id, name="Q1", queue_type="custom")
+    q2 = store.create_review_queue(exp_id, name="Q2", queue_type="custom")
+    store.add_items_to_review_queue(q1.queue_id, item_ids=["tr-del"])
+    store.add_items_to_review_queue(q2.queue_id, item_ids=["tr-del"])
+
+    store.delete_traces(exp_id, trace_ids=["tr-del"])
+
+    assert list(store.list_review_queue_items(q1.queue_id)) == []
+    assert list(store.list_review_queue_items(q2.queue_id)) == []

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_review_queues.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_review_queues.py
@@ -702,11 +702,6 @@ def test_create_custom_queue_rejects_default_name_case_insensitive(store, name):
     _assert_error_code(exc, INVALID_PARAMETER_VALUE)
 
 
-# --------------------------------------------------------------------------
-# Trace deletion cleans up attached items
-# --------------------------------------------------------------------------
-
-
 def test_delete_trace_removes_its_review_queue_items(store):
     exp_id = _create_experiments(store, "delete_trace_items")
     _create_trace(store, "tr-keep", experiment_id=exp_id)

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_review_queues.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_review_queues.py
@@ -732,3 +732,15 @@ def test_delete_trace_removes_items_from_every_queue(store):
 
     assert list(store.list_review_queue_items(q1.queue_id)) == []
     assert list(store.list_review_queue_items(q2.queue_id)) == []
+
+
+def test_delete_traces_by_timestamp_removes_review_queue_items(store):
+    # The timestamp-based delete path shares the same cleanup helper as the id-based one.
+    exp_id = _create_experiments(store, "delete_trace_items_ts")
+    _create_trace(store, "tr-old", experiment_id=exp_id, request_time=1000)
+    queue = store.create_review_queue(exp_id, name="Q", queue_type="custom")
+    store.add_items_to_review_queue(queue.queue_id, item_ids=["tr-old"])
+
+    store.delete_traces(exp_id, max_timestamp_millis=5000)
+
+    assert list(store.list_review_queue_items(queue.queue_id)) == []


### PR DESCRIPTION
### Related Issues/PRs

Relates to the recently added review queue feature (#23844 and related).

### What changes are proposed in this pull request?

Deleting a trace attached to a review queue left two problems behind, both fixed here in the SQLAlchemy tracking store:

- The queue item was stranded (`review_queue_items.item_id` has no FK into `trace_info`, so no cascade). `_delete_traces` now removes those rows in the same transaction.
- Submitting a review for the stranded item leaked the raw SQLAlchemy `IntegrityError` to the reviewer. `create_assessment` now translates the trace FK error into a clean `RESOURCE_DOES_NOT_EXIST` ("trace not found").

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New store tests cover both halves (workspace-enabled and -disabled). Before/after recordings:

**Before** (deleted trace lingers in the queue; submit leaks raw SQL):

https://github.com/user-attachments/assets/c3caa925-2119-457c-8f2a-b33e5577cdc3

**After** (queue item removed; mid-review deletion fails with a clean "trace not found"):

https://github.com/user-attachments/assets/6c285789-b2c8-4d0c-a0d7-cc61e64ccb26

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Deleting a trace now removes it from any review queues it was attached to, and submitting a review for a deleted trace returns a clear "trace not found" error instead of a raw database error.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)