### PR TITLE
Add shareable review queue URLs with a `startReview` deep link

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueDropdown.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueDropdown.test.tsx
@@ -165,8 +165,9 @@ describe('AddToReviewQueueDropdown', () => {
       }
       return undefined;
     };
+    // The toast deep-links to the queue the traces were just added to.
     expect(findLinkTarget(toastNode)).toBe(
-      generatePath(RoutePaths.experimentPageTabReviewQueue, { experimentId: 'exp-1' }),
+      `${generatePath(RoutePaths.experimentPageTabReviewQueue, { experimentId: 'exp-1' })}?selectedQueueId=rq-default`,
     );
   });
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueDropdown.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueDropdown.tsx
@@ -21,14 +21,14 @@ import { useListLabelSchemasQuery } from '../../components/label-schemas';
 import { useIsAuthAvailable } from '../../../account/hooks';
 import { useCanEditReviews, useCanManageReviews } from './hooks/useCanManageReviews';
 import Utils from '../../../common/utils/Utils';
-import { generatePath, Link } from '../../../common/utils/RoutingUtils';
-import { RoutePaths } from '../../routes';
+import { Link } from '../../../common/utils/RoutingUtils';
 import { CreateReviewQueueModal } from './CreateReviewQueueModal';
 import { getQueueAssignability } from './queueAssignability';
 import { canRemoveQueueItems, sameUser } from './queuePermissions';
 import { useAddItemsToReviewQueueMutation } from './hooks/useAddItemsToReviewQueueMutation';
 import { useAssignableUsersQuery } from './hooks/useAssignableUsersQuery';
 import { useGetOrCreateUserQueueMutation } from './hooks/useGetOrCreateUserQueueMutation';
+import { getReviewQueuePageRoute } from './hooks/useReviewQueueSearchParams';
 import { useListReviewQueuesQuery } from './hooks/useListReviewQueuesQuery';
 import { useRemoveItemsFromReviewQueueMutation } from './hooks/useRemoveItemsFromReviewQueueMutation';
 import { DEFAULT_REVIEWER, useIsReviewerResolved, useReviewer } from './hooks/useReviewer';
