### PR TITLE
Reject unknown review-queue enum strings cleanly in the REST store

### DIFF
--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -1117,12 +1117,13 @@ class RestStore(WorkspaceRestStoreMixin, RestGatewayStoreMixin, AbstractStore):
         users=None,
         schema_ids=None,
     ):
-        from mlflow.genai.review_queues import ReviewQueue, ReviewQueueType
+        from mlflow.genai.review_queues import ReviewQueue
+        from mlflow.genai.review_queues.validation import coerce_queue_type
 
         req = CreateReviewQueue(
             experiment_id=str(experiment_id),
             name=name,
-            queue_type=ReviewQueueType(str(queue_type)).to_proto(),
+            queue_type=coerce_queue_type(queue_type).to_proto(),
             users=list(users) if users is not None else [],
             schema_ids=list(schema_ids) if schema_ids is not None else [],
         )
@@ -1212,11 +1213,12 @@ class RestStore(WorkspaceRestStoreMixin, RestGatewayStoreMixin, AbstractStore):
         )
 
     def add_items_to_review_queue(self, queue_id, *, item_ids, item_type="trace"):
-        from mlflow.genai.review_queues import ReviewItemType, ReviewQueueItem
+        from mlflow.genai.review_queues import ReviewQueueItem
+        from mlflow.genai.review_queues.validation import coerce_item_type
 
         req = AddItemsToReviewQueue(
             queue_id=queue_id,
-            item_type=ReviewItemType(str(item_type)).to_proto(),
+            item_type=coerce_item_type(item_type).to_proto(),
             item_ids=list(item_ids),
         )
         response_proto = self._call_endpoint(
@@ -1235,11 +1237,12 @@ class RestStore(WorkspaceRestStoreMixin, RestGatewayStoreMixin, AbstractStore):
         )
 
     def list_review_queue_items(self, queue_id, *, status=None, max_results=None, page_token=None):
-        from mlflow.genai.review_queues import ReviewQueueItem, ReviewStatus
+        from mlflow.genai.review_queues import ReviewQueueItem
+        from mlflow.genai.review_queues.validation import coerce_status
 
         req = ListReviewQueueItems(queue_id=queue_id)
         if status is not None:
-            req.status = ReviewStatus(str(status)).to_proto()
+            req.status = coerce_status(status).to_proto()
         if max_results is not None:
             req.max_results = max_results
         if page_token is not None:
@@ -1253,12 +1256,13 @@ class RestStore(WorkspaceRestStoreMixin, RestGatewayStoreMixin, AbstractStore):
         return PagedList(items, response_proto.next_page_token or None)
 
     def set_review_queue_item_status(self, queue_id, *, item_id, status, completed_by=None):
-        from mlflow.genai.review_queues import ReviewQueueItem, ReviewStatus
+        from mlflow.genai.review_queues import ReviewQueueItem
+        from mlflow.genai.review_queues.validation import coerce_status
 
         req = SetReviewQueueItemStatus(
             queue_id=queue_id,
             item_id=item_id,
-            status=ReviewStatus(str(status)).to_proto(),
+            status=coerce_status(status).to_proto(),
         )
         if completed_by is not None:
             req.completed_by = completed_by

--- a/tests/store/tracking/test_rest_store_review_queues.py
+++ b/tests/store/tracking/test_rest_store_review_queues.py
@@ -1,6 +1,9 @@
 import json
 from unittest import mock
 
+import pytest
+
+from mlflow.exceptions import MlflowException
 from mlflow.protos import review_queues_pb2 as pb
 from mlflow.store.tracking.rest_store import RestStore
 from mlflow.utils.rest_utils import MlflowHostCreds
@@ -204,3 +207,27 @@ def test_remove_items_endpoint():
     assert captured["endpoint"] == "/api/3.0/mlflow/review-queues/items/remove"
     assert captured["body"]["queue_id"] == "rq-1"
     assert captured["body"]["item_ids"] == ["tr-1", "tr-2"]
+
+
+# Unknown enum strings are rejected with a clear MlflowException before the RPC,
+# rather than the bare ValueError a direct enum constructor would raise.
+
+
+def test_create_review_queue_rejects_unknown_queue_type():
+    with pytest.raises(MlflowException, match="`queue_type` must be one of"):
+        _store().create_review_queue("1", name="Q", queue_type="nonsense")
+
+
+def test_add_items_rejects_unknown_item_type():
+    with pytest.raises(MlflowException, match="`item_type` must be one of"):
+        _store().add_items_to_review_queue("rq-1", item_ids=["tr-1"], item_type="nonsense")
+
+
+def test_list_items_rejects_unknown_status():
+    with pytest.raises(MlflowException, match="`status` must be one of"):
+        _store().list_review_queue_items("rq-1", status="nonsense")
+
+
+def test_set_item_status_rejects_unknown_status():
+    with pytest.raises(MlflowException, match="`status` must be one of"):
+        _store().set_review_queue_item_status("rq-1", item_id="tr-1", status="nonsense")


### PR DESCRIPTION
### Related Issues/PRs

Relates to the review queue feature (#23844 and related).

### What changes are proposed in this pull request?

The REST tracking store built its request protos with raw enum constructors (`ReviewQueueType(...)`, `ReviewItemType(...)`, `ReviewStatus(...)`). An unrecognized string therefore raised a bare `ValueError`, unlike the rest of the review-queue surface which raises an `INVALID_PARAMETER_VALUE` `MlflowException` with a descriptive message.

This PR routes the REST-store enum parsing through the existing `coerce_queue_type` / `coerce_item_type` / `coerce_status` helpers in `mlflow/genai/review_queues/validation.py` (already used by the SQLAlchemy store), so the client raises a uniform, descriptive error and matches the DB-store behavior. The helpers also accept enum instances, so passing a `ReviewStatus` (etc.) directly still works.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added REST-store tests asserting that an unknown `queue_type`, `item_type`, or `status` raises `MlflowException` (with the shared "must be one of" message) before any RPC, rather than a bare `ValueError`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.