### PR TITLE
Enable multipart upload in DatabricksSDKModelsArtifactRepository

### DIFF
--- a/mlflow/store/artifact/databricks_sdk_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_sdk_artifact_repo.py
@@ -13,6 +13,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
 
 if TYPE_CHECKING:
+    from databricks.sdk import WorkspaceClient
     from databricks.sdk.service.files import FilesAPI
 
 
@@ -24,37 +25,42 @@ def _sdk_supports_large_file_uploads() -> bool:
 _logger = logging.getLogger(__name__)
 
 
+def _get_workspace_client() -> "WorkspaceClient":
+    """Builds a WorkspaceClient that uses multipart upload when the SDK supports it,
+    so files larger than the Files API single-request limit (5 GiB) can be uploaded.
+    """
+    from databricks.sdk import WorkspaceClient
+    from databricks.sdk.config import Config
+
+    supports_large_file_uploads = _sdk_supports_large_file_uploads()
+    wc = WorkspaceClient(
+        config=(
+            Config(enable_experimental_files_api_client=True)
+            if supports_large_file_uploads
+            else None
+        )
+    )
+    if supports_large_file_uploads:
+        # `Config` has a `multipart_upload_min_stream_size` parameter but the constructor
+        # doesn't set it. This is a bug in databricks-sdk.
+        # >>> from databricks.sdk.config import Config
+        # >>> config = Config(multipart_upload_chunk_size=123)
+        # >>> assert config.multipart_upload_chunk_size != 123
+        try:
+            wc.files._config.multipart_upload_chunk_size = MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE.get()
+        except AttributeError:
+            _logger.debug("Failed to set multipart_upload_chunk_size in Config", exc_info=True)
+    return wc
+
+
 # TODO: The following artifact repositories should use this class. Migrate them.
 #   - databricks_sdk_models_artifact_repo.py
 class DatabricksSdkArtifactRepository(ArtifactRepository):
     def __init__(
         self, artifact_uri: str, tracking_uri: str | None = None, registry_uri: str | None = None
     ) -> None:
-        from databricks.sdk import WorkspaceClient
-        from databricks.sdk.config import Config
-
         super().__init__(artifact_uri, tracking_uri, registry_uri)
-        supports_large_file_uploads = _sdk_supports_large_file_uploads()
-        wc = WorkspaceClient(
-            config=(
-                Config(enable_experimental_files_api_client=True)
-                if supports_large_file_uploads
-                else None
-            )
-        )
-        if supports_large_file_uploads:
-            # `Config` has a `multipart_upload_min_stream_size` parameter but the constructor
-            # doesn't set it. This is a bug in databricks-sdk.
-            # >>> from databricks.sdk.config import Config
-            # >>> config = Config(multipart_upload_chunk_size=123)
-            # >>> assert config.multipart_upload_chunk_size != 123
-            try:
-                wc.files._config.multipart_upload_chunk_size = (
-                    MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE.get()
-                )
-            except AttributeError:
-                _logger.debug("Failed to set multipart_upload_chunk_size in Config", exc_info=True)
-        self.wc = wc
+        self.wc = _get_workspace_client()
 
     @property
     def files_api(self) -> "FilesAPI":

--- a/mlflow/store/artifact/databricks_sdk_models_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_sdk_models_artifact_repo.py
@@ -8,9 +8,9 @@ from mlflow.store.artifact.cloud_artifact_repo import CloudArtifactRepository
 
 
 def _get_databricks_workspace_client():
-    from databricks.sdk import WorkspaceClient
+    from mlflow.store.artifact.databricks_sdk_artifact_repo import _get_workspace_client
 
-    return WorkspaceClient()
+    return _get_workspace_client()
 
 
 class DatabricksSDKModelsArtifactRepository(CloudArtifactRepository):

--- a/tests/store/artifact/test_databricks_sdk_models_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_sdk_models_artifact_repo.py
@@ -9,11 +9,13 @@ from databricks.sdk.service.files import DirectoryEntry, DownloadResponse
 
 from mlflow.entities.file_info import FileInfo
 from mlflow.entities.model_registry import ModelVersion
+from mlflow.environment_variables import MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE
 from mlflow.store._unity_catalog.registry.rest_store import (
     UcModelRegistryStore,
 )
 from mlflow.store.artifact.databricks_sdk_models_artifact_repo import (
     DatabricksSDKModelsArtifactRepository,
+    _get_databricks_workspace_client,
 )
 from mlflow.store.artifact.unity_catalog_models_artifact_repo import (
     UnityCatalogModelsArtifactRepository,
@@ -228,3 +230,31 @@ def test_mlflow_use_databricks_sdk_model_artifacts_repo_for_uc_seg(tmp_path, mon
             ),
             DatabricksSDKModelsArtifactRepository,
         )
+
+
+def test_workspace_client_enables_multipart_uploads():
+    with (
+        mock.patch("databricks.sdk.WorkspaceClient") as mock_workspace_client,
+        mock.patch("databricks.sdk.config.Config") as mock_config,
+    ):
+        client = _get_databricks_workspace_client()
+
+    mock_config.assert_called_once_with(enable_experimental_files_api_client=True)
+    mock_workspace_client.assert_called_once_with(config=mock_config.return_value)
+    assert client is mock_workspace_client.return_value
+    assert (
+        client.files._config.multipart_upload_chunk_size == MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE.get()
+    )
+
+
+def test_workspace_client_plain_on_old_sdk():
+    with (
+        mock.patch("databricks.sdk.WorkspaceClient") as mock_workspace_client,
+        mock.patch(
+            "mlflow.store.artifact.databricks_sdk_artifact_repo._sdk_supports_large_file_uploads",
+            return_value=False,
+        ),
+    ):
+        _get_databricks_workspace_client()
+
+    mock_workspace_client.assert_called_once_with(config=None)


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

`DatabricksSDKModelsArtifactRepository` builds a bare `WorkspaceClient`, so on `databricks-sdk < 0.69` every UC model artifact upload is a single-shot Files API PUT, which the server caps at 5 GiB. Uploads of larger files (e.g. multi-GB `env_pack` tarballs on Databricks serverless compute, where the preinstalled SDK is older) fail after exhausting the SDK retry budget with `TimeoutError('Timed out after 0:05:00')`.

This PR reuses the multipart-enabled client construction that `DatabricksSdkArtifactRepository` already has, extracting it into a shared `_get_workspace_client()` (sets `enable_experimental_files_api_client=True` when `databricks-sdk >= 0.45.0`, plus the existing multipart chunk size workaround) and using it from `DatabricksSDKModelsArtifactRepository._get_databricks_workspace_client()`. On `databricks-sdk >= 0.69` the flag is a harmless no-op since the multipart client is already the default. This is the first step of the existing TODO in `databricks_sdk_artifact_repo.py` to migrate the models repo onto that class.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

New tests in `tests/store/artifact/test_databricks_sdk_models_artifact_repo.py`:
- `test_workspace_client_enables_multipart_uploads`: the client is constructed with `Config(enable_experimental_files_api_client=True)` and the chunk size from `MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE`.
- `test_workspace_client_plain_on_old_sdk`: falls back to a plain `WorkspaceClient` when the SDK is too old to support the flag.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix `TimeoutError('Timed out after 0:05:00')` when registering Unity Catalog models with artifact files larger than 5 GiB through the Databricks SDK artifact repository, by uploading via the SDK's multipart Files API client.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
