### PR TITLE
Mark shap `>= 0.52.0` unsupported in cross version tests until CI runs Python 3.12

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -420,10 +420,13 @@ shap:
     pip_release: "shap"
   models:
     minimum: "0.46.0"
-    maximum: "0.52.0"
-    python:
-      # shap >= 0.52.0 dropped Python 3.10/3.11 support and requires Python >= 3.12
-      ">= 0.52.0": "3.12"
+    maximum: "0.51.0"
+    unsupported:
+      # shap >= 0.52.0 dropped Python 3.10/3.11 support and requires Python >= 3.12.
+      # The cross version test CI only runs Python 3.10/3.11 (the setup-python action
+      # rejects other versions), so mark these releases unsupported until CI can run
+      # Python 3.12.
+      - ">= 0.52.0"
     run: |
       pytest tests/shap
 

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -420,7 +420,10 @@ shap:
     pip_release: "shap"
   models:
     minimum: "0.46.0"
-    maximum: "0.51.0"
+    maximum: "0.52.0"
+    python:
+      # shap >= 0.52.0 dropped Python 3.10/3.11 support and requires Python >= 3.12
+      ">= 0.52.0": "3.12"
     run: |
       pytest tests/shap
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to # (cross version test failures)

### What changes are proposed in this pull request?

`shap` 0.52.0 dropped Python 3.10/3.11 support and now requires Python `>= 3.12`. The cross version test matrix tests one release above `maximum` (same major, released `>= 1` day ago), so shap 0.52.0 was still selected and its install step failed:

```
× No solution found when resolving dependencies:
╰─▶ Because the current Python version (3.10.20) does not satisfy Python>=3.12
    and shap==0.52.0 depends on Python>=3.12, we can conclude that shap==0.52.0
    cannot be used.
```

A per-version Python 3.12 override does not work: the cross version test CI's `setup-python` action hard-rejects any version other than 3.10/3.11 (`Invalid python version: '3.12'. Must be '3.10', or '3.11'.`).

So this PR marks shap `>= 0.52.0` as `unsupported`, excluding it from the matrix until CI is able to run Python 3.12.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Verified through the matrix loader that shap `>= 0.52.0` is filtered out (kept versions: `0.49.0`, `0.50.0`, `0.51.0`) and that the generated `ml_package_versions.py` stays consistent (the `ml-package-versions-consistency` hook produces no diff).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.
