### PR TITLE
fix MCP server name validation

### DIFF
--- a/mlflow/entities/mcp_server.py
+++ b/mlflow/entities/mcp_server.py
@@ -37,7 +37,8 @@ class MCPRemoteTransportType(str, Enum):
         return self.value
 
 
-_MCP_SERVER_NAME_NAMESPACE_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$")
+_MCP_SERVER_NAME_NAMESPACE_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9]$")
+_MCP_SERVER_NAME_SLUG_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9]$")
 _MCP_SERVER_RESERVED_SLUGS = {"aliases", "bindings", "tags", "versions"}
 
 
@@ -65,14 +66,13 @@ def validate_mcp_server_name(name: str) -> None:
             "such as 'com.example/server-name'."
         )
 
-    labels = namespace.split(".")
-    if len(labels) < 2 or any(not label for label in labels):
+    if _MCP_SERVER_NAME_NAMESPACE_RE.fullmatch(namespace) is None:
         raise MlflowException.invalid_parameter_value(
             "Invalid MCP server name. Expected '<reverse-dns namespace>/<server slug>' "
             "such as 'com.example/server-name'."
         )
 
-    if any(_MCP_SERVER_NAME_NAMESPACE_RE.fullmatch(label) is None for label in labels):
+    if _MCP_SERVER_NAME_SLUG_RE.fullmatch(slug) is None:
         raise MlflowException.invalid_parameter_value(
             "Invalid MCP server name. Expected '<reverse-dns namespace>/<server slug>' "
             "such as 'com.example/server-name'."

--- a/tests/server/test_mcp_server_api.py
+++ b/tests/server/test_mcp_server_api.py
@@ -105,6 +105,10 @@ def test_create_duplicate_server(client):
         "com.example/bindings",
         "com.example/tags",
         "com.example/versions",
+        "com.example/_server",
+        "com.example/server_",
+        "com.example/.server",
+        "com.example/server-",
     ],
 )
 def test_create_server_invalid_name_rejected(client, invalid_name):
@@ -112,6 +116,21 @@ def test_create_server_invalid_name_rejected(client, invalid_name):
     assert r.status_code == 400
     assert r.json()["error_code"] == "INVALID_PARAMETER_VALUE"
     assert "Expected '<reverse-dns namespace>/<server slug>'" in r.json()["message"]
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "io.github.TestOrg/server-name",
+        "com/server-name",
+        "io.github.test/server_name",
+        "io.github.test/server.name",
+    ],
+)
+def test_create_server_accepts_upstream_name_shapes(client, name):
+    r = client.post(PREFIX, json={"name": name})
+    assert r.status_code == 200
+    assert r.json()["name"] == name
 
 
 def test_get_server(client):
@@ -314,15 +333,38 @@ def test_create_version_invalid_server_name_rejected(client):
 
 
 @pytest.mark.parametrize(
+    "name",
+    [
+        "io.github.TestOrg/server-name",
+        "com/server-name",
+        "io.github.test/server_name",
+        "io.github.test/server.name",
+    ],
+)
+def test_create_version_accepts_upstream_name_shapes(client, name):
+    encoded_name = _encode_path_param(name)
+    r = client.post(
+        f"{PREFIX}/{encoded_name}/versions",
+        json={"server_json": {"name": name, "version": "1.0.0"}},
+    )
+    assert r.status_code == 200
+    assert r.json()["name"] == name
+
+
+@pytest.mark.parametrize(
     "invalid_name",
     [
         "com.example/aliases",
         "com.example/bindings",
         "com.example/tags",
         "com.example/versions",
+        "com.example/_server",
+        "com.example/server_",
+        "com.example/.server",
+        "com.example/server-",
     ],
 )
-def test_create_version_reserved_suffix_server_name_rejected(client, invalid_name):
+def test_create_version_invalid_server_name_rejected(client, invalid_name):
     encoded_name = _encode_path_param(invalid_name)
     r = client.post(
         f"{PREFIX}/{encoded_name}/versions",

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_mcp_server_registry.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_mcp_server_registry.py
@@ -6,7 +6,7 @@ from mlflow.exceptions import MlflowException
 pytestmark = pytest.mark.notrackingurimock
 
 
-def _server_json(name="io.github.test/server", version="1.0.0", description=None):
+def _server_json(name="io.github.test/servererver", version="1.0.0", description=None):
     server_json = {"name": name, "version": version, "title": f"Test {name}"}
     if description is not None:
         server_json["description"] = description
@@ -25,16 +25,16 @@ def _setup_server(store, name, versions=("1.0.0",), aliases=None):
 
 
 def test_create_mcp_server(store):
-    server = store.create_mcp_server("io.github.test/server", description="A test server")
-    assert server.name == "io.github.test/server"
+    server = store.create_mcp_server("io.github.test/servererver", description="A test server")
+    assert server.name == "io.github.test/servererver"
     assert server.description == "A test server"
     assert server.creation_timestamp is not None
 
 
 def test_create_mcp_server_duplicate_raises(store):
-    store.create_mcp_server("io.github.test/server")
+    store.create_mcp_server("io.github.test/servererver")
     with pytest.raises(MlflowException, match="already exists") as exc:
-        store.create_mcp_server("io.github.test/server")
+        store.create_mcp_server("io.github.test/servererver")
     assert exc.value.error_code == "RESOURCE_ALREADY_EXISTS"
 
 
@@ -57,6 +57,10 @@ def test_create_mcp_server_empty_name_raises(store):
         "com.example/bindings",
         "com.example/tags",
         "com.example/versions",
+        "com.example/_server",
+        "com.example/server_",
+        "com.example/.server",
+        "com.example/server-",
     ],
 )
 def test_create_mcp_server_invalid_name_raises(store, invalid_name):
@@ -67,16 +71,30 @@ def test_create_mcp_server_invalid_name_raises(store, invalid_name):
     assert exc.value.error_code == "INVALID_PARAMETER_VALUE"
 
 
+@pytest.mark.parametrize(
+    "name",
+    [
+        "io.github.TestOrg/server-name",
+        "com/server-name",
+        "io.github.test/servererver_name",
+        "io.github.test/servererver.name",
+    ],
+)
+def test_create_mcp_server_accepts_upstream_name_shapes(store, name):
+    server = store.create_mcp_server(name)
+    assert server.name == name
+
+
 def test_create_mcp_server_with_icons(store):
     icons = [{"src": "https://example.com/icon.png", "sizes": "32x32"}]
-    server = store.create_mcp_server("io.github.test/server", icons=icons)
+    server = store.create_mcp_server("io.github.test/servererver", icons=icons)
     assert server.icons == icons
 
 
 def test_get_mcp_server(store):
-    store.create_mcp_server("io.github.test/server", description="desc")
-    server = store.get_mcp_server("io.github.test/server")
-    assert server.name == "io.github.test/server"
+    store.create_mcp_server("io.github.test/servererver", description="desc")
+    server = store.get_mcp_server("io.github.test/servererver")
+    assert server.name == "io.github.test/servererver"
     assert server.description == "desc"
 
 
@@ -87,24 +105,24 @@ def test_get_mcp_server_not_found_raises(store):
 
 
 def test_get_mcp_server_with_tags(store):
-    store.create_mcp_server("io.github.test/server")
-    store.set_mcp_server_tag("io.github.test/server", "team", "platform")
-    server = store.get_mcp_server("io.github.test/server")
+    store.create_mcp_server("io.github.test/servererver")
+    store.set_mcp_server_tag("io.github.test/servererver", "team", "platform")
+    server = store.get_mcp_server("io.github.test/servererver")
     assert server.tags == {"team": "platform"}
 
 
 def test_get_mcp_server_access_bindings_include_resolved_versions(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.ACTIVE
     )
-    store.set_mcp_server_alias("io.github.test/s", "prod", "1.0.0")
+    store.set_mcp_server_alias("io.github.test/server", "prod", "1.0.0")
     store.create_mcp_access_binding(
-        "io.github.test/s", "https://direct.example.com", server_version="1.0.0"
+        "io.github.test/server", "https://direct.example.com", server_version="1.0.0"
     )
     store.create_mcp_access_binding(
-        "io.github.test/s", "https://alias.example.com", server_alias="prod"
+        "io.github.test/server", "https://alias.example.com", server_alias="prod"
     )
-    server = store.get_mcp_server("io.github.test/s")
+    server = store.get_mcp_server("io.github.test/server")
     bindings = {b.endpoint_url: b for b in server.access_bindings}
     assert bindings["https://direct.example.com"].resolved_version is not None
     assert bindings["https://direct.example.com"].resolved_version.version == "1.0.0"
@@ -114,11 +132,11 @@ def test_get_mcp_server_access_bindings_include_resolved_versions(store):
 
 def test_search_mcp_servers_access_bindings_include_resolved_versions(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.ACTIVE
     )
-    store.set_mcp_server_alias("io.github.test/s", "prod", "1.0.0")
+    store.set_mcp_server_alias("io.github.test/server", "prod", "1.0.0")
     store.create_mcp_access_binding(
-        "io.github.test/s", "https://alias.example.com", server_alias="prod"
+        "io.github.test/server", "https://alias.example.com", server_alias="prod"
     )
     server = store.search_mcp_servers()[0]
     assert len(server.access_bindings) == 1
@@ -133,15 +151,15 @@ def test_search_mcp_servers_empty(store):
 
 
 def test_search_mcp_servers_returns_all(store):
-    store.create_mcp_server("io.github.test/server-a")
-    store.create_mcp_server("io.github.test/server-b")
+    store.create_mcp_server("io.github.test/servererver-a")
+    store.create_mcp_server("io.github.test/servererver-b")
     result = store.search_mcp_servers()
     assert len(result) == 2
 
 
 def test_search_mcp_servers_pagination(store):
     for i in range(5):
-        store.create_mcp_server(f"io.github.test/server-{i:02d}")
+        store.create_mcp_server(f"io.github.test/servererver-{i:02d}")
     page1 = store.search_mcp_servers(max_results=2)
     assert len(page1) == 2
     assert page1.token is not None
@@ -154,24 +172,24 @@ def test_search_mcp_servers_pagination(store):
 
 
 def test_update_mcp_server_description(store):
-    store.create_mcp_server("io.github.test/server", description="old")
-    updated = store.update_mcp_server("io.github.test/server", description="new")
+    store.create_mcp_server("io.github.test/servererver", description="old")
+    updated = store.update_mcp_server("io.github.test/servererver", description="new")
     assert updated.description == "new"
 
 
 def test_update_mcp_server_display_name(store):
-    store.create_mcp_server("io.github.test/server")
-    updated = store.update_mcp_server("io.github.test/server", display_name="My Server")
+    store.create_mcp_server("io.github.test/servererver")
+    updated = store.update_mcp_server("io.github.test/servererver", display_name="My Server")
     assert updated.display_name == "My Server"
 
 
 def test_update_mcp_server_returns_complete_entity(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.ACTIVE
     )
-    store.set_mcp_server_tag("io.github.test/s", "env", "prod")
-    store.set_mcp_server_alias("io.github.test/s", "stable", "1.0.0")
-    updated = store.update_mcp_server("io.github.test/s", description="new desc")
+    store.set_mcp_server_tag("io.github.test/server", "env", "prod")
+    store.set_mcp_server_alias("io.github.test/server", "stable", "1.0.0")
+    updated = store.update_mcp_server("io.github.test/server", description="new desc")
     assert updated.description == "new desc"
     assert updated.status == MCPStatus.ACTIVE
     assert updated.tags == {"env": "prod"}
@@ -185,28 +203,28 @@ def test_update_mcp_server_not_found_raises(store):
 
 def test_update_mcp_server_no_latest_version_param(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/server", "2.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/servererver", "2.0.0"), status=MCPStatus.ACTIVE
     )
     with pytest.raises(TypeError, match="latest_version"):
-        store.update_mcp_server("io.github.test/server", latest_version="2.0.0")
+        store.update_mcp_server("io.github.test/servererver", latest_version="2.0.0")
 
 
 def test_create_mcp_server_version_rejects_semver_component_exceeding_db_integer_limit(store):
     with pytest.raises(MlflowException, match="server_json.version.*2147483647"):
         store.create_mcp_server_version(
-            _server_json("io.github.test/server", "2147483648.0.0"),
+            _server_json("io.github.test/servererver", "2147483648.0.0"),
             status=MCPStatus.ACTIVE,
         )
 
 
 def test_get_mcp_server_latest_version_uses_highest_active_semver(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/server", "1.2.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/servererver", "1.2.0"), status=MCPStatus.ACTIVE
     )
     store.create_mcp_server_version(
-        _server_json("io.github.test/server", "1.10.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/servererver", "1.10.0"), status=MCPStatus.ACTIVE
     )
-    updated = store.get_mcp_server("io.github.test/server")
+    updated = store.get_mcp_server("io.github.test/servererver")
     assert updated.latest_version == "1.10.0"
 
 
