### PR TITLE
feat(ts-sdk): add `MLFLOW_WORKSPACE` support to OSS auth provider

### DIFF
--- a/libs/typescript/core/src/auth/index.ts
+++ b/libs/typescript/core/src/auth/index.ts
@@ -25,7 +25,7 @@
  * 2. Bearer Token (MLFLOW_TRACKING_TOKEN)
  * 3. No authentication
  *
- * Workspace isolation (multi-tenant):
+ * Workspace support (servers with workspaces enabled):
  * - MLFLOW_WORKSPACE: sets the `X-MLFLOW-WORKSPACE` header for workspace-scoped requests
  *
  * @module auth
@@ -85,7 +85,7 @@ export interface AuthOptions {
   /** Bearer token for OSS MLflow */
   trackingServerToken?: string;
 
-  /** Workspace name for multi-tenant MLflow (sets X-MLFLOW-WORKSPACE header) */
+  /** Workspace name for MLflow servers with workspaces enabled (sets X-MLFLOW-WORKSPACE header) */
   workspace?: string;
 }
 
@@ -276,7 +276,7 @@ function createOssAuth(options: AuthOptions): AuthProvider {
     authHeader = `Bearer ${token}`;
   }
 
-  const workspace = process.env.MLFLOW_WORKSPACE || options.workspace;
+  const workspace = process.env.MLFLOW_WORKSPACE ?? options.workspace;
 
   // Headers provider for OSS MLflow
   // eslint-disable-next-line require-await, @typescript-eslint/require-await

--- a/libs/typescript/core/src/auth/index.ts
+++ b/libs/typescript/core/src/auth/index.ts
@@ -25,6 +25,9 @@
  * 2. Bearer Token (MLFLOW_TRACKING_TOKEN)
  * 3. No authentication
  *
+ * Workspace isolation (multi-tenant):
+ * - MLFLOW_WORKSPACE: sets the `X-MLFLOW-WORKSPACE` header for workspace-scoped requests
+ *
  * @module auth
  */
 
@@ -81,6 +84,9 @@ export interface AuthOptions {
 
   /** Bearer token for OSS MLflow */
   trackingServerToken?: string;
+
+  /** Workspace name for multi-tenant MLflow (sets X-MLFLOW-WORKSPACE header) */
+  workspace?: string;
 }
 
 /**
@@ -270,12 +276,17 @@ function createOssAuth(options: AuthOptions): AuthProvider {
     authHeader = `Bearer ${token}`;
   }
 
+  const workspace = process.env.MLFLOW_WORKSPACE || options.workspace;
+
   // Headers provider for OSS MLflow
   // eslint-disable-next-line require-await, @typescript-eslint/require-await
   const headersProvider: HeadersProvider = async () => {
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
     if (authHeader) {
       headers['Authorization'] = authHeader;
+    }
+    if (workspace) {
+      headers['X-MLFLOW-WORKSPACE'] = workspace;
     }
     return headers;
   };

--- a/libs/typescript/core/src/core/config.ts
+++ b/libs/typescript/core/src/core/config.ts
@@ -86,8 +86,8 @@ export interface MLflowTracingConfig {
   trackingServerToken?: string;
 
   /**
-   * Workspace name for multi-tenant MLflow servers.
-   * Sets the X-MLFLOW-WORKSPACE header on all requests.
+   * Workspace name for MLflow servers with workspaces enabled (OSS/non-Databricks only).
+   * Sets the X-MLFLOW-WORKSPACE header on requests to self-hosted MLflow.
    * Can also be set via MLFLOW_WORKSPACE environment variable (takes precedence).
    */
   workspace?: string;

