### PR TITLE
Add missing `ContextUtilization` RAGAS scorer class

### DIFF
--- a/docs/api_reference/api_inventory.txt
+++ b/docs/api_reference/api_inventory.txt
@@ -1292,6 +1292,7 @@ mlflow.genai.scorers.ragas.scorers.rag_metrics.AnswerRelevancy
 mlflow.genai.scorers.ragas.scorers.rag_metrics.ContextEntityRecall
 mlflow.genai.scorers.ragas.scorers.rag_metrics.ContextPrecision
 mlflow.genai.scorers.ragas.scorers.rag_metrics.ContextRecall
+mlflow.genai.scorers.ragas.scorers.rag_metrics.ContextUtilization
 mlflow.genai.scorers.ragas.scorers.rag_metrics.Faithfulness
 mlflow.genai.scorers.ragas.scorers.rag_metrics.NoiseSensitivity
 mlflow.genai.scorers.ragas.scorers.rag_metrics.NonLLMContextPrecisionWithReference

--- a/docs/api_reference/api_inventory.txt
+++ b/docs/api_reference/api_inventory.txt
@@ -1229,6 +1229,8 @@ mlflow.genai.scorers.ragas.ContextRecall
 mlflow.genai.scorers.ragas.ContextRecall.model_post_init
 mlflow.genai.scorers.ragas.ContextRelevance
 mlflow.genai.scorers.ragas.ContextRelevance.model_post_init
+mlflow.genai.scorers.ragas.ContextUtilization
+mlflow.genai.scorers.ragas.ContextUtilization.model_post_init
 mlflow.genai.scorers.ragas.DiscreteMetric
 mlflow.genai.scorers.ragas.DiscreteMetric.model_post_init
 mlflow.genai.scorers.ragas.ExactMatch

--- a/mlflow/genai/scorers/ragas/__init__.py
+++ b/mlflow/genai/scorers/ragas/__init__.py
@@ -330,6 +330,7 @@ from mlflow.genai.scorers.ragas.scorers import (
     ContextPrecision,
     ContextRecall,
     ContextRelevance,
+    ContextUtilization,
     DiscreteMetric,
     ExactMatch,
     FactualCorrectness,
@@ -356,6 +357,7 @@ __all__ = [
     "get_scorer",
     # RAG metrics
     "ContextPrecision",
+    "ContextUtilization",
     "NonLLMContextPrecisionWithReference",
     "ContextRecall",
     "NonLLMContextRecall",

--- a/mlflow/genai/scorers/ragas/scorers/__init__.py
+++ b/mlflow/genai/scorers/ragas/scorers/__init__.py
@@ -25,6 +25,7 @@ from mlflow.genai.scorers.ragas.scorers.rag_metrics import (
     ContextEntityRecall,
     ContextPrecision,
     ContextRecall,
+    ContextUtilization,
     Faithfulness,
     NoiseSensitivity,
     NonLLMContextPrecisionWithReference,
@@ -290,6 +291,7 @@ class ResponseGroundedness(RagasScorer):
 __all__ = [
     # RAG metrics
     "ContextPrecision",
+    "ContextUtilization",
     "NonLLMContextPrecisionWithReference",
     "ContextRecall",
     "NonLLMContextRecall",

--- a/mlflow/genai/scorers/ragas/scorers/rag_metrics.py
+++ b/mlflow/genai/scorers/ragas/scorers/rag_metrics.py
@@ -38,6 +38,28 @@ class ContextPrecision(RagasScorer):
     metric_name: ClassVar[str] = "ContextPrecision"
 
 
+@experimental(version="3.14.0")
+@format_docstring(_MODEL_API_DOC)
+class ContextUtilization(RagasScorer):
+    """
+    Evaluates how effectively the retrieved context is utilized in the generated response.
+
+    Args:
+        model: {{ model }}
+        **metric_kwargs: Additional metric-specific parameters
+
+    Examples:
+        .. code-block:: python
+
+            from mlflow.genai.scorers.ragas import ContextUtilization
+
+            scorer = ContextUtilization(model="openai:/gpt-4")
+            feedback = scorer(trace=trace)
+    """
+
+    metric_name: ClassVar[str] = "ContextUtilization"
+
+
 @experimental(version="3.8.0")
 class NonLLMContextPrecisionWithReference(RagasScorer):
     """

--- a/tests/genai/scorers/ragas/test_ragas_scorer.py
+++ b/tests/genai/scorers/ragas/test_ragas_scorer.py
@@ -19,6 +19,7 @@ from mlflow.genai.scorers.ragas import (
     ContextEntityRecall,
     ContextPrecision,
     ContextRecall,
+    ContextUtilization,
     DiscreteMetric,
     ExactMatch,
     FactualCorrectness,
@@ -176,6 +177,7 @@ def test_missing_reference_parameter_returns_mlflow_error():
     [
         # RAG Metrics
         (ContextPrecision, "ContextPrecision", {}),
+        (ContextUtilization, "ContextUtilization", {}),
         (ContextRecall, "ContextRecall", {}),
         (ContextEntityRecall, "ContextEntityRecall", {}),
         (NoiseSensitivity, "NoiseSensitivity", {}),


### PR DESCRIPTION
### Related Issues/PRs

Closes #23942

### What changes are proposed in this pull request?

#23942 reports that `ContextUtilization` is "falsely listed as available" on the [RAGAS scorers docs page](https://mlflow.org/docs/latest/genai/eval-monitor/scorers/third-party/ragas/). The root cause is not the docs: #19743 added `ContextUtilization` to the RAGAS metric registry and the docs table, but never created the scorer class, so the documented `from mlflow.genai.scorers.ragas import ContextUtilization` fails with an `ImportError` (and the `APILink` in the table points to a non-existent API).

The underlying RAGAS metric exists (`ragas.metrics.collections.ContextUtilization`, verified on ragas 0.3.9 and 0.4.3) and already works today via `get_scorer("ContextUtilization")`. Instead of removing the docs entry for a working metric, this PR adds the missing class so the docs become accurate:

- Add the `ContextUtilization` scorer class to `rag_metrics.py`, mirroring its sibling `ContextPrecision`
- Export it from `mlflow.genai.scorers.ragas` and add it to `api_inventory.txt`
- Add it to the namespaced-class instantiation test

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

`uv run --with ragas --with litellm pytest tests/genai/scorers/ragas/` - 122 passed.

### Does this PR require documentation update?

- [x] No. The docs table row and its `APILink` already exist; this PR makes them resolve correctly.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Added the `mlflow.genai.scorers.ragas.ContextUtilization` scorer class, which was documented but missing from the package.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Claude Code.