@@ -214,15 +232,15 @@ def test_resolved_parent_query_prefers_active_over_higher_deprecated_version(sto
     from mlflow.store.tracking.dbmodels.models import SqlMCPServer
 
     store.create_mcp_server_version(
-        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/servererver", "1.0.0"), status=MCPStatus.ACTIVE
     )
     store.create_mcp_server_version(
-        _server_json("io.github.test/server", "2.0.0"), status=MCPStatus.DEPRECATED
+        _server_json("io.github.test/servererver", "2.0.0"), status=MCPStatus.DEPRECATED
     )
 
     with store.ManagedSessionMaker() as session:
         query = store._get_query(session, SqlMCPServer).filter(
-            SqlMCPServer.name == "io.github.test/server"
+            SqlMCPServer.name == "io.github.test/servererver"
         )
         server = SqlMCPServer.with_resolved_latest(query).one()
         assert server.resolved_status == MCPStatus.ACTIVE.value
@@ -233,15 +251,15 @@ def test_resolved_parent_query_fallback_uses_highest_semver_without_active(store
     from mlflow.store.tracking.dbmodels.models import SqlMCPServer
 
     store.create_mcp_server_version(
-        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.DEPRECATED
+        _server_json("io.github.test/servererver", "1.0.0"), status=MCPStatus.DEPRECATED
     )
     store.create_mcp_server_version(
-        _server_json("io.github.test/server", "2.0.0"), status=MCPStatus.DRAFT
+        _server_json("io.github.test/servererver", "2.0.0"), status=MCPStatus.DRAFT
     )
 
     with store.ManagedSessionMaker() as session:
         query = store._get_query(session, SqlMCPServer).filter(
-            SqlMCPServer.name == "io.github.test/server"
+            SqlMCPServer.name == "io.github.test/servererver"
         )
         server = SqlMCPServer.with_resolved_latest(query).one()
         assert server.resolved_status == MCPStatus.DRAFT.value
@@ -250,58 +268,58 @@ def test_resolved_parent_query_fallback_uses_highest_semver_without_active(store
 
 def test_get_mcp_server_resolved_status(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.ACTIVE
     )
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "2.0.0"), status=MCPStatus.DRAFT
+        _server_json("io.github.test/server", "2.0.0"), status=MCPStatus.DRAFT
     )
-    server = store.get_mcp_server("io.github.test/s")
+    server = store.get_mcp_server("io.github.test/server")
     assert server.status == MCPStatus.ACTIVE
 
 
 def test_get_mcp_server_resolved_status_fallback(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "2.0.0"), status=MCPStatus.DEPRECATED
+        _server_json("io.github.test/server", "2.0.0"), status=MCPStatus.DEPRECATED
     )
-    server = store.get_mcp_server("io.github.test/s")
+    server = store.get_mcp_server("io.github.test/server")
     assert server.status == MCPStatus.DEPRECATED
     assert server.latest_version == "2.0.0"
 
 
 def test_get_mcp_server_description_falls_back_to_highest_active_semver(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.0.0", description="active description"),
+        _server_json("io.github.test/server", "1.0.0", description="active description"),
         status=MCPStatus.ACTIVE,
     )
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "2.0.0", description="deprecated description"),
+        _server_json("io.github.test/server", "2.0.0", description="deprecated description"),
         status=MCPStatus.DEPRECATED,
     )
-    server = store.get_mcp_server("io.github.test/s")
+    server = store.get_mcp_server("io.github.test/server")
     assert server.description == "active description"
 
 
 def test_get_mcp_server_description_falls_back_to_highest_non_deleted_version(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "2.0.0", description="deprecated description"),
+        _server_json("io.github.test/server", "2.0.0", description="deprecated description"),
         status=MCPStatus.DEPRECATED,
     )
-    server = store.get_mcp_server("io.github.test/s")
+    server = store.get_mcp_server("io.github.test/server")
     assert server.description == "deprecated description"
     assert server.latest_version == "2.0.0"
 
 
 def test_get_mcp_server_resolved_status_no_versions(store):
-    store.create_mcp_server("io.github.test/s")
-    server = store.get_mcp_server("io.github.test/s")
+    store.create_mcp_server("io.github.test/server")
+    server = store.get_mcp_server("io.github.test/server")
     assert server.status is None
 
 
 def test_delete_mcp_server(store):
-    store.create_mcp_server("io.github.test/server")
-    store.delete_mcp_server("io.github.test/server")
+    store.create_mcp_server("io.github.test/servererver")
+    store.delete_mcp_server("io.github.test/servererver")
     with pytest.raises(MlflowException, match="not found"):
-        store.get_mcp_server("io.github.test/server")
+        store.get_mcp_server("io.github.test/servererver")
 
 
 def test_delete_mcp_server_not_found_raises(store):
@@ -310,35 +328,37 @@ def test_delete_mcp_server_not_found_raises(store):
 
 
 def test_delete_mcp_server_cascades_to_versions(store):
-    store.create_mcp_server_version(_server_json("io.github.test/s1", "1.0.0"))
-    store.delete_mcp_server("io.github.test/s1")
+    store.create_mcp_server_version(_server_json("io.github.test/server1", "1.0.0"))
+    store.delete_mcp_server("io.github.test/server1")
     with pytest.raises(MlflowException, match="not found"):
-        store.get_mcp_server_version("io.github.test/s1", "1.0.0")
+        store.get_mcp_server_version("io.github.test/server1", "1.0.0")
 
 
 def test_delete_mcp_server_cascades_to_tags(store):
-    store.create_mcp_server("io.github.test/s1")
-    store.set_mcp_server_tag("io.github.test/s1", "k", "v")
-    store.delete_mcp_server("io.github.test/s1")
+    store.create_mcp_server("io.github.test/server1")
+    store.set_mcp_server_tag("io.github.test/server1", "k", "v")
+    store.delete_mcp_server("io.github.test/server1")
     with pytest.raises(MlflowException, match="not found"):
-        store.get_mcp_server("io.github.test/s1")
+        store.get_mcp_server("io.github.test/server1")
 
 
 def test_delete_mcp_server_cascades_to_aliases(store):
-    store.create_mcp_server_version(_server_json("io.github.test/s1", "1.0.0"))
-    store.set_mcp_server_alias("io.github.test/s1", "stable", "1.0.0")
-    store.delete_mcp_server("io.github.test/s1")
+    store.create_mcp_server_version(_server_json("io.github.test/server1", "1.0.0"))
+    store.set_mcp_server_alias("io.github.test/server1", "stable", "1.0.0")
+    store.delete_mcp_server("io.github.test/server1")
     # Recreate the server and verify the old alias is gone (was cascade-deleted).
-    store.create_mcp_server_version(_server_json("io.github.test/s1", "1.0.0"))
-    server = store.get_mcp_server("io.github.test/s1")
+    store.create_mcp_server_version(_server_json("io.github.test/server1", "1.0.0"))
+    server = store.get_mcp_server("io.github.test/server1")
     assert server.aliases == {}
 
 
 def test_delete_mcp_server_cascades_to_bindings(store):
-    _setup_server(store, "io.github.test/s1")
-    store.create_mcp_access_binding("io.github.test/s1", "https://a.com", server_version="1.0.0")
-    store.delete_mcp_server("io.github.test/s1")
-    result = store.search_mcp_access_bindings(server_name="io.github.test/s1")
+    _setup_server(store, "io.github.test/server1")
+    store.create_mcp_access_binding(
+        "io.github.test/server1", "https://a.com", server_version="1.0.0"
+    )
+    store.delete_mcp_server("io.github.test/server1")
+    result = store.search_mcp_access_bindings(server_name="io.github.test/server1")
     assert len(result) == 0
 
 
@@ -351,7 +371,7 @@ def test_create_mcp_server_version(store):
         source="https://github.com/org/repo",
         status=MCPStatus.ACTIVE,
     )
-    assert sv.name == "io.github.test/server"
+    assert sv.name == "io.github.test/servererver"
     assert sv.version == "1.0.0"
     assert sv.status == MCPStatus.ACTIVE
     assert sv.source == "https://github.com/org/repo"
@@ -365,9 +385,9 @@ def test_create_mcp_server_version_auto_creates_parent(store):
 
 
 def test_create_mcp_server_version_with_existing_parent(store):
-    store.create_mcp_server("io.github.test/server", description="existing")
+    store.create_mcp_server("io.github.test/servererver", description="existing")
     store.create_mcp_server_version(_server_json())
-    server = store.get_mcp_server("io.github.test/server")
+    server = store.get_mcp_server("io.github.test/servererver")
     assert server.description == "existing"
 
 
@@ -379,15 +399,15 @@ def test_create_mcp_server_version_duplicate_raises(store):
 
 
 def test_create_mcp_server_version_deleted_version_not_reusable(store):
-    original = _server_json("io.github.test/s", "1.0.0")
+    original = _server_json("io.github.test/server", "1.0.0")
     replacement = {
-        "name": "io.github.test/s",
+        "name": "io.github.test/server",
         "version": "1.0.0",
         "title": "Replacement Title",
         "description": "Replacement payload with same identity",
     }
     store.create_mcp_server_version(original)
-    store.delete_mcp_server_version("io.github.test/s", "1.0.0")
+    store.delete_mcp_server_version("io.github.test/server", "1.0.0")
     with pytest.raises(MlflowException, match="already exists") as exc:
         store.create_mcp_server_version(replacement)
     assert exc.value.error_code == "RESOURCE_ALREADY_EXISTS"
@@ -418,6 +438,10 @@ def test_create_mcp_server_version_missing_version_raises(store):
         "com.example/bindings",
         "com.example/tags",
         "com.example/versions",
+        "com.example/_server",
+        "com.example/server_",
+        "com.example/.server",
+        "com.example/server-",
     ],
 )
 def test_create_mcp_server_version_invalid_name_raises(store, invalid_name):
@@ -426,6 +450,20 @@ def test_create_mcp_server_version_invalid_name_raises(store, invalid_name):
     ) as exc:
         store.create_mcp_server_version({"name": invalid_name, "version": "1.0.0"})
     assert exc.value.error_code == "INVALID_PARAMETER_VALUE"
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "io.github.TestOrg/server-name",
+        "com/server-name",
+        "io.github.test/servererver_name",
+        "io.github.test/servererver.name",
+    ],
+)
+def test_create_mcp_server_version_accepts_upstream_name_shapes(store, name):
+    sv = store.create_mcp_server_version({"name": name, "version": "1.0.0"})
+    assert sv.name == name
 
 
 def test_create_mcp_server_version_with_tools(store):
@@ -453,7 +491,7 @@ def test_create_mcp_server_version_with_source(store):
 
 def test_get_mcp_server_version(store):
     store.create_mcp_server_version(_server_json())
-    sv = store.get_mcp_server_version("io.github.test/server", "1.0.0")
+    sv = store.get_mcp_server_version("io.github.test/servererver", "1.0.0")
     assert sv.version == "1.0.0"
 
 
@@ -464,33 +502,33 @@ def test_get_mcp_server_version_not_found_raises(store):
 
 def test_get_latest_mcp_server_version_highest_semver_active(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.2.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "1.2.0"), status=MCPStatus.ACTIVE
     )
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.10.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "1.10.0"), status=MCPStatus.ACTIVE
     )
-    latest = store.get_latest_mcp_server_version("io.github.test/s")
+    latest = store.get_latest_mcp_server_version("io.github.test/server")
     assert latest.version == "1.10.0"
 
 
 def test_prerelease_semver_resolution_end_to_end(store):
     for version in ("1.0.0-alpha.2", "1.0.0-alpha.10", "1.0.0-beta.1"):
         store.create_mcp_server_version(
-            _server_json("io.github.test/s", version), status=MCPStatus.ACTIVE
+            _server_json("io.github.test/server", version), status=MCPStatus.ACTIVE
         )
 
-    latest = store.get_latest_mcp_server_version("io.github.test/s")
+    latest = store.get_latest_mcp_server_version("io.github.test/server")
     assert latest.version == "1.0.0-beta.1"
 
-    server = store.get_mcp_server("io.github.test/s")
+    server = store.get_mcp_server("io.github.test/server")
     assert server.latest_version == "1.0.0-beta.1"
     assert server.status == MCPStatus.ACTIVE
 
-    aliased = store.get_mcp_server_version_by_alias("io.github.test/s", "latest")
+    aliased = store.get_mcp_server_version_by_alias("io.github.test/server", "latest")
     assert aliased.version == "1.0.0-beta.1"
 
     binding = store.create_mcp_access_binding(
-        "io.github.test/s",
+        "io.github.test/server",
         "https://latest.example.com",
         server_alias="latest",
     )
@@ -501,17 +539,17 @@ def test_prerelease_semver_resolution_end_to_end(store):
 def test_prerelease_numeric_tiebreak_applies_to_parent_metadata(store):
     for version in ("1.0.0-alpha.2", "1.0.0-alpha.10"):
         store.create_mcp_server_version(
-            _server_json("io.github.test/s", version), status=MCPStatus.ACTIVE
+            _server_json("io.github.test/server", version), status=MCPStatus.ACTIVE
         )
 
-    latest = store.get_latest_mcp_server_version("io.github.test/s")
+    latest = store.get_latest_mcp_server_version("io.github.test/server")
     assert latest.version == "1.0.0-alpha.10"
 
-    server = store.get_mcp_server("io.github.test/s")
+    server = store.get_mcp_server("io.github.test/server")
     assert server.latest_version == "1.0.0-alpha.10"
     assert server.status == MCPStatus.ACTIVE
 
-    searched = store.search_mcp_servers(filter_string="name = 'io.github.test/s'")
+    searched = store.search_mcp_servers(filter_string="name = 'io.github.test/server'")
     assert len(searched) == 1
     assert searched[0].latest_version == "1.0.0-alpha.10"
     assert searched[0].status == MCPStatus.ACTIVE
@@ -520,17 +558,17 @@ def test_prerelease_numeric_tiebreak_applies_to_parent_metadata(store):
 def test_prerelease_prefix_identifier_resolution_end_to_end(store):
     for version in ("1.0.0-alpha", "1.0.0-alpha1"):
         store.create_mcp_server_version(
-            _server_json("io.github.test/s", version), status=MCPStatus.ACTIVE
+            _server_json("io.github.test/server", version), status=MCPStatus.ACTIVE
         )
 
-    latest = store.get_latest_mcp_server_version("io.github.test/s")
+    latest = store.get_latest_mcp_server_version("io.github.test/server")
     assert latest.version == "1.0.0-alpha1"
 
-    server = store.get_mcp_server("io.github.test/s")
+    server = store.get_mcp_server("io.github.test/server")
     assert server.latest_version == "1.0.0-alpha1"
 
     binding = store.create_mcp_access_binding(
-        "io.github.test/s",
+        "io.github.test/server",
         "https://latest.example.com",
         server_alias="latest",
     )
@@ -541,39 +579,39 @@ def test_prerelease_prefix_identifier_resolution_end_to_end(store):
 def test_prerelease_prefix_identifier_with_hyphen_resolution_end_to_end(store):
     for version in ("1.0.0-alpha", "1.0.0-alpha-1"):
         store.create_mcp_server_version(
-            _server_json("io.github.test/s", version), status=MCPStatus.ACTIVE
+            _server_json("io.github.test/server", version), status=MCPStatus.ACTIVE
         )
 
-    latest = store.get_latest_mcp_server_version("io.github.test/s")
+    latest = store.get_latest_mcp_server_version("io.github.test/server")
     assert latest.version == "1.0.0-alpha-1"
 