--- a/libs/typescript/core/src/core/config.ts
+++ b/libs/typescript/core/src/core/config.ts
@@ -86,6 +86,13 @@ export interface MLflowTracingConfig {
   trackingServerToken?: string;
 
   /**
+   * Workspace name for multi-tenant MLflow servers.
+   * Sets the X-MLFLOW-WORKSPACE header on all requests.
+   * Can also be set via MLFLOW_WORKSPACE environment variable (takes precedence).
+   */
+  workspace?: string;
+
+  /**
    * Optional Databricks Unity Catalog trace location. When provided, the SDK
    * generates V4 trace IDs and persists trace tags / metadata via the V4
    * `CreateTraceInfo` endpoint, mirroring Python's
@@ -270,6 +277,7 @@ export function init(config: MLflowTracingInitOptions): void {
     trackingServerUsername: config.trackingServerUsername,
     trackingServerPassword: config.trackingServerPassword,
     trackingServerToken: config.trackingServerToken,
+    workspace: config.workspace,
   });
 
   // Build effective config, populating host and databricksToken from auth provider

--- a/libs/typescript/core/tests/core/auth.test.ts
+++ b/libs/typescript/core/tests/core/auth.test.ts
@@ -1,0 +1,122 @@
+import { createAuthProvider } from '../../src/auth';
+
+const ENV_KEYS = [
+  'MLFLOW_TRACKING_TOKEN',
+  'MLFLOW_TRACKING_USERNAME',
+  'MLFLOW_TRACKING_PASSWORD',
+  'MLFLOW_WORKSPACE',
+] as const;
+
+describe('createAuthProvider', () => {
+  describe('OSS auth (createOssAuth)', () => {
+    const savedEnv: Record<string, string | undefined> = {};
+
+    beforeEach(() => {
+      for (const key of ENV_KEYS) {
+        savedEnv[key] = process.env[key];
+        delete process.env[key];
+      }
+    });
+
+    afterEach(() => {
+      for (const key of ENV_KEYS) {
+        if (savedEnv[key] === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = savedEnv[key];
+        }
+      }
+    });
+
+    it('should include Bearer token header when MLFLOW_TRACKING_TOKEN is set', async () => {
+      process.env.MLFLOW_TRACKING_TOKEN = 'test-token';
+
+      const provider = createAuthProvider({ trackingUri: 'http://localhost:5000' });
+      const headers = await provider.getHeadersProvider()();
+
+      expect(headers['Authorization']).toBe('Bearer test-token');
+      expect(headers['Content-Type']).toBe('application/json');
+    });
+
+    it('should include Basic auth header when username and password are set', async () => {
+      process.env.MLFLOW_TRACKING_USERNAME = 'user';
+      process.env.MLFLOW_TRACKING_PASSWORD = 'pass';
+
+      const provider = createAuthProvider({ trackingUri: 'http://localhost:5000' });
+      const headers = await provider.getHeadersProvider()();
+
+      const expected = `Basic ${Buffer.from('user:pass').toString('base64')}`;
+      expect(headers['Authorization']).toBe(expected);
+    });
+
+    it('should not include Authorization header when no credentials are set', async () => {
+      const provider = createAuthProvider({ trackingUri: 'http://localhost:5000' });
+      const headers = await provider.getHeadersProvider()();
+
+      expect(headers['Authorization']).toBeUndefined();
+      expect(headers['Content-Type']).toBe('application/json');
+    });
+
+    it('should include X-MLFLOW-WORKSPACE header when MLFLOW_WORKSPACE is set', async () => {
+      process.env.MLFLOW_WORKSPACE = 'my-namespace';
+
+      const provider = createAuthProvider({ trackingUri: 'http://localhost:5000' });
+      const headers = await provider.getHeadersProvider()();
+
+      expect(headers['X-MLFLOW-WORKSPACE']).toBe('my-namespace');
+    });
+
+    it('should not include X-MLFLOW-WORKSPACE header when MLFLOW_WORKSPACE is not set', async () => {
+      const provider = createAuthProvider({ trackingUri: 'http://localhost:5000' });
+      const headers = await provider.getHeadersProvider()();
+
+      expect(headers['X-MLFLOW-WORKSPACE']).toBeUndefined();
+    });
+
+    it('should include both Authorization and X-MLFLOW-WORKSPACE when both are set', async () => {
+      process.env.MLFLOW_TRACKING_TOKEN = 'test-token';
+      process.env.MLFLOW_WORKSPACE = 'my-namespace';
+
+      const provider = createAuthProvider({ trackingUri: 'http://localhost:5000' });
+      const headers = await provider.getHeadersProvider()();
+
+      expect(headers['Authorization']).toBe('Bearer test-token');
+      expect(headers['X-MLFLOW-WORKSPACE']).toBe('my-namespace');
+      expect(headers['Content-Type']).toBe('application/json');
+    });
+
+    it('should use workspace from options when env var is not set', async () => {
+      const provider = createAuthProvider({
+        trackingUri: 'http://localhost:5000',
+        workspace: 'config-namespace',
+      });
+      const headers = await provider.getHeadersProvider()();
+
+      expect(headers['X-MLFLOW-WORKSPACE']).toBe('config-namespace');
+    });
+
+    it('should prefer MLFLOW_WORKSPACE env var over options', async () => {
+      process.env.MLFLOW_WORKSPACE = 'env-namespace';
+
+      const provider = createAuthProvider({
+        trackingUri: 'http://localhost:5000',
+        workspace: 'config-namespace',
+      });
+      const headers = await provider.getHeadersProvider()();
+
+      expect(headers['X-MLFLOW-WORKSPACE']).toBe('env-namespace');
+    });
+
+    it('should return the tracking URI as host', () => {
+      const provider = createAuthProvider({ trackingUri: 'http://localhost:5000' });
+
+      expect(provider.getHost()).toBe('http://localhost:5000');
+    });
+
+    it('should return undefined for getDatabricksToken', () => {
+      const provider = createAuthProvider({ trackingUri: 'http://localhost:5000' });
+
+      expect(provider.getDatabricksToken()).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
### Related Issues/PRs

Closes #23898

### What changes are proposed in this pull request?

The OSS auth provider (`createOssAuth` in `libs/typescript/core/src/auth/index.ts`) does not send the `X-MLFLOW-WORKSPACE` header. This causes all npm-based integrations (Claude Code plugin, OpenClaw, etc.) to fail with HTTP 400 on MLflow servers with workspaces enabled.

The Python SDK handles this via `MLFLOW_WORKSPACE` env var and `workspace_utils.WORKSPACE_HEADER_NAME`, but the TypeScript SDK has no workspace support.

**Changes:**
- `libs/typescript/core/src/auth/index.ts`: Add `workspace` to `AuthOptions`, read from env var or config option, set `X-MLFLOW-WORKSPACE` header in `createOssAuth`. Env var takes precedence over config option.
- `libs/typescript/core/src/core/config.ts`: Add `workspace` to `MLflowTracingConfig`, pass through to `createAuthProvider`.
- `libs/typescript/core/tests/core/auth.test.ts`: 10 unit tests covering workspace header (env var, config option, precedence, combinations with auth headers).

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests

**Unit tests:** 10/10 passing

**End-to-end on OpenShift cluster** with MLflow (workspaces enabled):

1. Built the Claude Code plugin from this branch
2. Deployed Claude Code with the following env vars set manually:
   - `MLFLOW_TRACKING_TOKEN` — SA token from `/var/run/secrets/kubernetes.io/serviceaccount/token`
   - `MLFLOW_WORKSPACE` — set to the namespace name (`pr-test`)
   - `MLFLOW_TRACKING_URI` — pointing to the MLflow server
3. Ran `claude -p "What is 2+2?"`
4. Stop-hook exported the trace successfully (HTTP 200)
5. Verified trace in MLflow (experiment `pr-test`, trace `tr-861068a14d1628a078fa05678c8c8772`, status OK)

Without this fix, the same setup fails with:
```
HTTP 400: {"error":{"code":"INVALID_PARAMETER_VALUE","message":"Workspace context is required for this request."}}
```

**Note:** `MLFLOW_TRACKING_TOKEN` and `MLFLOW_WORKSPACE` must still be set manually. The Python SDK's `kubernetes-namespaced` auth provider auto-discovers these from the pod filesystem — that automation (including token rotation) can be added to the TypeScript SDK in a follow-up.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Users deploying MLflow with workspaces enabled can now set `MLFLOW_WORKSPACE` (env var) or pass `workspace` in `MLflowTracingConfig` to enable workspace-scoped trace export from any npm-based MLflow integration.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release