### PR TITLE
fix: prevent 'Table already exists' error on db upgrade (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -84,8 +84,9 @@ def _is_empty_database(engine):
 
 
 def _initialize_tables(engine):
-    _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    if _is_empty_database(engine):
+        _logger.info("Creating initial MLflow database tables...")
+        InitialBase.metadata.create_all(engine)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When upgrading from MLflow 3.7.0 to 3.8.x, running `mlflow db upgrade` fails with `pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")`. This occurs because `_initialize_tables()` always calls `InitialBase.metadata.create_all(engine)` to create tables, and then runs Alembic migrations via `_upgrade_db`. Some migrations (e.g., the one adding the 'secrets' table) try to create tables that already exist, causing the error.

## Fix
Modified `_initialize_tables()` to only create initial tables if the database is empty (using `_is_empty_database()`). This prevents duplicate table creation while still allowing Alembic migrations to run correctly. This ensures idempotent upgrade behavior.

Closes #19943