-    server = store.get_mcp_server("io.github.test/s")
+    server = store.get_mcp_server("io.github.test/server")
     assert server.latest_version == "1.0.0-alpha-1"
 
 
 def test_prerelease_shorter_identifier_list_sorts_lower_end_to_end(store):
     for version in ("1.0.0-alpha", "1.0.0-alpha.1"):
         store.create_mcp_server_version(
-            _server_json("io.github.test/s", version), status=MCPStatus.ACTIVE
+            _server_json("io.github.test/server", version), status=MCPStatus.ACTIVE
         )
 
-    latest = store.get_latest_mcp_server_version("io.github.test/s")
+    latest = store.get_latest_mcp_server_version("io.github.test/server")
     assert latest.version == "1.0.0-alpha.1"
 
-    server = store.get_mcp_server("io.github.test/s")
+    server = store.get_mcp_server("io.github.test/server")
     assert server.latest_version == "1.0.0-alpha.1"
 
 
 def test_prerelease_numeric_identifier_sorts_lower_than_nonnumeric_end_to_end(store):
     for version in ("1.0.0-1", "1.0.0-alpha"):
         store.create_mcp_server_version(
-            _server_json("io.github.test/s", version), status=MCPStatus.ACTIVE
+            _server_json("io.github.test/server", version), status=MCPStatus.ACTIVE
         )
 
-    latest = store.get_latest_mcp_server_version("io.github.test/s")
+    latest = store.get_latest_mcp_server_version("io.github.test/server")
     assert latest.version == "1.0.0-alpha"
 
-    server = store.get_mcp_server("io.github.test/s")
+    server = store.get_mcp_server("io.github.test/server")
     assert server.latest_version == "1.0.0-alpha"
 
 
@@ -585,21 +623,21 @@ def test_build_metadata_uses_created_at_before_raw_version_as_latest_tiebreaker(
     )
     for version in ("1.0.0+xyz", "1.0.0+abc"):
         store.create_mcp_server_version(
-            _server_json("io.github.test/s", version), status=MCPStatus.ACTIVE
+            _server_json("io.github.test/server", version), status=MCPStatus.ACTIVE
         )
 
-    latest = store.get_latest_mcp_server_version("io.github.test/s")
+    latest = store.get_latest_mcp_server_version("io.github.test/server")
     assert latest.version == "1.0.0+abc"
 
-    server = store.get_mcp_server("io.github.test/s")
+    server = store.get_mcp_server("io.github.test/server")
     assert server.latest_version == "1.0.0+abc"
     assert server.status == MCPStatus.ACTIVE
 
-    aliased = store.get_mcp_server_version_by_alias("io.github.test/s", "latest")
+    aliased = store.get_mcp_server_version_by_alias("io.github.test/server", "latest")
     assert aliased.version == "1.0.0+abc"
 
     binding = store.create_mcp_access_binding(
-        "io.github.test/s",
+        "io.github.test/server",
         "https://latest.example.com",
         server_alias="latest",
     )
@@ -608,10 +646,10 @@ def test_build_metadata_uses_created_at_before_raw_version_as_latest_tiebreaker(
 
 
 def test_get_latest_mcp_server_version_ignores_non_active_versions(store):
-    store.create_mcp_server_version(_server_json("io.github.test/s", "1.0.0"))
-    store.update_mcp_server_version("io.github.test/s", "1.0.0", status=MCPStatus.ACTIVE)
-    store.create_mcp_server_version(_server_json("io.github.test/s", "2.0.0"))
-    latest = store.get_latest_mcp_server_version("io.github.test/s")
+    store.create_mcp_server_version(_server_json("io.github.test/server", "1.0.0"))
+    store.update_mcp_server_version("io.github.test/server", "1.0.0", status=MCPStatus.ACTIVE)
+    store.create_mcp_server_version(_server_json("io.github.test/server", "2.0.0"))
+    latest = store.get_latest_mcp_server_version("io.github.test/server")
     assert latest.version == "1.0.0"
 
 
@@ -626,21 +664,21 @@ def test_get_latest_mcp_server_version_same_timestamp_tiebreaker(store, monkeypa
         lambda: 1000,
     )
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.ACTIVE
     )
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "2.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "2.0.0"), status=MCPStatus.ACTIVE
     )
-    latest = store.get_latest_mcp_server_version("io.github.test/s")
+    latest = store.get_latest_mcp_server_version("io.github.test/server")
     assert latest.version == "2.0.0"
 
-    server = store.get_mcp_server("io.github.test/s")
+    server = store.get_mcp_server("io.github.test/server")
     assert server.status == MCPStatus.ACTIVE
 
 
 def test_get_latest_mcp_server_version_falls_back_to_draft(store):
-    store.create_mcp_server_version(_server_json("io.github.test/s", "1.0.0"))
-    latest = store.get_latest_mcp_server_version("io.github.test/s")
+    store.create_mcp_server_version(_server_json("io.github.test/server", "1.0.0"))
+    latest = store.get_latest_mcp_server_version("io.github.test/server")
     assert latest.version == "1.0.0"
 
 
@@ -651,46 +689,46 @@ def test_get_latest_mcp_server_version_server_not_found(store):
 
 def test_get_mcp_server_version_by_alias(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.ACTIVE
     )
-    store.set_mcp_server_alias("io.github.test/s", "stable", "1.0.0")
-    sv = store.get_mcp_server_version_by_alias("io.github.test/s", "stable")
+    store.set_mcp_server_alias("io.github.test/server", "stable", "1.0.0")
+    sv = store.get_mcp_server_version_by_alias("io.github.test/server", "stable")
     assert sv.version == "1.0.0"
 
 
 def test_get_mcp_server_version_by_latest_alias(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.ACTIVE
     )
-    sv = store.get_mcp_server_version_by_alias("io.github.test/s", "latest")
+    sv = store.get_mcp_server_version_by_alias("io.github.test/server", "latest")
     assert sv.version == "1.0.0"
 
 
 def test_get_mcp_server_version_by_alias_not_found(store):
-    store.create_mcp_server("io.github.test/s")
+    store.create_mcp_server("io.github.test/server")
     with pytest.raises(MlflowException, match="not found"):
-        store.get_mcp_server_version_by_alias("io.github.test/s", "io.github.test/nonexistent")
+        store.get_mcp_server_version_by_alias("io.github.test/server", "io.github.test/nonexistent")
 
 
 def test_search_mcp_server_versions(store):
-    store.create_mcp_server_version(_server_json("io.github.test/s", "1.0.0"))
-    store.create_mcp_server_version(_server_json("io.github.test/s", "2.0.0"))
-    result = store.search_mcp_server_versions("io.github.test/s")
+    store.create_mcp_server_version(_server_json("io.github.test/server", "1.0.0"))
+    store.create_mcp_server_version(_server_json("io.github.test/server", "2.0.0"))
+    result = store.search_mcp_server_versions("io.github.test/server")
     assert len(result) == 2
 
 
 def test_search_mcp_server_versions_scoped(store):
-    store.create_mcp_server_version(_server_json("io.github.test/s1", "1.0.0"))
-    store.create_mcp_server_version(_server_json("io.github.test/s2", "1.0.0"))
-    result = store.search_mcp_server_versions("io.github.test/s1")
+    store.create_mcp_server_version(_server_json("io.github.test/server1", "1.0.0"))
+    store.create_mcp_server_version(_server_json("io.github.test/server2", "1.0.0"))
+    result = store.search_mcp_server_versions("io.github.test/server1")
     assert len(result) == 1
-    assert result[0].name == "io.github.test/s1"
+    assert result[0].name == "io.github.test/server1"
 
 
 def test_update_mcp_server_version_status(store):
     store.create_mcp_server_version(_server_json())
     updated = store.update_mcp_server_version(
-        "io.github.test/server", "1.0.0", status=MCPStatus.ACTIVE
+        "io.github.test/servererver", "1.0.0", status=MCPStatus.ACTIVE
     )
     assert updated.status == MCPStatus.ACTIVE
 
@@ -698,35 +736,35 @@ def test_update_mcp_server_version_status(store):
 def test_update_mcp_server_version_null_status_raises(store):
     store.create_mcp_server_version(_server_json())
     with pytest.raises(MlflowException, match="status cannot be null") as exc:
-        store.update_mcp_server_version("io.github.test/server", "1.0.0", status=None)
+        store.update_mcp_server_version("io.github.test/servererver", "1.0.0", status=None)
     assert exc.value.error_code == "INVALID_PARAMETER_VALUE"
 
 
 def test_update_mcp_server_version_to_draft_recomputes_latest_version(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.ACTIVE
     )
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "2.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "2.0.0"), status=MCPStatus.ACTIVE
     )
-    store.update_mcp_server_version("io.github.test/s", "2.0.0", status=MCPStatus.DRAFT)
-    server = store.get_mcp_server("io.github.test/s")
+    store.update_mcp_server_version("io.github.test/server", "2.0.0", status=MCPStatus.DRAFT)
+    server = store.get_mcp_server("io.github.test/server")
     assert server.latest_version == "1.0.0"
     assert server.status == MCPStatus.ACTIVE
 
 
 def test_latest_resolution_falls_back_to_highest_non_active_semver(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.2.0"), status=MCPStatus.DEPRECATED
+        _server_json("io.github.test/server", "1.2.0"), status=MCPStatus.DEPRECATED
     )
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.3.0"), status=MCPStatus.DRAFT
+        _server_json("io.github.test/server", "1.3.0"), status=MCPStatus.DRAFT
     )
 
-    latest = store.get_latest_mcp_server_version("io.github.test/s")
+    latest = store.get_latest_mcp_server_version("io.github.test/server")
     assert latest.version == "1.3.0"
 
-    server = store.get_mcp_server("io.github.test/s")
+    server = store.get_mcp_server("io.github.test/server")
     assert server.latest_version == "1.3.0"
     assert server.status == MCPStatus.DRAFT
 
@@ -734,20 +772,24 @@ def test_latest_resolution_falls_back_to_highest_non_active_semver(store):
 def test_update_mcp_server_version_invalid_transition(store):
     store.create_mcp_server_version(_server_json(), status=MCPStatus.ACTIVE)
     with pytest.raises(MlflowException, match="Invalid status transition") as exc:
-        store.update_mcp_server_version("io.github.test/server", "1.0.0", status=MCPStatus.DELETED)
+        store.update_mcp_server_version(
+            "io.github.test/servererver", "1.0.0", status=MCPStatus.DELETED
+        )
     assert exc.value.error_code == "INVALID_PARAMETER_VALUE"
 
 
 def test_update_mcp_server_version_display_name(store):
     store.create_mcp_server_version(_server_json())
-    updated = store.update_mcp_server_version("io.github.test/server", "1.0.0", display_name="v1")
+    updated = store.update_mcp_server_version(
+        "io.github.test/servererver", "1.0.0", display_name="v1"
+    )
     assert updated.display_name == "v1"
 
 
 def test_update_mcp_server_version_tools(store):
     store.create_mcp_server_version(_server_json())
     tools = [MCPTool(name="calculator")]
-    updated = store.update_mcp_server_version("io.github.test/server", "1.0.0", tools=tools)
+    updated = store.update_mcp_server_version("io.github.test/servererver", "1.0.0", tools=tools)
     assert len(updated.tools) == 1
     assert updated.tools[0].name == "calculator"
 
@@ -757,7 +799,7 @@ def test_update_mcp_server_version_tools_empty_list_preserved(store):
         _server_json(),
         tools=[MCPTool(name="calculator")],
     )
-    updated = store.update_mcp_server_version("io.github.test/server", "1.0.0", tools=[])
+    updated = store.update_mcp_server_version("io.github.test/servererver", "1.0.0", tools=[])
     assert updated.tools == []
 
 
@@ -766,15 +808,15 @@ def test_update_mcp_server_version_tools_none_clears_tools(store):
         _server_json(),
         tools=[MCPTool(name="calculator")],
     )
-    updated = store.update_mcp_server_version("io.github.test/server", "1.0.0", tools=None)
+    updated = store.update_mcp_server_version("io.github.test/servererver", "1.0.0", tools=None)
     assert updated.tools is None
 
 
 def test_update_mcp_server_version_returns_complete_entity(store):
     store.create_mcp_server_version(_server_json(), status=MCPStatus.ACTIVE)
-    store.set_mcp_server_version_tag("io.github.test/server", "1.0.0", "env", "prod")
+    store.set_mcp_server_version_tag("io.github.test/servererver", "1.0.0", "env", "prod")
     updated = store.update_mcp_server_version(
-        "io.github.test/server", "1.0.0", display_name="Updated"
+        "io.github.test/servererver", "1.0.0", display_name="Updated"
     )
     assert updated.display_name == "Updated"
     assert updated.status == MCPStatus.ACTIVE
@@ -784,28 +826,30 @@ def test_update_mcp_server_version_returns_complete_entity(store):
 
 def test_update_mcp_server_version_deleted_raises(store):
     store.create_mcp_server_version(_server_json())
-    store.delete_mcp_server_version("io.github.test/server", "1.0.0")
+    store.delete_mcp_server_version("io.github.test/servererver", "1.0.0")
     with pytest.raises(MlflowException, match="not found") as exc:
-        store.update_mcp_server_version("io.github.test/server", "1.0.0", display_name="Updated")
+        store.update_mcp_server_version(
+            "io.github.test/servererver", "1.0.0", display_name="Updated"
+        )
     assert exc.value.error_code == "RESOURCE_DOES_NOT_EXIST"
 
 
 def test_delete_mcp_server_version_soft_delete(store):
     store.create_mcp_server_version(_server_json())
-    store.delete_mcp_server_version("io.github.test/server", "1.0.0")
+    store.delete_mcp_server_version("io.github.test/servererver", "1.0.0")
     with pytest.raises(MlflowException, match="not found"):
-        store.get_mcp_server_version("io.github.test/server", "1.0.0")
+        store.get_mcp_server_version("io.github.test/servererver", "1.0.0")
 
 
 def test_delete_mcp_server_version_clears_latest_pin(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.ACTIVE
     )
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "2.0.0"), status=MCPStatus.DEPRECATED
+        _server_json("io.github.test/server", "2.0.0"), status=MCPStatus.DEPRECATED
     )
