### PR TITLE
Constrain transformers for torch 2.5/2.6 in pytorch cross version tests

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -41,6 +41,10 @@ pytorch:
       # for torch < 2.5 (annotations stored as strings under `from __future__`).
       # https://github.com/huggingface/transformers/issues/42352
       "< 2.5": ["transformers<5"]
+      # transformers 5.10.x references torch.float8_e8m0fnu at import time, which
+      # only exists in torch >= 2.7, so importing any model fails on older torch.
+      # Fixed (guarded) in transformers 5.11.0.
+      ">= 2.5, < 2.7": ["transformers<5.10"]
     run: |
       pytest tests/pytorch/test_pytorch_model_export.py tests/pytorch/test_pytorch_metric_value_conversion_utils.py
 

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -43,8 +43,9 @@ pytorch:
       "< 2.5": ["transformers<5"]
       # transformers 5.10.x references torch.float8_e8m0fnu at import time, which
       # only exists in torch >= 2.7, so importing any model fails on older torch.
-      # Fixed (guarded) in transformers 5.11.0.
-      ">= 2.5, < 2.7": ["transformers<5.10"]
+      # Fixed (guarded) in transformers 5.11.0, so exclude only the broken 5.10
+      # line and keep testing newer transformers on torch 2.5/2.6.
+      ">= 2.5, < 2.7": ["transformers!=5.10.*"]
     run: |
       pytest tests/pytorch/test_pytorch_model_export.py tests/pytorch/test_pytorch_metric_value_conversion_utils.py
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to # (cross version test failures)

### What changes are proposed in this pull request?

The pytorch cross version tests (`test_pyfunc_serve_and_score_transformers`) pin torch to 2.5.1 / 2.6.0 and install the latest `transformers`. transformers 5.10.x references `torch.float8_e8m0fnu` at module import time (in `integrations/finegrained_fp8.py`), and that dtype only exists in torch `>= 2.7`. As a result, importing any model failed:

```
AttributeError: module 'torch' has no attribute 'float8_e8m0fnu'
-> ModuleNotFoundError: Could not import module 'BertModel'
```

transformers fixed this with a `hasattr` guard in 5.11.0. This PR mirrors the existing torch-version-gated transformers constraint and pins `transformers<5.10` for torch `>= 2.5, < 2.7`. torch `>= 2.7` continues to install the latest transformers (which has the dtype), and torch `< 2.5` keeps its existing `transformers<5` constraint.

### How is this PR tested?

- [x] Existing unit/integration tests

Validated the matrix requirement resolution per torch version using the flavor loader:

```
torch 2.4.1  -> transformers, transformers<5
torch 2.5.1  -> transformers, transformers<5.10
torch 2.6.0  -> transformers, transformers<5.10
torch 2.7.0  -> transformers
```

(Local execution of the torch/transformers job is not possible in the current offline environment; validated by the cross version test job in CI.)

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.