### PR TITLE
Render review-queue focus-mode trace input/output readably instead of raw JSON

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.tsx
@@ -20,20 +20,12 @@ import type { LabelSchema, LabelSchemaValue } from '../../components/label-schem
 import { useCreateReviewAssessmentMutation } from './hooks/useCreateReviewAssessmentMutation';
 import { useTraceAssessmentsQuery } from './hooks/useTraceAssessmentsQuery';
 import { buildPrefilledAnswers, buildPrefilledRationales, buildPriorAssessmentIds, isAnswered } from './reviewAnswers';
+import { ReviewTraceInputOutput } from './ReviewTraceInputOutput';
 import { StatusTag } from './ReviewQueueList';
 import { SegmentedProgressBar } from './SegmentedProgressBar';
 import type { ReviewQueueItem, ReviewStatus } from './types';
 
 const CID = 'mlflow.experiment-review-queue.focused-review';
-
-/** Pretty-print a request/response preview as JSON, falling back to the raw string. */
-const formatPreview = (raw: string): string => {
-  try {
-    return JSON.stringify(JSON.parse(raw), null, 2);
-  } catch {
-    return raw;
-  }
-};
 
 /**
  * Focused-review surface, three panels:
@@ -328,42 +320,7 @@ export const FocusedReview = ({
                 }
               />
             ) : (
-              [
-                requestPreview && {
-                  key: 'input',
-                  label: (
-                    <FormattedMessage defaultMessage="Input" description="Review focused view: trace input label" />
-                  ),
-                  value: formatPreview(requestPreview),
-                },
-                responsePreview && {
-                  key: 'output',
-                  label: (
-                    <FormattedMessage defaultMessage="Output" description="Review focused view: trace output label" />
-                  ),
-                  value: formatPreview(responsePreview),
-                },
-              ]
-                .filter((section): section is { key: string; label: JSX.Element; value: string } => Boolean(section))
-                .map((section) => (
-                  <div key={section.key} css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
-                    <Typography.Text bold>{section.label}</Typography.Text>
-                    <pre
-                      css={{
-                        margin: 0,
-                        padding: theme.spacing.sm,
-                        backgroundColor: theme.colors.backgroundSecondary,
-                        borderRadius: theme.borders.borderRadiusMd,
-                        fontFamily: 'monospace',
-                        fontSize: theme.typography.fontSizeSm,
-                        whiteSpace: 'pre-wrap',
-                        wordBreak: 'break-word',
-                      }}
-                    >
-                      {section.value}
-                    </pre>
-                  </div>
-                ))
+              <ReviewTraceInputOutput requestPreview={requestPreview} responsePreview={responsePreview} />
             )}
           </div>
         </div>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewTraceInputOutput.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewTraceInputOutput.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect } from '@jest/globals';
+
+import { deriveSection } from './ReviewTraceInputOutput';
+
+describe('deriveSection', () => {
+  it('renders a parsed conversation as chat messages', () => {
+    const section = deriveSection(JSON.stringify({ messages: [{ role: 'user', content: 'hi' }] }));
+    expect(section.kind).toBe('chat');
+    expect(section.kind === 'chat' && section.messages.length).toBeGreaterThan(0);
+  });
+
+  it('recognizes an Anthropic-shaped conversation (not just the default formats)', () => {
+    const section = deriveSection(
+      JSON.stringify({ messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }] }),
+    );
+    expect(section.kind).toBe('chat');
+  });
+
+  it('renders a plain-text payload as markdown', () => {
+    expect(deriveSection('## Heading\n\nsome **bold** text').kind).toBe('markdown');
+  });
+
+  it('renders a structured, non-conversation payload as JSON', () => {
+    expect(deriveSection('{"question": "what is mlflow?"}').kind).toBe('json');
+  });
+
+  it('renders a truncated/JSON-looking string as JSON, not markdown', () => {
+    // A payload truncated past the server preview cap: invalid JSON but clearly
+    // structured — must not be mangled by the markdown renderer.
+    expect(deriveSection('{"messages": [{"role": "user", "content": "a very long prompt that got cut o').kind).toBe(
+      'json',
+    );
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewTraceInputOutput.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewTraceInputOutput.tsx
@@ -1,0 +1,144 @@
+import { useMemo } from 'react';
+
+import { Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { GenAIMarkdownRenderer } from '@databricks/web-shared/genai-markdown-renderer';
+import { ModelTraceExplorerChatMessage, normalizeConversation } from '@databricks/web-shared/model-trace-explorer';
+import type { ModelTraceChatMessage } from '@databricks/web-shared/model-trace-explorer';
+import { FormattedMessage } from 'react-intl';
+
+// Conversation formats to try, matching the adjacent review surface
+// (GenAiEvaluationTracesReview.utils.tsx). `normalizeConversation` with no format
+// only covers OpenAI/LangChain/Gemini, so pass each explicitly to also catch
+// Anthropic-shaped payloads.
+const COMMON_MESSAGE_FORMATS = ['openai', 'langchain', 'anthropic'];
+
+// Parse a preview into JSON; return the raw string if it isn't valid JSON.
+const parsePreview = (raw: string): unknown => {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+};
+
+const toMessages = (parsed: unknown): ModelTraceChatMessage[] | null => {
+  for (const format of COMMON_MESSAGE_FORMATS) {
+    const messages = normalizeConversation(parsed, format);
+    if (messages && messages.length > 0) {
+      return messages;
+    }
+  }
+  return null;
+};
+
+type Section =
+  | { kind: 'chat'; messages: ModelTraceChatMessage[] }
+  | { kind: 'markdown'; text: string }
+  | { kind: 'json'; text: string };
+
+/**
+ * Decide how to render a preview, mirroring the Review App's preference order: a
+ * parsed conversation first, then readable markdown for plain text, then JSON.
+ * Exported for testing.
+ */
+export const deriveSection = (raw: string): Section => {
+  const parsed = parsePreview(raw);
+
+  if (typeof parsed === 'object' && parsed !== null) {
+    const messages = toMessages(parsed);
+    return messages ? { kind: 'chat', messages } : { kind: 'json', text: JSON.stringify(parsed, null, 2) };
+  }
+
+  // A string that failed to parse but looks like JSON (e.g. a payload truncated
+  // by the server's preview cap) is shown as a JSON block, not run through the
+  // markdown renderer where stray `*`/`#`/backticks would mangle it.
+  if (typeof parsed === 'string') {
+    return /^\s*[[{]/.test(parsed) ? { kind: 'json', text: parsed } : { kind: 'markdown', text: parsed };
+  }
+
+  // Scalars (number / boolean / null) — show their literal form.
+  return { kind: 'json', text: raw };
+};
+
+/**
+ * Renders a trace's input and output for the review focus view, mirroring the
+ * Databricks Review App's `AgentInputOutput`: an Input card and an Output card,
+ * each rendered for readability rather than as raw JSON. A payload that parses as
+ * a conversation renders as chat messages via `ModelTraceExplorerChatMessage`
+ * (role + markdown); a plain-text payload renders as markdown (the same engine
+ * those messages use); anything else falls back to pretty-printed JSON. The full
+ * trace stays available via the caller's full-trace drawer.
+ */
+export const ReviewTraceInputOutput = ({
+  requestPreview,
+  responsePreview,
+}: {
+  requestPreview?: string;
+  responsePreview?: string;
+}) => {
+  const { theme } = useDesignSystemTheme();
+
+  const input = useMemo(() => (requestPreview ? deriveSection(requestPreview) : null), [requestPreview]);
+  const output = useMemo(() => (responsePreview ? deriveSection(responsePreview) : null), [responsePreview]);
+
+  const renderCard = (key: string, label: React.ReactNode, section: Section) => (
+    <div
+      key={key}
+      css={{
+        backgroundColor: theme.colors.backgroundSecondary,
+        border: `1px solid ${theme.colors.border}`,
+        borderRadius: theme.borders.borderRadiusMd,
+        padding: theme.spacing.md,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: theme.spacing.sm,
+      }}
+    >
+      <Typography.Text bold color="secondary">
+        {label}
+      </Typography.Text>
+      {section.kind === 'chat' ? (
+        <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
+          {section.messages.map((message, i) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <ModelTraceExplorerChatMessage key={i} message={message} />
+          ))}
+        </div>
+      ) : section.kind === 'markdown' ? (
+        <GenAIMarkdownRenderer>{section.text}</GenAIMarkdownRenderer>
+      ) : (
+        <pre
+          css={{
+            margin: 0,
+            padding: theme.spacing.sm,
+            backgroundColor: theme.colors.backgroundPrimary,
+            borderRadius: theme.borders.borderRadiusSm,
+            fontFamily: 'monospace',
+            fontSize: theme.typography.fontSizeSm,
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+          }}
+        >
+          {section.text}
+        </pre>
+      )}
+    </div>
+  );
+
+  return (
+    <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
+      {input &&
+        renderCard(
+          'input',
+          <FormattedMessage defaultMessage="Input" description="Review focused view: trace input label" />,
+          input,
+        )}
+      {output &&
+        renderCard(
+          'output',
+          <FormattedMessage defaultMessage="Output" description="Review focused view: trace output label" />,
+          output,
+        )}
+    </div>
+  );
+};


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23844 (review queues)

### What changes are proposed in this pull request?

The review-queue focus mode rendered a trace's input/output as raw `JSON.stringify` in a `<pre>`, which reads poorly — especially for non-technical reviewers. This ports the Databricks Review App's `AgentInputOutput` rendering to OSS, reusing already-exported `@databricks/web-shared` primitives rather than reinventing a renderer.

A new `ReviewTraceInputOutput` renders the request/response previews in **Input** and **Output** cards, choosing how to render each payload (mirroring the Review App's preference order):

1. **Conversation → chat messages.** `normalizeConversation` (tried across `['openai', 'langchain', 'anthropic']`, matching the adjacent `GenAiEvaluationTracesReview` surface) → rendered with `ModelTraceExplorerChatMessage` (role label + markdown — the trace explorer's own message renderer).
2. **Plain text → markdown.** `GenAIMarkdownRenderer` (the same markdown engine `ModelTraceExplorerChatMessage` uses internally).
3. **Otherwise → pretty-printed JSON.** Also the path for a payload truncated past the server's preview cap (invalid-but-JSON-looking strings render as a JSON block rather than being mangled by the markdown renderer).

`FocusedReview`'s existing **"View full trace"** `ModelTraceExplorer` drawer is unchanged.

Note: MLflow collapses `request_preview`/`response_preview` to ~1000-char strings (last-message text or truncated `json.dumps`), so a plain text/markdown response typically takes the markdown path; structured conversation payloads take the chat path.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New `ReviewTraceInputOutput.test.tsx` covers the dispatch: parsed conversation → chat, Anthropic-shaped payload → chat (verifying the format loop), plain text → markdown, structured non-conversation → JSON, and a truncated/JSON-looking string → JSON (not markdown). Full review-queue jest suite passes (103). Manually verified in focus mode against a local basic-auth server with a chat-format trace (markdown response renders with headings/lists/code) and the existing non-chat traces (clean JSON/text fallback).

<img width="1659" height="643" alt="Screenshot 2026-06-13 at 7 54 05 AM" src="https://github.com/user-attachments/assets/412bcf7a-096f-4fe9-9171-5143f5550194" />

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Review-queue focus mode now renders a trace's input and output as a readable conversation/markdown instead of raw JSON.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.