-    store.delete_mcp_server_version("io.github.test/s", "2.0.0")
-    server = store.get_mcp_server("io.github.test/s")
+    store.delete_mcp_server_version("io.github.test/server", "2.0.0")
+    server = store.get_mcp_server("io.github.test/server")
     assert server.latest_version == "1.0.0"
     assert server.status == MCPStatus.ACTIVE
 
@@ -813,22 +857,22 @@ def test_delete_mcp_server_version_clears_latest_pin(store):
 def test_delete_mcp_server_version_active_raises(store):
     store.create_mcp_server_version(_server_json(), status=MCPStatus.ACTIVE)
     with pytest.raises(MlflowException, match="Invalid status transition"):
-        store.delete_mcp_server_version("io.github.test/server", "1.0.0")
+        store.delete_mcp_server_version("io.github.test/servererver", "1.0.0")
 
 
 def test_delete_mcp_server_version_cleans_up_aliases_and_bindings(store):
-    store.create_mcp_server_version(_server_json("io.github.test/s", "1.0.0"))
-    store.set_mcp_server_alias("io.github.test/s", "stable", "1.0.0")
+    store.create_mcp_server_version(_server_json("io.github.test/server", "1.0.0"))
+    store.set_mcp_server_alias("io.github.test/server", "stable", "1.0.0")
     store.create_mcp_access_binding(
-        "io.github.test/s", "https://direct.example.com", server_version="1.0.0"
+        "io.github.test/server", "https://direct.example.com", server_version="1.0.0"
     )
     store.create_mcp_access_binding(
-        "io.github.test/s", "https://alias.example.com", server_alias="stable"
+        "io.github.test/server", "https://alias.example.com", server_alias="stable"
     )
-    store.delete_mcp_server_version("io.github.test/s", "1.0.0")
-    server = store.get_mcp_server("io.github.test/s")
+    store.delete_mcp_server_version("io.github.test/server", "1.0.0")
+    server = store.get_mcp_server("io.github.test/server")
     assert server.aliases == {}
-    assert len(store.search_mcp_access_bindings(server_name="io.github.test/s")) == 0
+    assert len(store.search_mcp_access_bindings(server_name="io.github.test/server")) == 0
 
 
 def test_delete_mcp_server_version_not_found_raises(store):
@@ -840,60 +884,60 @@ def test_delete_mcp_server_version_not_found_raises(store):
 
 
 def test_create_mcp_access_binding_with_version(store):
-    _setup_server(store, "io.github.test/s")
+    _setup_server(store, "io.github.test/server")
     binding = store.create_mcp_access_binding(
-        "io.github.test/s", "https://mcp.example.com", server_version="1.0.0"
+        "io.github.test/server", "https://mcp.example.com", server_version="1.0.0"
     )
-    assert binding.server_name == "io.github.test/s"
+    assert binding.server_name == "io.github.test/server"
     assert binding.endpoint_url == "https://mcp.example.com"
     assert binding.server_version == "1.0.0"
     assert binding.transport_type == MCPRemoteTransportType.STREAMABLE_HTTP
 
 
 def test_create_mcp_access_binding_with_alias(store):
-    _setup_server(store, "io.github.test/s", aliases={"stable": "1.0.0"})
+    _setup_server(store, "io.github.test/server", aliases={"stable": "1.0.0"})
     binding = store.create_mcp_access_binding(
-        "io.github.test/s", "https://mcp.example.com", server_alias="stable"
+        "io.github.test/server", "https://mcp.example.com", server_alias="stable"
     )
     assert binding.server_alias == "stable"
 
 
 def test_create_mcp_access_binding_nonexistent_version_raises(store):
-    _setup_server(store, "io.github.test/s")
+    _setup_server(store, "io.github.test/server")
     with pytest.raises(MlflowException, match="not found"):
         store.create_mcp_access_binding(
-            "io.github.test/s", "https://mcp.example.com", server_version="9.9.0"
+            "io.github.test/server", "https://mcp.example.com", server_version="9.9.0"
         )
 
 
 def test_create_mcp_access_binding_nonexistent_alias_raises(store):
-    _setup_server(store, "io.github.test/s")
+    _setup_server(store, "io.github.test/server")
     with pytest.raises(MlflowException, match="not found"):
         store.create_mcp_access_binding(
-            "io.github.test/s", "https://mcp.example.com", server_alias="fake"
+            "io.github.test/server", "https://mcp.example.com", server_alias="fake"
         )
 
 
 def test_create_mcp_access_binding_deleted_version_raises(store):
-    store.create_mcp_server_version(_server_json("io.github.test/s", "1.0.0"))
-    store.delete_mcp_server_version("io.github.test/s", "1.0.0")
+    store.create_mcp_server_version(_server_json("io.github.test/server", "1.0.0"))
+    store.delete_mcp_server_version("io.github.test/server", "1.0.0")
     with pytest.raises(MlflowException, match="deleted MCP server version"):
         store.create_mcp_access_binding(
-            "io.github.test/s", "https://mcp.example.com", server_version="1.0.0"
+            "io.github.test/server", "https://mcp.example.com", server_version="1.0.0"
         )
 
 
 def test_create_mcp_access_binding_neither_raises(store):
-    _setup_server(store, "io.github.test/s")
+    _setup_server(store, "io.github.test/server")
     with pytest.raises(MlflowException, match="Exactly one"):
-        store.create_mcp_access_binding("io.github.test/s", "https://mcp.example.com")
+        store.create_mcp_access_binding("io.github.test/server", "https://mcp.example.com")
 
 
 def test_create_mcp_access_binding_both_raises(store):
-    _setup_server(store, "io.github.test/s", aliases={"stable": "1.0.0"})
+    _setup_server(store, "io.github.test/server", aliases={"stable": "1.0.0"})
     with pytest.raises(MlflowException, match="Exactly one"):
         store.create_mcp_access_binding(
-            "io.github.test/s",
+            "io.github.test/server",
             "https://mcp.example.com",
             server_version="1.0.0",
             server_alias="stable",
@@ -908,117 +952,129 @@ def test_create_mcp_access_binding_server_not_found(store):
 
 
 def test_get_mcp_access_binding_not_found_raises(store):
-    _setup_server(store, "io.github.test/s")
+    _setup_server(store, "io.github.test/server")
     with pytest.raises(MlflowException, match="not found"):
-        store.get_mcp_access_binding("io.github.test/s", 99999)
+        store.get_mcp_access_binding("io.github.test/server", 99999)
 
 
 def test_search_mcp_access_bindings_all(store):
-    _setup_server(store, "io.github.test/s1")
-    _setup_server(store, "io.github.test/s2")
-    store.create_mcp_access_binding("io.github.test/s1", "https://a.com", server_version="1.0.0")
-    store.create_mcp_access_binding("io.github.test/s2", "https://b.com", server_version="1.0.0")
+    _setup_server(store, "io.github.test/server1")
+    _setup_server(store, "io.github.test/server2")
+    store.create_mcp_access_binding(
+        "io.github.test/server1", "https://a.com", server_version="1.0.0"
+    )
+    store.create_mcp_access_binding(
+        "io.github.test/server2", "https://b.com", server_version="1.0.0"
+    )
     result = store.search_mcp_access_bindings()
     assert len(result) == 2
 
 
 def test_search_mcp_access_bindings_by_server(store):
-    _setup_server(store, "io.github.test/s1")
-    _setup_server(store, "io.github.test/s2")
-    store.create_mcp_access_binding("io.github.test/s1", "https://a.com", server_version="1.0.0")
-    store.create_mcp_access_binding("io.github.test/s2", "https://b.com", server_version="1.0.0")
-    result = store.search_mcp_access_bindings(server_name="io.github.test/s1")
+    _setup_server(store, "io.github.test/server1")
+    _setup_server(store, "io.github.test/server2")
+    store.create_mcp_access_binding(
+        "io.github.test/server1", "https://a.com", server_version="1.0.0"
+    )
+    store.create_mcp_access_binding(
+        "io.github.test/server2", "https://b.com", server_version="1.0.0"
+    )
+    result = store.search_mcp_access_bindings(server_name="io.github.test/server1")
     assert len(result) == 1
-    assert result[0].server_name == "io.github.test/s1"
+    assert result[0].server_name == "io.github.test/server1"
 
 
 def test_search_mcp_access_bindings_by_version(store):
-    _setup_server(store, "io.github.test/s", versions=("1.0.0", "2.0.0"))
-    store.create_mcp_access_binding("io.github.test/s", "https://a.com", server_version="1.0.0")
-    store.create_mcp_access_binding("io.github.test/s", "https://b.com", server_version="2.0.0")
+    _setup_server(store, "io.github.test/server", versions=("1.0.0", "2.0.0"))
+    store.create_mcp_access_binding(
+        "io.github.test/server", "https://a.com", server_version="1.0.0"
+    )
+    store.create_mcp_access_binding(
+        "io.github.test/server", "https://b.com", server_version="2.0.0"
+    )
     result = store.search_mcp_access_bindings(server_version="1.0.0")
     assert len(result) == 1
 
 
 def test_delete_mcp_access_binding(store):
-    _setup_server(store, "io.github.test/s")
+    _setup_server(store, "io.github.test/server")
     binding = store.create_mcp_access_binding(
-        "io.github.test/s", "https://a.com", server_version="1.0.0"
+        "io.github.test/server", "https://a.com", server_version="1.0.0"
     )
-    store.delete_mcp_access_binding("io.github.test/s", binding.binding_id)
+    store.delete_mcp_access_binding("io.github.test/server", binding.binding_id)
     with pytest.raises(MlflowException, match="not found"):
-        store.get_mcp_access_binding("io.github.test/s", binding.binding_id)
+        store.get_mcp_access_binding("io.github.test/server", binding.binding_id)
 
 
 # --- Tags ---
 
 
 def test_set_and_get_mcp_server_tag(store):
-    store.create_mcp_server("io.github.test/s")
-    store.set_mcp_server_tag("io.github.test/s", "env", "prod")
-    server = store.get_mcp_server("io.github.test/s")
+    store.create_mcp_server("io.github.test/server")
+    store.set_mcp_server_tag("io.github.test/server", "env", "prod")
+    server = store.get_mcp_server("io.github.test/server")
     assert server.tags == {"env": "prod"}
 
 
 def test_upsert_mcp_server_tag(store):
-    store.create_mcp_server("io.github.test/s")
-    store.set_mcp_server_tag("io.github.test/s", "env", "dev")
-    store.set_mcp_server_tag("io.github.test/s", "env", "prod")
-    server = store.get_mcp_server("io.github.test/s")
+    store.create_mcp_server("io.github.test/server")
+    store.set_mcp_server_tag("io.github.test/server", "env", "dev")
+    store.set_mcp_server_tag("io.github.test/server", "env", "prod")
+    server = store.get_mcp_server("io.github.test/server")
     assert server.tags == {"env": "prod"}
 
 
 def test_delete_mcp_server_tag(store):
-    store.create_mcp_server("io.github.test/s")
-    store.set_mcp_server_tag("io.github.test/s", "env", "prod")
-    store.delete_mcp_server_tag("io.github.test/s", "env")
-    server = store.get_mcp_server("io.github.test/s")
+    store.create_mcp_server("io.github.test/server")
+    store.set_mcp_server_tag("io.github.test/server", "env", "prod")
+    store.delete_mcp_server_tag("io.github.test/server", "env")
+    server = store.get_mcp_server("io.github.test/server")
     assert server.tags == {}
 
 
 def test_delete_mcp_server_tag_not_found_raises(store):
-    store.create_mcp_server("io.github.test/s")
+    store.create_mcp_server("io.github.test/server")
     with pytest.raises(MlflowException, match="not found"):
-        store.delete_mcp_server_tag("io.github.test/s", "io.github.test/nonexistent")
+        store.delete_mcp_server_tag("io.github.test/server", "io.github.test/nonexistent")
 
 
 def test_set_and_get_mcp_server_version_tag(store):
-    store.create_mcp_server_version(_server_json("io.github.test/s", "1.0.0"))
-    store.set_mcp_server_version_tag("io.github.test/s", "1.0.0", "env", "prod")
-    sv = store.get_mcp_server_version("io.github.test/s", "1.0.0")
+    store.create_mcp_server_version(_server_json("io.github.test/server", "1.0.0"))
+    store.set_mcp_server_version_tag("io.github.test/server", "1.0.0", "env", "prod")
+    sv = store.get_mcp_server_version("io.github.test/server", "1.0.0")
     assert sv.tags == {"env": "prod"}
 
 
 def test_upsert_mcp_server_version_tag(store):
-    store.create_mcp_server_version(_server_json("io.github.test/s", "1.0.0"))
-    store.set_mcp_server_version_tag("io.github.test/s", "1.0.0", "env", "dev")
-    store.set_mcp_server_version_tag("io.github.test/s", "1.0.0", "env", "prod")
-    sv = store.get_mcp_server_version("io.github.test/s", "1.0.0")
+    store.create_mcp_server_version(_server_json("io.github.test/server", "1.0.0"))
+    store.set_mcp_server_version_tag("io.github.test/server", "1.0.0", "env", "dev")
+    store.set_mcp_server_version_tag("io.github.test/server", "1.0.0", "env", "prod")
+    sv = store.get_mcp_server_version("io.github.test/server", "1.0.0")
     assert sv.tags == {"env": "prod"}
 
 
 def test_delete_mcp_server_version_tag(store):
-    store.create_mcp_server_version(_server_json("io.github.test/s", "1.0.0"))
-    store.set_mcp_server_version_tag("io.github.test/s", "1.0.0", "env", "prod")
-    store.delete_mcp_server_version_tag("io.github.test/s", "1.0.0", "env")
-    sv = store.get_mcp_server_version("io.github.test/s", "1.0.0")
+    store.create_mcp_server_version(_server_json("io.github.test/server", "1.0.0"))
+    store.set_mcp_server_version_tag("io.github.test/server", "1.0.0", "env", "prod")
+    store.delete_mcp_server_version_tag("io.github.test/server", "1.0.0", "env")
+    sv = store.get_mcp_server_version("io.github.test/server", "1.0.0")
     assert sv.tags == {}
 
 
 def test_set_mcp_server_version_tag_deleted_version_raises(store):
-    store.create_mcp_server_version(_server_json("io.github.test/s", "1.0.0"))
-    store.delete_mcp_server_version("io.github.test/s", "1.0.0")
+    store.create_mcp_server_version(_server_json("io.github.test/server", "1.0.0"))
+    store.delete_mcp_server_version("io.github.test/server", "1.0.0")
     with pytest.raises(MlflowException, match="not found") as exc:
-        store.set_mcp_server_version_tag("io.github.test/s", "1.0.0", "env", "prod")
+        store.set_mcp_server_version_tag("io.github.test/server", "1.0.0", "env", "prod")
     assert exc.value.error_code == "RESOURCE_DOES_NOT_EXIST"
 
 
 def test_delete_mcp_server_version_tag_deleted_version_raises(store):
-    store.create_mcp_server_version(_server_json("io.github.test/s", "1.0.0"))
-    store.set_mcp_server_version_tag("io.github.test/s", "1.0.0", "env", "prod")
-    store.delete_mcp_server_version("io.github.test/s", "1.0.0")
+    store.create_mcp_server_version(_server_json("io.github.test/server", "1.0.0"))
+    store.set_mcp_server_version_tag("io.github.test/server", "1.0.0", "env", "prod")
+    store.delete_mcp_server_version("io.github.test/server", "1.0.0")
     with pytest.raises(MlflowException, match="not found") as exc:
-        store.delete_mcp_server_version_tag("io.github.test/s", "1.0.0", "env")
+        store.delete_mcp_server_version_tag("io.github.test/server", "1.0.0", "env")
     assert exc.value.error_code == "RESOURCE_DOES_NOT_EXIST"
 
 
@@ -1026,78 +1082,78 @@ def test_delete_mcp_server_version_tag_deleted_version_raises(store):
 
 
 def test_set_and_resolve_mcp_server_alias(store):
-    store.create_mcp_server_version(_server_json("io.github.test/s", "1.0.0"))
-    store.set_mcp_server_alias("io.github.test/s", "stable", "1.0.0")
-    sv = store.get_mcp_server_version_by_alias("io.github.test/s", "stable")
+    store.create_mcp_server_version(_server_json("io.github.test/server", "1.0.0"))
+    store.set_mcp_server_alias("io.github.test/server", "stable", "1.0.0")
+    sv = store.get_mcp_server_version_by_alias("io.github.test/server", "stable")
     assert sv.version == "1.0.0"
 
 
 def test_upsert_mcp_server_alias_retargets(store):
-    store.create_mcp_server_version(_server_json("io.github.test/s", "1.0.0"))
-    store.create_mcp_server_version(_server_json("io.github.test/s", "2.0.0"))
-    store.set_mcp_server_alias("io.github.test/s", "stable", "1.0.0")
-    store.set_mcp_server_alias("io.github.test/s", "stable", "2.0.0")
-    sv = store.get_mcp_server_version_by_alias("io.github.test/s", "stable")
+    store.create_mcp_server_version(_server_json("io.github.test/server", "1.0.0"))
+    store.create_mcp_server_version(_server_json("io.github.test/server", "2.0.0"))
+    store.set_mcp_server_alias("io.github.test/server", "stable", "1.0.0")
+    store.set_mcp_server_alias("io.github.test/server", "stable", "2.0.0")
+    sv = store.get_mcp_server_version_by_alias("io.github.test/server", "stable")
     assert sv.version == "2.0.0"
 
 
 def test_set_mcp_server_alias_latest_reserved(store):
-    store.create_mcp_server("io.github.test/s")
+    store.create_mcp_server("io.github.test/server")
     with pytest.raises(MlflowException, match="reserved") as exc:
-        store.set_mcp_server_alias("io.github.test/s", "latest", "1.0.0")
+        store.set_mcp_server_alias("io.github.test/server", "latest", "1.0.0")
     assert exc.value.error_code == "INVALID_PARAMETER_VALUE"
 
 
 def test_set_mcp_server_alias_to_deleted_version_raises(store):
-    store.create_mcp_server_version(_server_json("io.github.test/s", "1.0.0"))
-    store.delete_mcp_server_version("io.github.test/s", "1.0.0")
+    store.create_mcp_server_version(_server_json("io.github.test/server", "1.0.0"))
+    store.delete_mcp_server_version("io.github.test/server", "1.0.0")
     with pytest.raises(MlflowException, match="Cannot set alias"):
-        store.set_mcp_server_alias("io.github.test/s", "stable", "1.0.0")
+        store.set_mcp_server_alias("io.github.test/server", "stable", "1.0.0")
 
 
 def test_delete_mcp_server_alias(store):
-    store.create_mcp_server_version(_server_json("io.github.test/s", "1.0.0"))
-    store.set_mcp_server_alias("io.github.test/s", "stable", "1.0.0")
-    store.delete_mcp_server_alias("io.github.test/s", "stable")
+    store.create_mcp_server_version(_server_json("io.github.test/server", "1.0.0"))
+    store.set_mcp_server_alias("io.github.test/server", "stable", "1.0.0")
+    store.delete_mcp_server_alias("io.github.test/server", "stable")
     with pytest.raises(MlflowException, match="not found"):
-        store.get_mcp_server_version_by_alias("io.github.test/s", "stable")
+        store.get_mcp_server_version_by_alias("io.github.test/server", "stable")
 
 
 def test_delete_mcp_server_alias_cleans_up_alias_bindings(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.ACTIVE
     )
-    store.set_mcp_server_alias("io.github.test/s", "stable", "1.0.0")
+    store.set_mcp_server_alias("io.github.test/server", "stable", "1.0.0")
     binding = store.create_mcp_access_binding(
-        "io.github.test/s",
+        "io.github.test/server",
         "https://alias.example.com",
         server_alias="stable",
     )
-    store.delete_mcp_server_alias("io.github.test/s", "stable")
+    store.delete_mcp_server_alias("io.github.test/server", "stable")
     with pytest.raises(MlflowException, match="not found"):
-        store.get_mcp_access_binding("io.github.test/s", binding.binding_id)
-    assert len(store.search_mcp_access_bindings(server_name="io.github.test/s")) == 0
-    server = store.get_mcp_server("io.github.test/s")
+        store.get_mcp_access_binding("io.github.test/server", binding.binding_id)
+    assert len(store.search_mcp_access_bindings(server_name="io.github.test/server")) == 0
+    server = store.get_mcp_server("io.github.test/server")
     assert server.aliases == {}
     assert server.access_bindings == []
 
 
 def test_delete_mcp_server_alias_not_found_raises(store):
-    store.create_mcp_server("io.github.test/s")
+    store.create_mcp_server("io.github.test/server")
     with pytest.raises(MlflowException, match="not found"):
-        store.delete_mcp_server_alias("io.github.test/s", "io.github.test/nonexistent")
+        store.delete_mcp_server_alias("io.github.test/server", "io.github.test/nonexistent")
 
 
 def test_set_mcp_server_alias_nonexistent_version_raises(store):
-    store.create_mcp_server("io.github.test/s")
+    store.create_mcp_server("io.github.test/server")
     with pytest.raises(MlflowException, match="not found"):
-        store.set_mcp_server_alias("io.github.test/s", "stable", "io.github.test/nonexistent")
+        store.set_mcp_server_alias("io.github.test/server", "stable", "io.github.test/nonexistent")
 
 
 def test_aliases_appear_on_server(store):
-    store.create_mcp_server_version(_server_json("io.github.test/s", "1.0.0"))
-    store.set_mcp_server_alias("io.github.test/s", "stable", "1.0.0")
-    server = store.get_mcp_server("io.github.test/s")
+    store.create_mcp_server_version(_server_json("io.github.test/server", "1.0.0"))
+    store.set_mcp_server_alias("io.github.test/server", "stable", "1.0.0")
+    server = store.get_mcp_server("io.github.test/server")
     assert "stable" in server.aliases
     assert server.aliases["stable"] == "1.0.0"
 
@@ -1118,7 +1174,9 @@ def test_aliases_appear_on_server(store):
 )
 def test_valid_status_transitions(store, from_status, to_status):
     store.create_mcp_server_version(_server_json(), status=from_status)
