### PR TITLE
Fix JSON response format for Gemini and Anthropic gateway providers

### DIFF
--- a/mlflow/gateway/providers/anthropic.py
+++ b/mlflow/gateway/providers/anthropic.py
@@ -206,7 +206,8 @@ class AnthropicAdapter(ProviderAdapter):
         # Transform response_format for Anthropic structured outputs
         # Anthropic uses output_config.format with {"type": "json_schema", "schema": {...}}
         if response_format := payload.pop("response_format", None):
-            if response_format.get("type") == "json_schema" and "json_schema" in response_format:
+            response_format_type = response_format.get("type")
+            if response_format_type == "json_schema" and "json_schema" in response_format:
                 json_schema = response_format["json_schema"]
                 schema = json_schema.get("schema", {})
                 try:
@@ -226,6 +227,18 @@ class AnthropicAdapter(ProviderAdapter):
                             "schema": schema,
                         }
                     }
+            elif response_format_type == "json_object":
+                # Anthropic has no schema-less JSON mode (its output_config.format
+                # requires a schema), so steer the model to emit JSON via a system
+                # instruction. This is best-effort rather than a hard constraint.
+                json_instruction = (
+                    "Respond with only a single valid JSON value. Do not include any "
+                    "explanatory text, markdown, or code fences before or after the JSON."
+                )
+                if existing_system := payload.get("system"):
+                    payload["system"] = f"{existing_system}\n{json_instruction}"
+                else:
+                    payload["system"] = json_instruction
 
         return payload
 

--- a/mlflow/gateway/providers/anthropic.py
+++ b/mlflow/gateway/providers/anthropic.py
@@ -232,8 +232,8 @@ class AnthropicAdapter(ProviderAdapter):
                 # requires a schema), so steer the model to emit JSON via a system
                 # instruction. This is best-effort rather than a hard constraint.
                 json_instruction = (
-                    "Respond with only a single valid JSON value. Do not include any "
-                    "explanatory text, markdown, or code fences before or after the JSON."
+                    "Respond with only a single valid JSON object. Do not include any "
+                    "explanatory text, markdown, or code fences before or after the JSON object."
                 )
                 if existing_system := payload.get("system"):
                     payload["system"] = f"{existing_system}\n{json_instruction}"

--- a/mlflow/gateway/providers/gemini.py
+++ b/mlflow/gateway/providers/gemini.py
@@ -167,13 +167,16 @@ class GeminiAdapter(ProviderAdapter):
 
         # Transform response_format for Gemini structured outputs
         if response_format := payload.pop("response_format", None):
-            if response_format.get("type") == "json_schema" and "json_schema" in response_format:
-                if "generationConfig" not in gemini_payload:
-                    gemini_payload["generationConfig"] = {}
-                gemini_payload["generationConfig"]["responseJsonSchema"] = response_format[
-                    "json_schema"
-                ]["schema"]
-                gemini_payload["generationConfig"]["responseMimeType"] = "application/json"
+            response_format_type = response_format.get("type")
+            if response_format_type == "json_schema" and "json_schema" in response_format:
+                generation_config = gemini_payload.setdefault("generationConfig", {})
+                generation_config["responseJsonSchema"] = response_format["json_schema"]["schema"]
+                generation_config["responseMimeType"] = "application/json"
+            elif response_format_type == "json_object":
+                # Gemini constrains output to valid JSON when responseMimeType is set,
+                # even without an explicit schema.
+                generation_config = gemini_payload.setdefault("generationConfig", {})
+                generation_config["responseMimeType"] = "application/json"
 
         # convert tool definition to Gemini format
         if tools := payload.pop("tools", None):

--- a/tests/gateway/providers/test_anthropic.py
+++ b/tests/gateway/providers/test_anthropic.py
@@ -1332,7 +1332,7 @@ async def test_chat_with_json_object_response_format():
         body = call_kwargs["json"]
         assert "output_config" not in body
         assert body["system"].startswith("You are helpful.")
-        assert "valid JSON" in body["system"]
+        assert "valid JSON object" in body["system"]
 
 
 def test_enforce_strict_schema_sets_additional_properties_false():

--- a/tests/gateway/providers/test_anthropic.py
+++ b/tests/gateway/providers/test_anthropic.py
@@ -1289,6 +1289,52 @@ async def test_chat_with_structured_output_sanitizes_schema():
         assert "output_config" not in call_kwargs["json"]
 
 
