### PR TITLE
Fix Artifacts tab crash on line-heavy text files by virtualizing `ShowArtifactTextView` rendering

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactTextView.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactTextView.test.tsx
@@ -1,0 +1,93 @@
+import { jest, describe, beforeEach, test, expect } from '@jest/globals';
+import { screen, waitFor } from '@testing-library/react';
+import { renderWithDesignSystem } from '../../../common/utils/TestUtils.react18';
+import ShowArtifactTextView, { isLineHeavy } from './ShowArtifactTextView';
+import { fetchArtifactUnified } from './utils/fetchArtifactUnified';
+
+jest.mock('./utils/fetchArtifactUnified', () => ({
+  fetchArtifactUnified: jest.fn(),
+}));
+
+// Render a fixed window of rows in tests; jsdom has no layout so the real
+// virtualizer would measure a zero-height scroll element and render nothing.
+const VIRTUALIZER_TEST_WINDOW = 50;
+jest.mock('@tanstack/react-virtual', () => {
+  const actual = jest.requireActual<typeof import('@tanstack/react-virtual')>('@tanstack/react-virtual');
+  return {
+    ...actual,
+    useVirtualizer: (opts: any) => ({
+      getVirtualItems: () =>
+        Array.from({ length: Math.min(opts.count, VIRTUALIZER_TEST_WINDOW) }, (_, i) => ({
+          index: i,
+          key: i,
+          start: i * 20,
+          size: 20,
+        })),
+      getTotalSize: () => opts.count * 20,
+      measureElement: () => {},
+    }),
+  };
+});
+
+const mockFetch = jest.mocked(fetchArtifactUnified);
+
+const renderView = (props = {}) =>
+  renderWithDesignSystem(<ShowArtifactTextView runUuid="run-1" path="output.log" {...props} />);
+
+describe('ShowArtifactTextView virtualization', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('renders small files fully without virtualization', async () => {
+    mockFetch.mockResolvedValue('line one\nline two\nline three');
+    renderView();
+    await waitFor(() => {
+      expect(screen.getByText(/line one/)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/line three/)).toBeInTheDocument();
+    // Non-virtualized path renders no windowed row containers
+    expect(document.querySelectorAll('[data-index]')).toHaveLength(0);
+  });
+
+  test('renders a line-heavy file without RangeError and mounts only the visible window', async () => {
+    // 140K lines exceeds V8's ~125K argument limit that crashes
+    // react-syntax-highlighter's default renderer
+    const lineCount = 140_000;
+    const text = Array.from({ length: lineCount }, (_, i) => `line-${i}`).join('\n');
+    mockFetch.mockResolvedValue(text);
+
+    renderView({ size: text.length });
+
+    await waitFor(() => {
+      expect(screen.getByText(/line-0/)).toBeInTheDocument();
+    });
+    const mountedRows = document.querySelectorAll('[data-index]');
+    expect(mountedRows.length).toBeGreaterThan(0);
+    expect(mountedRows.length).toBeLessThanOrEqual(VIRTUALIZER_TEST_WINDOW);
+  });
+
+  test('virtualized path preserves the pre/code structure and syntax highlighting', async () => {
+    const text = Array.from({ length: 6000 }, (_, i) => `row ${i}`).join('\n');
+    mockFetch.mockResolvedValue(text);
+    renderView({ size: text.length });
+
+    await waitFor(() => {
+      expect(document.querySelector('pre code')).toBeInTheDocument();
+    });
+    // Line content is preserved (tokenized into multiple spans by the `log` grammar,
+    // so compare textContent rather than looking up a single text node)
+    expect(document.querySelector('[data-index="0"]')?.textContent).toBe('row 0\n');
+    expect(document.querySelector('[data-index="1"]')?.textContent).toBe('row 1\n');
+  });
+});
+
+describe('isLineHeavy', () => {
+  test('returns false for files at or below the threshold', () => {
+    expect(isLineHeavy('')).toBe(false);
+    expect(isLineHeavy('one line')).toBe(false);
+    expect(isLineHeavy(Array(5000).fill('x').join('\n'))).toBe(false);
+  });
+
+  test('returns true for files above the threshold', () => {
+    expect(isLineHeavy(Array(5001).fill('x').join('\n'))).toBe(true);
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactTextView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactTextView.tsx
@@ -1,6 +1,7 @@
-import React, { Component } from 'react';
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import React, { Component, useCallback, useEffect, useRef, useState } from 'react';
+import { Prism as SyntaxHighlighter, createElement } from 'react-syntax-highlighter';
 import { coy as style, atomDark as darkStyle } from 'react-syntax-highlighter/dist/cjs/styles/prism';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import { getExtension, getLanguage } from '../../../common/utils/FileUtils';
 import { getArtifactContent } from '../../../common/utils/ArtifactUtils';
 import './ShowArtifactTextView.css';
@@ -12,6 +13,135 @@ import type { LoggedModelArtifactViewerProps } from './ArtifactViewComponents.ty
 import { fetchArtifactUnified } from './utils/fetchArtifactUnified';
 
 const LARGE_ARTIFACT_SIZE = 100 * 1024;
+// react-syntax-highlighter's default renderer flattens its per-line tree with a single
+// `[].concat(...lines)` call, which overflows V8's ~125K argument limit and throws
+// `RangeError: Maximum call stack size exceeded` for line-heavy files. Above this line
+// count we switch to a virtualized renderer, which both avoids that call and keeps the
+// DOM to ~the visible lines instead of one element per line.
+const VIRTUALIZATION_LINE_THRESHOLD = 5000;
+const ESTIMATED_LINE_HEIGHT = 20;
+const VIRTUALIZED_LINE_OVERSCAN = 25;
+
+type SyntaxHighlighterRendererProps = {
+  rows: any[];
+  stylesheet: any;
+  useInlineStyles: boolean;
+};
+
+type VirtualizedRowsProps = SyntaxHighlighterRendererProps & {
+  scrollElementRef: React.RefObject<HTMLPreElement>;
+};
+
+// Renders only the visible window of highlighted rows. The virtualizer lives here rather
+// than in VirtualizedSyntaxHighlighter so that scrolling re-renders only this component,
+// not <SyntaxHighlighter />, whose render re-processes the entire file.
+const VirtualizedRows = ({ rows, stylesheet, useInlineStyles, scrollElementRef }: VirtualizedRowsProps) => {
+  // Resolve the scroll element in an effect: this component mounts before the ref to its
+  // ancestor <pre> is attached, so reading scrollElementRef.current during render (or in
+  // getScrollElement directly) would leave the virtualizer permanently unmeasured.
+  const [scrollElement, setScrollElement] = useState<HTMLPreElement | null>(null);
+  useEffect(() => {
+    setScrollElement(scrollElementRef.current);
+  }, [scrollElementRef]);
+
+  const virtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => scrollElement,
+    estimateSize: () => ESTIMATED_LINE_HEIGHT,
+    overscan: VIRTUALIZED_LINE_OVERSCAN,
+  });
+
+  return (
+    <div style={{ height: virtualizer.getTotalSize(), position: 'relative' }}>
+      {virtualizer.getVirtualItems().map((virtualLine) => (
+        <div
+          key={virtualLine.key}
+          data-index={virtualLine.index}
+          ref={virtualizer.measureElement}
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+            transform: `translateY(${virtualLine.start}px)`,
+          }}
+        >
+          {createElement({
+            node: rows[virtualLine.index],
+            stylesheet,
+            useInlineStyles,
+            key: `line-${virtualLine.index}`,
+          })}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+type VirtualizedSyntaxHighlighterProps = {
+  language: string;
+  style: any;
+  customStyle: React.CSSProperties;
+  children: string;
+};
+
+// react-syntax-highlighter forwards unrecognized props to PreTag, which lets us attach
+// a ref to the scroll container without defining a component during render.
+const PreWithScrollRef = ({
+  scrollRef,
+  ...props
+}: React.HTMLProps<HTMLPreElement> & { scrollRef: React.RefObject<HTMLPreElement> }) => (
+  <pre {...props} ref={scrollRef} />
+);
+
+// Drop-in replacement for <SyntaxHighlighter /> for line-heavy files. Providing a custom
+// renderer makes react-syntax-highlighter keep per-line rows (wrapLines) instead of
+// flattening them through the argument-limited `[].concat(...)` call, and the renderer
+// mounts only the visible lines.
+const VirtualizedSyntaxHighlighter = ({
+  language,
+  style,
+  customStyle,
+  children,
+}: VirtualizedSyntaxHighlighterProps) => {
+  const preRef = useRef<HTMLPreElement>(null);
+
+  // The renderer identity must be stable across renders, otherwise the rendered rows
+  // are remounted on every render and the scroll container loses its scroll position.
+  const renderer = useCallback(
+    ({ rows, stylesheet, useInlineStyles }: SyntaxHighlighterRendererProps) => (
+      <VirtualizedRows
+        rows={rows}
+        stylesheet={stylesheet}
+        useInlineStyles={useInlineStyles}
+        scrollElementRef={preRef}
+      />
+    ),
+    [],
+  );
+
+  return (
+    <SyntaxHighlighter
+      language={language}
+      style={style}
+      customStyle={customStyle}
+      PreTag={PreWithScrollRef}
+      scrollRef={preRef}
+      renderer={renderer}
+    >
+      {children}
+    </SyntaxHighlighter>
+  );
+};
+
+// Exported for tests
+export function isLineHeavy(text: string): boolean {
+  let lines = 1;
+  for (let i = text.indexOf('\n'); i !== -1 && lines <= VIRTUALIZATION_LINE_THRESHOLD; i = text.indexOf('\n', i + 1)) {
+    lines++;
+  }
+  return lines > VIRTUALIZATION_LINE_THRESHOLD;
+}
 
 type Props = DesignSystemHocProps & {
   runUuid: string;
@@ -81,13 +211,15 @@ class ShowArtifactTextView extends Component<Props, State> {
         : this.state.text;
 
       const syntaxStyle = theme.isDarkMode ? darkStyle : style;
+      const text = renderedContent ?? '';
+      const TextSyntaxHighlighter = isLineHeavy(text) ? VirtualizedSyntaxHighlighter : SyntaxHighlighter;
 
       return (
         <div className="mlflow-ShowArtifactPage">
           <div className="text-area-border-box">
-            <SyntaxHighlighter language={language} style={syntaxStyle} customStyle={overrideStyles}>
-              {renderedContent ?? ''}
-            </SyntaxHighlighter>
+            <TextSyntaxHighlighter language={language} style={syntaxStyle} customStyle={overrideStyles}>
+              {text}
+            </TextSyntaxHighlighter>
           </div>
         </div>
       );


### PR DESCRIPTION
### Related Issues/PRs

Closes #23894

### What changes are proposed in this pull request?

The run Artifacts tab crashes with `RangeError: Maximum call stack size exceeded` when previewing a text/log artifact with a large number of lines. `react-syntax-highlighter`'s default renderer flattens its per-line tree with a single `[].concat(...lines)` call (`processLines()` in `highlight.js`), which spreads one argument per line and overflows V8's ~125K argument limit. Ordinary multi-MB log files (hundreds of thousands of lines, below the existing 50 MiB preview cap) hit this and become unviewable.

This PR makes `ShowArtifactTextView` render files above 5,000 lines through a custom virtualized renderer built on `@tanstack/react-virtual` (already a dependency — no new packages):

- Providing a custom `renderer` makes `react-syntax-highlighter` keep per-line rows (`wrapLines` path), which skips the argument-limited `[].concat(...)` call entirely.
- Only the visible window of lines (~60 elements) is mounted instead of one DOM element per line, so large files open instantly and scroll smoothly.
- The virtualizer lives in a child component of the highlighter's renderer, so scroll updates never re-trigger the highlighter's O(file size) line processing.
- Files at or below 5,000 lines take the exact same code path as before — no behavior change.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New tests in `ShowArtifactTextView.test.tsx` include a regression test that renders a 140K-line artifact (above the ~125K argument limit) — it throws `RangeError` without this fix — plus tests that the virtualized path mounts only the visible window and preserves the `pre`/`code` structure and line content.

Manually verified against a local dev server by logging a 12.4 MB / 270,000-line log artifact per the issue's repro script: the file previously crashed the artifact viewer (`RangeError` caught by `AppErrorBoundary`); with this change it opens instantly, scrolls smoothly to the middle of the file, and produces no console errors.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fixed the run Artifacts tab crashing with `RangeError: Maximum call stack size exceeded` when previewing line-heavy text/log artifacts; large files are now rendered with a virtualized viewer.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release