-    updated = store.update_mcp_server_version("io.github.test/server", "1.0.0", status=to_status)
+    updated = store.update_mcp_server_version(
+        "io.github.test/servererver", "1.0.0", status=to_status
+    )
     assert updated.status == to_status
 
 
@@ -1132,7 +1190,7 @@ def test_valid_status_transitions(store, from_status, to_status):
 def test_invalid_status_transitions(store, from_status, to_status):
     store.create_mcp_server_version(_server_json(), status=from_status)
     with pytest.raises(MlflowException, match="Invalid status transition"):
-        store.update_mcp_server_version("io.github.test/server", "1.0.0", status=to_status)
+        store.update_mcp_server_version("io.github.test/servererver", "1.0.0", status=to_status)
 
 
 # --- filter_string ---
@@ -1158,28 +1216,28 @@ def test_search_mcp_servers_filter_by_name_like(store):
 
 
 def test_search_mcp_servers_filter_by_tag(store):
-    store.create_mcp_server("io.github.test/s1")
-    store.create_mcp_server("io.github.test/s2")
-    store.create_mcp_server("io.github.test/s3")
-    store.set_mcp_server_tag("io.github.test/s1", "env", "prod")
-    store.set_mcp_server_tag("io.github.test/s2", "env", "staging")
-    store.set_mcp_server_tag("io.github.test/s3", "env", "prod")
+    store.create_mcp_server("io.github.test/server1")
+    store.create_mcp_server("io.github.test/server2")
+    store.create_mcp_server("io.github.test/server3")
+    store.set_mcp_server_tag("io.github.test/server1", "env", "prod")
+    store.set_mcp_server_tag("io.github.test/server2", "env", "staging")
+    store.set_mcp_server_tag("io.github.test/server3", "env", "prod")
     result = store.search_mcp_servers(filter_string="tags.env = 'prod'")
     assert len(result) == 2
     names = {s.name for s in result}
-    assert names == {"io.github.test/s1", "io.github.test/s3"}
+    assert names == {"io.github.test/server1", "io.github.test/server3"}
 
 
 def test_search_mcp_servers_filter_by_multiple_tags(store):
-    store.create_mcp_server("io.github.test/s1")
-    store.create_mcp_server("io.github.test/s2")
-    store.set_mcp_server_tag("io.github.test/s1", "env", "prod")
-    store.set_mcp_server_tag("io.github.test/s1", "team", "ai-hub")
-    store.set_mcp_server_tag("io.github.test/s2", "env", "prod")
-    store.set_mcp_server_tag("io.github.test/s2", "team", "other")
+    store.create_mcp_server("io.github.test/server1")
+    store.create_mcp_server("io.github.test/server2")
+    store.set_mcp_server_tag("io.github.test/server1", "env", "prod")
+    store.set_mcp_server_tag("io.github.test/server1", "team", "ai-hub")
+    store.set_mcp_server_tag("io.github.test/server2", "env", "prod")
+    store.set_mcp_server_tag("io.github.test/server2", "team", "other")
     result = store.search_mcp_servers(filter_string="tags.env = 'prod' AND tags.team = 'ai-hub'")
     assert len(result) == 1
-    assert result[0].name == "io.github.test/s1"
+    assert result[0].name == "io.github.test/server1"
 
 
 def test_search_mcp_servers_filter_attribute_and_tag(store):
@@ -1193,82 +1251,90 @@ def test_search_mcp_servers_filter_attribute_and_tag(store):
 
 
 def test_search_mcp_servers_filter_has_access_bindings_true(store):
-    _setup_server(store, "io.github.test/s1")
-    store.create_mcp_server("io.github.test/s2")
-    _setup_server(store, "io.github.test/s3")
-    store.create_mcp_access_binding("io.github.test/s1", "https://a.com", server_version="1.0.0")
-    store.create_mcp_access_binding("io.github.test/s3", "https://b.com", server_version="1.0.0")
+    _setup_server(store, "io.github.test/server1")
+    store.create_mcp_server("io.github.test/server2")
+    _setup_server(store, "io.github.test/server3")
+    store.create_mcp_access_binding(
+        "io.github.test/server1", "https://a.com", server_version="1.0.0"
+    )
+    store.create_mcp_access_binding(
+        "io.github.test/server3", "https://b.com", server_version="1.0.0"
+    )
     result = store.search_mcp_servers(filter_string="has_access_bindings = 'true'")
     assert len(result) == 2
     names = {s.name for s in result}
-    assert names == {"io.github.test/s1", "io.github.test/s3"}
+    assert names == {"io.github.test/server1", "io.github.test/server3"}
 
 
 def test_search_mcp_servers_filter_by_status_uses_resolved_latest(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s1", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server1", "1.0.0"), status=MCPStatus.ACTIVE
     )
     store.create_mcp_server_version(
-        _server_json("io.github.test/s1", "2.0.0"), status=MCPStatus.DEPRECATED
+        _server_json("io.github.test/server1", "2.0.0"), status=MCPStatus.DEPRECATED
     )
     store.create_mcp_server_version(
-        _server_json("io.github.test/s2", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server2", "1.0.0"), status=MCPStatus.ACTIVE
     )
     result = store.search_mcp_servers(filter_string="status = 'active'")
     names = {s.name for s in result}
-    assert names == {"io.github.test/s1", "io.github.test/s2"}
+    assert names == {"io.github.test/server1", "io.github.test/server2"}
 
 
 def test_search_mcp_servers_filter_by_status_with_active_version(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.ACTIVE
     )
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "2.0.0"), status=MCPStatus.DEPRECATED
+        _server_json("io.github.test/server", "2.0.0"), status=MCPStatus.DEPRECATED
     )
     result = store.search_mcp_servers(filter_string="status = 'active'")
     assert len(result) == 1
-    assert result[0].name == "io.github.test/s"
+    assert result[0].name == "io.github.test/server"
 
 
 def test_search_mcp_servers_filter_by_status_no_versions(store):