+@pytest.mark.asyncio
+async def test_chat_with_json_object_response_format():
+    config = {
+        "name": "chat",
+        "endpoint_type": "llm/v1/chat",
+        "model": {
+            "provider": "anthropic",
+            "name": "claude-sonnet-4-5",
+            "config": {
+                "anthropic_api_key": "key",
+            },
+        },
+    }
+
+    resp = {
+        "id": "msg_013Zva2CMHLNnXjNJJKqJ2EF",
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "text", "text": '{"answer": 42}'}],
+        "model": "claude-sonnet-4-5",
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 10, "output_tokens": 5},
+    }
+
+    mock_session_client = mock_http_client(MockAsyncResponse(resp))
+
+    with mock.patch("aiohttp.ClientSession", return_value=mock_session_client):
+        provider = AnthropicProvider(EndpointConfig(**config))
+        payload = {
+            "messages": [
+                {"role": "system", "content": "You are helpful."},
+                {"role": "user", "content": "Give me JSON"},
+            ],
+            "response_format": {"type": "json_object"},
+        }
+        await provider.chat(chat.RequestPayload(**payload))
+
+        # Anthropic has no schema-less JSON mode, so json_object is steered via a
+        # system instruction appended to the existing system message.
+        call_kwargs = mock_session_client.post.call_args[1]
+        body = call_kwargs["json"]
+        assert "output_config" not in body
+        assert body["system"].startswith("You are helpful.")
+        assert "valid JSON" in body["system"]
+
+
 def test_enforce_strict_schema_sets_additional_properties_false():
     schema = {
         "type": "object",

--- a/tests/gateway/providers/test_gemini.py
+++ b/tests/gateway/providers/test_gemini.py
@@ -1262,6 +1262,55 @@ async def test_chat_with_structured_output():
 
 
 @pytest.mark.asyncio
+async def test_chat_with_json_object_response_format():
+    config = {
+        "name": "chat",
+        "endpoint_type": "llm/v1/chat",
+        "model": {
+            "provider": "gemini",
+            "name": "gemini-2.0-flash",
+            "config": {
+                "gemini_api_key": "test-key",
+            },
+        },
+    }
+
+    resp = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [{"text": '{"answer": 42}'}],
+                    "role": "model",
+                },
+                "finishReason": "STOP",
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 10,
+            "candidatesTokenCount": 5,
+            "totalTokenCount": 15,
+        },
+    }
+
+    with mock.patch(
+        "aiohttp.ClientSession.post", return_value=MockAsyncResponse(resp)
+    ) as mock_post:
+        provider = GeminiProvider(EndpointConfig(**config))
+        payload = {
+            "messages": [{"role": "user", "content": "Give me JSON"}],
+            "response_format": {"type": "json_object"},
+        }
+        response = await provider.chat(chat.RequestPayload(**payload))
+
+        assert response.choices[0].message.content == '{"answer": 42}'
+
+        call_kwargs = mock_post.call_args[1]
+        generation_config = call_kwargs["json"]["generationConfig"]
+        assert generation_config["responseMimeType"] == "application/json"
+        assert "responseJsonSchema" not in generation_config
+
+
+@pytest.mark.asyncio
 async def test_chat_with_top_k_and_penalties():
     config = {
         "name": "chat",


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23273 and #19452

### What changes are proposed in this pull request?

The Gemini and Anthropic chat adapters in the AI Gateway only handled `response_format.type == "json_schema"` and silently dropped `{"type": "json_object"}`. As a result, selecting the plain **JSON** output format in the Prompt Playground (which sends `{"type": "json_object"}`) returned unconstrained plain text instead of JSON. The `json_schema` option happened to work because only that branch applied a provider-side constraint.

This PR adds `json_object` handling to both providers:

- **Gemini** (`mlflow/gateway/providers/gemini.py`): map `json_object` to `generationConfig.responseMimeType = "application/json"`, which constrains the response to valid JSON without requiring a schema (per [Gemini's structured output docs](https://ai.google.dev/gemini-api/docs/structured-output)). Also collapsed the repeated `generationConfig` initialization.
- **Anthropic** (`mlflow/gateway/providers/anthropic.py`): the Messages API has no schema-less JSON mode (`output_config.format` requires a schema), so `json_object` is steered via a system instruction appended to any existing system message. This is best-effort rather than a hard decode-time constraint.

The OpenAI-family providers (`openai`, `openai_compatible`, `mistral`, etc.) forward `response_format` verbatim in native OpenAI format and are unaffected.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Added `test_chat_with_json_object_response_format` to both `tests/gateway/providers/test_gemini.py` and `tests/gateway/providers/test_anthropic.py`. Full provider suites pass (43 Gemini + 64 Anthropic = 107 passed).

Manually tested in Playground (feat/playground branch) with OpenAI, Gemini and Anthropic provided models
- Text response format
- JSON object response format
- JSON schema response format
JSON schema used:
```
{
  "type": "object",
  "properties": {
    "location": { "type": "string" },
    "temperature": { "type": "number" }
  },
  "required": ["location", "temperature"],
  "additionalProperties": false
}
```
<img width="1902" height="1144" alt="Screenshot 2026-06-12 at 13 04 50" src="https://github.com/user-attachments/assets/3a661187-6541-4821-9a02-4d7156579057" />
<img width="1902" height="1143" alt="Screenshot 2026-06-12 at 13 06 12" src="https://github.com/user-attachments/assets/85946c8c-9c88-47ab-a8c5-f353c06b3a72" />
<img width="1907" height="1175" alt="Screenshot 2026-06-12 at 13 07 41" src="https://github.com/user-attachments/assets/75d794f8-aaf2-42f0-bdcf-8689292d2f4d" />

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Gemini and Anthropic AI Gateway endpoints now correctly constrain output to JSON when the `json_object` response format is requested (e.g. selecting "JSON" output in the Prompt Playground).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
