### PR TITLE
Refresh per-trace queue membership after adding/removing review-queue items

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/hooks/reviewQueueItemMutations.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/hooks/reviewQueueItemMutations.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { QueryClient, QueryClientProvider } from '@databricks/web-shared/query-client';
+
+import { useAddItemsToReviewQueueMutation } from './useAddItemsToReviewQueueMutation';
+import { LIST_REVIEW_QUEUE_ITEMS_QUERY_KEY } from './useListReviewQueueItemsQuery';
+import { LIST_REVIEW_QUEUES_QUERY_KEY } from './useListReviewQueuesQuery';
+import { useRemoveItemsFromReviewQueueMutation } from './useRemoveItemsFromReviewQueueMutation';
+
+jest.mock('../../../../common/utils/FetchUtils', () => ({
+  fetchAPI: jest.fn(() => Promise.resolve({})),
+  getAjaxUrl: (path: string) => path,
+}));
+
+// Renders the given mutation hook and fires it on click, against a real
+// QueryClient whose invalidateQueries is spied on.
+const renderMutation = (useMutationHook: () => { run: (p: { queue_id: string; item_ids: string[] }) => unknown }) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const spy = jest.spyOn(queryClient, 'invalidateQueries');
+  const Probe = () => {
+    const { run } = useMutationHook();
+    return (
+      <button type="button" onClick={() => run({ queue_id: 'rq-1', item_ids: ['tr-1'] })}>
+        go
+      </button>
+    );
+  };
+  render(
+    <QueryClientProvider client={queryClient}>
+      <Probe />
+    </QueryClientProvider>,
+  );
+  fireEvent.click(screen.getByText('go'));
+  return spy;
+};
+
+describe('review-queue item add/remove mutations', () => {
+  it('add invalidates both the queue trace list and the queue list (per-trace membership)', async () => {
+    const spy = renderMutation(() => {
+      const { addItemsToReviewQueueAsync } = useAddItemsToReviewQueueMutation();
+      return { run: addItemsToReviewQueueAsync };
+    });
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledWith([LIST_REVIEW_QUEUE_ITEMS_QUERY_KEY]);
+      expect(spy).toHaveBeenCalledWith([LIST_REVIEW_QUEUES_QUERY_KEY]);
+    });
+  });
+
+  it('remove invalidates both the queue trace list and the queue list (per-trace membership)', async () => {
+    const spy = renderMutation(() => {
+      const { removeItemsFromReviewQueueAsync } = useRemoveItemsFromReviewQueueMutation();
+      return { run: removeItemsFromReviewQueueAsync };
+    });
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledWith([LIST_REVIEW_QUEUE_ITEMS_QUERY_KEY]);
+      expect(spy).toHaveBeenCalledWith([LIST_REVIEW_QUEUES_QUERY_KEY]);
+    });
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/hooks/useAddItemsToReviewQueueMutation.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/hooks/useAddItemsToReviewQueueMutation.tsx
@@ -4,6 +4,7 @@ import { fetchAPI, getAjaxUrl } from '../../../../common/utils/FetchUtils';
 import type { ReviewQueueItem } from '../types';
 import { REVIEW_QUEUES_API_BASE } from './constants';
 import { LIST_REVIEW_QUEUE_ITEMS_QUERY_KEY } from './useListReviewQueueItemsQuery';
+import { LIST_REVIEW_QUEUES_QUERY_KEY } from './useListReviewQueuesQuery';
 
 export interface AddItemsToReviewQueueParams {
   queue_id: string;
@@ -18,7 +19,8 @@ interface AddItemsToReviewQueueResponse {
  * Attach traces to a review queue. Idempotent per trace (re-attaching keeps
  * the existing status). The server defaults `item_type` to TRACE, so it is
  * omitted here. Invalidates the queue's trace list so the Review tab reflects
- * the new attachments.
+ * the new attachments, and the queue list so the per-trace membership view
+ * (`itemId`) picks up this new membership.
  */
 export const useAddItemsToReviewQueueMutation = () => {
   const queryClient = useQueryClient();
@@ -36,6 +38,7 @@ export const useAddItemsToReviewQueueMutation = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries([LIST_REVIEW_QUEUE_ITEMS_QUERY_KEY]);
+      queryClient.invalidateQueries([LIST_REVIEW_QUEUES_QUERY_KEY]);
     },
   });
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/hooks/useRemoveItemsFromReviewQueueMutation.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/hooks/useRemoveItemsFromReviewQueueMutation.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@databricks/web-shared/query-client
 import { fetchAPI, getAjaxUrl } from '../../../../common/utils/FetchUtils';
 import { REVIEW_QUEUES_API_BASE } from './constants';
 import { LIST_REVIEW_QUEUE_ITEMS_QUERY_KEY } from './useListReviewQueueItemsQuery';
