### PR TITLE
Pass explicit task in transformers custom-components pipeline test

### DIFF
--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -1397,8 +1397,15 @@ def test_custom_components_pipeline(custom_components_pipeline, model_path):
         "feature_extractor": custom_components_pipeline.feature_extractor,
     }
 
+    # Pass the task explicitly rather than relying on inference from the Hub:
+    # the backing model's `pipeline_tag` is now `image-feature-extraction`, so
+    # task inference would build an unsupported pipeline type. The fixture
+    # pipeline is already built with the `feature-extraction` task.
     mlflow.transformers.save_model(
-        transformers_model=components, path=model_path, signature=signature
+        transformers_model=components,
+        path=model_path,
+        signature=signature,
+        task=custom_components_pipeline.task,
     )
 
     pyfunc_loaded = mlflow.pyfunc.load_model(model_path)


### PR DESCRIPTION
### Related Issues/PRs

Relates to # (cross version test failures)

### What changes are proposed in this pull request?

`test_custom_components_pipeline` saved raw pipeline components (`model` + `tokenizer` + `feature_extractor`) without specifying a task, so MLflow inferred the task from the Hugging Face Hub via `get_task()`. The backing model `hf-internal-testing/test_dynamic_model_with_tokenizer` now reports `pipeline_tag: image-feature-extraction`, so inference built an `ImageFeatureExtractionPipeline`, which is not enabled for pyfunc:

```
mlflow.exceptions.MlflowException: The loaded pipeline type ImageFeatureExtractionPipeline
is not enabled for pyfunc predict functionality.
```

This failed the transformers cross version tests on every version (4.41 -> 5.10).

The fixture pipeline is already constructed with the `feature-extraction` task, so this PR passes that task explicitly to `save_model`, decoupling the test from the volatile Hub `pipeline_tag`.

### How is this PR tested?

- [x] Existing unit/integration tests

Confirmed via the flavor source that a non-`None` `task` bypasses Hub task inference in `_build_pipeline_from_model_input`, so `save_model` builds the same `FeatureExtractionPipeline` the fixture already uses. (Local execution not possible in the current offline environment; validated by the cross version test job in CI.)

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.