### PR TITLE
Fixed duplicated cold start of WAL async CLI tracing daemon with binding wait timeout

### DIFF
--- a/libs/typescript/core/src/exporters/wal/supervisor.ts
+++ b/libs/typescript/core/src/exporters/wal/supervisor.ts
@@ -121,11 +121,23 @@ let spawnInFlight: Promise<void> | null = null;
  */
 async function waitForDaemonBind(timeoutMs: number, pollIntervalMs: number): Promise<void> {
   const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (await isDaemonAlive()) {
+  while (true) {
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
       return;
     }
-    await new Promise<void>((resolve) => setTimeout(resolve, pollIntervalMs));
+
+    const result = await Promise.race<boolean | 'timeout'>([
+      isDaemonAlive(),
+      new Promise((resolve) => setTimeout(() => resolve('timeout'), remainingMs)),
+    ]);
+    if (result === true || result === 'timeout') {
+      return;
+    }
+    const sleepMs = Math.min(pollIntervalMs, deadline - Date.now());
+    if (sleepMs > 0) {
+      await new Promise<void>((resolve) => setTimeout(resolve, sleepMs));
+    }
   }
 }
 

--- a/libs/typescript/core/src/exporters/wal/supervisor.ts
+++ b/libs/typescript/core/src/exporters/wal/supervisor.ts
@@ -127,10 +127,14 @@ async function waitForDaemonBind(timeoutMs: number, pollIntervalMs: number): Pro
       return;
     }
 
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
     const result = await Promise.race<boolean | 'timeout'>([
       isDaemonAlive(),
-      new Promise((resolve) => setTimeout(() => resolve('timeout'), remainingMs)),
+      new Promise((resolve) => {
+        timeoutHandle = setTimeout(() => resolve('timeout'), remainingMs);
+      }),
     ]);
+    clearTimeout(timeoutHandle);
     if (result === true || result === 'timeout') {
       return;
     }