+import { LIST_REVIEW_QUEUES_QUERY_KEY } from './useListReviewQueuesQuery';
 
 export interface RemoveItemsFromReviewQueueParams {
   queue_id: string;
@@ -12,7 +13,9 @@ export interface RemoveItemsFromReviewQueueParams {
 /**
  * Detach traces from a review queue. No-op for traces that aren't attached;
  * the traces and their assessments are untouched (they can be re-flagged).
- * Invalidates the queue's trace list so the Review tab drops the rows.
+ * Invalidates the queue's trace list so the Review tab drops the rows, and the
+ * queue list so the per-trace membership view (`itemId`) stops reporting this
+ * queue as a member (otherwise the flag-for-review picker re-checks it on reopen).
  */
 export const useRemoveItemsFromReviewQueueMutation = () => {
   const queryClient = useQueryClient();
@@ -26,6 +29,7 @@ export const useRemoveItemsFromReviewQueueMutation = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries([LIST_REVIEW_QUEUE_ITEMS_QUERY_KEY]);
+      queryClient.invalidateQueries([LIST_REVIEW_QUEUES_QUERY_KEY]);
     },
   });
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23931

### What changes are proposed in this pull request?

Fixes a stale-state bug in the "Assign to reviewers" / flag-for-review picker (`AddToReviewQueueDropdown`).

For a single trace, the picker seeds its queue checkboxes from a per-trace membership query — `useListReviewQueuesQuery({ itemId })`, keyed under `LIST_REVIEW_QUEUES_QUERY_KEY`. The add- and remove-items mutations only invalidated `LIST_REVIEW_QUEUE_ITEMS_QUERY_KEY` (the per-queue trace list), never the membership query. So after deselecting a queue (which correctly removes the trace), closing and reopening the picker re-checked that queue from the stale membership cache — even though the trace was no longer in it. The single-trace bulk "Assign to reviewers" action uses the same picker and hit the same bug.

The fix adds `queryClient.invalidateQueries([LIST_REVIEW_QUEUES_QUERY_KEY])` to both mutations' `onSuccess`. The key is a prefix, so this catches the `itemId`-filtered membership query (and the sidebar counts / Review-tab list, which are also genuinely stale after a membership change). This matches what the create/update/delete/get-or-create queue mutations already do.

Why `invalidateQueries` rather than relying on the membership query's `cacheTime: 0`: the picker's `Popover` content stays mounted while the dropdown is closed, so the membership query keeps a live observer and isn't garbage-collected between open/close. `cacheTime: 0` only evicts when there are zero observers, so an explicit invalidation is required to refetch.

This was introduced when the `item_id` membership filter and checkbox-seeding were added in #23931; before that the picker didn't seed checked-state from membership, so there was nothing to go stale.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New `reviewQueueItemMutations.test.tsx` renders each mutation against a real `QueryClient` and asserts `onSuccess` invalidates both `LIST_REVIEW_QUEUE_ITEMS_QUERY_KEY` and `LIST_REVIEW_QUEUES_QUERY_KEY` (fails without the fix). Full review-queue jest suite passes. Manually verified against a local basic-auth server: remove a trace from a queue, reopen the picker → the queue is now unchecked, and navigating to the queue confirms the trace is gone; re-adding and reopening shows it checked.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed the review-queue flag-for-review picker showing a trace as still assigned to a queue after it had been removed.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.