### PR TITLE
Support pydantic-ai `>= 1.95.0` capability-based instrumentation in autolog

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -942,7 +942,7 @@ pydantic_ai:
         "git+https://github.com/pydantic/pydantic-ai.git#egg=pydantic-ai"
   autologging:
     minimum: "0.2.5"
-    maximum: "1.94.0"
+    maximum: "1.106.0"
     requirements:
       ">= 0.0.0": ["mcp"]
     run: pytest tests/pydantic_ai

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -143,7 +143,7 @@ _ML_PACKAGE_VERSIONS = {
         },
         "autologging": {
             "minimum": "0.2.5",
-            "maximum": "1.94.0"
+            "maximum": "1.106.0"
         }
     },
     "smolagents": {

--- a/mlflow/pydantic_ai/__init__.py
+++ b/mlflow/pydantic_ai/__init__.py
@@ -8,6 +8,7 @@ from mlflow.pydantic_ai.autolog import (
     patched_async_class_call,
     patched_async_stream_call,
     patched_class_call,
+    patched_model_request_capability,
     patched_sync_stream_call,
 )
 from mlflow.telemetry.events import AutologgingEvent
@@ -180,6 +181,21 @@ def autolog(log_traces: bool = True, disable: bool = False, silent: bool = False
                 _patch_method(cls, method)
             except AttributeError as e:
                 _logger.error("Error patching %s.%s: %s", cls_path, method, e)
+
+    # pydantic-ai >= 1.95.0 moved model-request instrumentation off
+    # InstrumentedModel and onto the Instrumentation capability. The
+    # InstrumentedModel.request/request_stream patches above are no longer in the
+    # call path for these versions, so patch the capability's wrap_model_request
+    # hook to capture the LLM span. On older versions this module doesn't exist
+    # and the InstrumentedModel patches above still apply.
+    try:
+        from pydantic_ai.capabilities.instrumentation import Instrumentation
+
+        safe_patch(
+            FLAVOR_NAME, Instrumentation, "wrap_model_request", patched_model_request_capability
+        )
+    except ImportError:
+        pass
 
     _record_event(
         AutologgingEvent, {"flavor": FLAVOR_NAME, "log_traces": log_traces, "disable": disable}

--- a/mlflow/pydantic_ai/autolog.py
+++ b/mlflow/pydantic_ai/autolog.py
@@ -169,6 +169,60 @@ def patched_class_call(original, self, *args, **kwargs):
         return result
 
 
+async def patched_model_request_capability(original, self, *args, **kwargs):
+    """Capture the LLM span on pydantic-ai >= 1.95.0.
+
+    pydantic-ai 1.95.0 moved model-request instrumentation off ``InstrumentedModel``
+    and onto the ``Instrumentation`` capability. ``InstrumentedModel.request`` is no
+    longer in the call path; instead the capability's ``wrap_model_request`` hook is
+    invoked for both streaming and non-streaming model calls and returns the final
+    ``ModelResponse``. We keep the span named ``InstrumentedModel.request`` so the
+    trace shape is consistent with older pydantic-ai versions.
+    """
+    cfg = AutoLoggingConfig.init(flavor_name=mlflow.pydantic_ai.FLAVOR_NAME)
+    if not cfg.log_traces:
+        return await original(self, *args, **kwargs)
+
+    # wrap_model_request(self, ctx, *, request_context, handler)
+    ctx = args[0] if args else kwargs.get("ctx")
+    request_context = kwargs.get("request_context")
+
+    with mlflow.start_span(name="InstrumentedModel.request", span_type=SpanType.LLM) as span:
+        span.set_attribute(SpanAttributeKey.MESSAGE_FORMAT, "pydantic_ai")
+        _set_model_request_attributes(span, ctx, request_context)
+
+        result = await original(self, *args, **kwargs)
+
+        span.set_outputs(_serialize_output(result))
+        if usage_dict := _parse_usage(result):
+            span.set_attribute(SpanAttributeKey.CHAT_USAGE, usage_dict)
+        return result
+
+
+def _set_model_request_attributes(span: LiveSpan, ctx, request_context):
+    """Set model + input attributes for the capability-based LLM span (>= 1.95.0)."""
+    try:
+        model = getattr(ctx, "model", None)
+        if model is not None:
+            model_attrs = _get_model_attributes(model)
+            span.set_attributes({k: v for k, v in model_attrs.items() if v is not None})
+            if model_name := getattr(model, "model_name", None):
+                span.set_attribute(SpanAttributeKey.MODEL, model_name)
+                # On the concrete model the provider is exposed via `system`
+                # (e.g. "openai"); older InstrumentedModel used a "provider:model"
+                # model_name instead.
+                if provider := getattr(model, "system", None):
+                    span.set_attribute(SpanAttributeKey.MODEL_PROVIDER, provider)
+    except Exception as e:
+        _logger.warning("Failed saving model attributes: %s", e)
+
+    try:
+        if request_context is not None and (messages := getattr(request_context, "messages", None)):
+            span.set_inputs({"messages": [asdict(m) for m in messages]})
+    except Exception as e:
+        _logger.debug("Failed to set model request inputs: %s", e)
+
+
 def patched_async_stream_call(original, self, *args, **kwargs):
     @asynccontextmanager
     async def _wrapper():

--- a/tests/pydantic_ai/helper.py
+++ b/tests/pydantic_ai/helper.py
@@ -1,0 +1,52 @@
+"""Shared helpers for pydantic-ai autologging tests.
+
+pydantic-ai 1.95.0 moved model-request instrumentation off ``InstrumentedModel``
+and onto the ``Instrumentation`` capability (see
+https://github.com/pydantic/pydantic-ai/pull/4967). Tests inject a dummy model
+response by patching the *concrete* model's ``request``/``request_stream``, which
+sits below instrumentation in every supported version:
+
+* On older versions, ``InstrumentedModel.request`` (patched by MLflow autolog)
+  internally calls the wrapped concrete model's ``request``.
+* On >= 1.95.0, the capability's ``wrap_model_request`` hook calls the concrete
+  model's ``request`` via its handler.
+
+So patching the concrete model works regardless of pydantic-ai version, while
+MLflow's autolog still produces the LLM span.
+"""
+
+import importlib.metadata
+from unittest.mock import patch
+
+from packaging.version import Version
+
+PYDANTIC_AI_VERSION = Version(importlib.metadata.version("pydantic_ai"))
+
+# Instrumentation moved to the Instrumentation capability in 1.95.0. From this
+# version the single ``wrap_model_request`` hook handles both streaming and
+# non-streaming model calls, so the LLM span is always named
+# ``InstrumentedModel.request`` (older versions used a separate
+# ``InstrumentedModel.request_stream`` span for streaming).
+USES_CAPABILITY_INSTRUMENTATION = PYDANTIC_AI_VERSION >= Version("1.95.0")
+LLM_STREAM_SPAN_NAME = (
+    "InstrumentedModel.request"
+    if USES_CAPABILITY_INSTRUMENTATION
+    else "InstrumentedModel.request_stream"
+)
+
+
+def _concrete_openai_model_cls():
+    from pydantic_ai.models import openai
+
+    # OpenAIModel was renamed/split into OpenAIChatModel in recent versions.
+    return getattr(openai, "OpenAIChatModel", None) or openai.OpenAIModel
+
+
+def patch_model_request(**kwargs):
+    """Patch the concrete OpenAI model's ``request`` (accepts ``new``/``side_effect``)."""
+    return patch.object(_concrete_openai_model_cls(), "request", **kwargs)
+
+
+def patch_model_request_stream(**kwargs):
+    """Patch the concrete OpenAI model's ``request_stream`` (accepts ``new``/``side_effect``)."""
+    return patch.object(_concrete_openai_model_cls(), "request_stream", **kwargs)

--- a/tests/pydantic_ai/test_pydanticai_fluent_tracing.py
+++ b/tests/pydantic_ai/test_pydanticai_fluent_tracing.py
@@ -1,12 +1,10 @@
 import importlib.metadata
 from contextlib import asynccontextmanager
-from unittest.mock import patch
 
 import pytest
 from packaging.version import Version
 from pydantic_ai import Agent, RunContext
 from pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart
-from pydantic_ai.models.instrumented import InstrumentedModel
 from pydantic_ai.usage import Usage
 
 import mlflow
@@ -14,6 +12,11 @@ import mlflow.pydantic_ai  # ensure the integration module is importable
 from mlflow.entities import SpanType
 from mlflow.tracing.constant import SpanAttributeKey
 
+from tests.pydantic_ai.helper import (
+    LLM_STREAM_SPAN_NAME,
+    patch_model_request,
+    patch_model_request_stream,
+)
 from tests.tracing.helper import get_traces
 
 _FINAL_ANSWER_WITHOUT_TOOL = "Paris"
@@ -192,7 +195,7 @@ def test_agent_run_sync_enable_fluent_disable_autolog(simple_agent):
     async def request(self, *args, **kwargs):
         return dummy
 
-    with patch.object(InstrumentedModel, "request", new=request):
+    with patch_model_request(new=request):
         mlflow.pydantic_ai.autolog(log_traces=True)
 
         result = simple_agent.run_sync("France")
@@ -213,7 +216,7 @@ def test_agent_run_sync_enable_fluent_disable_autolog(simple_agent):
     assert span2.span_type == SpanType.LLM
     assert span2.parent_id == spans[1].span_id
 
-    with patch.object(InstrumentedModel, "request", new=request):
+    with patch_model_request(new=request):
         mlflow.pydantic_ai.autolog(disable=True)
         simple_agent.run_sync("France")
     assert len(get_traces()) == 1
@@ -226,7 +229,7 @@ async def test_agent_run_enable_fluent_disable_autolog(simple_agent):
     async def request(self, *args, **kwargs):
         return dummy
 
-    with patch.object(InstrumentedModel, "request", new=request):
+    with patch_model_request(new=request):
         mlflow.pydantic_ai.autolog(log_traces=True)
 
         result = await simple_agent.run("France")
@@ -251,7 +254,7 @@ def test_agent_run_sync_enable_disable_fluent_autolog_with_tool(agent_with_tool)
     async def request(self, *args, **kwargs):
         return next(sequence)
 
-    with patch.object(InstrumentedModel, "request", new=request):
+    with patch_model_request(new=request):
         mlflow.pydantic_ai.autolog(log_traces=True)
 
         result = agent_with_tool.run_sync("Put my money on square eighteen", deps=18)
@@ -271,7 +274,7 @@ async def test_agent_run_enable_disable_fluent_autolog_with_tool(agent_with_tool
     async def request(self, *args, **kwargs):
         return next(sequence)
 
-    with patch.object(InstrumentedModel, "request", new=request):
+    with patch_model_request(new=request):
         mlflow.pydantic_ai.autolog(log_traces=True)
 
         result = await agent_with_tool.run("Put my money on square eighteen", deps=18)
@@ -295,7 +298,7 @@ async def test_agent_run_stream_creates_trace(simple_agent):
     async def request_stream(self, *args, **kwargs):
         yield MockStreamedResponse(response, usage)
 
-    with patch.object(InstrumentedModel, "request_stream", new=request_stream):
+    with patch_model_request_stream(new=request_stream):
         mlflow.pydantic_ai.autolog(log_traces=True)
 
         async with simple_agent.run_stream("France") as result:
@@ -311,7 +314,7 @@ async def test_agent_run_stream_creates_trace(simple_agent):
     assert spans[0].name == "Agent.run_stream"
     assert spans[0].span_type == SpanType.AGENT
 
-    assert spans[1].name == "InstrumentedModel.request_stream"
+    assert spans[1].name == LLM_STREAM_SPAN_NAME
     assert spans[1].span_type == SpanType.LLM
     assert spans[1].parent_id == spans[0].span_id
 
@@ -333,7 +336,7 @@ def test_agent_run_stream_sync_creates_trace(simple_agent):
     async def request_stream(self, *args, **kwargs):
         yield MockStreamedResponse(response, usage)
 
-    with patch.object(InstrumentedModel, "request_stream", new=request_stream):
+    with patch_model_request_stream(new=request_stream):
         mlflow.pydantic_ai.autolog(log_traces=True)
 
         result = simple_agent.run_stream_sync("France")
@@ -355,7 +358,7 @@ def test_agent_run_stream_sync_creates_trace(simple_agent):
     assert "user_prompt" in spans[0].inputs
     assert spans[0].outputs is not None
 
-    assert spans[1].name == "InstrumentedModel.request_stream"
+    assert spans[1].name == LLM_STREAM_SPAN_NAME
     assert spans[1].span_type == SpanType.LLM
     assert spans[1].parent_id == spans[0].span_id
 
@@ -382,7 +385,7 @@ async def test_agent_run_stream_with_tool(agent_with_tool):
             resp = sequence[-1]
             yield MockStreamedResponse(resp, resp.usage)
 
-    with patch.object(InstrumentedModel, "request_stream", new=request_stream):
+    with patch_model_request_stream(new=request_stream):
         mlflow.pydantic_ai.autolog(log_traces=True)
 
         async with agent_with_tool.run_stream("Put my money on square eighteen", deps=18) as result:
@@ -412,7 +415,7 @@ def test_agent_run_stream_sync_with_tool(agent_with_tool):
             resp = sequence[-1]
             yield MockStreamedResponse(resp, resp.usage)
 
-    with patch.object(InstrumentedModel, "request_stream", new=request_stream):
+    with patch_model_request_stream(new=request_stream):
         mlflow.pydantic_ai.autolog(log_traces=True)
 
         result = agent_with_tool.run_stream_sync("Put my money on square eighteen", deps=18)

--- a/tests/pydantic_ai/test_pydanticai_tracing.py
+++ b/tests/pydantic_ai/test_pydanticai_tracing.py
@@ -22,6 +22,7 @@ from mlflow.pydantic_ai.autolog import (
 from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
 from mlflow.version import IS_TRACING_SDK_ONLY
 
+from tests.pydantic_ai.helper import patch_model_request
 from tests.tracing.helper import get_traces
 
 PYDANTIC_AI_VERSION = Version(importlib.metadata.version("pydantic_ai"))
@@ -128,7 +129,7 @@ def test_agent_run_sync_enable_disable_autolog(simple_agent, mock_litellm_cost):
     async def request(self, *args, **kwargs):
         return dummy
 
-    with patch("pydantic_ai.models.instrumented.InstrumentedModel.request", new=request):
+    with patch_model_request(new=request):
         mlflow.pydantic_ai.autolog(log_traces=True)
 
         result = simple_agent.run_sync("France")
@@ -182,7 +183,7 @@ def test_agent_run_sync_enable_disable_autolog(simple_agent, mock_litellm_cost):
         "total_tokens": 2,
     }
 
-    with patch("pydantic_ai.models.instrumented.InstrumentedModel.request", new=request):
+    with patch_model_request(new=request):
         mlflow.pydantic_ai.autolog(disable=True)
         simple_agent.run_sync("France")
     assert len(get_traces()) == 1
@@ -195,7 +196,7 @@ async def test_agent_run_enable_disable_autolog(simple_agent, mock_litellm_cost)
     async def request(self, *args, **kwargs):
         return dummy
 
-    with patch("pydantic_ai.models.instrumented.InstrumentedModel.request", new=request):
+    with patch_model_request(new=request):
         mlflow.pydantic_ai.autolog(log_traces=True)
 
         result = await simple_agent.run("France")
@@ -241,7 +242,7 @@ def test_agent_run_sync_enable_disable_autolog_with_tool(agent_with_tool, mock_l
             return sequence.pop(0)
         return resp
 
-    with patch("pydantic_ai.models.instrumented.InstrumentedModel.request", new=request):
+    with patch_model_request(new=request):
         mlflow.pydantic_ai.autolog(log_traces=True)
 
         result = agent_with_tool.run_sync("Put my money on square eighteen", deps=18)
@@ -281,7 +282,7 @@ async def test_agent_run_enable_disable_autolog_with_tool(agent_with_tool, mock_
             return sequence.pop(0)
         return resp
 
-    with patch("pydantic_ai.models.instrumented.InstrumentedModel.request", new=request):
+    with patch_model_request(new=request):
         mlflow.pydantic_ai.autolog(log_traces=True)
 
         result = await agent_with_tool.run("Put my money on square eighteen", deps=18)
@@ -313,10 +314,7 @@ async def test_agent_run_enable_disable_autolog_with_tool(agent_with_tool, mock_
 
 
 def test_agent_run_sync_failure(simple_agent):
-    with patch(
-        "pydantic_ai.models.instrumented.InstrumentedModel.request",
-        side_effect=ValueError("test error"),
-    ):
+    with patch_model_request(side_effect=ValueError("test error")):
         mlflow.pydantic_ai.autolog(log_traces=True)
 
         with pytest.raises(ValueError, match="test error"):
@@ -335,10 +333,7 @@ def test_agent_run_sync_failure(simple_agent):
     assert spans[2].name.startswith("InstrumentedModel.")
     assert spans[2].span_type == SpanType.LLM
 
-    with patch(
-        "pydantic_ai.models.instrumented.InstrumentedModel.request",
-        side_effect=ValueError("test error"),
-    ):
+    with patch_model_request(side_effect=ValueError("test error")):
         mlflow.pydantic_ai.autolog(disable=True)
 
         with pytest.raises(ValueError, match="test error"):
@@ -423,7 +418,7 @@ def test_autolog_auto_instrument_captures_llm_spans(mock_litellm_cost):
         return dummy
 
     # Mock must be set BEFORE autolog so autolog patches the mock
-    with patch("pydantic_ai.models.instrumented.InstrumentedModel.request", new=request):
+    with patch_model_request(new=request):
         mlflow.pydantic_ai.autolog(log_traces=True)
 
         # Create agent WITHOUT explicitly setting instrument=True
@@ -450,7 +445,7 @@ def test_autolog_does_not_capture_client_references(simple_agent):
     async def request(self, *args, **kwargs):
         return dummy
 
-    with patch("pydantic_ai.models.instrumented.InstrumentedModel.request", new=request):
+    with patch_model_request(new=request):
         mlflow.pydantic_ai.autolog(log_traces=True)
         simple_agent.run_sync("France")
 
@@ -462,7 +457,9 @@ def test_autolog_does_not_capture_client_references(simple_agent):
         attrs = span.attributes or {}
         for key in attrs:
             assert "client" not in key.lower() or key == "openai_client"
-            assert "provider" not in key.lower()
+            # mlflow.llm.provider is a deliberate semantic attribute, not a
+            # captured client reference.
+            assert "provider" not in key.lower() or key == SpanAttributeKey.MODEL_PROVIDER
             assert "_state" not in key.lower()
             assert "httpx" not in key.lower()
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to # (cross version test failures)

### What changes are proposed in this pull request?

pydantic-ai 1.95.0 ([pydantic/pydantic-ai#4967](https://github.com/pydantic/pydantic-ai/pull/4967)) moved model-request instrumentation off the `InstrumentedModel` wrapper and onto an injected `Instrumentation` capability. As a result `InstrumentedModel.request` / `request_stream` -- which MLflow autolog patches to create the LLM span -- are no longer in the call path, so **autologged traces lost the LLM span entirely on pydantic-ai `>= 1.95.0`** (only the `Agent.run` / `Agent.run_sync` spans remained). This is a real user-facing autolog regression, surfaced by the cross version tests on 1.96.1 and 1.106.0.

This PR:

- Patches the `Instrumentation.wrap_model_request` capability hook (invoked for both streaming and non-streaming model calls) to capture the LLM span on pydantic-ai `>= 1.95.0`, while keeping the existing `InstrumentedModel` patches for older versions. On versions without the capability module the new patch is skipped.
- Keeps the LLM span named `InstrumentedModel.request` so the trace shape stays consistent across pydantic-ai versions. Model name/provider are read from the concrete model (`model_name` + `system`).
- Updates the tests to inject the dummy model response by patching the **concrete** model's `request`/`request_stream`, which sits below instrumentation in every supported version, so a single mock works on both the legacy `InstrumentedModel` path and the new capability path.
- Bumps the tested `maximum` to 1.106.0.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Ran `tests/pydantic_ai` locally against pydantic-ai **1.96.1** (capability path) and **1.94.0** / **1.90.0** (legacy `InstrumentedModel` path) -- all pass. Verified end-to-end that the LLM span is restored on 1.96.1 with correct model name, provider, token usage, cost, and parenting under `Agent.run`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Restore MLflow Tracing LLM spans for pydantic-ai `>= 1.95.0`, which moved model-request instrumentation to its new `Instrumentation` capability.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.