### PR TITLE
Lock the review-queue row when editing questions or attaching items

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -8319,14 +8319,20 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
     def _review_queue_query(self, session):
         return self._get_query(session, SqlReviewQueue)
 
-    def _get_sql_review_queue(self, session, queue_id):
-        """Fetch the workspace-scoped queue row or raise RESOURCE_DOES_NOT_EXIST."""
-        sql_queue = (
-            self
-            ._review_queue_query(session)
-            .filter(SqlReviewQueue.queue_id == queue_id)
-            .one_or_none()
-        )
+    def _get_sql_review_queue(self, session, queue_id, *, for_update=False):
+        """Fetch the workspace-scoped queue row or raise RESOURCE_DOES_NOT_EXIST.
+
+        Pass ``for_update=True`` from mutating paths (attaching items, editing
+        questions) to lock the queue row for the rest of the transaction. The
+        question-freeze check reads the item count and then swaps the schema set;
+        without the lock a concurrent attach could slip an item in between, leaving
+        reviewers answering questions that were swapped out from under them. Taking
+        the row lock serializes the editing and attaching paths against each other.
+        """
+        query = self._review_queue_query(session).filter(SqlReviewQueue.queue_id == queue_id)
+        if for_update:
+            query = query.with_for_update()
+        sql_queue = query.one_or_none()
         if sql_queue is None:
             raise MlflowException(
                 f"Review queue with id '{queue_id}' not found.",
@@ -8573,7 +8579,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         from mlflow.genai.review_queues.validation import normalize_schema_ids, normalize_users
 
         with self.ManagedSessionMaker(read_only=False) as session:
-            sql_queue = self._get_sql_review_queue(session, queue_id)
+            sql_queue = self._get_sql_review_queue(session, queue_id, for_update=True)
             if ReviewQueueType(sql_queue.queue_type) == ReviewQueueType.USER:
                 raise MlflowException(
                     "A user queue's assigned user and schemas are fixed and cannot be updated.",
@@ -8661,7 +8667,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         normalized_item_ids = validate_item_ids_for_attach(item_ids)
 
         with self.ManagedSessionMaker(read_only=False) as session:
-            sql_queue = self._get_sql_review_queue(session, queue_id)
+            sql_queue = self._get_sql_review_queue(session, queue_id, for_update=True)
 
             existing_item_ids = {
                 row.item_id

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_review_queues.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_review_queues.py
@@ -1,4 +1,5 @@
 import time
+from unittest import mock
 
 import pytest
 
@@ -411,6 +412,36 @@ def test_update_questions_allowed_after_traces_detached(store):
     # With the queue empty again, questions can be edited.
     updated = store.update_review_queue(queue.queue_id, schema_ids=[ls1.schema_id, ls2.schema_id])
     assert sorted(updated.schema_ids) == sorted([ls1.schema_id, ls2.schema_id])
+
+
+def test_update_questions_locks_queue_row_for_update(store):
+    # The freeze check reads the item count then swaps the schema set; it must hold
+    # a row lock so a concurrent attach can't slip an item in between.
+    exp_id = _create_experiments(store, "update_row_lock")
+    ls = _pass_fail(store, exp_id, "quality")
+    queue = store.create_review_queue(
+        exp_id, name="q", queue_type="custom", schema_ids=[ls.schema_id]
+    )
+    original = type(store)._get_sql_review_queue
+    with mock.patch.object(
+        type(store), "_get_sql_review_queue", autospec=True, side_effect=original
+    ) as spy:
+        store.update_review_queue(queue.queue_id, schema_ids=[ls.schema_id])
+    assert spy.call_args.kwargs["for_update"] is True
+
+
+def test_add_items_locks_queue_row_for_update(store):
+    exp_id = _create_experiments(store, "add_row_lock")
+    ls = _pass_fail(store, exp_id, "quality")
+    queue = store.create_review_queue(
+        exp_id, name="q", queue_type="custom", schema_ids=[ls.schema_id]
+    )
+    original = type(store)._get_sql_review_queue
+    with mock.patch.object(
+        type(store), "_get_sql_review_queue", autospec=True, side_effect=original
+    ) as spy:
+        store.add_items_to_review_queue(queue.queue_id, item_ids=["tr-1"])
+    assert spy.call_args.kwargs["for_update"] is True
 
 
 def test_get_or_create_user_queue_owner_is_the_user(store):


### PR DESCRIPTION
### Related Issues/PRs

Relates to the review queue feature (#23844 and related).

### What changes are proposed in this pull request?

A review queue's questions are frozen once it has items attached: `update_review_queue` reads the attached-item count and, only if it is zero, swaps the queue's schema set. That read-then-act check ran without locking the queue row, so a concurrent `add_items_to_review_queue` could attach an item in the window between the count and the schema swap. The result is a queue with items reviewed against a schema set that was changed out from under the reviewers, defeating the freeze.

This PR takes a `SELECT ... FOR UPDATE` row lock on the queue in both mutating paths, via a new `for_update` argument to the shared `_get_sql_review_queue` helper. Editing questions and attaching items now serialize against each other on the queue row: whichever transaction acquires the lock first runs to completion, and the other observes the committed state (either it sees the new item and refuses the swap, or it sees the new schema set). Read-only callers (e.g. `get_review_queue`) are unchanged.

On backends without row-level locking (SQLite) `with_for_update()` is a harmless no-op, which is fine since those serialize writes at the transaction level anyway.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added store tests asserting both `update_review_queue` and `add_items_to_review_queue` request the row lock (`for_update=True`). They run under both the workspace-enabled and workspace-disabled store variants. Existing freeze-behavior tests continue to pass.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.