### PR TITLE
Fix migration `1bd49d398cd23` to be idempotent on MySQL retry

### DIFF
--- a/mlflow/store/db_migrations/versions/1bd49d398cd23_add_secrets_tables.py
+++ b/mlflow/store/db_migrations/versions/1bd49d398cd23_add_secrets_tables.py
@@ -82,7 +82,15 @@ END;
 """
 
 
+def _get_existing_tables():
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    return set(inspector.get_table_names())
+
+
 def _create_immutability_trigger():
+    # Drop before recreating so this is safe to call on a retry after a partial migration.
+    _drop_immutability_trigger()
     bind = op.get_bind()
     dialect = bind.engine.dialect.name
 
@@ -116,179 +124,187 @@ def _drop_immutability_trigger():
 
 
 def upgrade():
-    op.create_table(
-        "secrets",
-        sa.Column("secret_id", sa.String(length=36), nullable=False),
-        sa.Column("secret_name", sa.String(length=255), nullable=False),
-        sa.Column("encrypted_value", sa.LargeBinary(), nullable=False),
-        sa.Column("wrapped_dek", sa.LargeBinary(), nullable=False),
-        sa.Column("kek_version", sa.Integer(), nullable=False, default=1),
-        sa.Column("masked_value", sa.String(length=500), nullable=False),
-        sa.Column("provider", sa.String(length=64), nullable=True),
-        sa.Column("auth_config", sa.Text(), nullable=True),
-        sa.Column("description", sa.Text(), nullable=True),
-        sa.Column("created_by", sa.String(length=255), nullable=True),
-        sa.Column(
-            "created_at",
-            sa.BigInteger(),
-            default=lambda: int(time.time() * 1000),
-            nullable=False,
-        ),
-        sa.Column("last_updated_by", sa.String(length=255), nullable=True),
-        sa.Column(
-            "last_updated_at",
-            sa.BigInteger(),
-            default=lambda: int(time.time() * 1000),
-            nullable=False,
-        ),
-        sa.PrimaryKeyConstraint("secret_id", name="secrets_pk"),
-    )
-    with op.batch_alter_table("secrets", schema=None) as batch_op:
-        batch_op.create_index("unique_secret_name", ["secret_name"], unique=True)
+    existing_tables = _get_existing_tables()
 
-    op.create_table(
-        "endpoints",
-        sa.Column("endpoint_id", sa.String(length=36), nullable=False),
-        sa.Column("name", sa.String(length=255), nullable=True),
-        sa.Column("created_by", sa.String(length=255), nullable=True),
-        sa.Column(
-            "created_at",
-            sa.BigInteger(),
-            default=lambda: int(time.time() * 1000),
-            nullable=False,
-        ),
-        sa.Column("last_updated_by", sa.String(length=255), nullable=True),
-        sa.Column(
-            "last_updated_at",
-            sa.BigInteger(),
-            default=lambda: int(time.time() * 1000),
-            nullable=False,
-        ),
-        sa.PrimaryKeyConstraint("endpoint_id", name="endpoints_pk"),
-    )
-    with op.batch_alter_table("endpoints", schema=None) as batch_op:
-        batch_op.create_index("unique_endpoint_name", ["name"], unique=True)
-
-    op.create_table(
-        "model_definitions",
-        sa.Column("model_definition_id", sa.String(length=36), nullable=False),
-        sa.Column("name", sa.String(length=255), nullable=False),
-        sa.Column("secret_id", sa.String(length=36), nullable=True),
-        sa.Column("provider", sa.String(length=64), nullable=False),
-        sa.Column("model_name", sa.String(length=256), nullable=False),
-        sa.Column("created_by", sa.String(length=255), nullable=True),
-        sa.Column(
-            "created_at",
-            sa.BigInteger(),
-            default=lambda: int(time.time() * 1000),
-            nullable=False,
-        ),
-        sa.Column("last_updated_by", sa.String(length=255), nullable=True),
-        sa.Column(
-            "last_updated_at",
-            sa.BigInteger(),
-            default=lambda: int(time.time() * 1000),
-            nullable=False,
-        ),
-        sa.ForeignKeyConstraint(
-            ["secret_id"],
-            ["secrets.secret_id"],
-            name="fk_model_definitions_secret_id",
-            ondelete="SET NULL",
-        ),
-        sa.PrimaryKeyConstraint("model_definition_id", name="model_definitions_pk"),
-    )
-    with op.batch_alter_table("model_definitions", schema=None) as batch_op:
-        batch_op.create_index("unique_model_definition_name", ["name"], unique=True)
-        batch_op.create_index("index_model_definitions_secret_id", ["secret_id"], unique=False)
-        batch_op.create_index("index_model_definitions_provider", ["provider"], unique=False)
-
-    op.create_table(
-        "endpoint_model_mappings",
-        sa.Column("mapping_id", sa.String(length=36), nullable=False),
-        sa.Column("endpoint_id", sa.String(length=36), nullable=False),
-        sa.Column("model_definition_id", sa.String(length=36), nullable=False),
-        sa.Column("weight", sa.Float(), nullable=False, default=1.0),
-        sa.Column("created_by", sa.String(length=255), nullable=True),
-        sa.Column(
-            "created_at",
-            sa.BigInteger(),
-            default=lambda: int(time.time() * 1000),
-            nullable=False,
-        ),
-        sa.ForeignKeyConstraint(
-            ["endpoint_id"],
-            ["endpoints.endpoint_id"],
-            name="fk_endpoint_model_mappings_endpoint_id",
-            ondelete="CASCADE",
-        ),
-        sa.ForeignKeyConstraint(
-            ["model_definition_id"],
-            ["model_definitions.model_definition_id"],
-            name="fk_endpoint_model_mappings_model_definition_id",
-        ),
-        sa.PrimaryKeyConstraint("mapping_id", name="endpoint_model_mappings_pk"),
-    )
-    with op.batch_alter_table("endpoint_model_mappings", schema=None) as batch_op:
-        batch_op.create_index(
-            "index_endpoint_model_mappings_endpoint_id", ["endpoint_id"], unique=False
+    if "secrets" not in existing_tables:
+        op.create_table(
+            "secrets",
+            sa.Column("secret_id", sa.String(length=36), nullable=False),
+            sa.Column("secret_name", sa.String(length=255), nullable=False),
+            sa.Column("encrypted_value", sa.LargeBinary(), nullable=False),
+            sa.Column("wrapped_dek", sa.LargeBinary(), nullable=False),
+            sa.Column("kek_version", sa.Integer(), nullable=False, default=1),
+            sa.Column("masked_value", sa.String(length=500), nullable=False),
+            sa.Column("provider", sa.String(length=64), nullable=True),
+            sa.Column("auth_config", sa.Text(), nullable=True),
+            sa.Column("description", sa.Text(), nullable=True),
+            sa.Column("created_by", sa.String(length=255), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.BigInteger(),
+                default=lambda: int(time.time() * 1000),
+                nullable=False,
+            ),
+            sa.Column("last_updated_by", sa.String(length=255), nullable=True),
+            sa.Column(
+                "last_updated_at",
+                sa.BigInteger(),
+                default=lambda: int(time.time() * 1000),
+                nullable=False,
+            ),
+            sa.PrimaryKeyConstraint("secret_id", name="secrets_pk"),
         )
-        batch_op.create_index(
-            "index_endpoint_model_mappings_model_definition_id",
-            ["model_definition_id"],
-            unique=False,
+        with op.batch_alter_table("secrets", schema=None) as batch_op:
+            batch_op.create_index("unique_secret_name", ["secret_name"], unique=True)
+
+    if "endpoints" not in existing_tables:
+        op.create_table(
+            "endpoints",
+            sa.Column("endpoint_id", sa.String(length=36), nullable=False),
+            sa.Column("name", sa.String(length=255), nullable=True),
+            sa.Column("created_by", sa.String(length=255), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.BigInteger(),
+                default=lambda: int(time.time() * 1000),
+                nullable=False,
+            ),
+            sa.Column("last_updated_by", sa.String(length=255), nullable=True),
+            sa.Column(
+                "last_updated_at",
+                sa.BigInteger(),
+                default=lambda: int(time.time() * 1000),
+                nullable=False,
+            ),
+            sa.PrimaryKeyConstraint("endpoint_id", name="endpoints_pk"),
         )
-        batch_op.create_index(
-            "unique_endpoint_model_mapping",
-            ["endpoint_id", "model_definition_id"],
-            unique=True,
+        with op.batch_alter_table("endpoints", schema=None) as batch_op:
+            batch_op.create_index("unique_endpoint_name", ["name"], unique=True)
+
+    if "model_definitions" not in existing_tables:
+        op.create_table(
+            "model_definitions",
+            sa.Column("model_definition_id", sa.String(length=36), nullable=False),
+            sa.Column("name", sa.String(length=255), nullable=False),
+            sa.Column("secret_id", sa.String(length=36), nullable=True),
+            sa.Column("provider", sa.String(length=64), nullable=False),
+            sa.Column("model_name", sa.String(length=256), nullable=False),
+            sa.Column("created_by", sa.String(length=255), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.BigInteger(),
+                default=lambda: int(time.time() * 1000),
+                nullable=False,
+            ),
+            sa.Column("last_updated_by", sa.String(length=255), nullable=True),
+            sa.Column(
+                "last_updated_at",
+                sa.BigInteger(),
+                default=lambda: int(time.time() * 1000),
+                nullable=False,
+            ),
+            sa.ForeignKeyConstraint(
+                ["secret_id"],
+                ["secrets.secret_id"],
+                name="fk_model_definitions_secret_id",
+                ondelete="SET NULL",
+            ),
+            sa.PrimaryKeyConstraint("model_definition_id", name="model_definitions_pk"),
+        )
+        with op.batch_alter_table("model_definitions", schema=None) as batch_op:
+            batch_op.create_index("unique_model_definition_name", ["name"], unique=True)
+            batch_op.create_index("index_model_definitions_secret_id", ["secret_id"], unique=False)
+            batch_op.create_index("index_model_definitions_provider", ["provider"], unique=False)
+
+    if "endpoint_model_mappings" not in existing_tables:
+        op.create_table(
+            "endpoint_model_mappings",
+            sa.Column("mapping_id", sa.String(length=36), nullable=False),
+            sa.Column("endpoint_id", sa.String(length=36), nullable=False),
+            sa.Column("model_definition_id", sa.String(length=36), nullable=False),
+            sa.Column("weight", sa.Float(), nullable=False, default=1.0),
+            sa.Column("created_by", sa.String(length=255), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.BigInteger(),
+                default=lambda: int(time.time() * 1000),
+                nullable=False,
+            ),
+            sa.ForeignKeyConstraint(
+                ["endpoint_id"],
+                ["endpoints.endpoint_id"],
+                name="fk_endpoint_model_mappings_endpoint_id",
+                ondelete="CASCADE",
+            ),
+            sa.ForeignKeyConstraint(
+                ["model_definition_id"],
+                ["model_definitions.model_definition_id"],
+                name="fk_endpoint_model_mappings_model_definition_id",
+            ),
+            sa.PrimaryKeyConstraint("mapping_id", name="endpoint_model_mappings_pk"),
+        )
+        with op.batch_alter_table("endpoint_model_mappings", schema=None) as batch_op:
+            batch_op.create_index(
+                "index_endpoint_model_mappings_endpoint_id", ["endpoint_id"], unique=False
+            )
+            batch_op.create_index(
+                "index_endpoint_model_mappings_model_definition_id",
+                ["model_definition_id"],
+                unique=False,
+            )
+            batch_op.create_index(
+                "unique_endpoint_model_mapping",
+                ["endpoint_id", "model_definition_id"],
+                unique=True,
+            )
+
+    if "endpoint_bindings" not in existing_tables:
+        op.create_table(
+            "endpoint_bindings",
+            sa.Column("endpoint_id", sa.String(length=36), nullable=False),
+            sa.Column("resource_type", sa.String(length=50), nullable=False),
+            sa.Column("resource_id", sa.String(length=255), nullable=False),
+            sa.Column(
+                "created_at",
+                sa.BigInteger(),
+                default=lambda: int(time.time() * 1000),
+                nullable=False,
+            ),
+            sa.Column("created_by", sa.String(length=255), nullable=True),
+            sa.Column(
+                "last_updated_at",
+                sa.BigInteger(),
+                default=lambda: int(time.time() * 1000),
+                nullable=False,
+            ),
+            sa.Column("last_updated_by", sa.String(length=255), nullable=True),
+            sa.ForeignKeyConstraint(
+                ["endpoint_id"],
+                ["endpoints.endpoint_id"],
+                name="fk_endpoint_bindings_endpoint_id",
+                ondelete="CASCADE",
+            ),
+            sa.PrimaryKeyConstraint(
+                "endpoint_id", "resource_type", "resource_id", name="endpoint_bindings_pk"
+            ),
         )
 
-    op.create_table(
-        "endpoint_bindings",
-        sa.Column("endpoint_id", sa.String(length=36), nullable=False),
-        sa.Column("resource_type", sa.String(length=50), nullable=False),
-        sa.Column("resource_id", sa.String(length=255), nullable=False),
-        sa.Column(
-            "created_at",
-            sa.BigInteger(),
-            default=lambda: int(time.time() * 1000),
-            nullable=False,
-        ),
-        sa.Column("created_by", sa.String(length=255), nullable=True),
-        sa.Column(
-            "last_updated_at",
-            sa.BigInteger(),
-            default=lambda: int(time.time() * 1000),
-            nullable=False,
-        ),
-        sa.Column("last_updated_by", sa.String(length=255), nullable=True),
-        sa.ForeignKeyConstraint(
-            ["endpoint_id"],
-            ["endpoints.endpoint_id"],
-            name="fk_endpoint_bindings_endpoint_id",
-            ondelete="CASCADE",
-        ),
-        sa.PrimaryKeyConstraint(
-            "endpoint_id", "resource_type", "resource_id", name="endpoint_bindings_pk"
-        ),
-    )
-
-    op.create_table(
-        "endpoint_tags",
-        sa.Column("key", sa.String(length=250), nullable=False),
-        sa.Column("value", sa.String(length=5000), nullable=True),
-        sa.Column("endpoint_id", sa.String(length=36), nullable=False),
-        sa.ForeignKeyConstraint(
-            ["endpoint_id"],
-            ["endpoints.endpoint_id"],
-            name="fk_endpoint_tags_endpoint_id",
-            ondelete="CASCADE",
-        ),
-        sa.PrimaryKeyConstraint("key", "endpoint_id", name="endpoint_tag_pk"),
-    )
-    with op.batch_alter_table("endpoint_tags", schema=None) as batch_op:
-        batch_op.create_index("index_endpoint_tags_endpoint_id", ["endpoint_id"], unique=False)
+    if "endpoint_tags" not in existing_tables:
+        op.create_table(
+            "endpoint_tags",
+            sa.Column("key", sa.String(length=250), nullable=False),
+            sa.Column("value", sa.String(length=5000), nullable=True),
+            sa.Column("endpoint_id", sa.String(length=36), nullable=False),
+            sa.ForeignKeyConstraint(
+                ["endpoint_id"],
+                ["endpoints.endpoint_id"],
+                name="fk_endpoint_tags_endpoint_id",
+                ondelete="CASCADE",
+            ),
+            sa.PrimaryKeyConstraint("key", "endpoint_id", name="endpoint_tag_pk"),
+        )
+        with op.batch_alter_table("endpoint_tags", schema=None) as batch_op:
+            batch_op.create_index("index_endpoint_tags_endpoint_id", ["endpoint_id"], unique=False)
 
     _create_immutability_trigger()
 


### PR DESCRIPTION
### Related Issues/PRs

Closes #23721

### What changes are proposed in this pull request?

Migration `1bd49d398cd23` (`add_secrets_tables`) is not idempotent on MySQL. MySQL auto-commits DDL, so if anything in `upgrade()` fails after `CREATE TABLE secrets` executes (e.g. trigger creation), Alembic rolls back the Python transaction but the table is already persisted. On the next pod restart, `upgrade()` is retried from the same revision and immediately crashes with:

```
sqlalchemy.exc.OperationalError: (1050, "Table 'secrets' already exists")
```

This puts Kubernetes deployments (e.g. Helm init containers) into `Init:CrashLoopBackOff` with no recovery path other than a manual `UPDATE alembic_version`.

**Fix:**

1. Add `_get_existing_tables()` and guard each `op.create_table()` call with an existence check — matching the established pattern in migration `3500859a5d39` (`add_model_aliases_table`).
2. Make `_create_immutability_trigger()` call `_drop_immutability_trigger()` first (which already uses `IF EXISTS` for all dialects), so trigger creation is also safe to retry.

The `downgrade()` path is unchanged.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Four scenarios verified against SQLite (same Alembic code path as MySQL):

| Scenario | Result |
|---|---|
| Clean first-time run | All 6 tables created ✓ |
| Partial migration (only `secrets` exists) → retry | No crash, remaining tables created ✓ |
| Partial migration (3 of 6 tables exist) → retry | No crash, remaining tables created ✓ |
| Full migration already done → re-run is no-op | Tables unchanged ✓ |

Also verified via `_initialize_tables()` (the actual function called by Helm init containers) called twice in a row — idempotent, `alembic_version` unchanged.

All existing schema migration tests (23) and core SQLAlchemy store tests (42) pass.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix a crash-loop bug on MySQL where a failed first-time migration left the database half-initialized. Restarting the server (or pod) now correctly resumes the migration instead of failing with "Table already exists".

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release