-    store.create_mcp_server("io.github.test/s1")
+    store.create_mcp_server("io.github.test/server1")
     store.create_mcp_server_version(
-        _server_json("io.github.test/s2", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server2", "1.0.0"), status=MCPStatus.ACTIVE
     )
     result = store.search_mcp_servers(filter_string="status = 'active'")
     assert len(result) == 1
-    assert result[0].name == "io.github.test/s2"
+    assert result[0].name == "io.github.test/server2"
 
 
 def test_search_mcp_servers_empty_filter_string(store):
-    store.create_mcp_server("io.github.test/s1")
-    store.create_mcp_server("io.github.test/s2")
+    store.create_mcp_server("io.github.test/server1")
+    store.create_mcp_server("io.github.test/server2")
     result = store.search_mcp_servers(filter_string="")
     assert len(result) == 2
 
 
 def test_search_mcp_servers_filter_has_access_bindings_false(store):
-    _setup_server(store, "io.github.test/s1")
-    store.create_mcp_server("io.github.test/s2")
-    _setup_server(store, "io.github.test/s3")
-    store.create_mcp_access_binding("io.github.test/s1", "https://a.com", server_version="1.0.0")
-    store.create_mcp_access_binding("io.github.test/s3", "https://b.com", server_version="1.0.0")
+    _setup_server(store, "io.github.test/server1")
+    store.create_mcp_server("io.github.test/server2")
+    _setup_server(store, "io.github.test/server3")
+    store.create_mcp_access_binding(
+        "io.github.test/server1", "https://a.com", server_version="1.0.0"
+    )
+    store.create_mcp_access_binding(
+        "io.github.test/server3", "https://b.com", server_version="1.0.0"
+    )
     result = store.search_mcp_servers(filter_string="has_access_bindings = 'false'")
     assert len(result) == 1
-    assert result[0].name == "io.github.test/s2"
+    assert result[0].name == "io.github.test/server2"
 
 
 def test_search_mcp_access_bindings_filter_by_transport_type(store):
-    _setup_server(store, "io.github.test/s")
+    _setup_server(store, "io.github.test/server")
     store.create_mcp_access_binding(
-        "io.github.test/s",
+        "io.github.test/server",
         "https://a.com",
         server_version="1.0.0",
         transport_type=MCPRemoteTransportType.STREAMABLE_HTTP,
     )
     store.create_mcp_access_binding(
-        "io.github.test/s",
+        "io.github.test/server",
         "https://b.com",
         server_version="1.0.0",
         transport_type=MCPRemoteTransportType.SSE,
@@ -1280,32 +1346,32 @@ def test_search_mcp_access_bindings_filter_by_transport_type(store):
 
 def test_search_mcp_servers_filter_by_status_in(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s1", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server1", "1.0.0"), status=MCPStatus.ACTIVE
     )
     store.create_mcp_server_version(
-        _server_json("io.github.test/s2", "1.0.0"), status=MCPStatus.DRAFT
+        _server_json("io.github.test/server2", "1.0.0"), status=MCPStatus.DRAFT
     )
     store.create_mcp_server_version(
-        _server_json("io.github.test/s3", "1.0.0"), status=MCPStatus.DEPRECATED
+        _server_json("io.github.test/server3", "1.0.0"), status=MCPStatus.DEPRECATED
     )
     result = store.search_mcp_servers(filter_string="status IN ('active', 'deprecated')")
     assert len(result) == 2
     names = {s.name for s in result}
-    assert names == {"io.github.test/s1", "io.github.test/s3"}
+    assert names == {"io.github.test/server1", "io.github.test/server3"}
 
 
 def test_search_mcp_server_versions_filter_by_status_in(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.ACTIVE
     )
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "2.0.0"), status=MCPStatus.DRAFT
+        _server_json("io.github.test/server", "2.0.0"), status=MCPStatus.DRAFT
     )
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "3.0.0"), status=MCPStatus.DEPRECATED
+        _server_json("io.github.test/server", "3.0.0"), status=MCPStatus.DEPRECATED
     )
     result = store.search_mcp_server_versions(
-        "io.github.test/s", filter_string="status IN ('active', 'deprecated')"
+        "io.github.test/server", filter_string="status IN ('active', 'deprecated')"
     )
     assert len(result) == 2
     versions = {v.version for v in result}
@@ -1314,31 +1380,33 @@ def test_search_mcp_server_versions_filter_by_status_in(store):
 
 def test_search_mcp_servers_filter_by_status(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s1", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server1", "1.0.0"), status=MCPStatus.ACTIVE
     )
     store.create_mcp_server_version(
-        _server_json("io.github.test/s2", "1.0.0"), status=MCPStatus.DRAFT
+        _server_json("io.github.test/server2", "1.0.0"), status=MCPStatus.DRAFT
     )
     store.create_mcp_server_version(
-        _server_json("io.github.test/s3", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server3", "1.0.0"), status=MCPStatus.ACTIVE
     )
     result = store.search_mcp_servers(filter_string="status = 'active'")
     assert len(result) == 2
     names = {s.name for s in result}
-    assert names == {"io.github.test/s1", "io.github.test/s3"}
+    assert names == {"io.github.test/server1", "io.github.test/server3"}
 
 
 def test_search_mcp_server_versions_filter_by_status(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.ACTIVE
     )
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "2.0.0"), status=MCPStatus.DRAFT
+        _server_json("io.github.test/server", "2.0.0"), status=MCPStatus.DRAFT
     )
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "3.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "3.0.0"), status=MCPStatus.ACTIVE
     )
-    result = store.search_mcp_server_versions("io.github.test/s", filter_string="status = 'active'")
+    result = store.search_mcp_server_versions(
+        "io.github.test/server", filter_string="status = 'active'"
+    )
     assert len(result) == 2
     versions = {v.version for v in result}
     assert versions == {"1.0.0", "3.0.0"}
@@ -1353,13 +1421,13 @@ def test_search_mcp_servers_filter_invalid_attribute(store):
 
 
 def test_get_mcp_access_binding(store):
-    _setup_server(store, "io.github.test/s")
+    _setup_server(store, "io.github.test/server")
     created = store.create_mcp_access_binding(
-        "io.github.test/s", "https://a.com", server_version="1.0.0"
+        "io.github.test/server", "https://a.com", server_version="1.0.0"
     )
-    fetched = store.get_mcp_access_binding("io.github.test/s", created.binding_id)
+    fetched = store.get_mcp_access_binding("io.github.test/server", created.binding_id)
     assert fetched.binding_id == created.binding_id
-    assert fetched.server_name == "io.github.test/s"
+    assert fetched.server_name == "io.github.test/server"
     assert fetched.endpoint_url == "https://a.com"
     assert fetched.server_version == "1.0.0"
     assert fetched.transport_type == MCPRemoteTransportType.STREAMABLE_HTTP
@@ -1370,39 +1438,39 @@ def test_get_mcp_access_binding(store):
 
 def test_update_mcp_access_binding_version_clears_alias(store):
     _setup_server(
-        store, "io.github.test/s", versions=("1.0.0", "2.0.0"), aliases={"stable": "1.0.0"}
+        store, "io.github.test/server", versions=("1.0.0", "2.0.0"), aliases={"stable": "1.0.0"}
     )
     binding = store.create_mcp_access_binding(
-        "io.github.test/s", "https://a.com", server_alias="stable"
+        "io.github.test/server", "https://a.com", server_alias="stable"
     )
     assert binding.server_alias == "stable"
     updated = store.update_mcp_access_binding(
-        "io.github.test/s", binding.binding_id, server_version="2.0.0"
+        "io.github.test/server", binding.binding_id, server_version="2.0.0"
     )
     assert updated.server_version == "2.0.0"
     assert updated.server_alias is None
 
 
 def test_update_mcp_access_binding_alias_clears_version(store):
-    _setup_server(store, "io.github.test/s", aliases={"prod": "1.0.0"})
+    _setup_server(store, "io.github.test/server", aliases={"prod": "1.0.0"})
     binding = store.create_mcp_access_binding(
-        "io.github.test/s", "https://a.com", server_version="1.0.0"
+        "io.github.test/server", "https://a.com", server_version="1.0.0"
     )
     assert binding.server_version == "1.0.0"
     updated = store.update_mcp_access_binding(
-        "io.github.test/s", binding.binding_id, server_alias="prod"
+        "io.github.test/server", binding.binding_id, server_alias="prod"
     )
     assert updated.server_alias == "prod"
     assert updated.server_version is None
 
 
 def test_update_mcp_access_binding_endpoint_and_transport(store):
-    _setup_server(store, "io.github.test/s")
+    _setup_server(store, "io.github.test/server")
     binding = store.create_mcp_access_binding(
-        "io.github.test/s", "https://a.com", server_version="1.0.0"
+        "io.github.test/server", "https://a.com", server_version="1.0.0"
     )
     updated = store.update_mcp_access_binding(
-        "io.github.test/s",
+        "io.github.test/server",
         binding.binding_id,
         endpoint_url="https://b.com",
         transport_type=MCPRemoteTransportType.SSE,
@@ -1412,67 +1480,74 @@ def test_update_mcp_access_binding_endpoint_and_transport(store):
 
 
 def test_update_mcp_access_binding_endpoint_url_none_raises(store):
-    _setup_server(store, "io.github.test/s")
+    _setup_server(store, "io.github.test/server")
     binding = store.create_mcp_access_binding(
-        "io.github.test/s", "https://a.com", server_version="1.0.0"
+        "io.github.test/server", "https://a.com", server_version="1.0.0"
     )
     with pytest.raises(MlflowException, match="endpoint_url cannot be None") as exc:
-        store.update_mcp_access_binding("io.github.test/s", binding.binding_id, endpoint_url=None)
+        store.update_mcp_access_binding(
+            "io.github.test/server", binding.binding_id, endpoint_url=None
+        )
     assert exc.value.error_code == "INVALID_PARAMETER_VALUE"
 
 
 def test_update_mcp_access_binding_both_version_and_alias_raises(store):
-    _setup_server(store, "io.github.test/s", aliases={"stable": "1.0.0"})
+    _setup_server(store, "io.github.test/server", aliases={"stable": "1.0.0"})
     binding = store.create_mcp_access_binding(
-        "io.github.test/s", "https://a.com", server_version="1.0.0"
+        "io.github.test/server", "https://a.com", server_version="1.0.0"
     )
     with pytest.raises(MlflowException, match="Cannot set both"):
         store.update_mcp_access_binding(
-            "io.github.test/s", binding.binding_id, server_version="1.0.0", server_alias="stable"
+            "io.github.test/server",
+            binding.binding_id,
+            server_version="1.0.0",
+            server_alias="stable",
         )
 
 
 def test_update_mcp_access_binding_nonexistent_version_raises(store):
-    _setup_server(store, "io.github.test/s")
+    _setup_server(store, "io.github.test/server")
     binding = store.create_mcp_access_binding(
-        "io.github.test/s", "https://a.com", server_version="1.0.0"
+        "io.github.test/server", "https://a.com", server_version="1.0.0"
     )
     with pytest.raises(MlflowException, match="not found"):
         store.update_mcp_access_binding(
-            "io.github.test/s", binding.binding_id, server_version="9.9.0"
+            "io.github.test/server", binding.binding_id, server_version="9.9.0"
         )
 
 
 def test_update_mcp_access_binding_deleted_version_raises(store):
-    _setup_server(store, "io.github.test/s", versions=("1.0.0", "2.0.0"))
+    _setup_server(store, "io.github.test/server", versions=("1.0.0", "2.0.0"))
     binding = store.create_mcp_access_binding(
-        "io.github.test/s", "https://a.com", server_version="1.0.0"
+        "io.github.test/server", "https://a.com", server_version="1.0.0"
     )
-    store.delete_mcp_server_version("io.github.test/s", "2.0.0")
+    store.delete_mcp_server_version("io.github.test/server", "2.0.0")
     with pytest.raises(MlflowException, match="deleted MCP server version"):
         store.update_mcp_access_binding(
-            "io.github.test/s", binding.binding_id, server_version="2.0.0"
+            "io.github.test/server", binding.binding_id, server_version="2.0.0"
         )
 
 
 def test_update_mcp_access_binding_nonexistent_alias_raises(store):
-    _setup_server(store, "io.github.test/s")
+    _setup_server(store, "io.github.test/server")
     binding = store.create_mcp_access_binding(
-        "io.github.test/s", "https://a.com", server_version="1.0.0"
+        "io.github.test/server", "https://a.com", server_version="1.0.0"
     )
     with pytest.raises(MlflowException, match="not found"):
-        store.update_mcp_access_binding("io.github.test/s", binding.binding_id, server_alias="fake")
+        store.update_mcp_access_binding(
+            "io.github.test/server", binding.binding_id, server_alias="fake"
+        )
 
 
 def test_update_mcp_access_binding_wrong_server_raises(store):
-    _setup_server(store, "io.github.test/s1")
-    _setup_server(store, "io.github.test/s2")
+    _setup_server(store, "io.github.test/server1")
+    _setup_server(store, "io.github.test/server2")
     binding = store.create_mcp_access_binding(
-        "io.github.test/s1", "https://a.com", server_version="1.0.0"
+        "io.github.test/server1", "https://a.com", server_version="1.0.0"
     )
     with pytest.raises(MlflowException, match="does not belong"):
         store.update_mcp_access_binding(
-            "io.github.test/s2", binding.binding_id, endpoint_url="https://b.com"
+            "io.github.test/server2", binding.binding_id, endpoint_url="https://b.com"
         )
 
 
@@ -1481,17 +1556,17 @@ def test_update_mcp_access_binding_wrong_server_raises(store):
 
 def test_search_mcp_server_versions_pagination(store):
     for i in range(5):
-        store.create_mcp_server_version(_server_json("io.github.test/s", f"{i}.0.0"))
-    page1 = store.search_mcp_server_versions("io.github.test/s", max_results=2)
+        store.create_mcp_server_version(_server_json("io.github.test/server", f"{i}.0.0"))
+    page1 = store.search_mcp_server_versions("io.github.test/server", max_results=2)
     assert len(page1) == 2
     assert page1.token is not None
     page2 = store.search_mcp_server_versions(
-        "io.github.test/s", max_results=2, page_token=page1.token
+        "io.github.test/server", max_results=2, page_token=page1.token
     )
     assert len(page2) == 2
     assert page2.token is not None
     page3 = store.search_mcp_server_versions(
-        "io.github.test/s", max_results=2, page_token=page2.token
+        "io.github.test/server", max_results=2, page_token=page2.token
     )
     assert len(page3) == 1
     assert page3.token is None
@@ -1505,14 +1580,14 @@ def test_search_mcp_server_versions_pagination_same_timestamp_uses_version_tiebr
         lambda: 1000,
     )
     for version in ("1.0.0-beta", "1.0.0-alpha", "1.0.0-gamma"):
