### PR TITLE
Pin `databricks-vectorsearch<0.74` to fix the langchain cross-version matrix

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -650,7 +650,13 @@ langchain:
           "uvicorn",
           # Required for testing Databricks dependency extraction
           "databricks-langchain",
-          "databricks-vectorsearch",
+          # Pin <0.74: 0.74 renamed databricks-vectorsearch to databricks-ai-search and
+          # turned `databricks.vector_search.*` into a re-export that drops
+          # `VectorSearchIndex`. Both this dependency-extraction test AND databricks-langchain
+          # itself import that symbol from `databricks.vector_search.client` at import time,
+          # so 0.74 breaks the whole langchain matrix. Revisit once databricks-langchain
+          # moves to databricks-ai-search.
+          "databricks-vectorsearch<0.74",
           # Required for testing uc tools
           "unitycatalog-langchain",
         ]


### PR DESCRIPTION
### Related Issues/PRs

None — fixes a repo-wide CI break from an upstream release.

### What changes are proposed in this pull request?

The langchain **Cross version tests** matrix is failing because of an upstream release: **`databricks-vectorsearch` `0.74`** renamed the package to `databricks-ai-search` and turned `databricks.vector_search.*` into a thin re-export that **drops `VectorSearchIndex`**. The dep was unpinned, so CI installed `0.74`.

Two importers pull `VectorSearchIndex` from the old `databricks.vector_search.client` path, so `0.74` breaks the whole matrix:
1. `tests/langchain/test_langchain_databricks_dependency_extraction.py` imports it directly → collection error on every langchain version.
2. **`databricks-langchain` itself** imports it at package-init, so `from databricks_langchain import ChatDatabricks` (used by the model-as-code sample chains in `test_langchain_model_export.py`) fails on langchain 1.x once collection no longer aborts.

This caps the dependency at `<0.74`, keeping `VectorSearchIndex` available at the old path for both importers.

**Why not migrate to `databricks-ai-search` instead?** Migrating only our test's import doesn't help, because `databricks-langchain` (which we don't control) still imports `VectorSearchIndex` from `databricks.vector_search.client` at import time — so `databricks_langchain` is unusable with `0.74` regardless. The cap is the only thing that fixes the full matrix until databricks-langchain itself moves to `databricks-ai-search` (noted as a follow-up in the comment).

Verified locally with langchain 1.3.4: on `databricks-vectorsearch==0.74` the import raises; capping to `<0.74` resolves cleanly (vectorsearch 0.73, databricks-langchain 0.20.0) and `from databricks_langchain import ChatDatabricks` succeeds.

**Impact is test-only.** `databricks-vectorsearch` is declared only in `ml-package-versions.yml` (langchain cross-version tests) — not in any `requirements/*.txt`, `pyproject.toml`, or the skinny requirements. Shipped MLflow uses `DatabricksVectorSearchIndex` from `mlflow.models.resources` and reaches the index by duck-typing; it never imports the SDK symbol.

### How is this PR tested?

- [x] Existing unit/integration tests

The langchain cross-version matrix that was failing exercises this. Verified the resolution + imports locally with the breaking and capped versions; YAML parses; ruff + clint clean.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.