--- a/libs/typescript/core/src/exporters/wal/supervisor.ts
+++ b/libs/typescript/core/src/exporters/wal/supervisor.ts
@@ -12,6 +12,13 @@ import { getLockSocketPath } from './paths';
 const PROBE_TIMEOUT_MS = 1000;
 
 /**
+ * Upper bound on how long {@link ensureDaemon} waits for a freshly
+ * spawned daemon to bind its lock socket.
+ */
+const SPAWN_BIND_WAIT_TIMEOUT_MS = 2000;
+const SPAWN_BIND_WAIT_POLL_MS = 50;
+
+/**
  * Probe the daemon's liveness lock with a short timeout.
  *
  * Returns:
@@ -108,6 +115,21 @@ export function spawnDaemon(): void {
 let spawnInFlight: Promise<void> | null = null;
 
 /**
+ * Poll {@link isDaemonAlive} until it returns true or `timeoutMs`
+ * elapses. Does not throw on timeout — the IPC client's own retry
+ * loop will surface any persistent connection failure.
+ */
+async function waitForDaemonBind(timeoutMs: number, pollIntervalMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await isDaemonAlive()) {
+      return;
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+}
+
+/**
  * Ensure a daemon is alive; spawn one if not.
  */
 export function ensureDaemon(): Promise<void> {
@@ -120,6 +142,7 @@ export function ensureDaemon(): Promise<void> {
         return;
       }
       spawnDaemon();
+      await waitForDaemonBind(SPAWN_BIND_WAIT_TIMEOUT_MS, SPAWN_BIND_WAIT_POLL_MS);
     } catch (err) {
       console.error('[mlflow][wal] ensureDaemon failed:', err);
     } finally {

--- a/libs/typescript/core/src/exporters/wal/supervisor.ts
+++ b/libs/typescript/core/src/exporters/wal/supervisor.ts
@@ -121,11 +121,8 @@ let spawnInFlight: Promise<void> | null = null;
  */
 async function waitForDaemonBind(timeoutMs: number, pollIntervalMs: number): Promise<void> {
   const deadline = Date.now() + timeoutMs;
-  while (true) {
+  while (Date.now() < deadline) {
     const remainingMs = deadline - Date.now();
-    if (remainingMs <= 0) {
-      return;
-    }
 
     let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
     const result = await Promise.race<boolean | 'timeout'>([

--- a/libs/typescript/core/tests/exporters/wal/supervisor.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/supervisor.test.ts
@@ -258,5 +258,38 @@ describe('wal/supervisor', () => {
       const counterContents = await readFile(counterFile, 'utf8');
       expect(counterContents).toBe('+');
     });
+
+    it('dedupes a second ensureDaemon call during the spawn -> bind window', async () => {
+      const bindDelayMs = 300;
+      const lockPath = getLockSocketPath();
+      const slowBindStub = [
+        "const net = require('net');",
+        "const fs = require('fs');",
+        `fs.appendFileSync(${JSON.stringify(counterFile)}, '+');`,
+        `fs.appendFileSync(${JSON.stringify(pidFile)}, process.pid + '\\n');`,
+        'const server = net.createServer((s) => s.end());',
+        // Delay listen() to widen the spawn→bind window the fix is meant to cover.
+        `setTimeout(() => {`,
+        `  server.listen(${JSON.stringify(lockPath)}, () => {`,
+        `    setTimeout(() => process.exit(0), 3000);`,
+        `  });`,
+        `}, ${bindDelayMs});`,
+      ].join('\n');
+      await writeFile(stubScript, slowBindStub);
+
+      const spawnMock = childProcess.spawn as jest.MockedFunction<typeof childProcess.spawn>;
+      spawnMock.mockClear();
+
+      const first = ensureDaemon();
+      // Land the second call mid-bind-window: after spawnDaemon() has
+      // returned (~ms) but well before the stub's 300ms listen() fires.
+      await sleep(100);
+      const second = ensureDaemon();
+      await Promise.all([first, second]);
+      await sleep(200);
+
+      expect(await readFile(counterFile, 'utf8')).toBe('+');
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/libs/typescript/core/tests/exporters/wal/supervisor.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/supervisor.test.ts
@@ -286,7 +286,6 @@ describe('wal/supervisor', () => {
       await sleep(100);
       const second = ensureDaemon();
       await Promise.all([first, second]);
-      await sleep(200);
 
       expect(await readFile(counterFile, 'utf8')).toBe('+');
       expect(spawnMock).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/23937/files) to review incremental changes.
- [**stack/cli-tracing-async-batching-bug-squash**](https://github.com/mlflow/mlflow/pull/23937) [[Files changed](https://github.com/mlflow/mlflow/pull/23937/files)]

---------
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

Reported Issue during Bug Squash of CLI Async Batched Processing for Trace Exporting (Claude Code)

Fixes a cold-start race in the WAL daemon supervisor where each Stop hook was spawning 2–3 daemon child processes instead of 1. Since it will take a while before the first initialized daemon to bind, we should have bind timeout. The extras lost the PID-lock race and exited cleanly (no correctness issue), but they wasted ~60 MB of memory and ~100ms of work each, and produced spurious `Another daemon is already running; exiting cleanly` lines in `daemon.log`.

Before on cold start of daemon (during a new Stop hook):
```
[2026-06-12T08:09:32.823Z] [pid=29723] Daemon started; pid=29723, walDir=/Users/aaron.teo/.mlflow/wal
[2026-06-12T08:09:32.857Z] [pid=29726] Another daemon is already running; exiting cleanly.
[2026-06-12T08:09:32.965Z] [pid=29751] Another daemon is already running; exiting cleanly.
```

After (no new processes are started)
```
[2026-06-12T08:11:47.908Z] [pid=29723] Daemon exited with code 0.
[2026-06-12T08:14:08.761Z] [pid=35208] Daemon started; pid=35208, walDir=/Users/aaron.teo/.mlflow/wal
[2026-06-12T08:14:23.828Z] [pid=35208] Uploaded record d5589083-0ea1-42fe-a11a-d76de5e31054 (trace tr-4df2516438634ace48bec87a7642800d)
[2026-06-12T08:14:53.879Z] [pid=35208] Uploaded record 1ef030cd-f572-4f41-9eff-466e2edad9b5 (trace tr-de6cecd95159a667ad68d64496434cd4)
```

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
