### PR TITLE
Warn instead of erroring when `mlflow agent setup` runs outside a git repo

### DIFF
--- a/mlflow/agent/setup/cli.py
+++ b/mlflow/agent/setup/cli.py
@@ -90,7 +90,13 @@ def _run_setup(
     """Run the interactive setup flow and return the agent launch command, or None for --print."""
     repo_root = _git_root(Path.cwd())
     if repo_root is None:
-        raise click.ClickException("`mlflow agent setup` must be run inside a git working tree.")
+        click.secho(
+            "Not inside a git repository. The agent's edits cannot be reviewed or reverted "
+            "with git.",
+            fg="yellow",
+            err=True,
+        )
+        repo_root = Path.cwd()
 
     agent = _choose_agent(agent_name)
     payload["agent"] = agent.name

--- a/mlflow/agent/setup/cli.py
+++ b/mlflow/agent/setup/cli.py
@@ -41,7 +41,8 @@ def _find_available_port(start: int = 5000, end: int = 5100) -> int:
     raise click.ClickException(f"No available port found in {start}-{end - 1}.")
 
 
-def _git_root(start: Path) -> Path | None:
+def _git_root(start: Path) -> tuple[Path | None, str | None]:
+    """Return (repo_root, reason); the reason explains why repo_root is None."""
     try:
         out = subprocess.run(
             ["git", "rev-parse", "--show-toplevel"],
@@ -50,9 +51,11 @@ def _git_root(start: Path) -> Path | None:
             capture_output=True,
             text=True,
         )
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return None
-    return Path(out.stdout.strip())
+    except FileNotFoundError:
+        return None, "Git is not installed."
+    except subprocess.CalledProcessError:
+        return None, "Not inside a git repository."
+    return Path(out.stdout.strip()), None
 
 
 def _choose_agent(preferred: AgentName | None) -> AgentTool:
@@ -88,11 +91,10 @@ def _run_setup(
     payload: dict[str, Any],
 ) -> tuple[list[str], Path] | None:
     """Run the interactive setup flow and return the agent launch command, or None for --print."""
-    repo_root = _git_root(Path.cwd())
+    repo_root, reason = _git_root(Path.cwd())
     if repo_root is None:
         click.secho(
-            "Not inside a git repository. The agent's edits cannot be reviewed or reverted "
-            "with git.",
+            f"{reason} The agent's edits cannot be reviewed or reverted with git.",
             fg="yellow",
             err=True,
         )

--- a/tests/agent/test_cli.py
+++ b/tests/agent/test_cli.py
@@ -9,7 +9,7 @@ import pytest
 from click.testing import CliRunner
 
 from mlflow.agent.agents import AGENTS
-from mlflow.agent.setup.cli import setup
+from mlflow.agent.setup.cli import _git_root, setup
 from mlflow.telemetry.events import AgentSetupEvent
 
 
@@ -83,7 +83,7 @@ def test_setup_launches_agent_with_correct_argv(
 ):
     with (
         mock.patch("mlflow.agent.agents.shutil.which", return_value=f"/usr/local/bin/{agent}"),
-        mock.patch("mlflow.agent.setup.cli._git_root", return_value=tmp_git_repo),
+        mock.patch("mlflow.agent.setup.cli._git_root", return_value=(tmp_git_repo, None)),
         mock.patch(
             "mlflow.agent.setup.cli.subprocess.run",
             return_value=subprocess.CompletedProcess([], 0),
@@ -96,19 +96,40 @@ def test_setup_launches_agent_with_correct_argv(
     assert cmd[-1].startswith("# MLflow Tracing Setup")
 
 
-def test_setup_outside_git_falls_back_to_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+def test_git_root_outside_repo(tmp_path: Path):
+    root, reason = _git_root(tmp_path)
+    assert root is None
+    assert reason == "Not inside a git repository."
+
+
+def test_git_root_when_git_not_installed(tmp_path: Path):
+    with mock.patch(
+        "mlflow.agent.setup.cli.subprocess.run", side_effect=FileNotFoundError
+    ) as mock_run:
+        root, reason = _git_root(tmp_path)
+    assert root is None
+    assert reason == "Git is not installed."
+    mock_run.assert_called_once()
+
+
+@pytest.mark.parametrize("reason", ["Not inside a git repository.", "Git is not installed."])
+def test_setup_outside_git_falls_back_to_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, reason: str
+):
     monkeypatch.chdir(tmp_path)
     with (
         mock.patch(
             "mlflow.agent.agents.shutil.which", return_value="/usr/local/bin/claude"
         ) as mock_which,
-        mock.patch("mlflow.agent.setup.cli._git_root", return_value=None) as mock_git_root,
+        mock.patch(
+            "mlflow.agent.setup.cli._git_root", return_value=(None, reason)
+        ) as mock_git_root,
     ):
         result = CliRunner().invoke(
             setup, ["--agent", "claude", "--print"], input="1\n3\nhttp://localhost:5001\n"
         )
     assert result.exit_code == 0, result.stderr
-    assert "Not inside a git repository" in result.stderr
+    assert f"{reason} The agent's edits cannot be reviewed or reverted with git." in result.stderr
     assert (tmp_path / ".claude" / "skills").is_dir()
     mock_which.assert_called()
     mock_git_root.assert_called_once()

--- a/tests/agent/test_cli.py
+++ b/tests/agent/test_cli.py
@@ -96,6 +96,24 @@ def test_setup_launches_agent_with_correct_argv(
     assert cmd[-1].startswith("# MLflow Tracing Setup")
 
 
+def test_setup_outside_git_falls_back_to_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.chdir(tmp_path)
+    with (
+        mock.patch(
+            "mlflow.agent.agents.shutil.which", return_value="/usr/local/bin/claude"
+        ) as mock_which,
+        mock.patch("mlflow.agent.setup.cli._git_root", return_value=None) as mock_git_root,
+    ):
+        result = CliRunner().invoke(
+            setup, ["--agent", "claude", "--print"], input="1\n3\nhttp://localhost:5001\n"
+        )
+    assert result.exit_code == 0, result.stderr
+    assert "Not inside a git repository" in result.stderr
+    assert (tmp_path / ".claude" / "skills").is_dir()
+    mock_which.assert_called()
+    mock_git_root.assert_called_once()
+
+
 def test_setup_declined_skills_uses_bundled_path(tmp_git_repo: Path):
     with mock.patch(
         "mlflow.agent.agents.shutil.which", return_value="/usr/local/bin/claude"


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Make `mlflow agent setup` usable outside a git working tree. Instead of aborting with an error, the command now prints a warning ("Not inside a git repository." or "Git is not installed.", followed by "The agent's edits cannot be reviewed or reverted with git.") and falls back to the current directory as the project root.

Requiring git was stricter than necessary: users trying MLflow in a scratch directory or a not-yet-versioned project couldn't run the command at all, even though nothing in the flow depends on git beyond locating the project root.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