-        store.create_mcp_server_version(_server_json("io.github.test/s", version))
+        store.create_mcp_server_version(_server_json("io.github.test/server", version))
 
-    page1 = store.search_mcp_server_versions("io.github.test/s", max_results=1)
+    page1 = store.search_mcp_server_versions("io.github.test/server", max_results=1)
     page2 = store.search_mcp_server_versions(
-        "io.github.test/s", max_results=1, page_token=page1.token
+        "io.github.test/server", max_results=1, page_token=page1.token
     )
     page3 = store.search_mcp_server_versions(
-        "io.github.test/s", max_results=1, page_token=page2.token
+        "io.github.test/server", max_results=1, page_token=page2.token
     )
 
     assert [v.version for v in page1] == ["1.0.0-alpha"]
@@ -1565,20 +1640,20 @@ def test_search_mcp_servers_order_by_duplicate_key(store):
 
 
 def test_delete_mcp_access_binding_wrong_server_raises(store):
-    _setup_server(store, "io.github.test/s1")
-    _setup_server(store, "io.github.test/s2")
+    _setup_server(store, "io.github.test/server1")
+    _setup_server(store, "io.github.test/server2")
     binding = store.create_mcp_access_binding(
-        "io.github.test/s1", "https://a.com", server_version="1.0.0"
+        "io.github.test/server1", "https://a.com", server_version="1.0.0"
     )
     with pytest.raises(MlflowException, match="does not belong"):
-        store.delete_mcp_access_binding("io.github.test/s2", binding.binding_id)
+        store.delete_mcp_access_binding("io.github.test/server2", binding.binding_id)
 
 
 def test_delete_mcp_server_version_tag_not_found_raises(store):
-    store.create_mcp_server_version(_server_json("io.github.test/s", "1.0.0"))
+    store.create_mcp_server_version(_server_json("io.github.test/server", "1.0.0"))
     with pytest.raises(MlflowException, match="not found"):
         store.delete_mcp_server_version_tag(
-            "io.github.test/s", "1.0.0", "io.github.test/nonexistent"
+            "io.github.test/server", "1.0.0", "io.github.test/nonexistent"
         )
 
 
@@ -1588,10 +1663,10 @@ def test_update_mcp_server_version_not_found_raises(store):
 
 
 def test_search_mcp_access_bindings_pagination(store):
-    _setup_server(store, "io.github.test/s")
+    _setup_server(store, "io.github.test/server")
     for i in range(5):
         store.create_mcp_access_binding(
-            "io.github.test/s", f"https://{i}.com", server_version="1.0.0"
+            "io.github.test/server", f"https://{i}.com", server_version="1.0.0"
         )
     page1 = store.search_mcp_access_bindings(max_results=2)
     assert len(page1) == 2
@@ -1605,20 +1680,20 @@ def test_search_mcp_access_bindings_pagination(store):
 
 
 def test_search_mcp_server_versions_order_by(store):
-    store.create_mcp_server_version(_server_json("io.github.test/s", "1.0.0-alpha"))
-    store.create_mcp_server_version(_server_json("io.github.test/s", "1.0.0-beta"))
-    store.create_mcp_server_version(_server_json("io.github.test/s", "1.0.0-gamma"))
-    result = store.search_mcp_server_versions("io.github.test/s", order_by=["`version` DESC"])
+    store.create_mcp_server_version(_server_json("io.github.test/server", "1.0.0-alpha"))
+    store.create_mcp_server_version(_server_json("io.github.test/server", "1.0.0-beta"))
+    store.create_mcp_server_version(_server_json("io.github.test/server", "1.0.0-gamma"))
+    result = store.search_mcp_server_versions("io.github.test/server", order_by=["`version` DESC"])
     versions = [v.version for v in result]
     assert versions == ["1.0.0-gamma", "1.0.0-beta", "1.0.0-alpha"]
 
 
 def test_search_mcp_server_versions_order_by_version_uses_semver_desc(store):
     for version in ("1.2.0-alpha", "1.2.0", "1.10.0"):
-        store.create_mcp_server_version(_server_json("io.github.test/semver-desc", version))
+        store.create_mcp_server_version(_server_json("io.github.test/serveremver-desc", version))
 
     result = store.search_mcp_server_versions(
-        "io.github.test/semver-desc",
+        "io.github.test/serveremver-desc",
         order_by=["`version` DESC"],
     )
     versions = [v.version for v in result]
@@ -1627,10 +1702,10 @@ def test_search_mcp_server_versions_order_by_version_uses_semver_desc(store):
 
 def test_search_mcp_server_versions_order_by_version_uses_semver_asc(store):
     for version in ("1.2.0-alpha", "1.2.0", "1.10.0"):
-        store.create_mcp_server_version(_server_json("io.github.test/semver-asc", version))
+        store.create_mcp_server_version(_server_json("io.github.test/serveremver-asc", version))
 
     result = store.search_mcp_server_versions(
-        "io.github.test/semver-asc",
+        "io.github.test/serveremver-asc",
         order_by=["`version` ASC"],
     )
     versions = [v.version for v in result]
@@ -1639,10 +1714,12 @@ def test_search_mcp_server_versions_order_by_version_uses_semver_asc(store):
 
 def test_search_mcp_server_versions_order_by_version_ignores_build_metadata_precedence(store):
     for version in ("1.0.1", "1.0.0+aaa", "1.0.0+zzz"):
-        store.create_mcp_server_version(_server_json("io.github.test/semver-build-desc", version))
+        store.create_mcp_server_version(
+            _server_json("io.github.test/serveremver-build-desc", version)
+        )
 
     result = store.search_mcp_server_versions(
-        "io.github.test/semver-build-desc",
+        "io.github.test/serveremver-build-desc",
         order_by=["`version` DESC"],
     )
     versions = [v.version for v in result]
@@ -1652,10 +1729,10 @@ def test_search_mcp_server_versions_order_by_version_ignores_build_metadata_prec
 
 def test_search_mcp_server_versions_filter_by_version_equality_uses_exact_string_match(store):
     for version in ("1.0.0-alpha+aaa", "1.0.0-alpha+zzz", "1.0.0"):
-        store.create_mcp_server_version(_server_json("io.github.test/semver-eq", version))
+        store.create_mcp_server_version(_server_json("io.github.test/serveremver-eq", version))
 
     result = store.search_mcp_server_versions(
-        "io.github.test/semver-eq",
+        "io.github.test/serveremver-eq",
         filter_string="version = '1.0.0-alpha+aaa'",
     )
     versions = {v.version for v in result}
@@ -1664,10 +1741,10 @@ def test_search_mcp_server_versions_filter_by_version_equality_uses_exact_string
 
 def test_search_mcp_server_versions_filter_by_version_inequality_uses_semver_precedence(store):
     for version in ("1.2.0-alpha", "1.2.0", "1.10.0"):
-        store.create_mcp_server_version(_server_json("io.github.test/semver-gt", version))
+        store.create_mcp_server_version(_server_json("io.github.test/serveremver-gt", version))
 
     result = store.search_mcp_server_versions(
-        "io.github.test/semver-gt",
+        "io.github.test/serveremver-gt",
         filter_string="version > '1.2.0-alpha'",
     )
     versions = {v.version for v in result}
@@ -1675,11 +1752,11 @@ def test_search_mcp_server_versions_filter_by_version_inequality_uses_semver_pre
 
 
 def test_search_mcp_server_versions_filter_by_version_rejects_like(store):
-    store.create_mcp_server_version(_server_json("io.github.test/semver-like", "1.2.3"))
+    store.create_mcp_server_version(_server_json("io.github.test/serveremver-like", "1.2.3"))
 
     with pytest.raises(MlflowException, match="version only supports semantic comparators"):
         store.search_mcp_server_versions(
-            "io.github.test/semver-like",
+            "io.github.test/serveremver-like",
             filter_string="version LIKE '1.%'",
         )
 
@@ -1687,12 +1764,12 @@ def test_search_mcp_server_versions_filter_by_version_rejects_like(store):
 def test_create_mcp_access_binding_with_latest_alias(store):
     # Create server with an active version
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.ACTIVE
     )
 
     # Should be able to create a binding with server_alias="latest"
     binding = store.create_mcp_access_binding(
-        "io.github.test/s",
+        "io.github.test/server",
         "https://latest.example.com",
         server_alias="latest",
     )
@@ -1705,27 +1782,27 @@ def test_create_mcp_access_binding_with_latest_alias(store):
 
     # Create a newer version and verify "latest" now resolves to it
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "2.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "2.0.0"), status=MCPStatus.ACTIVE
     )
 
     # Retrieve the binding again to check resolution
-    retrieved_binding = store.get_mcp_access_binding("io.github.test/s", binding.binding_id)
+    retrieved_binding = store.get_mcp_access_binding("io.github.test/server", binding.binding_id)
     assert retrieved_binding.resolved_version.version == "2.0.0"
 
 
 def test_search_mcp_access_bindings_with_latest_alias(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.ACTIVE
     )
     store.create_mcp_access_binding(
-        "io.github.test/s",
+        "io.github.test/server",
         "https://latest.example.com",
         server_alias="latest",
     )
 
     # Search should find the binding and resolve its version
     bindings = store.search_mcp_access_bindings(
-        server_name="io.github.test/s",
+        server_name="io.github.test/server",
         server_alias="latest",
     )
     assert len(bindings) == 1
@@ -1735,18 +1812,18 @@ def test_search_mcp_access_bindings_with_latest_alias(store):
 
 def test_get_latest_version_without_active_version_falls_back_to_non_active(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.0.0"), status=MCPStatus.DEPRECATED
+        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.DEPRECATED
     )
-    latest = store.get_latest_mcp_server_version("io.github.test/s")
+    latest = store.get_latest_mcp_server_version("io.github.test/server")
     assert latest.version == "1.0.0"
 
 
 def test_create_binding_latest_alias_uses_non_active_fallback(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.0.0"), status=MCPStatus.DEPRECATED
+        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.DEPRECATED
     )
     binding = store.create_mcp_access_binding(
-        "io.github.test/s",
+        "io.github.test/server",
         "https://latest.example.com",
         server_alias="latest",
     )
@@ -1756,18 +1833,18 @@ def test_create_binding_latest_alias_uses_non_active_fallback(store):
 
 def test_search_binding_latest_alias_remains_resolvable_without_active_version(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.ACTIVE
     )
     binding = store.create_mcp_access_binding(
-        "io.github.test/s",
+        "io.github.test/server",
         "https://latest.example.com",
         server_alias="latest",
     )
     assert binding.resolved_version.version == "1.0.0"
 
-    store.update_mcp_server_version("io.github.test/s", "1.0.0", status=MCPStatus.DEPRECATED)
+    store.update_mcp_server_version("io.github.test/server", "1.0.0", status=MCPStatus.DEPRECATED)
 
-    bindings = store.search_mcp_access_bindings(server_name="io.github.test/s")
+    bindings = store.search_mcp_access_bindings(server_name="io.github.test/server")
     assert len(bindings) == 1
     assert bindings[0].binding_id == binding.binding_id
     assert bindings[0].resolved_version is not None