@@ -255,27 +255,30 @@ export const AddToReviewQueueDropdown = ({
     toggleCustomQueue(queue.queue_id);
   };
 
-  const showSuccessToast = useCallback(() => {
-    const reviewQueuePath = generatePath(RoutePaths.experimentPageTabReviewQueue, { experimentId });
-    Utils.displayGlobalInfoNotification(
-      <span css={{ whiteSpace: 'nowrap' }}>
-        {intl.formatMessage(
-          {
-            defaultMessage: 'Added {count, plural, one {# trace} other {# traces}} to review.',
-            description: 'Add to review queue: success toast after traces are added',
-          },
-          { count: itemIds.length },
-        )}{' '}
-        <Link componentId={`${CID}.toast-view-queue`} to={reviewQueuePath}>
-          {intl.formatMessage({
-            defaultMessage: 'View review queue',
-            description: 'Add to review queue: success toast link to the review queue page',
-          })}
-        </Link>
-      </span>,
-      3,
-    );
-  }, [experimentId, itemIds.length, intl]);
+  const showSuccessToast = useCallback(
+    (queueId: string) => {
+      const reviewQueuePath = getReviewQueuePageRoute(experimentId, queueId);
+      Utils.displayGlobalInfoNotification(
+        <span css={{ whiteSpace: 'nowrap' }}>
+          {intl.formatMessage(
+            {
+              defaultMessage: 'Added {count, plural, one {# trace} other {# traces}} to review.',
+              description: 'Add to review queue: success toast after traces are added',
+            },
+            { count: itemIds.length },
+          )}{' '}
+          <Link componentId={`${CID}.toast-view-queue`} to={reviewQueuePath}>
+            {intl.formatMessage({
+              defaultMessage: 'View review queue',
+              description: 'Add to review queue: success toast link to the review queue page',
+            })}
+          </Link>
+        </span>,
+        3,
+      );
+    },
+    [experimentId, itemIds.length, intl],
+  );
 
   const markBusy = (id: string) => setBusyIds((prev) => new Set(prev).add(id));
   const clearBusy = (id: string) =>
@@ -301,7 +304,7 @@ export const AddToReviewQueueDropdown = ({
       } else {
         await addItemsToReviewQueueAsync({ queue_id: queueId, item_ids: itemIds });
         setAddedQueueIds((prev) => new Set(prev).add(queueId));
-        showSuccessToast();
+        showSuccessToast(queueId);
       }
     } catch (e) {
       setSubmitError(e instanceof Error ? e.message : String(e));
@@ -331,7 +334,7 @@ export const AddToReviewQueueDropdown = ({
       } else {
         await addItemsToReviewQueueAsync({ queue_id: review_queue.queue_id, item_ids: itemIds });
         setAddedUsers((prev) => new Set(prev).add(username));
-        showSuccessToast();
+        showSuccessToast(review_queue.queue_id);
       }
     } catch (e) {
       setSubmitError(e instanceof Error ? e.message : String(e));

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ExperimentReviewQueuePage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ExperimentReviewQueuePage.tsx
@@ -7,6 +7,7 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import { useListLabelSchemasQuery } from '../../components/label-schemas';
 import { useParams } from '../../../common/utils/RoutingUtils';
 import Utils from '../../../common/utils/Utils';
+import { copyToClipboard } from '../../../common/utils/copyToClipboard';
 import Routes from '../../routes';
 import { useMlflowSidebar } from '../../../common/contexts/MlflowSidebarContext';
 import { useIsAuthAvailable } from '../../../account/hooks';
@@ -263,19 +264,31 @@ const ExperimentReviewQueuePage = () => {
   // Copy a shareable link to the selected queue — plain, or with the
   // start-review intent so the recipient lands in the focused review of the
   // queue's first to-do trace.
-  const copyQueueLink = ({ startReview }: { startReview: boolean }) => {
+  const copyQueueLink = async ({ startReview }: { startReview: boolean }) => {
     if (!experimentId || !selectedQueue) {
       return;
     }
     const path = getReviewQueuePageRoute(experimentId, selectedQueue.queue_id, { startReview });
-    navigator.clipboard.writeText(`${window.location.origin}${window.location.pathname}#${path}`);
-    Utils.displayGlobalInfoNotification(
-      intl.formatMessage({
-        defaultMessage: 'Link copied to clipboard.',
-        description: 'Review queue: toast after copying a shareable queue link',
-      }),
-      3,
-    );
+    // `copyToClipboard` falls back to execCommand on insecure-HTTP contexts and
+    // reports whether the copy actually landed — only confirm success when it did.
+    const copied = await copyToClipboard(`${window.location.origin}${window.location.pathname}#${path}`);
+    if (copied) {
+      Utils.displayGlobalInfoNotification(
+        intl.formatMessage({
+          defaultMessage: 'Link copied to clipboard.',
+          description: 'Review queue: toast after copying a shareable queue link',
+        }),
+        3,
+      );
+    } else {
+      Utils.displayGlobalErrorNotification(
+        intl.formatMessage({
+          defaultMessage: 'Could not copy link to clipboard.',
+          description: 'Review queue: toast when copying a shareable queue link fails',
+        }),
+        3,
+      );
+    }
   };
 
   const setOpenStatus = async (status: ReviewStatus) => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ExperimentReviewQueuePage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ExperimentReviewQueuePage.tsx
@@ -6,6 +6,7 @@ import { FormattedMessage, useIntl } from 'react-intl';
 
 import { useListLabelSchemasQuery } from '../../components/label-schemas';
 import { useParams } from '../../../common/utils/RoutingUtils';
+import Utils from '../../../common/utils/Utils';
 import Routes from '../../routes';
 import { useMlflowSidebar } from '../../../common/contexts/MlflowSidebarContext';
 import { useIsAuthAvailable } from '../../../account/hooks';
@@ -21,6 +22,7 @@ import { useDeleteReviewQueueMutation } from './hooks/useDeleteReviewQueueMutati
 import { useGetOrCreateUserQueueMutation } from './hooks/useGetOrCreateUserQueueMutation';
 import { useListReviewQueueItemsQuery } from './hooks/useListReviewQueueItemsQuery';
 import { useListReviewQueuesQuery } from './hooks/useListReviewQueuesQuery';
+import { getReviewQueuePageRoute, useReviewQueueSearchParams } from './hooks/useReviewQueueSearchParams';
 import { useUpdateReviewQueueMutation } from './hooks/useUpdateReviewQueueMutation';
 import { useRemoveItemsFromReviewQueueMutation } from './hooks/useRemoveItemsFromReviewQueueMutation';
 import { DEFAULT_REVIEWER, displayUser, useIsReviewerResolved, useReviewer } from './hooks/useReviewer';
@@ -51,9 +53,10 @@ const ExperimentReviewQueuePage = () => {
   const canManage = useCanManageReviews(experimentId ?? '');
   const canEdit = useCanEditReviews(experimentId ?? '');
 
-  const [selectedQueueIdState, setSelectedQueueIdState] = useState<string>();
-  // The trace open in focused review (null = show the queue's trace table).
-  const [openItemId, setOpenItemId] = useState<string | null>(null);
+  // Queue selection and the trace open in focused review (null = show the
+  // queue's trace table) live in the URL, so both are shareable links.
+  const { selectedQueueId, openItemId, startReviewRequested, selectQueue, setOpenItemId, consumeStartReview } =
+    useReviewQueueSearchParams();
   const [manageOpen, setManageOpen] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
   // The queue open in "Manage queue" (questions + members), from the right-pane gear.
@@ -95,20 +98,21 @@ const ExperimentReviewQueuePage = () => {
   // deselection (collapsing the sidebar's no-work group, or deleting the open
   // queue) must stick, not snap back to the USER queue. Gate on
   // `reviewerResolved` so a selection isn't committed against the `default`
-  // fallback while `/users/current` is still in flight.
+  // fallback while `/users/current` is still in flight. A deep link
+  // (`?selectedQueueId=...`) wins over auto-select via the undefined check;
+  // `preserveStartReview` keeps a bare `?startReview=true` link's intent alive
+  // through the auto-selection so it resolves against the visitor's own queue.
   const didAutoSelectQueue = useRef(false);
   useEffect(() => {
-    if (didAutoSelectQueue.current || selectedQueueIdState !== undefined || queuesLoading || !reviewerResolved) {
+    if (didAutoSelectQueue.current || selectedQueueId !== undefined || queuesLoading || !reviewerResolved) {
       return;
     }
     const userQueue = reviewQueues.find((q) => q.queue_type === 'USER' && sameUser(q.name, reviewer));
     if (userQueue) {
       didAutoSelectQueue.current = true;
-      setSelectedQueueIdState(userQueue.queue_id);
+      selectQueue(userQueue.queue_id, { preserveStartReview: true });
     }
-  }, [selectedQueueIdState, queuesLoading, reviewerResolved, reviewQueues, reviewer]);
-
-  const selectedQueueId = selectedQueueIdState;
+  }, [selectedQueueId, queuesLoading, reviewerResolved, reviewQueues, reviewer, selectQueue]);
   const selectedQueue = useMemo(
     () => reviewQueues.find((q) => q.queue_id === selectedQueueId) ?? null,
     [reviewQueues, selectedQueueId],
@@ -152,8 +156,7 @@ const ExperimentReviewQueuePage = () => {
         onSuccess: () => {
           // Drop the selection if the queue that was open got deleted.
           if (selectedQueueId === queueId) {
-            setSelectedQueueIdState(undefined);
-            setOpenItemId(null);
+            selectQueue(undefined);
           }
         },
       },
@@ -190,6 +193,17 @@ const ExperimentReviewQueuePage = () => {
     const todo = traces.filter((t) => t.status === 'PENDING').sort(byTraceNewest);
     return [...done, ...todo];
   }, [traces, traceCreatedMsById]);
+
+  // A `?startReview=true` deep link mirrors the "Start review" button: once
+  // the selected queue's items are in, jump to the first to-do trace (or stay
+  // on the list when there's none) and drop the one-shot intent param.
+  useEffect(() => {
+    if (!startReviewRequested || !selectedQueue || itemsLoading) {
+      return;
+    }
+    const firstToDo = orderedTraces.find((t) => t.status === 'PENDING');
+    consumeStartReview(firstToDo?.item_id ?? null);
+  }, [startReviewRequested, selectedQueue, itemsLoading, orderedTraces, consumeStartReview]);
 
   // A user queue inherits all of the experiment's schemas; a custom queue uses
   // its explicit subset.
@@ -246,9 +260,22 @@ const ExperimentReviewQueuePage = () => {
     return () => setHeaderHidden(false);
   }, [inFocusMode, setHeaderHidden]);
 
-  const selectQueue = (queueId: string) => {
-    setSelectedQueueIdState(queueId);
-    setOpenItemId(null);
+  // Copy a shareable link to the selected queue — plain, or with the
+  // start-review intent so the recipient lands in the focused review of the
+  // queue's first to-do trace.
+  const copyQueueLink = ({ startReview }: { startReview: boolean }) => {
+    if (!experimentId || !selectedQueue) {
+      return;
+    }
+    const path = getReviewQueuePageRoute(experimentId, selectedQueue.queue_id, { startReview });
+    navigator.clipboard.writeText(`${window.location.origin}${window.location.pathname}#${path}`);
+    Utils.displayGlobalInfoNotification(
+      intl.formatMessage({
+        defaultMessage: 'Link copied to clipboard.',
+        description: 'Review queue: toast after copying a shareable queue link',
+      }),
+      3,
+    );
   };
 
   const setOpenStatus = async (status: ReviewStatus) => {
@@ -354,7 +381,10 @@ const ExperimentReviewQueuePage = () => {
             : undefined
         }
         isRemovingItems={isRemovingItems}
-        // Manage and delete are separately gated (a manager can delete a USER queue).
+        // Gear menu: "Manage queue" (settings) only for editable CUSTOM queues;
+        // "Delete queue" is separate — a manager can delete a USER queue too.
+        // Copying a share link is permission-free.
+        onCopyLink={copyQueueLink}
         onManageQueue={canManageSelectedQueue ? () => setEditingQueueId(selectedQueue.queue_id) : undefined}
         onDeleteQueue={canDeleteSelectedQueue ? () => setConfirmDeleteQueueId(selectedQueue.queue_id) : undefined}
         onGoToTraces={

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewQueueList.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewQueueList.test.tsx
@@ -1,5 +1,6 @@
 import { describe, jest, it, expect } from '@jest/globals';
 import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { DesignSystemProvider } from '@databricks/design-system';
@@ -195,5 +196,35 @@ describe('ReviewQueueList', () => {
     // Switching filters resets the selection so hidden rows can't be deleted.
     fireEvent.click(screen.getByText('Completed (1)'));
     expect(screen.queryByRole('button', { name: 'Unassign' })).not.toBeInTheDocument();
+  });
+
+  it('offers copy-link menu items even without manage/delete permissions', async () => {
+    const onCopyLink = jest.fn();
+    renderWithProviders(
+      <ReviewQueueList
+        items={[item('tr-1', 'PENDING')]}
+        title="My queue"
+        onOpen={jest.fn()}
+        nowMs={NOW}
+        onCopyLink={onCopyLink}
+      />,
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Queue settings' }));
+    expect(screen.queryByText('Manage queue')).not.toBeInTheDocument();
+    expect(screen.queryByText('Delete queue')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Copy link to queue'));
+    expect(onCopyLink).toHaveBeenCalledWith({ startReview: false });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Queue settings' }));
+    await userEvent.click(screen.getByText('Copy start-review link'));
+    expect(onCopyLink).toHaveBeenCalledWith({ startReview: true });
+  });
+
+  it('hides the gear menu when no actions are available', () => {
+    renderWithProviders(
+      <ReviewQueueList items={[item('tr-1', 'PENDING')]} title="My queue" onOpen={jest.fn()} nowMs={NOW} />,
+    );
+    expect(screen.queryByRole('button', { name: 'Queue settings' })).not.toBeInTheDocument();
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewQueueList.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewQueueList.tsx
@@ -121,6 +121,7 @@ export const ReviewQueueList = ({
   latestQuestionCreatedAtMs,
   onRemoveItems,
   isRemovingItems,
+  onCopyLink,
   onManageQueue,
   onDeleteQueue,
   onGoToTraces,
@@ -138,7 +139,12 @@ export const ReviewQueueList = ({
    *  so the queue's manager can remove traces from this view. */
   onRemoveItems?: (itemIds: string[]) => void;
   isRemovingItems?: boolean;
-  /** When set, the gear menu shows "Manage queue" (and "Delete queue" if `onDeleteQueue` is set). */
+  /** Copy a shareable link to this queue; `startReview` deep-links into the
+   *  focused review of the first to-do trace. Permission-free, so unlike the
+   *  manage/delete actions it's offered to every viewer. */
+  onCopyLink?: (opts: { startReview: boolean }) => void;
+  /** When provided (editable custom queues only), a gear menu offers
+   *  "Manage queue"; `onDeleteQueue`, when also provided, adds "Delete queue". */
   onManageQueue?: () => void;
   onDeleteQueue?: () => void;
   onGoToTraces?: () => void;
@@ -289,14 +295,14 @@ export const ReviewQueueList = ({
 
   return (
     <div css={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0, gap: theme.spacing.sm }}>
-      {(title || selectable || onManageQueue || onDeleteQueue) && (
+      {(title || selectable || onCopyLink || onManageQueue || onDeleteQueue) && (
         <div css={{ display: 'flex', alignItems: 'flex-start', gap: theme.spacing.sm }}>
           <div css={{ minWidth: 0 }}>
             <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs / 2, minWidth: 0 }}>
               <Typography.Title level={3} withoutMargins ellipsis css={{ minWidth: 0 }}>
                 {title}
               </Typography.Title>
-              {(onManageQueue || onDeleteQueue) && (
+              {(onCopyLink || onManageQueue || onDeleteQueue) && (
                 <DropdownMenu.Root modal={false}>
                   <DropdownMenu.Trigger asChild>
                     <Button
@@ -309,7 +315,30 @@ export const ReviewQueueList = ({
                     />
                   </DropdownMenu.Trigger>
                   <DropdownMenu.Content align="start">
-                    {/* USER queues show only "Delete queue" (no settings); CUSTOM show both. */}
+                    {onCopyLink && (
+                      <>
+                        <DropdownMenu.Item
+                          componentId={`${CID}.copy-link`}
+                          onClick={() => onCopyLink({ startReview: false })}
+                        >
+                          <FormattedMessage
+                            defaultMessage="Copy link to queue"
+                            description="Review queue header: copy shareable queue link menu item"
+                          />
+                        </DropdownMenu.Item>
+                        <DropdownMenu.Item
+                          componentId={`${CID}.copy-start-review-link`}
+                          onClick={() => onCopyLink({ startReview: true })}
+                        >
+                          <FormattedMessage
+                            defaultMessage="Copy start-review link"
+                            description="Review queue header: copy link that opens the first to-do trace for review"
+                          />
+                        </DropdownMenu.Item>
+                      </>
+                    )}
+                    {/* A USER queue has no editable settings, so a manager sees
+                        only "Delete queue"; CUSTOM queues show both. */}
                     {onManageQueue && (
                       <DropdownMenu.Item componentId={`${CID}.manage-queue`} onClick={onManageQueue}>
                         <FormattedMessage

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/hooks/useReviewQueueSearchParams.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/hooks/useReviewQueueSearchParams.test.tsx
@@ -1,0 +1,116 @@
+import { jest, describe, beforeEach, test, expect } from '@jest/globals';
+import { renderHook, act } from '@testing-library/react';
+
+import { getReviewQueuePageRoute, useReviewQueueSearchParams } from './useReviewQueueSearchParams';
+import { useSearchParams } from '../../../../common/utils/RoutingUtils';
+
+jest.mock('../../../../common/utils/RoutingUtils', () => ({
+  ...(jest.requireActual<typeof import('../../../../common/utils/RoutingUtils')>(
+    '../../../../common/utils/RoutingUtils',
+  ) as any),
+  useSearchParams: jest.fn(),
+}));
+
+describe('getReviewQueuePageRoute', () => {
+  test('builds the queue deep link', () => {
+    expect(getReviewQueuePageRoute('exp-1')).toEqual('/experiments/exp-1/review-queue');
+    expect(getReviewQueuePageRoute('exp-1', 'rq-1')).toEqual('/experiments/exp-1/review-queue?selectedQueueId=rq-1');
+    expect(getReviewQueuePageRoute('exp-1', 'rq-1', { startReview: true })).toEqual(
+      '/experiments/exp-1/review-queue?selectedQueueId=rq-1&startReview=true',
+    );
+    expect(getReviewQueuePageRoute('exp-1', undefined, { startReview: true })).toEqual(
+      '/experiments/exp-1/review-queue?startReview=true',
+    );
+  });
+});
+
+describe('useReviewQueueSearchParams', () => {
+  let mockSearchParams = new URLSearchParams();
+  const mockSetSearchParams = jest.fn((setter) => {
+    // @ts-expect-error 'setter' is of type 'unknown'
+    mockSearchParams = setter(mockSearchParams);
+  });
+
+  const mockParams = (init?: Record<string, string>) => {
+    mockSearchParams = new URLSearchParams(init);
+    jest.mocked(useSearchParams).mockReturnValue([mockSearchParams, mockSetSearchParams]);
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockParams();
+  });
+
+  test('reads selection and start-review intent from the URL', () => {
+    mockParams({ selectedQueueId: 'rq-1', selectedItemId: 'tr-1', startReview: 'true' });
+
+    const { result } = renderHook(() => useReviewQueueSearchParams());
+
+    expect(result.current.selectedQueueId).toEqual('rq-1');
+    expect(result.current.openItemId).toEqual('tr-1');
+    expect(result.current.startReviewRequested).toBe(true);
+  });
+
+  test('selecting a queue closes the open item and voids the start-review intent', () => {
+    mockParams({ selectedQueueId: 'rq-1', selectedItemId: 'tr-1', startReview: 'true' });
+
+    const { result } = renderHook(() => useReviewQueueSearchParams());
+    act(() => result.current.selectQueue('rq-2'));
+
+    expect(mockSearchParams.get('selectedQueueId')).toEqual('rq-2');
+    expect(mockSearchParams.get('selectedItemId')).toBeNull();
+    expect(mockSearchParams.get('startReview')).toBeNull();
+  });
+
+  test('auto-select preserves the start-review intent', () => {
+    mockParams({ startReview: 'true' });
+
+    const { result } = renderHook(() => useReviewQueueSearchParams());
+    act(() => result.current.selectQueue('rq-1', { preserveStartReview: true }));
+
+    expect(mockSearchParams.get('selectedQueueId')).toEqual('rq-1');
+    expect(mockSearchParams.get('startReview')).toEqual('true');
+  });
+
+  test('clearing the queue selection drops all selection params', () => {
+    mockParams({ selectedQueueId: 'rq-1', selectedItemId: 'tr-1' });
+
+    const { result } = renderHook(() => useReviewQueueSearchParams());
+    act(() => result.current.selectQueue(undefined));
+
+    expect([...mockSearchParams.keys()]).toEqual([]);
+  });
+
+  test('opening and closing an item only touches the item param', () => {
+    mockParams({ selectedQueueId: 'rq-1' });
+
+    const { result } = renderHook(() => useReviewQueueSearchParams());
+    act(() => result.current.setOpenItemId('tr-1'));
+    expect(mockSearchParams.get('selectedItemId')).toEqual('tr-1');
+    expect(mockSearchParams.get('selectedQueueId')).toEqual('rq-1');
+
+    act(() => result.current.setOpenItemId(null));
+    expect(mockSearchParams.get('selectedItemId')).toBeNull();
+    expect(mockSearchParams.get('selectedQueueId')).toEqual('rq-1');
+  });
+
+  test('consuming the start-review intent swaps it for the first to-do item', () => {
+    mockParams({ selectedQueueId: 'rq-1', startReview: 'true' });
+
+    const { result } = renderHook(() => useReviewQueueSearchParams());
+    act(() => result.current.consumeStartReview('tr-todo'));
+
+    expect(mockSearchParams.get('startReview')).toBeNull();
+    expect(mockSearchParams.get('selectedItemId')).toEqual('tr-todo');
+  });
+
+  test('consuming the start-review intent with no to-do items stays on the list', () => {
+    mockParams({ selectedQueueId: 'rq-1', startReview: 'true' });
+
+    const { result } = renderHook(() => useReviewQueueSearchParams());
+    act(() => result.current.consumeStartReview(null));
+
+    expect(mockSearchParams.get('startReview')).toBeNull();
+    expect(mockSearchParams.get('selectedItemId')).toBeNull();
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/hooks/useReviewQueueSearchParams.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/hooks/useReviewQueueSearchParams.ts
@@ -1,0 +1,110 @@
+import { useCallback } from 'react';
+
+import { generatePath, useSearchParams } from '../../../../common/utils/RoutingUtils';
+import { RoutePaths } from '../../../routes';
+
+export const SELECTED_QUEUE_ID_QUERY_PARAM_KEY = 'selectedQueueId';
+export const SELECTED_ITEM_ID_QUERY_PARAM_KEY = 'selectedItemId';
+export const START_REVIEW_QUERY_PARAM_KEY = 'startReview';
+
+/**
+ * Build the in-app route to the Review tab, optionally deep-linking to a
+ * queue. With `startReview`, opening the link drops the visitor straight into
+ * the focused review of the queue's first to-do trace (see the consuming
+ * effect in `ExperimentReviewQueuePage`). With `startReview` and no
+ * `queueId`, the page's auto-select resolves the visitor's own USER queue
+ * first — a generic "start reviewing your queue" link.
+ */
+export const getReviewQueuePageRoute = (
+  experimentId: string,
+  queueId?: string,
+  { startReview = false }: { startReview?: boolean } = {},
+) => {
+  const path = generatePath(RoutePaths.experimentPageTabReviewQueue, { experimentId });
+  const params = new URLSearchParams();
+  if (queueId) {
+    params.set(SELECTED_QUEUE_ID_QUERY_PARAM_KEY, queueId);
+  }
+  if (startReview) {
+    params.set(START_REVIEW_QUERY_PARAM_KEY, 'true');
+  }
+  const query = params.toString();
+  return query ? `${path}?${query}` : path;
+};
+
+/**
+ * Query param-powered selection state for the Review tab, making the selected
+ * queue and the trace open in focused review shareable URLs (same pattern as
+ * the datasets tab's `useSelectedDatasetBySearchParam`).
+ *
+ * `startReview` is a one-shot intent param ("open the first to-do trace"),
+ * not state: the page consumes it via `consumeStartReview` once the queue's
+ * items have loaded, so reload/back after that point lands on the focused
+ * trace itself (`selectedItemId`), not a re-triggered jump.
+ */
+export const useReviewQueueSearchParams = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const selectedQueueId = searchParams.get(SELECTED_QUEUE_ID_QUERY_PARAM_KEY) ?? undefined;
+  const openItemId = searchParams.get(SELECTED_ITEM_ID_QUERY_PARAM_KEY);
+  const startReviewRequested = searchParams.has(START_REVIEW_QUERY_PARAM_KEY);
+
+  const selectQueue = useCallback(
+    (queueId: string | undefined, { preserveStartReview = false }: { preserveStartReview?: boolean } = {}) => {
+      setSearchParams(
+        (params) => {
+          if (queueId) {
+            params.set(SELECTED_QUEUE_ID_QUERY_PARAM_KEY, queueId);
+          } else {
+            params.delete(SELECTED_QUEUE_ID_QUERY_PARAM_KEY);
+          }
+          // Switching queues closes any focused trace; an explicit user
+          // selection also voids a pending start-review intent (auto-select
+          // preserves it so a bare `?startReview=true` link can resolve the
+          // visitor's own queue first).
+          params.delete(SELECTED_ITEM_ID_QUERY_PARAM_KEY);
+          if (!preserveStartReview) {
+            params.delete(START_REVIEW_QUERY_PARAM_KEY);
+          }
+          return params;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const setOpenItemId = useCallback(
+    (itemId: string | null) => {
+      setSearchParams(
+        (params) => {
+          if (itemId) {
+            params.set(SELECTED_ITEM_ID_QUERY_PARAM_KEY, itemId);
+          } else {
+            params.delete(SELECTED_ITEM_ID_QUERY_PARAM_KEY);
+          }
+          return params;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const consumeStartReview = useCallback(
+    (itemId: string | null) => {
+      setSearchParams(
+        (params) => {
+          params.delete(START_REVIEW_QUERY_PARAM_KEY);
+          if (itemId) {
+            params.set(SELECTED_ITEM_ID_QUERY_PARAM_KEY, itemId);
+          }
+          return params;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  return { selectedQueueId, openItemId, startReviewRequested, selectQueue, setOpenItemId, consumeStartReview };
+};

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -8867,6 +8867,10 @@
     "defaultMessage": "No metrics match the search filter",
     "description": "Message displayed when no metrics match the search filter in the logged model details metrics table"
   },
+  "i+JtEu": {
+    "defaultMessage": "Could not copy link to clipboard.",
+    "description": "Review queue: toast when copying a shareable queue link fails"
+  },
   "i+RyPC": {
     "defaultMessage": "Your request could not be fulfilled. Please try again.",
     "description": "A message shown on the experiment page if the runs request fails"

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -3851,6 +3851,10 @@
     "defaultMessage": "Description update failed",
     "description": "Partial save status message when experiment description update fails"
   },
+  "IWIjkw": {
+    "defaultMessage": "Copy link to queue",
+    "description": "Review queue header: copy shareable queue link menu item"
+  },
   "IWNUE0": {
     "defaultMessage": "Failed to load roles",
     "description": "Alert title shown when the roles query fails on the account page"
@@ -8587,6 +8591,10 @@
     "defaultMessage": "Edit",
     "description": "Trace actions dropdown group label"
   },
+  "gfCVGt": {
+    "defaultMessage": "Link copied to clipboard.",
+    "description": "Review queue: toast after copying a shareable queue link"
+  },
   "ghgW69": {
     "defaultMessage": "Select traces",
     "description": "Button to open the trace selection modal from the run evaluation modal"
@@ -12182,6 +12190,10 @@
   "z6qX4/": {
     "defaultMessage": "This endpoint may have been deleted",
     "description": "Tooltip for deleted endpoint"
+  },
+  "z8QLT1": {
+    "defaultMessage": "Copy start-review link",
+    "description": "Review queue header: copy link that opens the first to-do trace for review"
   },
   "z8srAp": {
     "defaultMessage": "Trace archival retention",


### PR DESCRIPTION
### Related Issues/PRs

N/A (user feedback: reviewers had to find their queue from the list because queues had no shareable URL)

### What changes are proposed in this pull request?

Make review queue selection on the Review tab URL-backed so every queue (and the trace open in focused review) has a shareable URL, and add a `startReview=true` deep link that drops the recipient straight into the focused review of the queue's first to-do trace:

- `?selectedQueueId=...` selects the queue; `?selectedItemId=...` pins the open trace (survives reload, follows the existing `useSelectedDatasetBySearchParam` pattern from the datasets tab).
- `?startReview=true` is a one-shot intent: once items load it opens the first to-do trace and the param is swapped for the concrete `selectedItemId`. A bare `?startReview=true` link resolves the visitor's own user queue via auto-select, so one generic link works for every reviewer.
- The queue header gear menu gains permission-free "Copy link to queue" and "Copy start-review link" items.
- The "View review queue" toast (shown after adding traces) now deep-links to the exact queue the traces were added to.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Manually verified against the dev server: auto-select writes the queue param, copy links land on the clipboard with a confirmation toast, and opening a `startReview` link cold lands in the focused review form of the first to-do trace.

Demo (2x speed; the bar at the top is a synthetic URL bar rendered into the page so the params are visible):

https://github.com/user-attachments/assets/72ca1ec2-cfad-4b0c-8e31-ced64eef80f2

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Review queues now have shareable URLs: the selected queue and open trace are encoded in the page URL, and a "Copy start-review link" action produces a link that takes a reviewer directly into the review form for the queue's first pending trace.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)