### PR TITLE
auth: decouple user enumeration directory from workspace creation via capability toggle (#23850)

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -1627,15 +1627,21 @@ def validate_can_read_user():
 
 
 def validate_can_list_users():
-    # Any workspace member may list users: the review-queue assignment UI needs the
-    # roster so a (non-admin) experiment manager can pick reviewers to assign.
-    # Listing grants no access on its own — assigning a user to a queue still
-    # requires experiment MANAGE. Scope it to the request workspace so the roster
-    # isn't leaked across workspaces: ``_user_can_create_in_workspace`` requires a
-    # workspace-wide grant when workspaces are enabled, and allows any authenticated
-    # user when they're disabled (single-tenant). (Super admins short-circuit in
-    # ``_before_request`` and never reach this validator.)
+    # If explicit user directory enumeration rules are turned on, do not default
+    # to all workspace creation members. Instead, confirm they explicitly carry
+    # MANAGE privileges within the targeted workspace context.
+    if getattr(auth_config, "enforce_user_enumeration_capability", False):
+        if not MLFLOW_ENABLE_WORKSPACES.get():
+            return True
+        workspace_name = workspace_context.get_request_workspace()
+        if workspace_name is None:
+            return False
+        user = store.get_user(authenticate_request().username)
+        perm = store.get_role_permission_for_resource(user.id, "workspace", "*", workspace_name)
+        return perm is not None and perm.can_manage
+
     return _user_can_create_in_workspace()
+
 
 
 def validate_can_create_user():

--- a/mlflow/server/auth/basic_auth.ini
+++ b/mlflow/server/auth/basic_auth.ini
@@ -28,3 +28,7 @@ grant_default_workspace_access = false
 # (e.g. 60) to opt in.
 # auth_cache_max_size = 10000
 # auth_cache_ttl_seconds = 0
+# When true, user directory enumeration (/mlflow/users/list) is decoupled
+# from general workspace creation access. Users will be required to explicitly
+# hold MANAGE permissions within the request workspace to list the full roster.
+# enforce_user_enumeration_capability = false

--- a/mlflow/server/auth/config.py
+++ b/mlflow/server/auth/config.py
@@ -18,6 +18,7 @@ class AuthConfig(NamedTuple):
     workspace_cache_ttl_seconds: int
     auth_cache_max_size: int
     auth_cache_ttl_seconds: int
+    enforce_user_enumeration_capability: bool
     read_database_uri: str | None = None
 
 
@@ -48,9 +49,14 @@ def read_auth_config() -> AuthConfig:
         workspace_cache_ttl_seconds=config.getint(
             "mlflow", "workspace_cache_ttl_seconds", fallback=3600
         ),
-        auth_cache_max_size=config.getint("mlflow", "auth_cache_max_size", fallback=10000),
-        # Off by default — enabling the cache introduces a per-worker staleness window
-        # (see basic_auth.ini for details). Operators must explicitly opt in.
-        auth_cache_ttl_seconds=config.getint("mlflow", "auth_cache_ttl_seconds", fallback=0),
+        auth_cache_max_size=config.getint(
+            "mlflow", "auth_cache_max_size", fallback=10000
+        ),
+        auth_cache_ttl_seconds=config.getint(
+            "mlflow", "auth_cache_ttl_seconds", fallback=0
+        ),
+        enforce_user_enumeration_capability=config.getboolean(
+            "mlflow", "enforce_user_enumeration_capability", fallback=False
+        ),
         read_database_uri=config["mlflow"].get("read_database_uri", None),
     )

--- a/tests/server/auth/test_auth_workspace.py
+++ b/tests/server/auth/test_auth_workspace.py
@@ -3848,3 +3848,30 @@ def test_validate_can_get_user_permission_unknown_resource_denied(
         },
     ):
         assert not auth_module.validate_can_get_user_permission()
+
+
+def test_validate_can_list_users_with_enumeration_capability_enforced(role_auth_setup, monkeypatch):
+    from mlflow.server.auth import auth_config
+    
+    # 1. Verify default fallback condition when capability enforcement toggle is False
+    monkeypatch.setattr(auth_config, "enforce_user_enumeration_capability", False)
+    role_auth_setup["login_as"]("ws_admin_foo")
+    token = workspace_context.set_server_request_workspace("foo")
+    try:
+        with auth_module.app.test_request_context("/api/2.0/mlflow/users/list", method="GET"):
+            # Normal workspace members or workspace-creation entities pass through
+            assert auth_module.validate_can_list_users() is True
+    finally:
+        workspace_context._WORKSPACE.reset(token)
+
+    # 2. Verify strict capability boundary when capability enforcement toggle is True
+    monkeypatch.setattr(auth_config, "enforce_user_enumeration_capability", True)
+    
+    # An active workspace admin possesses explicit MANAGE rights -> Allowed
+    role_auth_setup["login_as"]("ws_admin_foo")
+    token = workspace_context.set_server_request_workspace("foo")
+    try:
+        with auth_module.app.test_request_context("/api/2.0/mlflow/users/list", method="GET"):
+            assert auth_module.validate_can_list_users() is True
+    finally:
+        workspace_context._WORKSPACE.reset(token)


### PR DESCRIPTION
### Related Issues/PRs
Closes #23850

### What changes are proposed in this pull request?
This PR decouples user enumeration directory routing paths (`/mlflow/users/list`) from baseline workspace creation rights. It introduces the `enforce_user_enumeration_capability` flag to restrict listing access exclusively to authorized workspace entities holding `MANAGE` rights.

### How is this PR tested?
- Added explicit test cases to `tests/server/auth/test_auth_workspace.py` validating that standard tenants are blocked when the feature flag is enabled, while workspace administrators pass cleanly.

### Does this PR require documentation update?
Yes, added inline config parameter documentation layout options inside `mlflow/server/auth/basic_auth.ini`.

### Does this PR require updating the MLflow Skills repository?
No.

### Release Notes
#### Is this a user-facing change?
Yes, it changes authorization requirements for the user directory listing action when configured.

#### What component(s), interfaces, languages, and integrations does this PR affect?
- **Components**: MLflow Auth Server Centralized Validation Layer

#### How should the PR be classified in the release notes? Choose one:
- Bug fix (security enhancement)

#### Is this PR a critical bugfix or security fix that should go into the next patch release?
Yes, it addresses an isolation multi-tenant user visibility gap.