@@ -1776,62 +1853,62 @@ def test_search_binding_latest_alias_remains_resolvable_without_active_version(s
 
 def test_update_last_eligible_version_to_draft_keeps_latest_alias_bindings_when_resolvable(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.ACTIVE
     )
     binding = store.create_mcp_access_binding(
-        "io.github.test/s",
+        "io.github.test/server",
         "https://latest.example.com",
         server_alias="latest",
     )
 
-    store.update_mcp_server_version("io.github.test/s", "1.0.0", status=MCPStatus.DRAFT)
+    store.update_mcp_server_version("io.github.test/server", "1.0.0", status=MCPStatus.DRAFT)
 
-    bindings = store.search_mcp_access_bindings(server_name="io.github.test/s")
+    bindings = store.search_mcp_access_bindings(server_name="io.github.test/server")
     assert len(bindings) == 1
-    server = store.get_mcp_server("io.github.test/s")
+    server = store.get_mcp_server("io.github.test/server")
     assert len(server.access_bindings) == 1
-    persisted = store.get_mcp_access_binding("io.github.test/s", binding.binding_id)
+    persisted = store.get_mcp_access_binding("io.github.test/server", binding.binding_id)
     assert persisted.resolved_version is not None
     assert persisted.resolved_version.version == "1.0.0"
 
 
 def test_delete_last_eligible_version_cleans_up_latest_alias_bindings(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.ACTIVE
     )
     binding = store.create_mcp_access_binding(
-        "io.github.test/s",
+        "io.github.test/server",
         "https://latest.example.com",
         server_alias="latest",
     )
-    store.update_mcp_server_version("io.github.test/s", "1.0.0", status=MCPStatus.DEPRECATED)
+    store.update_mcp_server_version("io.github.test/server", "1.0.0", status=MCPStatus.DEPRECATED)
 
-    store.delete_mcp_server_version("io.github.test/s", "1.0.0")
+    store.delete_mcp_server_version("io.github.test/server", "1.0.0")
 
-    assert store.search_mcp_access_bindings(server_name="io.github.test/s") == []
-    server = store.get_mcp_server("io.github.test/s")
+    assert store.search_mcp_access_bindings(server_name="io.github.test/server") == []
+    server = store.get_mcp_server("io.github.test/server")
     assert server.access_bindings == []
     with pytest.raises(MlflowException, match="not found"):
-        store.get_mcp_access_binding("io.github.test/s", binding.binding_id)
+        store.get_mcp_access_binding("io.github.test/server", binding.binding_id)
 
 
 def test_search_unfiltered_returns_all_binding_types(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.ACTIVE
     )
-    store.set_mcp_server_alias("io.github.test/s", "prod", "1.0.0")
+    store.set_mcp_server_alias("io.github.test/server", "prod", "1.0.0")
 
     store.create_mcp_access_binding(
-        "io.github.test/s", "https://direct.example.com", server_version="1.0.0"
+        "io.github.test/server", "https://direct.example.com", server_version="1.0.0"
     )
     store.create_mcp_access_binding(
-        "io.github.test/s", "https://alias.example.com", server_alias="prod"
+        "io.github.test/server", "https://alias.example.com", server_alias="prod"
     )
     store.create_mcp_access_binding(
-        "io.github.test/s", "https://latest.example.com", server_alias="latest"
+        "io.github.test/server", "https://latest.example.com", server_alias="latest"
     )
 
-    bindings = store.search_mcp_access_bindings(server_name="io.github.test/s")
+    bindings = store.search_mcp_access_bindings(server_name="io.github.test/server")
     assert len(bindings) == 3
     urls = {b.endpoint_url for b in bindings}
     assert urls == {
@@ -1846,15 +1923,15 @@ def test_search_unfiltered_returns_all_binding_types(store):
 
 def test_update_binding_to_latest_alias(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.ACTIVE
     )
     binding = store.create_mcp_access_binding(
-        "io.github.test/s", "https://example.com", server_version="1.0.0"
+        "io.github.test/server", "https://example.com", server_version="1.0.0"
     )
     assert binding.server_version == "1.0.0"
 
     updated = store.update_mcp_access_binding(
-        "io.github.test/s",
+        "io.github.test/server",
         binding.binding_id,
         server_alias="latest",
     )
@@ -1866,12 +1943,12 @@ def test_update_binding_to_latest_alias(store):
 
 def test_get_mcp_server_includes_latest_alias_binding(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.ACTIVE
     )
     store.create_mcp_access_binding(
-        "io.github.test/s", "https://latest.example.com", server_alias="latest"
+        "io.github.test/server", "https://latest.example.com", server_alias="latest"
     )
-    server = store.get_mcp_server("io.github.test/s")
+    server = store.get_mcp_server("io.github.test/server")
     assert len(server.access_bindings) == 1
     b = server.access_bindings[0]
     assert b.server_alias == "latest"
@@ -1881,101 +1958,109 @@ def test_get_mcp_server_includes_latest_alias_binding(store):
 
 def test_search_mcp_servers_has_access_bindings_with_latest_alias(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s1", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server1", "1.0.0"), status=MCPStatus.ACTIVE
     )
     store.create_mcp_access_binding(
-        "io.github.test/s1", "https://latest.example.com", server_alias="latest"
+        "io.github.test/server1", "https://latest.example.com", server_alias="latest"
     )
     store.create_mcp_server_version(
-        _server_json("io.github.test/s2", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server2", "1.0.0"), status=MCPStatus.ACTIVE
     )
 
     result = store.search_mcp_servers(filter_string="has_access_bindings = 'true'")
     assert len(result) == 1
-    assert result[0].name == "io.github.test/s1"
+    assert result[0].name == "io.github.test/server1"
     assert len(result[0].access_bindings) == 1
     assert result[0].access_bindings[0].resolved_version.version == "1.0.0"
 
 
 def test_deleted_versions_excluded_from_get(store):
-    store.create_mcp_server_version(_server_json("io.github.test/s", "1.0.0"))
-    store.delete_mcp_server_version("io.github.test/s", "1.0.0")
+    store.create_mcp_server_version(_server_json("io.github.test/server", "1.0.0"))
+    store.delete_mcp_server_version("io.github.test/server", "1.0.0")
     with pytest.raises(MlflowException, match="not found"):
-        store.get_mcp_server_version("io.github.test/s", "1.0.0")
+        store.get_mcp_server_version("io.github.test/server", "1.0.0")
 
 
 def test_deleted_versions_excluded_from_search(store):
-    store.create_mcp_server_version(_server_json("io.github.test/s", "1.0.0"))
+    store.create_mcp_server_version(_server_json("io.github.test/server", "1.0.0"))
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "2.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "2.0.0"), status=MCPStatus.ACTIVE
     )
-    store.delete_mcp_server_version("io.github.test/s", "1.0.0")
-    result = store.search_mcp_server_versions("io.github.test/s")
+    store.delete_mcp_server_version("io.github.test/server", "1.0.0")
+    result = store.search_mcp_server_versions("io.github.test/server")
     assert len(result) == 1
     assert result[0].version == "2.0.0"
 
 
 def test_binding_resolved_version_direct(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.ACTIVE
     )
     store.create_mcp_access_binding(
-        server_name="io.github.test/s", endpoint_url="https://example.com", server_version="1.0.0"
+        server_name="io.github.test/server",
+        endpoint_url="https://example.com",
+        server_version="1.0.0",
     )
-    binding = store.search_mcp_access_bindings(server_name="io.github.test/s")[0]
+    binding = store.search_mcp_access_bindings(server_name="io.github.test/server")[0]
     assert binding.resolved_version is not None
     assert binding.resolved_version.version == "1.0.0"
-    assert binding.resolved_version.name == "io.github.test/s"
+    assert binding.resolved_version.name == "io.github.test/server"
 
 
 def test_binding_resolved_version_via_alias(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.ACTIVE
     )
-    store.set_mcp_server_alias("io.github.test/s", "prod", "1.0.0")
+    store.set_mcp_server_alias("io.github.test/server", "prod", "1.0.0")
     store.create_mcp_access_binding(
-        server_name="io.github.test/s", endpoint_url="https://example.com", server_alias="prod"
+        server_name="io.github.test/server", endpoint_url="https://example.com", server_alias="prod"
     )
-    binding = store.search_mcp_access_bindings(server_name="io.github.test/s")[0]
+    binding = store.search_mcp_access_bindings(server_name="io.github.test/server")[0]
     assert binding.resolved_version is not None
     assert binding.resolved_version.version == "1.0.0"
 
 
 def test_binding_resolved_version_on_get(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.ACTIVE
     )
     binding = store.create_mcp_access_binding(
-        server_name="io.github.test/s", endpoint_url="https://example.com", server_version="1.0.0"
+        server_name="io.github.test/server",
+        endpoint_url="https://example.com",
+        server_version="1.0.0",
     )
-    fetched = store.get_mcp_access_binding("io.github.test/s", binding.binding_id)
+    fetched = store.get_mcp_access_binding("io.github.test/server", binding.binding_id)
     assert fetched.resolved_version is not None
     assert fetched.resolved_version.version == "1.0.0"
 
 
 def test_binding_resolved_version_on_get_via_alias(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.ACTIVE
     )
-    store.set_mcp_server_alias("io.github.test/s", "prod", "1.0.0")
+    store.set_mcp_server_alias("io.github.test/server", "prod", "1.0.0")
     binding = store.create_mcp_access_binding(
-        server_name="io.github.test/s", endpoint_url="https://example.com", server_alias="prod"
+        server_name="io.github.test/server", endpoint_url="https://example.com", server_alias="prod"
     )
-    fetched = store.get_mcp_access_binding("io.github.test/s", binding.binding_id)
+    fetched = store.get_mcp_access_binding("io.github.test/server", binding.binding_id)
     assert fetched.resolved_version is not None
     assert fetched.resolved_version.version == "1.0.0"
 
 
 def test_search_bindings_filter_by_status(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.ACTIVE
     )
-    store.create_mcp_server_version(_server_json("io.github.test/s", "2.0.0"))
+    store.create_mcp_server_version(_server_json("io.github.test/server", "2.0.0"))
     store.create_mcp_access_binding(
-        server_name="io.github.test/s", endpoint_url="https://a.example.com", server_version="1.0.0"
+        server_name="io.github.test/server",
+        endpoint_url="https://a.example.com",
+        server_version="1.0.0",
     )
     store.create_mcp_access_binding(
-        server_name="io.github.test/s", endpoint_url="https://b.example.com", server_version="2.0.0"
+        server_name="io.github.test/server",
+        endpoint_url="https://b.example.com",
+        server_version="2.0.0",
     )
     result = store.search_mcp_access_bindings(filter_string="status = 'active'")
     assert len(result) == 1
@@ -1984,21 +2069,21 @@ def test_search_bindings_filter_by_status(store):
 
 def test_search_bindings_scoped_to_server_version_resolves_version(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.ACTIVE
     )
-    store.set_mcp_server_alias("io.github.test/s", "prod", "1.0.0")
+    store.set_mcp_server_alias("io.github.test/server", "prod", "1.0.0")
     store.create_mcp_access_binding(
-        server_name="io.github.test/s",
+        server_name="io.github.test/server",
         endpoint_url="https://direct.example.com",
         server_version="1.0.0",
     )
     store.create_mcp_access_binding(
-        server_name="io.github.test/s",
+        server_name="io.github.test/server",
         endpoint_url="https://alias.example.com",
         server_alias="prod",
     )
     result = store.search_mcp_access_bindings(
-        server_name="io.github.test/s", server_version="1.0.0"
+        server_name="io.github.test/server", server_version="1.0.0"
     )
     assert len(result) == 1
     assert result[0].endpoint_url == "https://direct.example.com"
@@ -2008,20 +2093,22 @@ def test_search_bindings_scoped_to_server_version_resolves_version(store):
 
 def test_search_bindings_scoped_to_server_alias_resolves_version(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.ACTIVE
     )
-    store.set_mcp_server_alias("io.github.test/s", "prod", "1.0.0")
+    store.set_mcp_server_alias("io.github.test/server", "prod", "1.0.0")
     store.create_mcp_access_binding(
-        server_name="io.github.test/s",
+        server_name="io.github.test/server",
         endpoint_url="https://direct.example.com",
         server_version="1.0.0",
     )
     store.create_mcp_access_binding(
-        server_name="io.github.test/s",
+        server_name="io.github.test/server",
         endpoint_url="https://alias.example.com",
         server_alias="prod",
     )
-    result = store.search_mcp_access_bindings(server_name="io.github.test/s", server_alias="prod")
+    result = store.search_mcp_access_bindings(
+        server_name="io.github.test/server", server_alias="prod"
+    )
     assert len(result) == 1
     assert result[0].endpoint_url == "https://alias.example.com"
     assert result[0].resolved_version is not None
@@ -2029,17 +2116,19 @@ def test_search_bindings_scoped_to_server_alias_resolves_version(store):
 
 
 def test_search_servers_numeric_timestamp_filter(store):
-    store.create_mcp_server("io.github.test/s")
+    store.create_mcp_server("io.github.test/server")
     result = store.search_mcp_servers(filter_string="created_at > 0")
     assert len(result) == 1
 
 
 def test_create_binding_returns_resolved_version(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.ACTIVE
     )
     binding = store.create_mcp_access_binding(
-        server_name="io.github.test/s", endpoint_url="https://example.com", server_version="1.0.0"
+        server_name="io.github.test/server",
+        endpoint_url="https://example.com",
+        server_version="1.0.0",
     )
     assert binding.resolved_version is not None
     assert binding.resolved_version.version == "1.0.0"
@@ -2047,13 +2136,15 @@ def test_create_binding_returns_resolved_version(store):
 
 def test_update_binding_returns_resolved_version(store):
     store.create_mcp_server_version(
-        _server_json("io.github.test/s", "1.0.0"), status=MCPStatus.ACTIVE
+        _server_json("io.github.test/server", "1.0.0"), status=MCPStatus.ACTIVE
     )
     binding = store.create_mcp_access_binding(
-        server_name="io.github.test/s", endpoint_url="https://example.com", server_version="1.0.0"
+        server_name="io.github.test/server",
+        endpoint_url="https://example.com",
+        server_version="1.0.0",
     )
     updated = store.update_mcp_access_binding(
-        server_name="io.github.test/s",
+        server_name="io.github.test/server",
         binding_id=binding.binding_id,
         endpoint_url="https://new.example.com",
     )
@@ -2062,29 +2153,33 @@ def test_update_binding_returns_resolved_version(store):
 
 
 def test_binding_to_deleted_version_hidden(store):
-    store.create_mcp_server_version(_server_json("io.github.test/s", "1.0.0"))
+    store.create_mcp_server_version(_server_json("io.github.test/server", "1.0.0"))
     store.create_mcp_access_binding(
-        server_name="io.github.test/s", endpoint_url="https://example.com", server_version="1.0.0"
+        server_name="io.github.test/server",
+        endpoint_url="https://example.com",
+        server_version="1.0.0",
     )
-    store.delete_mcp_server_version("io.github.test/s", "1.0.0")
-    result = store.search_mcp_access_bindings(server_name="io.github.test/s")
+    store.delete_mcp_server_version("io.github.test/server", "1.0.0")
+    result = store.search_mcp_access_bindings(server_name="io.github.test/server")
     assert len(result) == 0
 
 
 def test_has_access_bindings_excludes_stale_bindings(store):
-    store.create_mcp_server_version(_server_json("io.github.test/s", "1.0.0"))
+    store.create_mcp_server_version(_server_json("io.github.test/server", "1.0.0"))
     store.create_mcp_access_binding(
-        server_name="io.github.test/s", endpoint_url="https://example.com", server_version="1.0.0"
+        server_name="io.github.test/server",
+        endpoint_url="https://example.com",
+        server_version="1.0.0",
     )
     result = store.search_mcp_servers(filter_string="has_access_bindings = 'true'")
     assert len(result) == 1
-    store.delete_mcp_server_version("io.github.test/s", "1.0.0")
+    store.delete_mcp_server_version("io.github.test/server", "1.0.0")
     result = store.search_mcp_servers(filter_string="has_access_bindings = 'true'")
     assert len(result) == 0
 
 
 def test_has_access_bindings_duplicate_rejected(store):
-    store.create_mcp_server("io.github.test/s")
+    store.create_mcp_server("io.github.test/server")
     with pytest.raises(MlflowException, match="Invalid"):
         store.search_mcp_servers(
             filter_string="has_access_bindings = true AND has_access_bindings = false"


### PR DESCRIPTION
Treat reverse-DNS namespace labels as case-insensitive so valid mixed-case server names can be registered.

<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
