### PR TITLE
Validate trace existence and experiment scope when attaching review-queue items

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -4792,13 +4792,29 @@ def _add_items_to_review_queue():
         AddItemsToReviewQueue(),
         schema={"queue_id": [_assert_required, _assert_string]},
     )
-    kwargs: dict[str, object] = {"item_ids": list(request_message.item_ids)}
+    store = _get_tracking_store()
+    item_ids = list(request_message.item_ids)
+    kwargs: dict[str, object] = {"item_ids": item_ids}
     if (
         request_message.HasField("item_type")
         and request_message.item_type != REVIEW_ITEM_TYPE_UNSPECIFIED
     ):
         kwargs["item_type"] = ReviewItemType.from_proto(request_message.item_type)
-    items = _get_tracking_store().add_items_to_review_queue(request_message.queue_id, **kwargs)
+    # Items are trace references with no DB foreign key, so verify every trace
+    # exists in the queue's experiment before attaching. A missing or
+    # cross-experiment id would otherwise become a ghost PENDING item the UI
+    # can't render, and reviewing it would leak traces across experiments.
+    queue = store.get_review_queue(request_message.queue_id)
+    experiment_by_trace = {
+        info.trace_id: str(info.experiment_id) for info in store.batch_get_trace_infos(item_ids)
+    }
+    if invalid := [i for i in item_ids if experiment_by_trace.get(i) != str(queue.experiment_id)]:
+        raise MlflowException(
+            f"Cannot attach trace(s) {invalid} to review queue '{request_message.queue_id}': "
+            f"they do not exist in experiment '{queue.experiment_id}'.",
+            error_code=RESOURCE_DOES_NOT_EXIST,
+        )
+    items = store.add_items_to_review_queue(request_message.queue_id, **kwargs)
     response = AddItemsToReviewQueue.Response(items=[i.to_proto() for i in items])
     return _wrap_response(response)
 

--- a/tests/server/test_review_queue_handlers.py
+++ b/tests/server/test_review_queue_handlers.py
@@ -1,4 +1,5 @@
 import json
+from types import SimpleNamespace
 from unittest import mock
 
 import pytest
@@ -246,11 +247,30 @@ def test_delete_review_queue_routes():
     assert response.status_code == 200
 
 
+def _trace_info(trace_id, experiment_id="1"):
+    # The add-items handler only reads .trace_id / .experiment_id off the
+    # batch_get_trace_infos result, so a lightweight stand-in suffices.
+    return SimpleNamespace(trace_id=trace_id, experiment_id=experiment_id)
+
+
+def _run_add_items(request_message, *, queue_experiment_id="1", trace_infos, add_return):
+    with (
+        mock.patch(f"{_BASE_PATCH}._get_tracking_store") as mock_store,
+        mock.patch(f"{_BASE_PATCH}._get_request_message", return_value=request_message),
+    ):
+        store = mock_store.return_value
+        store.get_review_queue.return_value = _queue_entity(experiment_id=queue_experiment_id)
+        store.batch_get_trace_infos.return_value = trace_infos
+        store.add_items_to_review_queue.return_value = add_return
+        return store, _add_items_to_review_queue()
+
+
 def test_add_items_defaults_item_type_to_trace():
     request_message = AddItemsToReviewQueue(queue_id="rq-1", item_ids=["tr-1", "tr-2"])
-    items = [_item_entity("tr-1"), _item_entity("tr-2")]
-    store, response = _run_handler(
-        _add_items_to_review_queue, request_message, "add_items_to_review_queue", items
+    store, response = _run_add_items(
+        request_message,
+        trace_infos=[_trace_info("tr-1"), _trace_info("tr-2")],
+        add_return=[_item_entity("tr-1"), _item_entity("tr-2")],
     )
     kwargs = store.add_items_to_review_queue.call_args[1]
     assert kwargs["item_ids"] == ["tr-1", "tr-2"]
@@ -262,13 +282,29 @@ def test_add_items_defaults_item_type_to_trace():
 
 def test_add_items_forwards_explicit_item_type():
     request_message = AddItemsToReviewQueue(queue_id="rq-1", item_type=TRACE, item_ids=["tr-1"])
-    store, _ = _run_handler(
-        _add_items_to_review_queue,
+    store, _ = _run_add_items(
         request_message,
-        "add_items_to_review_queue",
-        [_item_entity("tr-1")],
+        trace_infos=[_trace_info("tr-1")],
+        add_return=[_item_entity("tr-1")],
     )
     assert store.add_items_to_review_queue.call_args[1]["item_type"] == ReviewItemType.TRACE
+
+
+def test_add_items_rejects_traces_not_in_queue_experiment():
+    # tr-2 doesn't exist anywhere; tr-3 exists but in a different experiment.
+    request_message = AddItemsToReviewQueue(queue_id="rq-1", item_ids=["tr-1", "tr-2", "tr-3"])
+    store, response = _run_add_items(
+        request_message,
+        queue_experiment_id="1",
+        trace_infos=[_trace_info("tr-1", "1"), _trace_info("tr-3", "2")],
+        add_return=[],
+    )
+    assert response.status_code == 404
+    body = json.loads(response.get_data())
+    assert body["error_code"] == "RESOURCE_DOES_NOT_EXIST"
+    assert "tr-2" in body["message"]
+    assert "tr-3" in body["message"]
+    store.add_items_to_review_queue.assert_not_called()
 
 
 def test_remove_items_routes():

--- a/tests/server/test_review_queue_handlers.py
+++ b/tests/server/test_review_queue_handlers.py
@@ -276,6 +276,8 @@ def test_add_items_defaults_item_type_to_trace():
     assert kwargs["item_ids"] == ["tr-1", "tr-2"]
     # Unset item_type is not forwarded; the store applies its TRACE default.
     assert "item_type" not in kwargs
+    # The existence check ran against exactly the requested ids.
+    store.batch_get_trace_infos.assert_called_once_with(["tr-1", "tr-2"])
     body = json.loads(response.get_data())
     assert [i["item_id"] for i in body["items"]] == ["tr-1", "tr-2"]
 
@@ -288,6 +290,7 @@ def test_add_items_forwards_explicit_item_type():
         add_return=[_item_entity("tr-1")],
     )
     assert store.add_items_to_review_queue.call_args[1]["item_type"] == ReviewItemType.TRACE
+    store.batch_get_trace_infos.assert_called_once_with(["tr-1"])
 
 
 def test_add_items_rejects_traces_not_in_queue_experiment():


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23844

### What changes are proposed in this pull request?

Review-queue items are trace references stored as a soft `String(50)` column with no foreign key, so `AddItemsToReviewQueue` previously accepted any item id, including ids for traces that don't exist or that belong to a different experiment than the queue. Such an id silently becomes a ghost `PENDING` item the UI cannot render, and opening it for review would surface a trace from outside the queue's experiment.

This PR adds handler-level validation in `_add_items_to_review_queue`: it batch-fetches trace metadata for the requested ids via `batch_get_trace_infos` and rejects the request with `RESOURCE_DOES_NOT_EXIST` if any id is missing or resolves to a different experiment than the queue's.

The check lives in the handler rather than the store on purpose. The store stays a permissive primitive (its unit tests intentionally attach synthetic trace ids), and the validation needs only one extra batched lookup at the API boundary where real traces are required.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added handler tests covering the happy path (all ids in the queue's experiment) and rejection when an id is missing entirely or belongs to a different experiment.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.