### PR TITLE
Clarify review-queue remove button: "Unassign" with unlink icon and hover tooltip

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewQueueList.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewQueueList.test.tsx
@@ -191,9 +191,9 @@ describe('ReviewQueueList', () => {
     // checkboxes[0] is select-all; [1] is the first row.
     const checkboxes = screen.getAllByRole('checkbox');
     fireEvent.click(checkboxes[1]);
-    expect(screen.getByRole('button', { name: /1 trace/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Unassign' })).toBeInTheDocument();
     // Switching filters resets the selection so hidden rows can't be deleted.
     fireEvent.click(screen.getByText('Completed (1)'));
-    expect(screen.queryByRole('button', { name: /trace/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Unassign' })).not.toBeInTheDocument();
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewQueueList.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewQueueList.tsx
@@ -5,6 +5,7 @@ import {
   Checkbox,
   DropdownMenu,
   GearIcon,
+  LinkOffIcon,
   NewWindowIcon,
   PlusIcon,
   SearchIcon,
@@ -15,7 +16,7 @@ import {
   TableHeader,
   TableRow,
   Tag,
-  TrashIcon,
+  Tooltip,
   Typography,
   useDesignSystemTheme,
 } from '@databricks/design-system';
@@ -320,20 +321,30 @@ export const ReviewQueueList = ({
             </Button>
           )}
           {selectable && selected.size > 0 && (
-            <Button
-              componentId={`${CID}.delete-selected`}
-              danger
-              icon={<TrashIcon />}
-              disabled={isRemovingItems}
-              loading={isRemovingItems}
-              onClick={handleDelete}
+            <Tooltip
+              componentId={`${CID}.unassign-selected.tooltip`}
+              content={intl.formatMessage(
+                {
+                  defaultMessage: 'Unassign {count, plural, one {# trace} other {# traces}} from the queue',
+                  description:
+                    'Review queue: tooltip explaining that the button removes the selected traces from the queue (the traces themselves are not deleted)',
+                },
+                { count: selected.size },
+              )}
             >
-              <FormattedMessage
-                defaultMessage="Remove {count, plural, one {# trace} other {# traces}} from queue"
-                description="Review queue: button that removes the selected traces from the queue (the traces themselves are not deleted)"
-                values={{ count: selected.size }}
-              />
-            </Button>
+              <Button
+                componentId={`${CID}.delete-selected`}
+                icon={<LinkOffIcon />}
+                disabled={isRemovingItems}
+                loading={isRemovingItems}
+                onClick={handleDelete}
+              >
+                <FormattedMessage
+                  defaultMessage="Unassign"
+                  description="Review queue: button that removes the selected traces from the queue (the traces themselves are not deleted)"
+                />
+              </Button>
+            </Tooltip>
           )}
         </div>
       )}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewQueueList.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewQueueList.tsx
@@ -329,8 +329,8 @@ export const ReviewQueueList = ({
               onClick={handleDelete}
             >
               <FormattedMessage
-                defaultMessage="Remove {count, plural, one {# trace} other {# traces}}"
-                description="Review queue: remove selected traces button"
+                defaultMessage="Remove {count, plural, one {# trace} other {# traces}} from queue"
+                description="Review queue: button that removes the selected traces from the queue (the traces themselves are not deleted)"
                 values={{ count: selected.size }}
               />
             </Button>

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -3487,6 +3487,10 @@
     "defaultMessage": "Predict on a Pandas DataFrame:",
     "description": "Section heading to display the code block on how we can use registered model to predict using pandas DataFrame"
   },
+  "GYxv/z": {
+    "defaultMessage": "Unassign {count, plural, one {# trace} other {# traces}} from the queue",
+    "description": "Review queue: tooltip explaining that the button removes the selected traces from the queue (the traces themselves are not deleted)"
+  },
   "GbEHyg": {
     "defaultMessage": "Name",
     "description": "Section title for endpoint name"
@@ -6111,6 +6115,10 @@
     "defaultMessage": "Created: {date}",
     "description": "Issue creation date label"
   },
+  "Uod74j": {
+    "defaultMessage": "Unassign",
+    "description": "Review queue: button that removes the selected traces from the queue (the traces themselves are not deleted)"
+  },
   "UpVskF": {
     "defaultMessage": "Expectations",
     "description": "Header for the dataset record expectations column"
@@ -7922,10 +7930,6 @@
   "dYbJha": {
     "defaultMessage": "Please provide run name",
     "description": "Experiment page > new run modal > invalid state - no run name provided"
-  },
-  "dcYM63": {
-    "defaultMessage": "Remove {count, plural, one {# trace} other {# traces}} from queue",
-    "description": "Review queue: button that removes the selected traces from the queue (the traces themselves are not deleted)"
   },
   "dd8i7f": {
     "defaultMessage": "Define custom instructions for LLM evaluation",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -5727,10 +5727,6 @@
     "defaultMessage": "LLM judge feedback",
     "description": "Tooltip content for LLM judge feedback"
   },
-  "SlI2G2": {
-    "defaultMessage": "Remove {count, plural, one {# trace} other {# traces}}",
-    "description": "Review queue: remove selected traces button"
-  },
   "Sm0bXt": {
     "defaultMessage": "None",
     "description": "Label for a user_frustration assessment with 'none' value"
@@ -7926,6 +7922,10 @@
   "dYbJha": {
     "defaultMessage": "Please provide run name",
     "description": "Experiment page > new run modal > invalid state - no run name provided"
+  },
+  "dcYM63": {
+    "defaultMessage": "Remove {count, plural, one {# trace} other {# traces}} from queue",
+    "description": "Review queue: button that removes the selected traces from the queue (the traces themselves are not deleted)"
   },
   "dd8i7f": {
     "defaultMessage": "Define custom instructions for LLM evaluation",


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23938

### What changes are proposed in this pull request?

Clarify the review-queue bulk remove button so it no longer reads as if it deletes the traces themselves. The button now shows a short "Unassign" label with an unlink icon, and the full "Unassign N traces from the queue" text appears on hover. The unlink icon (instead of a trash icon) avoids the impression that the traces are being deleted.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Verified in the dev server with a seeded queue. With traces selected, the button renders as "Unassign" and the tooltip reads "Unassign N traces from the queue":

https://github.com/user-attachments/assets/15b3afed-ee47-4cce-a3e3-37dc22340e56


### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release